### PR TITLE
feat(allocator): add `ReplaceWith` trait

### DIFF
--- a/crates/oxc_allocator/src/lib.rs
+++ b/crates/oxc_allocator/src/lib.rs
@@ -55,6 +55,7 @@ pub mod hash_set;
 pub mod ident_hasher;
 #[cfg(feature = "pool")]
 mod pool;
+mod replace_with;
 mod string_builder;
 mod take_in;
 #[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]
@@ -81,6 +82,7 @@ pub use hash_set::{HashSet, HashSet as ArenaHashSet};
 pub use ident_hasher::{IdentBuildHasher, ident_hash, pack_len_hash};
 #[cfg(feature = "pool")]
 pub use pool::*;
+pub use replace_with::ReplaceWith;
 pub use string_builder::{StringBuilder, StringBuilder as ArenaStringBuilder};
 pub use take_in::{Dummy, TakeIn};
 pub use vec::{Vec, Vec as ArenaVec};

--- a/crates/oxc_allocator/src/replace_with.rs
+++ b/crates/oxc_allocator/src/replace_with.rs
@@ -1,0 +1,422 @@
+use std::{
+    boxed::Box as StdBox, cell::Cell, marker::PhantomData, mem, ptr::NonNull, sync::Mutex,
+    vec::Vec as StdVec,
+};
+
+use crate::{Allocator, Box, Dummy, Vec};
+
+/// A trait to replace an existing AST node in place with a new node built from the old one.
+pub trait ReplaceWith<'a>: Dummy<'a> {
+    /// Replace the node in place with the value returned by `replacer`.
+    ///
+    /// `replacer` is called with an owned copy of the node, and whatever it returns is written back in its place.
+    /// This is for the common case where a node is taken purely to build a new node out of it
+    /// (typically wrapping the old node, or extracting just a part of it), which is then stored back in the same slot.
+    ///
+    /// Prefer this over [`take_in`] + writing the result back. That writes a dummy node into arena,
+    /// which takes up space in arena forever, even though it's pointless - it's overwritten immediately.
+    /// This method avoids the need for the dummy node, so is faster, and takes less memory.
+    ///
+    /// ```
+    /// # use oxc_allocator::{Allocator, Box, Dummy};
+    /// # enum Expression<'a> {
+    /// #     ParenthesizedExpression(Box<'a, ParenthesizedExpression<'a>>),
+    /// #     Empty,
+    /// # }
+    /// # struct ParenthesizedExpression<'a> {
+    /// #     expression: Expression<'a>,
+    /// # }
+    /// # impl<'a> Dummy<'a> for Expression<'a> {
+    /// #     fn dummy(allocator: &'a Allocator) -> Self {
+    /// #         Self::Empty
+    /// #     }
+    /// # }
+    /// # impl<'a> ReplaceWith<'a> for Expression<'a> {}
+    /// use oxc_allocator::ReplaceWith;
+    ///
+    /// // If `expr` is a parenthesized expression `(inner)`, unwrap it to `inner` in place
+    /// fn unwrap_parens<'a>(expr: &mut Expression<'a>) {
+    ///     if matches!(expr, Expression::ParenthesizedExpression(_)) {
+    ///         expr.replace_with(|expr| {
+    ///             let Expression::ParenthesizedExpression(paren) = expr else { unreachable!() };
+    ///             paren.unbox().expression
+    ///         });
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// # Panic handling
+    ///
+    /// If `replacer` panics, the original place is left holding a dummy (see [`Dummy`]), so it always
+    /// remains valid and usable. Building that dummy is the only situation in which this method allocates,
+    /// so the common (non-panicking) path allocates nothing.
+    ///
+    /// When compiled with `panic = "abort"`, the code for writing the dummy is optimized out entirely.
+    ///
+    /// Handling panics in this way is only required to avoid UB in obscure cases where `catch_unwind`
+    /// is used and the original value is accessed after the panic.
+    ///
+    /// Without the panic handling, these would both be Undefined Behavior:
+    ///
+    /// #### Double drop
+    ///
+    /// ```
+    /// use std::{
+    ///     boxed::Box as StdBox,
+    ///     mem::ManuallyDrop,
+    ///     panic::{AssertUnwindSafe, catch_unwind},
+    /// };
+    /// use oxc_allocator::{Allocator, Dummy, ReplaceWith};
+    ///
+    /// // `ManuallyDrop` wrapper is not required here, but it demonstrates that
+    /// // a const assertion in `replace_with` that `Self: !Drop` would not be
+    /// // sufficient to prevent UB - `Wrapper` is `!Drop`.
+    /// struct Wrapper(ManuallyDrop<StdBox<u32>>);
+    ///
+    /// impl ReplaceWith<'_> for Wrapper {}
+    ///
+    /// impl<'a> Dummy<'a> for Wrapper {
+    ///     fn dummy(_allocator: &'a Allocator) -> Self {
+    ///         Self(ManuallyDrop::new(StdBox::new(0)))
+    ///     }
+    /// }
+    ///
+    /// let mut wrapper = Wrapper(ManuallyDrop::new(StdBox::new(123)));
+    ///
+    /// let _ = catch_unwind(AssertUnwindSafe(|| {
+    ///     wrapper.replace_with(|old| {
+    ///         let boxed: StdBox<u32> = ManuallyDrop::into_inner(old.0);
+    ///         // `Box` is freed
+    ///         drop(boxed);
+    ///         panic!("Unwind before write-back");
+    ///     });
+    /// }));
+    ///
+    /// let boxed: StdBox<u32> = ManuallyDrop::into_inner(wrapper.0);
+    /// // Without the panic guard, `boxed` would be the same `Box`
+    /// // that was freed in closure above. Double drop!
+    /// drop(boxed);
+    /// ```
+    ///
+    /// #### Aliasing violation
+    ///
+    /// ```
+    /// use std::panic::{AssertUnwindSafe, catch_unwind};
+    /// use oxc_allocator::{Allocator, ArenaBox, Dummy, ReplaceWith};
+    ///
+    /// struct Wrapper<'a>(ArenaBox<'a, u32>);
+    ///
+    /// impl<'a> ReplaceWith<'a> for Wrapper<'a> {}
+    ///
+    /// impl<'a> Dummy<'a> for Wrapper<'a> {
+    ///     fn dummy(allocator: &'a Allocator) -> Self {
+    ///         Self(ArenaBox::new_in(0, &allocator))
+    ///     }
+    /// }
+    ///
+    /// let allocator = Allocator::new();
+    /// let allocator = &allocator;
+    ///
+    /// let mut wrapper = Wrapper(ArenaBox::new_in(1, &allocator));
+    /// let mut copy: Option<Wrapper> = None;
+    ///
+    /// let _ = catch_unwind(AssertUnwindSafe(|| {
+    ///     wrapper.replace_with(|old| {
+    ///         // Move the copy out of the closure
+    ///         copy = Some(old);
+    ///         panic!("Unwind before write-back");
+    ///     });
+    /// }));
+    ///
+    /// let mut boxed: ArenaBox<u32> = wrapper.0;
+    /// let mut copy: ArenaBox<u32> = copy.unwrap().0;
+    /// let boxed_mut: &mut u32 = boxed.as_mut();
+    /// let copy_mut: &mut u32 = copy.as_mut();
+    /// // Without the panic guard, `boxed` and `copy` would both point to same `u32`.
+    /// // We'd now have 2 `&mut u32`s pointing to same place. Aliasing violation!
+    /// *boxed_mut = 2;
+    /// *copy_mut = 3;
+    /// ```
+    ///
+    /// [`take_in`]: crate::TakeIn::take_in
+    //
+    // `#[inline]` so that compiler can elide reading fields of struct which are not used,
+    // rather than pulling whole struct onto the stack
+    #[inline]
+    fn replace_with(&mut self, replacer: impl FnOnce(Self) -> Self) {
+        let ptr = NonNull::from(self);
+
+        // SAFETY: `ptr` is derived from a `&mut Self`, so is valid for reads and writes, aligned,
+        // and points to an initialized `Self`. `ptr.read()` makes an owned bitwise copy of the node.
+        //
+        // This leaves a bitwise duplicate in `*ptr`, but it is never dropped or exposed as a value:
+        //
+        // * On success, `ptr.write(new)` below overwrites it (`write` does not drop the old contents -
+        //   correct, as ownership moved into `old`, and thence into `new`).
+        // * On panic, `PanicGuard::drop` overwrites it with a fresh dummy (again without dropping it),
+        //   before it can be accessed by any other code.
+        //
+        // So `*ptr` never retains a duplicate that could be observed alongside `old` (which would allow
+        // aliasing `&mut`s, double frees, etc), and no value is ever dropped twice.
+        // This holds for any `Self: Dummy` - `Drop` types included.
+        let old = unsafe { ptr.read() };
+
+        // Create a guard before calling `replacer`.
+        // If `replacer` unwinds, `guard`'s `Drop` writes a fresh dummy into `*ptr`,
+        // so the slot never keeps a bitwise duplicate of the value moved into `replacer`.
+        let guard = PanicGuard::<'a, Self> { ptr, marker: PhantomData };
+
+        let new = replacer(old);
+
+        // `replacer` returned normally. Disarm the guard - we write `new` ourselves below.
+        mem::forget(guard);
+
+        // Overwrite original value without dropping it.
+        // SAFETY: See above.
+        unsafe { ptr.write(new) };
+    }
+}
+
+// Blanket impls on wrapper types.
+//
+// `ReplaceWith` is not implemented on all types which implement `Dummy`, because there is no point
+// in using `replace_with` on `Copy` types - just copying these types is cheaper and simpler.
+//
+// Similarly, bound of `T: ReplaceWith` on `Option<T>` is to avoid implementing `ReplaceWith`
+// on `Option<T>` where `T: Copy`, and therefore `Option<T>` is `Copy` too.
+//
+// `Cell<T>` is not `Copy` even if `T` is, but `Cell::get` is available where `T: Copy`,
+// and is a better choice than `replace_with` in this case. So it's also bound on `T: ReplaceWith`.
+
+impl<'a, T: ReplaceWith<'a>> ReplaceWith<'a> for Option<T> {}
+
+impl<'a, T: Dummy<'a>> ReplaceWith<'a> for Box<'a, T> {}
+impl<'a, T> ReplaceWith<'a> for Box<'a, [T]> {}
+
+impl<'a, T> ReplaceWith<'a> for Vec<'a, T> {}
+
+impl<'a, T: ReplaceWith<'a>> ReplaceWith<'a> for Cell<T> {}
+
+/// Guard which restores a valid value to a slot if [`replace_with`]'s `replacer` panics.
+///
+/// `replace_with` reads the old node out of the slot with `NonNull::read`, leaving a bitwise duplicate behind,
+/// then calls `replacer`. If `replacer` panics, this guard's `Drop` overwrites that duplicate with a fresh dummy,
+/// so the slot cannot be observed holding a copy that aliases the value which was moved into `replacer`.
+/// On the success path the guard is `mem::forget`-ed, so it costs nothing.
+///
+/// [`replace_with`]: ReplaceWith::replace_with
+struct PanicGuard<'a, T: Dummy<'a>> {
+    ptr: NonNull<T>,
+    marker: PhantomData<&'a ()>,
+}
+
+impl<'a, T: Dummy<'a>> Drop for PanicGuard<'a, T> {
+    // A trivial forwarder to `write_dummy`, which is `#[inline(never)]` and does the real work.
+    //
+    // Keeping `drop` itself `#[inline]` lets it inline into the caller's unwind landing pad,
+    // where it reads `self.ptr` straight from a register and passes it *by value* to `write_dummy`.
+    // So the guard never has to be spilled to the stack - which it would be if `drop` were
+    // the out-of-line function, because then the landing pad would have to form `&guard`
+    // in memory to call it.
+    //
+    // `write_dummy` being `#[inline(never)]` still keeps the expensive work out of every `#[inline]`d
+    // `replace_with` call site's landing pad.
+    #[inline]
+    fn drop(&mut self) {
+        write_dummy(self.ptr);
+    }
+}
+
+/// Overwrite the bitwise duplicate left in `*ptr` (by `replace_with`) with a fresh dummy.
+///
+/// This is the cold panic-path body of `PanicGuard::drop`, factored out as a free function that takes
+/// `ptr` *by value* so it can be `#[inline(never)]` while `PanicGuard::drop` stays an inlinable
+/// forwarder (see the comment there for why that matters).
+#[inline(never)]
+fn write_dummy<'a, T: Dummy<'a>>(ptr: NonNull<T>) {
+    // `replacer` panicked. Build a fresh dummy in its own dedicated `'static` allocator.
+    let allocator = fresh_dummy_allocator();
+    let dummy = T::dummy(allocator);
+
+    // Write the dummy into `*ptr`.
+    // SAFETY: `ptr` was derived from a `&mut Self` in `replace_with` and remains valid.
+    // `write` overwrites the leftover duplicate without dropping it - correct, as that value's
+    // ownership was moved into `replacer`.
+    unsafe { ptr.write(dummy) };
+}
+
+/// Storage for the [`Allocator`]s that dummies are created in on the panic path of [`replace_with`].
+///
+/// A dummy written into a node's slot on panic must be a valid value for `'a`,
+/// which means allocating it in an [`Allocator`] that lives for at least `'a`.
+///
+/// `replace_with` can't reuse the AST's own allocator, because that isn't available there,
+/// and it can't share a single global allocator, because the dummy may retain a handle to whatever allocator
+/// it was built in (e.g. `Vec` contains a reference to the `Allocator`, and reallocates through it on `push`).
+/// A shared allocator would then be mutated without synchronization from whichever thread owns the AST.
+///
+/// We also can't have 1 `Allocator` per thread (in a `thread_local!`) because they don't live for `'static` -
+/// they're dropped when the thread exits. Some code moves ASTs to other threads (using `self_cell`)
+/// so there's no guarantee the thread would live long enough, and the synchronization problem discussed above
+/// could also come into play.
+///
+/// So each dummy gets its *own* dedicated [`Allocator`]. These allocators must:
+///
+/// 1. live for `'static` (the dummy escapes into the AST, whose lifetime we can't bound here), and
+/// 2. have stable addresses (a `Vec` in the dummy holds an `&Allocator` pointing to one).
+///
+/// We get both by boxing each `Allocator` and keeping the boxes alive forever in this `static`.
+/// The `Box` gives a stable heap address, and `Vec` growth only moves the `Box`es themselves,
+/// not the *contents* of the `Box`es (the `Allocator`s).
+///
+/// This is only ever touched on the panic path - i.e. when there is a bug in a `replacer` closure.
+/// So the `Mutex` is effectively never contended.
+///
+/// If the panic is caught (with `catch_unwind`) and the process kept alive, this leaks memory,
+/// because `Allocator`s are added to the `Vec`, but never removed, never freed.
+/// But panics should not be happening at all (and if they do, that's a bug and we'll fix it),
+/// so this is not a problem in practice.
+///
+/// No memory is leaked unless there's a panic in a `replacer` closure.
+///
+/// [`replace_with`]: ReplaceWith::replace_with
+#[expect(clippy::vec_box)]
+static DUMMY_ALLOCATORS: Mutex<StdVec<StdBox<Allocator>>> = Mutex::new(StdVec::new());
+
+/// Get a fresh [`Allocator`], dedicated to a single dummy, which lives for `'static`.
+///
+/// See [`DUMMY_ALLOCATORS`] for why each dummy needs its own `'static` allocator.
+fn fresh_dummy_allocator() -> &'static Allocator {
+    // `unwrap` can never fire here. `fresh_dummy_allocator` is only ever called from `PanicGuard::drop`,
+    // i.e. while unwinding from a `replacer` panic.
+    // The one operation below that could panic - `push` on capacity overflow - would therefore panic
+    // during an existing unwind, which is a double panic that aborts the process immediately.
+    // So the mutex can never be observed poisoned - anything that could poison it aborts first.
+    // Capacity overflow is unreachable anyway - the `Vec`'s reallocation OOMs and aborts long before
+    // ~`isize::MAX` entries.
+    let mut allocators = DUMMY_ALLOCATORS.lock().unwrap();
+
+    // Create an `Allocator` and store it in a `Box` in `DUMMY_ALLOCATORS`
+    allocators.push(StdBox::new(Allocator::new()));
+
+    // Get reference to the `Allocator` on the heap
+    let allocator = allocators.last().unwrap().as_ref();
+
+    // Extend `&Allocator`'s lifetime to `'static`.
+    // SAFETY: The `Allocator` is owned by `DUMMY_ALLOCATORS`, a `static` from which allocators
+    // are never removed, so it lives for `'static`. Growing the `Vec` later would move the `Box`
+    // but never moves its *contents* (the `Allocator` itself), so this reference remains valid.
+    unsafe { NonNull::from(allocator).as_ref() }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{
+        iter,
+        panic::{AssertUnwindSafe, catch_unwind},
+    };
+
+    use crate::{Allocator, Dummy, Vec};
+
+    use super::ReplaceWith;
+
+    #[test]
+    fn replace_with_wraps_old_value() {
+        let allocator = Allocator::default();
+        let allocator = &allocator;
+
+        let mut vec = Vec::from_iter_in([1u32, 2, 3], &allocator);
+        vec.replace_with(|old| {
+            // The closure receives the old value, not a dummy.
+            assert_eq!(&*old, &[1, 2, 3]);
+            // Build a new value out of the old one (prepend `0`).
+            Vec::from_iter_in(iter::once(0).chain(old), &allocator)
+        });
+        assert_eq!(&*vec, &[0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn replace_with_extracts_part_of_old_value() {
+        let allocator = Allocator::default();
+        let allocator = &allocator;
+
+        let mut vec = Vec::from_iter_in([10u32, 20, 30], &allocator);
+        // Keep just the first element of the old value.
+        vec.replace_with(|old| {
+            let first = old.into_iter().next().unwrap();
+            Vec::from_iter_in([first], &allocator)
+        });
+        assert_eq!(&*vec, &[10]);
+    }
+
+    #[test]
+    fn replace_with_identity_leaves_value_unchanged() {
+        let allocator = Allocator::default();
+        let allocator = &allocator;
+
+        let mut vec = Vec::from_iter_in([7u32], &allocator);
+        vec.replace_with(|old| old);
+        assert_eq!(&*vec, &[7]);
+    }
+
+    #[test]
+    fn replace_with_writes_dummy_on_panic() {
+        let allocator = Allocator::default();
+        let allocator = &allocator;
+
+        let mut vec = Vec::from_iter_in([1u32, 2, 3], &allocator);
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            vec.replace_with(|_old| panic!("boom"));
+        }));
+        assert!(result.is_err());
+
+        // The slot holds a fresh empty dummy - *not* a bitwise duplicate of the old value.
+        assert_eq!(&*vec, &[] as &[u32]);
+        // The dummy is fully usable: it has its own dedicated `'static` allocator, so it can grow.
+        vec.push(42);
+        assert_eq!(&*vec, &[42]);
+    }
+
+    /// A type holding a `&mut`. Duplicating a `&mut` is the classic way to make `replace_with` unsound.
+    /// This checks the panic guard prevents that - the guard replaces the slot with a dummy holding a *fresh* `&mut`,
+    /// so it never aliases the moved-out value.
+    struct RefHolder<'a>(&'a mut u64);
+
+    impl<'a> Dummy<'a> for RefHolder<'a> {
+        fn dummy(allocator: &'a Allocator) -> Self {
+            RefHolder(allocator.alloc(0u64))
+        }
+    }
+
+    impl<'a> ReplaceWith<'a> for RefHolder<'a> {}
+
+    #[test]
+    fn replace_with_mutating_through_moved_out_ref() {
+        let mut value = 10u64;
+        let mut holder = RefHolder(&mut value);
+
+        // Mutate through the moved-out reference, then put the same reference back.
+        holder.replace_with(|old| {
+            *old.0 += 1;
+            old
+        });
+        // The reference left in the slot is still valid and points at `value`.
+        *holder.0 += 100;
+
+        assert_eq!(value, 111);
+    }
+
+    #[test]
+    fn replace_with_swapping_in_a_different_ref() {
+        let mut a = 1u64;
+        let mut b = 2u64;
+
+        let mut holder = RefHolder(&mut a);
+        // Drop the old reference (to `a`) and store a reference to `b` instead.
+        holder.replace_with(|_old| RefHolder(&mut b));
+        *holder.0 += 40;
+
+        assert_eq!(a, 1);
+        assert_eq!(b, 42);
+    }
+}

