### PR TITLE
test(coverage): add TypeScript symbol, type, and error baseline conformance suites

### DIFF
--- a/tasks/coverage/snapshots/errors_typescript.snap
+++ b/tasks/coverage/snapshots/errors_typescript.snap
@@ -1,0 +1,901 @@
+commit: 7539c04d
+
+errors_typescript Summary:
+AST Parsed     : 7699/7699 (100.00%)
+Positive Passed: 7251/7699 (94.18%)
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/ArrowFunctionExpression1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration26.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/ClassDeclarationWithInvalidConstOnPropertyDeclaration.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/MemberAccessorDeclaration15.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/ParameterList13.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/ParameterList4.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/ParameterList5.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/ParameterList6.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/TransportStream.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessorParameterAccessibilityModifier.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessorWithInitializer.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessorWithoutBody1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessorWithoutBody2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientPropertyDeclarationInJs.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/anonymousModules.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/arraySigChecking.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/bigintPropertyName.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/castOfYield.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/catchClauseWithInitializer1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/class2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/classHeritageWithTrailingSeparator.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/classUpdateTests.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonJsExportTypeDeclarationError.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonMissingSemicolons.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/complicatedPrivacy.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/constDeclarations-invalidContexts.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/constDeclarations-scopes.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/constDeclarations-validContexts.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/constInClassExpression.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorInJsFile.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorInJsFile1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst11.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyMemberAccess.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumConflictsWithGlobalIdentifier.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumIdentifierLiterals.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumMemberResolution.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorOnInitializerInInterfaceProperty.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorOnInitializerInObjectTypeLiteralProperty.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorRecoveryWithDotFollowedByNamespaceKeyword.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorSpanForUnclosedJsxTag.tsx
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5ModuleInternalNamedImports.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImport1WithExport.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImportWithExport.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBinding1WithExport.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBindingWithExport.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingWithExport.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNameSpaceImportWithExport.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportWithExport.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportParseErrors.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportWithoutFromClauseWithExport.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentWithDeclareAndExportModifiers.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentWithDeclareModifier.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentWithExportModifier.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDeclarationsInAmbientNamespaces2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDefaultClassInNamespace.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDefaultFunctionInNamespace.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportInFunction.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/expressionTypeNodeShouldError.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/externModule.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/fatarrowfunctionsOptionalArgs.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/fatarrowfunctionsOptionalArgsErrors1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/fatarrowfunctionsOptionalArgsErrors2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/fatarrowfunctionsOptionalArgsErrors3.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/fillInMissingTypeArgsOnJSConstructCalls.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionTypesLackingReturnTypes.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionsWithModifiersInBlocks1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallWithoutArgs.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/gettersAndSettersErrors.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/giant.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/implementClausePrecedingExtends.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/implementsClauseAlreadySeen.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/importDeclWithDeclareModifierInAmbientContext.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/importDeclarationInModuleDeclaration1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/importInsideModule.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/incompleteDottedExpressionAtEOF.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexSignatureMustHaveTypeAnnotation.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexSignatureTypeCheck.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexSignatureTypeCheck2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexSignatureWithInitializer1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexTypeCheck.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexWithoutParamType.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/innerModExport1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/innerModExport2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/instantiateTypeParameter.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/intTypeCheck.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceNaming1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidUnicodeEscapeSequance.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidUnicodeEscapeSequance2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidUnicodeEscapeSequance4.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationAbstractModifier.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationAmbientVarDeclarationSyntax.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationBindMultipleDefaultExports.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationConstructorOverloadSyntax.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationEnumSyntax.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationExportAssignmentSyntax.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationFunctionOverloadSyntax.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationInterfaceSyntax.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationMethodOverloadSyntax.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationModuleSyntax.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationNonNullAssertion.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationReturnTypeSyntaxOfFunction.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationTypeAliasSyntax.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationTypeArgumentSyntaxOfCall.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationTypeAssertions.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationTypeOfParameter.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationTypeParameterSyntaxOfClass.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationTypeParameterSyntaxOfClassExpression.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationTypeParameterSyntaxOfFunction.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationTypeSyntaxOfVar.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationWithoutJsExtensions.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocTypedefNoCrash2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxAttributeWithoutExpressionReact.tsx
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-invalidContexts.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-scopes.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-validContexts.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/literalsInComputedProperties1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/manyCompilerErrorsInTheTwoFiles.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingCloseBrace.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingCloseBraceInObjectLiteral.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/misspelledNewMetaProperty.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleKeywordRepeatError.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleProperty1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/multipleClassPropertyModifiersErrors.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/newMissingIdentifier.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectBindingPattern_restElementWithPropertyName.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralMemberWithoutBlock1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalArgsWithDefaultValues.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalChainWithInstantiationExpression1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalSetterParam.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/parameterPropertyOutsideConstructor.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseInvalidNames.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseJsxElementInUnaryExpressionNoCrash1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseJsxElementInUnaryExpressionNoCrash2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseJsxElementInUnaryExpressionNoCrash3.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/parserConstructorDeclaration12.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/parserPrivateIdentifierInArrayAssignment.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/prettyContextNotDebugAssertion.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyGloImportParseErrors.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyImportParseErrors.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/privateNameJsx.tsx
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyWrappedInTry.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/readonlyInNonPropertyParameters.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/restParamModifier2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/restParameterWithBindingPattern3.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/shorthandPropertyAssignmentsInDestructuring.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/shorthandPropertyAssignmentsInDestructuring_ES6.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/slashBeforeVariableDeclaration1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticAsIdentifier.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticClassProps.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticModifierAlreadySeen.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticsInConstructorBodies.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringLiteralsErrors.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/superAccess2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/superErrors.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/superInLambdas.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/superWithTypeArgument.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/superWithTypeArgument2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/superWithTypeArgument3.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/switchStatementsWithMultipleDefaults.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/switchStatementsWithMultipleDefaults1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/taggedTemplatesWithIncompleteNoSubstitutionTemplate1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/taggedTemplatesWithIncompleteNoSubstitutionTemplate2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/taggedTemplatesWithIncompleteTemplateExpressions2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/templateLiteralEscapeSequence.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisAssignmentInNamespaceDeclaration1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/throwWithoutNewLine2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAliasDeclarationEmit3.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAliasDeclareKeywordNewlines.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInterfaceDeclarationsInBlockStatements1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/uncaughtCompilerError2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/unclosedExportClause01.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/unclosedExportClause02.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/unparenthesizedConstructorTypeInUnionOrIntersection.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/unparenthesizedFunctionTypeInUnionOrIntersection.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/unterminatedStringLiteralWithBackslash1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/validRegexp.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/compiler/varArgConstructorMemberParameter.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientModuleDeclarationWithReservedIdentifierInDottedPath.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientModuleDeclarationWithReservedIdentifierInDottedPath2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction6_es2017.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction6_es5.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncConstructor_es5.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction6_es6.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncConstructor_es6.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractMixedWithModifiers.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classBody/classBodyWithStatements.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendingOptionalChain.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock20.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock6.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock7.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/readonlyInAmbientClass.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameHashCharName.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameInInExpression.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameInInExpressionTransform.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesIncompatibleModifiers.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/nestedClassDeclaration.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessibilityModifiers.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessorDisallowedModifiers.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethodThisParameter.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/invalid/decoratorOnAwait.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/invalid/decoratorOnEnum.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/invalid/decoratorOnFunctionDeclaration.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/invalid/decoratorOnFunctionParameter.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/invalid/decoratorOnImportEquals1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/invalid/decoratorOnImportEquals2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/invalid/decoratorOnInterface.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/invalid/decoratorOnInternalModule.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/invalid/decoratorOnTypeAlias.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/invalid/decoratorOnUsing.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/invalid/decoratorOnVar.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionIncorrect2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionWithTypeArgument.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2018/invalidTaggedTemplateEscapeSequences.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames49_ES5.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames49_ES6.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames50_ES5.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames50_ES6.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration4.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/restElementWithInitializer1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/restElementWithInitializer2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInModuleName.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInModuleNameES6.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringUnterminated1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringUnterminated1_ES6.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringUnterminated2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringUnterminated2_ES6.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringUnterminated3.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringUnterminated3_ES6.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringUnterminated4.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringUnterminated4_ES6.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringUnterminated5.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringUnterminated5_ES6.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/unicodeExtendedEscapes/unicodeExtendedEscapesInStrings07.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/unicodeExtendedEscapes/unicodeExtendedEscapesInStrings12.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/unicodeExtendedEscapes/unicodeExtendedEscapesInStrings14.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/unicodeExtendedEscapes/unicodeExtendedEscapesInStrings17.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/unicodeExtendedEscapes/unicodeExtendedEscapesInStrings19.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/unicodeExtendedEscapes/unicodeExtendedEscapesInStrings20.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/unicodeExtendedEscapes/unicodeExtendedEscapesInStrings21.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/unicodeExtendedEscapes/unicodeExtendedEscapesInStrings22.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/unicodeExtendedEscapes/unicodeExtendedEscapesInStrings24.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/unicodeExtendedEscapes/unicodeExtendedEscapesInStrings25.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/unicodeExtendedEscapes/unicodeExtendedEscapesInTemplates07.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/unicodeExtendedEscapes/unicodeExtendedEscapesInTemplates12.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/unicodeExtendedEscapes/unicodeExtendedEscapesInTemplates14.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/unicodeExtendedEscapes/unicodeExtendedEscapesInTemplates17.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/unicodeExtendedEscapes/unicodeExtendedEscapesInTemplates19.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/variableDeclarations/VariableDeclaration11_es6.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorInAmbientContext1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorInAmbientContext2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorInAmbientContext3.d.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorInAmbientContext4.d.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorOverloads1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorOverloads2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorOverloads3.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/accessors/esDecorators-classDeclaration-accessors-nonStaticAbstract.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-exportModifier.2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-exportModifier.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-staticAmbient.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/commaOperator/commaOperatorWithoutOperand.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/newOperator/newOperatorErrorCases.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator5.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/objectLiterals/objectLiteralErrors.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/operators/incrementAndDecrement.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/superCalls/errorSuperCalls.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typePredicateOnVariableDeclaration02.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_js.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithEnumTypeInvalidOperations.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/deleteOperator/deleteOperatorInvalidOperations.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithEnumTypeInvalidOperations.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/typeofOperator/typeofOperatorInvalidOperations.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/voidOperator/voidOperatorInvalidOperations.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/importTsBeforeDTs.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/topLevelAwaitErrors.1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace_js.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportSpecifiers_js.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/grammarErrors.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importSpecifiers_js.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd-errors.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/importAssertion/importAssertion4.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/importAssertion/importAssertion5.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/importDefer/importDeferFromInvalid.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/importDefer/importDeferTypeConflict2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/importDefer/importMetaPropertyInvalidInCall.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfacesWithPredefinedTypesAsNames.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtendingClass2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsClassesErr.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsEnums.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsExportFormsErr.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsInterfaces.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsTypeReferences4.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxParsingError2.tsx
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxParsingErrorImmediateSpreadInAttributeValue.tsx
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxErrorRecovery1.tsx
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxFragmentErrors.tsx
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/unicodeEscapesInJsxtags.tsx
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/node/allowJs/nodeModulesAllowJsExportAssignment.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/node/allowJs/nodeModulesAllowJsImportAssignment.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/overrideParameterProperty.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript2018/forAwait/parser.forAwait.es2018.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript2021/numericSeparators/parser.numericSeparators.binaryNegative.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript2021/numericSeparators/parser.numericSeparators.decmialNegative.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript2021/numericSeparators/parser.numericSeparators.hexNegative.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript2021/numericSeparators/parser.numericSeparators.octalNegative.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript2021/numericSeparators/parser.numericSeparators.unicodeEscape.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserAccessors7.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserAccessors8.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserAccessors9.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserGetAccessorWithTypeParameters1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserSetAccessorWithTypeAnnotation1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserSetAccessorWithTypeParameters1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression10.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression13.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression14.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression15.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression16.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression17.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration3.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration5.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName6.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration10.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration11.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration9.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum7.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/Blocks/parserErrorRecovery_Block3.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ClassElements/parserErrorRecovery_ClassElement1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ClassElements/parserErrorRecovery_ClassElement2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/Expressions/parserErrorRecovery_Expression1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ExtendsOrImplementsClauses/parserErrorRecovery_ExtendsOrImplementsClause1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ExtendsOrImplementsClauses/parserErrorRecovery_ExtendsOrImplementsClause2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ExtendsOrImplementsClauses/parserErrorRecovery_ExtendsOrImplementsClause4.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ExtendsOrImplementsClauses/parserErrorRecovery_ExtendsOrImplementsClause5.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ExtendsOrImplementsClauses/parserErrorRecovery_ExtendsOrImplementsClause6.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/IfStatements/parserErrorRecoveryIfStatement5.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/IfStatements/parserErrorRecoveryIfStatement6.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ModuleElements/parserErrorRecovery_ModuleElement1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/TypeArgumentLists/TypeArgumentList1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/TypeArgumentLists/parserX_TypeArgumentList1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserEmptyParenthesizedExpression1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserErrantAccessibilityModifierInModule1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserErrantEqualsGreaterThanAfterFunction1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserErrantEqualsGreaterThanAfterFunction2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserErrantSemicolonInClass1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserFuzz1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserPublicBreak1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserUnfinishedTypeNameBeforeKeyword1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserUnterminatedGeneric2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Expressions/parserPostfixPostfixExpression1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Expressions/parserPostfixUnaryExpression1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserMemberAccessExpression1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserMemberAccessOffOfGenericType1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexMemberDeclarations/parserIndexMemberDeclaration10.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexMemberDeclarations/parserIndexMemberDeclaration9.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexSignatures/parserIndexSignature10.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexSignatures/parserIndexSignature3.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexSignatures/parserIndexSignature6.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexSignatures/parserIndexSignature8.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexSignatures/parserIndexSignature9.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration12.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration13.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration14.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration15.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration16.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration17.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration8.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberFunctionDeclarations/parserMemberFunctionDeclaration2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberVariableDeclarations/parserMemberVariableDeclaration2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ObjectTypes/parserObjectType6.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList13.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList4.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList5.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList6.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509668.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509669.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser512084.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser512325.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser521128.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser566700.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser585151.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity3.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens10.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens11.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens12.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens13.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens14.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens15.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens19.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens20.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens3.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens4.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens5.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens6.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens7.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens8.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens9.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement21.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserForInStatement2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserReturnStatement1.d.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserWithStatement2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration10.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration5.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration8.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserKeywordsAsIdentifierName2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserS7.9_A5.7_T1.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName16.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName26.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName30.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName34.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName35.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement21.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/plainJSBinderErrors.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/plainJSGrammarErrors.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannerS7.4_A2_T2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannerS7.8.4_A7.1_T4.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannerStringLiterals.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.11.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.16.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.4.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.6.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarationsInForAwaitOf.3.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarationsInForOf.5.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.13.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.16.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/labeledStatements/labeledStatementWithLabel.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/labeledStatements/labeledStatementWithLabel_es2015.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/labeledStatements/labeledStatementWithLabel_strict.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/import/importWithTypeArguments.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithParameterInitializers2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/constructSignatureWithAccessibilityModifiersOnParameters.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/constructSignatureWithAccessibilityModifiersOnParameters2.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/rest/objectRestNegative.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/rest/objectRestPropertyMustBeLast.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/rest/restElementMustBeLast.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/named/namedTupleMembersErrors.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/reservedNamesInAliases.ts
+
+Error Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts
+

--- a/tasks/coverage/snapshots/symbols_typescript.snap
+++ b/tasks/coverage/snapshots/symbols_typescript.snap
@@ -1,0 +1,13203 @@
+commit: 7539c04d
+
+symbols_typescript Summary:
+AST Parsed     : 8364/8364 (100.00%)
+Positive Passed: 1765/8364 (21.10%)
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/2dArrays.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/ClassDeclarationWithInvalidConstOnPropertyDeclaration2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/DeclarationErrorsNoEmitOnError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/abstractClassUnionInstantiation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/abstractInterfaceIdentifierName.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/abstractPropertyInConstructor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/acceptSymbolAsWeakType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/acceptableAlias1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessInstanceMemberFromStaticMethod01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessOverriddenBaseClassMember1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessStaticMemberFromInstanceMethod01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessorDeclarationEmitJs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessorDeclarationEmitVisibilityErrors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessorDeclarationOrder.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessorsEmit.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessors_spec_section-4.5_error-cases.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessors_spec_section-4.5_inference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/addMoreOverloadsToBaseSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasAssignments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasBug.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasDoesNotDuplicateSignatures.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasInaccessibleModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasInstantiationExpressionGenericIntersectionNoCrash1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasInstantiationExpressionGenericIntersectionNoCrash2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasOfGenericFunctionWithRestBehavedSameAsUnaliased.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasOnMergedModuleInterface.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasUsageInArray.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasUsageInFunctionExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasUsageInGenericFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasUsageInIndexerOfClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasUsageInObjectLiteral.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasUsageInOrExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasUsageInTypeArgumentOfExtendsClause.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasUsageInVarAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasUsedAsNameValue.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasWithInterfaceExportAssignmentUsedInVarInitializer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasesInSystemModule1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasesInSystemModule2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowImportClausesToMergeWithTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowJsClassThisTypeCrash.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowJsCrossMonorepoPackage.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowJscheckJsTypeParameterNoCrash.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImportsCanPaintCrossModuleDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientClassDeclarationWithExtends.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientClassMergesOverloadsWithInterface.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientClassOverloadForFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientConstLiterals.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientEnumElementInitializer1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientEnumElementInitializer2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientEnumElementInitializer3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientEnumElementInitializer4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientEnumElementInitializer5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientEnumElementInitializer6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientExternalModuleInAnotherExternalModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientExternalModuleReopen.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientExternalModuleWithInternalImportDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientExternalModuleWithoutInternalImportDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientFundule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientModuleExports.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientModuleWithTemplateLiterals.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientModules.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambiguousCallsWhereReturnTypesAgree.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambiguousOverloadResolution.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/amdDeclarationEmitNoExtraDeclare.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/amdLikeInputDeclarationEmit.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/amdModuleConstEnumUsage.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/amdModuleName1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/amdModuleName2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/anonClassDeclarationEmitIsAnon.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/anonterface.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/anonymousClassDeclarationDoesntPrintWithReadonly.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/anonymousClassExpression2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyAndUnknownHaveFalsyComponents.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyInferenceAnonymousFunctions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyIsAssignableToObject.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyIsAssignableToVoid.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyMappedTypesError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/argsInScope.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arguments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsAsPropertyName.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsAsPropertyName2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsObjectCreatesRestForJs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsObjectIterator01_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsObjectIterator02_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsObjectIterator03_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsPropertyNameInJsMode1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsPropertyNameInJsMode2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsReferenceInConstructor1_Js.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsReferenceInConstructor2_Js.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsReferenceInConstructor3_Js.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsReferenceInConstructor5_Js.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsReferenceInConstructor6_Js.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsReferenceInConstructor7_Js.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsReferenceInFunction1_Js.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsReferenceInMethod1_Js.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsReferenceInMethod2_Js.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsReferenceInMethod3_Js.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsReferenceInMethod5_Js.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsReferenceInMethod6_Js.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsReferenceInMethod7_Js.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsUsedInObjectLiteralProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arithmeticOnInvalidTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arityErrorRelatedSpanBindingPattern.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayAssignmentTest1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayAssignmentTest2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayAssignmentTest3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayAssignmentTest4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayAssignmentTest5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayAssignmentTest6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayAugment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayBestCommonTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayBindingPatternOmittedExpressions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayBufferIsViewNarrowsType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayCast.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayConcat2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayConcat3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayConstructors1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayDestructuringInSwitch1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayDestructuringInSwitch2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayEvery.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayFakeFlatNoCrashInferenceDeclarations.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayFilter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayFind.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayFlatMap.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayFlatNoCrashInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayFlatNoCrashInferenceDeclarations.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayFrom.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayFromAsync.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayLiteralAndArrayConstructorEquivalence1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayLiteralComments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayLiteralContextualType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayLiteralTypeInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayOfExportedClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayOfSubtypeIsAssignableToReadonlyArray.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayReferenceWithoutTypeArgs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arraySlice.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayToLocaleStringES2015.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayToLocaleStringES2020.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayTypeInSignatureOfInterfaceAndClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayconcat.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionParsingGenericInObject.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionWithObjectLiteralBody5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionWithObjectLiteralBody6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/asiInES6Classes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assertionFunctionWildcardImport1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assertionFunctionWildcardImport2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assertionFunctionsCanNarrowByDiscriminant.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assign1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignLambdaToNominalSubtypeOfFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignToEnum.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignToExistingClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignToFn.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignToModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignToObjectTypeWithPrototypeProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignToPrototype1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assigningFromObjectToAnythingElse.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompat1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatBug2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatBug3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatBug5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatForEnums.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatInterfaceWithStringIndexSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatWithOverloads.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability10.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability11.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability12.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability13.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability14.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability15.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability16.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability17.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability18.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability19.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability20.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability21.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability22.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability23.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability24.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability25.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability26.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability27.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability28.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability29.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability30.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability31.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability32.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability33.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability34.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability35.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability36.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability37.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability38.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability39.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability40.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability41.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability42.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability43.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability45.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability46.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability_checking-apply-member-off-of-function-interface.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability_checking-call-member-off-of-function-interface.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatibilityForConstrainedTypeParameters.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentIndexedToPrimitives.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentNestedInLiterals.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentNonObjectTypeConstraints.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentToConditionalBrandedStringTemplateOrMapping.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentToExpandingArrayType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentToObject.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentToObjectAndFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionContextuallyTypedReturns.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionNoReturnType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionReturnExpressionErrorSpans.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionReturnType.2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionReturnType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionsAcrossFiles.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionsAndStrictNullChecks.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncIIFE.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncYieldStarContextualType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentArray.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals1_1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals2_1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals3_1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals4_1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals6_1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentedTypeBracketNamedPropertyAccess.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentedTypesClass3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentedTypesExternalModule1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentedTypesModules3b.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentedTypesModules4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/autoAsiForStaticsInClassDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/autonumberingInEnums.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/avoid.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/avoidCycleWithVoidExpressionReturnedFromArrow.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/avoidListingPropertiesForTypesWithOnlyCallOrConstructSignatures.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/avoidNarrowingUsingConstVariableFromBindingElementWithLiteralInitializer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/awaitUnionPromise.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/awaitedType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/awaitedTypeCrash.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/awaitedTypeJQuery.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/awaitedTypeNoLib.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/awaitedTypeStrictNull.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/badExternalModuleReference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/badInferenceLowerPriorityThanGoodInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/badOverloadError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/badThisBinding.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/bangInModuleName.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/baseClassImprovedMismatchErrors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/baseConstraintOfDecorator.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/baseIndexSignatureResolution.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/baseTypeAfterDerivedType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/baseTypeOrderChecking.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/baseTypePrivateMemberClash.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/baseTypeWrappingInstantiationChain.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/bestChoiceType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/bestCommonTypeReturnStatement.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/bestCommonTypeWithContextualTyping.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/bestCommonTypeWithOptionalProperties.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/betterErrorForUnionCall.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/bigIntWithTargetES2016.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/bigIntWithTargetLessThanES2016.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/bigint64ArraySubarray.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/bigintWithLib.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/binaryArithmeticControlFlowGraphNotTooLarge.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/bindingPatternContextualTypeDoesNotCauseWidening.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/bindingPatternInParameter01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/bindingPatternOmittedExpressionNesting.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/binopAssignmentShouldHaveType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedBindingUsedBeforeDef.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedBindingsReassignedInLoop6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedClassDeclarationAcrossFiles.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/bluebirdStaticThis.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/booleanAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/booleanFilterAnyArray.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/booleanLiteralsContextuallyTypedFromUnion.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/builtinIterator.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/bundledDtsLateExportRenaming.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/cacheResolutions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedContextualTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/callOfConditionalTypeWithConcreteBranches.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/callOverloadViaElementAccessExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/callSignaturesShouldBeResolvedBeforeSpecialization.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/callbacksDontShareTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/callsOnComplexSignatures.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/cannotIndexGenericWritingError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/captureSuperPropertyAccessInSuperCall01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/captureThisInSuperCall.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop10.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop10_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop12.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop13.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop2_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop9_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/caseInsensitiveFileSystemWithCapsImportTypeDeclarations.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/castExpressionParentheses.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/castNewObjectBug.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/castParentheses.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/castTest.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/chainedAssignment1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/chainedAssignment2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/chainedAssignment3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/chainedAssignmentChecking.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/chainedCallsWithTypeParameterConstrainedToOtherTypeParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/chainedCallsWithTypeParameterConstrainedToOtherTypeParameter2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/chainedImportAlias.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/chainedSpecializationToObjectTypeLiteral.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkDestructuringShorthandAssigment2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkIndexConstraintOfJavascriptClassExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkInfiniteExpansionTermination.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkInfiniteExpansionTermination2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkInheritedProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkInterfaceBases.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkJsFiles7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkJsFiles_noErrorLocation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkJsObjectLiteralHasCheckedKeyof.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkJsObjectLiteralIndexSignatures.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkJsTypeDefNoUnusedLocalMarked.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkJsdocTypeTagOnExportAssignment1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkJsdocTypeTagOnExportAssignment2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkJsdocTypeTagOnExportAssignment3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkJsdocTypeTagOnExportAssignment5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkJsdocTypeTagOnExportAssignment6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkJsdocTypeTagOnExportAssignment7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkJsdocTypeTagOnExportAssignment8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkJsxNotSetError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkSuperCallBeforeThisAccessing1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkSuperCallBeforeThisAccessing3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkSuperCallBeforeThisAccessing4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkSuperCallBeforeThisAccessing6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkSuperCallBeforeThisAccessing7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkSwitchStatementIfCaseTypeIsString.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularAccessorAnnotations.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularBaseTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularConstrainedMappedTypeNoCrash.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularConstraintYieldsAppropriateError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularConstructorWithReturn.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularContextualMappedType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularContextualReturnType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularInlineMappedGenericTupleTypeNoCrash.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularMappedTypeConstraint.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularReferenceInImport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularReferenceInReturnType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularReferenceInReturnType2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularResolvedSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularTypeArgumentsLocalAndOuterNoCrash1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularTypeofWithFunctionModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularlyConstrainedMappedTypeContainingConditionalNoInfiniteInstantiationDepth.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularlyReferentialInterfaceAccessNoCrash.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularlySimplifyingConditionalTypesNoCrash.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classAccessorInitializationInferenceWithElementAccess1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classAttributeInferenceTemplate.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classAttributeInferenceTemplateJS.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classBlockScoping.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classDeclarationCheckUsedBeforeDefinitionInItself.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classDeclarationMergedInModuleWithContinuation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classDeclarationShouldBeOutOfScopeInComputedNames.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionExtendingAbstractClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionInClassStaticDeclarations.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionNames.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionTest1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionTest2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionWithResolutionOfNamespaceOfSameName01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionWithStaticProperties1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionWithStaticPropertiesES61.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionWithStaticPropertiesES62.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionWithStaticPropertiesES63.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionWithStaticPropertiesES64.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendingAbstractClassWithMemberCalledTheSameAsItsOwnTypeParam.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendingAny.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendingQualifiedName2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendsClauseClassMergedWithModuleNotReferingConstructor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendsClauseClassNotReferringConstructor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendsInterfaceInExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendsInterfaceInModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendsInterfaceThatExtendsClassWithPrivates1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendsNull3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classFieldSuperAccessible.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classFieldSuperAccessibleJs1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classFieldSuperAccessibleJs2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classFieldSuperNotAccessible.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classFieldSuperNotAccessibleJs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classFunctionMerging.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classFunctionMerging2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementingInterfaceIndexer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsClass2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsClass3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsClass4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsClass5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsClass7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsImportedInterface.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsMethodWIthTupleArgs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classIndexer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classIndexer2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classIndexer3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classIndexer4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classIndexer5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classMemberInitializerScoping.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classMemberInitializerWithLamdaScoping.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classMemberInitializerWithLamdaScoping2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classMemberInitializerWithLamdaScoping3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classMemberInitializerWithLamdaScoping4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classMemberInitializerWithLamdaScoping5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classMergedWithInterfaceMultipleBasesNoError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classMethodWithKeywordName1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classNonUniqueSymbolMethodHasSymbolIndexer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classOrder1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classOrder2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classOrderBug.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classOverloadForFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classPropInitializationInferenceWithElementAccess.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classPropertyErrorOnNameOnly.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classPropertyInferenceFromBroaderTypeConst.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classReferencedInContextualParameterWithinItsOwnBaseExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classSideInheritance1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classSideInheritance2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classSideInheritance3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classStaticInitializersUsePropertiesBeforeDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classTypeParametersInStatics.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classVarianceCircularity.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classVarianceResolveCircularity1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classVarianceResolveCircularity2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/classWithMultipleBaseClasses.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/clinterfaces.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleAcrossModuleDefinitions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleAndTypeParameters.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleGenericOnSelfMember.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleSplitAcrossFiles.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleStaticMembers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleTest1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleWithPriorUninstantiatedModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleWithRecursiveReference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/clodulesDerivedClasses.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collectionPatternNoError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenEnumWithEnumMemberConflict.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithAccessorChildren.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithConstructorChildren.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithEnumMemberConflict.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithFunctionChildren.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithMemberClassConflict.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithMemberInterfaceConflict.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithMemberVariable.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithMethodChildren.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithModuleChildren.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithModuleReopening.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithPrivateMember.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithUnicodeNames.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAmbientEnum.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAmbientModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndInternalModuleAliasInGlobalFile.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndUninstantiatedModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterClassConstructor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterClassMethod.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterInType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterInterfaceMembers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterUnderscoreIUsage.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndLocalFunctionInConstructor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndLocalFunctionInMethod.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndLocalFunctionInProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndLocalVarInConstructor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndLocalVarInMethod.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndLocalVarInProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndNameResolution.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndParameter1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndPropertyNameAsConstuctorParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndAliasInGlobal.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndAmbientClassInGlobal.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndAmbientVarInGlobal.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndClassInGlobal.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndEnumInGlobal.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndFunctionInGlobal.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndLocalVarInConstructor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndLocalVarInFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndLocalVarInLambda.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndLocalVarInMethod.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndLocalVarInProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndLocalVarWithSuperExperssion.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndModuleInGlobal.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndNameResolution.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndPropertyNameAsConstuctorParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndVarInGlobal.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commaOperatorInConditionalExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commaOperatorLeftSideUnused.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentBeforeStaticMethod1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentEmitOnParenthesizedAssertionInReturnStatement.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentEmitOnParenthesizedAssertionInReturnStatement2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentInMethodCall.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnAmbientClass1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnAmbientEnum.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnAmbientModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnAmbientVariable2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnAmbientfunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnClassAccessor1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnClassAccessor2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnClassMethod1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnElidedModule1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnExportEnumDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnInterface1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnSignature1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnStaticMember1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsAfterFunctionExpression1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsAfterSpread.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsBeforeFunctionExpression1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsOnObjectLiteral2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsOnPropertyOfObjectLiteral1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsOnReturnStatement1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsOnStaticMembers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsPropertySignature1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsTypeParameters.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonJsImportClassExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonJsIsolatedModules.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonJsUnusedLocals.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonSourceDir1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonSourceDir2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonSourceDir3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonSourceDir4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonSourceDir5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonSourceDir6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonSourceDirectory.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonjsAccessExports.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/comparabilityTypeParametersRelatedByUnion.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/comparableRelationBidirectional.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/complexNarrowingWithAny.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/complexRecursiveCollections.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/complicatedIndexedAccessKeyofReliesOnKeyofNeverUpperBound.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/complicatedIndexesOfIntersectionsAreInferencable.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/compositeContextualSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/compositeWithNodeModulesSourceFile.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/computedEnumTypeWidening.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/computedPropertiesInDestructuring2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/computedPropertiesInDestructuring2_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/computedPropertiesNarrowed.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/computedPropertiesTransformedInOtherwiseNonTSClasses.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/computedPropertiesWithSetterAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/computedPropertyBindingElementDeclarationNoCrash1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/computedPropertyNameAndTypeParameterConflict.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/computedPropertyNameWithImportedKey.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/computedTypesKeyofNoIndexSignatureType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/concatError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/concatTuples.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalEqualityOnLiteralObjects.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalEqualityTestingNullability.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalExpressions2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalReturnExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeAssignabilityWhenDeferred.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeClassMembers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeContextualTypeSimplificationsSuceeds.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeDoesntSpinForever.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeRelaxingConstraintAssignability.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeSimplification.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeSubclassExtendsTypeParam.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeVarianceBigArrayConstraintsPerformance.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypesASI.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypesSimplifyWhenTrivial.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/configFileExtendsAsList.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/conflictingMemberTypesInBases.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/conflictingTypeParameterSymbolTransfer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/consistentAliasVsNonAliasRecordBehavior.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constDeclarationShadowedByVarDeclaration3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constDeclarations-access3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constDeclarations-access4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constDeclarations-access5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constDeclarations-useBeforeDefinition2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constEnumDeclarations.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constEnumExternalModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constEnumMergingWithValues1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constEnumMergingWithValues2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constEnumMergingWithValues3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constEnumMergingWithValues4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constEnumMergingWithValues5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constEnumNoEmitReexport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constEnumNoPreserveDeclarationReexport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constEnumOnlyModuleMerging.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constEnumPreserveEmitNamedExport1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constEnumPreserveEmitNamedExport2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constEnumPreserveEmitReexport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constEnumSyntheticNodesComments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constEnumToStringNoComments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constEnumToStringWithComments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constEnums.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constIndexedAccess.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constantOverloadFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constantOverloadFunctionNoSubtypeError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintCheckInGenericBaseTypeReference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintErrors1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintPropagationThroughReturnTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintReferencingTypeParameterFromSameTypeParameterList.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintWithIndexedAccess.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraints0.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintsThatReferenceOtherContstraints1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintsUsedInPrototypeProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorArgWithGenericCallSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorArgs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorAsType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorInvocationWithTooFewTypeArgs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorOverloads2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorOverloads4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorOverloads5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorOverloads9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorParametersInVariableDeclarations.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorParametersThatShadowExternalNamesInVariableDeclarations.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorPropertyJs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorReturnsInvalidType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorWithCapturedSuper.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorWithParameterPropertiesAndPrivateFields.es2015.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextSensitiveReturnTypeInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualComputedNonBindablePropertyType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualOuterTypeParameters.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualOverloadListFromArrayUnion.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualOverloadListFromUnionWithPrimitiveNoImplicitAny.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualParamTypeVsNestedReturnTypeInference1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualParamTypeVsNestedReturnTypeInference2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualParamTypeVsNestedReturnTypeInference3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualParamTypeVsNestedReturnTypeInference4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualParameterAndSelfReferentialConstraint1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualPropertyOfGenericFilteringMappedType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualPropertyOfGenericMappedType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualReturnTypeOfIIFE.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualReturnTypeOfIIFE2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualReturnTypeOfIIFE3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureConditionalTypeInstantiationUsingDefault.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInArrayElementLibEs2015.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInArrayElementLibEs5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInObjectFreeze.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInstantiation1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInstantiation3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInstatiationContravariance.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInstatiationCovariance.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignature_objectLiteralMethodMayReturnNever.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTupleTypeParameterReadonly.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeAny.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeAppliedToVarArgs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeArrayReturnType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeBasedOnIntersectionWithAnyInTheMix1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeBasedOnIntersectionWithAnyInTheMix2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeBasedOnIntersectionWithAnyInTheMix3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeBasedOnIntersectionWithAnyInTheMix4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeBasedOnIntersectionWithAnyInTheMix5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeCaching.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeFunctionObjectPropertyIntersection.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeIterableUnions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeObjectSpreadExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeOfIndexedAccessParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeOnYield1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeOnYield2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeSelfReferencing.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeShouldBeLiteral.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypesNegatedTypeLikeConstraintInGenericMappedType1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypesNegatedTypeLikeConstraintInGenericMappedType2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypesNegatedTypeLikeConstraintInGenericMappedType3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping10.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping11.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping12.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping14.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping15.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping16.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping17.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping18.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping19.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping20.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping21.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping24.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping25.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping26.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping27.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping34.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping35.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping36.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping37.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingArrayDestructuringWithDefaults.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingArrayOfLambdas.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingFunctionReturningFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfAccessors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfArrayLiterals1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfConditionalExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfConditionalExpression2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfGenericFunctionTypedArguments1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfLambdaWithMultipleSignatures.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfObjectLiterals.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfOptionalMembers.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfTooShortOverloads.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingReturnStatementWithReturnTypeAnnotation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypeArgumentsKeyword.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypeAsyncFunctionReturnTypeFromUnion.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypeGeneratorReturnTypeFromUnion.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedBooleanLiterals.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedByDiscriminableUnion.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedByDiscriminableUnion2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedGenericAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedJsxAttribute.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedJsxAttribute2.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedJsxChildren.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedJsxChildren2.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedParametersOptionalInJSDoc.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedParametersWithInitializers1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedParametersWithInitializers2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedParametersWithInitializers3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedParametersWithInitializers4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedParametersWithQuestionToken.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedSymbolNamedProperties.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypingOrOperator.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypingOrOperator2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contravariantInferenceAndTypeGuard.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contravariantOnlyInferenceFromAnnotatedFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/contravariantOnlyInferenceFromAnnotatedFunctionJs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowAliasedDiscriminants.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowAnalysisOnBareThisKeyword.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowArrayErrors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowArrays.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowAutoAccessor1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowBreakContinueWithLabel.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowCaching.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowCommaExpressionAssertionMultiple.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowCommaExpressionAssertionWithinTernary.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowCommaExpressionFunctionCall.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowDestructuringLoop.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowDestructuringParameters.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowDestructuringVariablesInTryCatch.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowFavorAssertedTypeThroughTypePredicate.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowFinallyNoCatchAssignments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowForCatchAndFinally.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowForCompoundAssignmentToThisMember.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowForFunctionLike1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowForIndexSignatures.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowInitializedDestructuringVariables.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowInstanceof.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowInstanceofWithSymbolHasInstance.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowJavascript.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowLoopAnalysis.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowManyConsecutiveConditionsNoTimeout.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowNoImplicitAny.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowNullTypeAndLiteral.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowOuterVariable.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowPrivateClassField.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowPropertyDeclarations.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowPropertyInitializer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowSelfReferentialLoop.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowUnionContainingTypeParameter1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowWithIncompleteTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/copyrightWithNewLine1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/copyrightWithoutNewLine1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/correctOrderOfPromiseMethod.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/correlatedUnions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/covariance1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/crashInGetTextOfComputedPropertyName.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/crashInResolveInterface.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/crashInYieldStarInAsyncFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/crashInresolveReturnStatement.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/crashInsourcePropertyIsRelatableToTargetProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/crashIntypeCheckInvocationExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/crashIntypeCheckObjectCreationExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/customAsyncIterator.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/customEventDetail.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/cyclicGenericTypeInstantiation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/cyclicGenericTypeInstantiationInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/cyclicModuleImport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/cyclicTypeInstantiation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/dataViewConstructor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileAliasUseBeforeDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileAliasUseBeforeDeclaration2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileAmbientExternalModuleWithSingleExportedModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileClassWithIndexSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileClassWithStaticMethodReturningConstructor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileEmitDeclarationOnly.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileEnumUsedAsValue.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileEnums.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileExportAssignmentImportInternalModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileExportAssignmentOfGenericInterface.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileExportImportChain.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileExportImportChain2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileForClassWithMultipleBaseClasses.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileForClassWithPrivateOverloadedFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileForExportedImport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileForInterfaceWithOptionalFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileForInterfaceWithRestParams.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileForTypeParameters.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileGenericClassWithGenericExtendedClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileGenericType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileGenericType2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileImportChainInExportAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileImportModuleWithExportAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileImportedTypeUseInTypeArgPosition.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileInternalAliases.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileModuleAssignmentInObjectLiteralProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileModuleContinuation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileOptionalInterfaceMethod.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFilePrivateMethodOverloads.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileRegressionTests.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeofClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeofEnum.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeofFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeofInAnonymousType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileWithClassNameConflictingWithClassReferredByExtendsClause.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileWithExtendsClauseThatHasItsContainerNameConflict.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileWithInternalModuleNameConflictsInExtendsClause1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileWithInternalModuleNameConflictsInExtendsClause2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileWithInternalModuleNameConflictsInExtendsClause3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declInput-2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declInput.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declInput3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declInput4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationAssertionNodeNotReusedWhenTypeNotEquivalent1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitAliasExportStar.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitAliasFromIndirectFile.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitAliasInlineing.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitAnyComputedPropertyInClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitArrayTypesFromGenericArrayUsage.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitArrowFunctionNoRenaming.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitBindingPatternWithReservedWord.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitBindingPatterns.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitBindingPatternsFunctionExpr.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitBindingPatternsUnused.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitBundleWithAmbientReferences.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitClassAccessorsJs1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitClassMemberWithComputedPropertyName.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitClassMixinLocalClassDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitClassSetAccessorParamNameInJs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitClassSetAccessorParamNameInJs2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitClassSetAccessorParamNameInJs3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitCommonSourceDirectoryDoesNotContainAllFiles.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedNameCausesImportToBePainted.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedNameConstEnumAlias.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedNameWithQuestionToken.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedNamesInaccessible.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedPropertyName1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedPropertyNameEnum1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedPropertyNameEnum2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedPropertyNameSymbol1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedPropertyNameSymbol2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitConstantNoWidening.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitCrossFileCopiedGeneratedImportType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitCrossFileImportTypeOfAmbientModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDefaultExport8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDefaultExportWithStaticAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuring1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuring3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuring4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuring5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringArrayPattern1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringArrayPattern2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringArrayPattern3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringArrayPattern4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringArrayPattern5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringObjectLiteralPattern.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringObjectLiteralPattern1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringObjectLiteralPattern2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringOptionalBindingParametersInOverloads.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringPrivacyError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDistributiveConditionalWithInfer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDoesNotUseReexportedNamespaceAsLocal.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDuplicateParameterDestructuring.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitEnumReadonlyProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitEnumReferenceViaImportEquals.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpandoPropertyPrivateName.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpandoWithGenericConstraint.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExportAliasVisibiilityMarking.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExportAssignedNamespaceNoTripleSlashTypesReference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionWithNonlocalPrivateUniqueSymbol.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitFBoundedTypeParams.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitForDefaultExportClassExtendingExpression01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitForGlobalishSpecifierSymlink.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitForGlobalishSpecifierSymlink2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitForModuleImportingModuleAugmentationRetainsImport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitFunctionDuplicateNamespace.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitFunctionKeywordProp.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitGenericTypeParamerSerialization.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitGenericTypeParamerSerialization2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitGenericTypeParamerSerialization3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitGlobalThisPreserved.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitHasTypesRefOnNamespaceUse.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitHigherOrderRetainedGenerics.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitIndexTypeArray.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredDefaultExportType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredDefaultExportType2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredTypeAlias1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredTypeAlias2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredTypeAlias4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredTypeAlias5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredTypeAlias6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredTypeAlias7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredTypeAlias8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredTypeAlias9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredUndefinedPropFromFunctionInArray.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInlinedDistributiveConditional.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitIsolatedDeclarationErrorNotEmittedForNonEmittedFile.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitKeywordDestructuring.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitLambdaWithMissingTypeParameterNoCrash.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitLateBoundAssignments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitLateBoundAssignments2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitLateBoundJSAssignments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitLocalClassDeclarationMixin.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitLocalClassHasRequiredDeclare.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitMappedPrivateTypeTypeParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitMappedTypeDistributivityPreservesConstraints.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitMappedTypePreservesTypeParameterConstraint.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitMappedTypePropertyFromNumericStringKey.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitMappedTypeTemplateTypeofSymbol.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitMergedAliasWithConst.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitMethodDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitMixinPrivateProtected.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitMultipleComputedNamesSameDomain.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNameConflicts.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNameConflicts2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNameConflicts3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNameConflictsWithAlias.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNamespaceMergedWithInterfaceNestedFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNestedAnonymousMappedType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNoInvalidCommentReuse1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNoInvalidCommentReuse2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNoInvalidCommentReuse3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNoNonRequiredParens.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNonExportedBindingPattern.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitObjectLiteralAccessors1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitObjectLiteralAccessorsJs1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitOfTypeofAliasedExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitOptionalMappedTypePropertyNoStrictNullChecks1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitOptionalMappedTypePropertyNoStrictNullChecks2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitOptionalMappedTypePropertyNoStrictNullChecks3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitOptionalMappedTypePropertyNoStrictNullChecks4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitOptionalMethod.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitOutFileBundlePaths.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitOverloadedPrivateInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitParameterProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPartialNodeReuseTypeOf.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPartialNodeReuseTypeReferences.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPartialReuseComputedProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPreserveReferencedImports.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPrivateAsync.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPrivateNameCausesError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPrivateReadonlyLiterals.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPrivateSymbolCausesVarDeclarationEmit2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPrivateSymbolCausesVarDeclarationToBeEmitted.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPromise.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPropertyNumericStringKey.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitQualifiedAliasTypeArgument.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitReadonlyComputedProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitRecursiveConditionalAliasPreserved.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitReexportedSymlinkReference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitReexportedSymlinkReference2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitResolveTypesIfNotReusable.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitRetainedAnnotationRetainsImportInOutput.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitRetainsJsdocyComments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitReusesLambdaParameterNodes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitScopeConsistency.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitShadowing.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitShadowingInferNotRenamed.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitSimpleComputedNames1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitSpreadStringlyKeyedEnum.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitStringEnumUsedInNonlocalSpread.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitToDeclarationDirWithCompositeOption.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitToDeclarationDirWithDeclarationOption.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitToDeclarationDirWithoutCompositeAndDeclarationOptions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTopLevelNodeFromCrossFile.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTopLevelNodeFromCrossFile2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeAliasTypeParameterExtendingUnknownSymbol.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeAliasWithTypeParameters3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeAliasWithTypeParameters4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeAliasWithTypeParameters5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeAliasWithTypeParameters6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeParamMergedWithPrivate.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeParameterNameReusedInOverloads.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeParameterNameShadowedInternally.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeofDefaultExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeofRest.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeofThisInClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitUsingAlternativeContainingModules1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitUsingAlternativeContainingModules2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitUsingTypeAlias2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitWithComposite.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitWithInvalidPackageJsonTypings.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationFileOverwriteErrorWithOut.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationFilesGeneratingTypeReferences.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationFilesWithTypeReferences1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationFilesWithTypeReferences2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationFilesWithTypeReferences3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationFilesWithTypeReferences4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationFunctionTypeNonlocalShouldNotBeAnError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationImportTypeAliasInferredAndEmittable.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationMaps.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationMapsMultifile.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationMapsOutFile.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationMapsOutFile2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationMapsWithSourceMap.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationMapsWithoutDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationMerging1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationMerging2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationNoDanglingGenerics.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationQuotedMembers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationTypecheckNoUseBeforeReferenceCheck.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationsForFileShadowingGlobalNoError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationsForIndirectTypeAliasReference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationsForInferredTypeFromOtherFile.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationsIndirectGeneratedAliasReference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationsWithRecursiveInternalTypesProduceUniqueTypeParams.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declareClassInterfaceImplementation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declareDottedExtend.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declareExternalModuleWithExportAssignedFundule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declareFileExportAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declareFileExportAssignmentWithVarFromVariableStatement.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declaredExternalModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/declaredExternalModuleWithExportAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataConditionalType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataGenericTypeVariable.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataGenericTypeVariableDefault.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataGenericTypeVariableInScope.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataNoLibIsolatedModulesTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataNoStrictNull.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataPromise.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataTypeOnlyExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataTypeOnlyImport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorReferenceOnOtherProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorReferences.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorUsedBeforeDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorWithUnderscoreMethod.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/deduplicateImportsInSystem.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/deepComparisons.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/deepElaborationsIntoArrowExpressions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/deepExcessPropertyCheckingWhenTargetIsIntersection.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/deepKeysIndexing.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/deeplyDependentLargeArrayMutation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/deeplyNestedAssignabilityErrorsCombined.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/deeplyNestedAssignabilityIssue.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/deeplyNestedCheck.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/deeplyNestedConstraints.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/deeplyNestedMappedTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultArgsInFunctionExpressions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultDeclarationEmitNamedCorrectly.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultDeclarationEmitShadowedNamedCorrectly.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultIndexProps1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultIndexProps2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultIsNotVisibleInLocalScope.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultNamedExportWithType1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultNamedExportWithType3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultParameterAddsUndefinedWithStrictNullChecks.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultPropsEmptyCurlyBecomesAnyForJs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/deferredConditionalTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/deferredLookupTypeResolution.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/deferredLookupTypeResolution2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/definiteAssignmentOfDestructuredVariable.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/deleteReadonly.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/deleteReadonlyInStrictNullChecks.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/dependencyViaImportAlias.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/deprecatedCompilerOptions1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/deprecatedCompilerOptions2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/deprecatedCompilerOptions3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/deprecatedCompilerOptions4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/deprecatedCompilerOptions5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/deprecatedCompilerOptions6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/derivedClassOverridesPrivateFunction1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/derivedClasses.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/derivedInterfaceCallSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/derivedTypeCallingBaseImplWithOptionalParams.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/derivedTypeIncompatibleSignatures.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructureComputedProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructureOfVariableSameAsShorthand.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructureOptionalParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructureTupleWithVariableElement.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuredDeclarationEmit.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuredMaappedTypeIsNotImplicitlyAny.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringAssignmentWithDefault.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringAssignmentWithDefault2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringAssignmentWithExportedName.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringAssignment_private.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringInVariableDeclarations1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringInVariableDeclarations2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringInVariableDeclarations3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringInVariableDeclarations4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringInVariableDeclarations5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringInVariableDeclarations6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringInVariableDeclarations7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringInVariableDeclarations8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringInitializerContextualTypeFromContext.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringPropertyAssignmentNameIsNotAssignmentTarget.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringTempOccursAfterPrologue.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringTuple.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringTypeGuardFlow.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringWithConstraint.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringWithGenericParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringWithNewExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringWithNumberLiteral.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/detachedCommentAtStartOfConstructor1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/detachedCommentAtStartOfConstructor2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/detachedCommentAtStartOfLambdaFunction1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/detachedCommentAtStartOfLambdaFunction2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/didYouMeanElaborationsForExpressionsWhichCouldBeCalled.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/differentTypesWithSameName.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminableUnionWithIntersectedMembers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminantElementAccessCheck.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminantNarrowingCouldBeCircular.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminantOrderIndependence.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminantPropertyCheck.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminantPropertyInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminantUsingEvaluatableTemplateExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminantsAndNullOrUndefined.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminantsAndPrimitives.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminantsAndTypePredicates.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminateObjectTypesOnly.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminateWithDivergentAccessors1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminateWithMissingProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminatedUnionErrorMessage.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminatedUnionJsxElement.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminatedUnionWithIndexSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminatingUnionWithUnionPropertyAgainstUndefinedWithoutStrictNullChecks.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/dissallowSymbolAsWeakType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/distributiveConditionalTypeConstraints.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/distributiveConditionalTypeNeverIntersection1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/divergentAccessors1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/divergentAccessorsTypes1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/divergentAccessorsTypes2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/divergentAccessorsTypes6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/divergentAccessorsTypes7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/divergentAccessorsTypes8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/divergentAccessorsVisibility1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/divideAndConquerIntersections.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/doNotEmitPinnedCommentOnNotEmittedNode.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/doNotEmitPinnedCommentOnNotEmittedNodets.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/doNotEmitTripleSlashCommentsOnNotEmittedNode.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/doNotInferUnrelatedTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/doNotWidenAtObjectLiteralPropertyAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/doNotemitTripleSlashComments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/doesNotNarrowUnionOfConstructorsWithInstanceof.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/dottedModuleName2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/dottedNamesInSystem.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/dottedSymbolResolution1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/doubleMixinConditionalTypeBaseClassWorks.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/doubleUnderscoreEnumEmit.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/doubleUnderscoreMappedTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/doubleUnderscoreReactNamespace.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/dtsEmitTripleSlashAvoidUnnecessaryResolutionMode.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateErrorAssignability.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateErrorClassExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateErrorNameNotFound.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierDifferentModifiers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierRelatedSpans4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierRelatedSpans7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateLocalVariable4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateObjectLiteralProperty_computedNameNegative1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateOverloadInTypeAugmentation1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicatePackage.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicatePackage_packageIdIncludesSubModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicatePackage_referenceTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicatePackage_relativeImportWithinPackage.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicatePackage_relativeImportWithinPackage_scoped.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicatePackage_subModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateVarAndImport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateVariablesByScope.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateVarsAcrossFileBoundaries.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/dynamicImportEvaluateSpecifier.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/dynamicImportInDefaultExportExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/dynamicImportWithNestedThis_es2015.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/dynamicImportsDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/dynamicNames.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/dynamicNamesErrors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/dynamicRequire.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/elaboratedErrors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/elaboratedErrorsOnNullableTargets01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/elementAccessExpressionInternalComments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/elidedEmbeddedStatementsReplacedWithSemicolon.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/elidedJSImport1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitAccessExpressionOfCastedObjectLiteralExpressionInArrowFunctionES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitCapturingThisInTupleDestructuring1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitCapturingThisInTupleDestructuring2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitClassExpressionInDeclarationFile.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitClassExpressionInDeclarationFile2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitClassMergedWithConstNamespaceNotElided.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitMemberAccessExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitMethodCalledNew.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitOneLineVariableDeclarationRemoveCommentsFalse.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitSkipsThisWithRestParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitSuperCallBeforeEmitParameterPropertyDeclaration1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitSuperCallBeforeEmitParameterPropertyDeclaration1ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitSuperCallBeforeEmitPropertyDeclaration1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitSuperCallBeforeEmitPropertyDeclaration1ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitSuperCallBeforeEmitPropertyDeclarationAndParameterPropertyDeclaration1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitSuperCallBeforeEmitPropertyDeclarationAndParameterPropertyDeclaration1ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitTopOfFileTripleSlashCommentOnNotEmittedNodeIfRemoveCommentsIsFalse.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyArrayDestructuringExpressionVisitedByTransformer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyDeclarationEmitIsModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyIndexer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyObjectNotSubtypeOfIndexSignatureContainingObject1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyObjectNotSubtypeOfIndexSignatureContainingObject2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyOptionalBindingPatternInDeclarationSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumAssignmentCompat.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumAssignmentCompat2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumAssignmentCompat3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumAssignmentCompat4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumAssignmentCompat5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumAssignmentCompat6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumCodeGenNewLines1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumDecl1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumDeclarationEmitInitializerHasImport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumFromExternalModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumIndexer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumInitializersWithExponents.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumKeysQuotedAsObjectPropertiesInDeclarationEmit.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumLiteralAssignableToEnumInsideUnion.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumLiteralUnionNotWidened.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumLiteralsSubtypeReduction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumMapBackIntoItself.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumMemberNameNonIdentifier.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumMemberReduction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumNegativeLiteral1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumNumbering1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumOperations.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumPropertyAccessBeforeInitalisation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumUsedBeforeDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumWithExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumWithInfinityProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumWithNaNProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumWithNegativeInfinityProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumWithQuotedElementName1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumWithQuotedElementName2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumWithUnicodeEscape1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumWithoutInitializerAfterComputedMember.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumsWithMultipleDeclarations3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/erasableSyntaxOnly.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorConstructorSubtypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorElaborationDivesIntoApparentlyPresentPropsOnly.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorForUsingPropertyOfTypeAsType02.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorForwardReferenceForwadingConstructor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorHandlingInInstanceOf.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorMessageOnIntersectionsWithDiscriminants01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorMessagesIntersectionTypes01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorMessagesIntersectionTypes02.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorMessagesIntersectionTypes03.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorMessagesIntersectionTypes04.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorOnEnumReferenceInCondition.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorOnUnionVsObjectShouldDeeplyDisambiguate.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorOnUnionVsObjectShouldDeeplyDisambiguate2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorTypesAsTypeArguments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorWithSameNameType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorWithTruncatedType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorsForCallAndAssignmentAreSimilar.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorsInGenericTypeReference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorsOnUnionsOfOverlappingObjects01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorsWithInvokablesInUnions01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es2015modulekind.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es2015modulekindWithES6Target.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es2017basicAsync.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es2018ObjectAssign.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6-amd.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6-declaration-amd.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6-sourcemap-amd.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6-umd.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6-umd2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ClassSuperCodegenBug.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ClassTest2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ClassTest3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ClassTest4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ClassTest5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ClassTest7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ClassTest8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ExportAssignment4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ExportClause.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ExportClauseWithoutModuleSpecifier.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ExportDefaultClassDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ExportDefaultClassDeclaration2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImportDts.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBinding.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBindingDts.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportEqualsDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportEqualsDeclaration2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNameSpaceImport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNameSpaceImportAmd.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNameSpaceImportDts.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportAmd.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportDts.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportWithTypesAndValues.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportWithJsDocTags.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6MemberScoping.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6Module.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ModuleClassDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ModuleConst.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ModuleConstEnumDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ModuleConstEnumDeclaration2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ModuleEnumDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ModuleFunctionDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ModuleInternalImport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ModuleLet.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ModuleVariableStatement.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ModuleWithModuleGenTargetAmd.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ModuleWithModuleGenTargetCommonjs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6UseOfTopLevelRequire.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInterop.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropDefaultImports.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropDefaultMemberMustBeSyntacticallyDefaultExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropEnablesSyntheticDefaultImports.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropImportCall.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropImportNamespace.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropImportTSLibHasImport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropNamedDefaultImports.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropTslibHelpers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleIntersectionCrash.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/esNextWeakRefs_IterableWeakMap.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/escapedReservedCompilerNamedIdentifier.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/evalAfter0.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/evalOrArgumentsInDeclarationFunctions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/eventEmitterPatternWithRecordOfFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/evolvingArrayResolvedAssert.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/evolvingArrayTypeInAssert.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exactOptionalPropertyTypesIdentical.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exactSpellingSuggestion.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessPropertiesInOverloads.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessPropertyCheckIntersectionWithIndexSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessPropertyCheckWithEmptyObject.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessPropertyCheckWithMultipleDiscriminants.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessPropertyCheckWithNestedArrayIntersection.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessPropertyCheckWithSpread.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessPropertyCheckWithUnions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessPropertyCheckingIntersectionWithConditional.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessPropertyChecksWithNestedIntersections.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessPropertyErrorForFunctionTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessPropertyErrorsSuppressed.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessiveStackDepthFlatArray.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessivelyLargeTupleSpread.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exhaustiveSwitchWithWideningLiteralTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionBlockShadowing.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionContextualTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionContextualTypesJSDocInTs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionContextualTypesJs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionContextualTypesNoValue.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionExpressionsWithDynamicNames.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionExpressionsWithDynamicNames2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionNestedAssigmentsDeclared.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionNullishProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionSymbolProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionSymbolPropertyJs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/experimentalDecoratorMetadataUnresolvedTypeObjectInEmit.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/explicitAnyAfterSpreadNoImplicitAnyError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportArrayBindingPattern.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAsNamespace.d.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAsNamespaceConflict.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignClassAndModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignValueAndType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignedTypeAsTypeAnnotation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentEnum.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentInterface.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentInternalModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentMembersVisibleInAugmentation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentOfDeclaredExternalModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentOfGenericType1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentVariable.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentWithImportStatementPrivacyError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentWithPrivacyError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentWithoutAllowSyntheticDefaultImportsError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentWithoutIdentifier1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportClassExtendingIntersection.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDeclarationWithModuleSpecifierNameOnNextLine1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDeclarationsInAmbientNamespaces.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDefaultAbstractClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDefaultAsyncFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDefaultInterface.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDefaultInterfaceAndFunctionOverloads.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDefaultInterfaceAndValue.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDefaultProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDefaultProperty2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDefaultQualifiedNameNoError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDefaultStripsFreshness.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDefaultVariable.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportEqualCallable.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportEqualNamespaces.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportEqualsAmd.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportEqualsClassNoRedeclarationError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportEqualsCommonJs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportEqualsOfModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportEqualsProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportEqualsProperty2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportEqualsUmd.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportImport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportImportAndClodule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportImportMultipleFiles.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportImportNonInstantiatedModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportImportNonInstantiatedModule2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportNamespaceDeclarationRetainsVisibility.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportPrivateType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportRedeclarationTypeAliases.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportSpecifierAndExportedMemberDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportSpecifierAndLocalMemberDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportSpecifierForAGlobal.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportSpecifierReferencingOuterDeclaration1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportSpecifierReferencingOuterDeclaration2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportSpecifierReferencingOuterDeclaration3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportSpecifierReferencingOuterDeclaration4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarForValues.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarForValues10.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarForValues2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarForValues3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarForValues4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarForValues5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarForValues6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarForValues7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarForValues8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarForValues9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarForValuesInSystem.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarNotElided.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportToString.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportedInterfaceInaccessibleInCallbackInModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportedVariable1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportingContainingVisibleType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportsInAmbientModules1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportsInAmbientModules2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/expr.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/extBaseClass1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendAndImplementTheSameBaseType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendAndImplementTheSameBaseType2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendArray.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendBaseClassBeforeItsDeclared.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendGenericArray.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendGenericArray2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendNonClassSymbol1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendPrivateConstructorClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendedInterfaceGenericType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendedUnicodeEscapeSequenceIdentifiers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendedUnicodePlaneIdentifiers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendedUnicodePlaneIdentifiersJSDoc.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendingClassFromAliasAndUsageInIndexer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendingCollectionsWithCheckJs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendsUntypedModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/externFunc.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/externModuleClobber.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/externalModuleAssignToVar.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/externalModuleExportingGenericClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/externalModuleQualification.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/externalModuleReferenceDoubleUnderscore1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/externalModuleReferenceOfImportDeclarationWithExportModifier.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/externalModuleResolution.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/externalModuleResolution2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/extractInferenceImprovement.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/fakeInfinity1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/fakeInfinity2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/fakeInfinity3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/fallbackToBindingPatternForTypeInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/fatArrowSelf.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/fatarrowfunctions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/fatarrowfunctionsInFunctionParameterDefaults.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/fatarrowfunctionsInFunctions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/fileReferencesWithNoExtensions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/fillInMissingTypeArgsOnConstructCalls.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/firstMatchRegExpMatchArray.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/fixingTypeParametersRepeatedly1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/fixingTypeParametersRepeatedly2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/fixingTypeParametersRepeatedly3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/flatArrayNoExcessiveStackDepth.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/flowControlTypeGuardThenSwitch.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/flowInFinally1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/forAwaitForIntersection1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/forAwaitForUnion.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/forInStrictNullChecksNoError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/forLoopWithDestructuringDoesNotElideFollowingStatement.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/forOfStringConstituents.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/forOfTransformsExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/formatToPartsFractionalSecond.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/forwardRefInClassProperties.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/freshLiteralInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/funClodule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/funcdecl.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCallOnConstrainedTypeVariable.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionDeclarationWithArgumentOfTypeFunctionTypeArray.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionDeclarationWithResolutionOfTypeNamedArguments01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionDeclarationWithResolutionOfTypeOfSameName01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionExpressionAndLambdaMatchesFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionExpressionNames.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionExpressionWithResolutionOfTypeNamedArguments01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionMergedWithModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOnlyHasThrow.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads14.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads15.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads16.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads21.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads22.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads34.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads35.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads36.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads37.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads38.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads39.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads40.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads41.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads42.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads43.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads44.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads45.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloadsOnGenericArity1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloadsOnGenericArity2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloadsRecursiveGenericReturnType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionReturn.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionReturnTypeQuery.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionSignatureAssignmentCompat1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionSubtypingOfVarArgs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionSubtypingOfVarArgs2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionToFunctionWithPropError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionTypeArgumentArrayAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionTypeArgumentAssignmentCompat.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionVariableInReturnTypeAnnotation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithThrowButNoReturn1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionsInClassExpressions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionsMissingReturnStatementsAndExpressionsStrictNullChecks.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/funduleExportedClassIsUsedBeforeDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/funduleOfFunctionWithoutReturnTypeAnnotation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/funduleSplitAcrossFiles.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/funduleUsedAcrossFileBoundary.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/fuzzy.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/generativeRecursionWithTypeOf.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/generatorES6_2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/generatorES6_4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/generatorES6_6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/generatorReturnExpressionIsChecked.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericAndNonGenericInheritedSignature1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericAndNonGenericInheritedSignature2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArgumentCallSigAssignmentCompat.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArray1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArrayAssignmentCompatErrors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArrayExtenstions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArrayMethods1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArrayPropertyAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArrayWithoutTypeAnnotation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericAssignmentCompatOfFunctionSignatures1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericAssignmentCompatWithInterfaces1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericBaseClassLiteralProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericBaseClassLiteralProperty2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallAtYieldExpressionInGenericCall1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallAtYieldExpressionInGenericCall2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallAtYieldExpressionInGenericCall3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallInferenceConditionalType1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallInferenceConditionalType2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallInferenceInConditionalTypes1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallInferenceUsingThisTypeNoInvalidCacheReuseAfterMappedTypeApplication1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallInferenceWithGenericLocalFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallOnMemberReturningClosedOverObject.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallWithFixedArguments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallWithObjectLiteralArguments1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallWithinOwnBodyCastTypeParameterIdentity.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallbacksAndClassHierarchy.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCapturingFunctionNarrowing.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassImplementingGenericInterfaceFromAnotherModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassPropertyInheritanceSpecialization.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassStaticMethod.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassWithStaticFactory.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassWithStaticsUsingTypeArguments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClasses0.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClasses1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClasses2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClasses3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClasses4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassesInModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassesInModule2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCloduleInModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCloduleInModule2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCloneReturnTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCloneReturnTypes2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCombinators2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConditionalConstrainedToUnknownNotAssignableToConcreteObject.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstraint1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstraint2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstraint3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstraintDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstraintOnExtendedBuiltinTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstraintOnExtendedBuiltinTypes2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstraintSatisfaction1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstructorFunction1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericContextualTypingSpecialization.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericDefaults.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericDefaultsJs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericDerivedTypeWithSpecializedBase.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericDerivedTypeWithSpecializedBase2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionCallSignatureReturnTypeMismatch.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionInference1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionInference2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionSpecializations1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctions2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctions3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionsAndConditionalInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionsWithOptionalParameters1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionsWithOptionalParameters2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionsWithOptionalParameters3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunduleInModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunduleInModule2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericGetter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericGetter2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericGetter3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericImplements.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericIndexTypeHasSensibleErrorMessage.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericIndexedAccessMethodIntersectionCanBeAccessed.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericIndexedAccessVarianceComparisonResultCorrect.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericInference1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericInference2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericInferenceDefaultTypeParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericInferenceDefaultTypeParameterJsxReact.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericInheritedDefaultConstructors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericInstanceOf.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericInterfaceImplementation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericInterfaceTypeCall.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericIsNeverEmptyObject.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericLambaArgWithoutTypeArguments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericMappedTypeAsClause.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericMergedDeclarationUsingTypeParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericMergedDeclarationUsingTypeParameter2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericMethodOverspecialization.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericObjectLitReturnType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericObjectSpreadResultInSwitch.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericOfACloduleType1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericOfACloduleType2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericOverloadSignatures.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericPrototypeProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericPrototypeProperty2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericPrototypeProperty3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericRecursiveImplicitConstructorErrors1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericRecursiveImplicitConstructorErrors2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericRestArgs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericRestTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericReturnTypeFromGetter1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericReversingTypeParameters.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericReversingTypeParameters2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericSignatureIdentity.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericSpecializationToTypeLiteral1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericSpecializations1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericSpecializations3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericStaticAnyTypeFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTemplateOverloadResolution.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTupleWithSimplifiableElements.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeArgumentInference1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeAssertions1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeAssertions2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeAssertions4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeAssertions5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeAssertions6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeConstraints.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeParameterEquivalence2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeReferencesRequireTypeArgs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeWithCallableMembers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeWithMultipleBases1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeWithMultipleBases2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeWithMultipleBases3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeWithNonGenericBaseMisMatch.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericWithCallSignatureReturningSpecialization.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericWithCallSignatures1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericWithIndexerOfTypeParameterType1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericWithIndexerOfTypeParameterType2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericWithOpenTypeParameters1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/generics0.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/generics1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/generics1NoError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/generics2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/generics2NoError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/generics3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/generics4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/generics4NoError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/generics5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericsWithoutTypeParameters1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/getAccessorWithImpliedReturnTypeAndFunctionClassMerge.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/getAndSetAsMemberNames.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/getAndSetNotIdenticalType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/getAndSetNotIdenticalType2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/getAndSetNotIdenticalType3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/getParameterNameAtPosition.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/getsetReturnTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/getterErrorMessageNotDuplicated.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/getterSetterNonAccessor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/getterSetterSubtypeAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/getterThatThrowsShouldNotNeedReturn.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/gettersAndSettersAccessibility.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/gettersAndSettersTypesAgree.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/global.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/globalFunctionAugmentationOverload.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/globalIsContextualKeyword.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/globalThis.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/globalThisCapture.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/globalThisDeclarationEmit.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/globalThisDeclarationEmit2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/globalThisDeclarationEmit3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/grammarAmbiguities1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/heterogeneousArrayAndOverloads.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/hidingIndexSignatures.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/higherOrderMappedIndexLookupInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/homomorphicMappedTypeIntersectionAssignability.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/homomorphicMappedTypeNesting.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/homomorphicMappedTypeWithNonHomomorphicInstantiationSpreadable1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/hugeDeclarationOutputGetsTruncatedWithError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/i3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/icomparable.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/identicalGenericConditionalsWithInferRelated.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/identicalTypesNoDifferByCheckOrder.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/identityAndDivergentNormalizedTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/identityRelationNeverTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/ignoredJsxAttributes.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/illegalGenericWrapping1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/implementArrayInterface.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/implementGenericWithMismatchedTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/implementInterfaceAnyMemberWithVoid.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/implementPublicPropertyAsPrivate.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/implementsInClassExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/implementsIncorrectlyNoAssertion.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyAmbients.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyAnyReturningFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyCastedValue.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyDeclareFunctionExprWithoutFormalType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyDeclareFunctionWithoutFormalType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyDeclareMemberWithoutType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyDeclareMemberWithoutType2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyDeclareTypePropertyWithoutType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyFunctionInvocationWithAnyArguements.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyFunctionOverloadWithImplicitAnyReturnType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyFunctionReturnNullOrUndefined.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyGenericTypeInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyGenerics.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyGetAndSetAccessorWithAnyReturnType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyInAmbientDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyInAmbientDeclaration2.d.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyInCatch.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyWidenToAny.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitConstParameters.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitIndexSignatures.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/impliedNodeFormatInterop1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importAliasAnExternalModuleInsideAnInternalModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importAliasFromNamespace.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importAliasWithDottedName.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importAnImport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importAndVariableDeclarationConflict2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importAsBaseClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importDecl.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importDeclFromTypeNodeInJsSource.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importDeclRefereingExternalModuleWithNoResolve.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importDeclTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importDeclWithExportModifier.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importDeclWithExportModifierInAmbientContext.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importDeclarationNotCheckedAsValueWhenTargetNonValue.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importDeclarationUsedAsTypeQuery.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importElisionEnum.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importElisionExportNonExportAndDefault.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importEqualsError45874.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importExportInternalComments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importHelpersBundler.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importHelpersES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importHelpersNoHelpersForPrivateFields.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importHelpersVerbatimModuleSyntax.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importInTypePosition.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember12.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importOnAliasedIdentifiers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importPropertyFromMappedType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importShadowsGlobalName.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importShouldNotBeElidedInDeclarationEmit.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importTypeGenericArrowTypeParenthesized.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importTypeResolutionJSDocEOF.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importTypeTypeofClassStaticLookup.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importUsedAsTypeWithErrors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importUsedInExtendsList1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importUsedInGenericImportResolves.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importWithTrailingSlash_noResolve.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/import_reference-exported-alias.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/import_reference-to-type-alias.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/import_unneeded-require-when-referenecing-aliased-type-throug-array.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/import_var-referencing-an-imported-module-alias.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importedAliasedConditionalTypeInstantiation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importedAliasesInTypePositions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importedModuleAddToGlobal.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importedModuleClassNameClash.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importsInAmbientModules1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importsInAmbientModules2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/importsInAmbientModules3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inKeywordAndIntersection.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inKeywordAndUnknown.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inKeywordNarrowingWithNoUncheckedIndexedAccess.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inOperatorWithFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inOperatorWithGeneric.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/incompatibleAssignmentOfIdenticallyNamedTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/incompatibleGenericTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/incompatibleTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/incorrectNumberOfTypeArgumentsDuringErrorReporting.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/incorrectRecursiveMappedTypeConstraint.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/incrementOnNullAssertion.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/incrementalConfig.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/incrementalTsBuildInfoFile.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexIntoArraySubclass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexSignatureAndMappedType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexSignatureInOtherFile.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexSignatureInOtherFile1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexSignatureOfTypeUnknownStillRequiresIndexSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexSignatureWithInitializer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexSignaturesInferentialTyping.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexTypeNoSubstitutionTemplateLiteral.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexWithUndefinedAndNull.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexWithUndefinedAndNullStrictNullChecks.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexWithoutParamType2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessAndNullableNarrowing.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessCanBeHighOrder.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessConstraints.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessImplicitlyAny.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessKeyofNestedSimplifiedSubstituteUnwrapped.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessNormalization.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessPrivateMemberOfGenericConstraint.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessRelation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessRetainsIndexSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessToThisTypeOnIntersection01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessTypeConstraints.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexer2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexer3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexerA.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexerAssignability.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexerConstraints.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexerReturningTypeParameter1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexingTypesWithNever.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/indirectDiscriminantAndExcessProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/indirectGlobalSymbolPartOfObjectType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/indirectTypeParameterReferences.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/indirectUniqueSymbolDeclarationEmit.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferConditionalConstraintMappedMember.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferFromAnnotatedReturn1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferFromGenericFunctionReturnTypes2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferFromGenericFunctionReturnTypes3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferFromNestedSameShapeTuple.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferObjectTypeFromStringLiteralToKeyof.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferParameterWithMethodCallInitializer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferPropertyWithContextSensitiveReturnStatement.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferRestArgumentsMappedTuple.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferSecondaryParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferSetterParamType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferStringLiteralUnionForBindingElement.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferTupleFromBindingPattern.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferTypeConstraintInstantiationCircularity.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferTypeParameterConstraints.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferTypePredicates.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceAndHKTs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceAndSelfReferentialConstraint.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceContextualReturnTypeUnion1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceContextualReturnTypeUnion2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceContextualReturnTypeUnion3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceContextualReturnTypeUnion4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceDoesNotAddUndefinedOrNull.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceDoesntCompareAgainstUninstantiatedTypeParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceErasedSignatures.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceExactOptionalProperties1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceExactOptionalProperties2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceFromGenericClassNoCrash1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceFromIncompleteSource.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceFromParameterlessLambda.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceLimit.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceOfNullableObjectTypesWithCommonBase.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceOptionalProperties.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceOptionalPropertiesStrict.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceOptionalPropertiesToIndexSignatures.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceShouldFailOnEvolvingArrays.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceUnionOfObjectsMappedContextualType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingObjectLiteralMethod1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingObjectLiteralMethod2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingUsingApparentType1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingUsingApparentType2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingUsingApparentType3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingWithFunctionType2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingWithFunctionTypeNested.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingWithFunctionTypeSyntacticScenarios.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingWithFunctionTypeZip.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingWithObjectLiteralProperties.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferredIndexerOnNamespaceImport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferredNonidentifierTypesGetQuotes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferredRestTypeFixedOnce.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferredReturnTypeIncorrectReuse1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferrenceInfiniteLoopWithSubtyping.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferringAnyFunctionType1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferringAnyFunctionType5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferringReturnTypeFromConstructSignatureGeneric.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/infiniteConstraints.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/infiniteExpandingTypeThroughInheritanceInstantiation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingBaseTypes1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingBaseTypes2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingOverloads.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingTypeAssignability.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingTypes1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingTypes2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingTypes3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingTypes4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingTypes5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingTypesNonGenericBase.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/infinitelyGenerativeInheritance1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritSameNamePrivatePropertiesFromDifferentOrigins.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritSameNamePrivatePropertiesFromSameOrigin.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritSameNamePropertiesWithDifferentOptionality.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritSameNamePropertiesWithDifferentVisibility.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritance.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritance1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceGrandParentPrivateMemberCollision.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceGrandParentPrivateMemberCollisionWithPublicMember.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceGrandParentPublicMemberCollisionWithPrivateMember.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceMemberAccessorOverridingAccessor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceMemberAccessorOverridingProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceMemberFuncOverridingAccessor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceMemberFuncOverridingMethod.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceMemberFuncOverridingProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceMemberPropertyOverridingAccessor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceMemberPropertyOverridingMethod.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceMemberPropertyOverridingProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceOfGenericConstructorMethod1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceOfGenericConstructorMethod2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticAccessorOverridingAccessor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticAccessorOverridingMethod.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticAccessorOverridingProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticFuncOverridingAccessor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticFuncOverridingAccessorOfFuncType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticFuncOverridingMethod.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticFuncOverridingProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticFuncOverridingPropertyOfFuncType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticFunctionOverridingInstanceProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticMembersCompatible.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticMembersIncompatible.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticPropertyOverridingAccessor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticPropertyOverridingMethod.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticPropertyOverridingProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedConstructorPropertyContextualType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedFunctionAssignmentCompatibility.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedGenericCallSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedMembersAndIndexSignaturesFromDifferentBases.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedMembersAndIndexSignaturesFromDifferentBases2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedModuleMembersForClodule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedOverloadedSpecializedSignatures.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedStringIndexersFromDifferentBaseTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedStringIndexersFromDifferentBaseTypes2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/initializedDestructuringAssignmentTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/initializedParameterBeforeNonoptionalNotOptional.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/initializerWithThisPropertyAccess.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/initializersInAmbientEnums.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inlineConditionalHasSimilarAssignability.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inlineMappedTypeModifierDeclarationEmit.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/inlinedAliasAssignableToConstraintSameAsAlias.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/innerAliases2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/innerBoundLambdaEmit.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/innerExtern.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/innerTypeArgumentInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceAndStaticDeclarations1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceOfAssignability.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceOfInExternalModules.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceSubtypeCheck1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceSubtypeCheck2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceofNarrowReadonlyArray.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceofTypeAliasToGenericClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceofWithPrimitiveUnion.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/instantiateContextualTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/instantiateContextuallyTypedGenericThis.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/instantiateCrossFileMerge.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/instantiatedBaseTypeConstraints.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/instantiatedReturnTypeContravariance.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/instantiatedTypeAliasDisplay.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/instantiationExpressionErrorNoCrash.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces0.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/interface0.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceClassMerging.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceClassMerging2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceContextualType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceDeclaration2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceDeclaration3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceDeclaration5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceDeclaration6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceExtendsClass1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceExtendsClassWithPrivate1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceExtendsClassWithPrivate2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceImplementation1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceImplementation2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceImplementation3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceImplementation4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceImplementation5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceImplementation6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceImplementation7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceImplementation8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceInReopenedModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceInheritance.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceMergedUnconstrainedNoErrorIrrespectiveOfOrder.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceOnly.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfacePropertiesWithSameName1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfacePropertiesWithSameName2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfacePropertiesWithSameName3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceSubtyping.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceWithCommaSeparators.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceWithOptionalProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfacedecl.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfacedeclWithIndexerErrors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasClassInsideLocalModuleWithExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasClassInsideLocalModuleWithoutExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasClassInsideTopLevelModuleWithExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasClassInsideTopLevelModuleWithoutExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasEnum.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasEnumInsideLocalModuleWithExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasEnumInsideLocalModuleWithoutExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasEnumInsideTopLevelModuleWithExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasEnumInsideTopLevelModuleWithoutExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasFunctionInsideLocalModuleWithExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasFunctionInsideLocalModuleWithoutExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasFunctionInsideTopLevelModuleWithExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasFunctionInsideTopLevelModuleWithoutExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasInitializedModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasInitializedModuleInsideLocalModuleWithExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasInitializedModuleInsideLocalModuleWithoutExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasInitializedModuleInsideTopLevelModuleWithExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasInitializedModuleInsideTopLevelModuleWithoutExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasInterface.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasInterfaceInsideLocalModuleWithExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasInterfaceInsideLocalModuleWithoutExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasInterfaceInsideLocalModuleWithoutExportAccessError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasInterfaceInsideTopLevelModuleWithExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasInterfaceInsideTopLevelModuleWithoutExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasUninitializedModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasUninitializedModuleInsideLocalModuleWithExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasUninitializedModuleInsideLocalModuleWithoutExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasUninitializedModuleInsideLocalModuleWithoutExportAccessError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasUninitializedModuleInsideTopLevelModuleWithExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasUninitializedModuleInsideTopLevelModuleWithoutExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasVar.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasVarInsideLocalModuleWithExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasVarInsideLocalModuleWithoutExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasVarInsideTopLevelModuleWithExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasVarInsideTopLevelModuleWithoutExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasWithDottedNameEmit.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalImportInstantiatedModuleMergedWithClassNotReferencingInstanceNoConflict.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalImportUnInstantiatedModuleMergedWithClassNotReferencingInstanceNoConflict.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalImportUnInstantiatedModuleNotReferencingInstanceNoConflict.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionConstraintReduction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionOfMixinConstructorTypeAndNonConstructorType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionOfTypeVariableHasApparentSignatures.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionPropertyCheck.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionReductionGenericStringLikeType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionSatisfiesConstraint.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionTypeInference1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionTypeNormalization.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionTypeWithLeadingOperator.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionType_useDefineForClassFields.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionWithConstructSignaturePrototypeResult.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionsAndOptionalProperties.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionsAndReadonlyProperties.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionsOfLargeUnions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/intraBindingPatternReferences.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/intrinsics.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidConstraint1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidSplice.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidSymbolInTypeParameter1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidThisEmitInContextualObjectLiteral.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidUseOfTypeAsNamespace.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/invariantGenericErrorElaboration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/invokingNonGenericMethodWithTypeArguments2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/ipromise2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/ipromise3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/ipromise4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsAugmentation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsClasses.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsClassesExpressions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsDefault.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsEnums.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsExpandoFunctions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsExpressions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsFunctionDeclarations.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsObjects.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsReturnTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationLazySymbols.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationOutFile.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationsAddUndefined.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationsAddUndefined2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationsLiterals.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesAmbientConstEnum.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesConstEnum.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesDontElideReExportStar.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesGlobalNamespacesAndEnums.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesImportConstEnum.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesImportConstEnumTypeOnly.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesNonAmbientConstEnum.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesReExportType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModules_resolveJsonModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModules_resolveJsonModule_strict_outDir_commonJs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/iteratorsAndStrictNullChecks.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/javascriptCommonjsModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/javascriptDefinePropertyPrototypeNonConstructor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/javascriptImportDefaultBadExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/javascriptThisAssignmentInStaticBlock.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jqueryInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsDeclarationEmitDoesNotRenameImport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsDeclarationEmitExportAssignedArray.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsDeclarationEmitExportAssignedFunctionWithExtraTypedefsMembers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsDeclarationEmitExportedClassWithExtends.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsDeclarationsGlobalFileConstFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsDeclarationsGlobalFileConstFunctionNamed.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsDeclarationsInheritedTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsDeclarationsWithDefaultAsNamespaceLikeMerge.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsDocDeclarationEmitDoesNotUseNodeModulesPathWithoutError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsElementAccessNoContextualTypeCrash.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsEnumCrossFileExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsEnumFunctionLocalNoCrash.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsEnumTagOnObjectFrozen.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsExpandoObjectDefineProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsExportAssignmentNonMutableLocation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsExportMemberMergedWithModuleAugmentation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsExportMemberMergedWithModuleAugmentation3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsExtendsImplicitAny.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileAlternativeUseOfOverloadTag.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileClassPropertyInitalizationInObjectLiteral.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileClassPropertyType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileClassPropertyType2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileClassPropertyType3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileClassSelfReferencedProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationAwaitModifier.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationClassMethodContainingArrowFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationDuplicateVariable.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationDuplicateVariableErrorReported.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationExternalPackageError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationLetDeclarationOrder.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationLetDeclarationOrder2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationRestParamJsDocFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationShortHandProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationWithOutDeclarationFileNameSameAsInputJsFile.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationWithOutFileNameSameAsInputJsFile.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileESModuleWithEnumTag.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileFunctionOverloads.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileFunctionOverloads2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileFunctionParametersAsOptional.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileFunctionParametersAsOptional2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileImportPreservedWhenUsed.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileMethodOverloads.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileMethodOverloads2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileMethodOverloads3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileMethodOverloads4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileMethodOverloads5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsNoImplicitAnyNoCascadingReferenceErrors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsPropertyAssignedAfterMethodDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsPropertyAssignedAfterMethodDeclaration_nonError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsSelfReferencingArgumentsFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocAccessEnumType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocArrayObjectPromiseImplicitAny.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocArrayObjectPromiseNoImplicitAny.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocBracelessTypeTag1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocCallbackAndType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocClassMissingTypeArguments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocFunctionClassPropertiesDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocImportTypeNodeNamespace.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocParamTagInvalid.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocParamTagOnPropertyInitializer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocParameterParsingInvalidName.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocPropertyTagInvalid.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocReferenceGlobalTypeInCommonJs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocResolveNameFailureInTypedef.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocRestParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocRestParameter_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocTypedefMissingType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocTypedefNoCrash.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocTypedef_propertyWithNoType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocUnexpectedCharacter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/json.stringify.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsonFileImportChecksCallCorrectlyTwice.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxCallElaborationCheckNoCrash1.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxCallbackWithDestructuring.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxChildWrongType.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxChildrenGenericContextualTypes.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxChildrenIndividualErrorElaborations.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxChildrenSingleChildConfusableWithMultipleChildrenNoError.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxChildrenWrongType.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxClassAttributeResolution.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxComplexSignatureHasApplicabilityError.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxComponentTypeErrors.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxDeclarationsWithEsModuleInteropNoCrash.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxElementClassTooManyParams.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxElementsAsIdentifierNames.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxEmitAttributeWithPreserve.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxEmitWithAttributes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxEmptyExpressionNotCountedAsChild2.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxExcessPropsAndAssignability.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryAndReactNamespace.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryIdentifier.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryIdentifierAsParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryIdentifierWithAbsentParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryMissingErrorInsideAClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryNotIdentifierOrQualifiedName.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryNotIdentifierOrQualifiedName2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryQualifiedName.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryQualifiedNameResolutionError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFragmentFactoryNoUnusedLocals.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFragmentWrongType.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFunctionTypeChildren.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxGenericComponentWithSpreadingResultOfGenericFunction.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxHasLiteralType.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxImportInAttribute.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxImportSourceNonPragmaComment.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxInExtendsClause.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxInferenceProducesLiteralAsExpected.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxIntrinsicDeclaredUsingTemplateLiteralTypeSignatures.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxIntrinsicElementsCompatability.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxIntrinsicElementsExtendsRecord.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxIntrinsicUnions.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxIssuesErrorWhenTagExpectsTooManyArguments.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxLibraryManagedAttributesUnusedGeneric.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxLocalNamespaceIndexSignatureNoCrash.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxMultilineAttributeStringValues.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxMultilineAttributeValuesReact.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceGlobalReexport.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceGlobalReexportMissingAliasTarget.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceImplicitImportJSXNamespace.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceImplicitImportJSXNamespaceFromPragmaPickedOverGlobalOne.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceReexports.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxNamespacedNameNotComparedToNonMatchingIndexSignature.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxPartialSpread.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxPropsAsIdentifierNames.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxSpreadFirstUnionNoErrors.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxViaImport.2.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxViaImport.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/keyRemappingKeyofResult.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/keyRemappingKeyofResult2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/keyofDoesntContainSymbols.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/keyofGenericExtendingClassDoubleLayer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/keyofObjectWithGlobalSymbolIncluded.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/keywordExpressionInternalComments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/keywordField.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/keywordInJsxIdentifier.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/lambdaArgCrash.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/lambdaParameterWithTupleArgsHasCorrectAssignability.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/largeTupleTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/lateBoundAssignmentCandidateJS1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/lateBoundAssignmentCandidateJS2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/lateBoundAssignmentCandidateJS3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/lateBoundConstraintTypeChecksCorrectly.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/lateBoundDestructuringImplicitAnyError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/lateBoundFunctionMemberAssignmentDeclarations.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/lateBoundMethodNameAssigmentJS.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-access.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-useBeforeDefinition2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/letInNonStrictMode.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/letShadowedByNameInNestedScope.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/libTypeScriptOverrideSimple.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/libTypeScriptOverrideSimpleConfig.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/libTypeScriptSubfileResolving.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/libTypeScriptSubfileResolvingConfig.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/libdtsFix.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/library_ArraySlice.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/library_DatePrototypeProperties.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/library_ObjectPrototypeProperties.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/library_RegExpExecArraySlice.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/library_StringSlice.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/lift.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/limitDeepInstantiations.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/listFailure.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/literalFreshnessPropagationOnNarrowing.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/literalIntersectionYieldsLiteral.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/literalTypeNameAssertionNotTriggered.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/localAliasExportAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/localClassesInLoop.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/localClassesInLoop_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/localImportNameVsGlobalName.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/localTypeParameterInferencePriority.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/m7Bugs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mapConstructor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mapConstructorOnReadonlyTuple.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mapGroupBy.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mapOnTupleTypes01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mapOnTupleTypes02.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedArrayTupleIntersections.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedToToIndexSignatureInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeAndIndexSignatureRelation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeAsStringTemplate.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeCircularReferenceInAccessor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeContextualTypesApplied.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeGenericIndexedAccess.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeGenericInstantiationPreservesHomomorphism.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeGenericInstantiationPreservesInlineForm.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeGenericWithKnownKeys.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeIndexedAccess.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeIndexedAccessConstraint.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeInferenceAliasSubstitution.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeInferenceCircularity.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeInferenceFromApparentType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeInferenceToMappedType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeMultiInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeNestedGenericInstantiation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeNoTypeNoCrash.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeNotMistakenlyHomomorphic.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeOverArrayWithBareAnyRestCanBeUsedAsRestParam1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeParameterConstraint.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypePartialConstraints.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypePartialNonHomomorphicBaseConstraint.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeRecursiveInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeRecursiveInference2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeTupleConstraintAssignability.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeUnionConstrainTupleTreatedAsArrayLike.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeUnionConstraintInferences.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeWithAsClauseAndLateBoundProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeWithAsClauseAndLateBoundProperty2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeWithCombinedTypeMappers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeWithNameClauseAppliedToArrayType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/matchReturnTypeInAllBranches.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/matchingOfObjectLiteralConstraints.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/maxConstraints.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/memberAccessMustUseModuleInstances.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/memberAccessOnConstructorType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/memberVariableDeclarations1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergeMultipleInterfacesReexported.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedDeclarations1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedDeclarations2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedDeclarations4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedDeclarations5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedDeclarations6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedDeclarations7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedEnumDeclarationCodeGen.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedInstantiationAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedInterfaceFromMultipleFiles1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationCodeGen.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationCodeGen2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationCodeGen3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationCodeGen4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationCodeGen5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationWithSharedExportedVar.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/metadataOfStringLiteral.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/metadataOfUnion.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/methodChainError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/methodSignatureDeclarationEmit1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/methodSignatureHandledDeclarationKindForSymbol.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mismatchedExplicitTypeParameterAndArgumentType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mismatchedGenericArguments1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingDiscriminants.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingDiscriminants2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingImportAfterModuleImport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingMemberErrorHasShortPath.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingReturnStatement.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingReturnStatement1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingSelf.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingTypeArguments1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingTypeArguments3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/misspelledJsDocTypedefTags.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mixedExports.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mixedTypeEnumComparison.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mixinIntersectionIsValidbaseType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mixinOverMappedTypeNoCrash.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mixingApparentTypeOverrides.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mixingFunctionAndAmbientModule1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/modFunctionCrash.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_Dom.asynciterable.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_Dom.iterable.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_ErrorFromUsingWellknownSymbolWithOutES6WellknownSymbolLib.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_NoErrorDuplicateLibOptions1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_NoErrorDuplicateLibOptions2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_TargetES5UsingES6Lib.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_TargetES6UsingES6Lib.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_UsingES5LibAndES6FeatureLibs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_UsingES5LibES6ArrayLibES6WellknownSymbolLib.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_Worker.asynciterable.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_Worker.iterable.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAliasAsFunctionArgument.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAliasInterface.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAndInterfaceSharingName.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAndInterfaceSharingName2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAndInterfaceSharingName3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAndInterfaceSharingName4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAssignmentCompat1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAssignmentCompat2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAssignmentCompat3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAssignmentCompat4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationCollidingNamesInAugmentation1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationDeclarationEmit1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationDeclarationEmit2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationDoesInterfaceMergeOfReexport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationDoesNamespaceEnumMergeOfReexport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationDoesNamespaceMergeOfReexport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationDuringSyntheticDefaultCheck.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationExtendAmbientModule1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationExtendAmbientModule2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationExtendFileModule1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationExtendFileModule2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationGlobal1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationGlobal2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationGlobal3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationGlobal4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationGlobal5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationImportsAndExports1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationImportsAndExports4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationImportsAndExports5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationImportsAndExports6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationInAmbientModule1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationInAmbientModule2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationInAmbientModule3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationInAmbientModule4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationInAmbientModule5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationInDependency.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationInDependency2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationNoNewNames.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationOfAlias.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationWithNonExistentNamedImport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationsImports1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationsImports2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationsImports3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationsImports4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleClassArrayCodeGenTest.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleCodeGenTest3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleCodeGenTest5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleCodegenTest4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleCrashBug1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleDeclarationExportStarShadowingGlobalIsNameable.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleExports1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleExportsTypeNoExcessPropertyCheckFromContainedLiteral.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleExportsUnaryExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleIdentifiers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleImport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleImportedForTypeArgumentPosition.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleInTypePosition1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleLocalImportNotIncorrectlyRedirected.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleMemberMissingErrorIsRelative.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleMemberWithoutTypeAnnotation1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleMemberWithoutTypeAnnotation2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleMerge.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleMergeConstructor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleNewExportBug.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleNoneOutFile.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleOuterQualification.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/modulePreserve1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/modulePreserve2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/modulePreserveImportHelpers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleReopenedTypeOtherBlock.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleReopenedTypeSameBlock.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionAsTypeReferenceDirective.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionAsTypeReferenceDirectiveAmbient.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionAsTypeReferenceDirectiveScoped.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionPackageIdWithRelativeAndAbsolutePath.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithExtensions_notSupported.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithExtensions_notSupported2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithExtensions_notSupported3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithExtensions_withAmbientPresent.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithExtensions_withPaths.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithRequire.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithRequireAndImport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_empty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_notSpecified.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_one.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_oneBlank.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_oneNotFound.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_one_dirModuleWithIndex.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_one_externalModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_one_externalModulePath.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_one_externalModule_withPaths.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_one_externalTSModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_one_jsModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_one_jsonModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_threeLastIsBlank1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_threeLastIsBlank2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_threeLastIsBlank3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_threeLastIsBlank4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSymlinks.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSymlinks_notInNodeModules.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSymlinks_preserveSymlinks.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSymlinks_referenceTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSymlinks_withOutDir.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_automaticTypeDirectiveNames.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_classicPrefersTs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_explicitNodeModulesImport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_explicitNodeModulesImport_implicitAny.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_packageJson_notAtPackageRoot.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_packageJson_notAtPackageRoot_fakeScopedPackage.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_packageJson_scopedPackage.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_packageJson_yesAtPackageRoot.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_packageJson_yesAtPackageRoot_fakeScopedPackage.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_packageJson_yesAtPackageRoot_mainFieldInSubDirectory.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_relativeImportJsFile.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_relativeImportJsFile_noImplicitAny.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleSameValueDuplicateExportedBindings2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleSharesNameWithImportDeclarationInsideIt.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleSharesNameWithImportDeclarationInsideIt2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleSharesNameWithImportDeclarationInsideIt4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleSharesNameWithImportDeclarationInsideIt6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleSymbolMerging.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleVariables.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleVisibilityTest1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleVisibilityTest3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleVisibilityTest4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleWithNoValuesAsType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleWithValuesAsType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/module_augmentUninstantiatedModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/module_augmentUninstantiatedModule2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiExtendsSplitInterfaces1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiExtendsSplitInterfaces2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiImportExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiLineContextDiagnosticWithPretty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiLineErrors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiModuleClodule1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiModuleFundule1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiSignatureTypeInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/multipleBaseInterfaesWithIncompatibleProperties.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/multipleInferenceContexts.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mutrec.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mutuallyRecursiveGenericBaseTypes1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mutuallyRecursiveGenericBaseTypes2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mutuallyRecursiveInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/mutuallyRecursiveInterfaceDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nameCollisionWithBlockScopedVariable1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nameCollisionsInPropertyAssignments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/namedFunctionExpressionAssignedToClassProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/namedImportNonExistentName.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/namespaceDisambiguationInUnion.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/namespaceMergedWithFunctionWithOverloadsUsage.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/namespaces1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/namespaces2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/namespacesDeclaration2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/namespacesWithTypeAliasOnlyExportsMerge.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nanEquality.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByBooleanComparison.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByInstanceof.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByParenthesizedSwitchExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowCommaOperatorNestedWithinLHS.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowRefinedConstLikeParameterBIndingElementNameInInnerScope.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowSwitchOptionalChainContainmentEvolvingArrayNoCrash1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowTypeByInstanceof.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowUnknownByTypePredicate.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowedConstInMethod.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowedImports.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowedImports_assumeInitialized.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingAssignmentReadonlyRespectsAssertion.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingByDiscriminantInLoop.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingByTypeofInSwitch.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingConstrainedTypeParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingDestructuring.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingInCaseClauseAfterCaseClauseWithReturn.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingIntersection.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingMutualSubtypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingNoInfer1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingOfDottedNames.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingOfQualifiedNames.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingOrderIndependent.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingPastLastAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingPastLastAssignmentInModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingRestGenericCall.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingTruthyObject.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingTypeofDiscriminant.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingTypeofFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingTypeofObject.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingTypeofUndefined1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingTypeofUndefined2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingUnionToUnion.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingUnionWithBang.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingWithNonNullExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nativeToBoxedTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nearbyIdenticalGenericLambdasAssignable.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedCallbackErrorNotFlattened.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedExcessPropertyChecking.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedFreshLiteral.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedGenericConditionalTypeWithGenericImportType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedGenericSpreadInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedGenerics.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedHomomorphicMappedTypesWithArrayConstraint1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedIndexer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedInfinitelyExpandedRecursiveTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedLoopTypeGuards.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedObjectRest.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedRecursiveArraysOrObjectsError01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedSelf.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedTypeVariableInfersLiteral.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/neverNullishThroughParentheses.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/newAbstractInstance2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/newArrays.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/newMap.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/newNamesInGlobalAugmentations1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noAsConstNameLookup.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noBundledEmitFromNodeModules.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCircularDefinitionOnExportOfPrivateInMergedNamespace.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCircularitySelfReferentialGetter1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCircularitySelfReferentialGetter2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCircularitySelfReferentialGetter3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCircularitySelfReferentialGetter4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCollisionThisExpressionAndLocalVarInAccessors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCollisionThisExpressionAndLocalVarInConstructor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCollisionThisExpressionAndLocalVarInFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCollisionThisExpressionAndLocalVarInLambda.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCollisionThisExpressionAndLocalVarInMethod.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCollisionThisExpressionAndLocalVarInProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCollisionThisExpressionInFunctionAndVarInGlobal.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noConstraintInReturnType1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCrashOnImportShadowing.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCrashOnMixin.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCrashOnThisTypeUsage.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCrashUMDMergedWithGlobalValue.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noEmitAndComposite.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noEmitAndCompositeListFilesOnly.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noEmitAndIncremental.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noEmitAndIncrementalListFilesOnly.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noErrorTruncation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noErrorsInCallback.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noExcessiveStackDepthError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyAndPrivateMembersWithoutTypeAnnotations.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyDestructuringInPrivateMethod.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyDestructuringParameterDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyDestructuringVarDeclaration2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyForMethodParameters.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyInBareInterface.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyInCastExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyInContextuallyTypesFunctionParamter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyParametersInAmbientClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyParametersInClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyParametersInInterface.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyUnionNormalizedObjectLiteral1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyWithOverloads.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitReturnsExclusions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitReturnsInAsync1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitReturnsInAsync2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitThisBigThis.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitThisFunctions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noInferCommonPropertyCheck1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noInferUnionExcessPropertyCheck1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noIterationTypeErrorsInCFA.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noObjectKeysToKeyofT.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noParameterReassignmentIIFEAnnotated.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noParameterReassignmentJSIIFE.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noSubtypeReduction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noTypeArgumentOnReturnType1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUncheckedIndexAccess.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUncheckedIndexedAccessCompoundAssignments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUnusedLocals_destructuringAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUnusedLocals_potentialPredicateUnusedParam.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUnusedLocals_selfReference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUnusedLocals_writeOnly.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUnusedLocals_writeOnlyProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUnusedLocals_writeOnlyProperty_dynamicNames.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUsedBeforeDefinedErrorInTypeContext.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeColonModuleResolution.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeColonModuleResolution2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeModuleReexportFromDottedPath.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextCjsNamespaceImportDefault1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextCjsNamespaceImportDefault2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextEsmImportsOfPackagesWithExtensionlessMains.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextImportModeImplicitIndexResolution.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextImportModeImplicitIndexResolution2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextModuleResolution1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextModuleResolution2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextPackageImportMapRootDir.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextPackageSelfNameWithOutDir.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextPackageSelfNameWithOutDirDeclDir.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextPackageSelfNameWithOutDirDeclDirComposite.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextPackageSelfNameWithOutDirDeclDirCompositeNestedDirs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextPackageSelfNameWithOutDirDeclDirNestedDirs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextPackageSelfNameWithOutDirDeclDirRootDir.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextPackageSelfNameWithOutDirRootDir.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeResolution1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeResolution2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeResolution3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeResolution4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeResolution5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeResolution6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeResolution7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeResolution8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonConflictingRecursiveBaseTypeMembers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonContextuallyTypedLogicalOr.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonGenericClassExtendingGenericClassWithAny.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonInferrableTypePropagation1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonInferrableTypePropagation2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonInferrableTypePropagation3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonNullFullInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonNullMappedType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonNullParameterExtendingStringAssignableToString.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonNullReferenceMatching.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonNullableTypes1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonNullableWithNullableGenericIndexedAccessArg.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonObjectUnionNestedExcessPropertyCheck.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nondistributiveConditionalTypeInfer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nongenericConditionalNotPartiallyComputed.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nongenericPartialInstantiationsRelatedInBothDirections.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonnullAssertionPropegatesContextualType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/normalizedIntersectionTooComplex.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/null.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/nullableFunctionError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/numberAssignableToEnumInsideUnion.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericEnumMappedType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericIndexExpressions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericIndexerConstraint.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericIndexerConstraint1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericIndexerConstraint2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericIndexerConstraint3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericIndexerConstraint4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericIndexerConstraint5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericIndexerTyping1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericIndexerTyping2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericMethodName1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectAssignLikeNonUnionResult.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectBindingPatternContextuallyTypesArgument.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectCreate-errors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectCreate.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectCreate2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectCreationOfElementAccessExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectFreeze.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectFreezeLiteralsDontWiden.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectFromEntries.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectGroupBy.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectIndexer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectInstantiationFromUnionSpread.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLitGetterSetter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLitIndexerContextualType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLitPropertyScoping.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLitStructuralTypeMismatch.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLitTargetTypeCallSite.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteral1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteral2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralArraySpecialization.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralComputedNameNoDeclarationError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralEnumPropertyNames.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralExcessProperties.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralFreshnessWithSpread.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralFunctionArgContextualTyping2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralIndexerErrors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralIndexerNoImplicitAny.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralIndexers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralParameterResolution.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralPropertyImplicitlyAny.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralReferencingInternalProperties.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralThisWidenedOnUse.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralWithGetAccessorInsideFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralWithNumericPropertyName.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralsAgainstUnionsOfArrays01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectMembersOnTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectPropertyAsClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectRestBindingContextualInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectSpreadWithinMethodWithinObjectWithSpread.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/observableInferenceCanBeMade.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/omitTypeHelperModifiers01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/omitTypeTests01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalAccessorsInInterface1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalConstructorArgInSuper.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalFunctionArgAssignability.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalParamAssignmentCompat.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalParamInOverride.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalParameterInDestructuringWithInitializer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalParameterProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalParameterRetainsNull.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalPropertiesInClasses.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalPropertiesTest.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalTupleElementsAndUndefined.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/outFileIsDeprecated.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/outModuleConcatES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/overEagerReturnTypeSpecialization.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/overload1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadBindingAcrossDeclarationBoundaries.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadBindingAcrossDeclarationBoundaries2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadCrash.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadEquivalenceWithStatics.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadErrorMatchesImplementationElaboaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadGenericFunctionWithRestArgs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstConstraintChecks1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstConstraintChecks2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstConstraintChecks3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstConstraintChecks4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstInBaseWithBadImplementationInDerived.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstInCallback1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstInObjectLiteralImplementingAnInterface.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstInheritance1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstInheritance2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstInheritance3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstInheritance4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstNoNonSpecializedSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstNoStringImplementation2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnGenericArity.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnGenericClassAndNonGenericClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadResolutionOnDefaultConstructor1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadResolutionOverNonCTLambdas.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadResolutionOverNonCTObjectLit.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadResolutionTest1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadResolutionWithAny.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadRet.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadReturnTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadedConstructorFixesInferencesAppropriately.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadedStaticMethodSpecialization.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadingOnConstants1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadresolutionWithConstraintCheckingDeferred.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadsWithConstraints.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadsWithProvisionalErrors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/overrideBaseIntersectionMethod.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/overridingPrivateStaticMembers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/parameterDestructuringObjectLiteral.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/parameterListAsTupleType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/parameterNamesInTypeParameterList.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/parameterPropertyInConstructor4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/parameterPropertyInConstructorWithPrologues.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/parameterPropertyInitializerInInitializers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/parameterPropertyReferencingOtherParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/parameterReferenceInInitializer1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/parameterReferencesOtherParameter1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/parameterReferencesOtherParameter2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/paramsOnlyHaveLiteralTypesWhenAppropriatelyContextualized.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/paramterDestrcuturingDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/parenthesisDoesNotBlockAliasSymbolCreation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/parenthesizedArrowExpressionASI.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/parenthesizedJSDocCastAtReturnStatement.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseEntityNameWithReservedWord.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseGenericArrowRatherThanLeftShift.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseJsxExtends1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseJsxExtends2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseObjectLiteralsWithoutTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseShortform.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/parserIsClassMemberStart.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/parsingClassRecoversWhenHittingUnexpectedSemicolon.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/partialDiscriminatedUnionMemberHasGoodError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/partialOfLargeAPIIsAbleToBeWorkedWith.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/partialTypeNarrowedToByTypeGuard.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/partiallyAmbientFundule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/partiallyDiscriminantedUnions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution1_amd.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution1_node.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution2_classic.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution2_node.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution3_classic.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution3_node.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution4_classic.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution4_node.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution5_classic.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution5_node.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution6_classic.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution6_node.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution7_classic.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution7_node.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution8_classic.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution8_node.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution_rootImport_aliasWithRoot.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution_rootImport_aliasWithRoot_differentRootTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution_rootImport_aliasWithRoot_multipleAliases.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution_rootImport_noAliasWithRoot.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution_withExtension.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution_withExtensionInName.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution_withExtension_MapedToNodeModules.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution_withExtension_failedLookup.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/performanceComparisonOfStructurallyIdenticalInterfacesWithGenericSignatures.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/pickOfLargeObjectUnionWorks.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/potentiallyUnassignedVariableInCatch.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/potentiallyUncalledDecorators.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/predicateSemantics.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/preserveConstEnums.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/prespecializedGenericMembers1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/primaryExpressionMods.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/primitiveConstraints2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/primitiveUnionDetection.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyCannotNameVarTypeDeclFile.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyCheckAnonymousFunctionParameter2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyCheckCallbackOfInterfaceMethodWithTypeParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyCheckExportAssignmentOnExportedGenericInterface1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyCheckExportAssignmentOnExportedGenericInterface2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyCheckExternalModuleExportAssignmentOfGenericClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyCheckOnTypeParameterReferenceInConstructorParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyClassExtendsClauseDeclFile.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyClassImplementsClauseDeclFile.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyFunc.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyFunctionCannotNameParameterTypeDeclFile.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyFunctionCannotNameReturnTypeDeclFile.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyFunctionParameterDeclFile.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyFunctionReturnTypeDeclFile.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyGloClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyGloFunc.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyGloImport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyGloInterface.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyGloVar.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyImport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyInterface.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyInterfaceExtendsClauseDeclFile.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyLocalInternalReferenceImportWithExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyLocalInternalReferenceImportWithoutExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyTopLevelInternalReferenceImportWithExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyTopLevelInternalReferenceImportWithoutExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyTypeParameterOfFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyTypeParameterOfFunctionDeclFile.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyTypeParametersOfClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyTypeParametersOfClassDeclFile.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyTypeParametersOfInterface.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyTypeParametersOfInterfaceDeclFile.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyVar.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyVarDeclFile.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privateAccessInSubclass1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privateFieldsInClassExpressionDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privateInstanceVisibility.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privateInterfaceProperties.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privatePropertyInUnion.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privatePropertyUsingObjectType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privateVisibility.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/privateVisibles.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseAllOnAny01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseChaining.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseChaining1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseChaining2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseEmptyTupleNoException.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseIdentity.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseIdentity2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseIdentityWithAny.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseIdentityWithAny2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseIdentityWithConstraints.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/promisePermutations.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/promisePermutations2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/promisePermutations3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseTest.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseTry.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseTypeInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseTypeInferenceUnion.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseTypeStrictNull.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseVoidErrorCallback.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseWithResolvers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/promises.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/promisesWithConstraints.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/propTypeValidatorInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/propagationOfPromiseInitialization.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertiesAndIndexers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertiesAndIndexers2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertiesAndIndexersForNumericNames.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccess7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccessExpressionInnerComments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccessOfReadonlyIndexSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccessOnObjectLiteral.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccessibility1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccessibility2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyIdentityWithPrivacyMismatch.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyNamesWithStringLiteral.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyOverridingPrototype.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyParameterWithQuestionMark.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/protectedAccessThroughContextualThis.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/protectedMembers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/protectedMembersThisParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/protoAsIndexInIndexExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/protoAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/protoInIndexer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/prototypeInstantiatedWithBaseConstraint.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/prototypeOnConstructorFunctions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/publicMemberImplementedAsPrivateInDerivedClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/qualifiedName_ImportDeclarations-entity-names-referencing-a-var.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/qualifiedName_entity-name-resolution-does-not-affect-class-heritage.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/qualify.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/quickIntersectionCheckCorrectlyCachesErrors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/quotedAccessorName1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/quotedAccessorName2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/quotedFunctionName1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/quotedFunctionName2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/quotedPropertyName1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/quotedPropertyName2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/quotedPropertyName3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/raiseErrorOnParameterProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/ramdaToolsNoInfinite.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/ramdaToolsNoInfinite2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reExportGlobalDeclaration1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reExportGlobalDeclaration2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reExportGlobalDeclaration3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reExportGlobalDeclaration4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reExportUndefined1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reExportUndefined2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reachabilityCheckWithEmptyDefault.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecks1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecks10.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecks11.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecks2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecks4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecks5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecks6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecks7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecks9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecksIgnored.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactDefaultPropsInferenceSuccess.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactHOCSpreadprops.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactImportDropped.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactJsxReactResolvedNodeNext.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactJsxReactResolvedNodeNextEsm.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactNamespaceImportPresevation.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactNamespaceInvalidInput.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactNamespaceJSXEmit.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactNamespaceMissingDeclaration.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactReadonlyHOCAssignabilityReal.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactReduxLikeDeferredInferenceAllowsAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactSFCAndFunctionResolvable.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactTagNameComponentWithPropsNoOOM.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactTagNameComponentWithPropsNoOOM2.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactTransitiveImportHasValidDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/readonlyAssignmentInSubclassOfClassExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/readonlyFloat32ArrayAssignableWithFloat32Array.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/readonlyPropertySubtypeRelationDirected.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/readonlyTupleAndArrayElaboration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reboundBaseClassSymbol.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveArrayNotCircular.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveBaseCheck.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveBaseCheck2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveBaseConstructorCreation1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveBaseConstructorCreation2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveBaseConstructorCreation3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveClassBaseType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveClassInstantiationsWithDefaultConstructors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveClassReferenceTest.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveCloduleReference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalCrash2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalCrash3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalCrash4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalEvaluationNonInfinite.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalTypes2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveExcessPropertyChecks.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveExportAssignmentAndFindAliasedType1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveExportAssignmentAndFindAliasedType2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveExportAssignmentAndFindAliasedType3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveExportAssignmentAndFindAliasedType4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveExportAssignmentAndFindAliasedType5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveExportAssignmentAndFindAliasedType6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveExportAssignmentAndFindAliasedType7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveFieldSetting.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveFunctionTypes1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveGenericMethodCall.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveGenericUnionType1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveGenericUnionType2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveGetterAccess.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveIdenticalAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveInferenceBug.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveInheritance.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveInheritance3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveInheritanceGeneric.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveLetConst.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveMods.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveObjectLiteral.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveResolveDeclaredMembers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveResolveTypeMembers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveReverseMappedType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveSpecializationOfExtendedTypeWithError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveSpecializationOfSignatures.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveTupleTypeInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveTupleTypes1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveTupleTypes2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveTypeAliasWithSpreadConditionalReturnNotCircular.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveTypeComparison.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveTypeComparison2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveTypeParameterReferenceError1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveTypeParameterReferenceError2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveTypes1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveUnionTypeInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursivelyExpandingUnionNoStackoverflow.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursivelySpecializedConstructorDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/redeclarationOfVarWithGenericType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/redefineArray.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reducibleIndexedAccessTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportDefaultIsCallable.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportMissingDefault.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportMissingDefault1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportMissingDefault2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportMissingDefault3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportMissingDefault4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportMissingDefault5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportMissingDefault6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportMissingDefault7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportMissingDefault8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportNameAliasedAndHoisted.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportWrittenCorrectlyInDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/referenceSatisfiesExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/referenceTypesPreferedToPathIfPossible.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/regExpWithSlashInCharClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/regexMatchAll-esnext.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/regexMatchAll.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/regularExpressionExtendedUnicodeEscapes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/relatedViaDiscriminatedTypeNoError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/relatedViaDiscriminatedTypeNoError2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/relationComplexityError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/relativeNamesInClassicResolution.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/renamingDestructuredPropertyInFunctionType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/renamingDestructuredPropertyInFunctionType2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/renamingDestructuredPropertyInFunctionType3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reorderProperties.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireEmitSemicolon.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFile.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileNonRelative.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileNonRelativeWithoutExtension.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileNonRelativeWithoutExtensionResolvesToTs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithAlwaysStrictWithoutErrors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithAmd.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithModuleEmitUndefined.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithModuleNodeResolutionEmitAmd.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithModuleNodeResolutionEmitAmdOutFile.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithModuleNodeResolutionEmitEs2015.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithModuleNodeResolutionEmitEsNext.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithModuleNodeResolutionEmitSystem.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithModuleNodeResolutionEmitUmd.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithModuleNodeResolutionEmitUndefined.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithSourceMap.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithTraillingComma.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithoutAllowJs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithoutEsModuleInterop.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithoutExtension.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithoutExtensionResolvesToTs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithoutOutDir.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithoutResolveJsonModuleAndPathMapping.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFile_PathMapping.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/requiredInitializedParameter2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/requiredInitializedParameter3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/requiredInitializedParameter4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reservedNameOnModuleImport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reservedWords.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/resolutionCandidateFromPackageJsonField2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/resolveModuleNameWithSameLetDeclarationName1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/resolveModuleNameWithSameLetDeclarationName2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/resolveNameWithNamspace.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/resolvingClassDeclarationWhenInBaseTypeResolution.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/restArgAssignmentCompat.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/restElementAssignable.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/restIntersection.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/restInvalidArgumentType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/restParamUsingMappedTypeOverUnionConstraint.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/restParameterAssignmentCompatibility.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/restParameterTypeInstantiation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/restParameterWithBindingPattern1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/restParameterWithBindingPattern2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/restTypeRetainsMappyness.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/restUnion2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/restUnion3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnConditionalExpressionJSDocCast.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnInConstructor1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnInfiniteIntersection.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnTypeInferenceContextualParameterTypesInGenerator1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnTypeInferenceContextualTypeIgnoreAnyUnknown1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnTypeInferenceNotTooBroad.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnTypeParameterWithModules.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnTypePredicateIsInstantiateInContextOfTarget.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnTypeTypeArguments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reuseInnerModuleMember.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseInferenceInContextualInstantiation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedContravariantInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedIntersectionInference1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedIntersectionInference2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedPartiallyInferableTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTupleContext.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeAssignableToIndex.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeContextualTypeNotCircular.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeContextualTypesPerElementOfTupleConstraint.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeDeepDeclarationEmit.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeInferenceSameSource1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeInferenceWidening1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeInferenceWidening2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeIntersectionConstraint.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeLimitedConstraint.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypePrimitiveConstraintProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeRecursiveInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedUnionInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/reversedRecusiveTypeInstantiation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/satisfiesEmit.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/scopeCheckClassProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/scopeCheckExtendedClassInsidePublicMethod2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/scopeCheckInsidePublicMethod1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/scopeCheckStaticInitializer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/scopeTests.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfInCallback.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfInLambdas.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfRef.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfReferencingTypeReferenceInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfReferentialDefaultNoStackOverflow.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/setMethods.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/setterBeforeGetter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/shadowPrivateMembers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/shebangBeforeReferences.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/shorthand-property-es6-amd.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/shorthand-property-es6-es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/shorthandOfExportedEntity01_targetES2015_CommonJS.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/shorthandPropertyAssignmentInES6Module.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sigantureIsSubTypeIfTheyAreIdentical.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/signatureCombiningRestParameters1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/signatureCombiningRestParameters2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/signatureCombiningRestParameters3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/signatureCombiningRestParameters4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/signatureInstantiationWithRecursiveConstraints.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/signatureOverloadsWithComments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/signaturesUseJSDocForOptionalParameters.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/silentNeverPropagation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/simpleArrowFunctionParameterReferencedInObjectLiteral1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/simpleRecursionWithBaseCase2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/simpleRecursionWithBaseCase3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sliceResultCast.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/slightlyIndirectedDeepObjectLiteralElaborations.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMap-FileWithComments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapSample.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationClassWithDefaultConstructor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationClassWithDefaultConstructorAndCapturedThisStatement.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationClassWithDefaultConstructorAndExtendsClause.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationClasses.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringForObjectBindingPattern.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringForObjectBindingPattern2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringForObjectBindingPatternDefaultValues.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringForObjectBindingPatternDefaultValues2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringParameterNestedObjectBindingPattern.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringParameterNestedObjectBindingPatternDefaultValues.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringParameterObjectBindingPattern.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringParameterObjectBindingPatternDefaultValues.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatement.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatement1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatementArrayBindingPattern4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatementArrayBindingPattern5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatementArrayBindingPattern6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatementArrayBindingPattern7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatementDefaultValues.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatementNestedObjectBindingPattern.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatementNestedObjectBindingPatternWithDefaultValues.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatementObjectBindingPattern1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatementObjectBindingPattern2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatementObjectBindingPattern3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatementObjectBindingPattern4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationExportAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationExportAssignmentCommonjs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationFor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationForIn.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationFunctionPropertyAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationImport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationTryCatchFinally.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationWithComments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapWithCaseSensitiveFileNames.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapWithCaseSensitiveFileNamesAndOutDir.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapWithMultipleFilesWithCopyright.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapWithMultipleFilesWithFileEndingWithInterface.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapWithNonCaseSensitiveFileNames.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapWithNonCaseSensitiveFileNamesAndOutDir.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourcemapValidationDuplicateNames.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/specedNoStackBlown.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/specialIntersectionsInMappedTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/specializationError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/specializationOfExportedClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/specializationsShouldNotAffectEachOther.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/specializeVarArgs1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/specializedInheritedConstructors1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/specializedLambdaTypeArguments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/specializedOverloadWithRestParameters.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/specializedSignatureOverloadReturnTypeWithIndexers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionGlobal1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionGlobal2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionGlobal3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionGlobal4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionJSXAttribute.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionLeadingUnderscores01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadBooleanRespectsFreshness.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadExpressionContainingObjectExpressionContextualType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadExpressionContextualType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadExpressionContextualTypeWithNamespace.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadIdenticalTypesRemoved.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadIntersection.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadIntersectionJsx.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadInvalidArgumentType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadObjectNoCircular1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadObjectWithIndexDoesNotAddUndefinedToLocalIndex.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadOfObjectLiteralAssignableToIndexSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadOfParamsFromGeneratorMakesRequiredParams.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadTupleAccessedByTypeParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadTypeRemovesReadonly.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadUnionPropOverride.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadsAndContextualTupleTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/spuriousCircularityOnTypeImport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/stackDepthLimitCastingType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticAndMemberFunctions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticFieldWithInterfaceContext.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticGetter1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticGetter2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticGetterAndSetter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticIndexSignatureAndNormalIndexSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticInheritance.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticInstanceResolution.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticInstanceResolution2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticInstanceResolution3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticInstanceResolution5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticInterfaceAssignmentCompat.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMemberAccessOffDerivedType1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMemberOfClassAndPublicMemberOfAnotherClassAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMemberWithStringAndNumberNames.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMethodReferencingTypeArgument1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMethodWithTypeParameterExtendsClauseDeclFile.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMethodsReferencingClassTypeParameters.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMismatchBecauseOfPrototype.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticOffOfInstance1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticOffOfInstance2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticVisibility2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticsNotInScopeInClodule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictBooleanMemberAssignability.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictFunctionTypes1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictFunctionTypesErrors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictModeEnumMemberNameReserved.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictModeUseContextualKeyword.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictModeWordInExportDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictNullLogicalAndOr.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictNullNotNullIndexTypeNoLib.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictNullNotNullIndexTypeShouldWork.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictOptionalProperties2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictOptionalProperties3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictOptionalProperties4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictSubtypeAndNarrowing.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictTypeofUnionNarrowing.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringIncludes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringIndexerAndConstructor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringIndexerAndConstructor1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringIndexerAssignments1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringIndexerAssignments2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringLiteralObjectLiteralDeclaration1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringLiteralPropertyNameWithLineContinuation1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringMappingAssignability.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringMatchAll.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringPropCodeGen.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringRawType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringTrim.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/stripInternal1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/structural1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/styledComponentsInstantiaionLimitNotReached.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/subSubClassCanAccessProtectedConstructor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/subclassThisTypeAssignable01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/subclassThisTypeAssignable02.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/subclassUint8Array.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/subclassWithPolymorphicThisIsAssignable.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/substituteReturnTypeSatisfiesConstraint.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/substitutionTypeForIndexedAccessType2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/substitutionTypeForNonGenericIndexedAccessType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/substitutionTypeNoMergeOfAssignableType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/substitutionTypePassedToExtends.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/substitutionTypesCompareCorrectlyInRestrictiveInstances.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/substitutionTypesInIndexedAccessTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/subtypeReductionUnionConstraints.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/subtypeReductionWithAnyFunctionType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/subtypeRelationForNever.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/subtypingTransitivity.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/super2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/superAccessCastedCall.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/superAccessInFatArrow1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallArgsMustMatch.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallAssignResult.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatDerivesFromGenericType1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatDerivesFromGenericType2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatDerivesFromGenericTypeButWithIncorrectNumberOfTypeArguments1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatDerivesFromGenericTypeButWithNoTypeArguments1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatDerivesNonGenericTypeButWithTypeArguments1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallInNonStaticMethod.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallInStaticMethod.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallInsideObjectLiteralExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallWithCommentEmit01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallWithMissingBaseClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/superElementAccess.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/superHasMethodsFromMergedInterface.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/superInCatchBlock1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/superNoModifiersCrash.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/superPropertyAccessInComputedPropertiesOfNestedType_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/superPropertyAccess_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/superPropertyElementNoUnusedLexicalThisCapture.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/superWithGenericSpecialization.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/superWithGenerics.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/switchCaseCircularRefeference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/switchComparableCompatForBrands.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/symbolLinkDeclarationEmitModuleNames.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/symbolLinkDeclarationEmitModuleNamesImportRef.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/symbolLinkDeclarationEmitModuleNamesRootDir.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/symbolMergeValueAndImportedType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/symbolObserverMismatchingPolyfillsWorkTogether.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/symlinkedWorkspaceDependenciesNoDirectLinkGeneratesDeepNonrelativeName.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/symlinkedWorkspaceDependenciesNoDirectLinkGeneratesNonrelativeName.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/symlinkedWorkspaceDependenciesNoDirectLinkOptionalGeneratesNonrelativeName.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/symlinkedWorkspaceDependenciesNoDirectLinkPeerGeneratesNonrelativeName.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/syntheticDefaultExportsWithDynamicImports.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemDefaultImportCallable.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemJsForInNoException.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModule10.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModule11.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModule13.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModule14.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModule15.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModule16.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModule17.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModule18.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModule8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModuleAmbientDeclarations.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModuleConstEnums.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModuleConstEnumsSeparateCompilation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModuleNonTopLevelModuleMembers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModuleTargetES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModuleWithSuperClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemNamespaceAliasEmit.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemObjectShorthandRename.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/taggedPrimitiveNarrowing.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/taggedTemplatesInDifferentScopes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/targetTypeArgs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/targetTypeBaseCalls.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/targetTypeObjectLiteral.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/targetTypeObjectLiteralToAny.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/targetTypingOnFunctions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/templateExpressionAsPossiblyDiscriminantValue.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/templateExpressionNoInlininingOfConstantBindingWithInitializer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/templateLiteralConstantEvaluation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/templateLiteralIntersection.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/templateLiteralIntersection2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/templateLiteralIntersection3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/templateLiteralIntersection4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/templateLiteralsAndDecoratorMetadata.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/templateStringsArrayTypeRedefinedInES6Mode.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/testContainerList.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/testTypings.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisBinding2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisCapture1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisConditionalOnMethodReturnOfGenericInstance.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisExpressionInCallExpressionWithTypeArguments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisExpressionOfGenericObject.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInAccessors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInArrowFunctionInStaticInitializer1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInClassBodyStaticESNext.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInConstructorParameter1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInConstructorParameter2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInFunctionCall.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInFunctionCallJs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInGenericStaticMembers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInInnerFunctions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInLambda.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInModuleFunction1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInObjectJs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInPropertyBoundDeclarations.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInStaticMethod1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInStatics.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInTupleTypeParameterConstraints.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInTypeQuery.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisIndexOnExistingReadonlyFieldIsNotNever.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisShadowingErrorSpans.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisTypeAsConstraint.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisWhenTypeCheckFails.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/this_inside-object-literal-getters-and-setters.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/thislessFunctionsNotContextSensitive1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/thislessFunctionsNotContextSensitive2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/thislessFunctionsNotContextSensitive3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/toStringOnPrimitives.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/tooFewArgumentsInGenericFunctionTypedArgument.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/tooManyTypeParameters1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/topLevel.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/topLevelBlockExpando.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/topLevelExports.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/topLevelLambda2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/topLevelLambda3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/trackedSymbolsNoCrash.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/trailingCommaInHeterogenousArrayLiteral1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/transformsElideNullUndefinedType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/transitiveTypeArgumentInference1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/tripleSlashReferenceAbsoluteWindowsPath.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/truthinessCallExpressionCoercion.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/truthinessCallExpressionCoercion1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/truthinessCallExpressionCoercion2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/truthinessCallExpressionCoercion3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/truthinessCallExpressionCoercion4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/truthinessPromiseCoercion.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/tryCatchFinallyControlFlow.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsconfigMapOptionsAreCaseInsensitive.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/tslibInJs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/tslibMissingHelper.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/tslibMultipleMissingHelper.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/tslibNotFoundDifferentModules.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/tslibReExportHelpers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/tslibReExportHelpers2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxAttributeQuickinfoTypesSameAsObjectLiteral.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxAttributesHasInferrableIndex.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxDeepAttributeAssignabilityError.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxDefaultImports.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxDiscriminantPropertyInference.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxFragmentChildrenCheck.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxInferenceShouldNotYieldAnyOnUnions.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxInvokeComponentType.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxNotUsingApparentTypeOfSFC.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxReactPropsInferenceSucceedsOnIntersections.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxResolveExternalModuleExportsTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxSpreadDoesNotReportExcessProps.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxStatelessComponentDefaultProps.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxTypeArgumentPartialDefinitionStillErrors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxUnionMemberChecksFilterDataProps.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxUnionSpread.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/tupleTypeInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/tupleTypeInference2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/tupleTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/twiceNestedKeyofIndexInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAliasDoesntMakeModuleInstantiated.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAliasExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAnnotationBestCommonTypeInArrayLiteral.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgInference2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgInference2WithError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgInferenceWithNull.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentConstraintResolution1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentDefaultUsesConstraintOnCircularDefault.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentInferenceApparentType1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentInferenceApparentType2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentInferenceOrdering.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentInferenceWithConstraintAsCommonRoot.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentInferenceWithRecursivelyReferencedTypeAliasToTypeLiteral01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentInferenceWithRecursivelyReferencedTypeAliasToTypeLiteral02.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAssertionToGenericFunctionType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAssignabilityErrorMessage.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeCheckObjectCreationExpressionWithUndefinedCallResolutionData.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeCheckObjectLiteralMethodBody.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeCheckReturnExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeCheckTypeArgument.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeComparisonCaching.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeConstraintsWithConstructSignatures.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardConstructorNarrowAny.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardConstructorNarrowPrimitivesInUnion.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardConstructorPrimitiveTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowByMutableUntypedField.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowByUntypedField.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty10.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty11.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty12.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardOnContainerTypeNoHang.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeIdentityConsidersBrands.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInfer1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInferenceCacheInvalidation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInferenceFBoundedTypeParams.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInferenceLiteralUnion.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInferenceReturnTypeCallback.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInferenceTypePredicate.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInferenceTypePredicate2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInferenceWithExcessProperties.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInferenceWithExcessPropertiesJsx.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeLiteralCallback.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeMatch1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeMatch2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeName1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeOfOnTypeArg.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeOfPrototype.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeOfSuperCall.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeOfThisInStatics.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeOfYieldWithUnionInContextualReturnType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParamExtendsOtherTypeParam.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterAndArgumentOfSameName1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterAssignmentCompat1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterCompatibilityAccrossDeclarations.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterConstrainedToOuterTypeParameter2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterConstraintInstantiation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterConstraints1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterEquality.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterExtendingUnion1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterExtendingUnion2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterExtendsPrimitive.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterFixingWithConstraints.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterLeak.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterOrderReversal.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParametersAndParametersInComputedNames.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParametersInStaticAccessors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParametersInStaticMethods.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParametersInStaticProperties.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParametersShouldNotBeEqual.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParametersShouldNotBeEqual2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParametersShouldNotBeEqual3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePartameterConstraintInstantiatedWithDefaultWhenCheckingDefault.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicateAcceptingPartialOfRefinedType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicateFreshLiteralWidening.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicateInLoop.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicateInherit.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicateTopLevelTypeParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicateWithThisParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicatesCanNarrowByDiscriminant.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicatesInUnion.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicatesInUnion2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicatesInUnion3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicatesInUnion_noMatch.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicatesOptionalChaining1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicatesOptionalChaining2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicatesOptionalChaining3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectiveScopedPackageCustomTypeRoot.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectiveWithTypeAsFile.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives10.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives11.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives12.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives13.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeResolution.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeRootsFromMultipleNodeModulesDirectories.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeRootsFromNodeModulesInParentDirectory.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeUsedAsTypeLiteralIndex.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeUsedAsValueError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeUsedAsValueError2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeVal.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeVariableConstraintIntersections.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeVariableConstraintedToAliasNotAssignableToUnion.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeVariableTypeGuards.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typedArrays-es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typedArrays.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typedArraysCrossAssignability01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typedArraysSubarray.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typedGenericPrototypeMember.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofAmbientExternalModules.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofEnum.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofExternalModules.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofImportInstantiationExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofInObjectLiteralType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofInterface.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofInternalModules.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofObjectInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofSimple.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofStripsFreshness.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofThisInMethodSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofUndefined.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofUsedBeforeBlockScoped.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/umdGlobalConflict.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unaryPlus.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/uncalledFunctionChecksInConditional2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/uncaughtCompilerError1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/undeclaredModuleError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedArgumentInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedAssignableToGenericMappedIntersection.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedTypeArgument1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedTypeArgument2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/underscoreEscapedNameInEnum.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/underscoreMapFirst.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/underscoreTest1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/underscoreThisInDerivedClass01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/underscoreThisInDerivedClass02.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unicodeEscapesInJSDoc.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionCallMixedTypeParameterPresence.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionErrorMessageOnMatchingDiscriminant.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionExcessPropertyCheckNoApparentPropTypeMismatchErrors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionExcessPropsWithPartialMember.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionOfArraysFilterCall.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionOfClassCalls.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionOfEnumInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionOfFunctionAndSignatureIsCallable.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionReductionMutualSubtypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionReductionWithStringMappingAndIdenticalBaseTypeExistsNoCrash.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionRelationshipCheckPasses.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionSignaturesWithThisParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionSubtypeReductionErrors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionTypeErrorMessageTypeRefs01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionTypeParameterInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionTypeWithIndexAndMethodSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionTypeWithIndexAndTuple.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionTypeWithIndexedLiteralType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionTypeWithLeadingOperator.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionTypeWithRecursiveSubtypeReduction1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionTypeWithRecursiveSubtypeReduction2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionTypeWithRecursiveSubtypeReduction3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionWithIndexSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/uniqueSymbolAllowsIndexInObjectWithIndexSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/uniqueSymbolAssignmentOnGlobalAugmentationSuceeds.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/uniqueSymbolJs2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unknownLikeUnionObjectFlagsNotPropagated.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unknownPropertiesAreAssignableToObjectUnion.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unknownSymbolInGenericReturnType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unknownSymbols2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unknownTypeArgOnCall.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unknownTypeErrors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unmetTypeConstraintInImportCall.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unqualifiedCallToClassStatic1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unresolvableSelfReferencingAwaitedUnion.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unresolvedTypeAssertionSymbol.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unspecializedConstraints.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/untypedFunctionCallsWithTypeParameters1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/untypedModuleImport_withAugmentation2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedClassesinModule1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedClassesinNamespace5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedDestructuring.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedDestructuringParameters.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedIdentifiersConsolidated1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImportDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImportWithSpread.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports10.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports11.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports12.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports13.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports14.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports15.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports16.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports_entireImportDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedInvalidTypeArguments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsAndObjectSpread.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsAndObjectSpread2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsAndParametersDeferred.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsAndParametersOverloadSignatures.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsAndParametersTypeAliases.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsInForInOrOf1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsInMethod1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsInMethod2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsInMethod3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsStartingWithUnderscore.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedMethodsInInterface.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedMultipleParameters1InMethodDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedMultipleParameters2InMethodDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParameterProperty1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParameterProperty2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParametersInLambda1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParametersInLambda2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParametersThis.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParametersWithUnderscore.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateMethodInClass1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateMethodInClass2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateMethodInClass3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateMethodInClass4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateStaticMembers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateVariableInClass1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateVariableInClass2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateVariableInClass3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateVariableInClass4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateVariableInClass5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedSetterInClass2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedSingleParameterInMethodDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInInterface2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInLambda1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInLambda2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInLambda3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInMethod1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInMethod2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInMethod3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInMethod4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInMethod5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters10.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParametersCheckedByNoUnusedParameters.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParametersNotCheckedByNoUnusedLocals.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParametersWithUnderscore.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters_infer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters_templateTag.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters_templateTag2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesWithUnderscoreInBindingElement.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesWithUnderscoreInForOfLoop.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesinNamespaces2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesinNamespaces3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/unwitnessedTypeParameterVariance.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration_destructuring.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration_jsx.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration_propertyAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration_superClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDefinitionInDeclarationFiles.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/useUnknownInCatchVariables01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/usingModuleWithExportImportInValuePosition.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/validUseOfThisInSuper.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/valueOfTypedArray.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/varArgsOnConstructorTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/varAsID.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/vararg.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/vardecl.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/variableDeclarationDeclarationEmitUniqueSymbolPartialStatement.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/varianceAnnotationValidation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/varianceCallbacksAndIndexedAccesses.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/varianceCantBeStrictWhileStructureIsnt.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/varianceMeasurement.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/varianceProblingAndZeroOrderIndexSignatureRelationsAlign.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/varianceProblingAndZeroOrderIndexSignatureRelationsAlign2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/variancePropagation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/varianceRepeatedlyPropegatesWithUnreliableFlag.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/verbatim-declarations-parameters.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/verifyDefaultLib_dom.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/verifyDefaultLib_webworker.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/visibilityOfCrossModuleTypeUsage.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/visibilityOfTypeParameters.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/voidIsInitialized.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/voidReturnIndexUnionInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/voidUndefinedReduction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/vueLikeDataAndPropsInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/vueLikeDataAndPropsInference2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/weakType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/weakTypeAndPrimitiveNarrowing.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/webworkerIterable.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/wellKnownSymbolExpando.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/widenToAny1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/widenToAny2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/widenedTypes1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/withExportDecl.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/withImportDecl.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/wrappedIncovations1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/wrappedIncovations2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/wrappedRecursiveGenericType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/yieldExpression1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/compiler/yieldStarContextualType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/additionalChecks/noPropertyAccessFromIndexSignature1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientDeclarations.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientDeclarationsExternal.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientDeclarationsPatterns.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientDeclarationsPatterns_merging1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientDeclarationsPatterns_merging2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientDeclarationsPatterns_tooManyAsterisks.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientEnumDeclaration1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientEnumDeclaration2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientExternalModuleMerging.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientShorthand.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientShorthand_declarationEmit.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientShorthand_duplicate.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientShorthand_merging.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientShorthand_reExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction10_es2017.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction1_es2017.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunctionCapturesArguments_es2017.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunctionCapturesThis_es2017.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncUnParenthesizedArrowFunction_es2017.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncAwaitIsolatedModules_es2017.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncAwait_es2017.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncMethodWithSuperConflict_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncMethodWithSuper_es2017.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncUseStrict_es2017.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitBinaryExpression/awaitBinaryExpression1_es2017.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitBinaryExpression/awaitBinaryExpression2_es2017.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitBinaryExpression/awaitBinaryExpression3_es2017.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitBinaryExpression/awaitBinaryExpression4_es2017.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitBinaryExpression/awaitBinaryExpression5_es2017.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpression/awaitCallExpression1_es2017.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpression/awaitCallExpression2_es2017.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpression/awaitCallExpression3_es2017.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpression/awaitCallExpression4_es2017.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpression/awaitCallExpression5_es2017.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpression/awaitCallExpression6_es2017.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpression/awaitCallExpression7_es2017.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpression/awaitCallExpression8_es2017.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitClassExpression_es2017.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitInheritedPromise_es2017.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration11_es2017.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration13_es2017.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration14_es2017.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration1_es2017.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration8_es2017.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncAliasReturnType_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction10_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction1_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunctionCapturesArguments_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunctionCapturesThis_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncUnParenthesizedArrowFunction_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncAwaitIsolatedModules_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncAwait_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncImportedPromise_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncMethodWithSuper_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncQualifiedReturnType_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncUseStrict_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitBinaryExpression/awaitBinaryExpression1_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitBinaryExpression/awaitBinaryExpression2_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitBinaryExpression/awaitBinaryExpression3_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitBinaryExpression/awaitBinaryExpression4_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitBinaryExpression/awaitBinaryExpression5_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression1_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression2_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression3_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression4_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression5_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression6_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression7_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression8_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitClassExpression_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitUnion_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration11_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration13_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration14_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration15_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration1_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration8_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/asyncGenerators/asyncGeneratorGenericNonWrappedReturn.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/asyncGenerators/asyncGeneratorPromiseNextType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractAsIdentifier.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractClinterfaceAssignability.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractExtends.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractGeneric.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractImportInstantiation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInAModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInheritance1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInheritance2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractOverrideWithAbstract.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractSuperCalls.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractUsingAbstractMethod1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAndInterfaceMerge.d.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAndInterfaceMergeConflictingMembers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAndInterfaceWithSameName.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classBody/classWithEmptyBody.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classDeclarationLoop.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classExtendingBuiltinType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classExtendingClassLikeType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classExtendingNonConstructor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classExtendingNull.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classAppearsToHaveMembersOfObject.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendingClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendsItselfIndirectly.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendsItselfIndirectly2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendsItselfIndirectly3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendsShadowedConstructorFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classIsSubtypeOfBaseType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/constructorFunctionTypeIsAssignableToBaseType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/constructorFunctionTypeIsAssignableToBaseType2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/derivedTypeDoesNotRequireExtendsClause.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classImplementsMergedClassInterface.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/mergedClassInterface.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/mergedInheritedClassInterface.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/modifierOnClassDeclarationMemberInFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classExpression3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classExpression4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classExpression5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classExpressionLoop.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/extendClassExpressionFromModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/genericClassExpressionInFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/modifierOnClassExpressionMemberInFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock12.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock14.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock17.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock27.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock28.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlockUseBeforeDef3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlockUseBeforeDef4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlockUseBeforeDef5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/automaticConstructors/classWithoutExplicitConstructor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/automaticConstructors/derivedClassWithoutExplicitConstructor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/automaticConstructors/derivedClassWithoutExplicitConstructor2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/automaticConstructors/derivedClassWithoutExplicitConstructor3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorAccessibility.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorAccessibility2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorAccessibility3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorAccessibility4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorAccessibility5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorParametersAccessibility.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorParametersAccessibility2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorParametersAccessibility3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/constructorImplementationWithDefaultValues.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/constructorImplementationWithDefaultValues2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/constructorOverloadsWithOptionalParameters.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/declarationEmitReadonly.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/readonlyConstructorAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorWithAssignableReturnExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorWithExpressionLessReturn.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/quotedConstructors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/superCalls/emitStatementsBeforeSuperCall.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/superCalls/emitStatementsBeforeSuperCallWithDefineFields.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/indexMemberDeclarations/staticIndexers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/classPropertyAsPrivate.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/classPropertyAsProtected.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/classPropertyIsPublicByDefault.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/privateClassPropertyAccessibleWithinClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/privateProtectedMembersAreNotAccessibleDestructuring.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/privateStaticMemberAccessibility.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/privateStaticNotAccessibleInClodule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/privateStaticNotAccessibleInClodule2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/protectedStaticClassPropertyAccessibleWithinSubclass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/protectedStaticNotAccessibleInClodule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/classTypes/genericSetterInClassType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/classTypes/genericSetterInClassTypeJsDoc.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/classTypes/indexersInClassType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/classTypes/instancePropertiesInheritedIntoClassType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/classTypes/instancePropertyInClassType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/constructorFunctionTypes/classWithBaseClassButNoConstructor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/constructorFunctionTypes/classWithNoConstructorOrBaseClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/constructorFunctionTypes/classWithStaticMembers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/constructorFunctionTypes/constructorHasPrototypeProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassFunctionOverridesBaseClassAccessor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassIncludesInheritedMembers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassOverridesIndexersWithAssignmentCompatibility.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassOverridesPrivates.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassOverridesProtectedMembers4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassOverridesPublicMembers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassOverridesWithoutSubtype.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassTransitivity.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassTransitivity2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassTransitivity3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassTransitivity4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassWithAny.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassWithPrivateStaticShadowingPublicStatic.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedGenericClassWithAny.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOfThisInInstanceMember2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOfThisInStaticMembers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOfThisInStaticMembers2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOfThisInstanceMemberNarrowedWithLoopAntecedent.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameAccessors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameAccessorsCallExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameAmbientNoImplicitAny.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameCircularReference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameClassExpressionLoop.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameConstructorSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameEmitHelpers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameField.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameFieldAccess.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameFieldAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameFieldCallExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameFieldClassExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameFieldInitializer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameFieldParenthesisLeftAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameFieldUnaryMutation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameInLhsReceiverExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameLateSuper.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameMethod.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameMethodAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameMethodAsync.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameMethodCallExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameMethodInStaticFieldInit.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameNestedClassNameConflict.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameReadonly.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameSetterExprReturnValue.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameSetterNoGetter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticAccessors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticAccessorsCallExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticEmitHelpers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticFieldAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticFieldCallExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticFieldClassExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticFieldUnaryMutation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticMethod.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticMethodAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticMethodCallExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticMethodInStaticFieldInit.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameUnused.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesAndFields.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesAndkeyof.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesUnique-1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesUnique-4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesUnique-5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesUseBeforeDef.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateStaticNameShadowing.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateWriteOnlyAccessorRead.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/typeFromPrivatePropertyAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/typeFromPrivatePropertyAssignmentJs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/mixinAbstractClasses.2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/mixinAbstractClasses.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/mixinAbstractClassesReturnTypeInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/mixinAccessors1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/mixinAccessors2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/mixinAccessors3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/mixinAccessors4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/mixinAccessors5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/mixinClassesAnnotated.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/mixinClassesAnonymous.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/mixinClassesMembers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideMethod.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty10.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationES2022.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationESNext.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessor10.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessor8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessor9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessorNoUseDefineForClassFields.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/constructorParameterShadowsOuterScopes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/constructorParameterShadowsOuterScopes2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/initializerReferencingConstructorParameters.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/instanceMemberInitialization.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/instanceMemberWithComputedPropertyName.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/instanceMemberWithComputedPropertyName2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberAccessorDeclarations/accessorsAreNotContextuallyTyped.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberAccessorDeclarations/typeOfThisInAccessor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/derivedTypeAccessesHiddenBaseCallViaSuperPropertyAccess.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/instanceMemberAssignsToClassPrototype.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/memberFunctionsWithPrivateOverloads.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/memberFunctionsWithPublicOverloads.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/staticFactory1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/staticMemberAssignsToConstructorFunctionMembers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/typeOfThisInMemberFunctions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/overrideInterfaceProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/propertyOverridesAccessors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/propertyOverridesAccessors2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/propertyOverridesAccessors3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/propertyOverridesAccessors5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/propertyOverridesAccessors6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/propertyOverridesMethod.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticAndNonStaticPropertiesSameName.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticMemberInitialization.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyAndFunctionWithSameName.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflictsInAmbientContext.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/strictPropertyInitialization.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/thisInInstanceMemberInitializer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/thisPropertyOverridesAccessors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/staticIndexSignature/staticIndexSignature1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/staticIndexSignature/staticIndexSignature2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/staticIndexSignature/staticIndexSignature3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/staticIndexSignature/staticIndexSignature6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/staticIndexSignature/staticIndexSignature7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnum1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnum3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnumPropertyAccess1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnumPropertyAccess3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/assertionTypePredicates2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/constLocalsInFunctionExpressions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowAliasing2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowAssignmentExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowAssignmentPatternOrder.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowBinaryOrExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowBindingElement.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowBindingPatternOrder.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowComputedPropertyNames.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowDestructuringDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowDoWhileStatement.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowElementAccess.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowElementAccess2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowElementAccessNoCrash1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowForInStatement.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowForInStatement2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowForOfStatement.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowForStatement.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowIIFE.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowIfStatement.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowInOperator.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowInstanceOfGuardPrimitives.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowInstanceofExtendsFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowIteration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowIterationErrors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowIterationErrorsAsync.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowNullishCoalesce.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowOptionalChain2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowOptionalChain3.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowStringIndex.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowSuperPropertyAccess.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowTypeofObject.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowWhileStatement.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowWithTemplateLiterals.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/dependentDestructuredVariables.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/dependentDestructuredVariablesFromNestedPatterns.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/dependentDestructuredVariablesWithExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/neverReturningFunctions1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/switchWithConstrainedTypeVariable.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/typeGuardsAsAssertions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/typeGuardsNestedAssignments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/typeGuardsTypeParameters.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/anonymousClassAccessorsDeclarationEmit1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/classDoesNotDependOnPrivateMember.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/declarationEmitWorkWithInlineComments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/exportDefaultNamespace.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/leaveOptionalParameterAsWritten.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/libReferenceDeclarationEmit.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/libReferenceDeclarationEmitBundle.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/libReferenceNoLib.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/libReferenceNoLibBundle.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/nullPropertyName.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typePredicates/declarationEmitIdentifierPredicates01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typePredicates/declarationEmitIdentifierPredicatesWithPrivateName01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typePredicates/declarationEmitThisPredicates01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typePredicates/declarationEmitThisPredicates02.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typePredicates/declarationEmitThisPredicatesWithPrivateName01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typePredicates/declarationEmitThisPredicatesWithPrivateName02.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typeReferenceRelatedFiles.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typeofImportTypeOnlyExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typesVersionsDeclarationEmit.ambient.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typesVersionsDeclarationEmit.multiFile.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typesVersionsDeclarationEmit.multiFileBackReferenceToSelf.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typesVersionsDeclarationEmit.multiFileBackReferenceToUnmapped.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratedClassExportsCommonJS1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratedClassExportsCommonJS2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratedClassExportsSystem1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratedClassExportsSystem2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratedClassFromExternalModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod13.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod14.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod15.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod16.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod18.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty13.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorCallGeneric.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorInAmbientContext.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorMetadataWithTypeOnlyImport2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/legacyDecorators-contextualTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/directives/multiline.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/directives/ts-expect-error.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpression1ES2020.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpression2ES2020.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpression3ES2020.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpression4ES2020.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpression5ES2020.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpression6ES2020.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionAsyncES2020.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionAsyncES6AMD.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionAsyncES6CJS.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionAsyncES6System.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionAsyncES6UMD.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionCheckReturntype1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionDeclarationEmit2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionDeclarationEmit3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionES6AMD.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionES6CJS.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionES6System.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionES6UMD.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionErrorInES2015.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInAMD1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInAMD2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInAMD3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInAMD4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInCJS1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInCJS2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInCJS3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInCJS4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInCJS5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInExportEqualsAMD.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInExportEqualsCJS.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInExportEqualsUMD.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInSystem1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInSystem2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInSystem3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInSystem4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInUMD1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInUMD2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInUMD3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInUMD4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionNestedAMD.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionNestedCJS.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionNestedES2015.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionNestedES2020.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionNestedSystem.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionNestedUMD.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionNoModuleKindSpecified.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionReturnPromiseOfAny.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionShouldNotGetParen.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionSpecifierNotStringTypeError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/emitter/es2015/asyncGenerators/emitter.asyncGenerators.classMethods.es2015.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/emitter/es2015/asyncGenerators/emitter.asyncGenerators.objectLiteralMethods.es2015.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/emitter/es2018/asyncGenerators/emitter.asyncGenerators.classMethods.es2018.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/emitter/es2018/asyncGenerators/emitter.asyncGenerators.objectLiteralMethods.es2018.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/enums/enumBasics.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/enums/enumClassification.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/enums/enumConstantMemberWithString.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/enums/enumConstantMemberWithStringEmitDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/enums/enumConstantMemberWithTemplateLiterals.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/enums/enumConstantMemberWithTemplateLiteralsEmitDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/enums/enumErrorOnConstantBindingWithInitializer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/enums/enumExportMergingES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/enums/enumMerging.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/enums/enumShadowedInfinityNaN.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2016/es2016IntlAPIs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2017/es2017DateAPIs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2017/useObjectValuesAndEntries3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2017/useObjectValuesAndEntries4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2017/useSharedArrayBuffer4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2018/es2018IntlAPIs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2018/useRegexpGroups.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2019/globalThisTypeIndexAccess.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/bigintMissingES2019.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/bigintMissingES2020.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/bigintMissingESNext.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/constructBigint.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/es2020IntlAPIs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/intlNumberFormatES2020.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/localesObjectArgument.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/modules/exportAsNamespace5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2021/es2021LocalesObjectArgument.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2021/intlDateTimeFormatRangeES2021.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2021/logicalAssignment/logicalAssignment9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2022/arbitraryModuleNamespaceIdentifiers/arbitraryModuleNamespaceIdentifiers_exportEmpty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2022/es2022IntlAPIs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2022/es2022LocalesObjectArgument.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2022/es2024SharedMemory.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2023/intlNumberFormatES2023.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2024/resizableArrayBuffer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2024/sharedMemory.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2024/transferableArrayBuffer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2025/float16Array.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2025/intlDurationFormat.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2025/regExpEscape.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2025/syncIteratorHelpers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit10.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit11.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit13.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit14.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty10.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty11.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty12.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty13.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty14.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty15.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty16.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty17.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty18.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty19.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty20.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty21.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty22.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty23.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty24.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty25.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty26.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty27.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty28.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty29.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty30.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty31.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty32.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty33.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty34.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty35.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty37.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty38.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty40.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty41.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty45.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty46.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty47.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty48.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty49.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty50.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty51.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty55.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty56.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty57.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty58.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty60.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty61.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType10.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType11.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType12.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType14.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType15.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType16.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType17.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType18.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments01_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments09_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments10_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments18_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments19_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/binaryAndOctalIntegerLiteral/binaryIntegerLiteralES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/binaryAndOctalIntegerLiteral/octalIntegerLiteralES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithConstructorInES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithExtensionAndTypeArgumentInES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithExtensionInES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithGetterSetterInES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithLiteralPropertyNameInES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithMethodInES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithPropertyAccessInHeritageClause1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithPropertyAssignmentInES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithStaticPropertyAssignmentInES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithSuperMethodCall01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithThisKeywordInES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithTypeArgumentAndOverloadInES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithTypeArgumentInES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/exportDefaultClassWithStaticPropertyAssignmentsInES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/superCallBeforeThisAccessing1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/superCallBeforeThisAccessing2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/superCallBeforeThisAccessing5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/superCallBeforeThisAccessing8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classExpressions/classExpressionES63.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classExpressions/typeArgumentInferenceWithClassExpression1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classExpressions/typeArgumentInferenceWithClassExpression2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classExpressions/typeArgumentInferenceWithClassExpression3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames10_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames11_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames13_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames16_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames18_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames1_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames20_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames22_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames25_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames28_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames29_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames31_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames32_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames33_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames34_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames35_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames36_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames37_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames38_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames39_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames41_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames42_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames43_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames44_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames45_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames46_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames47_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames48_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames4_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames7_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType10_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType1_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType2_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType3_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType4_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType5_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType6_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType7_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType8_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType9_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesDeclarationEmit1_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesDeclarationEmit2_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesDeclarationEmit3_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesDeclarationEmit4_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesDeclarationEmit5_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesOnOverloads_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesSourceMap1_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesSourceMap2_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesWithStaticProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/accessor/decoratorOnClassAccessor1.es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/decoratorOnClass2.es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/decoratorOnClass3.es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/decoratorOnClass5.es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/decoratorOnClass6.es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/decoratorOnClass7.es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/decoratorOnClass8.es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/method/decoratorOnClassMethod1.es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/method/parameter/decoratorOnClassMethodParameter1.es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/property/decoratorOnClassProperty1.es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/defaultParameters/emitDefaultParametersFunctionPropertyES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/defaultParameters/emitDefaultParametersMethodES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/declarationInAmbientContext.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment1ES5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment1ES5iterable.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment1ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment5SiblingInitializer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringAssignabilityCheck.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringCatch.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringInFunctionType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment1ES5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment1ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment9SiblingInitializer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration3ES5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration3ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringVariableDeclaration1ES5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringVariableDeclaration1ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringVariableDeclaration2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringWithLiteralInitializers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringWithLiteralInitializers2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyAssignmentPatterns02_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyAssignmentPatterns04_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyObjectBindingPatternParameter04.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern10.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern11.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern12.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern13.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern14.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern15.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern16.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern17.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern18.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern19.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern20.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern21.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern22.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern23.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern24.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern25.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern26.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern27.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern28.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern29.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern30.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/nonIterableRestElement3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/objectBindingPatternKeywordIdentifiers05.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/objectBindingPatternKeywordIdentifiers06.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/optionalBindingParameters4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/optionalBindingParametersInOverloads1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/optionalBindingParametersInOverloads2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/restElementWithBindingPattern.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of12.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of13.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of14.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of15.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of16.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of17.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of18.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of19.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of20.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of21.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of22.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of23.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of25.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of26.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of27.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of28.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of29.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of30.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of31.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of33.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of34.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of35.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of37.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of38.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of39.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of40.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of41.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of42.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of43.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of44.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of45.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of46.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of47.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of48.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of49.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of50.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of57.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of58.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration9_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/functionPropertyAssignments/FunctionPropertyAssignments1_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/functionPropertyAssignments/FunctionPropertyAssignments5_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/memberFunctionDeclarations/MemberFunctionDeclaration1_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/memberFunctionDeclarations/MemberFunctionDeclaration2_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/memberFunctionDeclarations/MemberFunctionDeclaration3_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/memberFunctionDeclarations/MemberFunctionDeclaration7_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/moduleExportsAmd/decoratedDefaultExportsGetExportedAmd.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/moduleExportsAmd/outFilerootDirModuleNamesAmd.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/moduleExportsCommonjs/decoratedDefaultExportsGetExportedCommonjs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/moduleExportsSystem/decoratedDefaultExportsGetExportedSystem.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/moduleExportsSystem/outFilerootDirModuleNamesSystem.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/moduleExportsUmd/decoratedDefaultExportsGetExportedUmd.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/defaultExportInAwaitExpression01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/defaultExportInAwaitExpression02.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportBinding.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportSpellingSuggestion.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports1-es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports2-es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports3-es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports4-es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/newTarget/newTarget.es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/newTarget/newTargetNarrowing.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/propertyAccess/propertyAccessNumericLiterals.es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/restParameters/emitRestParametersFunctionPropertyES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/restParameters/emitRestParametersMethodES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentErrorFromMissingIdentifier.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesFunctionArgument.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesFunctionArgument2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesWithModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesWithModuleES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/arraySpreadInCall.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray10.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray11.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInCall.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInCall10.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInCall11.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInCall12.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInCall2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInCall3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInCall4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInCall5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInCall6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInCall7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInCall8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInCall9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsTypeArgumentInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsTypeArgumentInferenceES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithIncompatibleTypedTags.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithIncompatibleTypedTagsES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithManyCallAndMemberExpressions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithManyCallAndMemberExpressionsES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution2_ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithTypedTags.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithTypedTagsES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateUntypedTagCall01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplatesWithTypeArguments1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInInOperator.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInInOperatorES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInInstanceOf.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInInstanceOfES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInPropertyAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInPropertyAssignmentES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedInOperator.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedInOperatorES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedInstanceOf.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedInstanceOfES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedNewOperator.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedNewOperatorES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedObjectLiteral.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedObjectLiteralES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedUnaryPlus.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedUnaryPlusES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithPropertyAccess.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithPropertyAccessES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression10_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression11_es6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorInAmbientContext5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorNoImplicitReturns.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorOverloads4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorOverloads5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck10.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck11.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck12.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck13.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck17.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck18.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck19.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck20.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck21.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck22.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck23.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck24.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck25.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck26.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck27.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck28.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck29.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck30.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck31.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck41.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck42.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck43.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck44.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck45.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck46.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck48.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck52.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck53.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck54.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck56.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck59.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck62.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck63.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck64.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSIsReference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithEnum.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithEnumUnion.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithInvalidOperands.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-commonjs-classNamespaceMerge.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-commonjs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/esDecorators-contextualTypes.2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/esDecorators-contextualTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/esDecorators-preservesThis.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/esnext/esnextSharedMemory.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/arrayLiterals/arrayLiteralInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/arrayLiterals/arrayLiterals.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/arrayLiterals/arrayLiterals2ES5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/arrayLiterals/arrayLiterals2ES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/arrayLiterals/arrayLiterals3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/asOperator/asOperator1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/assignmentOperator/assignmentGenericLookupTypeNarrowing.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/assignmentOperator/assignmentLHSIsReference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/assignmentOperator/assignmentTypeNarrowing.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentLHSCannotBeAssigned.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/assignmentOperator/compoundAssignmentLHSIsReference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithAnyAndEveryType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithConstrainedTypeParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithInvalidOperands.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithNumberAndEnum.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithStringAndEveryType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithEnum.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithEnumUnion.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithInvalidOperands.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIntersectionType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnOptionalProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipPrimitiveType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNumberOperand.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNumericLiteral.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsAny.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsUndefined.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeEnumAndNumber.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnIndexSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnOptionalProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithTypeParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithValidOperands.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithInvalidOperands.es2015.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithInvalidOperands.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithInvalidStaticToString.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithLHSIsObject.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithRHSHasSymbolHasInstance.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithRHSIsSubtypeOfFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/logicalAndOperator/logicalAndOperatorStrictMode.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/logicalAndOperator/logicalAndOperatorWithEveryType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/logicalOrOperator/logicalOrExpressionIsContextuallyTyped.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/logicalOrOperator/logicalOrExpressionIsNotContextuallyTyped.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/logicalOrOperator/logicalOrOperatorWithEveryType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/logicalOrOperator/logicalOrOperatorWithTypeParameters.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/commaOperator/commaOperatorWithSecondOperandAnyType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/commaOperator/commaOperatorWithSecondOperandBooleanType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/commaOperator/commaOperatorWithSecondOperandNumberType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/commaOperator/commaOperatorWithSecondOperandObjectType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/commaOperator/commaOperatorWithSecondOperandStringType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/commaOperator/commaOperatorsMultipleOperators.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/conditonalOperator/conditionalOperatorConditionIsBooleanType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/conditonalOperator/conditionalOperatorConditionIsNumberType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/conditonalOperator/conditionalOperatorConditionIsObjectType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/conditonalOperator/conditionalOperatorConditoinIsAnyType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/conditonalOperator/conditionalOperatorConditoinIsStringType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/conditonalOperator/conditionalOperatorWithIdenticalBCT.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/conditonalOperator/conditionalOperatorWithoutIdenticalBCT.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/argumentExpressionContextualTyping.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/functionExpressionContextualTyping1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/generatedContextualTyping.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/iterableContextualTyping1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/objectLiteralContextualTyping.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/parenthesizedContexualTyping1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/parenthesizedContexualTyping2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/parenthesizedContexualTyping3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/superCallParameterContextualTyping1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/superCallParameterContextualTyping2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/superCallParameterContextualTyping3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/taggedTemplateContextualTyping1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/taggedTemplateContextualTyping2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/elementAccess/stringEnumInElementAccess01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/callOverload.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/callWithMissingVoid.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/callWithSpread.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/callWithSpread4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/callWithSpreadES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/forgottenNew.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/functionCalls.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/newWithSpread.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/newWithSpreadES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/overloadResolution.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/overloadResolutionConstructors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/typeArgumentInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstructSignatures.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceTransitiveConstraints.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConstraints.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithObjectLiteral.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functions/arrowFunctionExpressions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functions/contextuallyTypedFunctionExpressionsAndReturnAnnotations.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functions/contextuallyTypedIife.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functions/contextuallyTypedIifeStrict.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functions/typeOfThisInFunctionExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functions/voidParamAssignmentCompatibility.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/identifiers/scopeResolutionIdentifiers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/newOperator/newOperatorConformance.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/newOperator/newOperatorErrorCases_noImplicitAny.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingAssignmentVsPrivateFieldsJsEmit1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator12.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/objectLiterals/objectLiteralGettersAndSetters.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/objectLiterals/objectLiteralNormalization.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/callChain/callChain.2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/callChain/callChain.3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/callChain/callChain.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/callChain/callChainInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/callChain/superMethodCall.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/callChain/thisMethodCall.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/delete/deleteChain.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/elementAccessChain/elementAccessChain.2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/elementAccessChain/elementAccessChain.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/optionalChainingInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/propertyAccessChain/propertyAccessChain.2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/propertyAccessChain/propertyAccessChain.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/superCalls/superCalls.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/superPropertyAccess/superSymbolIndexedAccess1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/superPropertyAccess/superSymbolIndexedAccess2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/superPropertyAccess/superSymbolIndexedAccess3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/thisKeyword/typeOfThisGeneral.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/thisKeyword/typeOfThisInConstructorParamList.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeAssertions/constAssertionOnEnum.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/TypeGuardWithArrayUnion.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/TypeGuardWithEnumUnion.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/nullOrUndefinedTypeGuardIsOrderIndependent.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardFunctionGenerics.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardFunctionOfFormThis.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardIntersectionTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardNarrowsPrimitiveIntersection.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardNarrowsToLiteralType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardNarrowsToLiteralTypeUnion.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormExpr1AndExpr2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormExpr1OrExpr2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormFunctionEquality.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormInstanceOfOnInterface.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormIsType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormIsTypeOnInterfaces.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfBoolean.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfEqualEqualHasNoEffect.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfNotEqualHasNoEffect.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfNumber.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfOther.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfPrimitiveSubtype.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfString.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFromPropNameInUnionType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsDefeat.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInClassMethods.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInConditionalExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInDoStatement.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInExternalModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInForStatement.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInFunctionAndModuleBlock.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInGlobal.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInRightOperandOfAndAndOperator.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInWhileStatement.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsOnClassProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typePredicateASI.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfactionWithDefaultExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_asConstArrays.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_contextualTyping1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_contextualTyping2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_contextualTyping3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_ensureInterfaceImpl.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_errorLocations1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_propertyValueConformance3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_vacuousIntersectionOfContextualTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/bitwiseNotOperator/bitwiseNotOperatorWithBooleanType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/bitwiseNotOperator/bitwiseNotOperatorWithEnumType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/bitwiseNotOperator/bitwiseNotOperatorWithNumberType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/bitwiseNotOperator/bitwiseNotOperatorWithStringType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithNumberType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithEnumType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithNumberType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/logicalNotOperator/logicalNotOperatorWithBooleanType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/logicalNotOperator/logicalNotOperatorWithEnumType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/logicalNotOperator/logicalNotOperatorWithNumberType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/logicalNotOperator/logicalNotOperatorWithStringType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/negateOperator/negateOperatorWithBooleanType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/negateOperator/negateOperatorWithEnumType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/negateOperator/negateOperatorWithNumberType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/negateOperator/negateOperatorWithStringType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/plusOperator/plusOperatorWithBooleanType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/plusOperator/plusOperatorWithEnumType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/plusOperator/plusOperatorWithNumberType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/plusOperator/plusOperatorWithStringType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/typeofOperator/typeofOperatorWithBooleanType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/typeofOperator/typeofOperatorWithEnumType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/typeofOperator/typeofOperatorWithNumberType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/typeofOperator/typeofOperatorWithStringType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/voidOperator/voidOperatorWithBooleanType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/voidOperator/voidOperatorWithEnumType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/voidOperator/voidOperatorWithNumberType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/voidOperator/voidOperatorWithStringType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/valuesAndReferences/assignments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/amdImportAsPrimaryExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/amdImportNotAsPrimaryExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/commonJSImportAsPrimaryExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/commonJSImportNotAsPrimaryExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/commonJsImportBindingElementNarrowType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/es6/es6modulekind.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/es6/es6modulekindWithES2015Target.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/esnext/esnextmodulekind.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/esnext/esnextmodulekindWithES2015Target.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignDottedName.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignImportedIdentifier.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentCircularModules.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentConstrainedGenericType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentGenericType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentMergedInterface.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentMergedModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentOfExportNamespaceWithDefault.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentTopLevelClodule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentTopLevelEnumdule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentTopLevelFundule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentTopLevelIdentifier.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportDeclaredModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportNonLocalDeclarations.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportNonVisibleType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportTypeMergedWithExportStarAsNamespace.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/globalAugmentationModuleResolution.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/importImportOnlyModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/importNonExternalModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithExtensions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithoutExtension1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithoutExtension2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithoutExtension5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithoutExtension6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithoutExtension7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithoutExtension8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleScoping.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/nameDelimitedBySlashes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/nameWithFileExtension.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/nameWithRelativePaths.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/reexportClassDefinition.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/relativePathToDeclarationFile.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/topLevelAmbientModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/topLevelFileModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeAndNamespaceExportMerge.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/allowsImportingTsExtension.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/ambient.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/chained.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/circular1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/circular2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/circular3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/circular4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/cjsImportInES2015.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/computedPropertyName.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/enums.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportDeclaration_moduleSpecifier-isolatedModules.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportDeclaration_moduleSpecifier.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportDeclaration_value.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace10.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/extendsClause.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/filterNamespace_import.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/generic.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/implementsClause.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importClause_default.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importClause_namedImports.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importClause_namespaceImport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importDefaultNamedType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importDefaultNamedType2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importDefaultNamedType3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importEquals1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importEquals3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importsNotUsedAsValues_error.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/mergedWithLocalValue.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/namespaceImportTypeQuery.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/namespaceImportTypeQuery2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/namespaceImportTypeQuery3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/namespaceImportTypeQuery4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/nestedNamespace.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/preserveValueImports_importsNotUsedAsValues.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/preserveValueImports_mixedImports.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/renamed.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/typeQuery.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnlyMerge1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnlyMerge2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeValueMerge1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typesOnlyExternalModuleStillHasInstance.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd-augmentation-1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd-augmentation-2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd-augmentation-3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd-augmentation-4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/verbatimModuleSyntaxConstEnum.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/verbatimModuleSyntaxConstEnumUsage.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/verbatimModuleSyntaxDeclarationFile.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/verbatimModuleSyntaxInternalImportEquals.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/verbatimModuleSyntaxNoElisionCJS.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/verbatimModuleSyntaxNoElisionESM.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/functions/functionImplementations.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/functions/strictBindCallApply1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/functions/strictBindCallApply2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorAssignability.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorExplicitReturnType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnContextualType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnTypeFallback.5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnTypeIndirectReferenceToGlobalType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnTypeInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnTypeInferenceNonStrict.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorYieldContextualType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/importAttributes/importAttributes11.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/importAttributes/importAttributes7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/importAttributes/importAttributes8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/importAttributes/importAttributes9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/importDefer/importDefaultBindingDefer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/importDefer/importDeferDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/inferFromBindingPattern.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/genericAndNonGenericInterfaceWithTheSameName2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergeThreeInterfaces.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergeThreeInterfaces2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergeTwoInterfaces.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergeTwoInterfaces2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInheritedMembersSatisfyAbstractBase.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithConflictingPropertyNames.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithConflictingPropertyNames2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithIndexers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithIndexers2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithInheritedPrivates.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithInheritedPrivates2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithInheritedPrivates3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithMultipleBases.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithMultipleBases2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithMultipleBases3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithMultipleBases4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/twoMergedInterfacesWithDifferingOverloads.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/twoMergedInterfacesWithDifferingOverloads2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/derivedInterfaceIncompatibleWithBaseIndexer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersection.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceThatHidesBaseProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceThatHidesBaseProperty2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceThatIndirectlyInheritsFromItself.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithCallSignaturesThatHidesBaseSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithCallSignaturesThatHidesBaseSignature2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithConstructSignaturesThatHidesBaseSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithConstructSignaturesThatHidesBaseSignature2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithMultipleBaseTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithMultipleBaseTypes2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithOverloadedCallAndConstructSignatures.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithPropertyOfEveryType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithPropertyThatIsPrivateInBaseType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithPropertyThatIsPrivateInBaseType2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithSpecializedCallAndConstructSignatures.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithStringIndexerHidingBaseTypeIndexer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithStringIndexerHidingBaseTypeIndexer2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithStringIndexerHidingBaseTypeIndexer3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfacesExtendingClasses/implementingAnInterfaceExtendingClassWithPrivates.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfacesExtendingClasses/implementingAnInterfaceExtendingClassWithProtecteds.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtendingClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtendingClassWithPrivates.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtendingClassWithPrivates2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtendingClassWithProtecteds.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtendingClassWithProtecteds2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/AmbientModuleAndAmbientFunctionWithTheSameNameAndCommonRoot.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/AmbientModuleAndAmbientWithSameNameAndCommonRoot.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/AmbientModuleAndNonAmbientClassWithSameNameAndCommonRoot.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/AmbientModuleAndNonAmbientFunctionWithTheSameNameAndCommonRoot.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithModuleMemberThatUsesClassTypeParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithModulesExportedStaticFunctionUsingClassPrivateStatics.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithStaticFunctionAndNonExportedFunctionThatShareAName.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithStaticVariableAndNonExportedVarThatShareAName.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleWithSameNameAndCommonRoot.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleWithSameNameAndCommonRootES6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/EnumAndModuleWithSameNameAndCommonRoot.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/FunctionAndModuleWithSameNameAndCommonRoot.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/FunctionAndModuleWithSameNameAndDifferentCommonRoot.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ModuleAndEnumWithSameNameAndCommonRoot.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesThatMergeEachWithExportedAndNonExportedClassesOfTheSameName.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesThatMergeEachWithExportedAndNonExportedInterfacesOfTheSameName.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesThatMergeEachWithExportedAndNonExportedLocalVarsOfTheSameName.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesThatMergeEachWithExportedInterfacesOfTheSameName.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesThatMergeEachWithExportedLocalVarsOfTheSameName.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesThatMergeEachWithExportedModulesOfTheSameName.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesWithTheSameNameAndDifferentCommonRoot.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesWithTheSameNameAndSameCommonRoot.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/codeGeneration/exportCodeGen.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/codeGeneration/importStatements.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/codeGeneration/importStatementsInterfaces.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/codeGeneration/nameCollision.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportClassWhichExtendsInterfaceWithInaccessibleType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportClassWithAccessibleTypesInTypeParameterConstraintsClassHeritageListMemberTypeAnnotations.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportClassWithInaccessibleTypeInIndexerTypeAnnotations.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportClassWithInaccessibleTypeInTypeParameterConstraint.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportFunctionWithAccessibleTypesInParameterAndReturnTypeAnnotation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportFunctionWithInaccessibleTypesInParameterTypeAnnotation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportFunctionWithInaccessibleTypesInReturnTypeAnnotation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportInterfaceWithAccessibleTypesInTypeParameterConstraintsClassHeritageListMemberTypeAnnotations.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportInterfaceWithInaccessibleTypeInIndexerTypeAnnotations.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportInterfaceWithInaccessibleTypeInTypeParameterConstraint.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportModuleWithAccessibleTypesOnItsExportedMembers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportObjectLiteralAndObjectTypeLiteralWithAccessibleTypesInMemberTypeAnnotations.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportObjectLiteralAndObjectTypeLiteralWithAccessibleTypesInNestedMemberTypeAnnotations.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportVariableOfGenericTypeWithInaccessibleTypeAsTypeArgument.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportVariableWithAccessibleTypeInTypeAnnotation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportVariableWithInaccessibleTypeInTypeAnnotation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/importDeclarations/circularImportAlias.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/importDeclarations/exportImportAlias.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/importDeclarations/importAliasIdentifiers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/importDeclarations/invalidImportAliasIdentifiers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleBody/moduleWithStatementsOfEveryKind.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/InvalidNonInstantiatedModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/asiPreventsParsingAsNamespace05.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/instantiatedModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/nestedModules.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/nonInstantiatedModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/reExportAliasMakesInstantiated.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/assertionsAndNonReturningFunctions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/callbackCrossModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/callbackOnConstructor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/callbackTag1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/callbackTag2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/callbackTag4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/callbackTagNestedParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkExportsObjectAssignProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocSatisfiesTag1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocSatisfiesTag12.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocSatisfiesTag13.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocSatisfiesTag15.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocSatisfiesTag2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocSatisfiesTag3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocSatisfiesTag4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocSatisfiesTag5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocSatisfiesTag8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocSatisfiesTag9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocTypeTag4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocTypeTag6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocTypeTag7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocTypeTagOnObjectProperty1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocTypeTagOnObjectProperty2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocTypedefInParamTag1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkObjectDefineProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/constructorTagOnNestedBinaryExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/constructorTagWithThisTag.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsClassAccessor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsClassMethod.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsClassStatic2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsCommonjsRelativePath.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsConstsAsNamespacesWithReferences.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsExportDefinePropertyEmit.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsExportDoubleAssignmentInClosure.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsExportedClassAliases.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsFunctionWithDefaultAssignedMember.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsFunctions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsFunctionsCjs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsGetterSetter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsImportAliasExposedWithinNamespace.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsImportAliasExposedWithinNamespaceCjs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsImportTypeBundled.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsJSDocRedirectedLookups.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsNestedParams.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsNonIdentifierInferredNames.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsOptionalTypeLiteralProps1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsOptionalTypeLiteralProps2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsParameterTagReusesInputNodeInEmit1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsParameterTagReusesInputNodeInEmit2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsPrivateFields01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsReferenceToClassInstanceCrossFile.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsReusesExistingTypeAnnotations.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsSubclassWithExplicitNoArgumentConstructor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsThisTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsTypeAliases.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsTypeReassignmentFromDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsTypeReassignmentFromDeclaration2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsTypedefAndImportTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsTypedefAndLatebound.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsTypedefFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsTypedefPropertyAndExportAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsUniqueSymbolUsage.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/enumTagCircularReference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/enumTagImported.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/enumTagOnExports.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/enumTagOnExports2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/enumTagUseBeforeDefCrash.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/errorIsolation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/exportedAliasedEnumTag.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/exportedEnumTypeAndValue.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/extendsTag1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/extendsTag2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/extendsTag3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/extendsTag5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/extendsTag6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag17.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag23.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag24.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag25.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/inferThis.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocAccessibilityTags.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocAccessibilityTagsDeclarations.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocAugments_errorInExtendsExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocAugments_nameMismatch.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocAugments_notAClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocAugments_qualifiedName.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocAugments_withTypeParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocFunctionType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocFunction_missingReturn.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocImplementsTag.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocImplements_class.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocImplements_interface.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocImplements_interface_multiple.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocImplements_namespacedInterface.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocImplements_properties.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocImplements_signatures.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocImportType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocImportType2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocImportTypeReferenceToClassAlias.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocImportTypeReferenceToCommonjsModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocImportTypeReferenceToESModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocLinkTag1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocLinkTag2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocLinkTag3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocLinkTag4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocLinkTag5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocLinkTag6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocLinkTag7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocLinkTag8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocLinkTag9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocOverrideTag1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocParamTagTypeLiteral.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocParseDotDotDotInJSDocFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocParseParenthesizedJSDocParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocPostfixEqualsAddsOptionality.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocPrivateName1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocPrototypePropertyAccessWithType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocReadonly.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocReadonlyDeclarations.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTemplateClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTemplateConstructorFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTemplateConstructorFunction2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTemplateTag.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTemplateTag2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTemplateTag4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTemplateTag5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTemplateTag6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTemplateTagNameResolution.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTypeFromChainedAssignment2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTypeFromChainedAssignment3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTypeReferenceExports.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTypeReferenceToImport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTypeReferenceToImportOfClassExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTypeReferenceToImportOfFunctionExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTypeReferenceToMergedClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTypeTag.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTypeTagOnParameter1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocVariadicType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/moduleExportsElementAccessAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/moduleExportsElementAccessAssignment2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/overloadTag3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/paramTagBracketsAddOptionalUndefined.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/paramTagOnCallExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/paramTagOnFunctionUsingArguments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/paramTagTypeResolution.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/paramTagTypeResolution2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/returnTagTypeGuard.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/seeTag1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/templateInsideCallback.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/thisPrototypeMethodCompoundAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/thisPrototypeMethodCompoundAssignmentJs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/thisTag1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/tsNoCheckForTypescript.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/tsNoCheckForTypescriptComments1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/tsNoCheckForTypescriptComments2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/typeTagCircularReferenceOnConstructorFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/typeTagModuleExports.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/typeTagOnPropertyAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/typeTagPrototypeAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/typedefCrossModule.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/typedefMultipleTypeParameters.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/typedefOnSemicolonClassElement.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/typedefTagExtraneousProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/typedefTagNested.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenCanBeTupleType.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty1.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty10.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty11.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty12.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty13.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty14.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty15.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty16.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty2.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty3.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty4.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty5.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty6.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty7.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty8.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty9.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxGenericTagHasCorrectInferences.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxIntersectionElementPropsType.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxSubtleSkipContextSensitiveBug.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxUnionSFXContextualTypeInferredCorrectly.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/commentEmittingInPreserveJsx1.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/correctlyMarkAliasAsReferences1.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/correctlyMarkAliasAsReferences2.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/correctlyMarkAliasAsReferences3.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/correctlyMarkAliasAsReferences4.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/inline/inlineJsxAndJsxFragPragma.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/inline/inlineJsxAndJsxFragPragmaOverridesCompilerOptions.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/inline/inlineJsxFactoryDeclarations.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/inline/inlineJsxFactoryDeclarationsLocalTypes.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/inline/inlineJsxFactoryLocalTypeGlobalFallback.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/inline/inlineJsxFactoryOverridesCompilerOption.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/inline/inlineJsxFactoryWithFragmentIsError.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxReactTestSuite.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxSpreadOverwritesAttributeStrict.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeErrors.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution1.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution10.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution11.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution12.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution14.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution15.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution16.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution3.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution5.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution6.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution7.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution8.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution9.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxCorrectlyParseLessThanComparison1.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDefaultAttributesResolution1.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDefaultAttributesResolution2.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDefaultAttributesResolution3.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName4.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName5.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName6.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName7.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName8.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName9.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution10.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution11.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution12.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution13.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution14.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution15.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution16.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution17.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution18.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution19.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution2.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution3.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution4.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution5.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution9.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxEmit1.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxEmit2.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxEmit3.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxExternalModuleEmit1.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxExternalModuleEmit2.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxFragmentPreserveEmit.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxFragmentReactEmit.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType1.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType2.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType3.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType4.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType5.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType6.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType7.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType8.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType9.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxInArrowFunction.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxIntrinsicAttributeErrors.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxLibraryManagedAttributes.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxNamespacedAttributeName1.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxNamespacedAttributeName2.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxOpeningClosingNames.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxParseTests1.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxParseTests2.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxPreserveEmit3.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactComponentWithDefaultTypeParameter1.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactComponentWithDefaultTypeParameter2.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactComponentWithDefaultTypeParameter3.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit1.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit2.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit4.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit5.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit6.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit7.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitEntities.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitNesting.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitWhitespace.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitWhitespace2.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSfcReturnNull.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSfcReturnNullStrictNullChecks.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSfcReturnUndefinedStrictNullChecks.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution1.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution10.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution11.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution12.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution13.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution14.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution15.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution16.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution17.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution2.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution3.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution4.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution5.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution6.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution7.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution8.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution9.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadChildren.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadInvalidType.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload1.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload2.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload3.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload4.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload5.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload6.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentWithDefaultTypeParameter1.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentWithDefaultTypeParameter2.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponents3.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments1.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments2.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments3.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments4.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments5.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxTypeArgumentsJsxPreserveOutput.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxTypeErrors.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionElementType1.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionElementType2.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionElementType3.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionElementType4.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionElementType5.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionElementType6.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionTypeComponent1.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionTypeComponent2.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/declarationNotFoundPackageBundlesTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/importFromDot.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/node10IsNode_node.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/node10IsNode_node10.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/packageJsonMain.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/packageJsonMain_isNonRecursive.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/resolutionModeCache.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/scopedPackages.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/scopedPackagesClassic.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/selfNameModuleAugmentation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/typesVersions.ambientModules.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/typesVersions.emptyTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/typesVersions.justIndex.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/typesVersions.multiFile.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/untypedModuleImport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/untypedModuleImport_noImplicitAny.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/untypedModuleImport_noImplicitAny_relativePath.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/untypedModuleImport_noImplicitAny_scoped.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/untypedModuleImport_noImplicitAny_typesForPackageExist.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/untypedModuleImport_vsAmbient.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/untypedModuleImport_withAugmentation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/node/allowJs/nodeAllowJsPackageSelfName2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/node/esmModuleExports1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/node/esmModuleExports3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesPackageImportsRootWildcard.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesPackageImportsRootWildcardNode16.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeOverrideOldResolutionError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/nonjsExtensions/declarationFileForHtmlFileWithinDeclarationFile.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override10.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override13.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override14.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override15.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override19.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override20.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override21.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/overrideWithoutNoImplicitOverride1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override_js1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override_js2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override_js4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript3/Accessors/parserES3Accessors2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript3/Accessors/parserES3Accessors4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/AutomaticSemicolonInsertion/parserAutomaticSemicolonInsertion1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/CatchClauses/parserCatchClauseWithTypeAnnotation1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClass1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration16.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration17.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration19.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration20.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration23.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration26.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclarationIndexSignature1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnumDeclaration1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnumDeclaration3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnumDeclaration5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnumDeclaration6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserInterfaceKeywordInEnum.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserInterfaceKeywordInEnum1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/AccessibilityAfterStatic/parserAccessibilityAfterStatic11.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/AccessibilityAfterStatic/parserAccessibilityAfterStatic14.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/AccessibilityAfterStatic/parserAccessibilityAfterStatic2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/AccessibilityAfterStatic/parserAccessibilityAfterStatic3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/AccessibilityAfterStatic/parserAccessibilityAfterStatic4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/AccessibilityAfterStatic/parserAccessibilityAfterStatic5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/IncompleteMemberVariables/parserErrorRecovery_IncompleteMemberVariable1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ParameterLists/parserErrorRecovery_ParameterList6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserCommaInTypeMemberList1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserModifierOnPropertySignature2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ExportAssignments/parserExportAssignment6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Expressions/parserConditionalExpression1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguity1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguityWithBinaryOperator4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserCastVersusArrowFunction1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserConstructorAmbiguity1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserConstructorAmbiguity2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserConstructorAmbiguity3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserConstructorAmbiguity4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInInterfaceDeclaration1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInVariableDeclaration1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserObjectCreation1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexMemberDeclarations/parserIndexMemberDeclaration1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexMemberDeclarations/parserIndexMemberDeclaration2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexMemberDeclarations/parserIndexMemberDeclaration3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexMemberDeclarations/parserIndexMemberDeclaration4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexMemberDeclarations/parserIndexMemberDeclaration6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexSignatures/parserIndexSignature4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexSignatures/parserIndexSignature5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/InterfaceDeclarations/parserInterfaceDeclaration9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberVariableDeclarations/parserMemberVariableDeclaration5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature10.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature11.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature12.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModule1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModuleDeclaration11.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModuleDeclaration2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ObjectLiterals/parserObjectLiterals1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ObjectTypes/parserObjectType2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ObjectTypes/parserObjectType3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ObjectTypes/parserObjectType4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertyAssignments/parserFunctionPropertyAssignment1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertyAssignments/parserFunctionPropertyAssignment2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertyAssignments/parserFunctionPropertyAssignment3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertyAssignments/parserFunctionPropertyAssignment4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature10.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature11.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature12.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Protected/Protected5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Protected/Protected8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Protected/Protected9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RealWorld/parserindenter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509546.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509546_1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509546_2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509677.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser630933.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser643728.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser645484.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parserNotHexLiteral1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpression4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpression5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/ReturnStatements/parserReturnStatement4.js
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/ReturnStatements/parserReturnStatement4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserForStatement9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Types/parserTypeQuery8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parser15.4.4.14-9-2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserArgumentList1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserExportAsFunctionIdentifier.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserInExpression1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserKeywordsAsIdentifierName1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserOptionalTypeMembers1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserOverloadOnConstants1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserRealSource1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserRealSource12.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserRealSource2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserRealSource3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserRealSource5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserS7.2_A1.5_T2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserS7.6_A4.2_T1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserUnicode1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserUsingConstructorAsIdentifier.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parservoidInQualifiedName2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName10.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName11.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName12.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName13.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName14.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName15.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName17.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName18.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName19.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName20.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName21.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName22.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName23.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName24.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName25.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName28.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName29.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName31.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName32.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName40.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement11.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement12.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement13.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement14.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement15.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement16.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement25.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolIndexer1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolIndexer2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolIndexer3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolIndexer4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/pedantic/noUncheckedIndexedAccess.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/pedantic/noUncheckedIndexedAccessDestructuring.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/references/library-reference-1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/references/library-reference-10.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/references/library-reference-11.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/references/library-reference-12.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/references/library-reference-13.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/references/library-reference-14.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/references/library-reference-15.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/references/library-reference-2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/references/library-reference-3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/references/library-reference-4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/references/library-reference-5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/references/library-reference-6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/references/library-reference-7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/references/library-reference-8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/references/library-reference-scoped-packages.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/annotatedThisPropertyInitializerDoesntNarrow.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/assignmentToVoidZero1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/binderUninitializedModuleExportsAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/chainedPrototypeAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/checkSpecialPropertyAssignments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/circularMultipleAssignmentDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/classCanExtendConstructorFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/commonJSAliasedExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/commonJSImportClassTypeReference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/commonJSImportExportedClassExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/commonJSImportNestedClassTypeReference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/commonJSReexport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/conflictingCommonJSES2015Exports.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/constructorFunctionMergeWithClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/constructorFunctionMethodTypeParameters.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/constructorFunctions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/constructorFunctions2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/constructorFunctions3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/constructorFunctionsStrict.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/constructorNameInObjectLiteralAccessor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/contextualTypedSpecialAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/defaultPropertyAssignedClassWithPrototype.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/enumMergeWithExpando.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/exportNestedNamespaces.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/exportPropertyAssignmentNameResolution.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/globalMergeWithCommonJSAssignmentDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/inferingFromAny.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/inferringClassMembersFromAssignments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/inferringClassMembersFromAssignments2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/inferringClassMembersFromAssignments3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/inferringClassMembersFromAssignments4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/inferringClassMembersFromAssignments5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/inferringClassMembersFromAssignments6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/inferringClassMembersFromAssignments7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/inferringClassStaticMembersFromAssignments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/jsContainerMergeJsContainer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/jsContainerMergeTsDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/jsContainerMergeTsDeclaration2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/jsContainerMergeTsDeclaration3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/jsObjectsMarkedAsOpenEnded.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/jsdocConstructorFunctionTypeReference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/lateBoundAssignmentDeclarationSupport1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/lateBoundAssignmentDeclarationSupport2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/lateBoundAssignmentDeclarationSupport3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/lateBoundAssignmentDeclarationSupport4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/lateBoundAssignmentDeclarationSupport5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/lateBoundAssignmentDeclarationSupport6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/lateBoundAssignmentDeclarationSupport7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/lateBoundClassMemberAssignmentJS.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/lateBoundClassMemberAssignmentJS2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/lateBoundClassMemberAssignmentJS3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/malformedTags.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/methodsReturningThis.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportAlias.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportAlias2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportAlias3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportAlias4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportAlias5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportAliasElementAccessExpression.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportAliasExports.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportAliasImported.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportAssignment2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportAssignment3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportAssignment4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportAssignment5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportAssignment6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportAssignment7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportDuplicateAlias.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportDuplicateAlias2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportDuplicateAlias3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportNestedNamespaces.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportPropertyAssignmentDefault.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportWithExportPropertyAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/multipleDeclarations.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/namespaceAssignmentToRequireAlias.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/nestedDestructuringOfRequire.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/nestedPrototypeAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/plainJSGrammarErrors2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/privateConstructorFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/propertiesOfGenericConstructorFunctions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/propertyAssignmentUseParentType1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/propertyAssignmentUseParentType2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/propertyAssignmentUseParentType3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/prototypePropertyAssignmentMergeAcrossFiles.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/prototypePropertyAssignmentMergeWithInterfaceMethod.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/prototypePropertyAssignmentMergedTypeReference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/reExportJsFromTs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/requireAssertsFromTypescript.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/requireTwoPropertyAccesses.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/sourceFileMergeWithFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/spellingUncheckedJS.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/thisPropertyAssignmentCircular.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/thisPropertyAssignmentComputed.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/thisPropertyAssignmentInherited.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/thisTypeOfConstructorFunctions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/topLevelThisAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromContextualThisType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromJSConstructor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromJSInitializer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromJSInitializer2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromJSInitializer3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromJSInitializer4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromParamTagForFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment10.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment10_1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment11.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment12.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment13.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment14.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment15.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment16.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment17.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment18.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment19.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment20.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment22.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment23.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment24.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment25.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment27.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment30.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment31.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment32.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment33.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment34.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment35.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment36.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment37.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment38.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment39.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment40.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment8_1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment9.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment9_1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignmentWithExport.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPrototypeAssignment3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPrototypeAssignment4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/unannotatedParametersAreOptional.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/varRequireFromJavascript.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/varRequireFromTypescript.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannerEnum1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannerS7.2_A1.5_T2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannerS7.6_A4.2_T1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannertest1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/everyTypeWithAnnotationAndInitializer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/everyTypeWithAnnotationAndInvalidInitializer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/everyTypeWithInitializer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/invalidMultipleVariableDeclarations.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarationsWithAsyncIteratorObject.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarationsWithIteratorObject.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithIteratorObject.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithObjectLiterals1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/validMultipleVariableDeclarations.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-inStatements/for-inStatements.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-inStatements/for-inStatementsArray.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-inStatements/for-inStatementsAsyncIdentifier.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/forStatements/forStatements.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/forStatements/forStatementsMultipleInvalidDecl.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/forStatements/forStatementsMultipleValidDecl.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/ifDoWhileStatements/ifDoWhileStatements.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/returnStatements/invalidReturnStatements.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/returnStatements/returnStatements.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/switchStatements/switchStatements.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/throwStatements/throwInEnclosingStatements.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/throwStatements/throwStatements.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/tryStatements/tryStatements.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/any/anyAsGenericFunctionCall.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/any/assignAnyToEveryType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/any/assignEveryTypeToAny.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/any/narrowExceptionVariableInCatchClause.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/any/narrowFromAnyWithInstanceof.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/conditional/conditionalTypes2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/conditional/conditionalTypesExcessProperties.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/conditional/inferTypes2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/conditional/inferTypesInvalidExtendsDeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/conditional/inferTypesWithExtends1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/conditional/inferTypesWithExtends2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/conditional/variance.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/asyncFunctions/contextuallyTypeAsyncFunctionAwaitOperand.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/asyncFunctions/contextuallyTypeAsyncFunctionReturnType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/jsdoc/contextualTypeFromJSDoc.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/jsxAttributes/contextuallyTypedStringLiteralsInJsxAttributes01.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/jsxAttributes/contextuallyTypedStringLiteralsInJsxAttributes02.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTypedBindingInitializer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTypedBindingInitializerNegative.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTypedClassExpressionMethodDeclaration01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTypedClassExpressionMethodDeclaration02.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTypedObjectLiteralMethodDeclaration01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/partiallyAnnotatedFunction/partiallyAnnotatedFunctionInferenceError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/partiallyAnnotatedFunction/partiallyAnnotatedFunctionInferenceWithTypeParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/forAwait/types.forAwait.es2018.1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/forAwait/types.forAwait.es2018.2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeAmbient.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeAmbientMissing.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeAmdBundleRewrite.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeGenericTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeInJSDoc.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeLocal.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeLocalMissing.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/commonTypeIntersection.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/contextualIntersectionType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionAndUnionTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionAsWeakTypeSource.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionMemberOfUnionNarrowsCorrectly.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionNarrowing.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionOfUnionNarrowing.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionOfUnionOfUnitTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionThisTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionTypeAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionTypeEquivalence.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionTypeInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionTypeInference2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionTypeInference3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionTypeMembers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionTypeReadonly.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionWithUnionConstraint.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionsAndEmptyObjects.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/operatorsAndIntersectionTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/recursiveIntersectionTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/keyof/circularIndexedAccessErrors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/keyof/keyofAndForIn.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/keyof/keyofIntersection.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/booleanLiteralTypes1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/booleanLiteralTypes2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/enumLiteralTypes1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/enumLiteralTypes2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/enumLiteralTypes3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/literalTypeWidening.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/literalTypes1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/literalTypes2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/literalTypes3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/literalTypesAndDestructuring.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/literalTypesAndTypeAssertions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/literalTypesWidenInParameterPosition.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/numericLiteralTypes1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/numericLiteralTypes2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/numericStringLiteralTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringEnumLiteralTypes1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringEnumLiteralTypes2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringEnumLiteralTypes3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringLiteralsAssertionsInEqualityComparisons02.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringLiteralsAssignedToStringMappings.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringLiteralsWithEqualityChecks03.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringLiteralsWithEqualityChecks04.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringMappingDeferralInConditionalTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringMappingOverPatternLiterals.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringMappingReduction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/templateLiteralTypes2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/templateLiteralTypes3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/templateLiteralTypes4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/templateLiteralTypes5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/templateLiteralTypes6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/templateLiteralTypes7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/templateLiteralTypes8.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/templateLiteralTypesPatterns.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/localTypes/localTypes2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/localTypes/localTypes3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/localTypes/localTypes5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/isomorphicMappedTypeInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeAsClauseRecursiveNoCrash1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeAsClauseRelationships.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeAsClauses.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeConstraints.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeConstraints2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeErrors2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeIndexSignatureModifiers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeInferenceErrors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeModifiers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeOverlappingStringEnumKeys.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeRelationships.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypes1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypes2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypes3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypes4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypes5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypes6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypesAndObjects.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypesArraysTuples.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypesGenericTuples.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypesGenericTuples2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/recursiveMappedTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/augmentedTypeAssignmentCompatIndexSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/augmentedTypeBracketAccessIndexSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/classWithPrivateProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/classWithProtectedProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/classWithPublicProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeHidingMembersOfExtendedObject.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeHidingMembersOfObject.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeHidingMembersOfObjectAssignmentCompat.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeHidingMembersOfObjectAssignmentCompat2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypePropertyAccess.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithCallSignatureAppearsToBeFunctionType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithCallSignatureHidingMembersOfExtendedFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithCallSignatureHidingMembersOfFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithCallSignatureHidingMembersOfFunctionAssignmentCompat.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithConstructSignatureAppearsToBeFunctionType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithConstructSignatureHidingMembersOfExtendedFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithConstructSignatureHidingMembersOfFunction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithConstructSignatureHidingMembersOfFunctionAssignmentCompat.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithNumericProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithStringAndNumberIndexSignatureToAny.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithStringIndexerHidingObjectIndexer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithStringNamedPropertyOfIllegalCharacters.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/typesWithOptionalProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/typesWithPublicConstructor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/typesWithSpecializedCallSignatures.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/typesWithSpecializedConstructSignatures.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/namedTypes/classWithOptionalParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/namedTypes/genericInstantiationEquivalentToObjectLiteral.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/namedTypes/optionalMethods.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/never/neverInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/never/neverIntersectionNotCallable.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/never/neverType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/never/neverTypeErrors1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/never/neverTypeErrors2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/never/neverUnionIntersection.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/assignObjectToNonPrimitive.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveAndEmptyObject.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveAndTypeVariables.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveAsProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveAssignError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveConstraintOfIndexAccessType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveUnionIntersection.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignatureWithoutAnnotationsOrBody.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignatureWithoutReturnTypeAnnotationInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesThatDifferOnlyByReturnType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesThatDifferOnlyByReturnType2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesThatDifferOnlyByReturnType3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithOptionalParameters.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithOptionalParameters2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/identicalCallSignatures3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/parametersWithNoAnnotationAreAny.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/specializedSignatureIsSubtypeOfNonSpecializedSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/stringLiteralTypesInImplementationSignatures.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterAsTypeArgument.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/indexSignatures/numericIndexerConstrainsPropertyDeclarations.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/indexSignatures/numericIndexerConstrainsPropertyDeclarations2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/indexSignatures/numericIndexingResults.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/indexSignatures/stringIndexerConstrainsPropertyDeclarations.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/indexSignatures/stringIndexerConstrainsPropertyDeclarations2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/indexSignatures/stringIndexingResults.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/methodSignatures/functionLiterals.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/methodSignatures/methodSignaturesWithOverloads2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/objectTypeLiteralSyntax.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/propertySignatures/propertyNameWithoutTypeAnnotation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/propertySignatures/propertyNamesOfReservedWords.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/propertySignatures/stringNamedPropertyAccess.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/boolean/assignFromBooleanInterface.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/boolean/assignFromBooleanInterface2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/boolean/boolInsteadOfBoolean.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/boolean/booleanPropertyAccess.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/boolean/extendBooleanInterface.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/boolean/invalidBooleanAssignments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/boolean/validBooleanAssignments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/enum/invalidEnumAssignments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/enum/validEnumAssignments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/null/directReferenceToNull.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/null/validNullAssignments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/number/assignFromNumberInterface.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/number/assignFromNumberInterface2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/number/extendNumberInterface.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/number/invalidNumberAssignments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/number/numberPropertyAccess.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/number/validNumberAssignments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/string/assignFromStringInterface.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/string/assignFromStringInterface2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/string/extendStringInterface.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/string/invalidStringAssignments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/string/stringPropertyAccess.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/string/stringPropertyAccessWithError.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/string/validStringAssignments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/undefined/directReferenceToUndefined.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/undefined/invalidUndefinedAssignments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/undefined/invalidUndefinedValues.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/undefined/validUndefinedAssignments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/undefined/validUndefinedValues.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/void/invalidAssignmentsToVoid.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/void/invalidVoidAssignments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/void/invalidVoidValues.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/void/validVoidValues.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/rest/genericObjectRest.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/rest/genericRestParameters1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/rest/genericRestParameters2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/rest/genericRestParameters3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/rest/objectRest.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/rest/objectRest2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/rest/objectRestAssignment.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/rest/objectRestCatchES5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/rest/objectRestForOf.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/rest/objectRestParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/rest/objectRestReadonly.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/rest/restTuplesFromContextualTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeLiterals/arrayLiteral.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeLiterals/arrayOfFunctionTypes3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeLiterals/arrayTypeOfFunctionTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeLiterals/arrayTypeOfFunctionTypes2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeLiterals/arrayTypeOfTypeOf.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeLiterals/parenthesizedTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeLiterals/unionTypeLiterals.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/circularTypeofWithVarOrFunc.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/recursiveTypesWithTypeof.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeQueryOnClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeQueryWithReservedWords.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofClass2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofClassWithPrivates.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofModuleWithoutExports.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpreadComputedProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpreadIndexSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpreadNoTransform.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpreadRepeatedComplexity.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpreadRepeatedNullCheckPerf.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpreadSetonlyAccessor.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpreadStrictNull.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadContextualTypedBindingPattern.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadDuplicate.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadDuplicateExact.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadExcessProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadNonObject1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadNonPrimitive.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadObjectOrFalsy.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadOverwritesProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadOverwritesPropertyStrict.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadTypeVariable.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadUnion.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadUnion2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadUnion3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadUnion4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralCheckedInIf02.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAndTuples01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAsTags01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAsTags02.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAsTags03.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesInUnionTypes01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesInUnionTypes02.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesInUnionTypes03.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesInUnionTypes04.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloads03.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesTypePredicates01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/contextualThisType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/contextualThisTypeInJavascript.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/fluentClasses.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/fluentInterfaces.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/inferThisType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeAccessibility.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeAndConstraints.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInBasePropertyAndDerivedContainerOfBase01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInClasses.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInFunctions2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInFunctions3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInFunctions4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInInterfaces.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInObjectLiterals.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInTaggedTemplateCall.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInTuples.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInTypePredicate.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeOptionalCall.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeSyntacticContext.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/typeRelationships.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/unionThisTypeInFunctions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/castingTuple.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/contextualTypeWithTuple.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/indexerWithTuple.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/named/namedTupleMembers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/named/partiallyNamedTuples.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/named/partiallyNamedTuples2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/readonlyArraysAndTuples2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/strictTupleLength.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/tupleElementTypes1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/tupleElementTypes2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/tupleElementTypes3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/tupleElementTypes4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/tupleLengthCheck.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/typeInferenceWithTupleType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/variadicTuples1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/wideningTuples1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/wideningTuples2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/wideningTuples3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/wideningTuples4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/wideningTuples5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/wideningTuples6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/wideningTuples7.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/circularTypeAliasForUnionWithClass.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/circularTypeAliasForUnionWithInterface.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/classDoesNotDependOnBaseTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/directDependenceBetweenTypeAliases.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/genericTypeAliases.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/typeAliases.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/recurringTypeParamForContainerOfBase01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithIncorrectNumberOfTypeArguments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithZeroTypeArguments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/callNonGenericFunctionWithTypeArguments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/constraintSatisfactionWithAny.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/constraintSatisfactionWithEmptyObject.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateGenericClassWithWrongNumberOfTypeArguments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateGenericClassWithZeroTypeArguments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateNonGenericTypeWithTypeArguments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/typeParameterAsTypeParameterConstraint.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/typeParameterAsTypeParameterConstraint2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/typeParameterAsTypeParameterConstraintTransitively.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/typeParameterAsTypeParameterConstraintTransitively2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/wrappedAndRecursiveConstraints.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/wrappedAndRecursiveConstraints3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/wrappedAndRecursiveConstraints4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/innerTypeParameterShadowingOuterOne.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/innerTypeParameterShadowingOuterOne2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithConstraints.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithConstraints2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithConstraints3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithoutConstraints.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/staticMembersUsingClassTypeParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterConstModifiersReturnsAndYields.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterConstModifiersReverseMappedTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterConstModifiersWithIntersection.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterUsedAsConstraint.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParametersAvailableInNestedScope.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParametersAvailableInNestedScope3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSubtyping.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSupertype.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/anyAssignabilityInInheritance.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/anyAssignableToEveryType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/anyAssignableToEveryType2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignaturesWithOptionalParameters.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignaturesWithRestParameters.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignaturesWithOptionalParameters.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithDiscriminatedUnion.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithEnumIndexer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithGenericCallSignatures.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithGenericCallSignatures4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithGenericCallSignaturesWithOptionalParameters.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithNumericIndexer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithNumericIndexer2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithNumericIndexer3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembers2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembers3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembers4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembers5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembersAccessibility.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembersNumericNames.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembersOptionality.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembersOptionality2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembersStringNumericNames.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithStringIndexer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithStringIndexer2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithStringIndexer3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/callSignatureAssignabilityInInheritance.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/callSignatureAssignabilityInInheritance2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/callSignatureAssignabilityInInheritance3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/callSignatureAssignabilityInInheritance4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/callSignatureAssignabilityInInheritance5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/callSignatureAssignabilityInInheritance6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/constructSignatureAssignabilityInInheritance.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/constructSignatureAssignabilityInInheritance2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/constructSignatureAssignabilityInInheritance3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/constructSignatureAssignabilityInInheritance4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/constructSignatureAssignabilityInInheritance5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/constructSignatureAssignabilityInInheritance6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/covariantCallbacks.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/enumAssignability.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/enumAssignabilityInInheritance.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/everyTypeAssignableToAny.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/genericCallWithObjectTypeArgsAndInitializers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/intersectionIncludingPropFromGlobalAugmentation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/nullAssignableToEveryType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/numberAssignableToEnum.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/optionalPropertyAssignableToStringIndexSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/undefinedAssignableToEveryType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/unionTypesAssignability.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/bestCommonType/arrayLiteralWithMultipleBestCommonTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/bestCommonType/bestCommonTypeOfConditionalExpressions.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/bestCommonType/bestCommonTypeOfConditionalExpressions2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/bestCommonType/bestCommonTypeOfTuple.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/bestCommonType/bestCommonTypeOfTuple2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/bestCommonType/functionWithMultipleReturnStatements2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/bestCommonType/heterogeneousArrayLiterals.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/equalityWithEnumTypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/equalityWithIntersectionTypes01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/equalityWithUnionTypes01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/independentPropertyVariance.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/optionalProperties01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/optionalProperties02.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/typeAssertionsWithIntersectionTypes01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/typeAssertionsWithUnionTypes01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/weakTypesAndLiterals01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/instanceOf/narrowingConstrainedTypeVariable.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/instanceOf/narrowingGenericTypeFromInstanceof01.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/arrayLiteralsWithRecursiveGenerics.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/infiniteExpansionThroughInstantiation.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/infiniteExpansionThroughInstantiation2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/infiniteExpansionThroughTypeInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/nominalSubtypeCheckOfTypeParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/nominalSubtypeCheckOfTypeParameter2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/objectTypeWithRecursiveWrappedProperty.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/objectTypeWithRecursiveWrappedProperty2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/objectTypeWithRecursiveWrappedPropertyCheckedNominally.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/recursiveTypeInGenericConstraint.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/recursiveTypeReferences1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/recursiveTypesUsedAsFunctionParameters.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/enumIsNotASubtypeOfAnythingButNumber.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/nullIsSubtypeOfEverythingButUndefined.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/stringLiteralTypeIsSubtypeOfString.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfAny.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameter.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfUnion.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignatures2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignatures3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignatures4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignaturesWithOptionalParameters.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignaturesWithRestParameters.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignaturesWithSpecializedSignatures.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithConstructSignatures2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithConstructSignatures3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithConstructSignatures4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithConstructSignatures5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithConstructSignatures6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithConstructSignaturesWithOptionalParameters.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithConstructSignaturesWithSpecializedSignatures.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithGenericCallSignaturesWithOptionalParameters.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithGenericConstructSignaturesWithOptionalParameters.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithNumericIndexer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithNumericIndexer2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithNumericIndexer3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithNumericIndexer4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithNumericIndexer5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembersAccessibility.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembersAccessibility2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembersOptionality.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembersOptionality2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembersOptionality3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembersOptionality4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithOptionalProperties.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithStringIndexer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithStringIndexer2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithStringIndexer3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithStringIndexer4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/undefinedIsSubtypeOfEverything.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/unionSubtypeIfEveryConstituentTypeIsSubtype.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentity.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentity2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithCallSignatures.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithCallSignatures2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithCallSignaturesDifferingParamCounts.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithCallSignaturesWithOverloads.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithConstructSignatures2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithConstructSignaturesDifferingParamCounts.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignatures.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignatures2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesDifferingByConstraints.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesDifferingByConstraints2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesDifferingByConstraints3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesDifferingByReturnType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesDifferingByReturnType2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesDifferingTypeParameterCounts.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesDifferingTypeParameterCounts2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesDifferingTypeParameterNames.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesOptionalParams.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesOptionalParams2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesOptionalParams3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesDifferingByConstraints.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesDifferingByConstraints2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesDifferingByConstraints3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesDifferingByReturnType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesDifferingByReturnType2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesDifferingTypeParameterCounts.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesDifferingTypeParameterNames.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesOptionalParams.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesOptionalParams2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesOptionalParams3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithNumericIndexers1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithNumericIndexers2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithNumericIndexers3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithOptionality.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithPrivates.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithPrivates2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithPrivates3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithPublics.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithStringIndexers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithStringIndexers2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/primtiveTypesAreIdentical.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/typeParametersAreIdenticalToThemselves.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/bivariantInferences.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/discriminatedUnionInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallToOverloadedMethodWithOverloadedArguments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallTypeArgumentInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithArrayLiteralArgs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithConstraintsTypeArgumentInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithConstraintsTypeArgumentInference2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithConstructorTypedArguments5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithFunctionTypedArguments4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithFunctionTypedArguments5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGenericSignatureArguments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGenericSignatureArguments2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGenericSignatureArguments3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithNonSymmetricSubtypes.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectLiteralArgs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgs2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgsAndConstraints.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgsAndConstraints2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgsAndConstraints3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgsAndConstraints4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgsAndConstraints5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgsAndIndexers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgsAndIndexersErrors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgsAndNumericIndexer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgsAndStringIndexer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithTupleType.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericClassWithFunctionTypedMemberArguments.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericClassWithObjectTypeArgsAndConstraints.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericContextualTypes1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericContextualTypes2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericContextualTypes3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericFunctionParameters.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/indexSignatureTypeInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/intraExpressionInferencesJsx.tsx
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/keyofInferenceIntersectsResults.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/keyofInferenceLowerPriorityThanReturn.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/noInfer.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/noInferRedeclaration.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/unionAndIntersectionInference1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/unionAndIntersectionInference2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/unionAndIntersectionInference3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/unionTypeInference.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/widenedTypes/arrayLiteralWidened.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/widenedTypes/initializersWidened.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/widenedTypes/objectLiteralWidened.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/widenedTypes/strictNullChecksNoWidening.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/contextualTypeWithUnionTypeCallSignatures.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/contextualTypeWithUnionTypeIndexSignatures.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/contextualTypeWithUnionTypeMembers.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/contextualTypeWithUnionTypeObjectLiteral.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/discriminatedUnionTypes1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/discriminatedUnionTypes3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/discriminatedUnionTypes4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeCallSignatures.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeCallSignatures2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeCallSignatures5.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeCallSignatures6.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeConstructSignatures.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeEquivalence.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeFromArrayLiteral.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeIndexSignature.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeReduction2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/uniqueSymbol/uniqueSymbols.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarations.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarationsErrors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarationsInJs.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarationsInJsErrors.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/unknown/unknownControlFlow.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/unknown/unknownType1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/unknown/unknownType2.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/typings/typingsLookup1.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/typings/typingsLookup3.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/typings/typingsLookup4.ts
+
+Symbol Mismatch: tasks/coverage/typescript/tests/cases/conformance/typings/typingsLookupAmd.ts
+

--- a/tasks/coverage/snapshots/types_typescript.snap
+++ b/tasks/coverage/snapshots/types_typescript.snap
@@ -1,0 +1,16577 @@
+commit: 7539c04d
+
+types_typescript Summary:
+AST Parsed     : 8364/8364 (100.00%)
+Positive Passed: 78/8364 (0.93%)
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/2dArrays.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/ClassDeclarationWithInvalidConstOnPropertyDeclaration2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/DeclarationErrorsNoEmitOnError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/SystemModuleForStatementNoInitializer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/abstractClassInLocalScope.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/abstractClassInLocalScopeIsAbstract.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/abstractClassUnionInstantiation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/abstractIdentifierNameStrict.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/abstractInterfaceIdentifierName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/abstractPropertyInConstructor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/acceptSymbolAsWeakType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/acceptableAlias1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessInstanceMemberFromStaticMethod01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessOverriddenBaseClassMember1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessStaticMemberFromInstanceMethod01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessorDeclarationEmitJs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessorDeclarationEmitVisibilityErrors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessorDeclarationOrder.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessorsEmit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessors_spec_section-4.5_error-cases.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessors_spec_section-4.5_inference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/addMoreCallSignaturesToBaseSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/addMoreCallSignaturesToBaseSignature2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/addMoreOverloadsToBaseSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasAssignments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasBug.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasDoesNotDuplicateSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasInaccessibleModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasInaccessibleModule2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasInstantiationExpressionGenericIntersectionNoCrash1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasInstantiationExpressionGenericIntersectionNoCrash2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasOfGenericFunctionWithRestBehavedSameAsUnaliased.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasOnMergedModuleInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasUsageInArray.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasUsageInFunctionExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasUsageInGenericFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasUsageInIndexerOfClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasUsageInObjectLiteral.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasUsageInOrExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasUsageInTypeArgumentOfExtendsClause.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasUsageInVarAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasUsedAsNameValue.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasWithInterfaceExportAssignmentUsedInVarInitializer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasesInSystemModule1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasesInSystemModule2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowImportClausesToMergeWithTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowJsClassThisTypeCrash.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowJsCrossMonorepoPackage.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowJscheckJsTypeParameterNoCrash.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImportsCanPaintCrossModuleDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/alwaysStrictAlreadyUseStrict.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/alwaysStrictModule3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/alwaysStrictModule4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/alwaysStrictModule5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientClassDeclarationWithExtends.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientClassDeclaredBeforeBase.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientClassMergesOverloadsWithInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientClassOverloadForFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientConstLiterals.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientEnumElementInitializer1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientEnumElementInitializer2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientEnumElementInitializer3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientEnumElementInitializer4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientEnumElementInitializer5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientEnumElementInitializer6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientExternalModuleInAnotherExternalModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientExternalModuleReopen.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientExternalModuleWithInternalImportDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientExternalModuleWithoutInternalImportDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientFundule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientModuleExports.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientModuleWithClassDeclarationWithExtends.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientModuleWithTemplateLiterals.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientModules.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientNameRestrictions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambiguousCallsWhereReturnTypesAgree.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambiguousOverload.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambiguousOverloadResolution.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/amdDeclarationEmitNoExtraDeclare.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/amdDependencyComment1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/amdDependencyComment2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/amdDependencyCommentName1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/amdDependencyCommentName2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/amdDependencyCommentName3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/amdLikeInputDeclarationEmit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/amdModuleBundleNoDuplicateDeclarationEmitComments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/amdModuleConstEnumUsage.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/amdModuleName1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/amdModuleName2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/anonClassDeclarationEmitIsAnon.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/anonterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/anonymousClassDeclarationDoesntPrintWithReadonly.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/anonymousClassExpression1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/anonymousClassExpression2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyAndUnknownHaveFalsyComponents.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyAsReturnTypeForNewOnCall.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyIndexedAccessArrayNoException.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyInferenceAnonymousFunctions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyIsAssignableToObject.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyIsAssignableToVoid.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyMappedTypesError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyPlusAny1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/argsInScope.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arguments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsAsPropertyName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsAsPropertyName2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsObjectCreatesRestForJs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsObjectIterator01_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsObjectIterator02_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsObjectIterator03_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsPropertyNameInJsMode1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsPropertyNameInJsMode2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsReferenceInConstructor1_Js.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsReferenceInConstructor2_Js.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsReferenceInConstructor3_Js.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsReferenceInConstructor5_Js.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsReferenceInConstructor6_Js.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsReferenceInConstructor7_Js.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsReferenceInFunction1_Js.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsReferenceInMethod1_Js.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsReferenceInMethod2_Js.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsReferenceInMethod3_Js.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsReferenceInMethod5_Js.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsReferenceInMethod6_Js.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsReferenceInMethod7_Js.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsUsedInObjectLiteralProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arithAssignTyping.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arithmeticOnInvalidTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arithmeticOnInvalidTypes2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arityErrorRelatedSpanBindingPattern.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayAssignmentTest1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayAssignmentTest2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayAssignmentTest3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayAssignmentTest4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayAssignmentTest5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayAssignmentTest6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayAugment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayBestCommonTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayBindingPatternOmittedExpressions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayBufferIsViewNarrowsType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayCast.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayConcat2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayConcat3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayConstructors1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayDestructuringInSwitch1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayDestructuringInSwitch2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayEvery.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayFakeFlatNoCrashInferenceDeclarations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayFilter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayFind.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayFlatMap.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayFlatNoCrashInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayFlatNoCrashInferenceDeclarations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayFrom.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayFromAsync.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayIndexWithArrayFails.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayLiteral1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayLiteral2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayLiteralAndArrayConstructorEquivalence1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayLiteralComments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayLiteralContextualType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayLiteralInNonVarArgParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayLiteralTypeInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayOfExportedClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayOfSubtypeIsAssignableToReadonlyArray.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayReferenceWithoutTypeArgs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arraySlice.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayToLocaleStringES2015.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayToLocaleStringES2020.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayTypeInSignatureOfInterfaceAndClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayconcat.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrowExpressionBodyJSDoc.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrowExpressionJs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionInConstructorArgument1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionInExpressionStatement1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionInExpressionStatement2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionJSDocAnnotation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionParsingGenericInObject.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionWithObjectLiteralBody1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionWithObjectLiteralBody2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionWithObjectLiteralBody3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionWithObjectLiteralBody4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionWithObjectLiteralBody5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionWithObjectLiteralBody6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/asiAmbientFunctionDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/asiArith.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/asiBreak.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/asiContinue.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/asiInES6Classes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assertionFunctionWildcardImport1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assertionFunctionWildcardImport2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assertionFunctionsCanNarrowByDiscriminant.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assign1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignLambdaToNominalSubtypeOfFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignToEnum.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignToExistingClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignToFn.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignToModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignToObjectTypeWithPrototypeProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignToPrototype1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assigningFromObjectToAnythingElse.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assigningFunctionToTupleIssuesError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompat1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatBug2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatBug3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatBug5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatForEnums.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatInterfaceWithStringIndexSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatOnNew.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatWithOverloads.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability11.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability12.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability13.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability14.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability15.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability16.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability17.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability18.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability19.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability20.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability21.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability22.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability23.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability24.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability25.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability26.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability27.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability28.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability29.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability30.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability31.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability32.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability33.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability34.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability35.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability36.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability37.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability38.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability39.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability40.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability41.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability42.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability43.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability44.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability45.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability46.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability_checking-apply-member-off-of-function-interface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability_checking-call-member-off-of-function-interface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatibilityForConstrainedTypeParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentIndexedToPrimitives.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentNestedInLiterals.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentNonObjectTypeConstraints.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentRestElementWithErrorSourceType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentStricterConstraints.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentToConditionalBrandedStringTemplateOrMapping.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentToExpandingArrayType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentToFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentToObject.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentToObjectAndFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentToReferenceTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionContextuallyTypedReturns.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionNoReturnType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionReturnExpressionErrorSpans.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionReturnType.2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionReturnType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionWithForStatementNoInitializer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionsAcrossFiles.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionsAndStrictNullChecks.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncIIFE.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncImportNestedYield.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncYieldStarContextualType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals1_1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals2_1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals3_1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals4_1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals6_1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentedTypeBracketNamedPropertyAccess.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentedTypesClass3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentedTypesExternalModule1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentedTypesModules3b.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentedTypesModules4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/autoAsiForStaticsInClassDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/autoTypeAssignedUsingDestructuringFromNeverNoCrash.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/autonumberingInEnums.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/avoid.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/avoidCycleWithVoidExpressionReturnedFromArrow.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/avoidListingPropertiesForTypesWithOnlyCallOrConstructSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/avoidNarrowingUsingConstVariableFromBindingElementWithLiteralInitializer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/awaitExpressionInnerCommentEmit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/awaitUnionPromise.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/awaitedType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/awaitedTypeCrash.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/awaitedTypeJQuery.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/awaitedTypeNoLib.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/awaitedTypeStrictNull.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/badExternalModuleReference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/badInferenceLowerPriorityThanGoodInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/badOverloadError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/badThisBinding.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/bangInModuleName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/baseClassImprovedMismatchErrors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/baseConstraintOfDecorator.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/baseIndexSignatureResolution.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/baseTypeAfterDerivedType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/baseTypeOrderChecking.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/baseTypePrivateMemberClash.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/baseTypeWrappingInstantiationChain.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/bestChoiceType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/bestCommonTypeReturnStatement.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/bestCommonTypeWithContextualTyping.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/bestCommonTypeWithOptionalProperties.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/betterErrorForAccidentalCall.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/betterErrorForUnionCall.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/bigIntWithTargetES2016.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/bigIntWithTargetLessThanES2016.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/bigint64ArraySubarray.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/bigintWithLib.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/binaryArithmeticControlFlowGraphNotTooLarge.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/bind1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/bindingPatternContextualTypeDoesNotCauseWidening.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/bindingPatternInParameter01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/bindingPatternOmittedExpressionNesting.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/binopAssignmentShouldHaveType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/bitwiseCompoundAssignmentOperators.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedBindingCaptureThisInFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedBindingUsedBeforeDef.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedBindingsReassignedInLoop1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedBindingsReassignedInLoop2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedBindingsReassignedInLoop3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedBindingsReassignedInLoop4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedBindingsReassignedInLoop5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedBindingsReassignedInLoop6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedClassDeclarationAcrossFiles.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedFunctionDeclarationES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedFunctionDeclarationInStrictModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedFunctionDeclarationStrictES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedSameNameFunctionDeclarationES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedSameNameFunctionDeclarationStrictES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/bluebirdStaticThis.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/bom-utf16le.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/bom-utf8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/booleanAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/booleanFilterAnyArray.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/booleanLiteralsContextuallyTypedFromUnion.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/breakInIterationOrSwitchStatement1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/breakInIterationOrSwitchStatement2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/breakInIterationOrSwitchStatement4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/breakTarget1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/breakTarget2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/breakTarget3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/breakTarget4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/builtinIterator.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/bundledDtsLateExportRenaming.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/cacheResolutions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedContextualTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/callConstructAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/callExpressionWithTypeParameterConstrainedToOuterTypeParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/callOfConditionalTypeWithConcreteBranches.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/callOnClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/callOnInstance.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/callOverloadViaElementAccessExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/callSignatureFunctionOverload.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/callSignaturesShouldBeResolvedBeforeSpecialization.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/callWithWrongNumberOfTypeArguments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/callbackArgsDifferByOptionality.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/callbacksDontShareTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/callsOnComplexSignatures.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/cannotIndexGenericWritingError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/cannotInvokeNewOnIndexExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/captureSuperPropertyAccessInSuperCall01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/captureThisInSuperCall.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop10_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop11.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop11_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop12.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop13.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop1_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop2_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop3_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop4_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop5_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop6_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop7_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop8_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop9_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/caseInsensitiveFileSystemWithCapsImportTypeDeclarations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/castExpressionParentheses.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/castFunctionExpressionShouldBeParenthesized.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/castNewObjectBug.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/castOfAwait.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/castParentheses.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/castTest.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/catch.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/cf.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/chainedAssignment1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/chainedAssignment2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/chainedAssignment3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/chainedAssignmentChecking.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/chainedCallsWithTypeParameterConstrainedToOtherTypeParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/chainedCallsWithTypeParameterConstrainedToOtherTypeParameter2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/chainedImportAlias.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/chainedSpecializationToObjectTypeLiteral.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkDestructuringShorthandAssigment2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkIndexConstraintOfJavascriptClassExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkInfiniteExpansionTermination.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkInfiniteExpansionTermination2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkInheritedProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkInterfaceBases.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkJsFiles.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkJsFiles2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkJsFiles3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkJsFiles4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkJsFiles5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkJsFiles7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkJsFiles_noErrorLocation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkJsFiles_skipDiagnostics.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkJsObjectLiteralHasCheckedKeyof.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkJsObjectLiteralIndexSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkJsTypeDefNoUnusedLocalMarked.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkJsdocTypeTagOnExportAssignment1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkJsdocTypeTagOnExportAssignment2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkJsdocTypeTagOnExportAssignment3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkJsdocTypeTagOnExportAssignment5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkJsdocTypeTagOnExportAssignment6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkJsdocTypeTagOnExportAssignment7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkJsdocTypeTagOnExportAssignment8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkJsxNotSetError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkSuperCallBeforeThisAccessing1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkSuperCallBeforeThisAccessing3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkSuperCallBeforeThisAccessing4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkSuperCallBeforeThisAccessing6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkSuperCallBeforeThisAccessing7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkSwitchStatementIfCaseTypeIsString.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularAccessorAnnotations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularBaseConstraint.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularBaseTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularConstrainedMappedTypeNoCrash.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularConstraintYieldsAppropriateError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularConstructorWithReturn.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularContextualMappedType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularContextualReturnType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularInferredTypeOfVariable.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularInlineMappedGenericTupleTypeNoCrash.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularInstantiationExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularMappedTypeConstraint.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularModuleImports.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularReferenceInImport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularReferenceInReturnType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularReferenceInReturnType2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularResolvedSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularTypeArgumentsLocalAndOuterNoCrash1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularTypeofWithFunctionModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularlyConstrainedMappedTypeContainingConditionalNoInfiniteInstantiationDepth.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularlyReferentialInterfaceAccessNoCrash.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularlySimplifyingConditionalTypesNoCrash.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classAccessorInitializationInferenceWithElementAccess1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classAttributeInferenceTemplate.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classAttributeInferenceTemplateJS.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classBlockScoping.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classDeclarationBlockScoping1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classDeclarationBlockScoping2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classDeclarationCheckUsedBeforeDefinitionInFunctionDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classDeclarationCheckUsedBeforeDefinitionInItself.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classDeclarationMergedInModuleWithContinuation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classDeclarationShouldBeOutOfScopeInComputedNames.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classDeclaredBeforeClassFactory.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionExtendingAbstractClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionInClassStaticDeclarations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionNames.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionTest1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionTest2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionWithResolutionOfNamespaceOfSameName01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionWithStaticProperties1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionWithStaticPropertiesES61.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionWithStaticPropertiesES62.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionWithStaticPropertiesES63.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionWithStaticPropertiesES64.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendingAbstractClassWithMemberCalledTheSameAsItsOwnTypeParam.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendingAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendingQualifiedName2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendsClauseClassMergedWithModuleNotReferingConstructor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendsClauseClassNotReferringConstructor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendsInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendsInterfaceInExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendsInterfaceInModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendsInterfaceThatExtendsClassWithPrivates1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendsNull3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtensionNameOutput.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classFieldSuperAccessible.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classFieldSuperAccessibleJs1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classFieldSuperAccessibleJs2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classFieldSuperNotAccessible.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classFieldSuperNotAccessibleJs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classFunctionMerging.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classFunctionMerging2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementingInterfaceIndexer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsClass1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsClass2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsClass3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsClass4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsClass5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsClass7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsImportedInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsMethodWIthTupleArgs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsPrimitive.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classIndexer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classIndexer2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classIndexer3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classIndexer4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classIndexer5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classInheritence.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classMemberInitializerScoping.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classMemberInitializerWithLamdaScoping.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classMemberInitializerWithLamdaScoping2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classMemberInitializerWithLamdaScoping3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classMemberInitializerWithLamdaScoping4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classMemberInitializerWithLamdaScoping5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classMergedWithInterfaceMultipleBasesNoError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classMethodWithKeywordName1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classNonUniqueSymbolMethodHasSymbolIndexer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classOrder1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classOrder2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classOrderBug.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classOverloadForFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classPropInitializationInferenceWithElementAccess.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classPropertyErrorOnNameOnly.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classPropertyInferenceFromBroaderTypeConst.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classReferencedInContextualParameterWithinItsOwnBaseExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classSideInheritance1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classSideInheritance2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classSideInheritance3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classStaticInitializersUsePropertiesBeforeDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classTypeParametersInStatics.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classVarianceCircularity.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classVarianceResolveCircularity1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classVarianceResolveCircularity2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/classWithMultipleBaseClasses.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/clinterfaces.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleAcrossModuleDefinitions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleAndTypeParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleGenericOnSelfMember.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleSplitAcrossFiles.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleStaticMembers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleTest1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleWithPriorUninstantiatedModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleWithRecursiveReference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/clodulesDerivedClasses.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collectionPatternNoError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenEnumWithEnumMemberConflict.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithAccessorChildren.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithConstructorChildren.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithEnumMemberConflict.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithFunctionChildren.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithMemberClassConflict.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithMemberInterfaceConflict.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithMemberVariable.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithMethodChildren.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithModuleChildren.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithModuleReopening.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithPrivateMember.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithUnicodeNames.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAmbientClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAmbientEnum.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAmbientFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAmbientFunctionInGlobalFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAmbientModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAmbientVar.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndFunctionInGlobalFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndInternalModuleAliasInGlobalFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndUninstantiatedModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterArrowFunctions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterClassConstructor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterClassMethod.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterFunctionExpressions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterInType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterInterfaceMembers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterUnderscoreIUsage.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndLocalFunctionInConstructor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndLocalFunctionInMethod.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndLocalFunctionInProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndLocalVarInConstructor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndLocalVarInMethod.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndLocalVarInProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndNameResolution.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndParameter1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndPropertyNameAsConstuctorParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndAliasInGlobal.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndAmbientClassInGlobal.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndAmbientVarInGlobal.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndClassInGlobal.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndEnumInGlobal.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndFunctionInGlobal.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndLocalVarInConstructor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndLocalVarInFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndLocalVarInLambda.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndLocalVarInMethod.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndLocalVarInProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndLocalVarWithSuperExperssion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndModuleInGlobal.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndNameResolution.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndPropertyNameAsConstuctorParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndVarInGlobal.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commaOperator1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commaOperatorInConditionalExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commaOperatorLeftSideUnused.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentBeforeStaticMethod1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentEmitAtEndOfFile1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentEmitOnParenthesizedAssertionInReturnStatement.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentEmitOnParenthesizedAssertionInReturnStatement2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentEmitWithCommentOnLastLine.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentInEmptyParameterList1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentInMethodCall.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentInNamespaceDeclarationWithIdentifierPathName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentLeadingCloseBrace.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnAmbientClass1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnAmbientEnum.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnAmbientModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnAmbientVariable1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnAmbientVariable2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnAmbientfunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnArrayElement1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnArrayElement10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnArrayElement11.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnArrayElement12.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnArrayElement13.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnArrayElement14.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnArrayElement15.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnArrayElement16.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnArrayElement2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnArrayElement3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnArrayElement4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnArrayElement5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnArrayElement6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnArrayElement7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnArrayElement8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnArrayElement9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnBinaryOperator1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnBinaryOperator2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnBlock1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnClassAccessor1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnClassAccessor2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnClassMethod1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnDecoratedClassDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnExportEnumDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnExpressionStatement1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnIfStatement1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnImportStatement1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnImportStatement2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnImportStatement3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnParameter1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnParameter2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnParameter3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnParenthesizedExpressionOpenParen1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnSignature1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnSimpleArrowFunctionBody1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnStaticMember1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentWithUnreasonableIndentationLevel01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsAfterCaseClauses1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsAfterCaseClauses2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsAfterCaseClauses3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsAfterFunctionExpression1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsAfterSpread.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsArgumentsOfCallExpression1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsArgumentsOfCallExpression2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsAtEndOfFile1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsBeforeFunctionExpression1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsBeforeVariableStatement1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsOnObjectLiteral1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsOnObjectLiteral2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsOnPropertyOfObjectLiteral1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsOnReturnStatement1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsOnStaticMembers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsPropertySignature1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsTypeParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsVariableStatement1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonJsImportClassExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonJsIsolatedModules.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonJsUnusedLocals.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonSourceDir1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonSourceDir2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonSourceDir3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonSourceDir4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonSourceDir5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonSourceDir6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonSourceDirectory.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonjsAccessExports.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/comparabilityTypeParametersRelatedByUnion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/comparableRelationBidirectional.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/compareTypeParameterConstrainedByLiteralToLiteral.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/compilerOptionsDeclarationAndNoEmit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/compilerOptionsOutAndNoEmit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/compilerOptionsOutDirAndNoEmit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/compilerOptionsOutFileAndNoEmit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/complexNarrowingWithAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/complexRecursiveCollections.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/complicatedIndexedAccessKeyofReliesOnKeyofNeverUpperBound.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/complicatedIndexesOfIntersectionsAreInferencable.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/compositeContextualSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/compositeGenericFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/compositeWithNodeModulesSourceFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/compoundVarDecl1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/computedEnumTypeWidening.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/computedPropertiesInDestructuring2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/computedPropertiesInDestructuring2_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/computedPropertiesNarrowed.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/computedPropertiesTransformedInOtherwiseNonTSClasses.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/computedPropertiesWithSetterAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/computedPropertyBindingElementDeclarationNoCrash1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/computedPropertyNameAndTypeParameterConflict.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/computedPropertyNameWithImportedKey.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/computedTypesKeyofNoIndexSignatureType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/concatClassAndString.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/concatError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/concatTuples.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalAnyCheckTypePicksBothBranches.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalDoesntLeakUninstantiatedTypeParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalEqualityOnLiteralObjects.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalEqualityTestingNullability.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalExpression1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalExpressionNewLine1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalExpressionNewLine10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalExpressionNewLine2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalExpressionNewLine3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalExpressionNewLine4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalExpressionNewLine5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalExpressionNewLine6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalExpressionNewLine7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalExpressionNewLine8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalExpressionNewLine9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalExpressions2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalReturnExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeAnyUnion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeAssignabilityWhenDeferred.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeBasedContextualTypeReturnTypeWidening.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeClassMembers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeContextualTypeSimplificationsSuceeds.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeDoesntSpinForever.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeGenericInSignatureTypeParameterConstraint.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeRelaxingConstraintAssignability.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeSimplification.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeSubclassExtendsTypeParam.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeVarianceBigArrayConstraintsPerformance.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypesASI.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypesSimplifyWhenTrivial.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionallyDuplicateOverloadsCausedByOverloadResolution.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/configFileExtendsAsList.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/conflictingMemberTypesInBases.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/conflictingTypeParameterSymbolTransfer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/consistentAliasVsNonAliasRecordBehavior.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constDeclarationShadowedByVarDeclaration2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constDeclarationShadowedByVarDeclaration3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constDeclarations-access3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constDeclarations-access4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constDeclarations-access5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constDeclarations-ambient.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constDeclarations-scopes2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constDeclarations-useBeforeDefinition.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constDeclarations-useBeforeDefinition2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constDeclarations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constDeclarations2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constEnumDeclarations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constEnumExternalModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constEnumMergingWithValues1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constEnumMergingWithValues2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constEnumMergingWithValues3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constEnumMergingWithValues4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constEnumMergingWithValues5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constEnumNoEmitReexport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constEnumNoPreserveDeclarationReexport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constEnumOnlyModuleMerging.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constEnumPreserveEmitNamedExport1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constEnumPreserveEmitNamedExport2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constEnumPreserveEmitReexport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constEnumSyntheticNodesComments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constEnumToStringNoComments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constEnumToStringWithComments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constEnums.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constIndexedAccess.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constantOverloadFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constantOverloadFunctionNoSubtypeError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintCheckInGenericBaseTypeReference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintErrors1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintPropagationThroughReturnTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintReferencingTypeParameterFromSameTypeParameterList.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintWithIndexedAccess.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraints0.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintsThatReferenceOtherContstraints1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintsUsedInPrototypeProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorArgWithGenericCallSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorArgs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorAsType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorInvocationWithTooFewTypeArgs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorOverloads2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorOverloads4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorOverloads5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorOverloads9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorParametersInVariableDeclarations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorParametersThatShadowExternalNamesInVariableDeclarations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorPropertyJs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorReturningAPrimitive.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorReturnsInvalidType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorTypeWithTypeParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorWithCapturedSuper.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorWithParameterPropertiesAndPrivateFields.es2015.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextSensitiveReturnTypeInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualComputedNonBindablePropertyType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualOuterTypeParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualOverloadListFromArrayUnion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualOverloadListFromUnionWithPrimitiveNoImplicitAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualParamTypeVsNestedReturnTypeInference1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualParamTypeVsNestedReturnTypeInference2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualParamTypeVsNestedReturnTypeInference3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualParamTypeVsNestedReturnTypeInference4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualParameterAndSelfReferentialConstraint1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualPropertyOfGenericFilteringMappedType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualPropertyOfGenericMappedType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualReturnTypeOfIIFE.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualReturnTypeOfIIFE2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualReturnTypeOfIIFE3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSigInstantiationRestParams.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureConditionalTypeInstantiationUsingDefault.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInArrayElementLibEs2015.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInArrayElementLibEs5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInObjectFreeze.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInstantiation1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInstantiation2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInstantiation3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInstantiation4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInstantiationWithTypeParameterConstrainedToOuterTypeParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInstatiationContravariance.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInstatiationCovariance.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignature_objectLiteralMethodMayReturnNever.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTupleTypeParameterReadonly.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeAppliedToVarArgs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeArrayReturnType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeBasedOnIntersectionWithAnyInTheMix1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeBasedOnIntersectionWithAnyInTheMix2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeBasedOnIntersectionWithAnyInTheMix3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeBasedOnIntersectionWithAnyInTheMix4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeBasedOnIntersectionWithAnyInTheMix5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeCaching.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeFunctionObjectPropertyIntersection.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeIterableUnions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeLogicalOr.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeObjectSpreadExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeOfIndexedAccessParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeOnYield1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeOnYield2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeSelfReferencing.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeShouldBeLiteral.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypesNegatedTypeLikeConstraintInGenericMappedType1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypesNegatedTypeLikeConstraintInGenericMappedType2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypesNegatedTypeLikeConstraintInGenericMappedType3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping11.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping12.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping13.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping14.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping15.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping16.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping17.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping18.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping19.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping20.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping21.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping22.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping23.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping24.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping25.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping26.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping27.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping28.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping29.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping30.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping31.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping32.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping33.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping34.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping35.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping36.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping37.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping38.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping39.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping40.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping41.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingArrayDestructuringWithDefaults.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingArrayOfLambdas.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingFunctionReturningFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingFunctionReturningFunction2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfAccessors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfArrayLiterals1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfConditionalExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfConditionalExpression2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfGenericFunctionTypedArguments1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfLambdaWithMultipleSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfLambdaWithMultipleSignatures2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfObjectLiterals.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfOptionalMembers.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfTooShortOverloads.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingReturnStatementWithReturnTypeAnnotation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingTwoInstancesOfSameTypeParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingWithGenericAndNonGenericSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingWithGenericSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypeArgumentsKeyword.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypeAsyncFunctionReturnTypeFromUnion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypeGeneratorReturnTypeFromUnion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedBooleanLiterals.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedByDiscriminableUnion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedByDiscriminableUnion2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedGenericAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedJsxAttribute.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedJsxAttribute2.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedJsxChildren.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedJsxChildren2.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedParametersOptionalInJSDoc.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedParametersWithInitializers1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedParametersWithInitializers2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedParametersWithInitializers3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedParametersWithInitializers4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedParametersWithQuestionToken.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedSymbolNamedProperties.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypingOrOperator.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypingOrOperator2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypingOrOperator3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypingRestParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/continueInIterationStatement1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/continueInIterationStatement2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/continueInIterationStatement4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/continueLabel.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/continueStatementInternalComments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/continueTarget2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/continueTarget3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/continueTarget4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contravariantInferenceAndTypeGuard.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contravariantOnlyInferenceFromAnnotatedFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contravariantOnlyInferenceFromAnnotatedFunctionJs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contravariantOnlyInferenceWithAnnotatedOptionalParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contravariantOnlyInferenceWithAnnotatedOptionalParameterJs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/contravariantTypeAliasInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowAliasedDiscriminants.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowAnalysisOnBareThisKeyword.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowArrayErrors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowArrays.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowAutoAccessor1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowBreakContinueWithLabel.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowCaching.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowCommaExpressionAssertionMultiple.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowCommaExpressionAssertionWithinTernary.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowCommaExpressionFunctionCall.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowDestructuringLoop.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowDestructuringParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowDestructuringVariablesInTryCatch.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowFavorAssertedTypeThroughTypePredicate.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowFinallyNoCatchAssignments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowForCatchAndFinally.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowForCompoundAssignmentToThisMember.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowForFunctionLike1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowForIndexSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowForStatementContinueIntoIncrementor1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowInitializedDestructuringVariables.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowInstanceof.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowInstanceofWithSymbolHasInstance.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowJavascript.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowLoopAnalysis.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowManyCallExpressionStatementsPerf.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowManyConsecutiveConditionsNoTimeout.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowNoImplicitAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowNullTypeAndLiteral.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowOuterVariable.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowPrivateClassField.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowPropertyDeclarations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowPropertyInitializer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowSelfReferentialLoop.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowUnionContainingTypeParameter1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowWithIncompleteTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/convertKeywords.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/copyrightWithNewLine1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/copyrightWithoutNewLine1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/correctOrderOfPromiseMethod.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/correlatedUnions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/couldNotSelectGenericOverload.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/covariance1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/crashInGetTextOfComputedPropertyName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/crashInResolveInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/crashInYieldStarInAsyncFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/crashInresolveReturnStatement.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/crashInsourcePropertyIsRelatableToTargetProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/crashIntypeCheckInvocationExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/crashIntypeCheckObjectCreationExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/curiousNestedConditionalEvaluationResult.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/customAsyncIterator.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/customEventDetail.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/cyclicGenericTypeInstantiation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/cyclicGenericTypeInstantiationInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/cyclicModuleImport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/cyclicTypeInstantiation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/dataViewConstructor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/debugger.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/debuggerEmit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileAliasUseBeforeDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileAliasUseBeforeDeclaration2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileAmbientExternalModuleWithSingleExportedModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileClassWithIndexSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileClassWithStaticMethodReturningConstructor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileEmitDeclarationOnly.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileEmitDeclarationOnlyError1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileEmitDeclarationOnlyError2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileEnumUsedAsValue.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileEnums.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileExportAssignmentImportInternalModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileExportAssignmentOfGenericInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileExportImportChain.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileExportImportChain2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileForClassWithMultipleBaseClasses.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileForClassWithPrivateOverloadedFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileForExportedImport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileForFunctionTypeAsTypeParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileForInterfaceWithOptionalFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileForInterfaceWithRestParams.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileForTypeParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileForVarList.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileGenericClassWithGenericExtendedClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileGenericType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileGenericType2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileImportChainInExportAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileImportModuleWithExportAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileImportedTypeUseInTypeArgPosition.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileInternalAliases.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileModuleAssignmentInObjectLiteralProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileModuleContinuation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileModuleWithPropertyOfTypeModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileOptionalInterfaceMethod.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFilePrivateMethodOverloads.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileRegressionTests.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileRestParametersOfFunctionAndFunctionType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeofClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeofEnum.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeofFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeofInAnonymousType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeofModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileWithClassNameConflictingWithClassReferredByExtendsClause.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileWithExtendsClauseThatHasItsContainerNameConflict.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileWithInternalModuleNameConflictsInExtendsClause1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileWithInternalModuleNameConflictsInExtendsClause2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileWithInternalModuleNameConflictsInExtendsClause3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declInput-2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declInput.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declInput3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declInput4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationAssertionNodeNotReusedWhenTypeNotEquivalent1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitAliasExportStar.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitAliasFromIndirectFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitAliasInlineing.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitAmdModuleDefault.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitAmdModuleNameDirective.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitAnyComputedPropertyInClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitArrowFunctionNoRenaming.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitBindingPatternWithReservedWord.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitBindingPatterns.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitBindingPatternsFunctionExpr.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitBindingPatternsUnused.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitBundleWithAmbientReferences.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitClassAccessorsJs1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitClassInherritsAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitClassMemberWithComputedPropertyName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitClassMixinLocalClassDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitClassSetAccessorParamNameInJs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitClassSetAccessorParamNameInJs2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitClassSetAccessorParamNameInJs3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitCommonSourceDirectoryDoesNotContainAllFiles.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedNameCausesImportToBePainted.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedNameConstEnumAlias.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedNameWithQuestionToken.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedNamesInaccessible.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedPropertyName1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedPropertyNameEnum1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedPropertyNameEnum2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedPropertyNameSymbol1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedPropertyNameSymbol2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitConstantNoWidening.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitCrossFileCopiedGeneratedImportType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitCrossFileImportTypeOfAmbientModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDefaultExport1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDefaultExport3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDefaultExport4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDefaultExport5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDefaultExport6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDefaultExport7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDefaultExport8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDefaultExportWithStaticAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuring1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuring3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuring4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuring5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringArrayPattern1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringArrayPattern2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringArrayPattern3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringArrayPattern4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringArrayPattern5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringObjectLiteralPattern.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringObjectLiteralPattern1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringObjectLiteralPattern2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringOptionalBindingParametersInOverloads.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringPrivacyError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDistributiveConditionalWithInfer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDoesNotUseReexportedNamespaceAsLocal.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDuplicateParameterDestructuring.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitEnumReadonlyProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitEnumReferenceViaImportEquals.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpandoPropertyPrivateName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpandoWithGenericConstraint.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExportAliasVisibiilityMarking.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExportAssignedNamespaceNoTripleSlashTypesReference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionWithNonlocalPrivateUniqueSymbol.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitFBoundedTypeParams.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitFirstTypeArgumentGenericFunctionType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitForDefaultExportClassExtendingExpression01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitForGlobalishSpecifierSymlink.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitForGlobalishSpecifierSymlink2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitForModuleImportingModuleAugmentationRetainsImport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitForTypesWhichNeedImportTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitFunctionDuplicateNamespace.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitFunctionKeywordProp.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitGenericTypeParamerSerialization.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitGenericTypeParamerSerialization2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitGenericTypeParamerSerialization3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitGlobalThisPreserved.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitHasTypesRefOnNamespaceUse.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitHigherOrderRetainedGenerics.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitImportInExportAssignmentModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitIndexTypeArray.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredDefaultExportType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredDefaultExportType2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredTypeAlias1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredTypeAlias2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredTypeAlias3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredTypeAlias4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredTypeAlias5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredTypeAlias6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredTypeAlias7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredTypeAlias8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredTypeAlias9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredUndefinedPropFromFunctionInArray.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInlinedDistributiveConditional.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInvalidReference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInvalidReference2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInvalidReferenceAllowJs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitIsolatedDeclarationErrorNotEmittedForNonEmittedFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitKeywordDestructuring.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitLambdaWithMissingTypeParameterNoCrash.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitLateBoundAssignments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitLateBoundAssignments2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitLateBoundJSAssignments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitLocalClassDeclarationMixin.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitLocalClassHasRequiredDeclare.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitMappedPrivateTypeTypeParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitMappedTypeDistributivityPreservesConstraints.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitMappedTypePreservesTypeParameterConstraint.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitMappedTypePropertyFromNumericStringKey.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitMappedTypeTemplateTypeofSymbol.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitMergedAliasWithConst.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitMethodDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitMixinPrivateProtected.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitMultipleComputedNamesSameDomain.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNameConflicts.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNameConflicts2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNameConflicts3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNameConflictsWithAlias.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNamespaceMergedWithInterfaceNestedFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNestedAnonymousMappedType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNestedGenerics.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNoInvalidCommentReuse1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNoInvalidCommentReuse2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNoInvalidCommentReuse3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNoNonRequiredParens.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNonExportedBindingPattern.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitObjectLiteralAccessors1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitObjectLiteralAccessorsJs1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitOfFuncspace.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitOfTypeofAliasedExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitOptionalMappedTypePropertyNoStrictNullChecks1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitOptionalMappedTypePropertyNoStrictNullChecks2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitOptionalMappedTypePropertyNoStrictNullChecks3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitOptionalMappedTypePropertyNoStrictNullChecks4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitOptionalMethod.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitOutFileBundlePaths.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitOverloadedPrivateInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitParameterProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPartialNodeReuseTypeOf.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPartialNodeReuseTypeReferences.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPartialReuseComputedProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPreserveReferencedImports.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPrivateAsync.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPrivateNameCausesError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPrivateReadonlyLiterals.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPrivateSymbolCausesVarDeclarationEmit2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPrivateSymbolCausesVarDeclarationToBeEmitted.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPromise.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPropertyNumericStringKey.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitQualifiedAliasTypeArgument.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitReadonlyComputedProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitRecursiveConditionalAliasPreserved.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitReexportedSymlinkReference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitReexportedSymlinkReference2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitResolveTypesIfNotReusable.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitRetainedAnnotationRetainsImportInOutput.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitRetainsJsdocyComments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitReusesLambdaParameterNodes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitScopeConsistency.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitScopeConsistency3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitShadowing.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitShadowingInferNotRenamed.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitSimpleComputedNames1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitSpreadStringlyKeyedEnum.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitStringEnumUsedInNonlocalSpread.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitToDeclarationDirWithCompositeOption.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitToDeclarationDirWithDeclarationOption.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitToDeclarationDirWithoutCompositeAndDeclarationOptions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTopLevelNodeFromCrossFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTopLevelNodeFromCrossFile2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTransitiveImportOfHtmlDeclarationItem.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTupleRestSignatureLeadingVariadic.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeAliasTypeParameterExtendingUnknownSymbol.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeAliasWithTypeParameters1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeAliasWithTypeParameters2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeAliasWithTypeParameters3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeAliasWithTypeParameters4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeAliasWithTypeParameters5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeAliasWithTypeParameters6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeParamMergedWithPrivate.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeParameterNameInOuterScope.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeParameterNameReusedInOverloads.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeParameterNameShadowedInternally.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeofDefaultExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeofRest.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeofThisInClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitUsingAlternativeContainingModules1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitUsingAlternativeContainingModules2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitUsingTypeAlias2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitVarInElidedBlock.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitWithComposite.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitWithInvalidPackageJsonTypings.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationFileOverwriteError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationFileOverwriteErrorWithOut.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationFilesGeneratingTypeReferences.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationFilesWithTypeReferences1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationFilesWithTypeReferences2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationFilesWithTypeReferences3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationFilesWithTypeReferences4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationFunctionTypeNonlocalShouldNotBeAnError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationImportTypeAliasInferredAndEmittable.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationMaps.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationMapsMultifile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationMapsOutFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationMapsOutFile2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationMapsWithSourceMap.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationMapsWithoutDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationMerging1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationMerging2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationNoDanglingGenerics.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationQuotedMembers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationTypecheckNoUseBeforeReferenceCheck.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationsForFileShadowingGlobalNoError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationsForIndirectTypeAliasReference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationsForInferredTypeFromOtherFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationsIndirectGeneratedAliasReference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationsWithRecursiveInternalTypesProduceUniqueTypeParams.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declareClassInterfaceImplementation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declareDottedExtend.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declareExternalModuleWithExportAssignedFundule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declareFileExportAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declareFileExportAssignmentWithVarFromVariableStatement.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declareIdentifierAsBeginningOfStatementExpression01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declareModifierOnTypeAlias.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declaredExternalModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/declaredExternalModuleWithExportAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataConditionalType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataGenericTypeVariable.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataGenericTypeVariableDefault.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataGenericTypeVariableInScope.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataNoLibIsolatedModulesTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataNoStrictNull.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataPromise.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataTypeOnlyExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataTypeOnlyImport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorReferenceOnOtherProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorReferences.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorUsedBeforeDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorWithUnderscoreMethod.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/deduplicateImportsInSystem.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/deepComparisons.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/deepElaborationsIntoArrowExpressions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/deepExcessPropertyCheckingWhenTargetIsIntersection.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/deepKeysIndexing.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/deeplyDependentLargeArrayMutation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/deeplyDependentLargeArrayMutation2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/deeplyNestedAssignabilityErrorsCombined.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/deeplyNestedAssignabilityIssue.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/deeplyNestedCheck.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/deeplyNestedConditionalTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/deeplyNestedConstraints.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/deeplyNestedMappedTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultArgsInFunctionExpressions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultDeclarationEmitDefaultImport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultDeclarationEmitNamedCorrectly.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultDeclarationEmitShadowedNamedCorrectly.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultIndexProps1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultIndexProps2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultIsNotVisibleInLocalScope.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultNamedExportWithType1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultNamedExportWithType2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultNamedExportWithType3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultNamedExportWithType4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultOfAnyInStrictNullChecks.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultParameterAddsUndefinedWithStrictNullChecks.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultParameterTrailingComments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultPropsEmptyCurlyBecomesAnyForJs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/deferredConditionalTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/deferredConditionalTypes2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/deferredLookupTypeResolution.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/deferredLookupTypeResolution2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/deferredTypeReferenceWithinArrayWithinTuple.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/defineVariables_useDefineForClassFields.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/definiteAssignmentOfDestructuredVariable.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/deleteReadonly.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/deleteReadonlyInStrictNullChecks.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/dependencyViaImportAlias.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/deprecatedBool.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/deprecatedCompilerOptions1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/deprecatedCompilerOptions2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/deprecatedCompilerOptions3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/deprecatedCompilerOptions4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/deprecatedCompilerOptions5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/deprecatedCompilerOptions6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/derivedClassOverridesPrivateFunction1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/derivedClasses.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/derivedInterfaceCallSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/derivedTypeCallingBaseImplWithOptionalParams.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/derivedTypeIncompatibleSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructureComputedProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructureOfVariableSameAsShorthand.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructureOptionalParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructureTupleWithVariableElement.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuredDeclarationEmit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuredMaappedTypeIsNotImplicitlyAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringAssignmentWithDefault.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringAssignmentWithDefault2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringAssignmentWithExportedName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringAssignmentWithStrictNullChecks.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringAssignment_private.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringInVariableDeclarations1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringInVariableDeclarations2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringInVariableDeclarations3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringInVariableDeclarations4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringInVariableDeclarations5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringInVariableDeclarations6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringInVariableDeclarations7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringInVariableDeclarations8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringInitializerContextualTypeFromContext.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringPropertyAssignmentNameIsNotAssignmentTarget.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringTempOccursAfterPrologue.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringTuple.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringTypeGuardFlow.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringWithConstraint.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringWithGenericParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringWithNewExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringWithNumberLiteral.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/detachedCommentAtStartOfConstructor1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/detachedCommentAtStartOfConstructor2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/detachedCommentAtStartOfLambdaFunction1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/detachedCommentAtStartOfLambdaFunction2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/didYouMeanElaborationsForExpressionsWhichCouldBeCalled.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/didYouMeanStringLiteral.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/differentTypesWithSameName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminableUnionWithIntersectedMembers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminantElementAccessCheck.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminantNarrowingCouldBeCircular.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminantOrderIndependence.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminantPropertyCheck.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminantPropertyInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminantUsingEvaluatableTemplateExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminantsAndNullOrUndefined.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminantsAndPrimitives.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminantsAndTypePredicates.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminateObjectTypesOnly.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminateWithDivergentAccessors1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminateWithMissingProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminatedUnionErrorMessage.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminatedUnionJsxElement.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminatedUnionWithIndexSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminatingUnionWithUnionPropertyAgainstUndefinedWithoutStrictNullChecks.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/dissallowSymbolAsWeakType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/distributiveConditionalTypeConstraints.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/distributiveConditionalTypeNeverIntersection1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/divergentAccessors1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/divergentAccessorsTypes1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/divergentAccessorsTypes2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/divergentAccessorsTypes6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/divergentAccessorsTypes7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/divergentAccessorsTypes8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/divergentAccessorsVisibility1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/divideAndConquerIntersections.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/doNotEmitDetachedComments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/doNotEmitDetachedCommentsAtStartOfConstructor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/doNotEmitDetachedCommentsAtStartOfFunctionBody.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/doNotEmitDetachedCommentsAtStartOfLambdaFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/doNotEmitPinnedCommentNotOnTopOfFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/doNotEmitPinnedCommentOnNotEmittedNode.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/doNotEmitPinnedCommentOnNotEmittedNodets.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/doNotEmitPinnedDetachedComments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/doNotEmitTripleSlashCommentsOnNotEmittedNode.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/doNotInferUnrelatedTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/doNotWidenAtObjectLiteralPropertyAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/doNotemitTripleSlashComments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/doWhileLoop.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/doWhileUnreachableCode.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/doesNotNarrowUnionOfConstructorsWithInstanceof.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/dottedModuleName2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/dottedNamesInSystem.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/dottedSymbolResolution1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/doubleMixinConditionalTypeBaseClassWorks.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/doubleUnderStringLiteralAssignability.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/doubleUnderscoreEnumEmit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/doubleUnderscoreExportStarConflict.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/doubleUnderscoreLabels.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/doubleUnderscoreMappedTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/doubleUnderscoreReactNamespace.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/dtsEmitTripleSlashAvoidUnnecessaryResolutionMode.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateAnonymousInners1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateAnonymousModuleClasses.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateConstructSignature2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateConstructorOverloadSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateConstructorOverloadSignature2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateErrorAssignability.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateErrorClassExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateErrorNameNotFound.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierDifferentModifiers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierRelatedSpans2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierRelatedSpans4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierRelatedSpans7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierShouldNotShortCircuitBaseTypeBinding.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateLabel3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateLabel4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateLocalVariable3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateLocalVariable4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateObjectLiteralProperty_computedNameNegative1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateOverloadInTypeAugmentation1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicatePackage.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicatePackage_packageIdIncludesSubModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicatePackage_referenceTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicatePackage_relativeImportWithinPackage.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicatePackage_relativeImportWithinPackage_scoped.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicatePackage_subModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateVarAndImport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateVariableDeclaration1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateVariablesByScope.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateVariablesWithAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateVarsAcrossFileBoundaries.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/dynamicImportEvaluateSpecifier.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/dynamicImportInDefaultExportExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/dynamicImportWithNestedThis_es2015.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/dynamicImportsDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/dynamicModuleTypecheckError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/dynamicNames.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/dynamicNamesErrors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/dynamicRequire.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/elaboratedErrors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/elaboratedErrorsOnNullableTargets01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/elaborationForPossiblyCallableTypeStillReferencesArgumentAtTopLevel.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/elementAccessExpressionInternalComments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/elidedEmbeddedStatementsReplacedWithSemicolon.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/elidedJSImport1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/elidingImportNames.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitAccessExpressionOfCastedObjectLiteralExpressionInArrowFunctionES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitBOM.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitCapturingThisInTupleDestructuring1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitCapturingThisInTupleDestructuring2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitClassExpressionInDeclarationFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitClassExpressionInDeclarationFile2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitClassMergedWithConstNamespaceNotElided.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitMemberAccessExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitMethodCalledNew.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitOneLineVariableDeclarationRemoveCommentsFalse.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitPinnedCommentsOnTopOfFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitPostComments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitPreComments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitSkipsThisWithRestParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitSuperCallBeforeEmitParameterPropertyDeclaration1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitSuperCallBeforeEmitParameterPropertyDeclaration1ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitSuperCallBeforeEmitPropertyDeclaration1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitSuperCallBeforeEmitPropertyDeclaration1ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitSuperCallBeforeEmitPropertyDeclarationAndParameterPropertyDeclaration1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitSuperCallBeforeEmitPropertyDeclarationAndParameterPropertyDeclaration1ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitTopOfFileTripleSlashCommentOnNotEmittedNodeIfRemoveCommentsIsFalse.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyArgumentsListComment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyArrayDestructuringExpressionVisitedByTransformer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyDeclarationEmitIsModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyEnum.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyExpr.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyIndexer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyModuleName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyObjectNotSubtypeOfIndexSignatureContainingObject1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyObjectNotSubtypeOfIndexSignatureContainingObject2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyOptionalBindingPatternInDeclarationSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyThenWarning.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyThenWithoutWarning.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumAssignmentCompat.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumAssignmentCompat2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumAssignmentCompat3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumAssignmentCompat4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumAssignmentCompat5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumAssignmentCompat6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumCodeGenNewLines1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumDecl1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumDeclarationEmitInitializerHasImport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumFromExternalModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumIndexer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumInitializersWithExponents.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumKeysQuotedAsObjectPropertiesInDeclarationEmit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumLiteralAssignableToEnumInsideUnion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumLiteralUnionNotWidened.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumLiteralsSubtypeReduction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumMapBackIntoItself.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumMemberNameNonIdentifier.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumMemberReduction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumNegativeLiteral1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumNumbering1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumOperations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumPropertyAccessBeforeInitalisation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumUsedBeforeDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumWithExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumWithInfinityProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumWithNaNProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumWithNegativeInfinityProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumWithQuotedElementName1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumWithQuotedElementName2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumWithUnicodeEscape1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumWithoutInitializerAfterComputedMember.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumsWithMultipleDeclarations3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/erasableSyntaxOnly.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorConstructorSubtypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorElaborationDivesIntoApparentlyPresentPropsOnly.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorForBareSpecifierWithImplicitModuleResolutionNone.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorForUsingPropertyOfTypeAsType02.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorForwardReferenceForwadingConstructor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorHandlingInInstanceOf.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorLocationForInterfaceExtension.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorMessageOnIntersectionsWithDiscriminants01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorMessagesIntersectionTypes01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorMessagesIntersectionTypes02.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorMessagesIntersectionTypes03.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorMessagesIntersectionTypes04.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorOnContextuallyTypedReturnType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorOnEnumReferenceInCondition.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorOnUnionVsObjectShouldDeeplyDisambiguate.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorOnUnionVsObjectShouldDeeplyDisambiguate2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorTypesAsTypeArguments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorWithSameNameType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorWithTruncatedType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorsForCallAndAssignmentAreSimilar.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorsInGenericTypeReference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorsOnUnionsOfOverlappingObjects01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorsWithInvokablesInUnions01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es2015modulekind.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es2015modulekindWithES6Target.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es2017basicAsync.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es2018ObjectAssign.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6-amd.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6-declaration-amd.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6-sourcemap-amd.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6-umd.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6-umd2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ClassSuperCodegenBug.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ClassTest2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ClassTest3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ClassTest4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ClassTest5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ClassTest7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ClassTest8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ExportAll.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ExportAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ExportAssignment2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ExportAssignment3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ExportAssignment4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ExportClause.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ExportClauseWithoutModuleSpecifier.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ExportDefaultClassDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ExportDefaultClassDeclaration2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ExportDefaultExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ExportDefaultFunctionDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ExportDefaultIdentifier.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBinding.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImport1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImportDts.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBinding.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBinding1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBindingDts.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingNoDefaultProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportEqualsDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportEqualsDeclaration2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportEqualsExportModuleCommonJsError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportEqualsExportModuleEs2015Error.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNameSpaceImport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNameSpaceImportAmd.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNameSpaceImportDts.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportAmd.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportDts.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportInExportAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportInIndirectExportAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportNoExportMember.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportWithTypesAndValues.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportWithJsDocTags.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportWithoutFromClauseAmd.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6MemberScoping.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6Module.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ModuleClassDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ModuleConst.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ModuleConstEnumDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ModuleConstEnumDeclaration2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ModuleEnumDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ModuleFunctionDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ModuleInternalImport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ModuleLet.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ModuleModuleDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ModuleVariableStatement.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ModuleWithModuleGenTargetAmd.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ModuleWithModuleGenTargetCommonjs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6UseOfTopLevelRequire.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInterop.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropDefaultImports.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropDefaultMemberMustBeSyntacticallyDefaultExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropEnablesSyntheticDefaultImports.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropImportCall.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropImportDefaultWhenAllNamedAreDefaultAlias.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropImportNamespace.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropImportTSLibHasImport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropNamedDefaultImports.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropPrettyErrorRelatedInformation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropTslibHelpers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropUsesExportStarWhenDefaultPlusNames.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleIntersectionCrash.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/esNextWeakRefs_IterableWeakMap.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/escapedReservedCompilerNamedIdentifier.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/esmModeDeclarationFileWithExportAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/evalAfter0.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/evalOrArgumentsInDeclarationFunctions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/eventEmitterPatternWithRecordOfFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/evolvingArrayResolvedAssert.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/evolvingArrayTypeInAssert.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exactOptionalPropertyTypesIdentical.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exactSpellingSuggestion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessPropertiesInOverloads.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessPropertyCheckIntersectionWithIndexSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessPropertyCheckWithEmptyObject.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessPropertyCheckWithMultipleDiscriminants.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessPropertyCheckWithNestedArrayIntersection.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessPropertyCheckWithSpread.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessPropertyCheckWithUnions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessPropertyCheckingIntersectionWithConditional.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessPropertyChecksWithNestedIntersections.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessPropertyErrorForFunctionTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessPropertyErrorsSuppressed.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessiveStackDepthFlatArray.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessivelyLargeTupleSpread.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exhaustiveSwitchCheckCircularity.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exhaustiveSwitchImplicitReturn.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exhaustiveSwitchWithWideningLiteralTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionBlockShadowing.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionContextualTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionContextualTypesJSDocInTs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionContextualTypesJs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionContextualTypesNoValue.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionExpressionsWithDynamicNames.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionExpressionsWithDynamicNames2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionNestedAssigmentsDeclared.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionNullishProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionSymbolProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionSymbolPropertyJs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/experimentalDecoratorMetadataUnresolvedTypeObjectInEmit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/explicitAnyAfterSpreadNoImplicitAnyError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportArrayBindingPattern.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAsNamespace.d.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAsNamespaceConflict.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignClassAndModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignValueAndType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignedNamespaceIsVisibleInDeclarationEmit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignedTypeAsTypeAnnotation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentEnum.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentInternalModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentMembersVisibleInAugmentation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentOfDeclaredExternalModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentOfGenericType1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentVariable.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentWithImportStatementPrivacyError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentWithPrivacyError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentWithoutAllowSyntheticDefaultImportsError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentWithoutIdentifier1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportClassExtendingIntersection.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDeclarationWithModuleSpecifierNameOnNextLine1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDeclarationsInAmbientNamespaces.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDefaultAbstractClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDefaultAsyncFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDefaultForNonInstantiatedModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDefaultInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDefaultInterfaceAndFunctionOverloads.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDefaultInterfaceAndValue.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDefaultMarksIdentifierAsUsed.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDefaultMissingName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDefaultParenthesizeES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDefaultProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDefaultProperty2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDefaultQualifiedNameNoError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDefaultStripsFreshness.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDefaultVariable.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDefaultWithJSDoc1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDefaultWithJSDoc2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportEqualCallable.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportEqualNamespaces.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportEqualsAmd.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportEqualsClassNoRedeclarationError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportEqualsCommonJs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportEqualsOfModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportEqualsProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportEqualsProperty2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportEqualsUmd.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportImport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportImportAndClodule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportImportMultipleFiles.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportImportNonInstantiatedModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportImportNonInstantiatedModule2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportNamespaceDeclarationRetainsVisibility.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportPrivateType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportRedeclarationTypeAliases.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportSpecifierAndExportedMemberDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportSpecifierAndLocalMemberDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportSpecifierForAGlobal.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportSpecifierReferencingOuterDeclaration1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportSpecifierReferencingOuterDeclaration2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportSpecifierReferencingOuterDeclaration3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportSpecifierReferencingOuterDeclaration4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarForValues.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarForValues10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarForValues2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarForValues3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarForValues4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarForValues5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarForValues6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarForValues7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarForValues8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarForValues9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarForValuesInSystem.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarNotElided.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportToString.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportVisibility.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportedBlockScopedDeclarations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportedInterfaceInaccessibleInCallbackInModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportedVariable1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportingContainingVisibleType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportsInAmbientModules1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportsInAmbientModules2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/expr.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/extBaseClass1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendAndImplementTheSameBaseType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendAndImplementTheSameBaseType2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendArray.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendBaseClassBeforeItsDeclared.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendConstructSignatureInInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendGenericArray.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendGenericArray2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendNonClassSymbol1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendNonClassSymbol2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendPrivateConstructorClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendedInterfaceGenericType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendedUnicodeEscapeSequenceIdentifiers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendedUnicodePlaneIdentifiers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendedUnicodePlaneIdentifiersJSDoc.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendingClassFromAliasAndUsageInIndexer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendingCollectionsWithCheckJs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendsJavaScript.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendsUntypedModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/externFunc.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/externModuleClobber.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/externalModuleAssignToVar.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/externalModuleExportingGenericClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/externalModuleQualification.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/externalModuleReferenceDoubleUnderscore1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/externalModuleReferenceOfImportDeclarationWithExportModifier.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/externalModuleResolution.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/externalModuleResolution2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/extractInferenceImprovement.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/fakeInfinity1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/fakeInfinity2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/fakeInfinity3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/fallFromLastCase1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/fallFromLastCase2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/fallbackToBindingPatternForTypeInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/fatArrowSelf.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/fatArrowfunctionAsType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/fatarrowfunctions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/fatarrowfunctionsInFunctionParameterDefaults.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/fatarrowfunctionsInFunctions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/fileReferencesWithNoExtensions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/fileWithNextLine1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/fileWithNextLine2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/filesEmittingIntoSameOutput.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/filesEmittingIntoSameOutputWithOutOption.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/fillInMissingTypeArgsOnConstructCalls.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/firstMatchRegExpMatchArray.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/fixCrashAliasLookupForDefauledImport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/fixTypeParameterInSignatureWithRestParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/fixingTypeParametersRepeatedly1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/fixingTypeParametersRepeatedly2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/fixingTypeParametersRepeatedly3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/flatArrayNoExcessiveStackDepth.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/flowAfterFinally1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/flowControlTypeGuardThenSwitch.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/flowInFinally1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/forAwaitForIntersection1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/forAwaitForUnion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/forIn2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/forInModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/forInStatement1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/forInStatement2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/forInStatement3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/forInStatement5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/forInStatement6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/forInStrictNullChecksNoError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/forLoopEndingMultilineComments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/forLoopWithDestructuringDoesNotElideFollowingStatement.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/forOfStringConstituents.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/forOfTransformsExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/forStatementInnerComments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/formatToPartsFractionalSecond.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/forwardRefInClassProperties.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/freshLiteralInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/freshLiteralTypesInIntersections.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/fromAsIdentifier1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/fromAsIdentifier2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/funClodule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/funcdecl.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionAssignmentError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall11.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall12.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall13.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall14.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall16.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall17.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall18.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCallOnConstrainedTypeVariable.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionDeclarationWithArgumentOfTypeFunctionTypeArray.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionDeclarationWithResolutionOfTypeNamedArguments01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionDeclarationWithResolutionOfTypeOfSameName01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionExpressionAndLambdaMatchesFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionExpressionNames.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionExpressionReturningItself.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionExpressionWithResolutionOfTypeNamedArguments01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionExpressionWithResolutionOfTypeOfSameName01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionExpressionWithResolutionOfTypeOfSameName02.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionInIfStatementInModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionMergedWithModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOnlyHasThrow.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads12.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads13.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads14.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads15.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads16.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads21.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads22.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads23.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads24.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads25.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads26.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads27.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads28.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads29.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads30.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads31.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads32.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads33.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads34.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads35.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads36.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads37.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads38.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads39.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads40.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads41.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads42.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads43.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads44.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads45.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloadsOnGenericArity1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloadsOnGenericArity2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloadsRecursiveGenericReturnType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionParameterArityMismatch.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionReturn.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionReturnTypeQuery.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionReturningItself.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionSignatureAssignmentCompat1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionSubtypingOfVarArgs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionSubtypingOfVarArgs2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionToFunctionWithPropError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionTypeArgumentArityErrors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionTypeArgumentArrayAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionTypeArgumentAssignmentCompat.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionVariableInReturnTypeAnnotation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithAnyReturnTypeAndNoReturnExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements11.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements12.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements13.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements14.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements15.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements16.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithNoBestCommonType1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithNoBestCommonType2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithThrowButNoReturn1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionsInClassExpressions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionsMissingReturnStatementsAndExpressionsStrictNullChecks.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/funduleExportedClassIsUsedBeforeDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/funduleOfFunctionWithoutReturnTypeAnnotation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/funduleSplitAcrossFiles.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/funduleUsedAcrossFileBoundary.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/fuzzy.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/generativeRecursionWithTypeOf.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/generatorES6InAMDModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/generatorES6_1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/generatorES6_2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/generatorES6_3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/generatorES6_4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/generatorES6_5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/generatorES6_6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/generatorReturnExpressionIsChecked.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericAndNonGenericInheritedSignature1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericAndNonGenericInheritedSignature2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericAndNonGenericOverload1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArgumentCallSigAssignmentCompat.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArray0.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArray1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArrayAssignment1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArrayAssignmentCompatErrors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArrayExtenstions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArrayMethods1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArrayPropertyAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArrayWithoutTypeAnnotation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericAssignmentCompatOfFunctionSignatures1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericAssignmentCompatWithInterfaces1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericBaseClassLiteralProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericBaseClassLiteralProperty2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallAtYieldExpressionInGenericCall1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallAtYieldExpressionInGenericCall2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallAtYieldExpressionInGenericCall3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallInferenceConditionalType1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallInferenceConditionalType2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallInferenceInConditionalTypes1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallInferenceUsingThisTypeNoInvalidCacheReuseAfterMappedTypeApplication1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallInferenceWithGenericLocalFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallOnMemberReturningClosedOverObject.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallWithFixedArguments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallWithNonGenericArgs1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallWithObjectLiteralArguments1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallWithinOwnBodyCastTypeParameterIdentity.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallbackInvokedInsideItsContainingFunction1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallbacksAndClassHierarchy.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCapturingFunctionNarrowing.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassImplementingGenericInterfaceFromAnotherModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassInheritsConstructorFromNonGenericClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassPropertyInheritanceSpecialization.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassStaticMethod.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassWithStaticFactory.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassWithStaticsUsingTypeArguments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClasses0.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClasses1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClasses2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClasses3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClasses4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassesInModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassesInModule2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCloduleInModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCloduleInModule2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCloneReturnTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCloneReturnTypes2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCombinators2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConditionalConstrainedToUnknownNotAssignableToConcreteObject.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstraint1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstraint2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstraint3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstraintDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstraintOnExtendedBuiltinTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstraintOnExtendedBuiltinTypes2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstraintSatisfaction1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstructInvocationWithNoTypeArg.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstructSignatureInInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstructorFunction1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericContextualTypingSpecialization.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericDefaults.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericDefaultsJs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericDerivedTypeWithSpecializedBase.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericDerivedTypeWithSpecializedBase2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionCallSignatureReturnTypeMismatch.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionHasFreshTypeArgs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionInference1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionInference2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionSpecializations1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctions0.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctions1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctions2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctions3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionsAndConditionalInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionsNotContextSensitive.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionsWithOptionalParameters1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionsWithOptionalParameters2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionsWithOptionalParameters3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunduleInModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunduleInModule2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericGetter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericGetter2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericGetter3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericImplements.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericIndexTypeHasSensibleErrorMessage.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericIndexedAccessMethodIntersectionCanBeAccessed.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericIndexedAccessVarianceComparisonResultCorrect.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericInference1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericInference2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericInferenceDefaultTypeParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericInferenceDefaultTypeParameterJsxReact.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericInheritedDefaultConstructors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericInstanceOf.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericInterfaceFunctionTypeParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericInterfaceImplementation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericInterfaceTypeCall.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericInterfacesWithoutTypeArguments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericIsNeverEmptyObject.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericLambaArgWithoutTypeArguments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericMappedTypeAsClause.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericMergedDeclarationUsingTypeParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericMergedDeclarationUsingTypeParameter2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericMethodOverspecialization.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericNewInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericNumberIndex.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericObjectCreationWithoutTypeArgs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericObjectLitReturnType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericObjectSpreadResultInSwitch.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericOfACloduleType1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericOfACloduleType2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericOverloadSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericParameterAssignability1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericPrototypeProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericPrototypeProperty2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericPrototypeProperty3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericRecursiveImplicitConstructorErrors1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericRecursiveImplicitConstructorErrors2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericRestArgs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericRestTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericReturnTypeFromGetter1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericReversingTypeParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericReversingTypeParameters2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericSignatureIdentity.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericSignatureInheritance.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericSignatureInheritance2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericSpecializationToTypeLiteral1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericSpecializations1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericSpecializations3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericStaticAnyTypeFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTemplateOverloadResolution.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTupleWithSimplifiableElements.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeArgumentInference1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeAssertions1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeAssertions2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeAssertions3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeAssertions4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeAssertions5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeAssertions6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeConstraints.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeParameterEquivalence2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeReferencesRequireTypeArgs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeUsedWithoutTypeArguments1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeWithCallableMembers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeWithCallableMembers2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeWithMultipleBases1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeWithMultipleBases2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeWithMultipleBases3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeWithNonGenericBaseMisMatch.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericWithCallSignatureReturningSpecialization.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericWithCallSignatures1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericWithIndexerOfTypeParameterType1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericWithIndexerOfTypeParameterType2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericWithNoConstraintComparableWithCurlyCurly.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericWithOpenTypeParameters1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/generics0.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/generics1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/generics1NoError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/generics2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/generics2NoError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/generics3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/generics4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/generics4NoError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/generics5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericsAndHigherOrderFunctions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericsManyTypeParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericsWithoutTypeParameters1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/getAccessorWithImpliedReturnTypeAndFunctionClassMerge.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/getAndSetAsMemberNames.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/getAndSetNotIdenticalType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/getAndSetNotIdenticalType2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/getAndSetNotIdenticalType3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/getParameterNameAtPosition.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/getsetReturnTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/getterErrorMessageNotDuplicated.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/getterSetterNonAccessor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/getterSetterSubtypeAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/getterThatThrowsShouldNotNeedReturn.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/gettersAndSettersAccessibility.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/gettersAndSettersTypesAgree.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/global.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/globalFunctionAugmentationOverload.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/globalIsContextualKeyword.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/globalThis.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/globalThisCapture.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/globalThisDeclarationEmit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/globalThisDeclarationEmit2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/globalThisDeclarationEmit3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/grammarAmbiguities1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/heterogeneousArrayAndOverloads.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/hidingCallSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/hidingConstructSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/hidingIndexSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/higherOrderMappedIndexLookupInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/homomorphicMappedTypeIntersectionAssignability.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/homomorphicMappedTypeNesting.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/homomorphicMappedTypeWithNonHomomorphicInstantiationSpreadable1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/hugeDeclarationOutputGetsTruncatedWithError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/i3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/icomparable.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/idInProp.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/identicalGenericConditionalsWithInferRelated.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/identicalTypesNoDifferByCheckOrder.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/identityAndDivergentNormalizedTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/identityForSignaturesWithTypeParametersAndAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/identityForSignaturesWithTypeParametersSwitched.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/identityRelationNeverTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/ifElseWithStatements1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/ifStatementInternalComments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/ignoredJsxAttributes.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/illegalGenericWrapping1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/implementArrayInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/implementGenericWithMismatchedTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/implementInterfaceAnyMemberWithVoid.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/implementPublicPropertyAsPrivate.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/implementsInClassExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/implementsIncorrectlyNoAssertion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyAmbients.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyAnyReturningFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyCastedValue.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyDeclareFunctionExprWithoutFormalType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyDeclareFunctionWithoutFormalType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyDeclareFunctionWithoutFormalType2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyDeclareMemberWithoutType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyDeclareMemberWithoutType2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyDeclareTypePropertyWithoutType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyDeclareVariablesWithoutTypeAndInit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyFunctionInvocationWithAnyArguements.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyFunctionOverloadWithImplicitAnyReturnType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyFunctionReturnNullOrUndefined.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyGenericTypeInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyGenerics.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyGetAndSetAccessorWithAnyReturnType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyInAmbientDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyInAmbientDeclaration2.d.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyInCatch.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyNewExprLackConstructorSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyWidenToAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitConstParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitIndexSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/impliedNodeFormatInterop1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importAliasAnExternalModuleInsideAnInternalModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importAliasFromNamespace.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importAliasWithDottedName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importAnImport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importAndVariableDeclarationConflict2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importAsBaseClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importDecl.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importDeclFromTypeNodeInJsSource.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importDeclRefereingExternalModuleWithNoResolve.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importDeclTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importDeclWithExportModifier.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importDeclWithExportModifierInAmbientContext.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importDeclarationNotCheckedAsValueWhenTargetNonValue.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importDeclarationUsedAsTypeQuery.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importElisionEnum.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importElisionExportNonExportAndDefault.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importEqualsError45874.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importExportInternalComments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importHelpersBundler.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importHelpersES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importHelpersNoHelpersForPrivateFields.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importHelpersVerbatimModuleSyntax.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importInTypePosition.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember11.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember12.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importNotElidedWhenNotFound.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importOnAliasedIdentifiers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importPropertyFromMappedType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importShadowsGlobalName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importShouldNotBeElidedInDeclarationEmit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importTypeGenericArrowTypeParenthesized.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importTypeResolutionJSDocEOF.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importTypeTypeofClassStaticLookup.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importTypeWithUnparenthesizedGenericFunctionParsed.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importUsedAsTypeWithErrors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importUsedInExtendsList1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importUsedInGenericImportResolves.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importWithTrailingSlash_noResolve.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/import_reference-exported-alias.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/import_reference-to-type-alias.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/import_unneeded-require-when-referenecing-aliased-type-throug-array.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/import_var-referencing-an-imported-module-alias.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importedAliasedConditionalTypeInstantiation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importedAliasesInTypePositions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importedModuleAddToGlobal.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importedModuleClassNameClash.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importsInAmbientModules1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importsInAmbientModules2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/importsInAmbientModules3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inDoesNotOperateOnPrimitiveTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inKeywordAndIntersection.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inKeywordAndUnknown.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inKeywordNarrowingWithNoUncheckedIndexedAccess.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inOperator.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inOperatorWithFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inOperatorWithGeneric.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/incompatibleAssignmentOfIdenticallyNamedTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/incompatibleGenericTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/incompatibleTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/incorrectNumberOfTypeArgumentsDuringErrorReporting.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/incorrectRecursiveMappedTypeConstraint.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/incrementOnNullAssertion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/incrementalConfig.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/incrementalInvalid.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/incrementalOut.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/incrementalTsBuildInfoFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexClassByNumber.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexIntoArraySubclass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexIntoEnum.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexSignatureAndMappedType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexSignatureInOtherFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexSignatureInOtherFile1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexSignatureOfTypeUnknownStillRequiresIndexSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexSignatureWithInitializer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexSignaturesInferentialTyping.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexTypeNoSubstitutionTemplateLiteral.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexWithUndefinedAndNull.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexWithUndefinedAndNullStrictNullChecks.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexWithoutParamType2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessAndNullableNarrowing.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessCanBeHighOrder.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessConstraints.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessImplicitlyAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessKeyofNestedSimplifiedSubstituteUnwrapped.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessNormalization.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessPrivateMemberOfGenericConstraint.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessRelation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessRetainsIndexSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessToThisTypeOnIntersection01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessTypeConstraints.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessWithVariableElement.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexer2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexer3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexerA.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexerAssignability.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexerConstraints.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexerReturningTypeParameter1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexingTypesWithNever.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indirectDiscriminantAndExcessProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indirectGlobalSymbolPartOfObjectType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indirectSelfReference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indirectSelfReferenceGeneric.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indirectTypeParameterReferences.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/indirectUniqueSymbolDeclarationEmit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferConditionalConstraintMappedMember.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferFromAnnotatedReturn1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferFromGenericFunctionReturnTypes2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferFromGenericFunctionReturnTypes3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferFromNestedSameShapeTuple.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferObjectTypeFromStringLiteralToKeyof.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferParameterWithMethodCallInitializer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferPropertyWithContextSensitiveReturnStatement.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferRestArgumentsMappedTuple.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferSecondaryParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferSetterParamType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferStringLiteralUnionForBindingElement.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferTInParentheses.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferTupleFromBindingPattern.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferTypeArgumentsInSignatureWithRestParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferTypeConstraintInstantiationCircularity.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferTypeParameterConstraints.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferTypePredicates.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferTypesWithFixedTupleExtendsAtVariadicPosition.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceAndHKTs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceAndSelfReferentialConstraint.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceContextualReturnTypeUnion1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceContextualReturnTypeUnion2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceContextualReturnTypeUnion3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceContextualReturnTypeUnion4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceDoesNotAddUndefinedOrNull.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceDoesntCompareAgainstUninstantiatedTypeParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceErasedSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceExactOptionalProperties1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceExactOptionalProperties2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceFromGenericClassNoCrash1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceFromIncompleteSource.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceFromParameterlessLambda.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceLimit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceOfNullableObjectTypesWithCommonBase.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceOptionalProperties.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceOptionalPropertiesStrict.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceOptionalPropertiesToIndexSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceShouldFailOnEvolvingArrays.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceUnionOfObjectsMappedContextualType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingObjectLiteralMethod1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingObjectLiteralMethod2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingUsingApparentType1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingUsingApparentType2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingUsingApparentType3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingWithFunctionType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingWithFunctionType2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingWithFunctionTypeNested.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingWithFunctionTypeSyntacticScenarios.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingWithFunctionTypeZip.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingWithObjectLiteralProperties.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferredFunctionReturnTypeIsEmptyType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferredIndexerOnNamespaceImport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferredNonidentifierTypesGetQuotes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferredRestTypeFixedOnce.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferredReturnTypeIncorrectReuse1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferrenceInfiniteLoopWithSubtyping.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferringAnyFunctionType1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferringAnyFunctionType2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferringAnyFunctionType3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferringAnyFunctionType4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferringAnyFunctionType5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferringReturnTypeFromConstructSignatureGeneric.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/infiniteConstraints.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/infiniteExpandingTypeThroughInheritanceInstantiation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingBaseTypes1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingBaseTypes2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingOverloads.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingTypeAssignability.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingTypes1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingTypes2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingTypes3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingTypes4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingTypes5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingTypesNonGenericBase.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/infinitelyGenerativeInheritance1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritFromGenericTypeParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritSameNamePrivatePropertiesFromDifferentOrigins.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritSameNamePrivatePropertiesFromSameOrigin.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritSameNamePropertiesWithDifferentOptionality.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritSameNamePropertiesWithDifferentVisibility.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritance.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritance1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceGrandParentPrivateMemberCollision.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceGrandParentPrivateMemberCollisionWithPublicMember.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceGrandParentPublicMemberCollisionWithPrivateMember.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceMemberAccessorOverridingAccessor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceMemberAccessorOverridingProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceMemberFuncOverridingAccessor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceMemberFuncOverridingMethod.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceMemberFuncOverridingProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceMemberPropertyOverridingAccessor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceMemberPropertyOverridingMethod.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceMemberPropertyOverridingProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceOfGenericConstructorMethod1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceOfGenericConstructorMethod2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticAccessorOverridingAccessor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticAccessorOverridingMethod.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticAccessorOverridingProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticFuncOverridingAccessor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticFuncOverridingAccessorOfFuncType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticFuncOverridingMethod.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticFuncOverridingProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticFuncOverridingPropertyOfFuncType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticFunctionOverridingInstanceProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticMembersCompatible.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticMembersIncompatible.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticPropertyOverridingAccessor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticPropertyOverridingMethod.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticPropertyOverridingProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedConstructorPropertyContextualType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedConstructorWithRestParams.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedConstructorWithRestParams2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedFunctionAssignmentCompatibility.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedGenericCallSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedMembersAndIndexSignaturesFromDifferentBases.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedMembersAndIndexSignaturesFromDifferentBases2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedModuleMembersForClodule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedOverloadedSpecializedSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedStringIndexersFromDifferentBaseTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedStringIndexersFromDifferentBaseTypes2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/initializedDestructuringAssignmentTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/initializedParameterBeforeNonoptionalNotOptional.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/initializerWithThisPropertyAccess.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/initializersInAmbientEnums.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inlineConditionalHasSimilarAssignability.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inlineMappedTypeModifierDeclarationEmit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/inlinedAliasAssignableToConstraintSameAsAlias.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/innerAliases2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/innerBoundLambdaEmit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/innerExtern.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/innerFunc.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/innerOverloads.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/innerTypeArgumentInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/innerTypeCheckOfLambdaArgument.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceAndStaticDeclarations1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceOfAssignability.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceOfInExternalModules.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceSubtypeCheck1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceSubtypeCheck2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceofNarrowReadonlyArray.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceofTypeAliasToGenericClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceofWithPrimitiveUnion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/instantiateContextualTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/instantiateContextuallyTypedGenericThis.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/instantiateCrossFileMerge.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/instantiatedBaseTypeConstraints.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/instantiatedReturnTypeContravariance.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/instantiatedTypeAliasDisplay.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/instantiationExpressionErrorNoCrash.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces0.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interface0.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceClassMerging.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceClassMerging2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceContextualType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceDeclaration2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceDeclaration3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceDeclaration5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceDeclaration6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceExtendsClass1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceExtendsClassWithPrivate1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceExtendsClassWithPrivate2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceImplementation1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceImplementation2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceImplementation3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceImplementation4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceImplementation5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceImplementation6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceImplementation7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceImplementation8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceInReopenedModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceInheritance.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceInheritance2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceMergedUnconstrainedNoErrorIrrespectiveOfOrder.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceNameAsIdentifier.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceOnly.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfacePropertiesWithSameName1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfacePropertiesWithSameName2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfacePropertiesWithSameName3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceSubtyping.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceWithCommaSeparators.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceWithOptionalProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfacedecl.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfacedeclWithIndexerErrors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasClassInsideLocalModuleWithExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasClassInsideLocalModuleWithoutExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasClassInsideTopLevelModuleWithExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasClassInsideTopLevelModuleWithoutExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasEnum.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasEnumInsideLocalModuleWithExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasEnumInsideLocalModuleWithoutExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasEnumInsideTopLevelModuleWithExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasEnumInsideTopLevelModuleWithoutExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasFunctionInsideLocalModuleWithExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasFunctionInsideLocalModuleWithoutExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasFunctionInsideTopLevelModuleWithExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasFunctionInsideTopLevelModuleWithoutExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasInitializedModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasInitializedModuleInsideLocalModuleWithExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasInitializedModuleInsideLocalModuleWithoutExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasInitializedModuleInsideTopLevelModuleWithExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasInitializedModuleInsideTopLevelModuleWithoutExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasInterfaceInsideLocalModuleWithExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasInterfaceInsideLocalModuleWithoutExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasInterfaceInsideLocalModuleWithoutExportAccessError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasInterfaceInsideTopLevelModuleWithExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasInterfaceInsideTopLevelModuleWithoutExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasUninitializedModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasUninitializedModuleInsideLocalModuleWithExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasUninitializedModuleInsideLocalModuleWithoutExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasUninitializedModuleInsideLocalModuleWithoutExportAccessError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasUninitializedModuleInsideTopLevelModuleWithExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasUninitializedModuleInsideTopLevelModuleWithoutExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasVar.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasVarInsideLocalModuleWithExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasVarInsideLocalModuleWithoutExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasVarInsideTopLevelModuleWithExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasVarInsideTopLevelModuleWithoutExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasWithDottedNameEmit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalImportInstantiatedModuleMergedWithClassNotReferencingInstanceNoConflict.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalImportUnInstantiatedModuleMergedWithClassNotReferencingInstanceNoConflict.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalImportUnInstantiatedModuleNotReferencingInstanceNoConflict.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionApparentTypeCaching.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionConstraintReduction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionOfMixinConstructorTypeAndNonConstructorType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionOfTypeVariableHasApparentSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionPropertyCheck.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionReductionGenericStringLikeType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionSatisfiesConstraint.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionTypeInference1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionTypeNormalization.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionTypeWithLeadingOperator.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionType_useDefineForClassFields.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionWithConstructSignaturePrototypeResult.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionsAndOptionalProperties.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionsAndReadonlyProperties.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionsOfLargeUnions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/intraBindingPatternReferences.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/intrinsics.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidConstraint1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidReferenceSyntax1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidSplice.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidSymbolInTypeParameter1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidThisEmitInContextualObjectLiteral.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidTripleSlashReference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidTypeNames.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidUseOfTypeAsNamespace.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/invariantGenericErrorElaboration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/invocationExpressionInFunctionParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/invokingNonGenericMethodWithTypeArguments2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/ipromise2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/ipromise3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/ipromise4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorTypes1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsAugmentation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsClasses.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsClassesExpressions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsDefault.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsEnums.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsExpandoFunctions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsExpressions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsFunctionDeclarations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsObjects.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsReturnTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationLazySymbols.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationOutFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationsAddUndefined.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationsAddUndefined2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationsAllowJs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationsLiterals.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationsRequiresDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesAmbientConstEnum.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesConstEnum.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesDontElideReExportStar.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesExternalModuleForced.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesGlobalNamespacesAndEnums.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesImportConstEnum.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesImportConstEnumTypeOnly.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesNoEmitOnError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesNoExternalModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesNoExternalModuleMultiple.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesNonAmbientConstEnum.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesOut.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesPlainFile-ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesReExportType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesSourceMap.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesSpecifiedModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesUnspecifiedModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesWithDeclarationFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModules_resolveJsonModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModules_resolveJsonModule_strict_outDir_commonJs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/iteratorsAndStrictNullChecks.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/javascriptCommonjsModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/javascriptDefinePropertyPrototypeNonConstructor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/javascriptImportDefaultBadExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/javascriptThisAssignmentInStaticBlock.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jqueryInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsDeclarationEmitDoesNotRenameImport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsDeclarationEmitExportAssignedArray.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsDeclarationEmitExportAssignedFunctionWithExtraTypedefsMembers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsDeclarationEmitExportedClassWithExtends.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsDeclarationsGlobalFileConstFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsDeclarationsGlobalFileConstFunctionNamed.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsDeclarationsInheritedTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsDeclarationsWithDefaultAsNamespaceLikeMerge.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsDocDeclarationEmitDoesNotUseNodeModulesPathWithoutError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsElementAccessNoContextualTypeCrash.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsEnumCrossFileExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsEnumFunctionLocalNoCrash.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsEnumTagOnObjectFrozen.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsExpandoObjectDefineProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsExportAssignmentNonMutableLocation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsExportMemberMergedWithModuleAugmentation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsExportMemberMergedWithModuleAugmentation3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsExtendsImplicitAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileAlternativeUseOfOverloadTag.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileClassPropertyInitalizationInObjectLiteral.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileClassPropertyType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileClassPropertyType2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileClassPropertyType3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileClassSelfReferencedProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationAwaitModifier.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationClassMethodContainingArrowFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationConstModifier.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationDecoratorSyntax.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationDuplicateVariable.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationDuplicateVariableErrorReported.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationEmitBlockedCorrectly.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationEmitDeclarations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationEmitTrippleSlashReference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationErrorOnDeclarationsWithJsFileReferenceWithNoOut.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationErrorOnDeclarationsWithJsFileReferenceWithOut.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationErrorOnDeclarationsWithJsFileReferenceWithOutDir.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationExternalPackageError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationLetBeingRenamed.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationLetDeclarationOrder.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationLetDeclarationOrder2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationNoErrorWithoutDeclarationsWithJsFileReferenceWithNoOut.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationNoErrorWithoutDeclarationsWithJsFileReferenceWithOut.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationRestParamJsDocFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationRestParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationShortHandProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationSyntaxError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationWithDeclarationEmitPathSameAsInput.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationWithEnabledCompositeOption.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationWithJsEmitPathSameAsInput.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationWithMapFileAsJs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationWithMapFileAsJsWithInlineSourceMap.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationWithMapFileAsJsWithOutDir.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationWithOut.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationWithOutDeclarationFileNameSameAsInputJsFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationWithOutFileNameSameAsInputJsFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationWithoutOut.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileESModuleWithEnumTag.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileFunctionOverloads.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileFunctionOverloads2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileFunctionParametersAsOptional.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileFunctionParametersAsOptional2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileImportPreservedWhenUsed.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileMethodOverloads.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileMethodOverloads2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileMethodOverloads3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileMethodOverloads4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileMethodOverloads5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsNegativeElementAccessNotBound.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsNoImplicitAnyNoCascadingReferenceErrors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsPropertyAssignedAfterMethodDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsPropertyAssignedAfterMethodDeclaration_nonError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsSelfReferencingArgumentsFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocAccessEnumType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocArrayObjectPromiseImplicitAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocArrayObjectPromiseNoImplicitAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocBracelessTypeTag1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocCallbackAndType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocCastCommentEmit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocClassMissingTypeArguments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocFunctionClassPropertiesDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocImportTypeNodeNamespace.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocImportTypeResolution.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocParamTagInvalid.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocParamTagOnPropertyInitializer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocParameterParsingInvalidName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocPropertyTagInvalid.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocReferenceGlobalTypeInCommonJs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocResolveNameFailureInTypedef.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocRestParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocRestParameter_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocTypeCast.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocTypeGenericInstantiationAttempt.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocTypeNongenericInstantiationAttempt.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocTypecastNoTypeNoCrash.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocTypedefBeforeParenthesizedExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocTypedefMissingType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocTypedefNoCrash.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocTypedef_propertyWithNoType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocUnexpectedCharacter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/json.stringify.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsonFileImportChecksCallCorrectlyTwice.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxCallElaborationCheckNoCrash1.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxCallbackWithDestructuring.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxChildWrongType.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxChildrenGenericContextualTypes.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxChildrenIndividualErrorElaborations.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxChildrenSingleChildConfusableWithMultipleChildrenNoError.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxChildrenWrongType.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxClassAttributeResolution.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxComplexSignatureHasApplicabilityError.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxComponentTypeErrors.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxDeclarationsWithEsModuleInteropNoCrash.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxElementClassTooManyParams.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxElementsAsIdentifierNames.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxEmitAttributeWithPreserve.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxEmitWithAttributes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxEmptyExpressionNotCountedAsChild2.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxExcessPropsAndAssignability.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryAndJsxFragmentFactory.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryAndJsxFragmentFactoryErrorNotIdentifier.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryAndJsxFragmentFactoryNull.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryAndReactNamespace.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryButNoJsxFragmentFactory.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryIdentifier.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryIdentifierAsParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryIdentifierWithAbsentParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryMissingErrorInsideAClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryNotIdentifierOrQualifiedName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryNotIdentifierOrQualifiedName2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryQualifiedName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryQualifiedNameResolutionError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFragmentAndFactoryUsedOnFragmentUse.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFragmentFactoryNoUnusedLocals.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFragmentWrongType.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFunctionTypeChildren.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxGenericComponentWithSpreadingResultOfGenericFunction.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxHasLiteralType.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxHash.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxImportInAttribute.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxImportSourceNonPragmaComment.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxInExtendsClause.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxInferenceProducesLiteralAsExpected.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxIntrinsicDeclaredUsingTemplateLiteralTypeSignatures.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxIntrinsicElementsCompatability.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxIntrinsicElementsExtendsRecord.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxIntrinsicUnions.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxIssuesErrorWhenTagExpectsTooManyArguments.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxLibraryManagedAttributesUnusedGeneric.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxLocalNamespaceIndexSignatureNoCrash.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxMultilineAttributeStringValues.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxMultilineAttributeValuesReact.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceGlobalReexport.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceGlobalReexportMissingAliasTarget.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceImplicitImportJSXNamespace.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceImplicitImportJSXNamespaceFromPragmaPickedOverGlobalOne.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceReexports.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxNamespacedNameNotComparedToNonMatchingIndexSignature.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxNestedWithinTernaryParsesCorrectly.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxPartialSpread.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxPreserveWithJsInput.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxPropsAsIdentifierNames.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxSpreadFirstUnionNoErrors.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxViaImport.2.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxViaImport.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/keyRemappingKeyofResult.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/keyRemappingKeyofResult2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/keyofDoesntContainSymbols.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/keyofGenericExtendingClassDoubleLayer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/keyofModuleObjectHasCorrectKeys.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/keyofObjectWithGlobalSymbolIncluded.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/keywordExpressionInternalComments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/keywordField.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/keywordInJsxIdentifier.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/lambdaASIEmit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/lambdaArgCrash.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/lambdaExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/lambdaParameterWithTupleArgsHasCorrectAssignability.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/largeControlFlowGraph.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/largeTupleTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/lateBoundAssignmentCandidateJS1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/lateBoundAssignmentCandidateJS2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/lateBoundAssignmentCandidateJS3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/lateBoundConstraintTypeChecksCorrectly.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/lateBoundDestructuringImplicitAnyError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/lateBoundFunctionMemberAssignmentDeclarations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/lateBoundMethodNameAssigmentJS.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-access.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-scopes2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-useBeforeDefinition.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-useBeforeDefinition2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/letDeclarations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/letDeclarations2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/letInNonStrictMode.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/letKeepNamesOfTopLevelItems.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/letShadowedByNameInNestedScope.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/libTypeScriptOverrideSimple.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/libTypeScriptOverrideSimpleConfig.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/libTypeScriptSubfileResolving.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/libTypeScriptSubfileResolvingConfig.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/libdtsFix.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/library_ArraySlice.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/library_DatePrototypeProperties.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/library_ObjectPrototypeProperties.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/library_RegExpExecArraySlice.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/library_StringSlice.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/lift.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/limitDeepInstantiations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/listFailure.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/literalFreshnessPropagationOnNarrowing.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/literalIntersectionYieldsLiteral.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/literalTypeNameAssertionNotTriggered.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/literalWideningWithCompoundLikeAssignments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/literals-negative.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/literals1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/localAliasExportAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/localClassesInLoop.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/localClassesInLoop_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/localImportNameVsGlobalName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/localRequireFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/localTypeParameterInferencePriority.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/localVariablesReturnedFromCatchBlocks.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/logicalNotExpression1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/m7Bugs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mapConstructor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mapConstructorOnReadonlyTuple.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mapGroupBy.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mapOnTupleTypes01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mapOnTupleTypes02.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedArrayTupleIntersections.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedToToIndexSignatureInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeAndIndexSignatureRelation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeAsStringTemplate.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeCircularReferenceInAccessor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeContextualTypesApplied.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeGenericIndexedAccess.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeGenericInstantiationPreservesHomomorphism.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeGenericInstantiationPreservesInlineForm.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeGenericWithKnownKeys.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeIndexedAccess.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeIndexedAccessConstraint.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeInferenceAliasSubstitution.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeInferenceCircularity.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeInferenceFromApparentType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeInferenceToMappedType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeMultiInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeNestedGenericInstantiation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeNoTypeNoCrash.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeNotMistakenlyHomomorphic.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeOverArrayWithBareAnyRestCanBeUsedAsRestParam1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeParameterConstraint.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypePartialConstraints.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypePartialNonHomomorphicBaseConstraint.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeRecursiveInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeRecursiveInference2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeTupleConstraintAssignability.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeUnionConstrainTupleTreatedAsArrayLike.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeUnionConstraintInferences.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeWithAsClauseAndLateBoundProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeWithAsClauseAndLateBoundProperty2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeWithCombinedTypeMappers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeWithNameClauseAppliedToArrayType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/matchReturnTypeInAllBranches.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/matchingOfObjectLiteralConstraints.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/maxConstraints.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/maximum10SpellingSuggestions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/memberAccessMustUseModuleInstances.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/memberAccessOnConstructorType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/memberScope.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/memberVariableDeclarations1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergeMultipleInterfacesReexported.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedDeclarations1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedDeclarations2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedDeclarations4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedDeclarations5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedDeclarations6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedDeclarations7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedEnumDeclarationCodeGen.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedInstantiationAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedInterfaceFromMultipleFiles1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationCodeGen.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationCodeGen2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationCodeGen3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationCodeGen4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationCodeGen5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationWithSharedExportedVar.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/metadataOfStringLiteral.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/metadataOfUnion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/methodChainError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/methodSignatureDeclarationEmit1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/methodSignatureHandledDeclarationKindForSymbol.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mismatchedExplicitTypeParameterAndArgumentType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mismatchedGenericArguments1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingCommaInTemplateStringsArray.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingDiscriminants.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingDiscriminants2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingImportAfterModuleImport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingMemberErrorHasShortPath.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingReturnStatement.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingReturnStatement1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingSelf.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingSemicolonInModuleSpecifier.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingTypeArguments1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingTypeArguments2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingTypeArguments3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/misspelledJsDocTypedefTags.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mixedExports.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mixedTypeEnumComparison.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mixinIntersectionIsValidbaseType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mixinOverMappedTypeNoCrash.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mixingApparentTypeOverrides.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mixingFunctionAndAmbientModule1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/modFunctionCrash.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/modKeyword.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_Dom.asynciterable.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_Dom.iterable.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_ErrorFromUsingWellknownSymbolWithOutES6WellknownSymbolLib.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_NoErrorDuplicateLibOptions1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_NoErrorDuplicateLibOptions2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_TargetES5UsingES6Lib.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_TargetES6UsingES6Lib.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_UsingES5LibAndES6FeatureLibs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_UsingES5LibES6ArrayLibES6WellknownSymbolLib.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_Worker.asynciterable.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_Worker.iterable.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAliasAsFunctionArgument.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAliasInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAndInterfaceSharingName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAndInterfaceSharingName2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAndInterfaceSharingName3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAndInterfaceSharingName4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAsBaseType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAssignmentCompat1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAssignmentCompat2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAssignmentCompat3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAssignmentCompat4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationCollidingNamesInAugmentation1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationDeclarationEmit1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationDeclarationEmit2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationDoesInterfaceMergeOfReexport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationDoesNamespaceEnumMergeOfReexport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationDoesNamespaceMergeOfReexport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationDuringSyntheticDefaultCheck.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationExtendAmbientModule1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationExtendAmbientModule2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationExtendFileModule1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationExtendFileModule2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationGlobal1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationGlobal2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationGlobal3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationGlobal4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationGlobal5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationImportsAndExports1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationImportsAndExports4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationImportsAndExports5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationImportsAndExports6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationInAmbientModule1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationInAmbientModule2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationInAmbientModule3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationInAmbientModule4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationInAmbientModule5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationInDependency.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationInDependency2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationNoNewNames.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationOfAlias.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationWithNonExistentNamedImport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationsImports1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationsImports2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationsImports3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationsImports4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleClassArrayCodeGenTest.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleCodeGenTest3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleCodeGenTest5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleCodegenTest4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleCrashBug1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleDeclarationExportStarShadowingGlobalIsNameable.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleDetectionIsolatedModulesCjsFileScope.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleExportNonStructured.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleExports1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleExportsTypeNoExcessPropertyCheckFromContainedLiteral.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleExportsUnaryExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleIdentifiers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleImport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleImportedForTypeArgumentPosition.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleInTypePosition1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleLocalImportNotIncorrectlyRedirected.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleMemberMissingErrorIsRelative.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleMemberWithoutTypeAnnotation1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleMemberWithoutTypeAnnotation2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleMerge.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleMergeConstructor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleNewExportBug.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleNoEmit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleNoneOutFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleOuterQualification.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/modulePreserve1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/modulePreserve2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/modulePreserveImportHelpers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/modulePrologueAMD.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/modulePrologueCommonjs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/modulePrologueES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/modulePrologueSystem.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/modulePrologueUmd.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleRedifinitionErrors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleReopenedTypeOtherBlock.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleReopenedTypeSameBlock.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionAsTypeReferenceDirective.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionAsTypeReferenceDirectiveAmbient.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionAsTypeReferenceDirectiveScoped.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionNoResolve.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionNoTsCJS.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionNoTsESM.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionPackageIdWithRelativeAndAbsolutePath.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithExtensions_notSupported.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithExtensions_notSupported2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithExtensions_notSupported3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithExtensions_withAmbientPresent.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithExtensions_withPaths.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithRequire.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithRequireAndImport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_empty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_notSpecified.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_one.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_oneBlank.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_oneNotFound.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_one_dirModuleWithIndex.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_one_externalModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_one_externalModulePath.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_one_externalModule_withPaths.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_one_externalTSModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_one_jsModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_one_jsonModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_threeLastIsBlank1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_threeLastIsBlank2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_threeLastIsBlank3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_threeLastIsBlank4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSymlinks.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSymlinks_notInNodeModules.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSymlinks_preserveSymlinks.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSymlinks_referenceTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSymlinks_withOutDir.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_automaticTypeDirectiveNames.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_classicPrefersTs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_explicitNodeModulesImport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_explicitNodeModulesImport_implicitAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_noLeadingDot.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_packageJson_notAtPackageRoot.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_packageJson_notAtPackageRoot_fakeScopedPackage.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_packageJson_scopedPackage.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_packageJson_yesAtPackageRoot.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_packageJson_yesAtPackageRoot_fakeScopedPackage.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_packageJson_yesAtPackageRoot_mainFieldInSubDirectory.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_relativeImportJsFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_relativeImportJsFile_noImplicitAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleSameValueDuplicateExportedBindings1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleSameValueDuplicateExportedBindings2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleScopingBug.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleSharesNameWithImportDeclarationInsideIt.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleSharesNameWithImportDeclarationInsideIt2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleSharesNameWithImportDeclarationInsideIt4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleSharesNameWithImportDeclarationInsideIt6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleSymbolMerging.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleUnassignedVariable.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleVariables.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleVisibilityTest1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleVisibilityTest3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleVisibilityTest4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleWithNoValuesAsType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleWithTryStatement1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleWithValuesAsType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/module_augmentUninstantiatedModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/module_augmentUninstantiatedModule2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiCallOverloads.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiExtendsSplitInterfaces1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiExtendsSplitInterfaces2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiImportExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiLineContextDiagnosticWithPretty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiLineErrors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiModuleClodule1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiModuleFundule1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiSignatureTypeInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/multipleBaseInterfaesWithIncompatibleProperties.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/multipleInferenceContexts.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mutrec.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mutuallyRecursiveCallbacks.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mutuallyRecursiveGenericBaseTypes1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mutuallyRecursiveGenericBaseTypes2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mutuallyRecursiveInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/mutuallyRecursiveInterfaceDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nameCollisionWithBlockScopedVariable1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nameCollisionsInPropertyAssignments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/namedFunctionExpressionAssignedToClassProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/namedFunctionExpressionCall.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/namedFunctionExpressionCallErrors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/namedFunctionExpressionInModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/namedImportNonExistentName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/namespaceDisambiguationInUnion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/namespaceMergedWithFunctionWithOverloadsUsage.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/namespaces1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/namespaces2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/namespacesDeclaration2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/namespacesWithTypeAliasOnlyExportsMerge.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nanEquality.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByBooleanComparison.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByEquality.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByInstanceof.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByParenthesizedSwitchExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowCommaOperatorNestedWithinLHS.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowRefinedConstLikeParameterBIndingElementNameInInnerScope.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowSwitchOptionalChainContainmentEvolvingArrayNoCrash1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowTypeByInstanceof.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowUnknownByTypePredicate.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowUnknownByTypeofObject.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowedConstInMethod.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowedImports.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowedImports_assumeInitialized.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingAssignmentReadonlyRespectsAssertion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingByDiscriminantInLoop.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingByTypeofInSwitch.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingConstrainedTypeParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingDestructuring.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingInCaseClauseAfterCaseClauseWithReturn.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingIntersection.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingMutualSubtypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingNoInfer1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingOfDottedNames.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingOfQualifiedNames.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingOrderIndependent.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingPastLastAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingPastLastAssignmentInModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingPlainJsNoCrash1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingRestGenericCall.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingTruthyObject.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingTypeofDiscriminant.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingTypeofFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingTypeofObject.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingTypeofParenthesized1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingTypeofUndefined1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingTypeofUndefined2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingUnionToNeverAssigment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingUnionToUnion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingUnionWithBang.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingWithNonNullExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nativeToBoxedTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nearbyIdenticalGenericLambdasAssignable.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/negativeZero.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings11.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings12.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings13.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings14.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings15.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings16.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedCallbackErrorNotFlattened.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedExcessPropertyChecking.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedFreshLiteral.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedGenericConditionalTypeWithGenericImportType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedGenericSpreadInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedGenerics.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedHomomorphicMappedTypesWithArrayConstraint1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedIfStatement.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedIndexer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedInfinitelyExpandedRecursiveTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedLoopTypeGuards.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedModulePrivateAccess.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedObjectRest.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedRecursiveArraysOrObjectsError01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedRecursiveLambda.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedRedeclarationInES6AMD.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedSelf.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedThisContainer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedTypeVariableInfersLiteral.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/neverNullishThroughParentheses.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/newAbstractInstance.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/newAbstractInstance2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/newArrays.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/newExpressionWithTypeParameterConstrainedToOuterTypeParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/newFunctionImplicitAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/newLineFlagWithCRLF.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/newLineFlagWithLF.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/newLineInTypeofInstantiation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/newMap.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/newNamesInGlobalAugmentations1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/newNonReferenceType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/newOnInstanceSymbol.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noAsConstNameLookup.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noBundledEmitFromNodeModules.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCheckDoesNotReportError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCheckNoEmit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCheckRequiresEmitDeclarationOnly.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCircularDefinitionOnExportOfPrivateInMergedNamespace.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCircularitySelfReferentialGetter1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCircularitySelfReferentialGetter2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCircularitySelfReferentialGetter3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCircularitySelfReferentialGetter4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCollisionThisExpressionAndClassInGlobal.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCollisionThisExpressionAndLocalVarInAccessors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCollisionThisExpressionAndLocalVarInConstructor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCollisionThisExpressionAndLocalVarInFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCollisionThisExpressionAndLocalVarInLambda.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCollisionThisExpressionAndLocalVarInMethod.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCollisionThisExpressionAndLocalVarInProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCollisionThisExpressionAndVarInGlobal.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCollisionThisExpressionInFunctionAndVarInGlobal.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noConstraintInReturnType1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCrashOnImportShadowing.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCrashOnMixin.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCrashOnNoLib.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCrashOnParameterNamedRequire.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCrashOnThisTypeUsage.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCrashUMDMergedWithGlobalValue.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCrashWithVerbatimModuleSyntaxAndImportsNotUsedAsValues.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noEmitAndComposite.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noEmitAndCompositeListFilesOnly.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noEmitAndIncremental.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noEmitAndIncrementalListFilesOnly.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noEmitHelpers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noEmitOnError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noErrorTruncation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noErrorUsingImportExportModuleAugmentationInDeclarationFile1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noErrorsInCallback.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noExcessiveStackDepthError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyAndPrivateMembersWithoutTypeAnnotations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyDestructuringInPrivateMethod.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyDestructuringParameterDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyDestructuringVarDeclaration2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyForMethodParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyForwardReferencedInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyFunctionExpressionAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyFunctions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyInBareInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyInCastExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyInContextuallyTypesFunctionParamter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyParametersInAmbientClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyParametersInAmbientFunctions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyParametersInAmbientModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyParametersInBareFunctions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyParametersInClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyParametersInInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyParametersInModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyReferencingDeclaredInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyUnionNormalizedObjectLiteral1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyWithOverloads.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitReturnInConstructors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitReturnsExclusions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitReturnsInAsync1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitReturnsInAsync2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitReturnsWithProtectedBlocks1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitReturnsWithProtectedBlocks2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitReturnsWithProtectedBlocks3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitReturnsWithoutReturnExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitSymbolToString.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitThisBigThis.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitThisFunctions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitUseStrict_amd.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitUseStrict_commonjs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitUseStrict_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitUseStrict_system.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitUseStrict_umd.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noInferCommonPropertyCheck1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noInferUnionExcessPropertyCheck1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noIterationTypeErrorsInCFA.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noObjectKeysToKeyofT.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noParameterReassignmentIIFEAnnotated.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noParameterReassignmentJSIIFE.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noReachabilityErrorsOnEmptyStatement.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noSelfOnVars.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noStrictGenericChecks.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noSubstitutionTemplateStringLiteralTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noSubtypeReduction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noSymbolForMergeCrash.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noTypeArgumentOnReturnType1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUncheckedIndexAccess.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUncheckedIndexedAccessCompoundAssignments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUnusedLocals_destructuringAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUnusedLocals_potentialPredicateUnusedParam.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUnusedLocals_selfReference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUnusedLocals_selfReference_skipsBlockLocations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUnusedLocals_typeParameterMergedWithParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUnusedLocals_writeOnly.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUnusedLocals_writeOnlyProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUnusedLocals_writeOnlyProperty_dynamicNames.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUsedBeforeDefinedErrorInAmbientContext1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUsedBeforeDefinedErrorInTypeContext.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeColonModuleResolution.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeColonModuleResolution2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeModuleReexportFromDottedPath.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextCjsNamespaceImportDefault1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextCjsNamespaceImportDefault2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextEsmImportsOfPackagesWithExtensionlessMains.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextImportModeImplicitIndexResolution.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextImportModeImplicitIndexResolution2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextModuleResolution1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextModuleResolution2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextPackageImportMapRootDir.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextPackageSelfNameWithOutDir.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextPackageSelfNameWithOutDirDeclDir.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextPackageSelfNameWithOutDirDeclDirComposite.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextPackageSelfNameWithOutDirDeclDirCompositeNestedDirs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextPackageSelfNameWithOutDirDeclDirNestedDirs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextPackageSelfNameWithOutDirDeclDirRootDir.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextPackageSelfNameWithOutDirRootDir.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeResolution1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeResolution2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeResolution3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeResolution4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeResolution5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeResolution6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeResolution7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeResolution8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonArrayRestArgs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonConflictingRecursiveBaseTypeMembers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonContextuallyTypedLogicalOr.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonGenericClassExtendingGenericClassWithAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonInferrableTypePropagation1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonInferrableTypePropagation2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonInferrableTypePropagation3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonNullFullInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonNullMappedType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonNullParameterExtendingStringAssignableToString.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonNullReferenceMatching.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonNullableReduction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonNullableReductionNonStrict.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonNullableTypes1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonNullableWithNullableGenericIndexedAccessArg.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonObjectUnionNestedExcessPropertyCheck.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nondistributiveConditionalTypeInfer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nongenericConditionalNotPartiallyComputed.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nongenericPartialInstantiationsRelatedInBothDirections.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonnullAssertionPropegatesContextualType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonstrictTemplateWithNotOctalPrintsAsIs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/normalizedIntersectionTooComplex.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nounusedTypeParameterConstraint.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/null.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/nullableFunctionError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/numberAsInLHS.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/numberAssignableToEnumInsideUnion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/numberOnLeftSideOfInExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/numberToString.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/numberVsBigIntOperations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericEnumMappedType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericIndexExpressions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericIndexerConstraint.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericIndexerConstraint1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericIndexerConstraint2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericIndexerConstraint3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericIndexerConstraint4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericIndexerConstraint5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericIndexerTyping1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericIndexerTyping2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericMethodName1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectAssignLikeNonUnionResult.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectBindingPatternContextuallyTypesArgument.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectCreate-errors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectCreate.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectCreate2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectCreationOfElementAccessExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectFreeze.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectFreezeLiteralsDontWiden.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectFromEntries.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectGroupBy.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectIndexer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectInstantiationFromUnionSpread.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLitGetterSetter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLitIndexerContextualType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLitPropertyScoping.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLitStructuralTypeMismatch.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLitTargetTypeCallSite.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteral1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteral2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralArraySpecialization.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralComputedNameNoDeclarationError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralDeclarationGeneration1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralEnumPropertyNames.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralExcessProperties.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralFreshnessWithSpread.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralFunctionArgContextualTyping2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralIndexerErrors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralIndexerNoImplicitAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralIndexers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralParameterResolution.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralPropertyImplicitlyAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralReferencingInternalProperties.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralThisWidenedOnUse.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralWithGetAccessorInsideFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralWithNumericPropertyName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralsAgainstUnionsOfArrays01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectMembersOnTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectPropertyAsClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectRestBindingContextualInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectSpreadWithinMethodWithinObjectWithSpread.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/observableInferenceCanBeMade.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/omitTypeHelperModifiers01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/omitTypeTests01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalAccessorsInInterface1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalConstructorArgInSuper.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalFunctionArgAssignability.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalParamAssignmentCompat.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalParamInOverride.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalParamReferencingOtherParams1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalParamTypeComparison.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalParameterInDestructuringWithInitializer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalParameterProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalParameterRetainsNull.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalParamterAndVariableDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalParamterAndVariableDeclaration2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalPropertiesInClasses.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalPropertiesTest.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalTupleElementsAndUndefined.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionsCompositeWithIncrementalFalse.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionsInlineSourceMapMapRoot.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionsInlineSourceMapSourceRoot.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionsInlineSourceMapSourcemap.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionsOutAndNoModuleGen.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionsSourcemapInlineSources.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionsSourcemapInlineSourcesMapRoot.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionsSourcemapInlineSourcesSourceRoot.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionsStrictPropertyInitializationStrict.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionsStrictPropertyInitializationStrictNullChecks.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionsTsBuildInfoFileWithoutIncrementalAndComposite.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/outFileIsDeprecated.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/outModuleConcatES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overEagerReturnTypeSpecialization.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overload1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overload2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadBindingAcrossDeclarationBoundaries.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadBindingAcrossDeclarationBoundaries2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadCallTest.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadCrash.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadEquivalenceWithStatics.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadErrorMatchesImplementationElaboaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadGenericFunctionWithRestArgs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstAsTypeAnnotation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstConstraintChecks1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstConstraintChecks2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstConstraintChecks3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstConstraintChecks4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstDuplicateOverloads1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstInBaseWithBadImplementationInDerived.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstInCallback1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstInObjectLiteralImplementingAnInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstInheritance1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstInheritance2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstInheritance3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstInheritance4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstNoNonSpecializedSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstNoStringImplementation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstNoStringImplementation2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnGenericArity.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnGenericClassAndNonGenericClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadResolutionOnDefaultConstructor1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadResolutionOverCTLambda.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadResolutionOverNonCTLambdas.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadResolutionOverNonCTObjectLit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadResolutionTest1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadResolutionWithAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadRet.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadReturnTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadWithCallbacksWithDifferingOptionalityOnArgs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadedConstructorFixesInferencesAppropriately.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadedStaticMethodSpecialization.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadingOnConstants1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadingOnConstantsInImplementation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadresolutionWithConstraintCheckingDeferred.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadsAndTypeArgumentArity.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadsAndTypeArgumentArityErrors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadsWithConstraints.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadsWithProvisionalErrors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overrideBaseIntersectionMethod.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/overridingPrivateStaticMembers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/parameterDestructuringObjectLiteral.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/parameterListAsTupleType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/parameterNamesInTypeParameterList.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/parameterPropertyInConstructor4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/parameterPropertyInConstructorWithPrologues.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/parameterPropertyInitializerInInitializers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/parameterPropertyReferencingOtherParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/parameterReferenceInInitializer1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/parameterReferenceInInitializer2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/parameterReferencesOtherParameter1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/parameterReferencesOtherParameter2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/paramsOnlyHaveLiteralTypesWhenAppropriatelyContextualized.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/paramterDestrcuturingDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/parenthesisDoesNotBlockAliasSymbolCreation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/parenthesizedArrowExpressionASI.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/parenthesizedAsyncArrowFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/parenthesizedExpressionInternalComments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/parenthesizedJSDocCastAtReturnStatement.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/parenthesizedJSDocCastDoesNotNarrow.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/parenthesizedSatisfiesExpressionWithComments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseArrowFunctionWithFunctionReturnType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseCommaSeparatedNewlineNumber.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseCommaSeparatedNewlineString.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseEntityNameWithReservedWord.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseGenericArrowRatherThanLeftShift.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseJsxExtends1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseJsxExtends2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseObjectLiteralsWithoutTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseReplacementCharacter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseShortform.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/parserIsClassMemberStart.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/parsingClassRecoversWhenHittingUnexpectedSemicolon.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/parsingDeepParenthensizedExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/partialDiscriminatedUnionMemberHasGoodError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/partialOfLargeAPIIsAbleToBeWorkedWith.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/partialTypeNarrowedToByTypeGuard.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/partiallyAmbientClodule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/partiallyAmbientFundule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/partiallyDiscriminantedUnions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution1_amd.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution1_node.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution2_classic.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution2_node.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution3_classic.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution3_node.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution4_classic.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution4_node.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution5_classic.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution5_node.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution6_classic.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution6_node.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution7_classic.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution7_node.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution8_classic.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution8_node.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution_rootImport_aliasWithRoot.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution_rootImport_aliasWithRoot_differentRootTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution_rootImport_aliasWithRoot_multipleAliases.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution_rootImport_noAliasWithRoot.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution_withExtension.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution_withExtensionInName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution_withExtension_MapedToNodeModules.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution_withExtension_failedLookup.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathsValidation1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathsValidation2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathsValidation3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/performanceComparisonOfStructurallyIdenticalInterfacesWithGenericSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/pickOfLargeObjectUnionWorks.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/pinnedComments1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/potentiallyUnassignedVariableInCatch.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/potentiallyUncalledDecorators.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/predicateSemantics.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/prefixIncrementAsOperandOfPlusExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/prefixedNumberLiteralAssignToNumberLiteralType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/preserveConstEnums.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/preserveUnusedImports.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/prespecializedGenericMembers1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/prettyFileWithErrorsAndTabs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/primaryExpressionMods.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/primitiveConstraints1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/primitiveConstraints2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/primitiveTypeAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/primitiveUnionDetection.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyCannotNameVarTypeDeclFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyCheckAnonymousFunctionParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyCheckAnonymousFunctionParameter2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyCheckCallbackOfInterfaceMethodWithTypeParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyCheckExportAssignmentOnExportedGenericInterface1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyCheckExportAssignmentOnExportedGenericInterface2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyCheckExternalModuleExportAssignmentOfGenericClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyCheckOnTypeParameterReferenceInConstructorParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyCheckTypeOfFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyCheckTypeOfInvisibleModuleError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyCheckTypeOfInvisibleModuleNoError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyClassExtendsClauseDeclFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyClassImplementsClauseDeclFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyFunc.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyFunctionCannotNameParameterTypeDeclFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyFunctionCannotNameReturnTypeDeclFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyFunctionParameterDeclFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyFunctionReturnTypeDeclFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyGloClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyGloFunc.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyGloImport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyGloInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyGloVar.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyImport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyInterfaceExtendsClauseDeclFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyLocalInternalReferenceImportWithExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyLocalInternalReferenceImportWithoutExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyTopLevelInternalReferenceImportWithExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyTopLevelInternalReferenceImportWithoutExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyTypeParameterOfFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyTypeParameterOfFunctionDeclFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyTypeParametersOfClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyTypeParametersOfClassDeclFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyTypeParametersOfInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyTypeParametersOfInterfaceDeclFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyVar.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyVarDeclFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privateAccessInSubclass1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privateFieldsInClassExpressionDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privateInstanceVisibility.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privateInterfaceProperties.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privatePropertyInUnion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privatePropertyUsingObjectType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privateVisibility.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/privateVisibles.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseAllOnAny01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseChaining.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseChaining1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseChaining2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseEmptyTupleNoException.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseIdentity.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseIdentity2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseIdentityWithAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseIdentityWithAny2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseIdentityWithConstraints.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/promisePermutations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/promisePermutations2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/promisePermutations3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseTest.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseTry.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseTypeInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseTypeInferenceUnion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseTypeStrictNull.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseVoidErrorCallback.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseWithResolvers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/promises.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/promisesWithConstraints.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/propTypeValidatorInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/propagateNonInferrableType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/propagationOfPromiseInitialization.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertiesAndIndexers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertiesAndIndexers2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertiesAndIndexersForNumericNames.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccess6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccess7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccessExpressionInnerComments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccessOfReadonlyIndexSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccessOnObjectLiteral.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccessibility1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccessibility2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyIdentityWithPrivacyMismatch.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyNamesWithStringLiteral.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyOverridingPrototype.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyParameterWithQuestionMark.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/protectedAccessThroughContextualThis.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/protectedMembers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/protectedMembersThisParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/protoAsIndexInIndexExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/protoAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/protoInIndexer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/prototypeInstantiatedWithBaseConstraint.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/prototypeOnConstructorFunctions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/publicMemberImplementedAsPrivateInDerivedClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/qualifiedName_ImportDeclarations-entity-names-referencing-a-var.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/qualifiedName_entity-name-resolution-does-not-affect-class-heritage.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/qualify.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/quickIntersectionCheckCorrectlyCachesErrors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/quotedAccessorName1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/quotedAccessorName2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/quotedFunctionName1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/quotedFunctionName2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/quotedPropertyName1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/quotedPropertyName2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/quotedPropertyName3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/raiseErrorOnParameterProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/ramdaToolsNoInfinite.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/ramdaToolsNoInfinite2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/randomSemicolons1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reExportGlobalDeclaration1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reExportGlobalDeclaration2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reExportGlobalDeclaration3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reExportGlobalDeclaration4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reExportUndefined1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reExportUndefined2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reachabilityCheckWithEmptyDefault.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecks1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecks10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecks11.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecks2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecks3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecks4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecks5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecks6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecks7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecks8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecks9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecksIgnored.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactDefaultPropsInferenceSuccess.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactHOCSpreadprops.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactImportDropped.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactJsxReactResolvedNodeNext.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactJsxReactResolvedNodeNextEsm.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactNamespaceImportPresevation.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactNamespaceInvalidInput.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactNamespaceJSXEmit.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactNamespaceMissingDeclaration.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactReadonlyHOCAssignabilityReal.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactReduxLikeDeferredInferenceAllowsAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactSFCAndFunctionResolvable.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactTagNameComponentWithPropsNoOOM.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactTagNameComponentWithPropsNoOOM2.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactTransitiveImportHasValidDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/readonlyAssignmentInSubclassOfClassExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/readonlyFloat32ArrayAssignableWithFloat32Array.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/readonlyPropertySubtypeRelationDirected.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/readonlyTupleAndArrayElaboration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reboundBaseClassSymbol.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/rectype.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recur1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveArrayNotCircular.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveBaseCheck.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveBaseCheck2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveBaseConstructorCreation1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveBaseConstructorCreation2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveBaseConstructorCreation3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveClassBaseType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveClassInstantiationsWithDefaultConstructors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveClassReferenceTest.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveCloduleReference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalCrash1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalCrash2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalCrash3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalCrash4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalEvaluationNonInfinite.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalTypes2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveExcessPropertyChecks.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveExportAssignmentAndFindAliasedType1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveExportAssignmentAndFindAliasedType2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveExportAssignmentAndFindAliasedType3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveExportAssignmentAndFindAliasedType4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveExportAssignmentAndFindAliasedType5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveExportAssignmentAndFindAliasedType6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveExportAssignmentAndFindAliasedType7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveFieldSetting.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveFunctionTypes1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveGenericMethodCall.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveGenericSignatureInstantiation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveGenericUnionType1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveGenericUnionType2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveGetterAccess.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveIdenticalAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveIdenticalOverloadResolution.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveInference1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveInferenceBug.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveInheritance.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveInheritance2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveInheritance3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveInheritanceGeneric.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveLetConst.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveMods.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveNamedLambdaCall.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveObjectLiteral.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveResolveTypeMembers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveReturns.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveReverseMappedType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveSpecializationOfExtendedTypeWithError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveSpecializationOfSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveTupleTypeInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveTupleTypes1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveTupleTypes2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveTypeAliasWithSpreadConditionalReturnNotCircular.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveTypeComparison.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveTypeComparison2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveTypeIdentity.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveTypeParameterConstraintReferenceLacksTypeArgs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveTypeParameterReferenceError1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveTypeParameterReferenceError2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveTypes1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveUnionTypeInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursivelyExpandingUnionNoStackoverflow.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursivelySpecializedConstructorDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/redeclarationOfVarWithGenericType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/redefineArray.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reducibleIndexedAccessTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportDefaultIsCallable.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportMissingDefault.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportMissingDefault1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportMissingDefault2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportMissingDefault3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportMissingDefault4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportMissingDefault5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportMissingDefault6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportMissingDefault7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportMissingDefault8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportNameAliasedAndHoisted.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportWrittenCorrectlyInDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportedMissingAlias.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/referenceSatisfiesExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/referenceTypesPreferedToPathIfPossible.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/regExpWithSlashInCharClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/regexMatchAll-esnext.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/regexMatchAll.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/regularExpressionExtendedUnicodeEscapes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/relatedViaDiscriminatedTypeNoError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/relatedViaDiscriminatedTypeNoError2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/relationComplexityError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/relationalOperatorComparable.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/relativeNamesInClassicResolution.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/renamingDestructuredPropertyInFunctionType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/renamingDestructuredPropertyInFunctionType2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/renamingDestructuredPropertyInFunctionType3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reorderProperties.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireAsFunctionInExternalModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireEmitSemicolon.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfAnEmptyFile1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileNonRelative.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileNonRelativeWithoutExtension.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileNonRelativeWithoutExtensionResolvesToTs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithAlwaysStrictWithoutErrors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithAmd.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithEmptyObject.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithModuleEmitUndefined.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithModuleNodeResolutionEmitAmd.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithModuleNodeResolutionEmitAmdOutFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithModuleNodeResolutionEmitEs2015.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithModuleNodeResolutionEmitEsNext.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithModuleNodeResolutionEmitSystem.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithModuleNodeResolutionEmitUmd.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithModuleNodeResolutionEmitUndefined.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithSourceMap.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithTraillingComma.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithoutAllowJs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithoutEsModuleInterop.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithoutExtension.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithoutExtensionResolvesToTs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithoutOutDir.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithoutResolveJsonModuleAndPathMapping.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFile_PathMapping.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/requiredInitializedParameter1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/requiredInitializedParameter2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/requiredInitializedParameter3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/requiredInitializedParameter4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reservedNameOnModuleImport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reservedWords.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/resolutionCandidateFromPackageJsonField2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/resolveInterfaceNameWithSameLetDeclarationName1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/resolveInterfaceNameWithSameLetDeclarationName2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/resolveModuleNameWithSameLetDeclarationName1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/resolveModuleNameWithSameLetDeclarationName2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/resolveNameWithNamspace.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/resolveTypeAliasWithSameLetDeclarationName1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/resolvingClassDeclarationWhenInBaseTypeResolution.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/restArgAssignmentCompat.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/restElementAssignable.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/restIntersection.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/restInvalidArgumentType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/restParamUsingMappedTypeOverUnionConstraint.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/restParameterAssignmentCompatibility.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/restParameterNoTypeAnnotation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/restParameterTypeInstantiation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/restParameterWithBindingPattern1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/restParameterWithBindingPattern2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/restParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/restParamsWithNonRestParams.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/restTypeRetainsMappyness.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/restUnion2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/restUnion3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnConditionalExpressionJSDocCast.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnInConstructor1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnInfiniteIntersection.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnStatement1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnTypeInferenceContextualParameterTypesInGenerator1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnTypeInferenceContextualTypeIgnoreAnyUnknown1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnTypeInferenceNotTooBroad.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnTypeParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnTypeParameterWithModules.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnTypePredicateIsInstantiateInContextOfTarget.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnTypeTypeArguments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reuseInnerModuleMember.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseInferenceInContextualInstantiation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedContravariantInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedIntersectionInference1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedIntersectionInference2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedPartiallyInferableTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTupleContext.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeAssignableToIndex.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeContextualTypeNotCircular.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeContextualTypesPerElementOfTupleConstraint.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeDeepDeclarationEmit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeInferenceSameSource1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeInferenceWidening1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeInferenceWidening2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeIntersectionConstraint.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeLimitedConstraint.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypePrimitiveConstraintProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeRecursiveInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedUnionInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/reversedRecusiveTypeInstantiation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/satisfiesEmit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/scopeCheckClassProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/scopeCheckExtendedClassInsidePublicMethod2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/scopeCheckInsidePublicMethod1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/scopeCheckStaticInitializer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/scopeTests.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/scopingInCatchBlocks.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfInCallback.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfInLambdas.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfRef.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfReference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfReferencingFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfReferencingFile2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfReferencingFile3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfReferencingSpreadInLoop.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfReferencingTypeReferenceInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfReferentialDefaultNoStackOverflow.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfReferentialFunctionType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/separate1-1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/separate1-2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/setMethods.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/setterBeforeGetter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/shadowPrivateMembers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/shebang.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/shebangBeforeReferences.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/shorthand-property-es6-amd.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/shorthand-property-es6-es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/shorthandOfExportedEntity01_targetES2015_CommonJS.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/shorthandPropertyAssignmentInES6Module.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/shouldNotPrintNullEscapesIntoOctalLiterals.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sigantureIsSubTypeIfTheyAreIdentical.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/signatureCombiningRestParameters1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/signatureCombiningRestParameters2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/signatureCombiningRestParameters3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/signatureCombiningRestParameters4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/signatureCombiningRestParameters5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/signatureInstantiationWithRecursiveConstraints.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/signatureLengthMismatchCall.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/signatureLengthMismatchInOverload.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/signatureLengthMismatchWithOptionalParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/signatureOverloadsWithComments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/signaturesUseJSDocForOptionalParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/silentNeverPropagation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/simpleArrowFunctionParameterReferencedInObjectLiteral1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/simpleRecursionWithBaseCase1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/simpleRecursionWithBaseCase2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/simpleRecursionWithBaseCase3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/simpleRecursionWithBaseCase4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/simplifyingConditionalWithInteriorConditionalIsRelated.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/singletonLabeledTuple.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sliceResultCast.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/slightlyIndirectedDeepObjectLiteralElaborations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMap-FileWithComments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapForFunctionInInternalModuleWithCommentPrecedingStatement01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapForFunctionWithCommentPrecedingStatement01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapPercentEncoded.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapSample.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationClassWithDefaultConstructor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationClassWithDefaultConstructorAndCapturedThisStatement.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationClassWithDefaultConstructorAndExtendsClause.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationClasses.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringForObjectBindingPattern.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringForObjectBindingPattern2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringForObjectBindingPatternDefaultValues.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringForObjectBindingPatternDefaultValues2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringParameterNestedObjectBindingPattern.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringParameterNestedObjectBindingPatternDefaultValues.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringParameterObjectBindingPattern.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringParameterObjectBindingPatternDefaultValues.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatement.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatement1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatementArrayBindingPattern4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatementArrayBindingPattern5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatementArrayBindingPattern6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatementArrayBindingPattern7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatementDefaultValues.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatementNestedObjectBindingPattern.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatementNestedObjectBindingPatternWithDefaultValues.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatementObjectBindingPattern1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatementObjectBindingPattern2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatementObjectBindingPattern3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatementObjectBindingPattern4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDo.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationExportAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationExportAssignmentCommonjs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationFor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationForIn.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationFunctionExpressions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationFunctionPropertyAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationFunctions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationIfElse.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationImport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationLambdaSpanningMultipleLines.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationSwitch.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationTryCatchFinally.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationVariables.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationWhile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationWithComments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapWithCaseSensitiveFileNames.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapWithCaseSensitiveFileNamesAndOutDir.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapWithMultipleFilesWithCopyright.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapWithMultipleFilesWithFileEndingWithInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapWithNonCaseSensitiveFileNames.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapWithNonCaseSensitiveFileNamesAndOutDir.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourcemapValidationDuplicateNames.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/specedNoStackBlown.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/specialIntersectionsInMappedTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/specializationError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/specializationOfExportedClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/specializationsShouldNotAffectEachOther.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/specializeVarArgs1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/specializedInheritedConstructors1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/specializedLambdaTypeArguments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/specializedOverloadWithRestParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/specializedSignatureAsCallbackParameter1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/specializedSignatureInInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/specializedSignatureOverloadReturnTypeWithIndexers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionGlobal1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionGlobal2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionGlobal3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionGlobal4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionJSXAttribute.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionLeadingUnderscores01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/spliceTuples.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadBooleanRespectsFreshness.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadExpressionContainingObjectExpressionContextualType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadExpressionContextualType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadExpressionContextualTypeWithNamespace.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadIdenticalTypesRemoved.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadIntersection.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadIntersectionJsx.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadInvalidArgumentType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadObjectNoCircular1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadObjectWithIndexDoesNotAddUndefinedToLocalIndex.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadOfObjectLiteralAssignableToIndexSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadOfParamsFromGeneratorMakesRequiredParams.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadParameterTupleType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadTupleAccessedByTypeParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadTypeRemovesReadonly.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadUnionPropOverride.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadsAndContextualTupleTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/spuriousCircularityOnTypeImport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/stackDepthLimitCastingType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticAndMemberFunctions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticFieldWithInterfaceContext.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticGetter1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticGetter2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticGetterAndSetter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticIndexSignatureAndNormalIndexSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticInheritance.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticInstanceResolution.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticInstanceResolution2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticInstanceResolution3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticInstanceResolution5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticInterfaceAssignmentCompat.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMemberAccessOffDerivedType1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMemberOfClassAndPublicMemberOfAnotherClassAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMemberWithStringAndNumberNames.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMethodReferencingTypeArgument1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMethodWithTypeParameterExtendsClauseDeclFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMethodsReferencingClassTypeParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMismatchBecauseOfPrototype.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticOffOfInstance1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticOffOfInstance2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticPrototypePropertyOnClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticVisibility2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticsNotInScopeInClodule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/stradac.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictBooleanMemberAssignability.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictFunctionTypes1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictFunctionTypesErrors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictModeEnumMemberNameReserved.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictModeUseContextualKeyword.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictModeWordInExportDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictNullLogicalAndOr.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictNullNotNullIndexTypeNoLib.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictNullNotNullIndexTypeShouldWork.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictOptionalProperties2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictOptionalProperties3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictOptionalProperties4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictSubtypeAndNarrowing.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictTypeofUnionNarrowing.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringHasStringValuedNumericIndexer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringIncludes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringIndexerAndConstructor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringIndexerAndConstructor1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringIndexerAssignments1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringIndexerAssignments2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringLiteralObjectLiteralDeclaration1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringLiteralPropertyNameWithLineContinuation1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringMappingAssignability.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringMatchAll.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringPropCodeGen.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringRawType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringTrim.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/stripInternal1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/structural1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/structuralTypeInDeclareFileForModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/styleOptions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/styledComponentsInstantiaionLimitNotReached.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/subSubClassCanAccessProtectedConstructor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/subclassThisTypeAssignable01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/subclassThisTypeAssignable02.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/subclassUint8Array.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/subclassWithPolymorphicThisIsAssignable.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/substituteReturnTypeSatisfiesConstraint.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/substitutionTypeForIndexedAccessType1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/substitutionTypeForIndexedAccessType2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/substitutionTypeForNonGenericIndexedAccessType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/substitutionTypeNoMergeOfAssignableType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/substitutionTypePassedToExtends.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/substitutionTypesCompareCorrectlyInRestrictiveInstances.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/substitutionTypesInIndexedAccessTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/subtypeReductionUnionConstraints.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/subtypeReductionWithAnyFunctionType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/subtypeRelationForNever.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/subtypingTransitivity.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/super2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/superAccessCastedCall.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/superAccessInFatArrow1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallArgsMustMatch.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallAssignResult.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatDerivesFromGenericType1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatDerivesFromGenericType2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatDerivesFromGenericTypeButWithIncorrectNumberOfTypeArguments1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatDerivesFromGenericTypeButWithNoTypeArguments1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatDerivesNonGenericTypeButWithTypeArguments1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallInNonStaticMethod.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallInStaticMethod.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallInsideObjectLiteralExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallWithCommentEmit01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallWithMissingBaseClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/superElementAccess.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/superHasMethodsFromMergedInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/superInCatchBlock1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/superNoModifiersCrash.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/superPropertyAccessInComputedPropertiesOfNestedType_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/superPropertyAccess_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/superPropertyElementNoUnusedLexicalThisCapture.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/superWithGenericSpecialization.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/superWithGenerics.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/switchAssignmentCompat.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/switchCaseCircularRefeference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/switchCaseInternalComments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/switchCaseNarrowsMatchingClausesEvenWhenNonMatchingClausesExist.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/switchCases.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/switchCasesExpressionTypeMismatch.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/switchComparableCompatForBrands.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/switchFallThroughs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/symbolLinkDeclarationEmitModuleNames.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/symbolLinkDeclarationEmitModuleNamesImportRef.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/symbolLinkDeclarationEmitModuleNamesRootDir.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/symbolMergeValueAndImportedType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/symbolObserverMismatchingPolyfillsWorkTogether.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/symlinkedWorkspaceDependenciesNoDirectLinkGeneratesDeepNonrelativeName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/symlinkedWorkspaceDependenciesNoDirectLinkGeneratesNonrelativeName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/symlinkedWorkspaceDependenciesNoDirectLinkOptionalGeneratesNonrelativeName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/symlinkedWorkspaceDependenciesNoDirectLinkPeerGeneratesNonrelativeName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/syntheticDefaultExportsWithDynamicImports.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemDefaultExportCommentValidity.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemDefaultImportCallable.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemJsForInNoException.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModule1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModule10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModule11.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModule12.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModule13.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModule14.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModule15.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModule16.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModule17.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModule18.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModule2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModule3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModule4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModule5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModule6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModule7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModule8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModuleAmbientDeclarations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModuleConstEnums.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModuleConstEnumsSeparateCompilation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModuleDeclarationMerging.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModuleExportDefault.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModuleNonTopLevelModuleMembers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModuleTargetES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModuleTrailingComments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModuleWithSuperClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemNamespaceAliasEmit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemObjectShorthandRename.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/taggedPrimitiveNarrowing.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/taggedTemplateStringWithSymbolExpression01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/taggedTemplateStringsHexadecimalEscapes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/taggedTemplateStringsHexadecimalEscapesES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/taggedTemplateStringsWithMultilineTemplate.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/taggedTemplateStringsWithMultilineTemplateES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/taggedTemplateStringsWithUnicodeEscapes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/taggedTemplateStringsWithUnicodeEscapesES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/taggedTemplateStringsWithWhitespaceEscapes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/taggedTemplateStringsWithWhitespaceEscapesES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/taggedTemplatesInDifferentScopes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/tailRecursiveConditionalTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/targetTypeArgs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/targetTypeBaseCalls.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/targetTypeCalls.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/targetTypeObjectLiteral.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/targetTypeObjectLiteralToAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/targetTypeTest2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/targetTypeTest3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/targetTypeVoidFunc.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/targetTypingOnFunctions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/templateExpressionAsPossiblyDiscriminantValue.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/templateExpressionNoInlininingOfConstantBindingWithInitializer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/templateLiteralConstantEvaluation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/templateLiteralIntersection.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/templateLiteralIntersection2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/templateLiteralIntersection3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/templateLiteralIntersection4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/templateLiteralsAndDecoratorMetadata.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/templateLiteralsSourceMap.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/templateStringsArrayTypeRedefinedInES6Mode.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/ternaryExpressionSourceMap.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/testContainerList.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/testTypings.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisBinding2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisCapture1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisConditionalOnMethodReturnOfGenericInstance.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisExpressionInCallExpressionWithTypeArguments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisExpressionInIndexExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisExpressionOfGenericObject.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInAccessors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInArrowFunctionInStaticInitializer1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInClassBodyStaticESNext.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInConstructorParameter1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInConstructorParameter2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInFunctionCall.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInFunctionCallJs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInGenericStaticMembers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInInnerFunctions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInLambda.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInModuleFunction1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInObjectJs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInPropertyBoundDeclarations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInStaticMethod1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInStatics.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInTupleTypeParameterConstraints.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInTypeQuery.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisIndexOnExistingReadonlyFieldIsNotNever.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisReferencedInFunctionInsideArrowFunction1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisShadowingErrorSpans.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisTypeAsConstraint.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisWhenTypeCheckFails.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/this_inside-object-literal-getters-and-setters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/thislessFunctionsNotContextSensitive1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/thislessFunctionsNotContextSensitive2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/thislessFunctionsNotContextSensitive3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/toStringOnPrimitives.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/tooFewArgumentsInGenericFunctionTypedArgument.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/tooManyTypeParameters1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/topFunctionTypeNotCallable.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/topLevel.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/topLevelBlockExpando.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/topLevelExports.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/topLevelLambda2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/topLevelLambda3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/topLevelLambda4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/trackedSymbolsNoCrash.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/trailingCommaInHeterogenousArrayLiteral1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/transformsElideNullUndefinedType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/transitiveTypeArgumentInference1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/tripleSlashInCommentNotParsed.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/tripleSlashReferenceAbsoluteWindowsPath.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/truthinessCallExpressionCoercion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/truthinessCallExpressionCoercion1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/truthinessCallExpressionCoercion2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/truthinessCallExpressionCoercion3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/truthinessCallExpressionCoercion4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/truthinessPromiseCoercion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/tryCatchFinally.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/tryCatchFinallyControlFlow.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/tryStatementInternalComments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsconfigMapOptionsAreCaseInsensitive.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/tslibInJs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/tslibMissingHelper.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/tslibMultipleMissingHelper.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/tslibNotFoundDifferentModules.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/tslibReExportHelpers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/tslibReExportHelpers2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxAttributeQuickinfoTypesSameAsObjectLiteral.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxAttributesHasInferrableIndex.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxDeepAttributeAssignabilityError.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxDefaultImports.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxDiscriminantPropertyInference.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxFragmentChildrenCheck.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxInferenceShouldNotYieldAnyOnUnions.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxInvokeComponentType.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxNoTypeAnnotatedSFC.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxNotUsingApparentTypeOfSFC.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxReactPropsInferenceSucceedsOnIntersections.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxResolveExternalModuleExportsTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxSpreadDoesNotReportExcessProps.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxStatelessComponentDefaultProps.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxTypeArgumentPartialDefinitionStillErrors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxUnionMemberChecksFilterDataProps.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxUnionSpread.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/tupleTypeInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/tupleTypeInference2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/tupleTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/twiceNestedKeyofIndexInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAliasDeclareKeyword01.d.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAliasDoesntMakeModuleInstantiated.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAliasExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAliasFunctionTypeSharedSymbol.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAliasInstantiationNoLeak1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAnnotationBestCommonTypeInArrayLiteral.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgInference2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgInference2WithError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgInferenceWithNull.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentConstraintResolution1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentDefaultUsesConstraintOnCircularDefault.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentInferenceApparentType1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentInferenceApparentType2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentInferenceOrdering.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentInferenceWithConstraintAsCommonRoot.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentInferenceWithRecursivelyReferencedTypeAliasToTypeLiteral01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentInferenceWithRecursivelyReferencedTypeAliasToTypeLiteral02.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentsInFunctionExpressions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentsOnFunctionsWithNoTypeParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentsShouldDisallowNonGenericOverloads.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAssertionToGenericFunctionType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAssignabilityErrorMessage.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeCheckExportsVariable.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeCheckObjectCreationExpressionWithUndefinedCallResolutionData.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeCheckObjectLiteralMethodBody.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeCheckReturnExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeCheckTypeArgument.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeComparisonCaching.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeConstraintsWithConstructSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardConstructorNarrowAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardConstructorNarrowPrimitivesInUnion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardConstructorPrimitiveTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowByMutableUntypedField.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowByUntypedField.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty11.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty12.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardOnContainerTypeNoHang.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeIdentityConsidersBrands.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInfer1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInferenceCacheInvalidation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInferenceConflictingCandidates.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInferenceFBoundedTypeParams.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInferenceFixEarly.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInferenceLiteralUnion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInferenceReturnTypeCallback.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInferenceTypePredicate.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInferenceTypePredicate2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInferenceWithExcessProperties.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInferenceWithExcessPropertiesJsx.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInferenceWithTypeAnnotation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeLiteralCallback.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeMatch1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeMatch2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeName1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeOfOnTypeArg.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeOfOperator1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeOfPrototype.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeOfSuperCall.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeOfThisInStatics.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeOfYieldWithUnionInContextualReturnType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParamExtendsOtherTypeParam.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterAndArgumentOfSameName1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterArgumentEquivalence.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterArgumentEquivalence2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterArgumentEquivalence3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterArgumentEquivalence4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterArgumentEquivalence5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterAsBaseClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterAsElementType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterAssignmentCompat1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterAssignmentWithConstraints.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterCompatibilityAccrossDeclarations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterConstrainedToOuterTypeParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterConstrainedToOuterTypeParameter2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterConstraintInstantiation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterConstraints1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterDiamond1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterDiamond2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterDiamond3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterDiamond4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterDoesntBlockParameterLookup.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterEquality.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterExtendingUnion1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterExtendingUnion2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterExtendsPrimitive.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterFixingWithConstraints.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterHasSelfAsConstraint.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterInConstraint1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterLeak.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterListWithTrailingComma1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterOrderReversal.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParametersAndParametersInComputedNames.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParametersInStaticAccessors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParametersInStaticMethods.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParametersInStaticProperties.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParametersShouldNotBeEqual.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParametersShouldNotBeEqual2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParametersShouldNotBeEqual3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePartameterConstraintInstantiatedWithDefaultWhenCheckingDefault.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicateAcceptingPartialOfRefinedType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicateFreshLiteralWidening.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicateInLoop.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicateInherit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicateTopLevelTypeParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicateWithThisParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicatesCanNarrowByDiscriminant.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicatesInUnion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicatesInUnion2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicatesInUnion3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicatesInUnion_noMatch.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicatesOptionalChaining1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicatesOptionalChaining2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicatesOptionalChaining3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectiveScopedPackageCustomTypeRoot.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectiveWithFailedFromTypeRoot.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectiveWithTypeAsFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives11.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives12.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives13.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeResolution.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeRootsFromMultipleNodeModulesDirectories.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeRootsFromNodeModulesInParentDirectory.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeUsedAsTypeLiteralIndex.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeUsedAsValueError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeUsedAsValueError2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeVal.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeVariableConstraintIntersections.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeVariableConstraintedToAliasNotAssignableToUnion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeVariableTypeGuards.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typecheckCommaExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typecheckIfCondition.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typedArrays-es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typedArrays.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typedArraysCrossAssignability01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typedArraysSubarray.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typedGenericPrototypeMember.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofAmbientExternalModules.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofEnum.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofExternalModules.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofImportInstantiationExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofInObjectLiteralType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofInternalModules.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofObjectInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofSimple.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofStrictNull.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofStripsFreshness.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofThisInMethodSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofUndefined.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofUnknownSymbol.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofUsedBeforeBlockScoped.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/umdDependencyComment2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/umdDependencyCommentName1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/umdDependencyCommentName2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/umdGlobalConflict.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/umdNamedAmdMode.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unaryOperators1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unaryPlus.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/uncalledFunctionChecksInConditional.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/uncalledFunctionChecksInConditional2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/uncalledFunctionChecksInConditionalPerf.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/uncaughtCompilerError1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/undeclaredModuleError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/undeclaredVarEmit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedArgumentInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedAssignableToGenericMappedIntersection.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedInferentialTyping.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedTypeArgument1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedTypeArgument2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/underscoreEscapedNameInEnum.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/underscoreMapFirst.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/underscoreTest1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/underscoreThisInDerivedClass01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/underscoreThisInDerivedClass02.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unexportedInstanceClassVariables.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unicodeEscapesInJSDoc.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unicodeIdentifierNames.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unicodeStringLiteral.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionCallMixedTypeParameterPresence.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionErrorMessageOnMatchingDiscriminant.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionExcessPropertyCheckNoApparentPropTypeMismatchErrors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionExcessPropsWithPartialMember.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionOfArraysFilterCall.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionOfClassCalls.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionOfEnumInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionOfFunctionAndSignatureIsCallable.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionReductionMutualSubtypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionReductionWithStringMappingAndIdenticalBaseTypeExistsNoCrash.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionRelationshipCheckPasses.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionSignaturesWithThisParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionSubtypeReductionErrors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionTypeErrorMessageTypeRefs01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionTypeParameterInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionTypeWithIndexAndMethodSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionTypeWithIndexAndTuple.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionTypeWithIndexedLiteralType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionTypeWithLeadingOperator.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionTypeWithRecursiveSubtypeReduction1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionTypeWithRecursiveSubtypeReduction2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionTypeWithRecursiveSubtypeReduction3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionWithIndexSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/uniqueSymbolAllowsIndexInObjectWithIndexSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/uniqueSymbolAssignmentOnGlobalAugmentationSuceeds.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/uniqueSymbolJs2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unknownLikeUnionObjectFlagsNotPropagated.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unknownPropertiesAreAssignableToObjectUnion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unknownSymbolInGenericReturnType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unknownSymbols2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unknownTypeArgOnCall.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unknownTypeErrors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unmatchedParameterPositions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unmetTypeConstraintInImportCall.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unmetTypeConstraintInJSDocImportCall.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unqualifiedCallToClassStatic1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unreachableFlowAfterFinally.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unreachableJavascriptChecked.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unreachableJavascriptUnchecked.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unreachableSwitchTypeofAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unreachableSwitchTypeofUnknown.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unresolvableSelfReferencingAwaitedUnion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unresolvedTypeAssertionSymbol.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unspecializedConstraints.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/untypedArgumentInLambdaExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/untypedFunctionCallsWithTypeParameters1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/untypedModuleImport_withAugmentation2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedClassesinModule1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedClassesinNamespace1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedClassesinNamespace2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedClassesinNamespace3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedClassesinNamespace4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedClassesinNamespace5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedDestructuring.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedDestructuringParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedFunctionsinNamespaces1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedFunctionsinNamespaces2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedFunctionsinNamespaces3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedFunctionsinNamespaces4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedFunctionsinNamespaces5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedFunctionsinNamespaces6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedIdentifiersConsolidated1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImportDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImportWithSpread.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports11.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports12.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports13.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports14.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports15.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports16.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports_entireImportDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedInterfaceinNamespace4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedInterfaceinNamespace5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedInvalidTypeArguments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsAndObjectSpread.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsAndObjectSpread2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsAndParametersDeferred.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsAndParametersOverloadSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsAndParametersTypeAliases.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsAndParametersTypeAliases2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsInForInOrOf1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsInMethod1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsInMethod2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsInMethod3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsInRecursiveReturn.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsOnFunctionDeclarationWithinFunctionDeclaration1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsOnFunctionDeclarationWithinFunctionDeclaration2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsOnFunctionDeclarationWithinFunctionExpression1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsOnFunctionDeclarationWithinFunctionExpression2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsOnFunctionExpressionWithinFunctionDeclaration1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsOnFunctionExpressionWithinFunctionDeclaration2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsOnFunctionExpressionWithinFunctionExpression1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsOnFunctionExpressionWithinFunctionExpression2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsStartingWithUnderscore.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsinConstructor1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsinConstructor2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedMethodsInInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedMultipleParameter1InContructor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedMultipleParameter1InFunctionExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedMultipleParameter2InContructor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedMultipleParameter2InFunctionExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedMultipleParameters1InFunctionDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedMultipleParameters1InMethodDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedMultipleParameters2InFunctionDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedMultipleParameters2InMethodDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParameterInCatchClause.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParameterProperty1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParameterProperty2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParametersInLambda1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParametersInLambda2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParametersThis.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParametersWithUnderscore.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParametersinConstructor1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParametersinConstructor2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParametersinConstructor3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateMethodInClass1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateMethodInClass2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateMethodInClass3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateMethodInClass4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateStaticMembers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateVariableInClass1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateVariableInClass2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateVariableInClass3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateVariableInClass4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateVariableInClass5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedSemicolonInClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedSetterInClass2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedSingleParameterInContructor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedSingleParameterInFunctionDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedSingleParameterInFunctionExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedSingleParameterInMethodDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedSwitchStatement.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInFunction1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInFunction2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInFunction3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInFunction4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInInterface2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInLambda1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInLambda2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInLambda3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInMethod1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInMethod2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInMethod3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInMethod4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInMethod5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParametersCheckedByNoUnusedParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParametersNotCheckedByNoUnusedLocals.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParametersWithUnderscore.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters_infer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters_templateTag.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters_templateTag2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesWithUnderscoreInBindingElement.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesWithUnderscoreInForOfLoop.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesinBlocks1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesinBlocks2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesinForLoop.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesinForLoop2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesinForLoop3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesinForLoop4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesinModules1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesinNamespaces1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesinNamespaces2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesinNamespaces3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/unwitnessedTypeParameterVariance.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration_destructuring.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration_jsx.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration_propertyAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration_superClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDefinitionInDeclarationFiles.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/useUnknownInCatchVariables01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/usingModuleWithExportImportInValuePosition.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/validUseOfThisInSuper.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/valueOfTypedArray.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/varArgParamTypeCheck.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/varArgsOnConstructorTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/varAsID.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/varInFunctionInVarInitializer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/vararg.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/vardecl.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/variableDeclarationDeclarationEmitUniqueSymbolPartialStatement.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/variableDeclarationInnerCommentEmit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/variableDeclarator1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/varianceAnnotationValidation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/varianceCallbacksAndIndexedAccesses.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/varianceCantBeStrictWhileStructureIsnt.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/varianceMeasurement.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/varianceProblingAndZeroOrderIndexSignatureRelationsAlign.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/varianceProblingAndZeroOrderIndexSignatureRelationsAlign2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/variancePropagation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/varianceRepeatedlyPropegatesWithUnreliableFlag.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/verbatim-declarations-parameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/verbatimModuleSyntaxDefaultValue.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/verifyDefaultLib_dom.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/verifyDefaultLib_webworker.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/visSyntax.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/visibilityOfCrossModuleTypeUsage.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/visibilityOfTypeParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/voidArrayLit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/voidAsOperator.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/voidConstructor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/voidFunctionAssignmentCompat.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/voidIsInitialized.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/voidOperator1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/voidReturnIndexUnionInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/voidReturnLambdaValue.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/voidUndefinedReduction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/vueLikeDataAndPropsInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/vueLikeDataAndPropsInference2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/weakType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/weakTypeAndPrimitiveNarrowing.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/webworkerIterable.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/wellKnownSymbolExpando.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/whileStatementInnerComments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/widenToAny1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/widenToAny2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/widenedTypes1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/wideningWithTopLevelTypeParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/withExportDecl.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/withImportDecl.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/withStatementInternalComments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/wrappedIncovations1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/wrappedIncovations2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/wrappedRecursiveGenericType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/yieldExpression1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/yieldExpressionInFlowLoop.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/yieldExpressionInnerCommentEmit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/compiler/yieldStarContextualType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/additionalChecks/noPropertyAccessFromIndexSignature1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientDeclarations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientDeclarationsExternal.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientDeclarationsPatterns.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientDeclarationsPatterns_merging1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientDeclarationsPatterns_merging2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientDeclarationsPatterns_tooManyAsterisks.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientEnumDeclaration1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientEnumDeclaration2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientExternalModuleMerging.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientInsideNonAmbient.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientInsideNonAmbientExternalModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientShorthand.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientShorthand_declarationEmit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientShorthand_duplicate.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientShorthand_merging.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientShorthand_reExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction10_es2017.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction1_es2017.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction2_es2017.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction4_es2017.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunctionCapturesArguments_es2017.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunctionCapturesThis_es2017.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction_allowJs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncUnParenthesizedArrowFunction_es2017.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncAwaitIsolatedModules_es2017.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncAwait_es2017.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncMethodWithSuperConflict_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncMethodWithSuper_es2017.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncUseStrict_es2017.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitBinaryExpression/awaitBinaryExpression1_es2017.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitBinaryExpression/awaitBinaryExpression2_es2017.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitBinaryExpression/awaitBinaryExpression3_es2017.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitBinaryExpression/awaitBinaryExpression4_es2017.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitBinaryExpression/awaitBinaryExpression5_es2017.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpression/awaitCallExpression1_es2017.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpression/awaitCallExpression2_es2017.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpression/awaitCallExpression3_es2017.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpression/awaitCallExpression4_es2017.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpression/awaitCallExpression5_es2017.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpression/awaitCallExpression6_es2017.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpression/awaitCallExpression7_es2017.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpression/awaitCallExpression8_es2017.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitClassExpression_es2017.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitInheritedPromise_es2017.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/await_unaryExpression_es2017.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration11_es2017.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration13_es2017.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration14_es2017.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration1_es2017.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration2_es2017.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration4_es2017.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration8_es2017.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncAliasReturnType_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction10_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction1_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction2_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction4_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunctionCapturesArguments_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunctionCapturesThis_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncUnParenthesizedArrowFunction_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncAwaitIsolatedModules_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncAwait_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncImportedPromise_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncMethodWithSuper_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncMultiFile_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncQualifiedReturnType_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncUseStrict_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitBinaryExpression/awaitBinaryExpression1_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitBinaryExpression/awaitBinaryExpression2_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitBinaryExpression/awaitBinaryExpression3_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitBinaryExpression/awaitBinaryExpression4_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitBinaryExpression/awaitBinaryExpression5_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression1_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression2_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression3_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression4_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression5_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression6_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression7_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression8_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitClassExpression_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitUnion_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/await_unaryExpression_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration11_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration13_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration14_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration15_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration1_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration2_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration4_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration8_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/asyncGenerators/asyncGeneratorGenericNonWrappedReturn.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/asyncGenerators/asyncGeneratorPromiseNextType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractAsIdentifier.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractAssignabilityConstructorFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractClinterfaceAssignability.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractConstructorAssignability.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractExtends.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractFactoryFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractGeneric.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractImportInstantiation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInAModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInheritance1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInheritance2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInstantiations1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractOverrideWithAbstract.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractSingleLineDecl.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractSuperCalls.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractUsingAbstractMethod1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAndInterfaceMerge.d.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAndInterfaceMergeConflictingMembers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAndInterfaceWithSameName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classBody/classWithEmptyBody.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classDeclarationLoop.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classExtendingBuiltinType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classExtendingClassLikeType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classExtendingNonConstructor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classExtendingNull.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classAppearsToHaveMembersOfObject.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendingClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendsItself.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendsItselfIndirectly.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendsItselfIndirectly2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendsItselfIndirectly3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendsShadowedConstructorFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendsValidConstructorFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classIsSubtypeOfBaseType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/constructorFunctionTypeIsAssignableToBaseType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/constructorFunctionTypeIsAssignableToBaseType2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/derivedTypeDoesNotRequireExtendsClause.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classImplementsMergedClassInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classInsideBlock.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classWithSemicolonClassElement1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classWithSemicolonClassElement2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/mergeClassInterfaceAndModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/mergedClassInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/mergedInheritedClassInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/modifierOnClassDeclarationMemberInFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classExpression1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classExpression2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classExpression3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classExpression4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classExpression5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classExpressionLoop.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/extendClassExpressionFromModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/genericClassExpressionInFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/modifierOnClassExpressionMemberInFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock12.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock14.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock17.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock21.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock27.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock28.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlockUseBeforeDef3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlockUseBeforeDef4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlockUseBeforeDef5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/automaticConstructors/classWithoutExplicitConstructor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/automaticConstructors/derivedClassWithoutExplicitConstructor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/automaticConstructors/derivedClassWithoutExplicitConstructor2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/automaticConstructors/derivedClassWithoutExplicitConstructor3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorAccessibility.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorAccessibility2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorAccessibility3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorAccessibility4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorAccessibility5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorParametersAccessibility.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorParametersAccessibility2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorParametersAccessibility3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/constructorImplementationWithDefaultValues.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/constructorImplementationWithDefaultValues2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/constructorOverloadsWithOptionalParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/declarationEmitReadonly.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/readonlyConstructorAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorWithAssignableReturnExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorWithExpressionLessReturn.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/quotedConstructors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/superCalls/emitStatementsBeforeSuperCall.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/superCalls/emitStatementsBeforeSuperCallWithDefineFields.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/indexMemberDeclarations/staticIndexers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/classPropertyAsPrivate.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/classPropertyAsProtected.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/classPropertyIsPublicByDefault.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/privateClassPropertyAccessibleWithinClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/privateProtectedMembersAreNotAccessibleDestructuring.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/privateStaticMemberAccessibility.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/privateStaticNotAccessibleInClodule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/privateStaticNotAccessibleInClodule2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/protectedStaticClassPropertyAccessibleWithinSubclass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/protectedStaticNotAccessibleInClodule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/classTypes/genericSetterInClassType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/classTypes/genericSetterInClassTypeJsDoc.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/classTypes/indexersInClassType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/classTypes/instancePropertiesInheritedIntoClassType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/classTypes/instancePropertyInClassType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/constructorFunctionTypes/classWithBaseClassButNoConstructor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/constructorFunctionTypes/classWithConstructors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/constructorFunctionTypes/classWithNoConstructorOrBaseClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/constructorFunctionTypes/classWithStaticMembers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/constructorFunctionTypes/constructorHasPrototypeProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassFunctionOverridesBaseClassAccessor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassIncludesInheritedMembers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassOverridesIndexersWithAssignmentCompatibility.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassOverridesPrivates.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassOverridesProtectedMembers4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassOverridesPublicMembers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassOverridesWithoutSubtype.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassTransitivity.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassTransitivity2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassTransitivity3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassTransitivity4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassWithAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassWithPrivateStaticShadowingPublicStatic.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedGenericClassWithAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOfThisInInstanceMember2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOfThisInStaticMembers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOfThisInStaticMembers2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOfThisInstanceMemberNarrowedWithLoopAntecedent.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameAccessors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameAccessorsCallExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameAmbientNoImplicitAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameCircularReference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameClassExpressionLoop.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameConstructorSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameEmitHelpers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameField.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameFieldAccess.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameFieldAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameFieldCallExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameFieldClassExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameFieldInitializer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameFieldParenthesisLeftAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameFieldUnaryMutation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameInLhsReceiverExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameLateSuper.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameMethod.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameMethodAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameMethodAsync.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameMethodCallExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameMethodInStaticFieldInit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameNestedClassNameConflict.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameReadonly.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameSetterExprReturnValue.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameSetterNoGetter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticAccessors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticAccessorsCallExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticEmitHelpers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticFieldAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticFieldCallExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticFieldClassExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticFieldUnaryMutation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticMethod.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticMethodAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticMethodCallExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticMethodInStaticFieldInit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameUnused.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesAndFields.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesAndkeyof.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesUnique-1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesUnique-4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesUnique-5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesUseBeforeDef.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateStaticNameShadowing.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateWriteOnlyAccessorRead.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/typeFromPrivatePropertyAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/typeFromPrivatePropertyAssignmentJs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/mixinAbstractClasses.2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/mixinAbstractClasses.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/mixinAbstractClassesReturnTypeInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/mixinAccessors1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/mixinAccessors2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/mixinAccessors3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/mixinAccessors4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/mixinAccessors5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/mixinClassesAnnotated.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/mixinClassesAnonymous.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/mixinClassesMembers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/mixinWithBaseDependingOnSelfNoCrash1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideMethod.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationES2022.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationESNext.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessor10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessor8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessor9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessorNoUseDefineForClassFields.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/constructorParameterShadowsOuterScopes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/constructorParameterShadowsOuterScopes2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/initializerReferencingConstructorParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/instanceMemberInitialization.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/instanceMemberWithComputedPropertyName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/instanceMemberWithComputedPropertyName2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberAccessorDeclarations/accessorsAreNotContextuallyTyped.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberAccessorDeclarations/typeOfThisInAccessor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/derivedTypeAccessesHiddenBaseCallViaSuperPropertyAccess.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/instanceMemberAssignsToClassPrototype.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/memberFunctionsWithPrivateOverloads.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/memberFunctionsWithPublicOverloads.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/staticFactory1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/staticMemberAssignsToConstructorFunctionMembers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/typeOfThisInMemberFunctions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/overrideInterfaceProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/propertyOverridesAccessors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/propertyOverridesAccessors2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/propertyOverridesAccessors3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/propertyOverridesAccessors5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/propertyOverridesAccessors6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/propertyOverridesMethod.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticAndNonStaticPropertiesSameName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticMemberInitialization.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyAndFunctionWithSameName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflictsInAmbientContext.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/strictPropertyInitialization.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/thisInInstanceMemberInitializer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/thisPropertyOverridesAccessors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/staticIndexSignature/staticIndexSignature1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/staticIndexSignature/staticIndexSignature2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/staticIndexSignature/staticIndexSignature3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/staticIndexSignature/staticIndexSignature6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/staticIndexSignature/staticIndexSignature7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnum1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnum3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnum4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnumPropertyAccess1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnumPropertyAccess3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/assertionTypePredicates2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/constLocalsInFunctionExpressions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowAliasing2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowAssignmentExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowAssignmentPatternOrder.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowBinaryAndExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowBinaryOrExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowBindingElement.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowBindingPatternOrder.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowCommaOperator.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowComputedPropertyNames.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowConditionalExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowDestructuringDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowDoWhileStatement.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowElementAccess.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowElementAccess2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowElementAccessNoCrash1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowForInStatement.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowForInStatement2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowForOfStatement.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowForStatement.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowIIFE.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowIfStatement.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowInOperator.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowInstanceOfGuardPrimitives.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowInstanceofExtendsFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowIteration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowIterationErrors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowIterationErrorsAsync.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowNoIntermediateErrors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowNullishCoalesce.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowOptionalChain2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowOptionalChain3.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowStringIndex.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowSuperPropertyAccess.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowTruthiness.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowTypeofObject.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowWhileStatement.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowWithTemplateLiterals.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/dependentDestructuredVariables.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/dependentDestructuredVariablesFromNestedPatterns.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/dependentDestructuredVariablesWithExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/neverReturningFunctions1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/switchWithConstrainedTypeVariable.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/typeGuardsAsAssertions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/typeGuardsNestedAssignments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/typeGuardsTypeParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/anonymousClassAccessorsDeclarationEmit1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/classDoesNotDependOnPrivateMember.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/declarationEmitWorkWithInlineComments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/exportDefaultNamespace.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/leaveOptionalParameterAsWritten.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/libReferenceDeclarationEmit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/libReferenceDeclarationEmitBundle.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/libReferenceNoLib.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/libReferenceNoLibBundle.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/nullPropertyName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typePredicates/declarationEmitIdentifierPredicates01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typePredicates/declarationEmitIdentifierPredicatesWithPrivateName01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typePredicates/declarationEmitThisPredicates01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typePredicates/declarationEmitThisPredicates02.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typePredicates/declarationEmitThisPredicatesWithPrivateName01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typePredicates/declarationEmitThisPredicatesWithPrivateName02.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typeReferenceRelatedFiles.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typeofImportTypeOnlyExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typesVersionsDeclarationEmit.ambient.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typesVersionsDeclarationEmit.multiFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typesVersionsDeclarationEmit.multiFileBackReferenceToSelf.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typesVersionsDeclarationEmit.multiFileBackReferenceToUnmapped.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/constructableDecoratorOnClass01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratedClassExportsCommonJS1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratedClassExportsCommonJS2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratedClassExportsSystem1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratedClassExportsSystem2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratedClassFromExternalModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod13.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod14.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod15.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod16.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod18.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty13.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorCallGeneric.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorInAmbientContext.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorMetadataWithTypeOnlyImport2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/legacyDecorators-contextualTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/directives/multiline.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/directives/ts-expect-error-js.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/directives/ts-expect-error-nocheck-js.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/directives/ts-expect-error-nocheck.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/directives/ts-expect-error.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/directives/ts-ignore.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpression1ES2020.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpression2ES2020.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpression3ES2020.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpression4ES2020.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpression5ES2020.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpression6ES2020.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionAsyncES2020.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionAsyncES6AMD.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionAsyncES6CJS.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionAsyncES6System.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionAsyncES6UMD.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionCheckReturntype1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionDeclarationEmit1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionDeclarationEmit2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionDeclarationEmit3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionES6AMD.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionES6CJS.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionES6System.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionES6UMD.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionErrorInES2015.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInAMD1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInAMD2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInAMD3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInAMD4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInCJS1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInCJS2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInCJS3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInCJS4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInCJS5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInExportEqualsAMD.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInExportEqualsCJS.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInExportEqualsUMD.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInSystem1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInSystem2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInSystem3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInSystem4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInUMD1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInUMD2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInUMD3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInUMD4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInUMD5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionNestedAMD.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionNestedCJS.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionNestedES2015.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionNestedES2020.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionNestedSystem.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionNestedUMD.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionNoModuleKindSpecified.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionReturnPromiseOfAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionShouldNotGetParen.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionSpecifierNotStringTypeError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/emitter/es2015/asyncGenerators/emitter.asyncGenerators.classMethods.es2015.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/emitter/es2015/asyncGenerators/emitter.asyncGenerators.functionDeclarations.es2015.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/emitter/es2015/asyncGenerators/emitter.asyncGenerators.functionExpressions.es2015.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/emitter/es2015/asyncGenerators/emitter.asyncGenerators.objectLiteralMethods.es2015.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/emitter/es2018/asyncGenerators/emitter.asyncGenerators.classMethods.es2018.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/emitter/es2018/asyncGenerators/emitter.asyncGenerators.functionDeclarations.es2018.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/emitter/es2018/asyncGenerators/emitter.asyncGenerators.functionExpressions.es2018.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/emitter/es2018/asyncGenerators/emitter.asyncGenerators.objectLiteralMethods.es2018.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/emitter/es2019/noCatchBinding/emitter.noCatchBinding.es2019.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/enums/enumBasics.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/enums/enumClassification.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/enums/enumConstantMemberWithString.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/enums/enumConstantMemberWithStringEmitDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/enums/enumConstantMemberWithTemplateLiterals.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/enums/enumConstantMemberWithTemplateLiteralsEmitDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/enums/enumErrorOnConstantBindingWithInitializer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/enums/enumExportMergingES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/enums/enumMerging.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/enums/enumShadowedInfinityNaN.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2016/es2016IntlAPIs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2017/es2017DateAPIs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2017/useObjectValuesAndEntries3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2017/useObjectValuesAndEntries4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2017/useSharedArrayBuffer3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2017/useSharedArrayBuffer4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2018/es2018IntlAPIs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2018/useRegexpGroups.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2019/allowUnescapedParagraphAndLineSeparatorsInStringLiteral.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2019/globalThisTypeIndexAccess.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/bigintMissingES2019.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/bigintMissingES2020.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/bigintMissingESNext.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/constructBigint.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/es2020IntlAPIs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/intlNumberFormatES2020.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/localesObjectArgument.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/modules/exportAsNamespace5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2021/es2021LocalesObjectArgument.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2021/intlDateTimeFormatRangeES2021.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2021/logicalAssignment/logicalAssignment9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2022/arbitraryModuleNamespaceIdentifiers/arbitraryModuleNamespaceIdentifiers_exportEmpty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2022/arbitraryModuleNamespaceIdentifiers/arbitraryModuleNamespaceIdentifiers_importEmpty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2022/es2022IntlAPIs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2022/es2022LocalesObjectArgument.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2022/es2024SharedMemory.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2023/intlNumberFormatES2023.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2024/resizableArrayBuffer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2024/sharedMemory.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2024/transferableArrayBuffer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2025/float16Array.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2025/intlDurationFormat.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2025/regExpEscape.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2025/syncIteratorHelpers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit11.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit13.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit14.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty11.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty12.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty13.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty14.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty15.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty16.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty17.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty18.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty19.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty20.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty21.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty22.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty23.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty24.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty25.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty26.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty27.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty28.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty29.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty30.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty31.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty32.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty33.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty34.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty35.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty37.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty38.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty40.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty41.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty45.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty46.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty47.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty48.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty49.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty50.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty51.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty55.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty56.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty57.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty58.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty60.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty61.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType11.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType12.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType14.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType15.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType16.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType17.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType18.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType19.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionAsIsES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments01_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments02_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments09_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments10_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments18_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments19_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionsAsIsES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/binaryAndOctalIntegerLiteral/binaryIntegerLiteralES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/binaryAndOctalIntegerLiteral/octalIntegerLiteralES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/classWithSemicolonClassElementES61.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/classWithSemicolonClassElementES62.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationOverloadInES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithConstructorInES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithExtensionAndTypeArgumentInES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithExtensionInES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithGetterSetterInES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithLiteralPropertyNameInES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithMethodInES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithPropertyAccessInHeritageClause1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithPropertyAssignmentInES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithStaticPropertyAssignmentInES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithSuperMethodCall01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithThisKeywordInES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithTypeArgumentAndOverloadInES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithTypeArgumentInES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/exportDefaultClassWithStaticPropertyAssignmentsInES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/superCallBeforeThisAccessing1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/superCallBeforeThisAccessing2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/superCallBeforeThisAccessing5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/superCallBeforeThisAccessing8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classExpressions/classExpressionES61.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classExpressions/classExpressionES62.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classExpressions/classExpressionES63.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classExpressions/typeArgumentInferenceWithClassExpression1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classExpressions/typeArgumentInferenceWithClassExpression2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classExpressions/typeArgumentInferenceWithClassExpression3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames10_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames11_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames13_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames16_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames18_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames1_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames20_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames22_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames25_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames28_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames29_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames31_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames32_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames33_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames34_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames35_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames36_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames37_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames38_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames39_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames41_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames42_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames43_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames44_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames45_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames46_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames47_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames48_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames4_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames7_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType10_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType1_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType2_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType3_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType4_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType5_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType6_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType7_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType8_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType9_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesDeclarationEmit1_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesDeclarationEmit2_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesDeclarationEmit3_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesDeclarationEmit4_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesDeclarationEmit5_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesOnOverloads_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesSourceMap1_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesSourceMap2_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesWithStaticProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/accessor/decoratorOnClassAccessor1.es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/decoratorOnClass1.es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/decoratorOnClass2.es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/decoratorOnClass3.es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/decoratorOnClass4.es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/decoratorOnClass5.es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/decoratorOnClass6.es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/decoratorOnClass7.es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/decoratorOnClass8.es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/method/decoratorOnClassMethod1.es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/method/parameter/decoratorOnClassMethodParameter1.es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/property/decoratorOnClassProperty1.es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/defaultParameters/emitDefaultParametersFunctionES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/defaultParameters/emitDefaultParametersFunctionExpressionES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/defaultParameters/emitDefaultParametersFunctionPropertyES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/defaultParameters/emitDefaultParametersMethodES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/arrayAssignmentPatternWithAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/declarationInAmbientContext.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment1ES5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment1ES5iterable.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment1ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment5SiblingInitializer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringAssignabilityCheck.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringCatch.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringInFunctionType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment1ES5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment1ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment9SiblingInitializer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration3ES5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration3ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringVariableDeclaration1ES5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringVariableDeclaration1ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringVariableDeclaration2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringVoid.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringVoidStrictNullChecks.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringWithLiteralInitializers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringWithLiteralInitializers2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyArrayBindingPatternParameter01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyArrayBindingPatternParameter02.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyArrayBindingPatternParameter03.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyArrayBindingPatternParameter04.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyAssignmentPatterns01_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyAssignmentPatterns02_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyAssignmentPatterns03_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyAssignmentPatterns04_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyObjectBindingPatternParameter01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyObjectBindingPatternParameter02.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyObjectBindingPatternParameter03.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyObjectBindingPatternParameter04.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyVariableDeclarationBindingPatterns01_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern11.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern12.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern13.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern14.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern15.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern16.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern17.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern18.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern19.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern20.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern21.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern22.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern23.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern24.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern25.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern26.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern27.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern28.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern29.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern30.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/nonIterableRestElement1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/nonIterableRestElement2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/nonIterableRestElement3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/objectBindingPatternKeywordIdentifiers05.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/objectBindingPatternKeywordIdentifiers06.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/optionalBindingParameters4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/optionalBindingParametersInOverloads1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/optionalBindingParametersInOverloads2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/restElementWithAssignmentPattern1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/restElementWithAssignmentPattern3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/restElementWithAssignmentPattern5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/restElementWithBindingPattern.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of11.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of12.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of13.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of14.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of15.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of16.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of17.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of18.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of19.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of20.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of21.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of22.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of23.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of24.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of25.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of26.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of27.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of28.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of29.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of30.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of31.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of32.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of33.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of34.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of35.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of36.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of37.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of38.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of39.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of40.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of41.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of42.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of43.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of44.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of45.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of46.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of47.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of48.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of49.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of50.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of55.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of57.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of58.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration1_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration9_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/functionExpressions/FunctionExpression1_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/functionExpressions/FunctionExpression2_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/functionPropertyAssignments/FunctionPropertyAssignments1_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/functionPropertyAssignments/FunctionPropertyAssignments5_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/memberFunctionDeclarations/MemberFunctionDeclaration1_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/memberFunctionDeclarations/MemberFunctionDeclaration2_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/memberFunctionDeclarations/MemberFunctionDeclaration3_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/memberFunctionDeclarations/MemberFunctionDeclaration7_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/moduleExportsAmd/decoratedDefaultExportsGetExportedAmd.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/moduleExportsAmd/defaultExportsGetExportedAmd.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/moduleExportsAmd/outFilerootDirModuleNamesAmd.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/moduleExportsCommonjs/decoratedDefaultExportsGetExportedCommonjs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/moduleExportsCommonjs/defaultExportsGetExportedCommonjs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/moduleExportsSystem/decoratedDefaultExportsGetExportedSystem.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/moduleExportsSystem/defaultExportsGetExportedSystem.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/moduleExportsSystem/outFilerootDirModuleNamesSystem.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/moduleExportsUmd/decoratedDefaultExportsGetExportedUmd.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/moduleExportsUmd/defaultExportsGetExportedUmd.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/defaultExportInAwaitExpression01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/defaultExportInAwaitExpression02.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportBinding.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportSpellingSuggestion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports1-es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports2-es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports3-es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports4-es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/newTarget/newTarget.es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/newTarget/newTargetNarrowing.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/propertyAccess/propertyAccessNumericLiterals.es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/restParameters/emitRestParametersFunctionES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/restParameters/emitRestParametersFunctionExpressionES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/restParameters/emitRestParametersFunctionPropertyES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/restParameters/emitRestParametersMethodES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/restParameters/readonlyRestParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentErrorFromMissingIdentifier.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesFunctionArgument.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesFunctionArgument2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesWithModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesWithModuleES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/arrayLiteralSpread.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/arraySpreadInCall.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray11.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInCall.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInCall10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInCall11.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInCall12.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInCall2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInCall3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInCall4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInCall5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInCall6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInCall7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInCall8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInCall9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsPlainCharactersThatArePartsOfEscapes01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsPlainCharactersThatArePartsOfEscapes01_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsPlainCharactersThatArePartsOfEscapes02.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsPlainCharactersThatArePartsOfEscapes02_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsTypeArgumentInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsTypeArgumentInferenceES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithIncompatibleTypedTags.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithIncompatibleTypedTagsES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithManyCallAndMemberExpressions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithManyCallAndMemberExpressionsES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution2_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithTagNamedDeclare.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithTagNamedDeclareES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithTagsTypedAsAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithTagsTypedAsAnyES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithTypeErrorInFunctionExpressionsInSubstitutionExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithTypeErrorInFunctionExpressionsInSubstitutionExpressionES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithTypedTags.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithTypedTagsES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateUntypedTagCall01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateWithConstructableTag01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateWithConstructableTag02.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplatesWithTypeArguments1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringBinaryOperations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringBinaryOperationsES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringBinaryOperationsES6Invalid.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringBinaryOperationsInvalid.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringControlCharacterEscapes01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringControlCharacterEscapes01_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringControlCharacterEscapes02.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringControlCharacterEscapes02_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringControlCharacterEscapes03.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringControlCharacterEscapes03_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringControlCharacterEscapes04.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringControlCharacterEscapes04_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInArray.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInArrowFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInArrowFunctionES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInCallExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInCallExpressionES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInConditional.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInConditionalES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInDivision.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInEqualityChecks.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInEqualityChecksES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInFunctionExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInFunctionExpressionES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInInOperator.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInInOperatorES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInIndexExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInIndexExpressionES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInInstanceOf.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInInstanceOfES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInModulo.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInModuloES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInMultiplication.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInMultiplicationES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInNewExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInNewExpressionES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInNewOperator.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInNewOperatorES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInParentheses.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInParenthesesES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInPropertyAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInPropertyAssignmentES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInSwitchAndCase.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInSwitchAndCaseES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInTaggedTemplate.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInTaggedTemplateES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInTypeAssertion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInTypeAssertionES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInTypeOf.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInTypeOfES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInUnaryPlus.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInUnaryPlusES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInWhile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInWhileES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInYieldKeyword.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringMultiline1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringMultiline1_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringMultiline2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringMultiline2_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringMultiline3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringPlainCharactersThatArePartsOfEscapes01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringPlainCharactersThatArePartsOfEscapes01_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringPlainCharactersThatArePartsOfEscapes02.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringPlainCharactersThatArePartsOfEscapes02_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringTermination1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringTermination1_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringTermination2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringTermination2_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringTermination3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringTermination3_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringTermination4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringTermination4_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringTermination5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringTermination5_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWhitespaceEscapes1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWhitespaceEscapes1_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWhitespaceEscapes2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWhitespaceEscapes2_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithBackslashEscapes01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithBackslashEscapes01_ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithCommentsInArrowFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedAddition.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedAdditionES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedArray.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedArrayES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedArrowFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedArrowFunctionES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedComments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedCommentsES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedConditional.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedConditionalES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedDivision.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedDivisionES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedFunctionExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedFunctionExpressionES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedInOperator.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedInOperatorES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedInstanceOf.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedInstanceOfES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedModulo.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedModuloES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedMultiplication.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedMultiplicationES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedNewOperator.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedNewOperatorES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedObjectLiteral.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedObjectLiteralES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedTemplateString.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedTemplateStringES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedTypeAssertionOnAddition.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedTypeAssertionOnAdditionES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedTypeOfOperator.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedTypeOfOperatorES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedUnaryPlus.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedUnaryPlusES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedYieldKeywordES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmptyLiteralPortions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmptyLiteralPortionsES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithOpenCommentInStringPortion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithOpenCommentInStringPortionES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithPropertyAccess.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithPropertyAccessES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringsWithTypeErrorInFunctionExpressionsInSubstitutionExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringsWithTypeErrorInFunctionExpressionsInSubstitutionExpressionES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/variableDeclarations/VariableDeclaration10_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/variableDeclarations/VariableDeclaration12_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/variableDeclarations/VariableDeclaration3_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/variableDeclarations/VariableDeclaration5_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/variableDeclarations/VariableDeclaration7_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/variableDeclarations/VariableDeclaration8_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/variableDeclarations/VariableDeclaration9_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression10_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression11_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression13_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression19_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression3_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression4_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression6_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression7_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression9_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldStarExpression4_es6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorInAmbientContext5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorInAmbientContext6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorNoImplicitReturns.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorOverloads4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorOverloads5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck11.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck12.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck13.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck14.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck15.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck16.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck17.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck18.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck19.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck20.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck21.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck22.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck23.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck24.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck25.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck26.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck27.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck28.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck29.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck30.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck31.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck33.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck34.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck35.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck36.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck37.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck40.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck41.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck42.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck43.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck44.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck45.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck46.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck47.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck48.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck49.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck50.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck51.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck52.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck53.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck54.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck55.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck56.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck59.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck60.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck61.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck62.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck63.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck64.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/yieldExpressionInControlFlow.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSIsReference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/emitExponentiationOperatorInTempalteString4ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/emitExponentiationOperatorInTemplateString1ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/emitExponentiationOperatorInTemplateString2ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/emitExponentiationOperatorInTemplateString3ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithAnyAndNumber.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithEnum.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithEnumUnion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithInvalidOperands.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNew.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithTemplateStringInvalidES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithTypeParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-commonjs-classNamespaceMerge.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-commonjs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/esDecorators-arguments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/esDecorators-contextualTypes.2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/esDecorators-contextualTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/esDecorators-preservesThis.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/esnext/esnextSharedMemory.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/arrayLiterals/arrayLiteralInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/arrayLiterals/arrayLiterals.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/arrayLiterals/arrayLiterals2ES5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/arrayLiterals/arrayLiterals2ES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/arrayLiterals/arrayLiterals3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/asOperator/asOpEmitParens.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/asOperator/asOperator1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/asOperator/asOperator2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/asOperator/asOperator3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/asOperator/asOperator4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/asOperator/asOperatorASI.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/asOperator/asOperatorContextualType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/asOperator/asOperatorNames.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/assignmentOperator/assignmentGenericLookupTypeNarrowing.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/assignmentOperator/assignmentLHSIsReference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/assignmentOperator/assignmentTypeNarrowing.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentLHSCannotBeAssigned.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/assignmentOperator/compoundAssignmentLHSIsReference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithAnyAndEveryType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithConstrainedTypeParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithInvalidOperands.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithNumberAndEnum.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithStringAndEveryType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithAnyAndNumber.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithEnum.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithEnumUnion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithInvalidOperands.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithTypeParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalTypeParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIntersectionType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnOptionalProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipPrimitiveType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNumberOperand.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNumericLiteral.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsUndefined.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeEnumAndNumber.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnIndexSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnOptionalProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithTwoOperandsAreAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithTypeParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithValidOperands.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithInvalidOperands.es2015.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithInvalidOperands.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithInvalidStaticToString.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithLHSIsObject.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithLHSIsTypeParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithRHSHasSymbolHasInstance.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithRHSIsSubtypeOfFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/logicalAndOperator/logicalAndOperatorStrictMode.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/logicalAndOperator/logicalAndOperatorWithEveryType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/logicalAndOperator/logicalAndOperatorWithTypeParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/logicalOrOperator/logicalOrExpressionIsContextuallyTyped.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/logicalOrOperator/logicalOrExpressionIsNotContextuallyTyped.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/logicalOrOperator/logicalOrOperatorWithEveryType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/logicalOrOperator/logicalOrOperatorWithTypeParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/commaOperator/commaOperatorInvalidAssignmentType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/commaOperator/commaOperatorOtherInvalidOperation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/commaOperator/commaOperatorOtherValidOperation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/commaOperator/commaOperatorWithSecondOperandAnyType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/commaOperator/commaOperatorWithSecondOperandBooleanType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/commaOperator/commaOperatorWithSecondOperandNumberType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/commaOperator/commaOperatorWithSecondOperandObjectType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/commaOperator/commaOperatorWithSecondOperandStringType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/commaOperator/commaOperatorsMultipleOperators.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/conditonalOperator/conditionalOperatorConditionIsBooleanType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/conditonalOperator/conditionalOperatorConditionIsNumberType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/conditonalOperator/conditionalOperatorConditionIsObjectType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/conditonalOperator/conditionalOperatorConditoinIsAnyType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/conditonalOperator/conditionalOperatorConditoinIsStringType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/conditonalOperator/conditionalOperatorWithIdenticalBCT.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/conditonalOperator/conditionalOperatorWithoutIdenticalBCT.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/argumentExpressionContextualTyping.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/arrayLiteralExpressionContextualTyping.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/functionExpressionContextualTyping1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/functionExpressionContextualTyping2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/functionExpressionContextualTyping3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/generatedContextualTyping.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/iterableContextualTyping1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/objectLiteralContextualTyping.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/parenthesizedContexualTyping1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/parenthesizedContexualTyping2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/parenthesizedContexualTyping3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/superCallParameterContextualTyping1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/superCallParameterContextualTyping2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/superCallParameterContextualTyping3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/taggedTemplateContextualTyping1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/taggedTemplateContextualTyping2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/elementAccess/stringEnumInElementAccess01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/callOverload.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/callWithMissingVoid.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/callWithSpread.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/callWithSpread4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/callWithSpread5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/callWithSpreadES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/forgottenNew.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/functionCalls.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/grammarAmbiguities.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/newWithSpread.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/newWithSpreadES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/overloadResolution.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/overloadResolutionConstructors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/typeArgumentInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstructSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceErrors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceTransitiveConstraints.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConstraints.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithObjectLiteral.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functions/arrowFunctionExpressions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functions/contextuallyTypedFunctionExpressionsAndReturnAnnotations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functions/contextuallyTypedIife.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functions/contextuallyTypedIifeStrict.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functions/typeOfThisInFunctionExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functions/voidParamAssignmentCompatibility.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/identifiers/scopeResolutionIdentifiers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/newOperator/newOperatorConformance.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/newOperator/newOperatorErrorCases_noImplicitAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingAssignmentVsPrivateFieldsJsEmit1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator11.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator12.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator_es2020.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator_not_strict.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/objectLiterals/objectLiteralGettersAndSetters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/objectLiterals/objectLiteralNormalization.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/callChain/callChain.2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/callChain/callChain.3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/callChain/callChain.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/callChain/callChainInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/callChain/superMethodCall.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/callChain/thisMethodCall.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/delete/deleteChain.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/elementAccessChain/elementAccessChain.2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/elementAccessChain/elementAccessChain.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/optionalChainingInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/propertyAccessChain/propertyAccessChain.2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/propertyAccessChain/propertyAccessChain.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/superCalls/superCalls.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/superPropertyAccess/superSymbolIndexedAccess1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/superPropertyAccess/superSymbolIndexedAccess2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/superPropertyAccess/superSymbolIndexedAccess3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/thisKeyword/typeOfThisGeneral.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/thisKeyword/typeOfThisInConstructorParamList.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeAssertions/constAssertionOnEnum.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/TypeGuardWithArrayUnion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/TypeGuardWithEnumUnion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/nullOrUndefinedTypeGuardIsOrderIndependent.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardEnums.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardFunctionGenerics.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardFunctionOfFormThis.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardInClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardIntersectionTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardNarrowsPrimitiveIntersection.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardNarrowsToLiteralType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardNarrowsToLiteralTypeUnion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardNesting.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormExpr1AndExpr2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormExpr1OrExpr2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormFunctionEquality.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormInstanceOfOnInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormIsType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormIsTypeOnInterfaces.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormNotExpr.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfBoolean.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfEqualEqualHasNoEffect.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfIsOrderIndependent.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfNotEqualHasNoEffect.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfNumber.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfOther.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfPrimitiveSubtype.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfString.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFromPropNameInUnionType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardTautologicalConsistiency.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardTypeOfUndefined.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsDefeat.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInClassMethods.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInConditionalExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInDoStatement.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInExternalModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInForStatement.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInFunctionAndModuleBlock.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInGlobal.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInRightOperandOfAndAndOperator.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInWhileStatement.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsOnClassProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typePredicateASI.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfactionWithDefaultExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_asConstArrays.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_contextualTyping1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_contextualTyping2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_contextualTyping3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_ensureInterfaceImpl.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_errorLocations1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_propertyValueConformance3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_vacuousIntersectionOfContextualTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/bitwiseNotOperator/bitwiseNotOperatorWithBooleanType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/bitwiseNotOperator/bitwiseNotOperatorWithEnumType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/bitwiseNotOperator/bitwiseNotOperatorWithNumberType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/bitwiseNotOperator/bitwiseNotOperatorWithStringType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithNumberType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithEnumType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithNumberType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/logicalNotOperator/logicalNotOperatorWithBooleanType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/logicalNotOperator/logicalNotOperatorWithEnumType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/logicalNotOperator/logicalNotOperatorWithNumberType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/logicalNotOperator/logicalNotOperatorWithStringType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/negateOperator/negateOperatorWithBooleanType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/negateOperator/negateOperatorWithEnumType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/negateOperator/negateOperatorWithNumberType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/negateOperator/negateOperatorWithStringType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/plusOperator/plusOperatorWithBooleanType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/plusOperator/plusOperatorWithEnumType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/plusOperator/plusOperatorWithNumberType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/plusOperator/plusOperatorWithStringType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/typeofOperator/typeofOperatorWithBooleanType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/typeofOperator/typeofOperatorWithEnumType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/typeofOperator/typeofOperatorWithNumberType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/typeofOperator/typeofOperatorWithStringType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/voidOperator/voidOperatorWithBooleanType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/voidOperator/voidOperatorWithEnumType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/voidOperator/voidOperatorWithNumberType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/voidOperator/voidOperatorWithStringType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/valuesAndReferences/assignments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/amdImportAsPrimaryExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/amdImportNotAsPrimaryExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/asiPreventsParsingAsAmbientExternalModule01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/asiPreventsParsingAsAmbientExternalModule02.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/commonJSImportAsPrimaryExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/commonJSImportNotAsPrimaryExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/commonJsImportBindingElementNarrowType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/es6/es6modulekind.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/es6/es6modulekindWithES2015Target.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/esnext/esnextmodulekind.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/esnext/esnextmodulekindWithES2015Target.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignDottedName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignImportedIdentifier.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentCircularModules.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentConstrainedGenericType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentGenericType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentMergedInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentMergedModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentOfExportNamespaceWithDefault.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentTopLevelClodule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentTopLevelEnumdule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentTopLevelFundule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentTopLevelIdentifier.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportDeclaredModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportNonLocalDeclarations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportNonVisibleType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportTypeMergedWithExportStarAsNamespace.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/globalAugmentationModuleResolution.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/importImportOnlyModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/importNonExternalModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithExtensions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithoutExtension1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithoutExtension2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithoutExtension5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithoutExtension6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithoutExtension7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithoutExtension8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleScoping.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/nameDelimitedBySlashes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/nameWithFileExtension.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/nameWithRelativePaths.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/reexportClassDefinition.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/relativePathMustResolve.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/relativePathToDeclarationFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/topLevelAmbientModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/topLevelFileModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/topLevelFileModuleMissing.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeAndNamespaceExportMerge.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/allowsImportingTsExtension.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/ambient.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/chained.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/circular1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/circular2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/circular3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/circular4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/cjsImportInES2015.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/computedPropertyName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/enums.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportDeclaration_moduleSpecifier-isolatedModules.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportDeclaration_moduleSpecifier.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportDeclaration_value.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/extendsClause.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/filterNamespace_import.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/generic.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/implementsClause.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importClause_default.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importClause_namedImports.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importClause_namespaceImport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importDefaultNamedType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importDefaultNamedType2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importDefaultNamedType3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importEquals1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importEquals3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importsNotUsedAsValues_error.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/mergedWithLocalValue.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/namespaceImportTypeQuery.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/namespaceImportTypeQuery2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/namespaceImportTypeQuery3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/namespaceImportTypeQuery4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/nestedNamespace.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/preserveValueImports_importsNotUsedAsValues.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/preserveValueImports_mixedImports.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/renamed.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/typeQuery.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnlyMerge1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnlyMerge2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeValueMerge1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typesOnlyExternalModuleStillHasInstance.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd-augmentation-1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd-augmentation-2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd-augmentation-3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd-augmentation-4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/verbatimModuleSyntaxConstEnum.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/verbatimModuleSyntaxConstEnumUsage.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/verbatimModuleSyntaxDeclarationFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/verbatimModuleSyntaxInternalImportEquals.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/verbatimModuleSyntaxNoElisionCJS.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/verbatimModuleSyntaxNoElisionESM.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/functions/functionImplementations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/functions/functionOverloadCompatibilityWithVoid02.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/functions/functionOverloadCompatibilityWithVoid03.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/functions/strictBindCallApply1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/functions/strictBindCallApply2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorAssignability.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorExplicitReturnType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorImplicitAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnContextualType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnTypeFallback.1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnTypeFallback.2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnTypeFallback.3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnTypeFallback.4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnTypeFallback.5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnTypeIndirectReferenceToGlobalType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnTypeInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnTypeInferenceNonStrict.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorYieldContextualType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/importAttributes/importAttributes11.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/importAttributes/importAttributes7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/importAttributes/importAttributes8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/importAttributes/importAttributes9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/importDefer/importBindingDefer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/importDefer/importBindingDefer2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/importDefer/importDefaultBindingDefer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/importDefer/importDeferComments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/importDefer/importDeferDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/importDefer/importEqualsBindingDefer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/inferFromBindingPattern.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/genericAndNonGenericInterfaceWithTheSameName2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergeThreeInterfaces.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergeThreeInterfaces2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergeTwoInterfaces.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergeTwoInterfaces2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInheritedMembersSatisfyAbstractBase.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithConflictingPropertyNames.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithConflictingPropertyNames2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithIndexers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithIndexers2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithInheritedPrivates.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithInheritedPrivates2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithInheritedPrivates3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithMultipleBases.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithMultipleBases2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithMultipleBases3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithMultipleBases4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/twoMergedInterfacesWithDifferingOverloads.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/twoMergedInterfacesWithDifferingOverloads2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/derivedInterfaceDoesNotHideBaseSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/derivedInterfaceIncompatibleWithBaseIndexer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersection.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceThatHidesBaseProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceThatHidesBaseProperty2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceThatIndirectlyInheritsFromItself.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithCallAndConstructSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithCallSignaturesThatHidesBaseSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithCallSignaturesThatHidesBaseSignature2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithConstructSignaturesThatHidesBaseSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithConstructSignaturesThatHidesBaseSignature2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithMultipleBaseTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithMultipleBaseTypes2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithOverloadedCallAndConstructSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithPropertyOfEveryType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithPropertyThatIsPrivateInBaseType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithPropertyThatIsPrivateInBaseType2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithSpecializedCallAndConstructSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithStringIndexerHidingBaseTypeIndexer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithStringIndexerHidingBaseTypeIndexer2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithStringIndexerHidingBaseTypeIndexer3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfacesExtendingClasses/implementingAnInterfaceExtendingClassWithPrivates.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfacesExtendingClasses/implementingAnInterfaceExtendingClassWithProtecteds.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtendingClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtendingClassWithPrivates.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtendingClassWithPrivates2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtendingClassWithProtecteds.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtendingClassWithProtecteds2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/AmbientModuleAndAmbientFunctionWithTheSameNameAndCommonRoot.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/AmbientModuleAndAmbientWithSameNameAndCommonRoot.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/AmbientModuleAndNonAmbientClassWithSameNameAndCommonRoot.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/AmbientModuleAndNonAmbientFunctionWithTheSameNameAndCommonRoot.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithModuleMemberThatUsesClassTypeParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithModulesExportedStaticFunctionUsingClassPrivateStatics.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithStaticFunctionAndNonExportedFunctionThatShareAName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithStaticVariableAndNonExportedVarThatShareAName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleWithSameNameAndCommonRoot.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleWithSameNameAndCommonRootES6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/EnumAndModuleWithSameNameAndCommonRoot.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/FunctionAndModuleWithSameNameAndCommonRoot.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/FunctionAndModuleWithSameNameAndDifferentCommonRoot.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ModuleAndEnumWithSameNameAndCommonRoot.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesThatMergeEachWithExportedAndNonExportedClassesOfTheSameName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesThatMergeEachWithExportedAndNonExportedInterfacesOfTheSameName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesThatMergeEachWithExportedAndNonExportedLocalVarsOfTheSameName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesThatMergeEachWithExportedInterfacesOfTheSameName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesThatMergeEachWithExportedLocalVarsOfTheSameName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesThatMergeEachWithExportedModulesOfTheSameName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesWithTheSameNameAndDifferentCommonRoot.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesWithTheSameNameAndSameCommonRoot.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/codeGeneration/exportCodeGen.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/codeGeneration/importStatements.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/codeGeneration/importStatementsInterfaces.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/codeGeneration/nameCollision.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportClassWhichExtendsInterfaceWithInaccessibleType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportClassWithAccessibleTypesInTypeParameterConstraintsClassHeritageListMemberTypeAnnotations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportClassWithInaccessibleTypeInIndexerTypeAnnotations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportClassWithInaccessibleTypeInTypeParameterConstraint.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportFunctionWithAccessibleTypesInParameterAndReturnTypeAnnotation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportFunctionWithInaccessibleTypesInParameterTypeAnnotation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportFunctionWithInaccessibleTypesInReturnTypeAnnotation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportInterfaceWithAccessibleTypesInTypeParameterConstraintsClassHeritageListMemberTypeAnnotations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportInterfaceWithInaccessibleTypeInIndexerTypeAnnotations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportInterfaceWithInaccessibleTypeInTypeParameterConstraint.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportModuleWithAccessibleTypesOnItsExportedMembers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportObjectLiteralAndObjectTypeLiteralWithAccessibleTypesInMemberTypeAnnotations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportObjectLiteralAndObjectTypeLiteralWithAccessibleTypesInNestedMemberTypeAnnotations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportVariableOfGenericTypeWithInaccessibleTypeAsTypeArgument.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportVariableWithAccessibleTypeInTypeAnnotation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportVariableWithInaccessibleTypeInTypeAnnotation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/importDeclarations/circularImportAlias.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/importDeclarations/exportImportAlias.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/importDeclarations/importAliasIdentifiers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/importDeclarations/invalidImportAliasIdentifiers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleBody/moduleWithStatementsOfEveryKind.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/InvalidNonInstantiatedModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/asiPreventsParsingAsNamespace01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/asiPreventsParsingAsNamespace02.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/asiPreventsParsingAsNamespace03.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/asiPreventsParsingAsNamespace04.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/asiPreventsParsingAsNamespace05.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/instantiatedModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/nestedModules.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/nonInstantiatedModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/reExportAliasMakesInstantiated.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/assertionsAndNonReturningFunctions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/callOfPropertylessConstructorFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/callbackCrossModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/callbackOnConstructor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/callbackTag1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/callbackTag2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/callbackTag3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/callbackTag4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/callbackTagNamespace.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/callbackTagNestedParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/callbackTagVariadicType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkExportsObjectAssignProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocParamOnVariableDeclaredFunctionExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocParamTag1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocReturnTag1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocReturnTag2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocSatisfiesTag1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocSatisfiesTag12.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocSatisfiesTag13.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocSatisfiesTag15.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocSatisfiesTag2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocSatisfiesTag3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocSatisfiesTag4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocSatisfiesTag5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocSatisfiesTag8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocSatisfiesTag9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocTypeTag1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocTypeTag3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocTypeTag4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocTypeTag5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocTypeTag6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocTypeTag7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocTypeTag8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocTypeTagOnObjectProperty1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocTypeTagOnObjectProperty2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocTypedefInParamTag1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocTypedefOnlySourceFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkObjectDefineProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/constructorTagOnClassConstructor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/constructorTagOnNestedBinaryExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/constructorTagWithThisTag.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsClassAccessor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsClassMethod.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsClassStatic2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsCommonjsRelativePath.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsConstsAsNamespacesWithReferences.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsExportDefinePropertyEmit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsExportDoubleAssignmentInClosure.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsExportedClassAliases.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsFunctionWithDefaultAssignedMember.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsFunctions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsFunctionsCjs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsGetterSetter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsImportAliasExposedWithinNamespace.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsImportAliasExposedWithinNamespaceCjs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsImportNamespacedType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsImportTypeBundled.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsJSDocRedirectedLookups.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsNestedParams.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsNonIdentifierInferredNames.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsOptionalTypeLiteralProps1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsOptionalTypeLiteralProps2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsParameterTagReusesInputNodeInEmit1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsParameterTagReusesInputNodeInEmit2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsPrivateFields01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsReferenceToClassInstanceCrossFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsReusesExistingNodesMappingJSDocTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsReusesExistingTypeAnnotations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsSubclassWithExplicitNoArgumentConstructor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsThisTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsTypeAliases.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsTypeReassignmentFromDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsTypeReassignmentFromDeclaration2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsTypedefAndImportTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsTypedefAndLatebound.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsTypedefFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsTypedefPropertyAndExportAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsUniqueSymbolUsage.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/enumTagCircularReference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/enumTagImported.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/enumTagOnExports.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/enumTagOnExports2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/enumTagUseBeforeDefCrash.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/errorIsolation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/exportedAliasedEnumTag.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/exportedEnumTypeAndValue.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/extendsTag1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/extendsTag2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/extendsTag3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/extendsTag4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/extendsTag5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/extendsTag6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/extendsTagEmit.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag16.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag17.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag18.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag19.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag20.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag23.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag24.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag25.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/inferThis.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/instantiateTemplateTagTypeParameterOnVariableStatement.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocAccessibilityTags.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocAccessibilityTagsDeclarations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocAugments_errorInExtendsExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocAugments_nameMismatch.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocAugments_notAClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocAugments_qualifiedName.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocAugments_withTypeParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocBindingInUnreachableCode.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocFunctionType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocFunction_missingReturn.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocImplementsTag.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocImplements_class.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocImplements_interface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocImplements_interface_multiple.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocImplements_namespacedInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocImplements_properties.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocImplements_signatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocImportType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocImportType2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocImportTypeReferenceToClassAlias.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocImportTypeReferenceToCommonjsModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocImportTypeReferenceToESModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocImportTypeReferenceToStringLiteral.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocIndexSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocLinkTag1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocLinkTag2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocLinkTag3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocLinkTag4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocLinkTag6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocLinkTag7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocLinkTag8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocLinkTag9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocLiteral.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocNeverUndefinedNull.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocOverrideTag1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocParamTagTypeLiteral.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocParseDotDotDotInJSDocFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocParseHigherOrderFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocParseMatchingBackticks.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocParseParenthesizedJSDocParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocParseStarEquals.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocPostfixEqualsAddsOptionality.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocPrivateName1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocPrototypePropertyAccessWithType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocReadonly.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocReadonlyDeclarations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocReturnTag1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocSignatureOnReturnedFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTemplateClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTemplateConstructorFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTemplateConstructorFunction2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTemplateTag.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTemplateTag2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTemplateTag4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTemplateTag5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTemplateTag6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTemplateTagNameResolution.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTwoLineTypedef.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTypeDefAtStartOfFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTypeFromChainedAssignment2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTypeFromChainedAssignment3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTypeReferenceExports.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTypeReferenceToImport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTypeReferenceToImportOfClassExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTypeReferenceToImportOfFunctionExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTypeReferenceToMergedClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTypeReferenceToValue.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTypeReferenceUseBeforeDef.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTypeTag.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTypeTagOnParameter1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTypeTagParameterType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTypeTagRequiredParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocVariableDeclarationWithTypeAnnotation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocVariadicType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/linkTagEmit1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/moduleExportsElementAccessAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/moduleExportsElementAccessAssignment2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/noAssertForUnparseableTypedefs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/noDuplicateJsdoc1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/overloadTag3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/paramTagBracketsAddOptionalUndefined.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/paramTagNestedWithoutTopLevelObject.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/paramTagNestedWithoutTopLevelObject2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/paramTagNestedWithoutTopLevelObject3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/paramTagNestedWithoutTopLevelObject4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/paramTagOnCallExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/paramTagOnFunctionUsingArguments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/paramTagTypeResolution.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/paramTagTypeResolution2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/parseLinkTag.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/parseThrowsTag.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/returnTagTypeGuard.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/seeTag1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/seeTag2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/seeTag3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/seeTag4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/templateInsideCallback.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/thisPrototypeMethodCompoundAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/thisPrototypeMethodCompoundAssignmentJs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/thisTag1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/thisTag2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/tsNoCheckForTypescript.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/tsNoCheckForTypescriptComments1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/tsNoCheckForTypescriptComments2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/typeParameterExtendsUnionConstraintDistributed.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/typeTagCircularReferenceOnConstructorFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/typeTagModuleExports.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/typeTagNoErasure.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/typeTagOnPropertyAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/typeTagPrototypeAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/typeTagWithGenericSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/typedefCrossModule.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/typedefMultipleTypeParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/typedefOnSemicolonClassElement.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/typedefScope1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/typedefTagExtraneousProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/typedefTagNested.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/typedefTagTypeResolution.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenCanBeTupleType.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty1.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty10.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty11.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty12.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty13.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty14.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty15.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty16.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty2.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty3.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty4.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty5.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty6.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty7.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty8.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty9.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxGenericTagHasCorrectInferences.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxIntersectionElementPropsType.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxSubtleSkipContextSensitiveBug.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxUnionSFXContextualTypeInferredCorrectly.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/commentEmittingInPreserveJsx1.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/correctlyMarkAliasAsReferences1.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/correctlyMarkAliasAsReferences2.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/correctlyMarkAliasAsReferences3.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/correctlyMarkAliasAsReferences4.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/inline/inlineJsxAndJsxFragPragma.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/inline/inlineJsxAndJsxFragPragmaOverridesCompilerOptions.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/inline/inlineJsxFactoryDeclarations.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/inline/inlineJsxFactoryDeclarationsLocalTypes.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/inline/inlineJsxFactoryLocalTypeGlobalFallback.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/inline/inlineJsxFactoryOverridesCompilerOption.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/inline/inlineJsxFactoryWithFragmentIsError.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxReactTestSuite.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxSpreadOverwritesAttributeStrict.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeErrors.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution1.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution10.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution11.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution12.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution13.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution14.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution15.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution16.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution3.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution5.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution6.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution7.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution8.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution9.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxCorrectlyParseLessThanComparison1.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDefaultAttributesResolution1.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDefaultAttributesResolution2.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDefaultAttributesResolution3.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName1.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName4.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName5.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName6.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName7.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName8.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName9.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution10.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution11.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution12.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution13.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution14.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution15.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution16.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution17.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution18.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution19.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution2.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution3.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution4.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution5.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution8.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution9.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxEmit1.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxEmit2.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxEmit3.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxExternalModuleEmit1.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxExternalModuleEmit2.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxFragmentPreserveEmit.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxFragmentReactEmit.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType1.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType2.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType3.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType4.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType5.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType6.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType7.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType8.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType9.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxInArrowFunction.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxIntrinsicAttributeErrors.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxLibraryManagedAttributes.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxNamespacedAttributeName1.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxNamespacedAttributeName2.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxNamespacedTagName1.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxNamespacedTagName2.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxNoJsx.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxOpeningClosingNames.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxParseTests1.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxParseTests2.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxPreserveEmit3.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactComponentWithDefaultTypeParameter1.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactComponentWithDefaultTypeParameter2.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactComponentWithDefaultTypeParameter3.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit1.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit2.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit3.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit4.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit5.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit6.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit7.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitEntities.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitNesting.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitWhitespace.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitWhitespace2.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSfcReturnNull.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSfcReturnNullStrictNullChecks.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSfcReturnUndefinedStrictNullChecks.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution1.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution10.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution11.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution12.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution13.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution14.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution15.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution16.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution17.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution2.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution3.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution4.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution5.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution6.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution7.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution8.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution9.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadChildren.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadInvalidType.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload1.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload2.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload3.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload4.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload5.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload6.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentWithDefaultTypeParameter1.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentWithDefaultTypeParameter2.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponents3.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments1.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments2.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments3.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments4.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments5.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxTypeArgumentsJsxPreserveOutput.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxTypeErrors.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionElementType1.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionElementType2.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionElementType3.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionElementType4.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionElementType5.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionElementType6.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionTypeComponent1.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionTypeComponent2.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/declarationNotFoundPackageBundlesTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/importFromDot.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/node10IsNode_node.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/node10IsNode_node10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/packageJsonMain.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/packageJsonMain_isNonRecursive.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/resolutionModeCache.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/scopedPackages.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/scopedPackagesClassic.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/selfNameModuleAugmentation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/typesVersions.ambientModules.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/typesVersions.emptyTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/typesVersions.justIndex.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/typesVersions.multiFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/untypedModuleImport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/untypedModuleImport_noImplicitAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/untypedModuleImport_noImplicitAny_relativePath.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/untypedModuleImport_noImplicitAny_scoped.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/untypedModuleImport_noImplicitAny_typesForPackageExist.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/untypedModuleImport_vsAmbient.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/untypedModuleImport_withAugmentation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/node/allowJs/nodeAllowJsPackageSelfName2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/node/esmModuleExports1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/node/esmModuleExports3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesPackageImportsRootWildcard.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesPackageImportsRootWildcardNode16.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeOverrideOldResolutionError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/nonjsExtensions/declarationFileForHtmlFileWithinDeclarationFile.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override13.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override14.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override15.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override19.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override20.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override21.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/overrideWithoutNoImplicitOverride1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override_js1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override_js2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override_js4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript2021/numericSeparators/parser.numericSeparators.binary.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript2021/numericSeparators/parser.numericSeparators.hex.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript2021/numericSeparators/parser.numericSeparators.octal.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript3/Accessors/parserES3Accessors2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript3/Accessors/parserES3Accessors4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrayLiteralExpressions/parserArrayLiteralExpression1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrayLiteralExpressions/parserArrayLiteralExpression10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrayLiteralExpressions/parserArrayLiteralExpression11.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrayLiteralExpressions/parserArrayLiteralExpression12.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrayLiteralExpressions/parserArrayLiteralExpression13.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrayLiteralExpressions/parserArrayLiteralExpression14.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrayLiteralExpressions/parserArrayLiteralExpression15.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrayLiteralExpressions/parserArrayLiteralExpression2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrayLiteralExpressions/parserArrayLiteralExpression3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrayLiteralExpressions/parserArrayLiteralExpression4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrayLiteralExpressions/parserArrayLiteralExpression5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrayLiteralExpressions/parserArrayLiteralExpression6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrayLiteralExpressions/parserArrayLiteralExpression7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrayLiteralExpressions/parserArrayLiteralExpression8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrayLiteralExpressions/parserArrayLiteralExpression9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression11.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression12.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/AutomaticSemicolonInsertion/parserAutomaticSemicolonInsertion1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/CatchClauses/parserCatchClauseWithTypeAnnotation1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClass1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration16.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration17.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration19.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration20.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration23.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration26.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration7.d.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclarationIndexSignature1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnumDeclaration1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnumDeclaration2.d.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnumDeclaration3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnumDeclaration5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnumDeclaration6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserInterfaceKeywordInEnum.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserInterfaceKeywordInEnum1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/AccessibilityAfterStatic/parserAccessibilityAfterStatic11.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/AccessibilityAfterStatic/parserAccessibilityAfterStatic14.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/AccessibilityAfterStatic/parserAccessibilityAfterStatic2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/AccessibilityAfterStatic/parserAccessibilityAfterStatic3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/AccessibilityAfterStatic/parserAccessibilityAfterStatic4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/AccessibilityAfterStatic/parserAccessibilityAfterStatic5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ArrowFunctions/ArrowFunction4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ArrowFunctions/parserX_ArrowFunction4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/IncompleteMemberVariables/parserErrorRecovery_IncompleteMemberVariable1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ParameterLists/parserErrorRecovery_ParameterList6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/VariableLists/parserVariableStatement1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/VariableLists/parserVariableStatement2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/VariableLists/parserVariableStatement3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/VariableLists/parserVariableStatement4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserCommaInTypeMemberList1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserModifierOnPropertySignature2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ExportAssignments/parserExportAssignment1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ExportAssignments/parserExportAssignment2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ExportAssignments/parserExportAssignment6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Expressions/parserConditionalExpression1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Expressions/parserInvocationOfMemberAccessOffOfObjectCreationExpression1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Expressions/parserObjectCreation2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration1.d.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Fuzz/parser768531.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguity1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguity2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguity3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguityWithBinaryOperator1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguityWithBinaryOperator2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguityWithBinaryOperator3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguityWithBinaryOperator4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserCastVersusArrowFunction1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserConstructorAmbiguity1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserConstructorAmbiguity2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserConstructorAmbiguity3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserConstructorAmbiguity4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericClass1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericClass2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInInterfaceDeclaration1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInVariableDeclaration1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGreaterThanTokenAmbiguity1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGreaterThanTokenAmbiguity10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGreaterThanTokenAmbiguity5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGreaterThanTokenAmbiguity6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserObjectCreation1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexMemberDeclarations/parserIndexMemberDeclaration1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexMemberDeclarations/parserIndexMemberDeclaration2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexMemberDeclarations/parserIndexMemberDeclaration3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexMemberDeclarations/parserIndexMemberDeclaration4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexMemberDeclarations/parserIndexMemberDeclaration6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexSignatures/parserIndexSignature4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexSignatures/parserIndexSignature5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/InterfaceDeclarations/parserInterfaceDeclaration9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberVariableDeclarations/parserMemberVariableDeclaration5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature11.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature12.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModule1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModuleDeclaration11.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModuleDeclaration2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ObjectLiterals/parserObjectLiterals1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ObjectTypes/parserObjectType1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ObjectTypes/parserObjectType2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ObjectTypes/parserObjectType3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ObjectTypes/parserObjectType4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList12.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertyAssignments/parserFunctionPropertyAssignment1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertyAssignments/parserFunctionPropertyAssignment2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertyAssignments/parserFunctionPropertyAssignment3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertyAssignments/parserFunctionPropertyAssignment4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature11.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature12.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Protected/Protected3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Protected/Protected5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Protected/Protected8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Protected/Protected9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RealWorld/parserindenter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509534.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509546.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509546_1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509546_2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509677.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509693.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509698.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser536727.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser596700.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser630933.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser643728.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser645086_3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser645086_4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser645484.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parserNotHexLiteral1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parserTernaryAndCommaOperators1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parseRegularExpressionMixedWithComments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpression1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpression2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpression3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpression4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpression5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpression6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/BreakStatements/parser_breakInIterationOrSwitchStatement1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/BreakStatements/parser_breakInIterationOrSwitchStatement2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/BreakStatements/parser_breakInIterationOrSwitchStatement4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/BreakStatements/parser_breakTarget1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/BreakStatements/parser_breakTarget2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/BreakStatements/parser_breakTarget3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/BreakStatements/parser_breakTarget4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/ContinueStatements/parser_continueInIterationStatement1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/ContinueStatements/parser_continueInIterationStatement2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/ContinueStatements/parser_continueInIterationStatement4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/ContinueStatements/parser_continueLabel.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/ContinueStatements/parser_continueTarget2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/ContinueStatements/parser_continueTarget3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/ContinueStatements/parser_continueTarget4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/LabeledStatements/parser_duplicateLabel3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/LabeledStatements/parser_duplicateLabel4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/ReturnStatements/parserReturnStatement3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/ReturnStatements/parserReturnStatement4.js
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/ReturnStatements/parserReturnStatement4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserDoStatement2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserForStatement2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserForStatement3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserForStatement9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserIfStatement2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode15-negative.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/TupleTypes/TupleType1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/TupleTypes/TupleType2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/TupleTypes/TupleType3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/TupleTypes/TupleType5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Types/parserTypeQuery1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Types/parserTypeQuery2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Types/parserTypeQuery5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Types/parserTypeQuery6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Types/parserTypeQuery7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Types/parserTypeQuery8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Types/parserTypeQuery9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration11.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration4.d.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parser15.4.4.14-9-2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserAdditiveExpression1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserArgumentList1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserEmptyStatement1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserExportAsFunctionIdentifier.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserImportDeclaration1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserInExpression1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserKeywordsAsIdentifierName1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserNotRegex2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserObjectCreationArrayLiteral2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserObjectCreationArrayLiteral4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserOptionalTypeMembers1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserOverloadOnConstants1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserParenthesizedVariableAndFunctionInTernary.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserParenthesizedVariableAndParenthesizedFunctionInTernary.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserRealSource1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserRealSource12.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserRealSource2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserRealSource3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserRealSource5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserS7.2_A1.5_T2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserS7.3_A1.1_T2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserS7.6_A4.2_T1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserSbp_7.9_A9_T3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserUnicode1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserUnicode2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserUnicode3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserUnicodeWhitespaceCharacter1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserUsingConstructorAsIdentifier.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserVoidExpression1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parservoidInQualifiedName0.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parservoidInQualifiedName2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName11.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName12.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName13.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName14.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName15.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName17.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName18.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName19.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName20.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName21.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName22.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName23.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName24.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName25.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName28.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName29.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName31.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName32.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName40.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement11.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement12.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement13.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement14.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement15.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement16.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement17.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement18.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement19.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement23.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement24.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement25.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolIndexer1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolIndexer2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolIndexer3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolIndexer4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/pedantic/noUncheckedIndexedAccess.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/pedantic/noUncheckedIndexedAccessDestructuring.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/references/library-reference-1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/references/library-reference-10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/references/library-reference-11.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/references/library-reference-12.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/references/library-reference-13.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/references/library-reference-14.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/references/library-reference-15.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/references/library-reference-2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/references/library-reference-3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/references/library-reference-4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/references/library-reference-5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/references/library-reference-6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/references/library-reference-7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/references/library-reference-8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/references/library-reference-scoped-packages.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/annotatedThisPropertyInitializerDoesntNarrow.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/assignmentToVoidZero1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/binderUninitializedModuleExportsAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/chainedPrototypeAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/checkSpecialPropertyAssignments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/circularMultipleAssignmentDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/classCanExtendConstructorFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/commonJSAliasedExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/commonJSImportClassTypeReference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/commonJSImportExportedClassExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/commonJSImportNestedClassTypeReference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/commonJSReexport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/conflictingCommonJSES2015Exports.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/constructorFunctionMergeWithClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/constructorFunctionMethodTypeParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/constructorFunctions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/constructorFunctions2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/constructorFunctions3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/constructorFunctionsStrict.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/constructorNameInObjectLiteralAccessor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/contextualTypedSpecialAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/defaultPropertyAssignedClassWithPrototype.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/enumMergeWithExpando.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/exportNestedNamespaces.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/exportPropertyAssignmentNameResolution.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/globalMergeWithCommonJSAssignmentDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/inferingFromAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/inferringClassMembersFromAssignments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/inferringClassMembersFromAssignments2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/inferringClassMembersFromAssignments3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/inferringClassMembersFromAssignments4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/inferringClassMembersFromAssignments5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/inferringClassMembersFromAssignments6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/inferringClassMembersFromAssignments7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/inferringClassMembersFromAssignments8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/inferringClassStaticMembersFromAssignments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/jsContainerMergeJsContainer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/jsContainerMergeTsDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/jsContainerMergeTsDeclaration2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/jsContainerMergeTsDeclaration3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/jsObjectsMarkedAsOpenEnded.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/jsdocConstructorFunctionTypeReference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/lateBoundAssignmentDeclarationSupport1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/lateBoundAssignmentDeclarationSupport2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/lateBoundAssignmentDeclarationSupport3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/lateBoundAssignmentDeclarationSupport4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/lateBoundAssignmentDeclarationSupport5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/lateBoundAssignmentDeclarationSupport6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/lateBoundAssignmentDeclarationSupport7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/lateBoundClassMemberAssignmentJS.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/lateBoundClassMemberAssignmentJS2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/lateBoundClassMemberAssignmentJS3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/malformedTags.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/methodsReturningThis.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/mixedPropertyElementAccessAssignmentDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportAlias.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportAlias2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportAlias3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportAlias4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportAlias5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportAliasElementAccessExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportAliasExports.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportAliasImported.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportAssignment2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportAssignment3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportAssignment4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportAssignment5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportAssignment6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportAssignment7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportDuplicateAlias.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportDuplicateAlias2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportDuplicateAlias3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportNestedNamespaces.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportPropertyAssignmentDefault.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportWithExportPropertyAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/multipleDeclarations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/namespaceAssignmentToRequireAlias.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/nestedDestructuringOfRequire.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/nestedPrototypeAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/plainJSGrammarErrors2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/plainJSTypeErrors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/privateConstructorFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/propertiesOfGenericConstructorFunctions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/propertyAssignmentOnImportedSymbol.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/propertyAssignmentOnParenthesizedNumber.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/propertyAssignmentOnUnresolvedImportedSymbol.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/propertyAssignmentUseParentType1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/propertyAssignmentUseParentType2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/propertyAssignmentUseParentType3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/prototypePropertyAssignmentMergeAcrossFiles.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/prototypePropertyAssignmentMergeWithInterfaceMethod.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/prototypePropertyAssignmentMergedTypeReference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/reExportJsFromTs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/requireAssertsFromTypescript.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/requireTwoPropertyAccesses.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/sourceFileMergeWithFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/spellingUncheckedJS.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/thisPropertyAssignmentCircular.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/thisPropertyAssignmentComputed.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/thisPropertyAssignmentInherited.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/thisTypeOfConstructorFunctions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/topLevelThisAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromContextualThisType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromJSConstructor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromJSInitializer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromJSInitializer2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromJSInitializer3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromJSInitializer4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromParamTagForFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment10.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment10_1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment11.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment12.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment13.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment14.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment15.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment16.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment17.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment18.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment19.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment20.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment22.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment23.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment24.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment25.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment27.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment30.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment31.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment32.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment33.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment34.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment35.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment36.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment37.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment38.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment39.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment40.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment8_1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment9.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment9_1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignmentWithExport.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPrototypeAssignment3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPrototypeAssignment4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeLookupInIIFE.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeTagOnFunctionReferencesGeneric.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/unannotatedParametersAreOptional.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/varRequireFromJavascript.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/varRequireFromTypescript.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript3/scannerES3NumericLiteral1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript3/scannerES3NumericLiteral5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript3/scannerES3NumericLiteral7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannerAdditiveExpression1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannerEnum1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannerImportDeclaration1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannerNonAsciiHorizontalWhitespace.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannerS7.2_A1.5_T2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannerS7.3_A1.1_T2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannerS7.6_A4.2_T1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannerStringLiteralWithContainingNullCharacter1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannertest1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/scanner/jsdocInvalidTokens.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/everyTypeWithAnnotationAndInitializer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/everyTypeWithAnnotationAndInvalidInitializer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/everyTypeWithInitializer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/invalidMultipleVariableDeclarations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/recursiveInitializer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarationsWithAsyncIteratorObject.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarationsWithIteratorObject.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithIteratorObject.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithObjectLiterals1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/validMultipleVariableDeclarations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/breakStatements/doWhileBreakStatements.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/breakStatements/forBreakStatements.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/breakStatements/forInBreakStatements.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/breakStatements/invalidSwitchBreakStatement.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/breakStatements/switchBreakStatements.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/breakStatements/whileBreakStatements.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/continueStatements/doWhileContinueStatements.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/continueStatements/forContinueStatements.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/continueStatements/forInContinueStatements.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/continueStatements/whileContinueStatements.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-inStatements/for-inStatements.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-inStatements/for-inStatementsArray.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-inStatements/for-inStatementsAsyncIdentifier.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/forStatements/forStatements.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/forStatements/forStatementsMultipleInvalidDecl.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/forStatements/forStatementsMultipleValidDecl.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/ifDoWhileStatements/ifDoWhileStatements.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/returnStatements/invalidReturnStatements.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/returnStatements/returnStatements.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/switchStatements/switchStatements.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/throwStatements/throwInEnclosingStatements.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/throwStatements/throwStatements.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/tryStatements/tryStatements.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/any/anyAsConstructor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/any/anyAsFunctionCall.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/any/anyAsGenericFunctionCall.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/any/anyPropertyAccess.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/any/assignAnyToEveryType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/any/assignEveryTypeToAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/any/narrowExceptionVariableInCatchClause.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/any/narrowFromAnyWithInstanceof.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/conditional/conditionalTypes2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/conditional/conditionalTypesExcessProperties.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/conditional/inferTypes2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/conditional/inferTypesInvalidExtendsDeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/conditional/inferTypesWithExtends1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/conditional/inferTypesWithExtends2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/conditional/inferTypesWithExtendsDependingOnTypeVariables.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/conditional/variance.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/asyncFunctions/contextuallyTypeAsyncFunctionAwaitOperand.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/asyncFunctions/contextuallyTypeAsyncFunctionReturnType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/commaOperator/contextuallyTypeCommaOperator01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/commaOperator/contextuallyTypeCommaOperator02.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/commaOperator/contextuallyTypeCommaOperator03.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/jsdoc/contextualTypeFromJSDoc.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/jsxAttributes/contextuallyTypedStringLiteralsInJsxAttributes01.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/jsxAttributes/contextuallyTypedStringLiteralsInJsxAttributes02.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/logicalAnd/contextuallyTypeLogicalAnd01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/logicalAnd/contextuallyTypeLogicalAnd02.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/logicalAnd/contextuallyTypeLogicalAnd03.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTypedBindingInitializer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTypedBindingInitializerNegative.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTypedClassExpressionMethodDeclaration01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTypedClassExpressionMethodDeclaration02.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTypedObjectLiteralMethodDeclaration01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/partiallyAnnotatedFunction/partiallyAnnotatedFunctionInferenceError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/partiallyAnnotatedFunction/partiallyAnnotatedFunctionInferenceWithTypeParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/partiallyAnnotatedFunction/partiallyAnnotatedFunctionWitoutTypeParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/forAwait/types.forAwait.es2018.1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/forAwait/types.forAwait.es2018.2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/forAwait/types.forAwait.es2018.3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeAmbient.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeAmbientMissing.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeAmdBundleRewrite.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeGenericTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeInJSDoc.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeLocal.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeLocalMissing.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/commonTypeIntersection.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/contextualIntersectionType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionAndUnionTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionAsWeakTypeSource.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionMemberOfUnionNarrowsCorrectly.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionNarrowing.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionOfUnionNarrowing.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionOfUnionOfUnitTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionThisTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionTypeAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionTypeEquivalence.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionTypeInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionTypeInference2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionTypeInference3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionTypeMembers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionTypeOverloading.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionTypeReadonly.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionWithUnionConstraint.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionsAndEmptyObjects.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/operatorsAndIntersectionTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/recursiveIntersectionTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/keyof/circularIndexedAccessErrors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/keyof/keyofAndForIn.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/keyof/keyofIntersection.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/booleanLiteralTypes1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/booleanLiteralTypes2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/enumLiteralTypes1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/enumLiteralTypes2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/enumLiteralTypes3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/literalTypeWidening.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/literalTypes1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/literalTypes2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/literalTypes3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/literalTypesAndDestructuring.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/literalTypesAndTypeAssertions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/literalTypesWidenInParameterPosition.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/numericLiteralTypes1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/numericLiteralTypes2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/numericLiteralTypes3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/numericStringLiteralTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringEnumLiteralTypes1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringEnumLiteralTypes2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringEnumLiteralTypes3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringLiteralsAssertionsInEqualityComparisons01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringLiteralsAssertionsInEqualityComparisons02.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringLiteralsAssignedToStringMappings.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringLiteralsWithEqualityChecks01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringLiteralsWithEqualityChecks02.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringLiteralsWithEqualityChecks03.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringLiteralsWithEqualityChecks04.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringLiteralsWithSwitchStatements01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringLiteralsWithSwitchStatements02.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringLiteralsWithSwitchStatements03.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringLiteralsWithSwitchStatements04.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringLiteralsWithTypeAssertions01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringMappingDeferralInConditionalTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringMappingOverPatternLiterals.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringMappingReduction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/templateLiteralTypes2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/templateLiteralTypes3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/templateLiteralTypes4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/templateLiteralTypes5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/templateLiteralTypes6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/templateLiteralTypes7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/templateLiteralTypes8.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/templateLiteralTypesPatterns.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/templateLiteralTypesPatternsPrefixSuffixAssignability.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/localTypes/localTypes2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/localTypes/localTypes3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/localTypes/localTypes5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/isomorphicMappedTypeInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeAsClauseRecursiveNoCrash1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeAsClauseRelationships.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeAsClauses.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeConstraints.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeConstraints2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeErrors2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeIndexSignatureModifiers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeInferenceErrors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeModifiers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeOverlappingStringEnumKeys.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeRelationships.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypes1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypes2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypes3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypes4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypes5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypes6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypesAndObjects.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypesArraysTuples.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypesGenericTuples.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypesGenericTuples2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/recursiveMappedTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/augmentedTypeAssignmentCompatIndexSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/augmentedTypeBracketAccessIndexSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/classWithPrivateProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/classWithProtectedProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/classWithPublicProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeHidingMembersOfExtendedObject.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeHidingMembersOfObject.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeHidingMembersOfObjectAssignmentCompat.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeHidingMembersOfObjectAssignmentCompat2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypePropertyAccess.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithCallSignatureAppearsToBeFunctionType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithCallSignatureHidingMembersOfExtendedFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithCallSignatureHidingMembersOfFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithCallSignatureHidingMembersOfFunctionAssignmentCompat.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithConstructSignatureAppearsToBeFunctionType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithConstructSignatureHidingMembersOfExtendedFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithConstructSignatureHidingMembersOfFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithConstructSignatureHidingMembersOfFunctionAssignmentCompat.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithNumericProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithStringAndNumberIndexSignatureToAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithStringIndexerHidingObjectIndexer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithStringNamedPropertyOfIllegalCharacters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/typesWithOptionalProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/typesWithPrivateConstructor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/typesWithProtectedConstructor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/typesWithPublicConstructor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/typesWithSpecializedCallSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/typesWithSpecializedConstructSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/namedTypes/classWithOptionalParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/namedTypes/genericInstantiationEquivalentToObjectLiteral.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/namedTypes/optionalMethods.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/never/neverInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/never/neverIntersectionNotCallable.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/never/neverType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/never/neverTypeErrors1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/never/neverTypeErrors2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/never/neverUnionIntersection.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/assignObjectToNonPrimitive.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveAndEmptyObject.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveAndTypeVariables.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveAsProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveAssignError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveConstraintOfIndexAccessType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveInFunction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveIndexingWithForIn.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveIndexingWithForInNoImplicitAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveIndexingWithForInSupressError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveRhsSideOfInExpression.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveUnionIntersection.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignatureWithoutAnnotationsOrBody.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignatureWithoutReturnTypeAnnotationInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesThatDifferOnlyByReturnType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesThatDifferOnlyByReturnType2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesThatDifferOnlyByReturnType3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithOptionalParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithOptionalParameters2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/identicalCallSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/identicalCallSignatures2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/identicalCallSignatures3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/parametersWithNoAnnotationAreAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/specializedSignatureIsSubtypeOfNonSpecializedSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/specializedSignatureWithOptional.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/stringLiteralTypesInImplementationSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterAsTypeArgument.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/constructSignatures/constructSignaturesWithIdenticalOverloads.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/constructSignatures/constructSignaturesWithOverloads.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/constructSignatures/constructSignaturesWithOverloadsThatDifferOnlyByReturnType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/indexSignatures/numericIndexerConstrainsPropertyDeclarations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/indexSignatures/numericIndexerConstrainsPropertyDeclarations2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/indexSignatures/numericIndexingResults.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/indexSignatures/stringIndexerConstrainsPropertyDeclarations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/indexSignatures/stringIndexerConstrainsPropertyDeclarations2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/indexSignatures/stringIndexingResults.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/methodSignatures/functionLiterals.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/methodSignatures/methodSignaturesWithOverloads2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/objectTypeLiteralSyntax.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/propertySignatures/propertyNameWithoutTypeAnnotation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/propertySignatures/propertyNamesOfReservedWords.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/propertySignatures/stringNamedPropertyAccess.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/boolean/assignFromBooleanInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/boolean/assignFromBooleanInterface2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/boolean/boolInsteadOfBoolean.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/boolean/booleanPropertyAccess.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/boolean/extendBooleanInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/boolean/invalidBooleanAssignments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/boolean/validBooleanAssignments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/enum/invalidEnumAssignments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/enum/validEnumAssignments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/null/directReferenceToNull.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/null/validNullAssignments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/number/assignFromNumberInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/number/assignFromNumberInterface2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/number/extendNumberInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/number/invalidNumberAssignments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/number/numberPropertyAccess.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/number/validNumberAssignments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/string/assignFromStringInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/string/assignFromStringInterface2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/string/extendStringInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/string/invalidStringAssignments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/string/stringPropertyAccess.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/string/stringPropertyAccessWithError.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/string/validStringAssignments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/stringLiteral/stringLiteralType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/undefined/directReferenceToUndefined.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/undefined/invalidUndefinedAssignments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/undefined/invalidUndefinedValues.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/undefined/validUndefinedAssignments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/undefined/validUndefinedValues.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/void/invalidAssignmentsToVoid.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/void/invalidVoidAssignments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/void/invalidVoidValues.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/void/validVoidAssignments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/void/validVoidValues.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/rest/genericObjectRest.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/rest/genericRestArity.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/rest/genericRestArityStrict.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/rest/genericRestParameters1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/rest/genericRestParameters2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/rest/genericRestParameters3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/rest/objectRest.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/rest/objectRest2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/rest/objectRestAssignment.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/rest/objectRestCatchES5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/rest/objectRestForOf.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/rest/objectRestParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/rest/objectRestReadonly.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/rest/restTuplesFromContextualTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeLiterals/arrayLiteral.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeLiterals/arrayOfFunctionTypes3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeLiterals/arrayTypeOfFunctionTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeLiterals/arrayTypeOfFunctionTypes2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeLiterals/arrayTypeOfTypeOf.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeLiterals/functionLiteral.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeLiterals/functionLiteralForOverloads.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeLiterals/functionLiteralForOverloads2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeLiterals/parenthesizedTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeLiterals/unionTypeLiterals.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/circularTypeofWithVarOrFunc.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/recursiveTypesWithTypeof.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeQueryOnClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeQueryWithReservedWords.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofClass2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofClassWithPrivates.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofModuleWithoutExports.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofThisWithImplicitThis.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofTypeParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeReferences/nonGenericTypeReferenceWithTypeArguments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpreadComputedProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpreadIndexSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpreadNoTransform.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpreadRepeatedComplexity.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpreadRepeatedNullCheckPerf.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpreadSetonlyAccessor.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpreadStrictNull.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadContextualTypedBindingPattern.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadDuplicate.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadDuplicateExact.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadExcessProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadNonObject1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadNonPrimitive.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadObjectOrFalsy.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadOverwritesProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadOverwritesPropertyStrict.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadTypeVariable.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadUnion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadUnion2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadUnion3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadUnion4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralCheckedInIf01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralCheckedInIf02.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralMatchedInSwitch01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypeAssertion01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAndLogicalOrExpressions01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAndParenthesizedExpressions01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAndTuples01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAsTags01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAsTags02.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAsTags03.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAsTypeParameterConstraint01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAsTypeParameterConstraint02.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesInUnionTypes01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesInUnionTypes02.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesInUnionTypes03.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesInUnionTypes04.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloadAssignability01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloadAssignability02.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloadAssignability03.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloadAssignability04.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloadAssignability05.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloads01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloads02.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloads03.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloads04.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesTypePredicates01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesWithTemplateStrings01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesWithTemplateStrings02.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesWithVariousOperators01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/typeArgumentsWithStringLiteralTypes01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/contextualThisType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/contextualThisTypeInJavascript.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/fluentClasses.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/fluentInterfaces.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/inferThisType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeAccessibility.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeAndConstraints.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInBasePropertyAndDerivedContainerOfBase01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInClasses.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInFunctions2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInFunctions3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInFunctions4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInInterfaces.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInObjectLiterals.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInTaggedTemplateCall.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInTuples.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInTypePredicate.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeOptionalCall.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeSyntacticContext.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/typeRelationships.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/unionThisTypeInFunctions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/castingTuple.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/contextualTypeWithTuple.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/emptyTuples/emptyTuplesTypeAssertion01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/emptyTuples/emptyTuplesTypeAssertion02.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/indexerWithTuple.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/named/namedTupleMembers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/named/partiallyNamedTuples.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/named/partiallyNamedTuples2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/named/partiallyNamedTuples3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/readonlyArraysAndTuples2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/strictTupleLength.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/tupleElementTypes1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/tupleElementTypes2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/tupleElementTypes3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/tupleElementTypes4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/tupleLengthCheck.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/typeInferenceWithTupleType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/variadicTuples1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/variadicTuples3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/wideningTuples1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/wideningTuples2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/wideningTuples3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/wideningTuples4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/wideningTuples5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/wideningTuples6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/wideningTuples7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/asiPreventsParsingAsTypeAlias01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/asiPreventsParsingAsTypeAlias02.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/circularTypeAliasForUnionWithClass.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/circularTypeAliasForUnionWithInterface.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/classDoesNotDependOnBaseTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/directDependenceBetweenTypeAliases.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/genericTypeAliases.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/typeAliases.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/recurringTypeParamForContainerOfBase01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithIncorrectNumberOfTypeArguments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithZeroTypeArguments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/callNonGenericFunctionWithTypeArguments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/constraintSatisfactionWithAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/constraintSatisfactionWithAny2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/constraintSatisfactionWithEmptyObject.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateGenericClassWithWrongNumberOfTypeArguments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateGenericClassWithZeroTypeArguments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateNonGenericTypeWithTypeArguments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/typeParameterAsTypeParameterConstraint.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/typeParameterAsTypeParameterConstraint2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/typeParameterAsTypeParameterConstraintTransitively.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/typeParameterAsTypeParameterConstraintTransitively2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/wrappedAndRecursiveConstraints.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/wrappedAndRecursiveConstraints2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/wrappedAndRecursiveConstraints3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/wrappedAndRecursiveConstraints4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterAsBaseType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/innerTypeParameterShadowingOuterOne.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/innerTypeParameterShadowingOuterOne2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithConstraints.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithConstraints2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithConstraints3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithoutConstraints.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/staticMembersUsingClassTypeParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterConstModifiersReturnsAndYields.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterConstModifiersReverseMappedTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterConstModifiersWithIntersection.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterDirectlyConstrainedToItself.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterIndirectlyConstrainedToItself.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterUsedAsConstraint.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParametersAvailableInNestedScope.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParametersAvailableInNestedScope2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParametersAvailableInNestedScope3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSubtyping.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSupertype.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/anyAssignabilityInInheritance.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/anyAssignableToEveryType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/anyAssignableToEveryType2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatBetweenTupleAndArray.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignaturesWithOptionalParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignaturesWithRestParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignaturesWithOptionalParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithDiscriminatedUnion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithEnumIndexer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithGenericCallSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithGenericCallSignatures2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithGenericCallSignatures3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithGenericCallSignatures4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithGenericCallSignaturesWithOptionalParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithNumericIndexer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithNumericIndexer2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithNumericIndexer3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembers2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembers3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembers4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembers5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembersAccessibility.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembersNumericNames.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembersOptionality.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembersOptionality2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembersStringNumericNames.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithStringIndexer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithStringIndexer2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithStringIndexer3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/callSignatureAssignabilityInInheritance.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/callSignatureAssignabilityInInheritance2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/callSignatureAssignabilityInInheritance3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/callSignatureAssignabilityInInheritance4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/callSignatureAssignabilityInInheritance5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/callSignatureAssignabilityInInheritance6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/constructSignatureAssignabilityInInheritance.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/constructSignatureAssignabilityInInheritance2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/constructSignatureAssignabilityInInheritance3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/constructSignatureAssignabilityInInheritance4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/constructSignatureAssignabilityInInheritance5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/constructSignatureAssignabilityInInheritance6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/covariantCallbacks.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/enumAssignability.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/enumAssignabilityInInheritance.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/everyTypeAssignableToAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/genericCallWithObjectTypeArgsAndInitializers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/intersectionIncludingPropFromGlobalAugmentation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/nullAssignableToEveryType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/numberAssignableToEnum.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/optionalPropertyAssignableToStringIndexSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/undefinedAssignableToEveryType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/unionTypesAssignability.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/bestCommonType/arrayLiteralWithMultipleBestCommonTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/bestCommonType/bestCommonTypeOfConditionalExpressions.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/bestCommonType/bestCommonTypeOfConditionalExpressions2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/bestCommonType/bestCommonTypeOfTuple.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/bestCommonType/bestCommonTypeOfTuple2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/bestCommonType/functionWithMultipleReturnStatements.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/bestCommonType/functionWithMultipleReturnStatements2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/bestCommonType/heterogeneousArrayLiterals.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/equalityWithEnumTypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/equalityWithIntersectionTypes01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/equalityWithUnionTypes01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/independentPropertyVariance.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/optionalProperties01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/optionalProperties02.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/switchCaseWithIntersectionTypes01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/switchCaseWithUnionTypes01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/typeAssertionsWithIntersectionTypes01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/typeAssertionsWithUnionTypes01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/weakTypesAndLiterals01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/instanceOf/narrowingConstrainedTypeVariable.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/instanceOf/narrowingGenericTypeFromInstanceof01.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/arrayLiteralsWithRecursiveGenerics.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/infiniteExpansionThroughInstantiation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/infiniteExpansionThroughInstantiation2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/infiniteExpansionThroughTypeInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/nominalSubtypeCheckOfTypeParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/nominalSubtypeCheckOfTypeParameter2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/objectTypeWithRecursiveWrappedProperty.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/objectTypeWithRecursiveWrappedProperty2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/objectTypeWithRecursiveWrappedPropertyCheckedNominally.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/recursiveTypeInGenericConstraint.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/recursiveTypeReferences1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/recursiveTypeReferences2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/recursiveTypesUsedAsFunctionParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/enumIsNotASubtypeOfAnythingButNumber.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/nullIsSubtypeOfEverythingButUndefined.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/stringLiteralTypeIsSubtypeOfString.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfAny.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameter.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfUnion.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignatures2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignatures3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignatures4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignaturesA.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignaturesWithOptionalParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignaturesWithRestParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignaturesWithSpecializedSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithConstructSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithConstructSignatures2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithConstructSignatures3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithConstructSignatures4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithConstructSignatures5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithConstructSignatures6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithConstructSignaturesWithOptionalParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithConstructSignaturesWithSpecializedSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithGenericCallSignaturesWithOptionalParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithGenericConstructSignaturesWithOptionalParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithNumericIndexer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithNumericIndexer2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithNumericIndexer3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithNumericIndexer4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithNumericIndexer5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembersAccessibility.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembersAccessibility2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembersOptionality.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembersOptionality2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembersOptionality3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembersOptionality4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithOptionalProperties.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithStringIndexer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithStringIndexer2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithStringIndexer3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithStringIndexer4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/undefinedIsSubtypeOfEverything.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/unionSubtypeIfEveryConstituentTypeIsSubtype.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentity.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentity2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithCallSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithCallSignatures2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithCallSignatures3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithCallSignaturesDifferingParamCounts.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithCallSignaturesDifferingParamCounts2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithCallSignaturesWithOverloads.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithComplexConstraints.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithConstructSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithConstructSignatures2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithConstructSignaturesDifferingParamCounts.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignatures2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesDifferingByConstraints.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesDifferingByConstraints2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesDifferingByConstraints3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesDifferingByReturnType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesDifferingByReturnType2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesDifferingTypeParameterCounts.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesDifferingTypeParameterCounts2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesDifferingTypeParameterNames.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesOptionalParams.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesOptionalParams2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesOptionalParams3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesDifferingByConstraints.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesDifferingByConstraints2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesDifferingByConstraints3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesDifferingByReturnType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesDifferingByReturnType2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesDifferingTypeParameterCounts.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesDifferingTypeParameterNames.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesOptionalParams.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesOptionalParams2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesOptionalParams3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithNumericIndexers1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithNumericIndexers2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithNumericIndexers3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithOptionality.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithPrivates.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithPrivates2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithPrivates3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithPublics.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithStringIndexers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithStringIndexers2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/primtiveTypesAreIdentical.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/typeParametersAreIdenticalToThemselves.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/unionTypeIdentity.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/bivariantInferences.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/contextualSignatureInstantiation.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/discriminatedUnionInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallToOverloadedMethodWithOverloadedArguments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallTypeArgumentInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithArrayLiteralArgs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithConstraintsTypeArgumentInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithConstraintsTypeArgumentInference2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithConstructorTypedArguments5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithFunctionTypedArguments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithFunctionTypedArguments2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithFunctionTypedArguments3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithFunctionTypedArguments4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithFunctionTypedArguments5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGenericSignatureArguments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGenericSignatureArguments2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGenericSignatureArguments3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithNonSymmetricSubtypes.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectLiteralArgs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgs2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgsAndConstraints.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgsAndConstraints2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgsAndConstraints3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgsAndConstraints4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgsAndConstraints5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgsAndIndexers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgsAndIndexersErrors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgsAndNumericIndexer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgsAndStringIndexer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithOverloadedConstructorTypedArguments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithOverloadedConstructorTypedArguments2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithOverloadedFunctionTypedArguments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithOverloadedFunctionTypedArguments2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithTupleType.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericClassWithFunctionTypedMemberArguments.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericClassWithObjectTypeArgsAndConstraints.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericContextualTypes1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericContextualTypes2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericContextualTypes3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericFunctionParameters.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/indexSignatureTypeInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/intraExpressionInferencesJsx.tsx
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/keyofInferenceIntersectsResults.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/keyofInferenceLowerPriorityThanReturn.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/noInfer.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/noInferRedeclaration.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/unionAndIntersectionInference1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/unionAndIntersectionInference2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/unionAndIntersectionInference3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/unionTypeInference.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/widenedTypes/arrayLiteralWidened.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/widenedTypes/initializersWidened.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/widenedTypes/objectLiteralWidened.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/widenedTypes/strictNullChecksNoWidening.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/contextualTypeWithUnionTypeCallSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/contextualTypeWithUnionTypeIndexSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/contextualTypeWithUnionTypeMembers.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/contextualTypeWithUnionTypeObjectLiteral.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/discriminatedUnionTypes1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/discriminatedUnionTypes3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/discriminatedUnionTypes4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeCallSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeCallSignatures2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeCallSignatures3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeCallSignatures4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeCallSignatures5.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeCallSignatures6.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeCallSignatures7.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeConstructSignatures.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeEquivalence.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeFromArrayLiteral.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeIndexSignature.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeReduction.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeReduction2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/uniqueSymbol/uniqueSymbols.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarations.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarationsErrors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarationsInJs.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarationsInJsErrors.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/unknown/unknownControlFlow.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/unknown/unknownType1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/unknown/unknownType2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/typings/typingsLookup1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/typings/typingsLookup3.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/typings/typingsLookup4.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/typings/typingsLookupAmd.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/typings/typingsSuggestion1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/typings/typingsSuggestion2.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/typings/typingsSuggestionBun1.ts
+
+Type Mismatch: tasks/coverage/typescript/tests/cases/conformance/typings/typingsSuggestionBun2.ts
+

--- a/tasks/coverage/src/lib.rs
+++ b/tasks/coverage/src/lib.rs
@@ -480,6 +480,17 @@ impl AppArgs {
             typescript::error_baseline::run_errors_typescript,
         );
     }
+
+    /// Run TypeScript `.types` baseline conformance. Scaffold only until oxc has a type checker
+    /// (reports 0%); the runner is wired and ready.
+    pub fn run_types(&self, data: &TestData) {
+        self.run_tool(
+            "types_typescript",
+            TYPESCRIPT_PATH,
+            &data.typescript,
+            typescript::type_symbol_baseline::run_types_typescript,
+        );
+    }
 }
 
 #[test]

--- a/tasks/coverage/src/lib.rs
+++ b/tasks/coverage/src/lib.rs
@@ -460,6 +460,26 @@ impl AppArgs {
     pub fn run_runtime(&self) {
         runtime::run(self.filter.as_deref(), self.detail);
     }
+
+    /// Run TypeScript `.symbols` baseline conformance (symbol resolution vs TypeScript).
+    pub fn run_symbols(&self, data: &TestData) {
+        self.run_tool(
+            "symbols_typescript",
+            TYPESCRIPT_PATH,
+            &data.typescript,
+            typescript::type_symbol_baseline::run_symbols_typescript,
+        );
+    }
+
+    /// Run TypeScript `.errors.txt` baseline conformance (parser diagnostics vs TypeScript).
+    pub fn run_errors(&self, data: &TestData) {
+        self.run_tool(
+            "errors_typescript",
+            TYPESCRIPT_PATH,
+            &data.typescript,
+            typescript::error_baseline::run_errors_typescript,
+        );
+    }
 }
 
 #[test]

--- a/tasks/coverage/src/lib.rs
+++ b/tasks/coverage/src/lib.rs
@@ -461,29 +461,21 @@ impl AppArgs {
         runtime::run(self.filter.as_deref(), self.detail);
     }
 
-    /// Run TypeScript `.symbols` baseline conformance (symbol resolution vs TypeScript).
-    pub fn run_symbols(&self, data: &TestData) {
+    /// Run the TypeScript baseline conformance suites against the `.symbols`, `.errors.txt`,
+    /// and `.types` baselines. `.types` is a scaffold (reports ~0%) until oxc has a type checker.
+    pub fn run_types(&self, data: &TestData) {
         self.run_tool(
             "symbols_typescript",
             TYPESCRIPT_PATH,
             &data.typescript,
             typescript::type_symbol_baseline::run_symbols_typescript,
         );
-    }
-
-    /// Run TypeScript `.errors.txt` baseline conformance (parser diagnostics vs TypeScript).
-    pub fn run_errors(&self, data: &TestData) {
         self.run_tool(
             "errors_typescript",
             TYPESCRIPT_PATH,
             &data.typescript,
             typescript::error_baseline::run_errors_typescript,
         );
-    }
-
-    /// Run TypeScript `.types` baseline conformance. Scaffold only until oxc has a type checker
-    /// (reports 0%); the runner is wired and ready.
-    pub fn run_types(&self, data: &TestData) {
         self.run_tool(
             "types_typescript",
             TYPESCRIPT_PATH,

--- a/tasks/coverage/src/main.rs
+++ b/tasks/coverage/src/main.rs
@@ -46,8 +46,6 @@ fn main() {
         "runtime" => app_args.run_runtime(),
         "estree" => app_args.run_estree(&data),
         "estree_tokens" => app_args.run_estree_tokens(&data),
-        "symbols" => app_args.run_symbols(&data),
-        "errors" => app_args.run_errors(&data),
         "types" => app_args.run_types(&data),
         "all" => {
             app_args.run_all();

--- a/tasks/coverage/src/main.rs
+++ b/tasks/coverage/src/main.rs
@@ -46,6 +46,8 @@ fn main() {
         "runtime" => app_args.run_runtime(),
         "estree" => app_args.run_estree(&data),
         "estree_tokens" => app_args.run_estree_tokens(&data),
+        "symbols" => app_args.run_symbols(&data),
+        "errors" => app_args.run_errors(&data),
         "all" => {
             app_args.run_all();
             app_args.run_runtime();

--- a/tasks/coverage/src/main.rs
+++ b/tasks/coverage/src/main.rs
@@ -48,6 +48,7 @@ fn main() {
         "estree_tokens" => app_args.run_estree_tokens(&data),
         "symbols" => app_args.run_symbols(&data),
         "errors" => app_args.run_errors(&data),
+        "types" => app_args.run_types(&data),
         "all" => {
             app_args.run_all();
             app_args.run_runtime();

--- a/tasks/coverage/src/typescript/error_baseline.rs
+++ b/tasks/coverage/src/typescript/error_baseline.rs
@@ -1,0 +1,146 @@
+//! TypeScript `.errors.txt` conformance for oxc's parser diagnostics.
+//!
+//! typescript-go's `internal/testutil/tsbaseline/error_baseline.go` *generates* the full
+//! `.errors.txt` (a summary block plus per-file source with `~~~~` squiggles and
+//! `!!! error TSxxxx:` messages) and compares the text. oxc's parser only produces syntax
+//! errors, and its wording differs from TypeScript's, so reproducing that text would score
+//! ~0%. Instead we compare ERROR POSITIONS extracted from the baseline summary headers
+//! (`path(line,col): error TSxxxx:`) against oxc's diagnostic positions. oxc's parser
+//! attaches real TypeScript codes (`ts_error` -> `with_error_code("TS", ...)`), so we also
+//! require code agreement whenever oxc has a code.
+//!
+//! Results are reported through the shared [`CoverageResult`] machinery (same summary /
+//! snapshot format as the other suites). A file passes when oxc's diagnostics agree with the
+//! baseline: no false positives, and every baseline position whose TS code oxc can emit is
+//! found. Type / binder errors (`TS2xxx`, `TS18xxx`) oxc can never produce are the
+//! type-checker surface and are excluded from the pass criterion.
+
+use lazy_regex::{Lazy, Regex, lazy_regex};
+use oxc::{allocator::Allocator, parser::Parser};
+use rayon::prelude::*;
+use rustc_hash::FxHashSet;
+
+use super::{meta::TestCaseContent, scanner};
+use crate::{CoverageResult, TestResult, TypeScriptFile};
+
+/// A 1-based error location (matching TypeScript's `.errors.txt` summary), plus the TS code.
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct Pos {
+    file: String,
+    line: u32,
+    col: u32,
+    /// The `TSxxxx` number (without the `TS` prefix). `None` for oxc diagnostics with no code.
+    code: Option<String>,
+}
+
+// Summary header line: `path(line,col): error TSxxxx: message`. `file` is non-greedy so it can
+// contain `/`; the `(\d+,\d+)` comma disambiguates filenames that themselves contain parens.
+// Global `error TSxxxx:` lines (no location), `!!!`, `~~~~`, and any `Found N errors` footer do
+// not match, so they are excluded automatically.
+static BASELINE_HEADER: Lazy<Regex> = lazy_regex!(
+    r"(?m)^(?P<file>[^\r\n(]+?)\((?P<line>\d+),(?P<col>\d+)\): error TS(?P<code>\d+): "
+);
+
+fn parse_baseline_positions(texts: &[String]) -> Vec<Pos> {
+    let mut set = FxHashSet::default();
+    for text in texts {
+        for cap in BASELINE_HEADER.captures_iter(text) {
+            set.insert(Pos {
+                file: cap["file"].to_string(),
+                line: cap["line"].parse().unwrap_or(0),
+                col: cap["col"].parse().unwrap_or(0),
+                code: Some(cap["code"].to_string()),
+            });
+        }
+    }
+    set.into_iter().collect()
+}
+
+fn oxc_positions(unit_name: &str, content: &str, source_type: oxc::span::SourceType) -> Vec<Pos> {
+    let allocator = Allocator::default();
+    // No `'use strict'` injection — it would shift every line and break position matching.
+    let ret = Parser::new(&allocator, content, source_type).parse();
+    let line_starts = scanner::compute_line_starts(content);
+    ret.diagnostics
+        .iter()
+        .filter_map(|d| {
+            let offset = d.labels.first()?.offset();
+            let (line, col) = scanner::line_and_character(content, &line_starts, offset);
+            let code = if d.code.scope.as_deref() == Some("TS") {
+                d.code.number.as_deref().map(str::to_string)
+            } else {
+                None
+            };
+            // Convert to TypeScript's 1-based line/col.
+            Some(Pos { file: unit_name.to_string(), line: line + 1, col: col + 1, code })
+        })
+        .collect()
+}
+
+/// Does oxc position `o` match baseline position `b`? Single-unit tests ignore the filename
+/// (the header path can be absolute / renamed); multi-unit tests match by unit name. Code must
+/// agree when oxc has one.
+fn pos_matches(o: &Pos, b: &Pos, ignore_file: bool) -> bool {
+    let file_ok = ignore_file || o.file == b.file || b.file.ends_with(&o.file);
+    file_ok && o.line == b.line && o.col == b.col && (o.code.is_none() || o.code == b.code)
+}
+
+/// A sorted, human-readable position list for the `--diff` view of a mismatch.
+fn positions_text(positions: &[Pos]) -> String {
+    let mut lines: Vec<String> = positions
+        .iter()
+        .map(|p| {
+            format!("{}({}, {}): TS{}", p.file, p.line, p.col, p.code.as_deref().unwrap_or("-"))
+        })
+        .collect();
+    lines.sort();
+    lines.join("\n")
+}
+
+/// Conformance runner in the shared `CoverageResult` form (mirrors `run_semantic_typescript`),
+/// so `AppArgs::run_tool` prints and snapshots it exactly like the other suites.
+pub fn run_errors_typescript(files: &[TypeScriptFile]) -> Vec<CoverageResult> {
+    files
+        .par_iter()
+        .filter_map(|f| {
+            let texts = TestCaseContent::get_error_files(&f.path, &f.settings);
+            // Only score files that ship an `.errors.txt` baseline.
+            if texts.is_empty() {
+                return None;
+            }
+            let baseline = parse_baseline_positions(&texts);
+            let ignore_file = f.units.len() <= 1;
+
+            let result = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                f.units
+                    .iter()
+                    .flat_map(|u| oxc_positions(&u.name, &u.content, u.source_type))
+                    .collect::<Vec<Pos>>()
+            })) {
+                Err(_) => TestResult::ParseError("Panicked while parsing".to_string(), true),
+                Ok(oxc) => {
+                    // The reachable subset for this file: baseline positions whose TS code oxc
+                    // actually emitted here (i.e. the syntax errors oxc is capable of reporting).
+                    let oxc_codes: FxHashSet<&str> =
+                        oxc.iter().filter_map(|p| p.code.as_deref()).collect();
+                    let no_false_positives =
+                        oxc.iter().all(|o| baseline.iter().any(|b| pos_matches(o, b, ignore_file)));
+                    let found_reachable = baseline
+                        .iter()
+                        .filter(|b| b.code.as_deref().is_some_and(|c| oxc_codes.contains(c)))
+                        .all(|b| oxc.iter().any(|o| pos_matches(o, b, ignore_file)));
+                    if no_false_positives && found_reachable {
+                        TestResult::Passed
+                    } else {
+                        TestResult::Mismatch(
+                            "Error Mismatch",
+                            positions_text(&oxc),
+                            positions_text(&baseline),
+                        )
+                    }
+                }
+            };
+            Some(CoverageResult { path: f.path.clone(), should_fail: false, result })
+        })
+        .collect()
+}

--- a/tasks/coverage/src/typescript/meta.rs
+++ b/tasks/coverage/src/typescript/meta.rs
@@ -345,7 +345,7 @@ impl TestCaseContent {
     //   * `filename(module=es2022).errors.txt`
     //   * `filename(target=esnext).errors.txt`
     //   * `filename.errors.txt`
-    fn get_error_files(path: &Path, options: &CompilerSettings) -> Vec<String> {
+    pub(crate) fn get_error_files(path: &Path, options: &CompilerSettings) -> Vec<String> {
         #[must_use]
         fn create_suffixes<T: Display>(name: &str, flags: &[T]) -> Option<Vec<String>> {
             if flags.len() < 2 {

--- a/tasks/coverage/src/typescript/mod.rs
+++ b/tasks/coverage/src/typescript/mod.rs
@@ -1,6 +1,9 @@
 pub mod constants;
 mod diagnostics_code_collector;
+pub mod error_baseline;
 pub mod meta;
+pub mod scanner;
 pub mod transpile_runner;
+pub mod type_symbol_baseline;
 
 pub use diagnostics_code_collector::save_reviewed_tsc_diagnostics_codes;

--- a/tasks/coverage/src/typescript/scanner.rs
+++ b/tasks/coverage/src/typescript/scanner.rs
@@ -1,0 +1,118 @@
+//! Ports of TypeScript's scanner / line-position helpers used by the symbol/type/error
+//! baseline harnesses.
+//!
+//! Mirrors typescript-go `internal/scanner` (`ComputeECMALineStarts`,
+//! `GetECMALineOfPosition`, `GetECMALineAndUTF16CharacterOfPosition`) and the regexes in
+//! `internal/testutil/tsbaseline/{type_symbol_baseline,error_baseline}.go`.
+//!
+//! oxc `Span`s are UTF-8 byte offsets, so every offset here is a byte offset. ECMA line
+//! terminators are `\n`, `\r`, `\r\n` (a single break), `U+2028` (LS) and `U+2029` (PS).
+//! Columns are counted in UTF-16 code units to match
+//! `GetECMALineAndUTF16CharacterOfPosition`.
+
+use lazy_regex::{Lazy, Regex, lazy_regex};
+
+/// `bracketLineRegex` in `type_symbol_baseline.go`: a line consisting solely of `{` or `}`.
+pub static BRACKET_LINE: Lazy<Regex> = lazy_regex!(r"^\s*[{}]\s*$");
+
+/// `lineDelimiter` in typescript-go: `\r?\n`, used to strip line breaks from a node's
+/// source text before printing it on a `>` annotation line.
+pub static LINE_DELIMITER: Lazy<Regex> = lazy_regex!(r"\r?\n");
+
+/// Is there a `U+2028` (LS) or `U+2029` (PS) encoded at byte `i`? (`E2 80 A8` / `E2 80 A9`.)
+fn is_ls_or_ps(bytes: &[u8], i: usize) -> bool {
+    i + 2 < bytes.len()
+        && bytes[i] == 0xE2
+        && bytes[i + 1] == 0x80
+        && matches!(bytes[i + 2], 0xA8 | 0xA9)
+}
+
+/// Port of `ComputeECMALineStarts`: byte offset where each line begins. `starts[0]` is always
+/// `0`; a trailing terminator yields a final (empty) line start at `text.len()`.
+#[expect(clippy::cast_possible_truncation)]
+pub fn compute_line_starts(text: &str) -> Vec<u32> {
+    let bytes = text.as_bytes();
+    let mut starts = vec![0u32];
+    let mut i = 0usize;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\n' => {
+                i += 1;
+                starts.push(i as u32);
+            }
+            b'\r' => {
+                i += 1;
+                if i < bytes.len() && bytes[i] == b'\n' {
+                    i += 1;
+                }
+                starts.push(i as u32);
+            }
+            0xE2 if is_ls_or_ps(bytes, i) => {
+                i += 3;
+                starts.push(i as u32);
+            }
+            _ => i += 1,
+        }
+    }
+    starts
+}
+
+/// Port of `GetECMALineOfPosition`: 0-based line index of a byte offset.
+#[expect(clippy::cast_possible_truncation)]
+pub fn line_of_position(line_starts: &[u32], pos: u32) -> u32 {
+    // The line is the largest `i` with `line_starts[i] <= pos`.
+    (line_starts.partition_point(|&s| s <= pos) - 1) as u32
+}
+
+/// Port of `GetECMALineAndUTF16CharacterOfPosition`: (0-based line, 0-based UTF-16 column).
+#[expect(clippy::cast_possible_truncation)]
+pub fn line_and_character(text: &str, line_starts: &[u32], pos: u32) -> (u32, u32) {
+    let line = line_of_position(line_starts, pos);
+    let line_start = line_starts[line as usize] as usize;
+    let col = text[line_start..pos as usize].encode_utf16().count() as u32;
+    (line, col)
+}
+
+/// Split `text` into line contents on ECMA terminators (terminators stripped). Port of
+/// `codeLinesRegexp.Split`; `\r\n` is treated as one break.
+pub fn split_lines(text: &str) -> Vec<&str> {
+    let bytes = text.as_bytes();
+    let mut lines = Vec::new();
+    let mut line_start = 0usize;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\n' => {
+                lines.push(&text[line_start..i]);
+                i += 1;
+                line_start = i;
+            }
+            b'\r' => {
+                lines.push(&text[line_start..i]);
+                i += 1;
+                if i < bytes.len() && bytes[i] == b'\n' {
+                    i += 1;
+                }
+                line_start = i;
+            }
+            0xE2 if is_ls_or_ps(bytes, i) => {
+                lines.push(&text[line_start..i]);
+                i += 3;
+                line_start = i;
+            }
+            _ => i += 1,
+        }
+    }
+    lines.push(&text[line_start..]);
+    lines
+}
+
+/// Port of `node.Pos()` (trivia-inclusive start = end of the previous token).
+///
+/// `token_ends` are the ascending end offsets of every lexed token. For a node beginning at
+/// byte `start`, its leading trivia begins where the previous token ended, which is the
+/// largest token end `<= start`. Comments are trivia, not tokens, so this matches TypeScript.
+pub fn full_start(token_ends: &[u32], start: u32) -> u32 {
+    let k = token_ends.partition_point(|&e| e <= start);
+    if k == 0 { 0 } else { token_ends[k - 1] }
+}

--- a/tasks/coverage/src/typescript/type_symbol_baseline.rs
+++ b/tasks/coverage/src/typescript/type_symbol_baseline.rs
@@ -1,0 +1,274 @@
+//! Line-by-line port of typescript-go's symbol baseline harness
+//! `internal/testutil/tsbaseline/type_symbol_baseline.go`.
+//!
+//! Only the `.symbols` half is ported: `.types` needs a type checker, which oxc does not
+//! have. The walker visits the same nodes as the Go `forEachASTNode` (via `oxc_ast_visit`),
+//! resolves the two lexically-resolvable kinds through `oxc_semantic`, and emits an
+//! `<<unresolved>>` marker for member / `this` / lib nodes (which need a checker) so the
+//! output stays line-aligned with the shipped baseline. Scoring is a line-diff against the
+//! baseline counting matching `>` annotation lines.
+
+use std::{fmt::Write as _, path::Path};
+
+use oxc::{
+    allocator::Allocator,
+    ast::AstKind,
+    ast_visit::Visit,
+    parser::{Parser, config::TokensParserConfig},
+    semantic::{Semantic, SemanticBuilder},
+    span::{GetSpan, Span},
+    syntax::{node::NodeId, symbol::SymbolId},
+};
+use rayon::prelude::*;
+use similar::{ChangeTag, TextDiff};
+
+use super::scanner::{
+    self, BRACKET_LINE, LINE_DELIMITER, full_start, line_and_character, line_of_position,
+};
+use crate::{CoverageResult, TestResult, TypeScriptFile, workspace_root};
+
+/// Emitted for nodes oxc cannot resolve to a symbol (members, `this`/`super`, lib globals).
+/// Must never be equal to a real `Symbol(...)` string.
+const UNRESOLVED: &str = "<<unresolved>>";
+
+/// Port of `typeWriterResult` (symbol fields only).
+struct TypeWriterResult {
+    line: u32,
+    /// Raw node source text (may span lines); line-delimiters are stripped at output time.
+    source_text: String,
+    symbol: String,
+}
+
+/// Port of `typeWriterWalker`, backed by `oxc_ast_visit::Visit` in place of `forEachASTNode`.
+struct SymbolWalker<'a> {
+    semantic: &'a Semantic<'a>,
+    content: &'a str,
+    line_starts: &'a [u32],
+    token_ends: &'a [u32],
+    unit_name: &'a str,
+    results: Vec<TypeWriterResult>,
+}
+
+impl<'a> Visit<'a> for SymbolWalker<'a> {
+    // Port of `visitNode`'s filter (`IsExpressionNode || KindIdentifier || IsDeclarationName`)
+    // fused with `writeTypeOrSymbol`. `enter_node` fires pre-order in source order, matching
+    // the Go depth-first `forEachASTNode` walk.
+    fn enter_node(&mut self, kind: AstKind<'a>) {
+        let symbol = match kind {
+            AstKind::IdentifierReference(it) => self.resolve(
+                it.reference_id
+                    .get()
+                    .and_then(|r| self.semantic.scoping().get_reference(r).symbol_id()),
+            ),
+            AstKind::BindingIdentifier(it) => self.resolve(it.symbol_id.get()),
+            AstKind::IdentifierName(_)
+            | AstKind::StaticMemberExpression(_)
+            | AstKind::ComputedMemberExpression(_)
+            | AstKind::PrivateFieldExpression(_)
+            | AstKind::ThisExpression(_)
+            | AstKind::Super(_) => UNRESOLVED.to_string(),
+            // Literals, calls, binary/array/object/arrow, `TSQualifiedName`, etc. — the Go
+            // checker returns nil for these, so they never appear in a `.symbols` baseline.
+            _ => return,
+        };
+        self.write(kind.span(), symbol);
+    }
+}
+
+impl SymbolWalker<'_> {
+    fn resolve(&self, symbol_id: Option<SymbolId>) -> String {
+        symbol_id.map_or_else(|| UNRESOLVED.to_string(), |sid| self.format_symbol(sid))
+    }
+
+    /// Port of `writeTypeOrSymbol`'s symbol branch: `Symbol(name, Decl(file, line, col), ...)`.
+    fn format_symbol(&self, sid: SymbolId) -> String {
+        let scoping = self.semantic.scoping();
+        let mut s = format!("Symbol({}", scoping.symbol_name(sid));
+        let decls: Vec<NodeId> = scoping.symbol_declarations(sid).collect();
+        for (i, &nid) in decls.iter().enumerate() {
+            if i >= 5 {
+                let _ = write!(s, " ... and {} more", decls.len() - 5);
+                break;
+            }
+            let full = full_start(self.token_ends, self.decl_start(nid));
+            let (line, col) = line_and_character(self.content, self.line_starts, full);
+            let _ = write!(s, ", Decl({}, {line}, {col})", self.unit_name);
+        }
+        s.push(')');
+        s
+    }
+
+    /// Byte offset of the declaration node's start, before `full_start` is applied. Ports TS's
+    /// choice of declaration node: exported declarations start before `export`, so climb to the
+    /// export wrapper (but not for variables, whose declarator starts after `var`/`let`/`const`).
+    fn decl_start(&self, nid: NodeId) -> u32 {
+        let nodes = self.semantic.nodes();
+        let span = nodes.kind(nid).span();
+        match nodes.parent_kind(nid) {
+            AstKind::ExportNamedDeclaration(export) => export.span().start,
+            AstKind::ExportDefaultDeclaration(export) => export.span().start,
+            _ => span.start,
+        }
+    }
+
+    fn write(&mut self, span: Span, symbol: String) {
+        let line = line_of_position(self.line_starts, span.start);
+        let source_text = self.content[span.start as usize..span.end as usize].to_string();
+        self.results.push(TypeWriterResult { line, source_text, symbol });
+    }
+}
+
+/// Port of the per-file body of `iterateBaseline` (type_symbol_baseline.go:199-252).
+fn iterate_unit(unit_name: &str, content: &str, results: &[TypeWriterResult]) -> String {
+    let mut out = String::new();
+    out.push_str("=== ");
+    out.push_str(unit_name);
+    out.push_str(" ===\r\n");
+
+    let code_lines = scanner::split_lines(content);
+    let mut last_index_written: Option<usize> = None;
+
+    for result in results {
+        let line = result.line as usize;
+        match last_index_written {
+            None => {
+                out.push_str(&code_lines[..=line].join("\r\n"));
+                out.push_str("\r\n");
+            }
+            Some(liw) if liw != line => {
+                if !(liw + 1 < code_lines.len()
+                    && (BRACKET_LINE.is_match(code_lines[liw + 1])
+                        || code_lines[liw + 1].trim().is_empty()))
+                {
+                    out.push_str("\r\n");
+                }
+                out.push_str(&code_lines[liw + 1..=line].join("\r\n"));
+                out.push_str("\r\n");
+            }
+            Some(_) => {}
+        }
+        last_index_written = Some(line);
+
+        let line_text = LINE_DELIMITER.replace_all(&result.source_text, "");
+        out.push('>');
+        out.push_str(&line_text);
+        out.push_str(" : ");
+        out.push_str(&result.symbol);
+        out.push_str("\r\n");
+    }
+
+    let next = last_index_written.map_or(0, |l| l + 1);
+    if next < code_lines.len() {
+        if !(BRACKET_LINE.is_match(code_lines[next]) || code_lines[next].trim().is_empty()) {
+            out.push_str("\r\n");
+        }
+        out.push_str(&code_lines[next..].join("\r\n"));
+    }
+    out.push_str("\r\n");
+    out
+}
+
+/// The `tests/cases/...` header path (strips the leading `typescript/` component).
+fn header_path(path: &Path) -> String {
+    let s = path.to_string_lossy();
+    s.strip_prefix("typescript/").unwrap_or(&s).to_string()
+}
+
+/// Port of `generateBaseline`: walk every unit, emit the `//// [path] ////` header + sections.
+fn generate_for_file(f: &TypeScriptFile, header: &str) -> String {
+    let mut joined = String::new();
+    for unit in &f.units {
+        let allocator = Allocator::default();
+        let ret = Parser::new(&allocator, &unit.content, unit.source_type)
+            .with_config(TokensParserConfig)
+            .parse();
+        let token_ends: Vec<u32> = ret.tokens.iter().map(oxc::parser::Token::end).collect();
+        let line_starts = scanner::compute_line_starts(&unit.content);
+
+        let results = if ret.panicked {
+            Vec::new()
+        } else {
+            let semantic =
+                SemanticBuilder::new_compiler().with_build_nodes(true).build(&ret.program).semantic;
+            let mut walker = SymbolWalker {
+                semantic: &semantic,
+                content: &unit.content,
+                line_starts: &line_starts,
+                token_ends: &token_ends,
+                unit_name: &unit.name,
+                results: Vec::new(),
+            };
+            walker.visit_program(semantic.nodes().program());
+            walker.results
+        };
+
+        joined.push_str(&iterate_unit(&unit.name, &unit.content, &results));
+    }
+
+    if joined.is_empty() {
+        return String::new();
+    }
+    format!("//// [{header}] ////\r\n\r\n{joined}")
+}
+
+/// Line-diff score: of the baseline's `>` annotation lines, how many oxc reproduced exactly.
+fn score(baseline: &str, oxc: &str) -> (usize, usize) {
+    let diff = TextDiff::from_lines(baseline, oxc);
+    let mut matched = 0;
+    let mut total = 0;
+    for change in diff.iter_all_changes() {
+        let line = change.value().trim_end_matches(['\r', '\n']);
+        if !line.starts_with('>') {
+            continue;
+        }
+        match change.tag() {
+            ChangeTag::Equal => {
+                matched += 1;
+                total += 1;
+            }
+            ChangeTag::Delete => total += 1,
+            ChangeTag::Insert => {}
+        }
+    }
+    (matched, total)
+}
+
+/// Conformance runner in the shared `CoverageResult` form (mirrors `run_semantic_typescript`),
+/// so `AppArgs::run_tool` prints and snapshots it exactly like the other suites. A file passes
+/// when oxc reproduces every `>` symbol line in the baseline; the remaining gap is the
+/// type-checker surface (members, `this`, qualified names, lib globals). Use `--diff` to inspect
+/// a mismatch.
+pub fn run_symbols_typescript(files: &[TypeScriptFile]) -> Vec<CoverageResult> {
+    files
+        .par_iter()
+        .filter_map(|f| {
+            if f.should_fail {
+                return None;
+            }
+            let stem = Path::new(&f.path).file_stem()?.to_string_lossy().into_owned();
+            let baseline_path = workspace_root()
+                .join("typescript/tests/baselines/reference")
+                .join(format!("{stem}.symbols"));
+            // Only score files that ship a `.symbols` baseline.
+            let baseline = std::fs::read_to_string(&baseline_path).ok()?;
+
+            let header = header_path(&f.path);
+            let result = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                generate_for_file(f, &header)
+            })) {
+                Err(_) => {
+                    TestResult::ParseError("Panicked while generating symbols".to_string(), true)
+                }
+                Ok(generated) => {
+                    let (matched, total) = score(&baseline, &generated);
+                    if matched == total {
+                        TestResult::Passed
+                    } else {
+                        TestResult::Mismatch("Symbol Mismatch", generated, baseline)
+                    }
+                }
+            };
+            Some(CoverageResult { path: f.path.clone(), should_fail: false, result })
+        })
+        .collect()
+}

--- a/tasks/coverage/src/typescript/type_symbol_baseline.rs
+++ b/tasks/coverage/src/typescript/type_symbol_baseline.rs
@@ -12,7 +12,7 @@
 //! walk, output format, comparison, snapshot) is wired and ready for a checker to fill in the
 //! type strings. This mirrors the Go `isSymbolBaseline` bool that parameterizes both walks.
 
-use std::{fmt::Write as _, path::Path};
+use std::{borrow::Cow, fmt::Write as _, path::Path};
 
 use oxc::{
     allocator::Allocator,
@@ -42,18 +42,20 @@ enum BaselineKind {
     Types,
 }
 
-/// Port of `typeWriterResult` (symbol fields only).
+/// Port of `typeWriterResult` (symbol fields only). `symbol` is `Cow` so the ubiquitous
+/// `UNRESOLVED` placeholder (every node in `Types` mode) doesn't allocate.
 struct TypeWriterResult {
     line: u32,
     /// Raw node source text (may span lines); line-delimiters are stripped at output time.
     source_text: String,
-    symbol: String,
+    symbol: Cow<'static, str>,
 }
 
 /// Port of `typeWriterWalker`, backed by `oxc_ast_visit::Visit` in place of `forEachASTNode`.
+/// `semantic` is `None` in `Types` mode, which never resolves symbols (see `generate_for_file`).
 struct SymbolWalker<'a> {
     kind: BaselineKind,
-    semantic: &'a Semantic<'a>,
+    semantic: Option<&'a Semantic<'a>>,
     content: &'a str,
     line_starts: &'a [u32],
     token_ends: &'a [u32],
@@ -71,7 +73,7 @@ impl<'a> Visit<'a> for SymbolWalker<'a> {
             AstKind::IdentifierReference(it) if self.kind == BaselineKind::Symbols => self.resolve(
                 it.reference_id
                     .get()
-                    .and_then(|r| self.semantic.scoping().get_reference(r).symbol_id()),
+                    .and_then(|r| self.sema().scoping().get_reference(r).symbol_id()),
             ),
             AstKind::BindingIdentifier(it) if self.kind == BaselineKind::Symbols => {
                 self.resolve(it.symbol_id.get())
@@ -83,7 +85,7 @@ impl<'a> Visit<'a> for SymbolWalker<'a> {
             | AstKind::ComputedMemberExpression(_)
             | AstKind::PrivateFieldExpression(_)
             | AstKind::ThisExpression(_)
-            | AstKind::Super(_) => UNRESOLVED.to_string(),
+            | AstKind::Super(_) => Cow::Borrowed(UNRESOLVED),
             // Literals, calls, binary/array/object/arrow, `TSQualifiedName`, etc. — the Go
             // checker returns nil for these in the symbol walk, so they never appear in a
             // `.symbols` baseline. (`.types` annotates them too, but oxc can't type them, so
@@ -94,14 +96,19 @@ impl<'a> Visit<'a> for SymbolWalker<'a> {
     }
 }
 
-impl SymbolWalker<'_> {
-    fn resolve(&self, symbol_id: Option<SymbolId>) -> String {
-        symbol_id.map_or_else(|| UNRESOLVED.to_string(), |sid| self.format_symbol(sid))
+impl<'a> SymbolWalker<'a> {
+    /// Semantic analysis, present only in `Symbols` mode (built alongside the walker).
+    fn sema(&self) -> &Semantic<'a> {
+        self.semantic.expect("symbol resolution requires semantic analysis")
+    }
+
+    fn resolve(&self, symbol_id: Option<SymbolId>) -> Cow<'static, str> {
+        symbol_id.map_or(Cow::Borrowed(UNRESOLVED), |sid| Cow::Owned(self.format_symbol(sid)))
     }
 
     /// Port of `writeTypeOrSymbol`'s symbol branch: `Symbol(name, Decl(file, line, col), ...)`.
     fn format_symbol(&self, sid: SymbolId) -> String {
-        let scoping = self.semantic.scoping();
+        let scoping = self.sema().scoping();
         let mut s = format!("Symbol({}", scoping.symbol_name(sid));
         let decls: Vec<NodeId> = scoping.symbol_declarations(sid).collect();
         for (i, &nid) in decls.iter().enumerate() {
@@ -121,7 +128,7 @@ impl SymbolWalker<'_> {
     /// choice of declaration node: exported declarations start before `export`, so climb to the
     /// export wrapper (but not for variables, whose declarator starts after `var`/`let`/`const`).
     fn decl_start(&self, nid: NodeId) -> u32 {
-        let nodes = self.semantic.nodes();
+        let nodes = self.sema().nodes();
         let span = nodes.kind(nid).span();
         match nodes.parent_kind(nid) {
             AstKind::ExportNamedDeclaration(export) => export.span().start,
@@ -130,11 +137,17 @@ impl SymbolWalker<'_> {
         }
     }
 
-    fn write(&mut self, span: Span, symbol: String) {
+    fn write(&mut self, span: Span, symbol: Cow<'static, str>) {
         let line = line_of_position(self.line_starts, span.start);
         let source_text = self.content[span.start as usize..span.end as usize].to_string();
         self.results.push(TypeWriterResult { line, source_text, symbol });
     }
+}
+
+/// A source line that a `>` annotation group must not be separated from by a blank line:
+/// a lone `{`/`}` (`bracketLineRegex`) or a whitespace-only line.
+fn is_blank_or_bracket(line: &str) -> bool {
+    BRACKET_LINE.is_match(line) || line.trim().is_empty()
 }
 
 /// Port of the per-file body of `iterateBaseline` (type_symbol_baseline.go:199-252).
@@ -155,10 +168,7 @@ fn iterate_unit(unit_name: &str, content: &str, results: &[TypeWriterResult]) ->
                 out.push_str("\r\n");
             }
             Some(liw) if liw != line => {
-                if !(liw + 1 < code_lines.len()
-                    && (BRACKET_LINE.is_match(code_lines[liw + 1])
-                        || code_lines[liw + 1].trim().is_empty()))
-                {
+                if !(liw + 1 < code_lines.len() && is_blank_or_bracket(code_lines[liw + 1])) {
                     out.push_str("\r\n");
                 }
                 out.push_str(&code_lines[liw + 1..=line].join("\r\n"));
@@ -178,7 +188,7 @@ fn iterate_unit(unit_name: &str, content: &str, results: &[TypeWriterResult]) ->
 
     let next = last_index_written.map_or(0, |l| l + 1);
     if next < code_lines.len() {
-        if !(BRACKET_LINE.is_match(code_lines[next]) || code_lines[next].trim().is_empty()) {
+        if !is_blank_or_bracket(code_lines[next]) {
             out.push_str("\r\n");
         }
         out.push_str(&code_lines[next..].join("\r\n"));
@@ -198,28 +208,55 @@ fn generate_for_file(f: &TypeScriptFile, header: &str, kind: BaselineKind) -> St
     let mut joined = String::new();
     for unit in &f.units {
         let allocator = Allocator::default();
-        let ret = Parser::new(&allocator, &unit.content, unit.source_type)
-            .with_config(TokensParserConfig)
-            .parse();
-        let token_ends: Vec<u32> = ret.tokens.iter().map(oxc::parser::Token::end).collect();
         let line_starts = scanner::compute_line_starts(&unit.content);
 
-        let results = if ret.panicked {
-            Vec::new()
-        } else {
-            let semantic =
-                SemanticBuilder::new_compiler().with_build_nodes(true).build(&ret.program).semantic;
-            let mut walker = SymbolWalker {
-                kind,
-                semantic: &semantic,
-                content: &unit.content,
-                line_starts: &line_starts,
-                token_ends: &token_ends,
-                unit_name: &unit.name,
-                results: Vec::new(),
-            };
-            walker.visit_program(semantic.nodes().program());
-            walker.results
+        // `Types` mode never resolves symbols, so it needs neither the token stream (for
+        // declaration positions) nor semantic analysis — skip both.
+        let results = match kind {
+            BaselineKind::Symbols => {
+                let ret = Parser::new(&allocator, &unit.content, unit.source_type)
+                    .with_config(TokensParserConfig)
+                    .parse();
+                if ret.panicked {
+                    Vec::new()
+                } else {
+                    let token_ends: Vec<u32> =
+                        ret.tokens.iter().map(oxc::parser::Token::end).collect();
+                    let semantic = SemanticBuilder::new_compiler()
+                        .with_build_nodes(true)
+                        .build(&ret.program)
+                        .semantic;
+                    let mut walker = SymbolWalker {
+                        kind,
+                        semantic: Some(&semantic),
+                        content: &unit.content,
+                        line_starts: &line_starts,
+                        token_ends: &token_ends,
+                        unit_name: &unit.name,
+                        results: Vec::new(),
+                    };
+                    walker.visit_program(semantic.nodes().program());
+                    walker.results
+                }
+            }
+            BaselineKind::Types => {
+                let ret = Parser::new(&allocator, &unit.content, unit.source_type).parse();
+                if ret.panicked {
+                    Vec::new()
+                } else {
+                    let mut walker = SymbolWalker {
+                        kind,
+                        semantic: None,
+                        content: &unit.content,
+                        line_starts: &line_starts,
+                        token_ends: &[],
+                        unit_name: &unit.name,
+                        results: Vec::new(),
+                    };
+                    walker.visit_program(&ret.program);
+                    walker.results
+                }
+            }
         };
 
         joined.push_str(&iterate_unit(&unit.name, &unit.content, &results));

--- a/tasks/coverage/src/typescript/type_symbol_baseline.rs
+++ b/tasks/coverage/src/typescript/type_symbol_baseline.rs
@@ -1,12 +1,16 @@
-//! Line-by-line port of typescript-go's symbol baseline harness
+//! Line-by-line port of typescript-go's symbol/type baseline harness
 //! `internal/testutil/tsbaseline/type_symbol_baseline.go`.
 //!
-//! Only the `.symbols` half is ported: `.types` needs a type checker, which oxc does not
-//! have. The walker visits the same nodes as the Go `forEachASTNode` (via `oxc_ast_visit`),
-//! resolves the two lexically-resolvable kinds through `oxc_semantic`, and emits an
-//! `<<unresolved>>` marker for member / `this` / lib nodes (which need a checker) so the
-//! output stays line-aligned with the shipped baseline. Scoring is a line-diff against the
-//! baseline counting matching `>` annotation lines.
+//! The walker visits the same nodes as the Go `forEachASTNode` (via `oxc_ast_visit`) and,
+//! for the `.symbols` baseline, resolves the two lexically-resolvable kinds through
+//! `oxc_semantic`, emitting an `<<unresolved>>` marker for member / `this` / lib nodes (which
+//! need a checker) so the output stays line-aligned with the shipped baseline. Scoring is a
+//! line-diff against the baseline counting matching `>` annotation lines.
+//!
+//! The `.types` baseline is a **scaffold**: oxc has no type checker, so every type payload is
+//! `<<unresolved>>` and the suite reports 0% — but the full runner (baseline discovery, AST
+//! walk, output format, comparison, snapshot) is wired and ready for a checker to fill in the
+//! type strings. This mirrors the Go `isSymbolBaseline` bool that parameterizes both walks.
 
 use std::{fmt::Write as _, path::Path};
 
@@ -27,9 +31,16 @@ use super::scanner::{
 };
 use crate::{CoverageResult, TestResult, TypeScriptFile, workspace_root};
 
-/// Emitted for nodes oxc cannot resolve to a symbol (members, `this`/`super`, lib globals).
-/// Must never be equal to a real `Symbol(...)` string.
+/// Emitted for nodes oxc cannot resolve (members, `this`/`super`, lib globals) and for every
+/// node in the `.types` scaffold. Must never equal a real `Symbol(...)` or type string.
 const UNRESOLVED: &str = "<<unresolved>>";
+
+/// Which baseline to generate. Mirrors typescript-go's `isSymbolBaseline` bool.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum BaselineKind {
+    Symbols,
+    Types,
+}
 
 /// Port of `typeWriterResult` (symbol fields only).
 struct TypeWriterResult {
@@ -41,6 +52,7 @@ struct TypeWriterResult {
 
 /// Port of `typeWriterWalker`, backed by `oxc_ast_visit::Visit` in place of `forEachASTNode`.
 struct SymbolWalker<'a> {
+    kind: BaselineKind,
     semantic: &'a Semantic<'a>,
     content: &'a str,
     line_starts: &'a [u32],
@@ -52,26 +64,33 @@ struct SymbolWalker<'a> {
 impl<'a> Visit<'a> for SymbolWalker<'a> {
     // Port of `visitNode`'s filter (`IsExpressionNode || KindIdentifier || IsDeclarationName`)
     // fused with `writeTypeOrSymbol`. `enter_node` fires pre-order in source order, matching
-    // the Go depth-first `forEachASTNode` walk.
+    // the Go depth-first `forEachASTNode` walk. In `Types` mode every payload is the
+    // `UNRESOLVED` placeholder (no type checker); in `Symbols` mode identifiers resolve.
     fn enter_node(&mut self, kind: AstKind<'a>) {
-        let symbol = match kind {
-            AstKind::IdentifierReference(it) => self.resolve(
+        let payload = match kind {
+            AstKind::IdentifierReference(it) if self.kind == BaselineKind::Symbols => self.resolve(
                 it.reference_id
                     .get()
                     .and_then(|r| self.semantic.scoping().get_reference(r).symbol_id()),
             ),
-            AstKind::BindingIdentifier(it) => self.resolve(it.symbol_id.get()),
-            AstKind::IdentifierName(_)
+            AstKind::BindingIdentifier(it) if self.kind == BaselineKind::Symbols => {
+                self.resolve(it.symbol_id.get())
+            }
+            AstKind::IdentifierReference(_)
+            | AstKind::BindingIdentifier(_)
+            | AstKind::IdentifierName(_)
             | AstKind::StaticMemberExpression(_)
             | AstKind::ComputedMemberExpression(_)
             | AstKind::PrivateFieldExpression(_)
             | AstKind::ThisExpression(_)
             | AstKind::Super(_) => UNRESOLVED.to_string(),
             // Literals, calls, binary/array/object/arrow, `TSQualifiedName`, etc. — the Go
-            // checker returns nil for these, so they never appear in a `.symbols` baseline.
+            // checker returns nil for these in the symbol walk, so they never appear in a
+            // `.symbols` baseline. (`.types` annotates them too, but oxc can't type them, so
+            // the scaffold leaves them out; a checker would broaden this arm.)
             _ => return,
         };
-        self.write(kind.span(), symbol);
+        self.write(kind.span(), payload);
     }
 }
 
@@ -175,7 +194,7 @@ fn header_path(path: &Path) -> String {
 }
 
 /// Port of `generateBaseline`: walk every unit, emit the `//// [path] ////` header + sections.
-fn generate_for_file(f: &TypeScriptFile, header: &str) -> String {
+fn generate_for_file(f: &TypeScriptFile, header: &str, kind: BaselineKind) -> String {
     let mut joined = String::new();
     for unit in &f.units {
         let allocator = Allocator::default();
@@ -191,6 +210,7 @@ fn generate_for_file(f: &TypeScriptFile, header: &str) -> String {
             let semantic =
                 SemanticBuilder::new_compiler().with_build_nodes(true).build(&ret.program).semantic;
             let mut walker = SymbolWalker {
+                kind,
                 semantic: &semantic,
                 content: &unit.content,
                 line_starts: &line_starts,
@@ -235,10 +255,12 @@ fn score(baseline: &str, oxc: &str) -> (usize, usize) {
 
 /// Conformance runner in the shared `CoverageResult` form (mirrors `run_semantic_typescript`),
 /// so `AppArgs::run_tool` prints and snapshots it exactly like the other suites. A file passes
-/// when oxc reproduces every `>` symbol line in the baseline; the remaining gap is the
-/// type-checker surface (members, `this`, qualified names, lib globals). Use `--diff` to inspect
-/// a mismatch.
-pub fn run_symbols_typescript(files: &[TypeScriptFile]) -> Vec<CoverageResult> {
+/// when oxc reproduces every `>` line in the baseline. Use `--diff` to inspect a mismatch.
+fn run_baseline(files: &[TypeScriptFile], kind: BaselineKind) -> Vec<CoverageResult> {
+    let (ext, case) = match kind {
+        BaselineKind::Symbols => ("symbols", "Symbol Mismatch"),
+        BaselineKind::Types => ("types", "Type Mismatch"),
+    };
     files
         .par_iter()
         .filter_map(|f| {
@@ -248,27 +270,40 @@ pub fn run_symbols_typescript(files: &[TypeScriptFile]) -> Vec<CoverageResult> {
             let stem = Path::new(&f.path).file_stem()?.to_string_lossy().into_owned();
             let baseline_path = workspace_root()
                 .join("typescript/tests/baselines/reference")
-                .join(format!("{stem}.symbols"));
-            // Only score files that ship a `.symbols` baseline.
+                .join(format!("{stem}.{ext}"));
+            // Only score files that ship a baseline of this kind.
             let baseline = std::fs::read_to_string(&baseline_path).ok()?;
 
             let header = header_path(&f.path);
             let result = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                generate_for_file(f, &header)
+                generate_for_file(f, &header, kind)
             })) {
                 Err(_) => {
-                    TestResult::ParseError("Panicked while generating symbols".to_string(), true)
+                    TestResult::ParseError("Panicked while generating baseline".to_string(), true)
                 }
                 Ok(generated) => {
                     let (matched, total) = score(&baseline, &generated);
                     if matched == total {
                         TestResult::Passed
                     } else {
-                        TestResult::Mismatch("Symbol Mismatch", generated, baseline)
+                        TestResult::Mismatch(case, generated, baseline)
                     }
                 }
             };
             Some(CoverageResult { path: f.path.clone(), should_fail: false, result })
         })
         .collect()
+}
+
+/// `.symbols` conformance: does oxc's symbol resolution match TypeScript's? The remaining gap
+/// is the type-checker surface (members, `this`, qualified names, lib globals).
+pub fn run_symbols_typescript(files: &[TypeScriptFile]) -> Vec<CoverageResult> {
+    run_baseline(files, BaselineKind::Symbols)
+}
+
+/// `.types` conformance — **scaffold**. oxc has no type checker, so every type is
+/// `<<unresolved>>` and this reports 0% until a checker is wired into the walker's `Types` arm.
+/// The runner itself (baseline discovery, walk, output, comparison, snapshot) is complete.
+pub fn run_types_typescript(files: &[TypeScriptFile]) -> Vec<CoverageResult> {
+    run_baseline(files, BaselineKind::Types)
 }


### PR DESCRIPTION
## Summary

Ports typescript-go's symbol/type/error baseline harnesses (`internal/testutil/tsbaseline/{type_symbol_baseline,error_baseline}.go`) into `tasks/coverage` as new conformance suites, measuring oxc against the `.symbols`, `.types`, and `.errors.txt` baselines already shipped in the TypeScript submodule (~14k each). All report through the shared `CoverageResult` machinery, so their summaries/snapshots look exactly like the other suites.

Run with `cargo coverage symbols` / `cargo coverage types` / `cargo coverage errors`.

## What's measured

- **symbols** — walk the AST (`oxc_ast_visit`), resolve lexical bindings via `oxc_semantic`, emit `Symbol(name, Decl(file, line, col), ...)` with declaration positions recovered from the parser token stream (to match TypeScript's trivia-inclusive `node.pos`), then diff against the baseline.
  `AST Parsed 8364/8364 (100%)`, `Positive Passed 1765/8364 (21.10%)`.
- **errors** — match oxc parser diagnostic positions + TS codes (oxc's parser attaches real `TSxxxx` codes via `ts_error`) against the `.errors.txt` summary headers.
  `AST Parsed 7699/7699 (100%)`, `Positive Passed 7251/7699 (94.18%)`.
- **types** — **scaffold**. Same harness parameterized by kind (mirroring typescript-go's `isSymbolBaseline`), but oxc has no type checker, so every type payload is `<<unresolved>>`. The full runner (baseline discovery, walk, output format, comparison, snapshot) is wired and ready for a checker to fill in the walker's `Types` arm.
  `AST Parsed 8364/8364 (100%)`, `Positive Passed 78/8364 (0.93%)` — the passes are files with empty type baselines.

## Notes

- oxc has no type checker, so `.types` and the type-checker surface of `.symbols`/`.errors.txt` (member/`this` symbols, qualified names, lib globals, `TS2xxx`/`TS18xxx` errors) are out of reach — that gap is the measurable target for a future checker, which is exactly what the `.types` scaffold sets up.
- The suites are opt-in subcommands (like `transpiler`), not part of `cargo coverage all`.

---

🤖 Written with [Claude Code](https://claude.com/claude-code) (AI assistance); reviewed by the author, per oxc's AI usage disclosure policy.
