### PR TITLE
feat(type_checker): discover tsconfig.json and enumerate project files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2632,7 +2632,7 @@ dependencies = [
  "oxc_resolver",
  "oxc_semantic",
  "oxc_span",
- "rustc-hash 2.1.2",
+ "rustc-hash",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -651,7 +651,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2345,9 +2345,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_resolver"
-version = "11.22.0"
+version = "11.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a73a86454f0d1c18deb29396e0eb2a932b552f710d13e42f6536321d1f1326d8"
+checksum = "136a61141e3b45c8e5388464cbd85dc0e0437b79d6e496803f47210386cf18ea"
 dependencies = [
  "cfg-if",
  "compact_str",
@@ -2621,13 +2621,18 @@ dependencies = [
 name = "oxc_type_checker"
 version = "0.138.0"
 dependencies = [
+ "bpaf",
+ "cow-utils",
+ "indexmap",
  "oxc_allocator",
  "oxc_ast",
  "oxc_ast_visit",
  "oxc_diagnostics",
  "oxc_parser",
+ "oxc_resolver",
  "oxc_semantic",
  "oxc_span",
+ "rustc-hash 2.1.2",
 ]
 
 [[package]]
@@ -3122,7 +3127,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3217,7 +3222,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3510,7 +3515,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3987,7 +3992,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,7 +178,7 @@ javascript-globals = "1.5.0" # JavaScript global definitions
 json-strip-comments = "3.1.0" # Strip JSON comments
 oxc-browserslist = "3.0.0" # Browser compatibility queries
 oxc_index = { version = "5.0.0", features = ["nonmax", "serde"] } # Type-safe indices
-oxc_resolver = "11.16.3" # Module resolution
+oxc_resolver = "11.23.0" # Module resolution
 oxc_sourcemap = "8.0.2" # Source map generation
 
 #

--- a/crates/oxc_type_checker/Cargo.toml
+++ b/crates/oxc_type_checker/Cargo.toml
@@ -26,8 +26,6 @@ description = "An experimental type checker for JavaScript and TypeScript (work 
 [lints]
 workspace = true
 
-[lib]
-test = false
 
 [[bin]]
 name = "oxc_tsc"

--- a/crates/oxc_type_checker/Cargo.toml
+++ b/crates/oxc_type_checker/Cargo.toml
@@ -29,12 +29,24 @@ workspace = true
 [lib]
 test = false
 
+[[bin]]
+name = "oxc_tsc"
+path = "src/main.rs"
+test = false
+doctest = false
+
 [dependencies]
 oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }
 oxc_diagnostics = { workspace = true }
+oxc_resolver = { workspace = true }
 oxc_semantic = { workspace = true }
 oxc_span = { workspace = true }
+
+bpaf = { workspace = true, features = ["derive"] }
+cow-utils = { workspace = true }
+indexmap = { workspace = true }
+rustc-hash = { workspace = true }
 
 [dev-dependencies]
 oxc_allocator = { workspace = true }

--- a/crates/oxc_type_checker/src/extension.rs
+++ b/crates/oxc_type_checker/src/extension.rs
@@ -1,0 +1,41 @@
+//! Ported from typescript-go `internal/tspath/extension.go`.
+//!
+//! Dotted extension constants and the *grouped* priority arrays used when enumerating
+//! project files. Grouping encodes extension precedence: within a group an earlier
+//! extension shadows a later one for the same basename (e.g. `.ts` over `.d.ts`/`.js`),
+//! while different groups (`.cts` vs `.ts`) are independent.
+
+pub const EXTENSION_TS: &str = ".ts";
+pub const EXTENSION_TSX: &str = ".tsx";
+pub const EXTENSION_DTS: &str = ".d.ts";
+pub const EXTENSION_JS: &str = ".js";
+pub const EXTENSION_JSX: &str = ".jsx";
+pub const EXTENSION_JSON: &str = ".json";
+pub const EXTENSION_MJS: &str = ".mjs";
+pub const EXTENSION_MTS: &str = ".mts";
+pub const EXTENSION_DMTS: &str = ".d.mts";
+pub const EXTENSION_CJS: &str = ".cjs";
+pub const EXTENSION_CTS: &str = ".cts";
+pub const EXTENSION_DCTS: &str = ".d.cts";
+
+/// `AllSupportedExtensions`: TS + JS, grouped by priority.
+pub const ALL_SUPPORTED_EXTENSIONS: &[&[&str]] = &[
+    &[EXTENSION_TS, EXTENSION_TSX, EXTENSION_DTS, EXTENSION_JS, EXTENSION_JSX],
+    &[EXTENSION_CTS, EXTENSION_DCTS, EXTENSION_CJS],
+    &[EXTENSION_MTS, EXTENSION_DMTS, EXTENSION_MJS],
+];
+
+/// `SupportedTSExtensions`: TS only, grouped by priority.
+pub const SUPPORTED_TS_EXTENSIONS: &[&[&str]] = &[
+    &[EXTENSION_TS, EXTENSION_TSX, EXTENSION_DTS],
+    &[EXTENSION_CTS, EXTENSION_DCTS],
+    &[EXTENSION_MTS, EXTENSION_DMTS],
+];
+
+/// The extra priority group appended when `resolveJsonModule` is enabled.
+pub const JSON_GROUP: &[&str] = &[EXTENSION_JSON];
+
+/// Flatten grouped extension arrays into a single ordered list.
+pub fn flatten(groups: &[&'static [&'static str]]) -> Vec<&'static str> {
+    groups.iter().flat_map(|group| group.iter().copied()).collect()
+}

