### PR TITLE
feat(type_checker): add experimental type checker crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2618,6 +2618,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxc_type_checker"
+version = "0.138.0"
+dependencies = [
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_ast_visit",
+ "oxc_diagnostics",
+ "oxc_parser",
+ "oxc_semantic",
+ "oxc_span",
+]
+
+[[package]]
 name = "oxfmt"
 version = "0.57.0"
 dependencies = [

--- a/crates/oxc_type_checker/Cargo.toml
+++ b/crates/oxc_type_checker/Cargo.toml
@@ -28,7 +28,6 @@ workspace = true
 
 [lib]
 test = false
-doctest = false
 
 [dependencies]
 oxc_ast = { workspace = true }

--- a/crates/oxc_type_checker/Cargo.toml
+++ b/crates/oxc_type_checker/Cargo.toml
@@ -1,0 +1,42 @@
+# oxc_type_checker
+#
+# An experimental, work-in-progress type checker for JavaScript and TypeScript.
+#
+# This crate is a deliberately small scaffold: it wires the parser and semantic
+# analyzer together, walks the AST, and gives you a place to emit diagnostics.
+# It performs no type checking yet — it exists as a starting point for people who
+# want to experiment with building a type checker on top of oxc.
+
+[package]
+name = "oxc_type_checker"
+version = "0.138.0"
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+homepage.workspace = true
+include = ["/examples", "/src"]
+keywords.workspace = true
+license.workspace = true
+# Experimental scaffold — not published to crates.io yet.
+publish = false
+repository.workspace = true
+rust-version.workspace = true
+description = "An experimental type checker for JavaScript and TypeScript (work in progress)"
+
+[lints]
+workspace = true
+
+[lib]
+test = false
+doctest = false
+
+[dependencies]
+oxc_ast = { workspace = true }
+oxc_ast_visit = { workspace = true }
+oxc_diagnostics = { workspace = true }
+oxc_semantic = { workspace = true }
+oxc_span = { workspace = true }
+
+[dev-dependencies]
+oxc_allocator = { workspace = true }
+oxc_parser = { workspace = true }

--- a/crates/oxc_type_checker/README.md
+++ b/crates/oxc_type_checker/README.md
@@ -1,0 +1,3 @@
+# Oxc Type Checker
+
+Experimental.

--- a/crates/oxc_type_checker/examples/checker.rs
+++ b/crates/oxc_type_checker/examples/checker.rs
@@ -1,0 +1,68 @@
+#![expect(clippy::print_stdout)]
+//! # Oxc Type Checker Example
+//!
+//! Runs the experimental [`oxc_type_checker`] type checker over a file, wiring up the parser
+//! and semantic analyzer along the way.
+//!
+//! ## Usage
+//!
+//! Create a `test.ts` file and run:
+//!
+//! ```bash
+//! cargo run -p oxc_type_checker --example checker [filename]
+//! ```
+//!
+//! Since the checker is a scaffold that performs no checks yet, a well-formed file simply
+//! reports "No type errors found". Add checks in `crates/oxc_type_checker/src/lib.rs` and watch
+//! them show up here.
+
+use std::{env, path::Path, sync::Arc};
+
+use oxc_allocator::Allocator;
+use oxc_parser::Parser;
+use oxc_semantic::SemanticBuilder;
+use oxc_span::SourceType;
+use oxc_type_checker::TypeChecker;
+
+fn main() -> std::io::Result<()> {
+    let name = env::args().nth(1).unwrap_or_else(|| "test.ts".to_string());
+    let path = Path::new(&name);
+    let source_text: Arc<str> = Arc::from(std::fs::read_to_string(path)?);
+    let source_type = SourceType::from_path(path).unwrap_or_else(|_| SourceType::ts());
+
+    // Memory arena in which the parser and semantic model allocate.
+    let allocator = Allocator::default();
+
+    // 1. Parse the source text into an AST.
+    let parser_ret = Parser::new(&allocator, &source_text, source_type).parse();
+    if !parser_ret.diagnostics.is_empty() {
+        println!("Parsing failed:\n");
+        print_diagnostics(parser_ret.diagnostics, &source_text);
+        return Ok(());
+    }
+    let program = parser_ret.program;
+
+    // 2. Run semantic analysis to build the symbol table and scope tree.
+    let semantic_ret = SemanticBuilder::new().build(&program);
+    if !semantic_ret.diagnostics.is_empty() {
+        println!("Semantic analysis reported problems:\n");
+        print_diagnostics(semantic_ret.diagnostics, &source_text);
+    }
+
+    // 3. Type check.
+    let checker_ret = TypeChecker::new().check(&program, &semantic_ret.semantic);
+    if checker_ret.diagnostics.is_empty() {
+        println!("No type errors found in {name}.");
+    } else {
+        print_diagnostics(checker_ret.diagnostics, &source_text);
+    }
+
+    Ok(())
+}
+
+fn print_diagnostics(diagnostics: oxc_diagnostics::Diagnostics, source_text: &Arc<str>) {
+    for diagnostic in diagnostics.into_vec() {
+        let report = diagnostic.with_source_code(Arc::clone(source_text));
+        println!("{report:?}");
+    }
+}

--- a/crates/oxc_type_checker/src/diagnostics.rs
+++ b/crates/oxc_type_checker/src/diagnostics.rs
@@ -1,0 +1,19 @@
+use std::borrow::Cow;
+
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_span::Span;
+
+/// Build a type-error diagnostic labelled at `span`.
+///
+/// This is a convenience template for reporting problems from the checker. As real checks
+/// land, prefer dedicated constructors that carry precise, TypeScript-style error codes
+/// (for example `TS2322: Type 'string' is not assignable to type 'number'.`), following
+/// the pattern used by `oxc_isolated_declarations`.
+///
+/// ```ignore
+/// self.diagnostics.push(type_error("Type 'string' is not assignable to type 'number'.", span));
+/// ```
+#[cold]
+pub fn type_error<M: Into<Cow<'static, str>>>(message: M, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(message).with_label(span)
+}