--- a/crates/oxc_allocator/src/take_in.rs
+++ b/crates/oxc_allocator/src/take_in.rs
@@ -4,7 +4,14 @@ use crate::{Allocator, Box, GetAllocator, Vec};
 
 /// A trait to replace an existing AST node with a dummy.
 pub trait TakeIn<'a>: Dummy<'a> {
-    /// Replace node with a dummy.
+    /// Replace node with a dummy, and return the original.
+    ///
+    /// If you're taking the node out to build a new node from it and store the result back
+    /// in the same slot, prefer [`replace_with`]. `take_in` writes a dummy into the arena,
+    /// which takes up space there forever. `replace_with` avoids that (no dummy), so is faster
+    /// and uses less memory.
+    ///
+    /// [`replace_with`]: crate::ReplaceWith::replace_with
     #[must_use]
     fn take_in<A: GetAllocator<'a>>(&mut self, allocator_accessor: &A) -> Self {
         let allocator = allocator_accessor.allocator();
@@ -14,6 +21,13 @@ pub trait TakeIn<'a>: Dummy<'a> {
 
     /// Replace node with a dummy, allocate the original node into the arena,
     /// and return it as a [`Box<Self>`].
+    ///
+    /// If you're taking the node out to build a new node from it and store the result back
+    /// in the same slot, prefer [`replace_with`]. `take_in` writes a dummy into the arena,
+    /// which takes up space there forever. `replace_with` avoids that (no dummy), so is faster
+    /// and uses less memory.
+    ///
+    /// [`replace_with`]: crate::ReplaceWith::replace_with
     #[must_use]
     fn take_in_box<A: GetAllocator<'a>>(&mut self, allocator_accessor: &A) -> Box<'a, Self> {
         let allocator = allocator_accessor.allocator();

--- a/crates/oxc_ast_macros/src/generated/derived_traits.rs
+++ b/crates/oxc_ast_macros/src/generated/derived_traits.rs
@@ -9,6 +9,7 @@ pub fn get_trait_crate_and_generics(trait_name: &str) -> Option<(TokenStream, To
         "CloneIn" => (quote!(::oxc_allocator::CloneIn), quote!(< 'static >)),
         "Dummy" => (quote!(::oxc_allocator::Dummy), quote!(< 'static >)),
         "TakeIn" => (quote!(::oxc_allocator::TakeIn), quote!(< 'static >)),
+        "ReplaceWith" => (quote!(::oxc_allocator::ReplaceWith), quote!(< 'static >)),
         "GetAddress" => (quote!(::oxc_allocator::GetAddress), TokenStream::new()),
         "UnstableAddress" => (quote!(::oxc_allocator::UnstableAddress), TokenStream::new()),
         "GetSpan" => (quote!(::oxc_span::GetSpan), TokenStream::new()),

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -119,7 +119,14 @@ struct ModuleContentDependent<'a> {
     section_contents: SectionContents<'a>,
 }
 
-// Safety: dependent borrows from owner. They're safe to be sent together.
+// SAFETY: `dependent` borrows from `owner` (the `Allocator`). They're safe to send together.
+//
+// One case doesn't fit that "sent together" picture: `ReplaceWith`'s panic path (in `oxc_allocator`)
+// writes a dummy backed by its own dedicated, global `'static` allocator, which does not travel with
+// this bundle. Sending is still sound, because each such dummy allocator is exclusively owned -
+// reachable only through the single value that holds it, and mutated only via `&mut` to that value -
+// so no two threads can touch one. The invariant this really rests on is single-ownership of each
+// referenced allocator, not co-location.
 unsafe impl Send for ModuleContent<'_> {}
 
 /// source text and semantic for each source section. They are in the same order as `ProcessedModule.section_module_records`

--- a/crates/oxc_semantic/src/scoping.rs
+++ b/crates/oxc_semantic/src/scoping.rs
@@ -257,8 +257,15 @@ mod scoping_cell {
         }
     }
 
-    /// SAFETY: `ScopingCell` can be `Send` because both the `Allocator` and `Vec`s / `HashMap`s
-    /// storing their data in that `Allocator` are moved to another thread together.
+    /// SAFETY: `ScopingCell` can be `Send` because both the `Allocator`, and the `Vec`s / `HashMap`s
+    /// storing their data in that `Allocator`, are moved to another thread together.
+    ///
+    /// One case doesn't fit that "moved together" picture: `ReplaceWith`'s panic path (in `oxc_allocator`)
+    /// writes a dummy backed by its own dedicated, global `'static` allocator, which does *not* travel
+    /// with this bundle. Sending is still sound, because each such dummy allocator is exclusively owned -
+    /// reachable only through the single value that holds it, and mutated only via `&mut` to that value -
+    /// so no two threads can ever touch one. The invariant this impl really rests on is single-ownership
+    /// of each referenced allocator, not co-location.
     unsafe impl Send for ScopingCell {}
 
     /// SAFETY: `ScopingCell` can be `Sync` if `ScopingInner` is `Sync`, because `ScopingCell` provides

--- a/tasks/ast_tools/src/derives/mod.rs
+++ b/tasks/ast_tools/src/derives/mod.rs
@@ -20,6 +20,7 @@ mod dummy;
 pub mod estree;
 mod get_address;
 mod get_span;
+mod replace_with;
 mod take_in;
 mod unstable_address;
 
@@ -29,6 +30,7 @@ pub use dummy::DeriveDummy;
 pub use estree::DeriveESTree;
 pub use get_address::DeriveGetAddress;
 pub use get_span::{DeriveGetSpan, DeriveGetSpanMut};
+pub use replace_with::DeriveReplaceWith;
 pub use take_in::DeriveTakeIn;
 pub use unstable_address::DeriveUnstableAddress;
 

--- a/tasks/ast_tools/src/derives/replace_with.rs
+++ b/tasks/ast_tools/src/derives/replace_with.rs
@@ -1,0 +1,46 @@
+//! Derive for `ReplaceWith` trait.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+
+use crate::schema::{Def, Schema};
+
+use super::{Derive, StructOrEnum, define_derive};
+
+/// Derive for `ReplaceWith` trait.
+pub struct DeriveReplaceWith;
+
+define_derive!(DeriveReplaceWith);
+
+impl Derive for DeriveReplaceWith {
+    fn trait_name(&self) -> &'static str {
+        "ReplaceWith"
+    }
+
+    fn trait_has_lifetime(&self) -> bool {
+        true
+    }
+
+    fn crate_name(&self) -> &'static str {
+        "oxc_allocator"
+    }
+
+    fn prelude(&self) -> TokenStream {
+        quote! {
+            use oxc_allocator::ReplaceWith;
+        }
+    }
+
+    fn derive(&self, type_def: StructOrEnum, schema: &Schema) -> TokenStream {
+        let ty = type_def.ty(schema);
+        if type_def.has_lifetime(schema) {
+            quote! {
+                impl<'a> ReplaceWith<'a> for #ty {}
+            }
+        } else {
+            quote! {
+                impl ReplaceWith<'_> for #ty {}
+            }
+        }
+    }
+}

--- a/tasks/ast_tools/src/main.rs
+++ b/tasks/ast_tools/src/main.rs
@@ -248,6 +248,7 @@ const DERIVES: &[&(dyn Derive + Sync)] = &[
     &derives::DeriveCloneIn,
     &derives::DeriveDummy,
     &derives::DeriveTakeIn,
+    &derives::DeriveReplaceWith,
     &derives::DeriveGetAddress,
     &derives::DeriveUnstableAddress,
     &derives::DeriveGetSpan,


### PR DESCRIPTION
## The problem

A common pattern we have when mutating an AST (e.g. in transformer) is:

- Take a node from the AST.
- Wrap it in some other node, or extract a field from that node.
- Write the result back into the same place in AST the original came from.

Rust does not make this easy, due to aliasing rules. Currently we do something like this (example from arrow function transform):

```rs
let Statement::ExpressionStatement(expr_stmt) = match stmt else { unreachable!() };
let expr = expr_stmt.expression.take_in(ctx);
*stmt = Statement::new_return_statement(expr.span(), Some(expr), ctx);
```

The problem with this is that `take_in` writes a dummy `Expression` into the AST, in order to get the owned `Expression`. This is pointless, as the whole `Statement` that contains that dummy `Expression` is overwritten in the next line - the dummy is immediately disconnected from the AST. But that dummy node lives on forever in the arena, consuming memory.

## Solution in this PR

Introduce `ReplaceWith` trait which replaces the node in place, without writing a dummy:

```rs
stmt.replace_with(|stmt| {
    let Statement::ExpressionStatement(expr_stmt) = stmt else { unreachable!() };
    let expr = expr_stmt.unbox().expression;
    Statement::new_return_statement(expr.span(), Some(expr), ctx)
});
```

The closure receives an owned copy of the `Statement`, and can do whatever it needs to with it. The closure has to return a new `Statement` which is written to the "hole" the original came from.

This PR only adds the trait. Later PRs in this stack implement the trait on AST types, and then use it in various crates.

## Implementation

The difficulty is in making this sound even if the closure panics, and `std::panic::catch_unwind` is in use, allowing the old value to be observed.

A naive implementation would allow UB as follows:

```rs
use std::panic::{AssertUnwindSafe, catch_unwind};
use oxc_allocator::{Allocator, ArenaBox, ReplaceWith};

let allocator = Allocator::new();
let allocator = &allocator;

let mut boxed: ArenaBox<u32> = ArenaBox::new_in(1, &allocator);
let mut copy: Option<ArenaBox<u32>> = None;

let _ = catch_unwind(AssertUnwindSafe(|| {
    boxed.replace_with(|old| {
        // Move the copy out of the closure
        copy = Some(old);
        panic!("Unwind before write-back");
    });
}));

let mut copy: ArenaBox<u32> = copy.unwrap();
let boxed_mut: &mut u32 = boxed.as_mut();
let copy_mut: &mut u32 = copy.as_mut();
// `boxed_mut` and `copy_mut` both point to same `u32`.
// We have 2 `&mut u32`s pointing to same place. Aliasing violation!
*boxed_mut = 2;
*copy_mut = 3;
```

The solution is to make it possible to implement `ReplaceWith` only on types that also implement `Dummy`.

If the closure panics, a guard is triggered which writes a dummy into the original slot which the type was moved out of. This happens before any other code can observe the value in the slot.

To keep the API ergonomic, we don't want to have to pass in an `&Allocator` to `replace_with`. But the dummy has to be allocated *somewhere*. So we use a global store of `Allocator`s, stored in a `static`, which live for the entire life of the process. When a panic occurs, a new `Allocator` is created, and the dummy is allocated in it.

This is a memory leak - the `Allocator` containing the dummy will never be freed until the process exits.

However, in practice this is fine, because:

#### 1. It shouldn't happen

The guard only triggers, and these leaked `Allocator`s are only created, if the closure panics - which it never should. If the closure *does* panic, that's a bug, and we'll aim to fix it swiftly.

#### 2. Panic usually exits process

It's unusual to use `catch_unwind`. Generally a panic is not caught and it causes the process to exit. So an `Allocator` can be leaked, but only for the few milliseconds before the process exits, and it's freed again.

#### 3. `panic = "abort"`

Oxc's apps (Oxlint, Oxfmt) and NAPI packages (`oxc-parser` etc) are compiled with `panic = "abort"`.

With `panic = "abort"`, panics are converted to process abort. In that case, the compiler sees that the guard can never fire. It removes the guard and all the code which creates `Allocator`s and allocates dummies into them. So all these mechanics are completely zero cost, and no leak ever occurs.