--- a/crates/oxc_type_checker/src/fold.rs
+++ b/crates/oxc_type_checker/src/fold.rs
@@ -1,0 +1,156 @@
+//! Unicode case-folding primitives matching the Go standard library functions tsgo uses.
+//!
+//! tsgo leans on three distinct Go behaviors, each with its own quirks, so each gets a
+//! dedicated port here rather than approximating all of them with one lowercase pass:
+//!
+//! - [`to_file_name_lower_case`] — `tspath.ToFileNameLowerCase`, canonical dedup keys.
+//! - [`str_fold_eq`] — `strings.EqualFold`, the matcher's case-insensitive equality.
+//! - [`compare_case_insensitive`] — `stringutil.CompareStringsCaseInsensitive`, sort order.
+
+use std::cmp::Ordering;
+
+use cow_utils::CowUtils;
+
+/// U+0130 LATIN CAPITAL LETTER I WITH DOT ABOVE. Its lowercase form (`i` + combining dot)
+/// has its own uppercase form, so tsgo keeps it un-lowered in canonical file names, and its
+/// case-fold orbit contains only itself.
+const CAPITAL_I_WITH_DOT: char = '\u{0130}';
+/// U+0131 LATIN SMALL LETTER DOTLESS I. Like U+0130, it case-folds only to itself.
+const SMALL_DOTLESS_I: char = '\u{0131}';
+
+/// The single-character lowercase mapping (Go `unicode.ToLower`).
+///
+/// Rust's `char::to_lowercase` is the *full* mapping, which differs from the simple one
+/// only for U+0130 (two chars); callers that reach this either exclude U+0130 or want its
+/// first char (`i`), which equals the simple mapping.
+fn simple_lower(c: char) -> char {
+    c.to_lowercase().next().unwrap_or(c)
+}
+
+/// Port of tsgo `tspath.ToFileNameLowerCase`: lowercase for canonical file-name keys,
+/// leaving U+0130 untouched (its lowercase form can coexist with it on disk).
+pub fn to_file_name_lower_case(file_name: &str) -> String {
+    if file_name.is_ascii() {
+        return file_name.cow_to_ascii_lowercase().into_owned();
+    }
+    file_name.chars().map(|c| if c == CAPITAL_I_WITH_DOT { c } else { simple_lower(c) }).collect()
+}
+
+/// Port of Go `strings.EqualFold` (simple Unicode case-folding) for a single char pair.
+fn chars_fold_eq(a: char, b: char) -> bool {
+    if a == b {
+        return true;
+    }
+    if a.is_ascii() && b.is_ascii() {
+        return a.eq_ignore_ascii_case(&b);
+    }
+    // The Turkish dotted/dotless i fold only to themselves (Go SimpleFold orbit of one).
+    if matches!(a, CAPITAL_I_WITH_DOT | SMALL_DOTLESS_I)
+        || matches!(b, CAPITAL_I_WITH_DOT | SMALL_DOTLESS_I)
+    {
+        return false;
+    }
+    if simple_lower(a) == simple_lower(b) {
+        return true;
+    }
+    // Same simple uppercase catches orbits the lowercase map misses (σ/ς, µ/μ). Skip
+    // multi-char (full-only) uppercase expansions like ß -> SS, which simple folding
+    // does not equate.
+    let mut ua = a.to_uppercase();
+    let mut ub = b.to_uppercase();
+    match (ua.next(), ua.next(), ub.next(), ub.next()) {
+        (Some(x), None, Some(y), None) => x == y,
+        _ => false,
+    }
+}
+
+/// Port of Go `strings.EqualFold`: char-wise simple case-folded equality.
+pub fn str_fold_eq(a: &str, b: &str) -> bool {
+    if a == b {
+        return true;
+    }
+    if a.is_ascii() && b.is_ascii() {
+        return a.eq_ignore_ascii_case(b);
+    }
+    let mut ca = a.chars();
+    let mut cb = b.chars();
+    loop {
+        match (ca.next(), cb.next()) {
+            (None, None) => return true,
+            (Some(x), Some(y)) if chars_fold_eq(x, y) => {}
+            _ => return false,
+        }
+    }
+}
+
+/// Byte-safe case-folded suffix test: `false` when `suffix`'s byte length lands inside a
+/// multi-byte char of `s` (mirroring Go, where the byte slice then fails `EqualFold`).
+pub fn has_suffix_fold(s: &str, suffix: &str) -> bool {
+    s.len() >= suffix.len()
+        && s.get(s.len() - suffix.len()..).is_some_and(|tail| str_fold_eq(tail, suffix))
+}
+
+/// Port of tsgo `stringutil.CompareStringsCaseInsensitive`: char-wise comparison of the
+/// simple-lowercased chars (here U+0130 *does* lower to `i`, unlike the canonical key).
+pub fn compare_case_insensitive(a: &str, b: &str) -> Ordering {
+    if a == b {
+        return Ordering::Equal;
+    }
+    let mut ca = a.chars();
+    let mut cb = b.chars();
+    loop {
+        match (ca.next(), cb.next()) {
+            (None, None) => return Ordering::Equal,
+            (None, Some(_)) => return Ordering::Less,
+            (Some(_), None) => return Ordering::Greater,
+            (Some(x), Some(y)) => match simple_lower(x).cmp(&simple_lower(y)) {
+                Ordering::Equal => {}
+                unequal => return unequal,
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn file_name_lower_case() {
+        assert_eq!(to_file_name_lower_case("/User/JOSÉ/X.ts"), "/user/josé/x.ts");
+        assert_eq!(to_file_name_lower_case("/a/Σ.ts"), "/a/σ.ts");
+        // U+0130 is kept; ASCII around it still lowers.
+        assert_eq!(to_file_name_lower_case("A\u{0130}B"), "a\u{0130}b");
+    }
+
+    #[test]
+    fn fold_eq() {
+        assert!(str_fold_eq("Ä.ts", "ä.ts"));
+        assert!(str_fold_eq("σ", "ς"));
+        assert!(str_fold_eq("Σ", "ς"));
+        assert!(str_fold_eq("µ", "μ"));
+        assert!(str_fold_eq("\u{212A}", "k")); // Kelvin sign
+        assert!(str_fold_eq("ſ", "S")); // long s
+        assert!(!str_fold_eq("ß", "SS")); // simple folding, not full
+        assert!(str_fold_eq("ß", "ẞ"));
+        assert!(!str_fold_eq("\u{0130}", "i"));
+        assert!(!str_fold_eq("\u{0131}", "I"));
+        assert!(!str_fold_eq("a", "ab"));
+    }
+
+    #[test]
+    fn suffix_fold() {
+        assert!(has_suffix_fold("lib.MIN.js", ".min.js"));
+        // 12 bytes; the last-7-bytes window starts inside the emoji -> no match, no panic.
+        assert!(!has_suffix_fold("abcd🎉xxxx", ".min.js"));
+        assert!(!has_suffix_fold("x", ".min.js"));
+    }
+
+    #[test]
+    fn case_insensitive_compare() {
+        assert_eq!(compare_case_insensitive("a", "B"), Ordering::Less);
+        assert_eq!(compare_case_insensitive("Ä", "ä"), Ordering::Equal);
+        // U+0130 lowers to plain `i` here, per Go unicode.ToLower.
+        assert_eq!(compare_case_insensitive("\u{0130}", "i"), Ordering::Equal);
+    }
+}

--- a/crates/oxc_type_checker/src/lib.rs
+++ b/crates/oxc_type_checker/src/lib.rs
@@ -59,12 +59,16 @@ use oxc_diagnostics::Diagnostics;
 use oxc_semantic::Semantic;
 
 mod diagnostics;
+mod fold;
 
 pub mod extension;
 pub mod project;
 pub mod tsconfig;
 pub mod tspath;
 pub mod vfsmatch;
+
+#[cfg(test)]
+mod tests;
 
 pub use crate::diagnostics::type_error;
 

--- a/crates/oxc_type_checker/src/lib.rs
+++ b/crates/oxc_type_checker/src/lib.rs
@@ -60,6 +60,12 @@ use oxc_semantic::Semantic;
 
 mod diagnostics;
 
+pub mod extension;
+pub mod project;
+pub mod tsconfig;
+pub mod tspath;
+pub mod vfsmatch;
+
 pub use crate::diagnostics::type_error;
 
 /// Options controlling how the [`TypeChecker`] behaves.

--- a/crates/oxc_type_checker/src/main.rs
+++ b/crates/oxc_type_checker/src/main.rs
@@ -1,0 +1,66 @@
+//! `oxc_tsc` — experimental CLI that discovers a `tsconfig.json` and prints the project's
+//! TypeScript files (the root files from the config's `files`/`include`/`exclude` specs).
+//!
+//! ```bash
+//! oxc_tsc                       # discover tsconfig.json from the current directory upward
+//! oxc_tsc -p path/to/tsconfig.json
+//! oxc_tsc -p path/to/dir        # uses <dir>/tsconfig.json
+//! ```
+#![expect(clippy::print_stdout, clippy::print_stderr)]
+
+use std::{
+    path::PathBuf,
+    process::{ExitCode, Termination},
+};
+
+use bpaf::Bpaf;
+use oxc_type_checker::project;
+
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Discover a tsconfig.json and list the project's files.
+#[derive(Debug, Clone, Bpaf)]
+#[bpaf(options, version(VERSION))]
+struct DiscoverCommand {
+    /// Path to a `tsconfig.json` file, or a directory containing one
+    #[bpaf(short('p'), long("project"), argument("PATH"))]
+    project: Option<PathBuf>,
+}
+
+enum RunResult {
+    Success,
+    Failed,
+}
+
+impl Termination for RunResult {
+    fn report(self) -> ExitCode {
+        match self {
+            Self::Success => ExitCode::SUCCESS,
+            Self::Failed => ExitCode::FAILURE,
+        }
+    }
+}
+
+fn main() -> RunResult {
+    let command = discover_command().run();
+
+    match project::discover(command.project.as_deref()) {
+        Ok(result) => {
+            for diagnostic in &result.diagnostics {
+                eprintln!("{diagnostic:?}");
+            }
+            // tsgo's internal order is literal -> wildcard -> json; sort for stable CLI output.
+            let mut files = result.files;
+            files.sort();
+            files.dedup();
+            for file in &files {
+                println!("{file}");
+            }
+            RunResult::Success
+        }
+        Err(error) => {
+            eprintln!("error: {error}");
+            RunResult::Failed
+        }
+    }
+}

--- a/crates/oxc_type_checker/src/main.rs
+++ b/crates/oxc_type_checker/src/main.rs
@@ -49,11 +49,9 @@ fn main() -> RunResult {
             for diagnostic in &result.diagnostics {
                 eprintln!("{diagnostic:?}");
             }
-            // tsgo's internal order is literal -> wildcard -> json; sort for stable CLI output.
-            let mut files = result.files;
-            files.sort();
-            files.dedup();
-            for file in &files {
+            // Print in tsgo's order (literal -> wildcard -> json), duplicates included,
+            // so the output can be diffed directly against `tsgo --showConfig`.
+            for file in &result.files {
                 println!("{file}");
             }
             RunResult::Success

--- a/crates/oxc_type_checker/src/project.rs
+++ b/crates/oxc_type_checker/src/project.rs
@@ -1,0 +1,165 @@
+//! Project discovery.
+//!
+//! Find the `tsconfig.json`, parse it via [`oxc_resolver`], and enumerate the project's files.
+//! Ports `findConfigFile` and the `-p`/`--project` resolution from typescript-go
+//! `internal/execute/tsc.go`.
+
+use std::{fmt, path::Path};
+
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_resolver::TsConfig;
+
+use crate::{
+    tsconfig::{CompilerOptionsView, ConfigFileSpecs},
+    tspath::TsPath,
+    vfsmatch::StdFs,
+};
+
+/// The outcome of discovering + enumerating a project.
+pub struct DiscoverResult {
+    /// Absolute path of the `tsconfig.json` that was loaded.
+    pub config_file: String,
+    /// Absolute, normalized paths of the project's files.
+    pub files: Vec<String>,
+    /// Diagnostics produced while validating the config's file specs.
+    pub diagnostics: Vec<OxcDiagnostic>,
+}
+
+/// Why discovery failed.
+#[derive(Debug)]
+pub enum DiscoverError {
+    /// `-p <dir>` was given but `<dir>/tsconfig.json` does not exist.
+    CannotFindTsconfigAt(String),
+    /// `-p <file>` was given but the file does not exist.
+    SpecifiedPathDoesNotExist(String),
+    /// No `tsconfig.json` was found walking up from the search directory.
+    NoConfigFound(String),
+    /// The config file could not be read.
+    Read(String),
+    /// The config file could not be parsed.
+    Parse(String),
+}
+
+impl fmt::Display for DiscoverError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::CannotFindTsconfigAt(path) => {
+                write!(f, "Cannot find a tsconfig.json file at the specified directory: '{path}'.")
+            }
+            Self::SpecifiedPathDoesNotExist(path) => {
+                write!(f, "The specified path does not exist: '{path}'.")
+            }
+            Self::NoConfigFound(path) => {
+                write!(f, "Cannot find a tsconfig.json file at the current directory: '{path}'.")
+            }
+            Self::Read(message) => write!(f, "{message}"),
+            Self::Parse(message) => write!(f, "failed to parse tsconfig.json: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for DiscoverError {}
+
+/// A resolved TypeScript project: an absolute `tsconfig.json` and its directory.
+pub struct Project {
+    config_file: String,
+    base_path: String,
+}
+
+impl Project {
+    /// Resolve which project to load (ports `internal/execute/tsc.go`).
+    ///
+    /// With `-p`/`--project`, a directory uses `<dir>/tsconfig.json` and a file is used as-is.
+    /// Otherwise `tsconfig.json` is discovered by walking up from `cwd`.
+    ///
+    /// # Errors
+    /// Fails if the `-p` target (or its `tsconfig.json`) does not exist, or if no `tsconfig.json`
+    /// is found walking up from `cwd`.
+    pub fn resolve(project: Option<&Path>, cwd: &str) -> Result<Self, DiscoverError> {
+        let config_file = Self::resolve_config_file_name(project, cwd)?;
+        let config_file = TsPath::from(config_file.as_str()).normalized_absolute(cwd).into_string();
+        let base_path = TsPath::from(config_file.as_str()).directory().into_string();
+        Ok(Self { config_file, base_path })
+    }
+
+    /// Absolute path of the resolved `tsconfig.json`.
+    pub fn config_file(&self) -> &str {
+        &self.config_file
+    }
+
+    /// Parse the config and enumerate the project's files.
+    ///
+    /// # Errors
+    /// Fails if the config file cannot be read or its JSON cannot be parsed.
+    pub fn load(&self) -> Result<DiscoverResult, DiscoverError> {
+        let text = std::fs::read_to_string(&self.config_file)
+            .map_err(|err| DiscoverError::Read(err.to_string()))?;
+        let path = Path::new(&self.config_file);
+        let tsconfig = TsConfig::parse(true, path, path, text)
+            .map_err(|err| DiscoverError::Parse(err.to_string()))?;
+        let options = CompilerOptionsView::from_resolver(&tsconfig.compiler_options);
+        let (specs, diagnostics) = ConfigFileSpecs::from_tsconfig(&tsconfig, &options);
+
+        let host = StdFs { use_case_sensitive_file_names: default_use_case_sensitive_file_names() };
+        let files = specs.file_names(&self.base_path, &options, &host);
+
+        Ok(DiscoverResult { config_file: self.config_file.clone(), files, diagnostics })
+    }
+
+    fn resolve_config_file_name(
+        project: Option<&Path>,
+        cwd: &str,
+    ) -> Result<String, DiscoverError> {
+        let Some(project) = project else {
+            let search_path = TsPath::from(cwd).normalized().into_string();
+            return Self::find_config_file(&search_path)
+                .ok_or(DiscoverError::NoConfigFound(search_path));
+        };
+
+        let file_or_directory =
+            TsPath::from(project.to_string_lossy().as_ref()).normalized().into_string();
+        if Path::new(&file_or_directory).is_dir() {
+            let config_file_name =
+                TsPath::from(file_or_directory.as_str()).combine(&["tsconfig.json"]).into_string();
+            if Path::new(&config_file_name).is_file() {
+                Ok(config_file_name)
+            } else {
+                Err(DiscoverError::CannotFindTsconfigAt(config_file_name))
+            }
+        } else if Path::new(&file_or_directory).is_file() {
+            Ok(file_or_directory)
+        } else {
+            Err(DiscoverError::SpecifiedPathDoesNotExist(file_or_directory))
+        }
+    }
+
+    /// Walk up from `search_path`, returning the first ancestor containing a `tsconfig.json`.
+    fn find_config_file(search_path: &str) -> Option<String> {
+        TsPath::from(search_path).for_each_ancestor(|ancestor| {
+            let config = TsPath::from(ancestor).combine(&["tsconfig.json"]).into_string();
+            Path::new(&config).is_file().then_some(config)
+        })
+    }
+}
+
+/// Discover and enumerate a project, using the current working directory.
+///
+/// # Errors
+/// Fails if the config file cannot be resolved (see [`Project::resolve`]) or loaded (see
+/// [`Project::load`]).
+pub fn discover(project: Option<&Path>) -> Result<DiscoverResult, DiscoverError> {
+    let cwd = current_directory();
+    Project::resolve(project, &cwd)?.load()
+}
+
+/// Whether the running platform's file system is case-sensitive (used as tsgo's
+/// `useCaseSensitiveFileNames`; a reasonable default, refined by an FS probe as a follow-up).
+fn default_use_case_sensitive_file_names() -> bool {
+    !cfg!(any(target_os = "macos", target_os = "windows"))
+}
+
+fn current_directory() -> String {
+    std::env::current_dir()
+        .map(|dir| TsPath::from_slashes(&dir.to_string_lossy()).into_string())
+        .unwrap_or_default()
+}

--- a/crates/oxc_type_checker/src/project.rs
+++ b/crates/oxc_type_checker/src/project.rs
@@ -1,13 +1,13 @@
 //! Project discovery.
 //!
-//! Find the `tsconfig.json`, parse it via [`oxc_resolver`], and enumerate the project's files.
-//! Ports `findConfigFile` and the `-p`/`--project` resolution from typescript-go
-//! `internal/execute/tsc.go`.
+//! Find the `tsconfig.json`, parse it (with `extends` chains resolved) via [`oxc_resolver`],
+//! and enumerate the project's files. Ports `findConfigFile` and the `-p`/`--project`
+//! resolution from typescript-go `internal/execute/tsc.go`.
 
-use std::{fmt, path::Path};
+use std::{fmt, path::Path, sync::Arc, sync::OnceLock};
 
 use oxc_diagnostics::OxcDiagnostic;
-use oxc_resolver::TsConfig;
+use oxc_resolver::{ResolveError, ResolveOptions, Resolver, TsConfig};
 
 use crate::{
     tsconfig::{CompilerOptionsView, ConfigFileSpecs},
@@ -28,13 +28,14 @@ pub struct DiscoverResult {
 /// Why discovery failed.
 #[derive(Debug)]
 pub enum DiscoverError {
-    /// `-p <dir>` was given but `<dir>/tsconfig.json` does not exist.
+    /// `-p <dir>` was given but `<dir>/tsconfig.json` does not exist. tsgo reuses the
+    /// "current directory" diagnostic (TS5081) here, with the joined config path.
     CannotFindTsconfigAt(String),
-    /// `-p <file>` was given but the file does not exist.
+    /// `-p <file>` was given but the file does not exist (TS5058).
     SpecifiedPathDoesNotExist(String),
-    /// No `tsconfig.json` was found walking up from the search directory.
+    /// No `tsconfig.json` was found walking up from the search directory (TS5081).
     NoConfigFound(String),
-    /// The config file could not be read.
+    /// The config file could not be read (TS5083).
     Read(String),
     /// The config file could not be parsed.
     Parse(String),
@@ -43,16 +44,13 @@ pub enum DiscoverError {
 impl fmt::Display for DiscoverError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::CannotFindTsconfigAt(path) => {
-                write!(f, "Cannot find a tsconfig.json file at the specified directory: '{path}'.")
+            Self::CannotFindTsconfigAt(path) | Self::NoConfigFound(path) => {
+                write!(f, "Cannot find a tsconfig.json file at the current directory: {path}.")
             }
             Self::SpecifiedPathDoesNotExist(path) => {
                 write!(f, "The specified path does not exist: '{path}'.")
             }
-            Self::NoConfigFound(path) => {
-                write!(f, "Cannot find a tsconfig.json file at the current directory: '{path}'.")
-            }
-            Self::Read(message) => write!(f, "{message}"),
+            Self::Read(path) => write!(f, "Cannot read file '{path}'."),
             Self::Parse(message) => write!(f, "failed to parse tsconfig.json: {message}"),
         }
     }
@@ -87,23 +85,43 @@ impl Project {
         &self.config_file
     }
 
-    /// Parse the config and enumerate the project's files.
+    /// Parse the config (resolving `extends` chains) and enumerate the project's files.
     ///
     /// # Errors
     /// Fails if the config file cannot be read or its JSON cannot be parsed.
     pub fn load(&self) -> Result<DiscoverResult, DiscoverError> {
-        let text = std::fs::read_to_string(&self.config_file)
-            .map_err(|err| DiscoverError::Read(err.to_string()))?;
-        let path = Path::new(&self.config_file);
-        let tsconfig = TsConfig::parse(true, path, path, text)
-            .map_err(|err| DiscoverError::Parse(err.to_string()))?;
-        let options = CompilerOptionsView::from_resolver(&tsconfig.compiler_options);
-        let (specs, diagnostics) = ConfigFileSpecs::from_tsconfig(&tsconfig, &options);
+        let tsconfig = self.parse_tsconfig()?;
+        let options =
+            CompilerOptionsView::from_resolver(&tsconfig.compiler_options, &self.base_path);
+        let (specs, mut diagnostics) =
+            ConfigFileSpecs::from_tsconfig(&tsconfig, &options, &self.base_path);
 
-        let host = StdFs { use_case_sensitive_file_names: default_use_case_sensitive_file_names() };
+        let host = StdFs { use_case_sensitive_file_names: use_case_sensitive_file_names() };
         let files = specs.file_names(&self.base_path, &options, &host);
+        if specs.should_report_no_input_files(&files) {
+            diagnostics.push(specs.no_inputs_diagnostic(&self.config_file));
+        }
 
         Ok(DiscoverResult { config_file: self.config_file.clone(), files, diagnostics })
+    }
+
+    /// Parse the config, resolving `extends`. If the `extends` chain cannot be resolved
+    /// (e.g. it names an uninstalled package), fall back to parsing this file alone —
+    /// tsgo reports the unresolvable base as a diagnostic but still enumerates files.
+    fn parse_tsconfig(&self) -> Result<Arc<TsConfig>, DiscoverError> {
+        let resolver = Resolver::new(ResolveOptions::default());
+        match resolver.resolve_tsconfig(Path::new(&self.config_file)) {
+            Ok(tsconfig) => Ok(tsconfig),
+            Err(ResolveError::Json(json_error)) => Err(DiscoverError::Parse(json_error.message)),
+            Err(_) => {
+                let text = std::fs::read_to_string(&self.config_file)
+                    .map_err(|_| DiscoverError::Read(self.config_file.clone()))?;
+                let path = Path::new(&self.config_file);
+                TsConfig::parse(true, path, path, text)
+                    .map(Arc::new)
+                    .map_err(|err| DiscoverError::Parse(err.to_string()))
+            }
+        }
     }
 
     fn resolve_config_file_name(
@@ -116,8 +134,10 @@ impl Project {
                 .ok_or(DiscoverError::NoConfigFound(search_path));
         };
 
+        // tsgo absolutizes the `-p` value against the current directory while parsing the
+        // command line (`--project` is an `IsFilePath` option), so `-p .` works.
         let file_or_directory =
-            TsPath::from(project.to_string_lossy().as_ref()).normalized().into_string();
+            TsPath::from(project.to_string_lossy().as_ref()).normalized_absolute(cwd).into_string();
         if Path::new(&file_or_directory).is_dir() {
             let config_file_name =
                 TsPath::from(file_or_directory.as_str()).combine(&["tsconfig.json"]).into_string();
@@ -152,13 +172,73 @@ pub fn discover(project: Option<&Path>) -> Result<DiscoverResult, DiscoverError>
     Project::resolve(project, &cwd)?.load()
 }
 
-/// Whether the running platform's file system is case-sensitive (used as tsgo's
-/// `useCaseSensitiveFileNames`; a reasonable default, refined by an FS probe as a follow-up).
-fn default_use_case_sensitive_file_names() -> bool {
-    !cfg!(any(target_os = "macos", target_os = "windows"))
+/// Whether the file system is case-sensitive, probed once like tsgo's `osvfs`: stat the
+/// running executable's path with its case swapped — if the swapped path does not exist,
+/// the file system is case-sensitive.
+fn use_case_sensitive_file_names() -> bool {
+    static USE_CASE_SENSITIVE: OnceLock<bool> = OnceLock::new();
+    *USE_CASE_SENSITIVE.get_or_init(probe_case_sensitivity)
 }
 
+fn probe_case_sensitivity() -> bool {
+    // win32/win64 are case insensitive platforms (tsgo hardcodes this too).
+    if cfg!(windows) {
+        return false;
+    }
+    let fallback = || !cfg!(target_os = "macos");
+    let Ok(exe) = std::env::current_exe() else {
+        return fallback();
+    };
+    let exe = exe.to_string_lossy();
+    let swapped = swap_case(&exe);
+    if swapped == exe {
+        // No letters to swap; tsgo would stat the identical path and conclude insensitive.
+        return false;
+    }
+    match std::fs::metadata(&swapped) {
+        Ok(_) => false,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => true,
+        // tsgo panics here; fall back to a per-OS default instead.
+        Err(_) => fallback(),
+    }
+}
+
+/// tsgo `swapCase`: upper-case every lower-case char and vice-versa (simple mappings only,
+/// so multi-char expansions like `ß` -> `SS` are left untouched, as in Go).
+fn swap_case(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            let mut upper = c.to_uppercase();
+            match (upper.next(), upper.next()) {
+                (Some(u), None) if u != c => u,
+                _ => {
+                    let mut lower = c.to_lowercase();
+                    match (lower.next(), lower.next()) {
+                        (Some(l), None) => l,
+                        _ => c,
+                    }
+                }
+            }
+        })
+        .collect()
+}
+
+/// The current working directory. Like Go's `os.Getwd` (which tsgo uses), this prefers the
+/// logical `$PWD` when it refers to the same directory as the physical one, preserving
+/// symlinked paths.
 fn current_directory() -> String {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+
+        if let Ok(pwd) = std::env::var("PWD")
+            && pwd.starts_with('/')
+            && let (Ok(logical), Ok(physical)) = (std::fs::metadata(&pwd), std::fs::metadata("."))
+            && (logical.dev(), logical.ino()) == (physical.dev(), physical.ino())
+        {
+            return TsPath::from_slashes(&pwd).into_string();
+        }
+    }
     std::env::current_dir()
         .map(|dir| TsPath::from_slashes(&dir.to_string_lossy()).into_string())
         .unwrap_or_default()

--- a/crates/oxc_type_checker/src/tests.rs
+++ b/crates/oxc_type_checker/src/tests.rs
@@ -1,0 +1,143 @@
+//! Behavior tests for the file-enumeration port, pinned against `tsgo` output.
+
+use rustc_hash::FxHashMap;
+
+use crate::vfsmatch::{Entries, FileSystemHost, read_directory};
+
+/// In-memory [`FileSystemHost`]: maps a directory path to its (immediate) files and subdirs.
+struct MemFs {
+    case_sensitive: bool,
+    dirs: FxHashMap<String, (Vec<String>, Vec<String>)>,
+}
+
+impl MemFs {
+    fn new(case_sensitive: bool, files: &[&str]) -> Self {
+        let mut dirs: FxHashMap<String, (Vec<String>, Vec<String>)> = FxHashMap::default();
+        for file in files {
+            let (mut dir, name) = file.rsplit_once('/').unwrap();
+            if dir.is_empty() {
+                dir = "/";
+            }
+            dirs.entry(dir.to_string()).or_default().0.push(name.to_string());
+            // Record each ancestor directory's child directory.
+            while let Some((parent, child)) = dir.rsplit_once('/') {
+                let parent = if parent.is_empty() { "/" } else { parent };
+                let subdirs = &mut dirs.entry(parent.to_string()).or_default().1;
+                if !subdirs.iter().any(|d| d == child) {
+                    subdirs.push(child.to_string());
+                }
+                if parent == "/" {
+                    break;
+                }
+                dir = parent;
+            }
+        }
+        for (files, subdirs) in dirs.values_mut() {
+            files.sort();
+            subdirs.sort();
+        }
+        Self { case_sensitive, dirs }
+    }
+}
+
+impl FileSystemHost for MemFs {
+    fn use_case_sensitive_file_names(&self) -> bool {
+        self.case_sensitive
+    }
+
+    fn get_accessible_entries(&self, dir: &str) -> Entries {
+        self.dirs.get(dir).map_or_else(Entries::default, |(files, dirs)| Entries {
+            files: files.clone(),
+            directories: dirs.clone(),
+            symlinks: None,
+        })
+    }
+
+    fn realpath(&self, path: &str) -> String {
+        path.to_string()
+    }
+}
+
+fn run(
+    fs: &MemFs,
+    root: &str,
+    extensions: &[&str],
+    excludes: &[&str],
+    includes: &[&str],
+    depth: usize,
+) -> Vec<String> {
+    let excludes: Vec<String> = excludes.iter().map(ToString::to_string).collect();
+    let includes: Vec<String> = includes.iter().map(ToString::to_string).collect();
+    read_directory(fs, root, root, extensions, &excludes, &includes, depth)
+}
+
+const TS: &[&str] = &[".ts"];
+
+/// Non-ASCII patterns and file names must fail to match, not panic (Go slices bytes and
+/// lets the comparison fail).
+#[test]
+fn non_ascii_wildcard_does_not_panic() {
+    let fs = MemFs::new(true, &["/p/src/🎉x.ts", "/p/src/aéx.ts"]);
+    assert_eq!(run(&fs, "/p", TS, &[], &["src/*éx.ts"], 0), ["/p/src/aéx.ts"]);
+
+    // `?` against a multi-byte char advances one char; mid-char literal windows fail.
+    let fs = MemFs::new(true, &["/p/src/é.ts", "/p/src/ab.ts"]);
+    assert_eq!(run(&fs, "/p", TS, &[], &["src/?.ts"], 0), ["/p/src/é.ts"]);
+
+    // Multi-byte name whose ".ts" suffix window is byte-aligned still matches.
+    let fs = MemFs::new(false, &["/p/src/abcd🎉xxxx.ts"]);
+    assert_eq!(run(&fs, "/p", TS, &[], &["src/*.ts"], 0), ["/p/src/abcd🎉xxxx.ts"]);
+}
+
+/// Case-insensitive matching uses Unicode simple folding, like Go's `strings.EqualFold`.
+#[test]
+fn unicode_case_folding() {
+    let fs = MemFs::new(false, &["/p/Ä.ts"]);
+    assert_eq!(run(&fs, "/p", TS, &[], &["ä.ts"], 0), ["/p/Ä.ts"]);
+    // Kelvin sign folds to `k`.
+    let fs = MemFs::new(false, &["/p/\u{212A}.ts"]);
+    assert_eq!(run(&fs, "/p", TS, &[], &["k.ts"], 0), ["/p/\u{212A}.ts"]);
+    // U+0130 folds only to itself.
+    let fs = MemFs::new(false, &["/p/\u{0130}.ts"]);
+    assert!(run(&fs, "/p", TS, &[], &["i.ts"], 0).is_empty());
+    // On a case-sensitive file system nothing folds.
+    let fs = MemFs::new(true, &["/p/Ä.ts"]);
+    assert!(run(&fs, "/p", TS, &[], &["ä.ts"], 0).is_empty());
+}
+
+/// `depth == 0` means unlimited (Go's signed decrement never re-reaches zero); `1` walks
+/// only the top level.
+#[test]
+fn depth_semantics() {
+    let files = &["/p/top.ts", "/p/sub/mid.ts", "/p/sub/deep/bot.ts"];
+    let fs = MemFs::new(true, files);
+    assert_eq!(run(&fs, "/p", TS, &[], &[], 0).len(), 3);
+    assert_eq!(run(&fs, "/p", TS, &[], &[], 1), ["/p/top.ts"]);
+    assert_eq!(run(&fs, "/p", TS, &[], &[], 2).len(), 2);
+    assert_eq!(run(&fs, "/p", TS, &[], &[], crate::vfsmatch::UNLIMITED_DEPTH).len(), 3);
+}
+
+/// A rooted include whose first component is a wildcard produces an empty include base
+/// path, which must dissolve into the walked root instead of walking `current_dir` and
+/// emitting mangled relative paths.
+#[test]
+fn rooted_wildcard_include_base_path() {
+    let fs = MemFs::new(true, &["/tmp/outside.ts", "/tmp/sub/mid.ts", "/tmp/sub/deep/bot.ts"]);
+    let includes = vec!["/**/*.ts".to_string()];
+    let files = read_directory(&fs, "/tmp", "/tmp/sub", TS, &[], &includes, 0);
+    assert_eq!(files, ["/tmp/sub/mid.ts", "/tmp/sub/deep/bot.ts"]);
+}
+
+/// `.min.js` is excluded from wildcard file matches unless the pattern mentions `.min.`,
+/// with Unicode-aware suffix detection when case-insensitive.
+#[test]
+fn min_js_exclusion() {
+    let js: &[&str] = &[".js"];
+    let fs = MemFs::new(false, &["/p/lib/a.js", "/p/lib/b.MIN.js"]);
+    assert_eq!(run(&fs, "/p", js, &[], &["lib/*.js"], 0), ["/p/lib/a.js"]);
+    assert_eq!(
+        run(&fs, "/p", js, &[], &["lib/*.min.js"], 0),
+        ["/p/lib/b.MIN.js"],
+        "explicit .min. pattern re-includes, case-folded"
+    );
+}

--- a/crates/oxc_type_checker/src/tsconfig.rs
+++ b/crates/oxc_type_checker/src/tsconfig.rs
@@ -1,0 +1,360 @@
+//! The file-enumeration half of typescript-go `internal/tsoptions/tsconfigparsing.go`.
+//!
+//! tsconfig *parsing* (JSONC, `extends`, `references`) is delegated to
+//! [`oxc_resolver::TsConfig`]; this module ports the parts `oxc_resolver` does not do:
+//! computing the default include/exclude specs, validating them, and expanding
+//! `files`/`include`/`exclude` into the concrete project file list (with extension-priority
+//! dedup) via [`crate::vfsmatch`].
+//!
+//! Not yet ported (follow-ups): `extends`-chain merging (so a config that inherits
+//! `include`/`exclude`/`files` from a base is not resolved yet) and `${configDir}`
+//! substitution in specs.
+
+use indexmap::IndexMap;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_resolver::{CompilerOptions, TsConfig};
+use rustc_hash::FxBuildHasher;
+
+use crate::{extension, tspath::TsPath, vfsmatch};
+
+const DEFAULT_INCLUDE_SPEC: &str = "**/*";
+
+/// Insertion-ordered map used to collect and dedup matched files, mirroring tsgo's
+/// `collections.OrderedMap`. Deletion uses `shift_remove` to preserve insertion order.
+type FileMap = IndexMap<String, String, FxBuildHasher>;
+
+/// The compiler options the file matcher cares about, resolved from
+/// [`oxc_resolver::CompilerOptions`].
+#[derive(Debug, Default, Clone)]
+pub struct CompilerOptionsView {
+    pub allow_js: bool,
+    pub resolve_json_module: bool,
+    pub out_dir: Option<String>,
+    pub declaration_dir: Option<String>,
+}
+
+impl CompilerOptionsView {
+    pub fn from_resolver(options: &CompilerOptions) -> Self {
+        // `allowJs` defaults to the value of `checkJs` (TS's `getAllowJSCompilerOption`).
+        let check_js = options.check_js.unwrap_or(false);
+        Self {
+            allow_js: options.allow_js.unwrap_or(check_js),
+            resolve_json_module: options.resolve_json_module.unwrap_or(false),
+            out_dir: options.out_dir.as_ref().map(|p| p.to_string_lossy().into_owned()),
+            declaration_dir: options
+                .declaration_dir
+                .as_ref()
+                .map(|p| p.to_string_lossy().into_owned()),
+        }
+    }
+
+    /// The supported extension priority groups (`.js` groups only when `allowJs`).
+    fn supported_extensions(&self) -> &'static [&'static [&'static str]] {
+        if self.allow_js {
+            extension::ALL_SUPPORTED_EXTENSIONS
+        } else {
+            extension::SUPPORTED_TS_EXTENSIONS
+        }
+    }
+
+    /// [`Self::supported_extensions`] plus a `.json` group when `resolveJsonModule` is on.
+    fn supported_extensions_with_json(&self) -> Vec<&'static [&'static str]> {
+        let mut extensions = self.supported_extensions().to_vec();
+        if self.resolve_json_module {
+            extensions.push(extension::JSON_GROUP);
+        }
+        extensions
+    }
+}
+
+/// Validated `files`/`include`/`exclude` specs, with defaults already applied.
+#[derive(Debug, Default, Clone)]
+#[expect(clippy::struct_field_names, reason = "names mirror tsgo's configFileSpecs fields")]
+pub struct ConfigFileSpecs {
+    pub validated_files_spec: Vec<String>,
+    pub validated_include_specs: Vec<String>,
+    pub validated_exclude_specs: Vec<String>,
+}
+
+impl ConfigFileSpecs {
+    /// Build the specs from a parsed tsconfig, applying tsgo's default include/exclude rules and
+    /// validating them. Returned diagnostics flag invalid specs.
+    pub fn from_tsconfig(
+        tsconfig: &TsConfig,
+        options: &CompilerOptionsView,
+    ) -> (Self, Vec<OxcDiagnostic>) {
+        let to_strings = |specs: &Vec<std::path::PathBuf>| -> Vec<String> {
+            specs.iter().map(|p| p.to_string_lossy().into_owned()).collect()
+        };
+        let files_spec = tsconfig.files.as_ref().map(&to_strings);
+        let mut include_specs = tsconfig.include.as_ref().map(&to_strings);
+        let mut exclude_specs = tsconfig.exclude.as_ref().map(&to_strings);
+
+        // When `exclude` is absent, default it to `outDir`/`declarationDir` (so build outputs are
+        // not re-included). `node_modules`/`bower_components`/`jspm_packages` are handled
+        // implicitly by the matcher, not here.
+        if exclude_specs.is_none() {
+            let mut values = Vec::new();
+            if let Some(out_dir) = &options.out_dir
+                && !out_dir.is_empty()
+            {
+                values.push(out_dir.clone());
+            }
+            if let Some(declaration_dir) = &options.declaration_dir
+                && !declaration_dir.is_empty()
+            {
+                values.push(declaration_dir.clone());
+            }
+            if !values.is_empty() {
+                exclude_specs = Some(values);
+            }
+        }
+
+        // When neither `files` nor `include` is present, default `include` to `**/*`.
+        if files_spec.is_none() && include_specs.is_none() {
+            include_specs = Some(vec![DEFAULT_INCLUDE_SPEC.to_string()]);
+        }
+
+        let mut diagnostics = Vec::new();
+        let mut validate = |specs: Option<Vec<String>>, disallow_trailing_recursion: bool| {
+            specs.map_or_else(Vec::new, |specs| {
+                let (validated, errors) = Self::validate_specs(&specs, disallow_trailing_recursion);
+                diagnostics.extend(errors);
+                validated
+            })
+        };
+        let validated_include_specs = validate(include_specs, true);
+        let validated_exclude_specs = validate(exclude_specs, false);
+
+        let specs = Self {
+            validated_files_spec: files_spec.unwrap_or_default(),
+            validated_include_specs,
+            validated_exclude_specs,
+        };
+        (specs, diagnostics)
+    }
+
+    /// Expand the specs into the concrete, absolute project file list, resolving relative specs
+    /// against `base_path` and walking the filesystem via `host`.
+    pub fn file_names(
+        &self,
+        base_path: &str,
+        options: &CompilerOptionsView,
+        host: &dyn vfsmatch::FileSystemHost,
+    ) -> Vec<String> {
+        FileExpander::new(options, host).expand(self, base_path)
+    }
+
+    fn validate_specs(
+        specs: &[String],
+        disallow_trailing_recursion: bool,
+    ) -> (Vec<String>, Vec<OxcDiagnostic>) {
+        let mut errors = Vec::new();
+        let mut final_specs = Vec::new();
+        for spec in specs {
+            if let Some(message) = Self::spec_to_diagnostic(spec, disallow_trailing_recursion) {
+                errors.push(OxcDiagnostic::error(message));
+            } else {
+                final_specs.push(spec.clone());
+            }
+        }
+        (final_specs, errors)
+    }
+
+    fn spec_to_diagnostic(spec: &str, disallow_trailing_recursion: bool) -> Option<String> {
+        if disallow_trailing_recursion && Self::invalid_trailing_recursion(spec) {
+            return Some(format!(
+                "File specification cannot end in a recursive directory wildcard ('**'): '{spec}'."
+            ));
+        }
+        if Self::invalid_dot_dot_after_recursive_wildcard(spec) {
+            return Some(format!(
+                "File specification cannot contain a parent directory ('..') that appears after a recursive directory wildcard ('**'): '{spec}'."
+            ));
+        }
+        None
+    }
+
+    fn invalid_trailing_recursion(spec: &str) -> bool {
+        // Matches `**`, `/**`, `**/`, and `/**/`, but not `a**b`.
+        let s = spec.strip_suffix('/').unwrap_or(spec);
+        s == "**" || s.ends_with("/**")
+    }
+
+    fn invalid_dot_dot_after_recursive_wildcard(s: &str) -> bool {
+        // True when some `/..` segment appears after some `**/` segment.
+        let wildcard_index = if s.starts_with("**/") { Some(0) } else { s.find("/**/") };
+        let Some(wildcard_index) = wildcard_index else {
+            return false;
+        };
+        let last_dot_index = if s.ends_with("/..") { Some(s.len()) } else { s.rfind("/../") };
+        last_dot_index.is_some_and(|last| last > wildcard_index)
+    }
+}
+
+/// Collects + de-duplicates the files matched by a project's specs. Mirrors the three ordered
+/// maps in tsgo's `getFileNamesFromConfigSpecs` (literal / wildcard / wildcard-json).
+struct FileExpander<'a> {
+    options: &'a CompilerOptionsView,
+    host: &'a dyn vfsmatch::FileSystemHost,
+    use_case_sensitive: bool,
+    /// Extension priority groups (no `.json`), used for the sibling-shadowing dedup.
+    supported_extensions: &'static [&'static [&'static str]],
+    literal: FileMap,
+    wildcard: FileMap,
+    wildcard_json: FileMap,
+}
+
+impl<'a> FileExpander<'a> {
+    fn new(options: &'a CompilerOptionsView, host: &'a dyn vfsmatch::FileSystemHost) -> Self {
+        Self {
+            options,
+            host,
+            use_case_sensitive: host.use_case_sensitive_file_names(),
+            supported_extensions: options.supported_extensions(),
+            literal: FileMap::default(),
+            wildcard: FileMap::default(),
+            wildcard_json: FileMap::default(),
+        }
+    }
+
+    /// Case-folded de-dup key for `value` (the file path or a raw spec).
+    fn key(&self, value: &str) -> String {
+        TsPath::from(value).canonical(self.use_case_sensitive)
+    }
+
+    /// Order mirrors tsgo: literal (`files`) entries first, then wildcard matches, then wildcard
+    /// `.json` matches. Literal files are always included and immune to include/exclude.
+    fn expand(mut self, specs: &ConfigFileSpecs, base_path: &str) -> Vec<String> {
+        let base_path = TsPath::from(base_path).normalized().into_string();
+
+        for file_name in &specs.validated_files_spec {
+            let file =
+                TsPath::from(file_name.as_str()).normalized_absolute(&base_path).into_string();
+            let key = self.key(file_name);
+            self.literal.insert(key, file);
+        }
+
+        if !specs.validated_include_specs.is_empty() {
+            let extensions_flat =
+                extension::flatten(&self.options.supported_extensions_with_json());
+            let files = vfsmatch::read_directory(
+                self.host,
+                &base_path,
+                &base_path,
+                &extensions_flat,
+                &specs.validated_exclude_specs,
+                &specs.validated_include_specs,
+                vfsmatch::UNLIMITED_DEPTH,
+            );
+
+            let json_matcher = self.json_matcher(specs, &base_path);
+            for file in files {
+                if TsPath::from(file.as_str()).file_extension_is(extension::EXTENSION_JSON) {
+                    self.include_json(json_matcher.as_ref(), file);
+                    continue;
+                }
+                if self.has_higher_priority_sibling(&file) {
+                    continue;
+                }
+                self.remove_lower_priority_siblings(&file);
+                let key = self.key(&file);
+                if !self.literal.contains_key(&key) && !self.wildcard.contains_key(&key) {
+                    self.wildcard.insert(key, file);
+                }
+            }
+        }
+
+        let mut result =
+            Vec::with_capacity(self.literal.len() + self.wildcard.len() + self.wildcard_json.len());
+        result.extend(self.literal.into_values());
+        result.extend(self.wildcard.into_values());
+        result.extend(self.wildcard_json.into_values());
+        result
+    }
+
+    /// The matcher for `.json` include specs (those explicitly ending in `.json`), if any.
+    fn json_matcher(
+        &self,
+        specs: &ConfigFileSpecs,
+        base_path: &str,
+    ) -> Option<vfsmatch::SpecMatcher> {
+        let json_includes: Vec<String> = specs
+            .validated_include_specs
+            .iter()
+            .filter(|include| include.ends_with(extension::EXTENSION_JSON))
+            .cloned()
+            .collect();
+        vfsmatch::SpecMatcher::new(
+            &json_includes,
+            base_path,
+            vfsmatch::Usage::Files,
+            self.use_case_sensitive,
+        )
+    }
+
+    /// Add a `.json` file if it matches a `.json` include spec.
+    fn include_json(&mut self, json_matcher: Option<&vfsmatch::SpecMatcher>, file: String) {
+        if json_matcher.and_then(|m| m.match_index(&file)).is_some() {
+            let key = self.key(&file);
+            if !self.literal.contains_key(&key) && !self.wildcard_json.contains_key(&key) {
+                self.wildcard_json.insert(key, file);
+            }
+        }
+    }
+
+    /// Whether a higher-priority-extension sibling of `file` was already included (so `file`
+    /// should be skipped). E.g. `foo.ts` shadows `foo.d.ts`/`foo.js` in the same directory.
+    fn has_higher_priority_sibling(&self, file: &str) -> bool {
+        let file_path = TsPath::from(file);
+        let extension_group = Self::matched_extension_group(&file_path, self.supported_extensions);
+        if extension_group.is_empty() {
+            return false;
+        }
+        for &ext in &extension_group {
+            // A `.d.ts` file also matches the `.ts` suffix; don't treat them as the same file.
+            if file_path.file_extension_is(ext)
+                && (ext != extension::EXTENSION_TS
+                    || !file_path.file_extension_is(extension::EXTENSION_DTS))
+            {
+                return false;
+            }
+            let sibling = self.key(file_path.change_extension(ext).as_str());
+            if self.literal.contains_key(&sibling) || self.wildcard.contains_key(&sibling) {
+                // LEGACY: a `.d.ts` may coexist with its `.js`/`.jsx` counterpart.
+                if ext == extension::EXTENSION_DTS
+                    && (file_path.file_extension_is(extension::EXTENSION_JS)
+                        || file_path.file_extension_is(extension::EXTENSION_JSX))
+                {
+                    continue;
+                }
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Remove already-included wildcard files with a lower extension priority than `file`.
+    fn remove_lower_priority_siblings(&mut self, file: &str) {
+        let file_path = TsPath::from(file);
+        let extension_group = Self::matched_extension_group(&file_path, self.supported_extensions);
+        for &ext in extension_group.iter().rev() {
+            if file_path.file_extension_is(ext) {
+                return;
+            }
+            let lower_priority = self.key(file_path.change_extension(ext).as_str());
+            self.wildcard.shift_remove(&lower_priority);
+        }
+    }
+
+    /// The concatenation of every priority group whose extensions `file` matches.
+    fn matched_extension_group<'e>(file: &TsPath, extensions: &[&'e [&'e str]]) -> Vec<&'e str> {
+        let mut group = Vec::new();
+        for &priority_group in extensions {
+            if file.file_extension_is_one_of(priority_group) {
+                group.extend_from_slice(priority_group);
+            }
+        }
+        group
+    }
+}

--- a/crates/oxc_type_checker/src/tsconfig.rs
+++ b/crates/oxc_type_checker/src/tsconfig.rs
@@ -1,14 +1,14 @@
 //! The file-enumeration half of typescript-go `internal/tsoptions/tsconfigparsing.go`.
 //!
-//! tsconfig *parsing* (JSONC, `extends`, `references`) is delegated to
-//! [`oxc_resolver::TsConfig`]; this module ports the parts `oxc_resolver` does not do:
-//! computing the default include/exclude specs, validating them, and expanding
-//! `files`/`include`/`exclude` into the concrete project file list (with extension-priority
-//! dedup) via [`crate::vfsmatch`].
+//! tsconfig *parsing* (JSONC, `extends` chains, `references`) is delegated to
+//! [`oxc_resolver`]; this module ports the parts `oxc_resolver` does not do: computing the
+//! default include/exclude specs, validating them, substituting `${configDir}`, and
+//! expanding `files`/`include`/`exclude` into the concrete project file list (with
+//! extension-priority dedup) via [`crate::vfsmatch`].
 //!
-//! Not yet ported (follow-ups): `extends`-chain merging (so a config that inherits
-//! `include`/`exclude`/`files` from a base is not resolved yet) and `${configDir}`
-//! substitution in specs.
+//! Known divergence from tsgo: relative `files`/`include`/`exclude` specs inherited from a
+//! base config in a *different directory* are not re-based against that base's directory
+//! (`oxc_resolver` merges them verbatim); same-directory `extends` is exact.
 
 use indexmap::IndexMap;
 use oxc_diagnostics::OxcDiagnostic;
@@ -18,6 +18,71 @@ use rustc_hash::FxBuildHasher;
 use crate::{extension, tspath::TsPath, vfsmatch};
 
 const DEFAULT_INCLUDE_SPEC: &str = "**/*";
+
+/// The `${configDir}` template variable (tsgo `configDirTemplate`).
+const CONFIG_DIR_TEMPLATE: &str = "${configDir}";
+
+/// tsgo `startsWithConfigDirTemplate`: a case-*insensitive* prefix check.
+fn starts_with_config_dir_template(value: &str) -> bool {
+    value
+        .get(..CONFIG_DIR_TEMPLATE.len())
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case(CONFIG_DIR_TEMPLATE))
+}
+
+/// tsgo `getSubstitutedPathWithConfigDirTemplate`: replace the first *exact-case*
+/// occurrence (so `${CONFIGDIR}/x` passes the prefix check but is left unreplaced,
+/// faithfully reproducing tsgo) and resolve against `base_path`.
+fn substitute_config_dir(value: &str, base_path: &str) -> String {
+    let replaced = match value.find(CONFIG_DIR_TEMPLATE) {
+        Some(index) => {
+            let mut out = String::with_capacity(value.len());
+            out.push_str(&value[..index]);
+            out.push_str("./");
+            out.push_str(&value[index + CONFIG_DIR_TEMPLATE.len()..]);
+            out
+        }
+        None => value.to_string(),
+    };
+    TsPath::from(replaced.as_str()).normalized_absolute(base_path).into_string()
+}
+
+fn substitute_config_dir_in_specs(specs: &mut [String], base_path: &str) {
+    for spec in specs {
+        if starts_with_config_dir_template(spec) {
+            *spec = substitute_config_dir(spec, base_path);
+        }
+    }
+}
+
+/// Compact JSON encoding of a string array, for the "No inputs were found" diagnostic
+/// (tsgo `core.StringifyJson`; HTML escaping of `<`/`>`/`&` is not reproduced).
+fn json_string_array(specs: &[String]) -> String {
+    use std::fmt::Write;
+
+    let mut out = String::from("[");
+    for (i, spec) in specs.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        out.push('"');
+        for c in spec.chars() {
+            match c {
+                '"' => out.push_str("\\\""),
+                '\\' => out.push_str("\\\\"),
+                '\n' => out.push_str("\\n"),
+                '\r' => out.push_str("\\r"),
+                '\t' => out.push_str("\\t"),
+                c if (c as u32) < 0x20 => {
+                    write!(out, "\\u{:04x}", c as u32).unwrap();
+                }
+                c => out.push(c),
+            }
+        }
+        out.push('"');
+    }
+    out.push(']');
+    out
+}
 
 /// Insertion-ordered map used to collect and dedup matched files, mirroring tsgo's
 /// `collections.OrderedMap`. Deletion uses `shift_remove` to preserve insertion order.
@@ -34,18 +99,44 @@ pub struct CompilerOptionsView {
 }
 
 impl CompilerOptionsView {
-    pub fn from_resolver(options: &CompilerOptions) -> Self {
-        // `allowJs` defaults to the value of `checkJs` (TS's `getAllowJSCompilerOption`).
+    pub fn from_resolver(options: &CompilerOptions, base_path: &str) -> Self {
+        // `allowJs` defaults to the value of `checkJs` (tsgo `GetAllowJS`).
         let check_js = options.check_js.unwrap_or(false);
+        // `${configDir}`-prefixed dirs are left untouched by `oxc_resolver` (everything
+        // else arrives absolutized); substitute them here (tsgo
+        // `handleOptionConfigDirTemplateSubstitution`).
+        let dir_option = |dir: Option<&std::path::PathBuf>| {
+            dir.map(|p| {
+                let s = TsPath::from_slashes(&p.to_string_lossy()).into_string();
+                if starts_with_config_dir_template(&s) {
+                    substitute_config_dir(&s, base_path)
+                } else {
+                    s
+                }
+            })
+        };
         Self {
             allow_js: options.allow_js.unwrap_or(check_js),
-            resolve_json_module: options.resolve_json_module.unwrap_or(false),
-            out_dir: options.out_dir.as_ref().map(|p| p.to_string_lossy().into_owned()),
-            declaration_dir: options
-                .declaration_dir
-                .as_ref()
-                .map(|p| p.to_string_lossy().into_owned()),
+            resolve_json_module: Self::effective_resolve_json_module(options),
+            out_dir: dir_option(options.out_dir.as_ref()),
+            declaration_dir: dir_option(options.declaration_dir.as_ref()),
         }
+    }
+
+    /// tsgo `GetResolveJsonModule`: an explicit value wins; otherwise `node20`/`nodenext`
+    /// modules resolve JSON, `node16`/`node18` do not, and every other module kind
+    /// (including unset, whose target-derived kinds are never `node*`) falls through to
+    /// the default bundler module resolution, which does.
+    ///
+    /// `oxc_resolver` does not expose `moduleResolution`, so an explicit non-bundler
+    /// override there is not honored yet.
+    fn effective_resolve_json_module(options: &CompilerOptions) -> bool {
+        options.resolve_json_module.unwrap_or_else(|| match options.module.as_deref() {
+            Some(module) => {
+                !module.eq_ignore_ascii_case("node16") && !module.eq_ignore_ascii_case("node18")
+            }
+            None => true,
+        })
     }
 
     /// The supported extension priority groups (`.js` groups only when `allowJs`).
@@ -69,19 +160,29 @@ impl CompilerOptionsView {
 
 /// Validated `files`/`include`/`exclude` specs, with defaults already applied.
 #[derive(Debug, Default, Clone)]
-#[expect(clippy::struct_field_names, reason = "names mirror tsgo's configFileSpecs fields")]
 pub struct ConfigFileSpecs {
     pub validated_files_spec: Vec<String>,
     pub validated_include_specs: Vec<String>,
     pub validated_exclude_specs: Vec<String>,
+    /// Raw `include` specs, with the `**/*` default applied (tsgo `includeSpecs`); used by
+    /// the "No inputs were found" diagnostic.
+    include_specs: Vec<String>,
+    /// Raw `exclude` specs, with the `outDir`/`declarationDir` default applied.
+    exclude_specs: Vec<String>,
+    /// tsgo `canJsonReportNoInputFiles`: neither `files` nor `references` was present.
+    /// (A present-but-empty `references: []` is indistinguishable from an absent one via
+    /// `oxc_resolver`, so it does not suppress the diagnostic as it would in tsgo.)
+    can_report_no_input_files: bool,
 }
 
 impl ConfigFileSpecs {
-    /// Build the specs from a parsed tsconfig, applying tsgo's default include/exclude rules and
-    /// validating them. Returned diagnostics flag invalid specs.
+    /// Build the specs from a parsed tsconfig, applying tsgo's default include/exclude rules,
+    /// validating them, and substituting `${configDir}`. Returned diagnostics flag invalid
+    /// specs and an empty `files` list.
     pub fn from_tsconfig(
         tsconfig: &TsConfig,
         options: &CompilerOptionsView,
+        base_path: &str,
     ) -> (Self, Vec<OxcDiagnostic>) {
         let to_strings = |specs: &Vec<std::path::PathBuf>| -> Vec<String> {
             specs.iter().map(|p| p.to_string_lossy().into_owned()).collect()
@@ -89,6 +190,20 @@ impl ConfigFileSpecs {
         let files_spec = tsconfig.files.as_ref().map(&to_strings);
         let mut include_specs = tsconfig.include.as_ref().map(&to_strings);
         let mut exclude_specs = tsconfig.exclude.as_ref().map(&to_strings);
+
+        let mut diagnostics = Vec::new();
+
+        // An explicitly empty `files` with nothing else to compile is an error (tsgo
+        // "The files list in config file is empty" check; TS18002).
+        if files_spec.as_ref().is_some_and(Vec::is_empty)
+            && tsconfig.references.is_empty()
+            && tsconfig.extends.is_none()
+        {
+            let config = TsPath::from_slashes(&tsconfig.path().to_string_lossy());
+            diagnostics.push(OxcDiagnostic::error(format!(
+                "The 'files' list in config file '{config}' is empty."
+            )));
+        }
 
         // When `exclude` is absent, default it to `outDir`/`declarationDir` (so build outputs are
         // not re-included). `node_modules`/`bower_components`/`jspm_packages` are handled
@@ -115,7 +230,10 @@ impl ConfigFileSpecs {
             include_specs = Some(vec![DEFAULT_INCLUDE_SPEC.to_string()]);
         }
 
-        let mut diagnostics = Vec::new();
+        let can_report_no_input_files = files_spec.is_none() && tsconfig.references.is_empty();
+        let raw_include_specs = include_specs.clone().unwrap_or_default();
+        let raw_exclude_specs = exclude_specs.clone().unwrap_or_default();
+
         let mut validate = |specs: Option<Vec<String>>, disallow_trailing_recursion: bool| {
             specs.map_or_else(Vec::new, |specs| {
                 let (validated, errors) = Self::validate_specs(&specs, disallow_trailing_recursion);
@@ -123,15 +241,40 @@ impl ConfigFileSpecs {
                 validated
             })
         };
-        let validated_include_specs = validate(include_specs, true);
-        let validated_exclude_specs = validate(exclude_specs, false);
+        let mut validated_files_spec = files_spec.unwrap_or_default();
+        let mut validated_include_specs = validate(include_specs, true);
+        let mut validated_exclude_specs = validate(exclude_specs, false);
+
+        // `${configDir}` substitution happens after validation, on the validated specs
+        // (tsgo `getSubstitutedStringArrayWithConfigDirTemplate` call sites).
+        substitute_config_dir_in_specs(&mut validated_files_spec, base_path);
+        substitute_config_dir_in_specs(&mut validated_include_specs, base_path);
+        substitute_config_dir_in_specs(&mut validated_exclude_specs, base_path);
 
         let specs = Self {
-            validated_files_spec: files_spec.unwrap_or_default(),
+            validated_files_spec,
             validated_include_specs,
             validated_exclude_specs,
+            include_specs: raw_include_specs,
+            exclude_specs: raw_exclude_specs,
+            can_report_no_input_files,
         };
         (specs, diagnostics)
+    }
+
+    /// tsgo `shouldReportNoInputFiles`: the expanded file list is empty and the config had
+    /// no `files` or `references` to justify that.
+    pub fn should_report_no_input_files(&self, file_names: &[String]) -> bool {
+        file_names.is_empty() && self.can_report_no_input_files
+    }
+
+    /// The TS18003 "No inputs were found" diagnostic for this config.
+    pub fn no_inputs_diagnostic(&self, config_file: &str) -> OxcDiagnostic {
+        OxcDiagnostic::error(format!(
+            "No inputs were found in config file '{config_file}'. Specified 'include' paths were '{}' and 'exclude' paths were '{}'.",
+            json_string_array(&self.include_specs),
+            json_string_array(&self.exclude_specs),
+        ))
     }
 
     /// Expand the specs into the concrete, absolute project file list, resolving relative specs

--- a/crates/oxc_type_checker/src/tspath.rs
+++ b/crates/oxc_type_checker/src/tspath.rs
@@ -10,6 +10,8 @@ use std::{borrow::Cow, fmt};
 
 use cow_utils::CowUtils;
 
+use crate::fold;
+
 /// Known extensions, longest declaration extensions first, used by [`TsPath::change_extension`].
 const EXTENSIONS_TO_REMOVE: &[&str] = &[
     ".d.ts", ".d.mts", ".d.cts", ".mjs", ".mts", ".cjs", ".cts", ".ts", ".js", ".tsx", ".jsx",
@@ -107,13 +109,13 @@ impl TsPath {
         Self::normalized_components_of(&combined)
     }
 
-    /// Case-folded key for de-duplication (ASCII approximation of tsgo's `ToFileNameLowerCase`,
-    /// which deliberately avoids lower-casing certain unicode chars).
+    /// Case-folded key for de-duplication (tsgo's `GetCanonicalFileName` /
+    /// `ToFileNameLowerCase`, which lowercases everything except U+0130).
     pub fn canonical(&self, use_case_sensitive_file_names: bool) -> String {
         if use_case_sensitive_file_names {
             self.0.clone()
         } else {
-            self.0.cow_to_ascii_lowercase().into_owned()
+            fold::to_file_name_lower_case(&self.0)
         }
     }
 
@@ -136,12 +138,17 @@ impl TsPath {
         TsPath(Self::change_any_extension(&self.0, new_extension, EXTENSIONS_TO_REMOVE))
     }
 
-    /// Whether `child` is contained within (or equal to) this path. The volume/root component is
-    /// always compared case-insensitively, matching tsgo. Both must already be absolute (tsgo
-    /// threads a `currentDirectory` through; the only caller here passes absolute base paths).
-    pub fn contains(&self, child: &str, use_case_sensitive_file_names: bool) -> bool {
-        let parent = Self::combine_into("", &[&self.0]);
-        let child = Self::combine_into("", &[child]);
+    /// Whether `child` is contained within (or equal to) this path (tsgo `ContainsPath`).
+    /// Relative inputs are resolved against `current_directory` first; the volume/root
+    /// component is always compared case-insensitively (Unicode fold), matching tsgo.
+    pub fn contains(
+        &self,
+        child: &str,
+        use_case_sensitive_file_names: bool,
+        current_directory: &str,
+    ) -> bool {
+        let parent = Self::combine_into(current_directory, &[&self.0]);
+        let child = Self::combine_into(current_directory, &[child]);
         if parent.is_empty() || child.is_empty() {
             return false;
         }
@@ -155,7 +162,7 @@ impl TsPath {
         }
         for (i, parent_component) in parent_components.iter().enumerate() {
             let equal = if i == 0 || !use_case_sensitive_file_names {
-                parent_component.eq_ignore_ascii_case(&child_components[i])
+                fold::str_fold_eq(parent_component, &child_components[i])
             } else {
                 *parent_component == child_components[i]
             };

--- a/crates/oxc_type_checker/src/tspath.rs
+++ b/crates/oxc_type_checker/src/tspath.rs
@@ -1,0 +1,407 @@
+//! Path utilities ported from typescript-go `internal/tspath/path.go` (POSIX + DOS + UNC
+//! subset — URL/untitled roots are omitted since tsconfig specs are filesystem paths).
+//!
+//! tsgo's free `Path` helpers are wrapped in a [`TsPath`] newtype (mirroring Go's `type Path`)
+//! so callers read as `path.directory().combine(&["tsconfig.json"])`. Trailing-separator
+//! preservation and the byte-scanner fast paths tsgo keeps for other callers are dropped: the
+//! matcher re-normalizes every spec, so the component-based results still match.
+
+use std::{borrow::Cow, fmt};
+
+use cow_utils::CowUtils;
+
+/// Known extensions, longest declaration extensions first, used by [`TsPath::change_extension`].
+const EXTENSIONS_TO_REMOVE: &[&str] = &[
+    ".d.ts", ".d.mts", ".d.cts", ".mjs", ".mts", ".cjs", ".cts", ".ts", ".js", ".tsx", ".jsx",
+    ".json",
+];
+
+/// A filesystem path with `/` separators; a thin newtype over `String` (tsgo's `type Path`).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+pub struct TsPath(String);
+
+impl From<&str> for TsPath {
+    fn from(path: &str) -> Self {
+        Self(path.to_string())
+    }
+}
+
+impl From<String> for TsPath {
+    fn from(path: String) -> Self {
+        Self(path)
+    }
+}
+
+impl fmt::Display for TsPath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<str> for TsPath {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl TsPath {
+    /// Build a path from an OS string, converting backslashes to forward slashes.
+    pub fn from_slashes(path: &str) -> Self {
+        Self(Self::to_slashes(path).into_owned())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_string(self) -> String {
+        self.0
+    }
+
+    /// Whether the path is rooted on a disk (POSIX `/`, DOS `c:/`, or UNC).
+    pub fn is_rooted(&self) -> bool {
+        Self::root_len(&self.0) != 0
+    }
+
+    pub fn has_trailing_separator(&self) -> bool {
+        Self::ends_with_separator(&self.0)
+    }
+
+    pub fn without_trailing_separator(&self) -> &str {
+        Self::trim_trailing_separator(&self.0)
+    }
+
+    /// Combine with more path segments. An absolute segment replaces the accumulated result;
+    /// relative ones are appended. Slashes are normalized but `.`/`..` are not resolved.
+    #[must_use]
+    pub fn combine(&self, paths: &[&str]) -> TsPath {
+        TsPath(Self::combine_into(&self.0, paths))
+    }
+
+    /// Leading portion up to (but not including) the last directory separator.
+    #[must_use]
+    pub fn directory(&self) -> TsPath {
+        TsPath(Self::dir_of(&self.0))
+    }
+
+    /// Trailing file name after the last separator, without any trailing separator.
+    pub fn base_name(&self) -> String {
+        Self::base_of(&self.0)
+    }
+
+    /// Normalize `.`/`..` and slashes.
+    #[must_use]
+    pub fn normalized(&self) -> TsPath {
+        TsPath(Self::normalized_absolute_of(&self.0, ""))
+    }
+
+    /// Resolve against `current_directory` into a normalized absolute path.
+    #[must_use]
+    pub fn normalized_absolute(&self, current_directory: &str) -> TsPath {
+        TsPath(Self::normalized_absolute_of(&self.0, current_directory))
+    }
+
+    /// The normalized path components (root first) after resolving against `current_directory`.
+    pub fn normalized_components(&self, current_directory: &str) -> Vec<String> {
+        let combined = Self::combine_into(current_directory, &[&self.0]);
+        Self::normalized_components_of(&combined)
+    }
+
+    /// Case-folded key for de-duplication (ASCII approximation of tsgo's `ToFileNameLowerCase`,
+    /// which deliberately avoids lower-casing certain unicode chars).
+    pub fn canonical(&self, use_case_sensitive_file_names: bool) -> String {
+        if use_case_sensitive_file_names {
+            self.0.clone()
+        } else {
+            self.0.cow_to_ascii_lowercase().into_owned()
+        }
+    }
+
+    pub fn file_extension_is(&self, extension: &str) -> bool {
+        self.0.len() > extension.len() && self.0.ends_with(extension)
+    }
+
+    pub fn file_extension_is_one_of(&self, extensions: &[&str]) -> bool {
+        extensions.iter().any(|ext| self.file_extension_is(ext))
+    }
+
+    /// Whether the base name contains a `.`.
+    pub fn has_extension(&self) -> bool {
+        Self::base_of(&self.0).contains('.')
+    }
+
+    /// Replace the path's known extension with `new_extension`.
+    #[must_use]
+    pub fn change_extension(&self, new_extension: &str) -> TsPath {
+        TsPath(Self::change_any_extension(&self.0, new_extension, EXTENSIONS_TO_REMOVE))
+    }
+
+    /// Whether `child` is contained within (or equal to) this path. The volume/root component is
+    /// always compared case-insensitively, matching tsgo. Both must already be absolute (tsgo
+    /// threads a `currentDirectory` through; the only caller here passes absolute base paths).
+    pub fn contains(&self, child: &str, use_case_sensitive_file_names: bool) -> bool {
+        let parent = Self::combine_into("", &[&self.0]);
+        let child = Self::combine_into("", &[child]);
+        if parent.is_empty() || child.is_empty() {
+            return false;
+        }
+        if parent == child {
+            return true;
+        }
+        let parent_components = Self::reduce_components(&Self::components_of(&parent, ""));
+        let child_components = Self::reduce_components(&Self::components_of(&child, ""));
+        if child_components.len() < parent_components.len() {
+            return false;
+        }
+        for (i, parent_component) in parent_components.iter().enumerate() {
+            let equal = if i == 0 || !use_case_sensitive_file_names {
+                parent_component.eq_ignore_ascii_case(&child_components[i])
+            } else {
+                *parent_component == child_components[i]
+            };
+            if !equal {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Call `callback` on this path and each ancestor directory, returning the first `Some`.
+    pub fn for_each_ancestor<T>(&self, mut callback: impl FnMut(&str) -> Option<T>) -> Option<T> {
+        let mut directory = self.0.clone();
+        loop {
+            if let Some(result) = callback(&directory) {
+                return Some(result);
+            }
+            let parent = Self::dir_of(&directory);
+            if parent == directory {
+                return None;
+            }
+            directory = parent;
+        }
+    }
+
+    // ---- private helpers operating on raw `&str` ----
+
+    fn is_separator(c: u8) -> bool {
+        c == b'/' || c == b'\\'
+    }
+
+    fn is_volume(c: u8) -> bool {
+        c.is_ascii_alphabetic()
+    }
+
+    fn to_slashes(path: &str) -> Cow<'_, str> {
+        path.cow_replace('\\', "/")
+    }
+
+    fn ends_with_separator(path: &str) -> bool {
+        path.as_bytes().last().is_some_and(|&c| Self::is_separator(c))
+    }
+
+    fn trim_trailing_separator(path: &str) -> &str {
+        if Self::ends_with_separator(path) { &path[..path.len() - 1] } else { path }
+    }
+
+    fn ensure_separator(path: &str) -> String {
+        if Self::ends_with_separator(path) { path.to_string() } else { format!("{path}/") }
+    }
+
+    /// `GetRootLength` for POSIX (`/`), UNC (`//server/`) and DOS (`c:/`) paths.
+    fn root_len(path: &str) -> usize {
+        let bytes = path.as_bytes();
+        let ln = bytes.len();
+        if ln == 0 {
+            return 0;
+        }
+        let ch0 = bytes[0];
+        if ch0 == b'/' || ch0 == b'\\' {
+            if ln == 1 || bytes[1] != ch0 {
+                return 1;
+            }
+            let offset = 2;
+            return match path[offset..].bytes().position(|b| b == ch0) {
+                None => ln,
+                Some(p1) => p1 + offset + 1,
+            };
+        }
+        if Self::is_volume(ch0) && ln > 1 && bytes[1] == b':' {
+            if ln == 2 {
+                return 2;
+            }
+            let ch2 = bytes[2];
+            if ch2 == b'/' || ch2 == b'\\' {
+                return 3;
+            }
+        }
+        0
+    }
+
+    fn combine_into(first: &str, paths: &[&str]) -> String {
+        let mut result = Self::to_slashes(first).into_owned();
+        for &p in paths {
+            if p.is_empty() {
+                continue;
+            }
+            let trailing = Self::to_slashes(p);
+            if result.is_empty() || Self::root_len(&trailing) != 0 {
+                result = trailing.into_owned();
+            } else {
+                if !Self::ends_with_separator(&result) {
+                    result.push('/');
+                }
+                result.push_str(&trailing);
+            }
+        }
+        result
+    }
+
+    fn components_of(path: &str, current_directory: &str) -> Vec<String> {
+        let path = Self::combine_into(current_directory, &[path]);
+        let root_len = Self::root_len(&path);
+        let mut rest: Vec<&str> = path[root_len..].split('/').collect();
+        if rest.last() == Some(&"") {
+            rest.pop();
+        }
+        let mut out = Vec::with_capacity(rest.len() + 1);
+        out.push(path[..root_len].to_string());
+        out.extend(rest.into_iter().map(str::to_string));
+        out
+    }
+
+    fn dir_of(path: &str) -> String {
+        let path = Self::to_slashes(path);
+        let root_len = Self::root_len(&path);
+        if root_len == path.len() {
+            return path.into_owned();
+        }
+        let path = Self::trim_trailing_separator(&path);
+        let cut = match path.rfind('/') {
+            Some(i) => root_len.max(i),
+            None => root_len,
+        };
+        path[..cut].to_string()
+    }
+
+    fn base_of(path: &str) -> String {
+        let path = Self::to_slashes(path);
+        let root_len = Self::root_len(&path);
+        if root_len == path.len() {
+            return String::new();
+        }
+        let path = Self::trim_trailing_separator(&path);
+        let start = root_len.max(path.rfind('/').map_or(0, |i| i + 1));
+        path[start..].to_string()
+    }
+
+    fn join_components(components: &[String]) -> String {
+        if components.is_empty() {
+            return String::new();
+        }
+        let root = &components[0];
+        let mut result = if root.is_empty() { String::new() } else { Self::ensure_separator(root) };
+        result.push_str(&components[1..].join("/"));
+        result
+    }
+
+    /// Drop `.`/empty components and collapse `..` where possible (never above the root).
+    fn reduce_components(components: &[String]) -> Vec<String> {
+        if components.is_empty() {
+            return Vec::new();
+        }
+        let mut reduced = vec![components[0].clone()];
+        for component in &components[1..] {
+            if component.is_empty() || component == "." {
+                continue;
+            }
+            if component == ".." {
+                let last_is_dotdot = reduced.last().map(String::as_str) == Some("..");
+                if reduced.len() > 1 {
+                    if !last_is_dotdot {
+                        reduced.pop();
+                        continue;
+                    }
+                } else if !reduced[0].is_empty() {
+                    continue;
+                }
+            }
+            reduced.push(component.clone());
+        }
+        reduced
+    }
+
+    fn normalized_components_of(path: &str) -> Vec<String> {
+        let root_len = Self::root_len(path);
+        let bytes = path.as_bytes();
+        let mut components: Vec<String> = Vec::with_capacity(8);
+        components.push(path[..root_len].to_string());
+        let mut i = root_len;
+        while i < bytes.len() {
+            while i < bytes.len() && bytes[i] == b'/' {
+                i += 1;
+            }
+            if i >= bytes.len() {
+                break;
+            }
+            let start = i;
+            while i < bytes.len() && bytes[i] != b'/' {
+                i += 1;
+            }
+            let component = &path[start..i];
+            if component.is_empty() || component == "." {
+                continue;
+            }
+            if component == ".." {
+                let last_is_dotdot = components.last().map(String::as_str) == Some("..");
+                if components.len() > 1 {
+                    if !last_is_dotdot {
+                        components.pop();
+                        continue;
+                    }
+                } else if !components[0].is_empty() {
+                    continue;
+                }
+            }
+            components.push(component.to_string());
+        }
+        components
+    }
+
+    fn normalized_absolute_of(file_name: &str, current_directory: &str) -> String {
+        let combined = if Self::root_len(file_name) == 0 && !current_directory.is_empty() {
+            Self::combine_into(current_directory, &[file_name])
+        } else {
+            Self::to_slashes(file_name).into_owned()
+        };
+        Self::join_components(&Self::normalized_components_of(&combined))
+    }
+
+    fn any_extension(path: &str, extensions: &[&str]) -> String {
+        let path = Self::trim_trailing_separator(path);
+        for &extension in extensions {
+            // Every candidate extension starts with '.'.
+            if path.len() >= extension.len() {
+                let idx = path.len() - extension.len();
+                if path.as_bytes()[idx] == b'.' && &path[idx..] == extension {
+                    return extension.to_string();
+                }
+            }
+        }
+        String::new()
+    }
+
+    fn change_any_extension(path: &str, new_extension: &str, extensions: &[&str]) -> String {
+        let pathext = Self::any_extension(path, extensions);
+        if pathext.is_empty() {
+            return path.to_string();
+        }
+        let result = &path[..path.len() - pathext.len()];
+        if new_extension.is_empty() {
+            result.to_string()
+        } else if new_extension.starts_with('.') {
+            format!("{result}{new_extension}")
+        } else {
+            format!("{result}.{new_extension}")
+        }
+    }
+}

--- a/crates/oxc_type_checker/src/vfsmatch.rs
+++ b/crates/oxc_type_checker/src/vfsmatch.rs
@@ -1,0 +1,749 @@
+//! Ported from typescript-go `internal/vfs/vfsmatch/vfsmatch.go`.
+//!
+//! A regex-free glob matcher + directory walker. This is the heart of "get all the
+//! TypeScript files for a project": given `include`/`exclude` specs and a set of supported
+//! extensions, it walks the filesystem and returns the matching files, encoding the
+//! package-folder / `.min.js` / dotfile exclusions structurally (tsgo moved off the old
+//! regex approach, and Rust's `regex` cannot express its negative look-aheads anyway).
+//!
+//! The [`FileSystemHost`] trait abstracts the filesystem so the matcher can be unit-tested
+//! against an in-memory tree; [`StdFs`] is the real `std::fs` implementation.
+
+use cow_utils::CowUtils;
+use rustc_hash::FxHashSet;
+
+use crate::tspath::TsPath;
+
+/// How a set of patterns is being used, which changes matching rules.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Usage {
+    /// Matching concrete files (applies the `.min.js` default exclusion).
+    Files,
+    /// Matching directories to decide whether to descend into them.
+    Directories,
+    /// Matching exclude patterns (looser trailing-`**` rules, no package-folder skipping).
+    Exclude,
+}
+
+/// Pass as the `depth` argument to [`read_directory`] for no depth limit.
+pub const UNLIMITED_DEPTH: usize = usize::MAX;
+
+/// Directory entries returned by a [`FileSystemHost`].
+///
+/// `files` and `directories` must be sorted for deterministic output. `symlinks` names the
+/// entries in `directories` that are symlinks (so the walker re-resolves their real path);
+/// `None` means the host does not track symlinks and every directory's real path is resolved
+/// via [`FileSystemHost::realpath`].
+#[derive(Debug, Default)]
+pub struct Entries {
+    pub files: Vec<String>,
+    pub directories: Vec<String>,
+    pub symlinks: Option<FxHashSet<String>>,
+}
+
+/// Filesystem abstraction (tsgo's `vfs.FS`, reduced to what the matcher needs).
+pub trait FileSystemHost {
+    fn use_case_sensitive_file_names(&self) -> bool;
+    fn get_accessible_entries(&self, dir: &str) -> Entries;
+    fn realpath(&self, path: &str) -> String;
+}
+
+/// Enumerate files under `path` matching `includes`/`excludes` and one of `extensions`.
+pub fn read_directory(
+    host: &dyn FileSystemHost,
+    current_dir: &str,
+    path: &str,
+    extensions: &[&str],
+    excludes: &[String],
+    includes: &[String],
+    depth: usize,
+) -> Vec<String> {
+    let use_cs = host.use_case_sensitive_file_names();
+    let path = TsPath::from(path).normalized().into_string();
+    let current_directory = TsPath::from(current_dir).normalized().into_string();
+    let absolute_path =
+        TsPath::from(current_directory.as_str()).combine(&[path.as_str()]).into_string();
+
+    let file_matcher = GlobMatcher::new(includes, excludes, &absolute_path, use_cs, Usage::Files);
+    let directory_matcher =
+        GlobMatcher::new(includes, excludes, &absolute_path, use_cs, Usage::Directories);
+
+    let results_len = file_matcher.includes.len().max(1);
+    let mut visitor = GlobVisitor {
+        host,
+        file_matcher: &file_matcher,
+        directory_matcher: &directory_matcher,
+        extensions,
+        use_case_sensitive_file_names: use_cs,
+        visited: FxHashSet::default(),
+        results: vec![Vec::new(); results_len],
+    };
+
+    for base_path in get_base_paths(&path, includes, use_cs) {
+        let absolute =
+            TsPath::from(current_directory.as_str()).combine(&[base_path.as_str()]).into_string();
+        visitor.visit(&base_path, &absolute, depth, "");
+    }
+
+    if visitor.results.len() == 1 {
+        return visitor.results.pop().unwrap_or_default();
+    }
+    visitor.results.into_iter().flatten().collect()
+}
+
+/// An `include` path `foo` is implicitly the glob `foo/**/*` when its last component has no
+/// extension and no glob characters of its own.
+fn is_implicit_glob(last_path_component: &str) -> bool {
+    !last_path_component.contains(['.', '*', '?'])
+}
+
+fn get_include_base_path(absolute: &str) -> String {
+    match absolute.find(['*', '?']) {
+        None => {
+            if TsPath::from(absolute).has_extension() {
+                TsPath::from(absolute).directory().without_trailing_separator().to_string()
+            } else {
+                absolute.to_string()
+            }
+        }
+        Some(wildcard_offset) => {
+            let cut = absolute[..wildcard_offset].rfind('/').unwrap_or(0);
+            absolute[..cut].to_string()
+        }
+    }
+}
+
+/// The unique non-wildcard base paths among the include patterns; the walk starts from each.
+fn get_base_paths(
+    path: &str,
+    includes: &[String],
+    use_case_sensitive_file_names: bool,
+) -> Vec<String> {
+    let mut base_paths = vec![path.to_string()];
+    if includes.is_empty() {
+        return base_paths;
+    }
+
+    let mut include_base_paths: Vec<String> = includes
+        .iter()
+        .map(|include| {
+            let absolute = if TsPath::from(include.as_str()).is_rooted() {
+                include.clone()
+            } else {
+                TsPath::from(path).combine(&[include.as_str()]).normalized().into_string()
+            };
+            get_include_base_path(&absolute)
+        })
+        .collect();
+
+    include_base_paths.sort_by(|a, b| {
+        if use_case_sensitive_file_names {
+            a.cmp(b)
+        } else {
+            a.cow_to_ascii_lowercase().cmp(&b.cow_to_ascii_lowercase())
+        }
+    });
+
+    for include_base_path in include_base_paths {
+        let contained = base_paths.iter().any(|bp| {
+            TsPath::from(bp.as_str()).contains(&include_base_path, use_case_sensitive_file_names)
+        });
+        if !contained {
+            base_paths.push(include_base_path);
+        }
+    }
+
+    base_paths
+}
+
+/// A single path segment in a glob pattern.
+#[derive(Debug)]
+enum Component {
+    /// Exact string match (e.g. `src`).
+    Literal(String),
+    /// Contains `*`/`?` (e.g. `*.ts`). Include patterns skip common package folders.
+    Wildcard { segments: Vec<Segment>, skip_package_folders: bool },
+    /// `**` matches zero or more directories.
+    DoubleAsterisk,
+}
+
+/// A piece of a wildcard component: `*.ts` becomes `[Star, Literal(".ts")]`.
+#[derive(Debug)]
+enum Segment {
+    Literal(String),
+    /// `*` matches any run of characters except `/`.
+    Star,
+    /// `?` matches a single character except `/`.
+    Question,
+}
+
+/// A compiled glob pattern.
+#[derive(Debug)]
+struct GlobPattern {
+    components: Vec<Component>,
+    is_exclude: bool,
+    case_sensitive: bool,
+    /// For `Files` usage: `.min.js` is excluded unless the pattern mentions it.
+    exclude_min_js: bool,
+}
+
+impl Component {
+    fn parse(s: &str, is_include: bool) -> Component {
+        if s == "**" {
+            return Component::DoubleAsterisk;
+        }
+        if !s.contains(['*', '?']) {
+            return Component::Literal(s.to_string());
+        }
+        Component::Wildcard { segments: parse_segments(s), skip_package_folders: is_include }
+    }
+}
+
+fn parse_segments(s: &str) -> Vec<Segment> {
+    let mut result = Vec::new();
+    let mut start = 0;
+    for (i, &c) in s.as_bytes().iter().enumerate() {
+        if c == b'*' || c == b'?' {
+            if i > start {
+                result.push(Segment::Literal(s[start..i].to_string()));
+            }
+            result.push(if c == b'*' { Segment::Star } else { Segment::Question });
+            start = i + 1;
+        }
+    }
+    if start < s.len() {
+        result.push(Segment::Literal(s[start..].to_string()));
+    }
+    result
+}
+
+impl GlobPattern {
+    /// Compile a glob spec (e.g. `src/**/*.ts`) into a pattern, or `None` if it matches nothing.
+    fn compile(
+        spec: &str,
+        base_path: &str,
+        usage: Usage,
+        case_sensitive: bool,
+    ) -> Option<GlobPattern> {
+        let mut parts = TsPath::from(spec).normalized_components(base_path);
+
+        // "src/**" without a trailing filename matches nothing (for include patterns).
+        if usage != Usage::Exclude && parts.last().map(String::as_str) == Some("**") {
+            return None;
+        }
+
+        // Normalize root: "/home/" -> "/home".
+        parts[0] = TsPath::from(parts[0].as_str()).without_trailing_separator().to_string();
+
+        // Directories implicitly match all files: "src" -> "src/**/*".
+        if is_implicit_glob(parts.last().map_or("", String::as_str)) {
+            parts.push("**".to_string());
+            parts.push("*".to_string());
+        }
+
+        let is_include = usage != Usage::Exclude;
+        let components = parts.iter().map(|part| Component::parse(part, is_include)).collect();
+
+        Some(GlobPattern {
+            components,
+            is_exclude: usage == Usage::Exclude,
+            case_sensitive,
+            exclude_min_js: usage == Usage::Files,
+        })
+    }
+
+    fn matches(&self, path: &str) -> bool {
+        self.match_path_parts(path, "", 0, 0, false)
+    }
+
+    fn matches_parts(&self, prefix: &str, suffix: &str) -> bool {
+        self.match_path_parts(prefix, suffix, 0, 0, false)
+    }
+
+    fn matches_prefix_parts(&self, prefix: &str, suffix: &str) -> bool {
+        self.match_path_parts(prefix, suffix, 0, 0, true)
+    }
+
+    /// Match the virtual path `prefix + suffix` against this pattern. Splitting into
+    /// prefix/suffix avoids allocating a combined string on the hot call site (directory
+    /// prefix ending in `/` plus a single entry name).
+    fn match_path_parts(
+        &self,
+        prefix: &str,
+        suffix: &str,
+        mut path_offset: usize,
+        mut comp_idx: usize,
+        prefix_only: bool,
+    ) -> bool {
+        loop {
+            let (path_part, next_offset, ok) = next_path_part_parts(prefix, suffix, path_offset);
+            if !ok {
+                if prefix_only {
+                    return true;
+                }
+                return self.pattern_satisfied(comp_idx);
+            }
+
+            if comp_idx >= self.components.len() {
+                return self.is_exclude && !prefix_only;
+            }
+
+            match &self.components[comp_idx] {
+                Component::DoubleAsterisk => {
+                    if self.match_path_parts(prefix, suffix, path_offset, comp_idx + 1, prefix_only)
+                    {
+                        return true;
+                    }
+                    if !self.is_exclude
+                        && (is_hidden_path(path_part) || is_package_folder(path_part))
+                    {
+                        return false;
+                    }
+                    path_offset = next_offset;
+                    continue;
+                }
+                Component::Literal(literal) => {
+                    if !self.strings_equal(literal, path_part) {
+                        return false;
+                    }
+                }
+                Component::Wildcard { segments, skip_package_folders } => {
+                    if *skip_package_folders && is_package_folder(path_part) {
+                        return false;
+                    }
+                    if !self.match_wildcard(segments, path_part) {
+                        return false;
+                    }
+                }
+            }
+
+            path_offset = next_offset;
+            comp_idx += 1;
+        }
+    }
+
+    /// The remaining components can match empty input (only trailing `**`).
+    fn pattern_satisfied(&self, comp_idx: usize) -> bool {
+        self.components[comp_idx..].iter().all(|c| matches!(c, Component::DoubleAsterisk))
+    }
+
+    fn match_wildcard(&self, segs: &[Segment], s: &str) -> bool {
+        // Include patterns: a leading wildcard cannot match a hidden file.
+        if !self.is_exclude
+            && matches!(segs.first(), Some(Segment::Star | Segment::Question))
+            && is_hidden_path(s)
+        {
+            return false;
+        }
+
+        // Fast path: single `*` followed by a literal suffix (e.g. "*.ts").
+        if let [Segment::Star, Segment::Literal(suffix)] = segs {
+            if s.len() < suffix.len() || !self.strings_equal(suffix, &s[s.len() - suffix.len()..]) {
+                return false;
+            }
+            return self.should_include_min_js(s, segs);
+        }
+
+        self.match_segments(segs, s) && self.should_include_min_js(s, segs)
+    }
+
+    /// Iterative wildcard match that records only the last `*` position to avoid exponential
+    /// backtracking (O(n*m)).
+    fn match_segments(&self, segs: &[Segment], s: &str) -> bool {
+        let s_bytes = s.as_bytes();
+        let mut seg_idx = 0;
+        let mut s_idx = 0;
+        let mut star: Option<(usize, usize)> = None; // (segment index of `*`, string index at `*`)
+
+        while s_idx < s.len() {
+            if let Some(seg) = segs.get(seg_idx) {
+                match seg {
+                    Segment::Literal(lit) => {
+                        let end = s_idx + lit.len();
+                        if end <= s.len() && self.strings_equal(lit, &s[s_idx..end]) {
+                            s_idx = end;
+                            seg_idx += 1;
+                            continue;
+                        }
+                    }
+                    Segment::Question => {
+                        if s_bytes[s_idx] != b'/' {
+                            s_idx += utf8_char_len(s, s_idx);
+                            seg_idx += 1;
+                            continue;
+                        }
+                    }
+                    Segment::Star => {
+                        star = Some((seg_idx, s_idx));
+                        seg_idx += 1;
+                        continue;
+                    }
+                }
+            }
+
+            // Current segment didn't match; backtrack to the last `*` if possible.
+            if let Some((star_seg, star_s)) = star
+                && star_s < s.len()
+                && s_bytes[star_s] != b'/'
+            {
+                let next = star_s + utf8_char_len(s, star_s);
+                star = Some((star_seg, next));
+                s_idx = next;
+                seg_idx = star_seg + 1;
+                continue;
+            }
+
+            return false;
+        }
+
+        // Consume any trailing stars.
+        while matches!(segs.get(seg_idx), Some(Segment::Star)) {
+            seg_idx += 1;
+        }
+        seg_idx >= segs.len()
+    }
+
+    fn should_include_min_js(&self, filename: &str, segs: &[Segment]) -> bool {
+        if !self.exclude_min_js {
+            return true;
+        }
+        if !self.has_min_js_suffix(filename) {
+            return true;
+        }
+        // Allow when the user's pattern explicitly references the `.min.` suffix.
+        self.pattern_mentions_min_suffix(segs)
+    }
+
+    fn has_min_js_suffix(&self, filename: &str) -> bool {
+        const MIN_JS: &str = ".min.js";
+        if self.case_sensitive {
+            filename.ends_with(MIN_JS)
+        } else {
+            filename.len() >= MIN_JS.len()
+                && filename[filename.len() - MIN_JS.len()..].eq_ignore_ascii_case(MIN_JS)
+        }
+    }
+
+    fn pattern_mentions_min_suffix(&self, segs: &[Segment]) -> bool {
+        segs.iter().any(|seg| {
+            let Segment::Literal(lit) = seg else {
+                return false;
+            };
+            if self.case_sensitive {
+                lit.contains(".min.js") || lit.contains(".min.")
+            } else {
+                let lower = lit.cow_to_lowercase();
+                lower.contains(".min.js") || lower.contains(".min.")
+            }
+        })
+    }
+
+    fn strings_equal(&self, a: &str, b: &str) -> bool {
+        if self.case_sensitive { a == b } else { a.eq_ignore_ascii_case(b) }
+    }
+}
+
+fn utf8_char_len(s: &str, idx: usize) -> usize {
+    s[idx..].chars().next().map_or(1, char::len_utf8)
+}
+
+/// Extract the next path component from `s` starting at `offset`.
+fn next_path_part_single(s: &str, mut offset: usize) -> (&str, usize, bool) {
+    if offset >= s.len() {
+        return ("", offset, false);
+    }
+    let bytes = s.as_bytes();
+    if offset == 0 && bytes[0] == b'/' {
+        return ("", 1, true);
+    }
+    while offset < s.len() && bytes[offset] == b'/' {
+        offset += 1;
+    }
+    if offset >= s.len() {
+        return ("", offset, false);
+    }
+    let rest = &s[offset..];
+    if let Some(idx) = rest.find('/') {
+        (&rest[..idx], offset + idx, true)
+    } else {
+        (rest, s.len(), true)
+    }
+}
+
+/// Like [`next_path_part_single`] over the virtual path `prefix + suffix`.
+fn next_path_part_parts<'a>(
+    prefix: &'a str,
+    suffix: &'a str,
+    mut offset: usize,
+) -> (&'a str, usize, bool) {
+    if suffix.is_empty() {
+        return next_path_part_single(prefix, offset);
+    }
+    if prefix.is_empty() {
+        return next_path_part_single(suffix, offset);
+    }
+
+    // On the hot call site `prefix` is a directory path ending in '/' and `suffix` is a
+    // single entry name (no '/'), so this stays simple.
+    let total_len = prefix.len() + suffix.len();
+    if offset >= total_len {
+        return ("", offset, false);
+    }
+
+    let pbytes = prefix.as_bytes();
+    if offset == 0 && pbytes[0] == b'/' {
+        return ("", 1, true);
+    }
+
+    if offset < prefix.len() {
+        while offset < prefix.len() && pbytes[offset] == b'/' {
+            offset += 1;
+        }
+        if offset < prefix.len() {
+            let rest = &prefix[offset..];
+            // `prefix` ends in '/', so a separator is guaranteed for the hot call site.
+            let idx = rest.find('/').unwrap_or(rest.len());
+            return (&rest[..idx], offset + idx, true);
+        }
+        // Otherwise fall through into the suffix region.
+    }
+
+    let s_off = offset - prefix.len();
+    if s_off >= suffix.len() {
+        return ("", offset, false);
+    }
+    (&suffix[s_off..], total_len, true)
+}
+
+fn is_hidden_path(name: &str) -> bool {
+    name.as_bytes().first() == Some(&b'.')
+}
+
+fn is_package_folder(name: &str) -> bool {
+    match name.len() {
+        12 => name.eq_ignore_ascii_case("node_modules"),
+        13 => name.eq_ignore_ascii_case("jspm_packages"),
+        16 => name.eq_ignore_ascii_case("bower_components"),
+        _ => false,
+    }
+}
+
+fn ensure_trailing_slash(s: &str) -> String {
+    if !s.is_empty() && !s.ends_with('/') { format!("{s}/") } else { s.to_string() }
+}
+
+/// Combined include + exclude patterns.
+struct GlobMatcher {
+    includes: Vec<GlobPattern>,
+    excludes: Vec<GlobPattern>,
+    /// True if include specs were provided (even if none compiled to a usable pattern).
+    had_includes: bool,
+}
+
+impl GlobMatcher {
+    fn new(
+        include_specs: &[String],
+        exclude_specs: &[String],
+        base_path: &str,
+        case_sensitive: bool,
+        usage: Usage,
+    ) -> Self {
+        let includes = include_specs
+            .iter()
+            .filter_map(|spec| GlobPattern::compile(spec, base_path, usage, case_sensitive))
+            .collect();
+        let excludes = exclude_specs
+            .iter()
+            .filter_map(|spec| {
+                GlobPattern::compile(spec, base_path, Usage::Exclude, case_sensitive)
+            })
+            .collect();
+        Self { includes, excludes, had_includes: !include_specs.is_empty() }
+    }
+
+    /// The index of the matching include bucket for `prefix + suffix`, or `None`.
+    fn matches_file_parts(&self, prefix: &str, suffix: &str) -> Option<usize> {
+        if self.excludes.iter().any(|e| e.matches_parts(prefix, suffix)) {
+            return None;
+        }
+        if self.includes.is_empty() {
+            return if self.had_includes { None } else { Some(0) };
+        }
+        self.includes.iter().position(|inc| inc.matches_parts(prefix, suffix))
+    }
+
+    /// Whether files under `prefix + suffix` could match any pattern (to prune the walk).
+    fn matches_directory_parts(&self, prefix: &str, suffix: &str) -> bool {
+        if self.excludes.iter().any(|e| e.matches_parts(prefix, suffix)) {
+            return false;
+        }
+        if self.includes.is_empty() {
+            return !self.had_includes;
+        }
+        self.includes.iter().any(|inc| inc.matches_prefix_parts(prefix, suffix))
+    }
+}
+
+/// Walks directories collecting files that match the glob patterns.
+struct GlobVisitor<'a> {
+    host: &'a dyn FileSystemHost,
+    file_matcher: &'a GlobMatcher,
+    directory_matcher: &'a GlobMatcher,
+    extensions: &'a [&'a str],
+    use_case_sensitive_file_names: bool,
+    visited: FxHashSet<String>,
+    /// One bucket per include pattern (or a single bucket when there are no includes).
+    results: Vec<Vec<String>>,
+}
+
+impl GlobVisitor<'_> {
+    fn visit(
+        &mut self,
+        path: &str,
+        absolute_path: &str,
+        mut depth: usize,
+        resolved_real_path: &str,
+    ) {
+        let host = self.host;
+        let file_matcher = self.file_matcher;
+        let directory_matcher = self.directory_matcher;
+        let extensions = self.extensions;
+        let use_cs = self.use_case_sensitive_file_names;
+
+        // Detect symlink cycles by canonical real path.
+        let real_path = if resolved_real_path.is_empty() {
+            host.realpath(absolute_path)
+        } else {
+            resolved_real_path.to_string()
+        };
+        let canonical_path = TsPath::from(real_path.as_str()).canonical(use_cs);
+        if !self.visited.insert(canonical_path) {
+            return;
+        }
+
+        let entries = host.get_accessible_entries(absolute_path);
+        let path_prefix = ensure_trailing_slash(path);
+        let abs_prefix = ensure_trailing_slash(absolute_path);
+
+        for file in &entries.files {
+            if !extensions.is_empty()
+                && !TsPath::from(file.as_str()).file_extension_is_one_of(extensions)
+            {
+                continue;
+            }
+            if let Some(idx) = file_matcher.matches_file_parts(&abs_prefix, file) {
+                self.results[idx].push(format!("{path_prefix}{file}"));
+            }
+        }
+
+        if depth != UNLIMITED_DEPTH {
+            if depth == 0 {
+                return;
+            }
+            depth -= 1;
+            if depth == 0 {
+                return;
+            }
+        }
+
+        for dir in &entries.directories {
+            if !directory_matcher.matches_directory_parts(&abs_prefix, dir) {
+                continue;
+            }
+            let abs_dir = format!("{abs_prefix}{dir}");
+            let child_real_path = match &entries.symlinks {
+                // Non-symlink directory: compute the real path incrementally.
+                Some(symlinks) if !symlinks.contains(dir) => {
+                    TsPath::from(real_path.as_str()).combine(&[dir.as_str()]).into_string()
+                }
+                // Symlink directory, or the host doesn't track symlinks: force a `realpath` call.
+                _ => String::new(),
+            };
+            self.visit(&format!("{path_prefix}{dir}"), &abs_dir, depth, &child_real_path);
+        }
+    }
+}
+
+/// Matches a path against one or more glob specs (used for the JSON-only include bucket).
+pub struct SpecMatcher {
+    patterns: Vec<GlobPattern>,
+}
+
+impl SpecMatcher {
+    /// Build a matcher, or `None` if no spec compiles to a usable pattern.
+    pub fn new(
+        specs: &[String],
+        base_path: &str,
+        usage: Usage,
+        use_case_sensitive_file_names: bool,
+    ) -> Option<SpecMatcher> {
+        if specs.is_empty() {
+            return None;
+        }
+        let patterns: Vec<GlobPattern> = specs
+            .iter()
+            .filter_map(|spec| {
+                GlobPattern::compile(spec, base_path, usage, use_case_sensitive_file_names)
+            })
+            .collect();
+        if patterns.is_empty() { None } else { Some(SpecMatcher { patterns }) }
+    }
+
+    /// The index of the first matching pattern, or `None`.
+    pub fn match_index(&self, path: &str) -> Option<usize> {
+        self.patterns.iter().position(|p| p.matches(path))
+    }
+}
+
+/// Real filesystem host backed by `std::fs`.
+pub struct StdFs {
+    pub use_case_sensitive_file_names: bool,
+}
+
+impl FileSystemHost for StdFs {
+    fn use_case_sensitive_file_names(&self) -> bool {
+        self.use_case_sensitive_file_names
+    }
+
+    fn get_accessible_entries(&self, dir: &str) -> Entries {
+        let mut files = Vec::new();
+        let mut directories = Vec::new();
+        let mut symlinks = FxHashSet::default();
+
+        if let Ok(read) = std::fs::read_dir(dir) {
+            for entry in read.flatten() {
+                let Ok(file_type) = entry.file_type() else {
+                    continue;
+                };
+                let name = entry.file_name().to_string_lossy().into_owned();
+                let is_symlink = file_type.is_symlink();
+                // `file_type` does not follow symlinks; classify the target via `metadata`.
+                let is_dir = if is_symlink {
+                    std::fs::metadata(entry.path()).is_ok_and(|m| m.is_dir())
+                } else {
+                    file_type.is_dir()
+                };
+                if is_dir {
+                    directories.push(name.clone());
+                    if is_symlink {
+                        symlinks.insert(name);
+                    }
+                } else {
+                    files.push(name);
+                }
+            }
+        }
+
+        // tsgo's vfs yields sorted entries; `read_dir` does not, so sort for determinism.
+        files.sort();
+        directories.sort();
+        Entries { files, directories, symlinks: Some(symlinks) }
+    }
+
+    fn realpath(&self, path: &str) -> String {
+        std::fs::canonicalize(path).map_or_else(
+            |_| path.to_string(),
+            |p| TsPath::from_slashes(&p.to_string_lossy()).into_string(),
+        )
+    }
+}

--- a/crates/oxc_type_checker/src/vfsmatch.rs
+++ b/crates/oxc_type_checker/src/vfsmatch.rs
@@ -12,7 +12,7 @@
 use cow_utils::CowUtils;
 use rustc_hash::FxHashSet;
 
-use crate::tspath::TsPath;
+use crate::{fold, tspath::TsPath};
 
 /// How a set of patterns is being used, which changes matching rules.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -25,15 +25,16 @@ pub enum Usage {
     Exclude,
 }
 
-/// Pass as the `depth` argument to [`read_directory`] for no depth limit.
+/// Pass as the `depth` argument to [`read_directory`] for no depth limit. A depth of `0`
+/// also means unlimited, matching tsgo (whose signed decrement never re-reaches zero).
 pub const UNLIMITED_DEPTH: usize = usize::MAX;
 
 /// Directory entries returned by a [`FileSystemHost`].
 ///
 /// `files` and `directories` must be sorted for deterministic output. `symlinks` names the
-/// entries in `directories` that are symlinks (so the walker re-resolves their real path);
-/// `None` means the host does not track symlinks and every directory's real path is resolved
-/// via [`FileSystemHost::realpath`].
+/// entries that are symlinks — the walker re-resolves the real path of directories listed
+/// there; `None` means the host does not track symlinks and every directory's real path is
+/// resolved via [`FileSystemHost::realpath`].
 #[derive(Debug, Default)]
 pub struct Entries {
     pub files: Vec<String>,
@@ -59,6 +60,7 @@ pub fn read_directory(
     depth: usize,
 ) -> Vec<String> {
     let use_cs = host.use_case_sensitive_file_names();
+    let depth = if depth == 0 { UNLIMITED_DEPTH } else { depth };
     let path = TsPath::from(path).normalized().into_string();
     let current_directory = TsPath::from(current_dir).normalized().into_string();
     let absolute_path =
@@ -137,16 +139,18 @@ fn get_base_paths(
         .collect();
 
     include_base_paths.sort_by(|a, b| {
-        if use_case_sensitive_file_names {
-            a.cmp(b)
-        } else {
-            a.cow_to_ascii_lowercase().cmp(&b.cow_to_ascii_lowercase())
-        }
+        if use_case_sensitive_file_names { a.cmp(b) } else { fold::compare_case_insensitive(a, b) }
     });
 
+    // Resolving against `path` also swallows the empty base path a rooted spec with a
+    // wildcard in its first component produces (tsgo passes `path` as CurrentDirectory).
     for include_base_path in include_base_paths {
         let contained = base_paths.iter().any(|bp| {
-            TsPath::from(bp.as_str()).contains(&include_base_path, use_case_sensitive_file_names)
+            TsPath::from(bp.as_str()).contains(
+                &include_base_path,
+                use_case_sensitive_file_names,
+                path,
+            )
         });
         if !contained {
             base_paths.push(include_base_path);
@@ -336,9 +340,11 @@ impl GlobPattern {
             return false;
         }
 
-        // Fast path: single `*` followed by a literal suffix (e.g. "*.ts").
+        // Fast path: single `*` followed by a literal suffix (e.g. "*.ts"). `get` mirrors
+        // Go byte slicing: a window splitting a multi-byte char simply fails to match.
         if let [Segment::Star, Segment::Literal(suffix)] = segs {
-            if s.len() < suffix.len() || !self.strings_equal(suffix, &s[s.len() - suffix.len()..]) {
+            let tail = s.len().checked_sub(suffix.len()).and_then(|start| s.get(start..));
+            if !tail.is_some_and(|tail| self.strings_equal(suffix, tail)) {
                 return false;
             }
             return self.should_include_min_js(s, segs);
@@ -360,7 +366,9 @@ impl GlobPattern {
                 match seg {
                     Segment::Literal(lit) => {
                         let end = s_idx + lit.len();
-                        if end <= s.len() && self.strings_equal(lit, &s[s_idx..end]) {
+                        // `get` mirrors Go byte slicing: a range splitting a multi-byte
+                        // char fails to match and falls through to backtracking.
+                        if s.get(s_idx..end).is_some_and(|sub| self.strings_equal(lit, sub)) {
                             s_idx = end;
                             seg_idx += 1;
                             continue;
@@ -419,8 +427,7 @@ impl GlobPattern {
         if self.case_sensitive {
             filename.ends_with(MIN_JS)
         } else {
-            filename.len() >= MIN_JS.len()
-                && filename[filename.len() - MIN_JS.len()..].eq_ignore_ascii_case(MIN_JS)
+            fold::has_suffix_fold(filename, MIN_JS)
         }
     }
 
@@ -439,7 +446,7 @@ impl GlobPattern {
     }
 
     fn strings_equal(&self, a: &str, b: &str) -> bool {
-        if self.case_sensitive { a == b } else { a.eq_ignore_ascii_case(b) }
+        if self.case_sensitive { a == b } else { fold::str_fold_eq(a, b) }
     }
 }
 
@@ -517,6 +524,13 @@ fn next_path_part_parts<'a>(
 
 fn is_hidden_path(name: &str) -> bool {
     name.as_bytes().first() == Some(&b'.')
+}
+
+/// Whether `file_type` is a regular file. Wraps `FileType::is_file` so the intentional
+/// "regular files only" choice (symlinks are classified separately) reads as deliberate.
+#[expect(clippy::filetype_is_file, reason = "symlinks are handled in a separate branch")]
+fn is_regular_file(file_type: std::fs::FileType) -> bool {
+    file_type.is_file()
 }
 
 fn is_package_folder(name: &str) -> bool {
@@ -637,9 +651,6 @@ impl GlobVisitor<'_> {
         }
 
         if depth != UNLIMITED_DEPTH {
-            if depth == 0 {
-                return;
-            }
             depth -= 1;
             if depth == 0 {
                 return;
@@ -716,21 +727,25 @@ impl FileSystemHost for StdFs {
                     continue;
                 };
                 let name = entry.file_name().to_string_lossy().into_owned();
-                let is_symlink = file_type.is_symlink();
-                // `file_type` does not follow symlinks; classify the target via `metadata`.
-                let is_dir = if is_symlink {
-                    std::fs::metadata(entry.path()).is_ok_and(|m| m.is_dir())
-                } else {
-                    file_type.is_dir()
-                };
-                if is_dir {
-                    directories.push(name.clone());
-                    if is_symlink {
+                if file_type.is_dir() {
+                    directories.push(name);
+                } else if is_regular_file(file_type) {
+                    files.push(name);
+                } else if file_type.is_symlink() {
+                    // Classify by the target (`metadata` follows the link). Dangling
+                    // symlinks and links to special files are dropped, matching tsgo.
+                    let Ok(metadata) = std::fs::metadata(entry.path()) else {
+                        continue;
+                    };
+                    if metadata.is_dir() {
+                        directories.push(name.clone());
+                        symlinks.insert(name);
+                    } else if metadata.is_file() {
+                        files.push(name.clone());
                         symlinks.insert(name);
                     }
-                } else {
-                    files.push(name);
                 }
+                // Other special files (FIFOs, sockets, devices) are dropped, matching tsgo.
             }
         }
 


### PR DESCRIPTION
Adds an `oxc_tsc` binary (a `bpaf` CLI) to the experimental `oxc_type_checker` crate that discovers a `tsconfig.json` and prints the project's TypeScript files (the root files from `files`/`include`/`exclude`).

## Usage

```
oxc_tsc                       # discover tsconfig.json by walking up from the cwd
oxc_tsc -p path/to/tsconfig.json
oxc_tsc -p path/to/dir        # uses <dir>/tsconfig.json
```

## Implementation

tsconfig parsing (JSONC, `extends` chains, `references`) is delegated to `oxc_resolver` (>= 11.23.0). The file matcher and enumeration are a faithful port of typescript-go (tsgo), organized into idiomatic structs:

- `tspath` / `extension` — path + extension helpers (`internal/tspath`); paths are a `TsPath` newtype
- `vfsmatch` — regex-free glob matcher + directory walker (`internal/vfs/vfsmatch`)
- `tsconfig` — default include/exclude, spec validation, `${configDir}` substitution, extension-priority dedup (`internal/tsoptions`)
- `project` — `findConfigFile` + `-p` resolution (`internal/execute/tsc.go`)
- `fold` — the Unicode case-folding primitives tsgo relies on (`ToFileNameLowerCase`, `strings.EqualFold`, `CompareStringsCaseInsensitive`)

`extends` chains are resolved (a base config's `include`/`exclude`/`files` are honored), with a graceful fallback to a lone parse when a base can't be resolved. `${configDir}` is substituted in the specs and in `outDir`/`declarationDir`.

Behaviour matches `tsc`: `.gitignore` is intentionally ignored; `node_modules` / `bower_components` / `jspm_packages` and dotfiles are skipped; `files[]` entries are verbatim and immune to `exclude`; extension priority dedups (`.ts` over `.tsx`/`.d.ts`/`.js`, with the legacy `.js`+`.d.ts` coexistence and separate `.cts`/`.mts` groups); solution-style configs (`files:[]`/`include:[]` + `references`) enumerate 0 root files.

## Validation

A differential harness compares `oxc_tsc` against `tsgo` (built from source): 19 synthetic fixtures plus real projects (cnpmcore 351 files, vite 4, vinext 1273) match `tsgo --showConfig` / `--listFilesOnly` exactly.

Comparing against the tsgo source found and fixed several behavioral divergences in the matcher/discovery — most notably a panic on non-ASCII file names/patterns, ASCII-only (vs Unicode) case folding, the `resolveJsonModule` effective default, dangling-symlink/special-file handling, `-p .` resolution, `depth == 0` semantics, and the discovery error messages (TS5058 / TS5081). Unit tests (in-memory `FileSystemHost`) cover the matcher fixes.

## Follow-ups (not in this PR)

- `references` / solution-style traversal (a solution root emits 0 root files; the files live in the referenced sub-projects).
- Cross-directory `extends`: relative `include`/`exclude`/`files` inherited from a base config in a different directory are merged verbatim rather than re-based against that base's directory.