--- a/crates/oxc_type_checker/src/lib.rs
+++ b/crates/oxc_type_checker/src/lib.rs
@@ -1,0 +1,141 @@
+//! # Oxc Type Checker
+//!
+//! An **experimental**, work-in-progress type checker for JavaScript and TypeScript.
+//!
+//! This crate is intentionally a thin scaffold. It does *not* type check anything yet.
+//! Instead it provides the plumbing you need to start experimenting with a type checker
+//! built on top of oxc:
+//!
+//! - a [`TypeChecker`] entry point with room for [`TypeCheckerOptions`],
+//! - an AST walk over the program via [`oxc_ast_visit::Visit`],
+//! - access to symbol and scope information through [`oxc_semantic::Semantic`], and
+//! - a [`Diagnostics`] collector plus a [`type_error`] helper for reporting problems.
+//!
+//! ## Usage
+//!
+//! ```rust
+//! use oxc_allocator::Allocator;
+//! use oxc_type_checker::TypeChecker;
+//! use oxc_parser::Parser;
+//! use oxc_semantic::SemanticBuilder;
+//! use oxc_span::SourceType;
+//!
+//! let allocator = Allocator::default();
+//! let source_text = "const x: number = 1;";
+//! let source_type = SourceType::ts();
+//!
+//! let parser_ret = Parser::new(&allocator, source_text, source_type).parse();
+//! let semantic_ret = SemanticBuilder::new().build(&parser_ret.program);
+//!
+//! let checker_ret = TypeChecker::new().check(&parser_ret.program, &semantic_ret.semantic);
+//! assert!(checker_ret.diagnostics.is_empty());
+//! ```
+//!
+//! ## Adding a check
+//!
+//! Type checks live in the private `TypeCheckerVisitor`. Override the relevant `visit_*`
+//! method, inspect the node (using `self.semantic` to resolve identifiers and look up
+//! symbols), push a [`type_error`] onto `self.diagnostics` when something is wrong, and
+//! remember to keep walking the subtree with the matching `walk_*` function:
+//!
+//! ```ignore
+//! use oxc_ast::ast::TSTypeAliasDeclaration;
+//! use oxc_ast_visit::{Visit, walk::walk_ts_type_alias_declaration};
+//!
+//! impl<'a> Visit<'a> for TypeCheckerVisitor<'a, '_> {
+//!     fn visit_ts_type_alias_declaration(&mut self, decl: &TSTypeAliasDeclaration<'a>) {
+//!         // ... inspect `decl`, and on error:
+//!         // self.diagnostics.push(type_error("some type error", decl.span));
+//!         walk_ts_type_alias_declaration(self, decl);
+//!     }
+//! }
+//! ```
+//!
+//! See `examples/checker.rs` for a runnable end-to-end example.
+
+use oxc_ast::ast::Program;
+use oxc_ast_visit::Visit;
+use oxc_diagnostics::Diagnostics;
+use oxc_semantic::Semantic;
+
+mod diagnostics;
+
+pub use crate::diagnostics::type_error;
+
+/// Options controlling how the [`TypeChecker`] behaves.
+///
+/// Empty for now. Add knobs here — strictness flags, the target `lib`, and so on — as
+/// the checker grows.
+#[derive(Debug, Default, Clone)]
+pub struct TypeCheckerOptions;
+
+/// The result of running [`TypeChecker::check`].
+#[non_exhaustive]
+pub struct TypeCheckerReturn {
+    /// Type errors and warnings collected during checking.
+    pub diagnostics: Diagnostics,
+}
+
+/// An experimental type checker.
+///
+/// A [`TypeChecker`] is cheap to create and can be reused to check multiple programs. Build
+/// one with [`TypeChecker::new`] (optionally [`TypeChecker::with_options`]) and run it with
+/// [`TypeChecker::check`].
+#[derive(Debug, Default, Clone)]
+pub struct TypeChecker {
+    options: TypeCheckerOptions,
+}
+
+impl TypeChecker {
+    /// Create a checker with default [options](TypeCheckerOptions).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Override the checker's [options](TypeCheckerOptions).
+    #[must_use]
+    pub fn with_options(mut self, options: TypeCheckerOptions) -> Self {
+        self.options = options;
+        self
+    }
+
+    /// Type check `program`.
+    ///
+    /// `semantic` supplies the symbol table and scope tree for `program` (build it with
+    /// [`oxc_semantic::SemanticBuilder`]). The returned [`TypeCheckerReturn`] carries any
+    /// diagnostics that were produced — an empty list means no problems were found.
+    pub fn check<'a>(&self, program: &Program<'a>, semantic: &Semantic<'a>) -> TypeCheckerReturn {
+        let mut visitor = TypeCheckerVisitor {
+            semantic,
+            options: &self.options,
+            diagnostics: Diagnostics::new(),
+        };
+        visitor.visit_program(program);
+        TypeCheckerReturn { diagnostics: visitor.diagnostics }
+    }
+}
+
+/// Walks the AST and accumulates diagnostics.
+///
+/// This is where type checking happens. Right now it inherits the default (no-op) walk
+/// from [`Visit`], so it reports nothing; override `visit_*` methods to add checks. See
+/// the crate-level docs for the pattern.
+struct TypeCheckerVisitor<'a, 'c> {
+    /// Symbol and scope information for the program being checked. Use it to resolve
+    /// identifiers to symbols, inspect symbol flags, walk references, and so on.
+    #[expect(dead_code, reason = "scaffold: available to the checks you add")]
+    semantic: &'c Semantic<'a>,
+    /// Configuration for the checks you add.
+    #[expect(dead_code, reason = "scaffold: available to the checks you add")]
+    options: &'c TypeCheckerOptions,
+    /// Type errors and warnings, surfaced via [`TypeCheckerReturn::diagnostics`].
+    diagnostics: Diagnostics,
+}
+
+impl<'a> Visit<'a> for TypeCheckerVisitor<'a, '_> {
+    // Override `visit_*` methods here to implement type checks.
+    //
+    // Reach for `self.semantic` when a check needs symbol or scope information, push onto
+    // `self.diagnostics` (e.g. with `type_error(..)`) to report a problem, and call the
+    // matching `walk_*` free function so traversal continues into the node's children.
+}


### PR DESCRIPTION
Adds `oxc_type_checker`, an experimental scaffold crate for people to experiment with building a type checker on top of oxc.

## What it does

- `TypeChecker::new().check(&program, &semantic)` wires parser → semantic → an `oxc_ast_visit::Visit` walk and returns the collected `oxc_diagnostics`.
- Performs **no type checking yet** — a well-formed program reports nothing. It's a starting point with a documented extension point (override a `visit_*` method, push a `type_error`, call the matching `walk_*`).
- Ships a runnable example: `cargo run -p oxc_type_checker --example checker test.ts`.

## Notes

- `publish = false`; it's a workspace member but intentionally not added to `[workspace.dependencies]` — nothing consumes it yet, which would otherwise trip `cargo shear`.
- No tests by design (`test = false`).
