### PR TITLE
perf(transformer): use `ReplaceWith` instead of `TakeIn`

### DIFF
--- a/crates/oxc_transformer/src/common/arrow_function_converter.rs
+++ b/crates/oxc_transformer/src/common/arrow_function_converter.rs
@@ -91,7 +91,7 @@ use compact_str::CompactString;
 use indexmap::IndexMap;
 use rustc_hash::{FxBuildHasher, FxHashSet};
 
-use oxc_allocator::{ArenaBox, ArenaVec, TakeIn};
+use oxc_allocator::{ArenaBox, ArenaVec, ReplaceWith, TakeIn};
 use oxc_ast::{ast::*, builder::NONE};
 use oxc_ast_visit::{VisitMut, walk_mut::walk_expression};
 use oxc_data_structures::stack::{NonEmptyStack, SparseStack};
@@ -444,11 +444,12 @@ impl<'a> Traverse<'a, TransformState<'a>> for ArrowFunctionConverter<'a> {
                 return;
             }
 
-            let Expression::ArrowFunctionExpression(arrow_function_expr) = expr.take_in(ctx) else {
-                unreachable!()
-            };
-
-            *expr = Self::transform_arrow_function_expression(arrow_function_expr, ctx);
+            expr.replace_with(|expr| {
+                let Expression::ArrowFunctionExpression(arrow_function_expr) = expr else {
+                    unreachable!()
+                };
+                Self::transform_arrow_function_expression(arrow_function_expr, ctx)
+            });
         }
     }
 
@@ -1356,8 +1357,10 @@ impl<'a> ConstructorBodyThisAfterSuperInserter<'a, '_> {
     fn transform_super_call_expression(&mut self, expr: &mut Expression<'a>) {
         let assignment = self.create_assignment_to_this_temp_var();
         let span = expr.span();
-        let exprs = ArenaVec::from_array_in([expr.take_in(self.ctx), assignment], self.ctx);
-        *expr = Expression::new_sequence_expression(span, exprs, self.ctx);
+        expr.replace_with(|expr| {
+            let exprs = ArenaVec::from_array_in([expr, assignment], self.ctx);
+            Expression::new_sequence_expression(span, exprs, self.ctx)
+        });
     }
 
     /// `_this = this`

--- a/crates/oxc_transformer/src/decorator/legacy/mod.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/mod.rs
@@ -49,7 +49,8 @@ use std::borrow::Cow;
 use std::mem;
 
 use oxc_allocator::{
-    Address, ArenaBox, ArenaVec, CloneIn, GetAddress, GetAllocator, TakeIn, UnstableAddress,
+    Address, ArenaBox, ArenaVec, CloneIn, GetAddress, GetAllocator, ReplaceWith, TakeIn,
+    UnstableAddress,
 };
 use oxc_ast::{ast::*, builder::NONE};
 use oxc_ast_visit::{Visit, VisitMut};
@@ -1395,14 +1396,15 @@ impl<'a> LegacyDecorator<'a> {
                 //   static [_a = a()] = 0;
                 // ```
 
-                let key_expr = key.to_expression_mut();
+                let key = key.to_expression_mut();
 
                 // Create a unique binding for the computed property key, and insert it outside of the class
-                let binding = VarDeclarationsStore::create_uid_var_based_on_node(key_expr, ctx);
+                let binding = VarDeclarationsStore::create_uid_var_based_on_node(key, ctx);
                 let operator = AssignmentOperator::Assign;
                 let left = binding.create_write_target(ctx);
-                let right = key_expr.take_in(ctx);
-                *key = PropertyKey::new_assignment_expression(SPAN, operator, left, right, ctx);
+                key.replace_with(|right| {
+                    Expression::new_assignment_expression(SPAN, operator, left, right, ctx)
+                });
                 binding.create_read_expression(ctx)
             }
         }

--- a/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
+++ b/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
@@ -32,7 +32,7 @@
 //! * Exponentiation operator TC39 proposal: <https://github.com/tc39/proposal-exponentiation-operator>
 //! * Exponentiation operator specification: <https://tc39.es/ecma262/#sec-exp-operator>
 
-use oxc_allocator::{ArenaVec, CloneIn, GetAllocator, TakeIn};
+use oxc_allocator::{ArenaVec, CloneIn, GetAllocator, ReplaceWith, TakeIn};
 use oxc_ast::{ast::*, builder::NONE};
 use oxc_semantic::ReferenceFlags;
 use oxc_span::{SPAN, Span};
@@ -109,11 +109,13 @@ impl<'a> ExponentiationOperator<'a> {
     // `#[inline]` so compiler knows `expr` is a `BinaryExpression`
     #[inline]
     fn convert_binary_expression(expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
-        let binary_expr = match expr.take_in(ctx) {
-            Expression::BinaryExpression(binary_expr) => binary_expr.unbox(),
-            _ => unreachable!(),
-        };
-        *expr = Self::math_pow(binary_expr.span, binary_expr.left, binary_expr.right, ctx);
+        expr.replace_with(|expr| {
+            let binary_expr = match expr {
+                Expression::BinaryExpression(binary_expr) => binary_expr.unbox(),
+                _ => unreachable!(),
+            };
+            Self::math_pow(binary_expr.span, binary_expr.left, binary_expr.right, ctx)
+        });
     }
 
     /// Convert `AssignmentExpression` where assignee is an identifier.
@@ -515,8 +517,7 @@ impl<'a> ExponentiationOperator<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) {
         let span = assign_expr.span;
-        let pow_right = assign_expr.right.take_in(ctx);
-        assign_expr.right = Self::math_pow(span, pow_left, pow_right, ctx);
+        assign_expr.right.replace_with(|pow_right| Self::math_pow(span, pow_left, pow_right, ctx));
         assign_expr.operator = AssignmentOperator::Assign;
     }
 
@@ -529,8 +530,10 @@ impl<'a> ExponentiationOperator<'a> {
     ) {
         if !temp_var_inits.is_empty() {
             temp_var_inits.reserve_exact(1);
-            temp_var_inits.push(expr.take_in(ctx));
-            *expr = Expression::new_sequence_expression(span, temp_var_inits, ctx);
+            expr.replace_with(|expr| {
+                temp_var_inits.push(expr);
+                Expression::new_sequence_expression(span, temp_var_inits, ctx)
+            });
         }
     }
 

--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -53,7 +53,7 @@
 
 use std::{borrow::Cow, mem};
 
-use oxc_allocator::{ArenaBox, ArenaStringBuilder, ArenaVec, GetAllocator, TakeIn};
+use oxc_allocator::{ArenaBox, ArenaStringBuilder, ArenaVec, GetAllocator, ReplaceWith, TakeIn};
 use oxc_ast::{ast::*, builder::NONE};
 use oxc_ast_visit::Visit;
 use oxc_semantic::{ReferenceFlags, ScopeFlags, ScopeId, SymbolFlags};
@@ -555,11 +555,11 @@ impl<'a> AsyncGeneratorExecutor<'a> {
         // If the arrow's expression is true, we need to wrap the only one expression with return statement.
         if arrow.expression {
             let statement = body.statements.first_mut().unwrap();
-            let expression = match statement {
-                Statement::ExpressionStatement(es) => es.expression.take_in(ctx),
-                _ => unreachable!(),
-            };
-            *statement = Statement::new_return_statement(expression.span(), Some(expression), ctx);
+            statement.replace_with(|statement| {
+                let Statement::ExpressionStatement(es) = statement else { unreachable!() };
+                let expression = es.unbox().expression;
+                Statement::new_return_statement(expression.span(), Some(expression), ctx)
+            });
         }
 
         let params = arrow.params.take_in_box(ctx);

--- a/crates/oxc_transformer/src/es2018/object_rest_spread.rs
+++ b/crates/oxc_transformer/src/es2018/object_rest_spread.rs
@@ -31,7 +31,7 @@ use std::{iter, mem};
 
 use serde::Deserialize;
 
-use oxc_allocator::{Address, ArenaBox, ArenaVec, GetAddress, GetAllocator, TakeIn};
+use oxc_allocator::{Address, ArenaBox, ArenaVec, GetAddress, GetAllocator, ReplaceWith, TakeIn};
 use oxc_ast::{ast::*, builder::NONE};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_ecmascript::{BoundNames, ToJsString, WithoutGlobalReferenceInformation};
@@ -384,8 +384,10 @@ impl<'a> ObjectRestSpread<'a> {
         let mut exprs = vec![];
         Self::recursive_walk_assignment_target(&mut assign_expr.left, &mut decls, &mut exprs, ctx);
         Self::insert_var_declaration_before_containing_statement(decls, ctx);
-        let expressions = ArenaVec::from_iter_in(iter::chain([expr.take_in(ctx)], exprs), ctx);
-        *expr = Expression::new_sequence_expression(SPAN, expressions, ctx);
+        expr.replace_with(|expr| {
+            let expressions = ArenaVec::from_iter_in(iter::chain([expr], exprs), ctx);
+            Expression::new_sequence_expression(SPAN, expressions, ctx)
+        });
     }
 
     // Insert `var _foo` before the statement that contains the transformed assignment.
@@ -715,13 +717,15 @@ impl<'a> ObjectRestSpread<'a> {
             return block.scope_id();
         }
         let scope_id = ctx.create_child_scope(parent_scope_id, ScopeFlags::empty());
-        let span = stmt.span();
-        let stmts = if matches!(stmt, Statement::EmptyStatement(_)) {
-            ArenaVec::new_in(ctx)
-        } else {
-            ArenaVec::from_value_in(stmt.take_in(ctx), ctx)
-        };
-        *stmt = Statement::new_block_statement_with_scope_id(span, stmts, scope_id, ctx);
+        stmt.replace_with(|stmt| {
+            let span = stmt.span();
+            let stmts = if matches!(stmt, Statement::EmptyStatement(_)) {
+                ArenaVec::new_in(ctx)
+            } else {
+                ArenaVec::from_value_in(stmt, ctx)
+            };
+            Statement::new_block_statement_with_scope_id(span, stmts, scope_id, ctx)
+        });
         scope_id
     }
 

--- a/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
+++ b/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
@@ -28,7 +28,7 @@
 //! * Babel plugin implementation: <https://github.com/babel/babel/tree/v7.26.2/packages/babel-plugin-transform-nullish-coalescing-operator>
 //! * Nullish coalescing TC39 proposal: <https://github.com/tc39-transfer/proposal-nullish-coalescing>
 
-use oxc_allocator::{ArenaBox, ArenaVec, TakeIn};
+use oxc_allocator::{ArenaBox, ArenaVec, ReplaceWith};
 use oxc_ast::{ast::*, builder::NONE};
 use oxc_semantic::{ScopeFlags, SymbolFlags};
 use oxc_span::SPAN;
@@ -59,10 +59,10 @@ impl<'a> Traverse<'a, TransformState<'a>> for NullishCoalescingOperator {
 impl<'a> NullishCoalescingOperator {
     #[cold] // Most `Expression`s are not `??` `LogicalExpression`s
     fn transform_logical_expression(expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
-        // Take ownership of the `LogicalExpression`
-        let Expression::LogicalExpression(logical_expr) = expr.take_in(ctx) else { unreachable!() };
-
-        *expr = Self::transform_logical_expression_impl(logical_expr, ctx);
+        expr.replace_with(|expr| {
+            let Expression::LogicalExpression(logical_expr) = expr else { unreachable!() };
+            Self::transform_logical_expression_impl(logical_expr, ctx)
+        });
     }
 
     fn transform_logical_expression_impl(

--- a/crates/oxc_transformer/src/es2020/optional_chaining.rs
+++ b/crates/oxc_transformer/src/es2020/optional_chaining.rs
@@ -49,7 +49,7 @@
 
 use std::mem;
 
-use oxc_allocator::{ArenaVec, CloneIn, GetAllocator, TakeIn};
+use oxc_allocator::{ArenaVec, CloneIn, GetAllocator, ReplaceWith, TakeIn};
 use oxc_ast::{ast::*, builder::NONE};
 use oxc_span::{GetSpan, SPAN, Span};
 use oxc_traverse::{Ancestor, BoundIdentifier, MaybeBoundIdentifier, Traverse};
@@ -387,11 +387,10 @@ impl<'a> OptionalChaining<'a> {
             } else {
                 // `foo.bar` -> `_foo$bar = foo.bar`
                 let binding = VarDeclarationsStore::create_uid_var_based_on_node(object, ctx);
-                *object = Self::create_assignment_expression(
-                    binding.create_write_target(ctx),
-                    object.take_in(ctx),
-                    ctx,
-                );
+                let write_target = binding.create_write_target(ctx);
+                object.replace_with(|object| {
+                    Self::create_assignment_expression(write_target, object, ctx)
+                });
                 binding.create_read_expression(ctx)
             };
             Argument::from(context)
@@ -552,9 +551,10 @@ impl<'a> OptionalChaining<'a> {
             if ident.name == "eval" {
                 // `eval?.()` is an indirect eval call transformed to `(0,eval)()`
                 let zero = Expression::new_number_0(ctx);
-                let original_callee = expr.take_in(ctx);
-                let expressions = ArenaVec::from_array_in([zero, original_callee], ctx);
-                *expr = Expression::new_sequence_expression(SPAN, expressions, ctx);
+                expr.replace_with(|original_callee| {
+                    let expressions = ArenaVec::from_array_in([zero, original_callee], ctx);
+                    Expression::new_sequence_expression(SPAN, expressions, ctx)
+                });
             }
 
             let left1 = binding.create_read_expression(ctx);
@@ -666,11 +666,10 @@ impl<'a> OptionalChaining<'a> {
                         let binding =
                             VarDeclarationsStore::create_uid_var_based_on_node(object, ctx);
                         // `(_foo = foo)`
-                        *object = Self::create_assignment_expression(
-                            binding.create_write_target(ctx),
-                            object.take_in(ctx),
-                            ctx,
-                        );
+                        let write_target = binding.create_write_target(ctx);
+                        object.replace_with(|object| {
+                            Self::create_assignment_expression(write_target, object, ctx)
+                        });
                         binding.to_maybe_bound_identifier()
                     });
                 self.set_binding_context(binding);

--- a/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
@@ -101,7 +101,7 @@
 
 use std::iter;
 
-use oxc_allocator::{ArenaVec, TakeIn};
+use oxc_allocator::{ArenaVec, ReplaceWith};
 use rustc_hash::FxHashMap;
 
 use oxc_ast::{ast::*, builder::NONE};
@@ -612,21 +612,22 @@ impl<'a> ConstructorParamsSuperReplacer<'a, '_> {
         });
 
         let ctx = &mut *self.ctx;
-        let super_call = expr.take_in(ctx);
-        *expr = Expression::new_call_expression(
-            span,
-            Expression::new_static_member_expression(
-                SPAN,
-                super_binding.create_read_expression(ctx),
-                IdentifierName::new(SPAN, "call", ctx),
+        expr.replace_with(|super_call| {
+            Expression::new_call_expression(
+                span,
+                Expression::new_static_member_expression(
+                    SPAN,
+                    super_binding.create_read_expression(ctx),
+                    IdentifierName::new(SPAN, "call", ctx),
+                    false,
+                    ctx,
+                ),
+                NONE,
+                ArenaVec::from_value_in(Argument::from(super_call), ctx),
                 false,
                 ctx,
-            ),
-            NONE,
-            ArenaVec::from_value_in(Argument::from(super_call), ctx),
-            false,
-            ctx,
-        );
+            )
+        });
     }
 }
 

--- a/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
@@ -3,7 +3,7 @@
 
 use std::mem;
 
-use oxc_allocator::{ArenaBox, ArenaVec, TakeIn};
+use oxc_allocator::{ArenaBox, ArenaVec, ReplaceWith, TakeIn};
 use oxc_ast::{ast::*, builder::NONE};
 use oxc_span::SPAN;
 use oxc_str::static_ident;
@@ -265,15 +265,19 @@ impl<'a> ClassProperties<'a> {
 
         if self.private_fields_as_properties {
             // `object.#prop(arg)` -> `_classPrivateFieldLooseBase(object, _prop)[_prop](arg)`
-            let prop_binding = self.classes_stack.find_private_prop(&field_expr.field).prop_binding;
+            call_expr.callee.replace_with(|callee| {
+                let Expression::PrivateFieldExpression(field_expr) = callee else { unreachable!() };
 
-            let object = field_expr.object.take_in(ctx);
-            call_expr.callee = Expression::from(Self::create_private_field_member_expr_loose(
-                object,
-                prop_binding,
-                field_expr.span,
-                ctx,
-            ));
+                let prop_binding =
+                    self.classes_stack.find_private_prop(&field_expr.field).prop_binding;
+                let field_expr = field_expr.unbox();
+                Expression::from(Self::create_private_field_member_expr_loose(
+                    field_expr.object,
+                    prop_binding,
+                    field_expr.span,
+                    ctx,
+                ))
+            });
             return;
         }
 
@@ -496,15 +500,21 @@ impl<'a> ClassProperties<'a> {
         if self.private_fields_as_properties {
             // `object.#prop = value` -> `_classPrivateFieldLooseBase(object, _prop)[_prop] = value`
             // Same for all other assignment operators e.g. `+=`, `&&=`, `??=`.
-            let object = field_expr.object.take_in(ctx);
-            let replacement = Self::create_private_field_member_expr_loose(
-                object,
-                // At least one of `get_binding` or `set_binding` is always present
-                get_binding.unwrap_or_else(|| set_binding.as_ref().unwrap()),
-                field_expr.span,
-                ctx,
-            );
-            assign_expr.left = AssignmentTarget::from(replacement);
+            assign_expr.left.replace_with(|left| {
+                let AssignmentTarget::PrivateFieldExpression(field_expr) = left else {
+                    unreachable!()
+                };
+
+                let field_expr = field_expr.unbox();
+                let replacement = Self::create_private_field_member_expr_loose(
+                    field_expr.object,
+                    // At least one of `get_binding` or `set_binding` is always present.
+                    get_binding.unwrap_or_else(|| set_binding.as_ref().unwrap()),
+                    field_expr.span,
+                    ctx,
+                );
+                AssignmentTarget::from(replacement)
+            });
             return;
         }
 
@@ -632,18 +642,18 @@ impl<'a> ClassProperties<'a> {
 
                 if let Some(operator) = operator.to_binary_operator() {
                     // `Class.#prop += value` -> `_prop._ = _prop._ + value`
-                    let value = assign_expr.right.take_in(ctx);
                     assign_expr.operator = AssignmentOperator::Assign;
-                    assign_expr.right =
-                        Expression::new_binary_expression(SPAN, prop_obj, operator, value, ctx);
+                    assign_expr.right.replace_with(|value| {
+                        Expression::new_binary_expression(SPAN, prop_obj, operator, value, ctx)
+                    });
                 } else if let Some(operator) = operator.to_logical_operator() {
                     // `Class.#prop &&= value` -> `_prop._ && (_prop._ = value)`
                     let span = assign_expr.span;
                     assign_expr.span = SPAN;
                     assign_expr.operator = AssignmentOperator::Assign;
-                    let right = expr.take_in(ctx);
-                    *expr =
-                        Expression::new_logical_expression(span, prop_obj, operator, right, ctx);
+                    expr.replace_with(|right| {
+                        Expression::new_logical_expression(span, prop_obj, operator, right, ctx)
+                    });
                 } else {
                     // The above covers all types of `AssignmentOperator`
                     unreachable!();
@@ -722,9 +732,10 @@ impl<'a> ClassProperties<'a> {
                     assign_expr.operator = AssignmentOperator::Assign;
                     assign_expr.right =
                         self.create_assert_class_brand(class_ident2, object2, value, SPAN, ctx);
-                    let right = expr.take_in(ctx);
                     // `_assertClassBrand(Class, object, _prop)._ && (_prop._ = _assertClassBrand(Class, object, value))`
-                    *expr = Expression::new_logical_expression(span, left, operator, right, ctx);
+                    expr.replace_with(|right| {
+                        Expression::new_logical_expression(span, left, operator, right, ctx)
+                    });
                 } else {
                     // The above covers all types of `AssignmentOperator`
                     unreachable!();
@@ -754,26 +765,28 @@ impl<'a> ClassProperties<'a> {
         class_binding: Option<&BoundIdentifier<'a>>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        let assign_expr = match expr.take_in(ctx) {
-            Expression::AssignmentExpression(assign_expr) => assign_expr.unbox(),
-            _ => unreachable!(),
-        };
-        let AssignmentExpression { span, operator, right: value, left, .. } = assign_expr;
-        let AssignmentTarget::PrivateFieldExpression(field_expr) = left else { unreachable!() };
-        let PrivateFieldExpression { field, object, .. } = field_expr.unbox();
+        expr.replace_with(|expr| {
+            let Expression::AssignmentExpression(assign_expr) = expr else {
+                unreachable!();
+            };
+            let AssignmentExpression { span, operator, right: value, left, .. } =
+                assign_expr.unbox();
+            let AssignmentTarget::PrivateFieldExpression(field_expr) = left else { unreachable!() };
+            let PrivateFieldExpression { field, object, .. } = field_expr.unbox();
 
-        if operator == AssignmentOperator::Assign {
-            // `object.#prop = value` -> `_classPrivateFieldSet2(_prop, object, value)`
-            *expr = self.create_private_setter(
-                &field.name,
-                class_binding,
-                set_binding,
-                object,
-                value,
-                span,
-                ctx,
-            );
-        } else {
+            if operator == AssignmentOperator::Assign {
+                // `object.#prop = value` -> `_classPrivateFieldSet2(_prop, object, value)`
+                return self.create_private_setter(
+                    &field.name,
+                    class_binding,
+                    set_binding,
+                    object,
+                    value,
+                    span,
+                    ctx,
+                );
+            }
+
             // Make 2 copies of `object`
             let (object1, object2) = self.duplicate_object(object.into_inner_expression(), ctx);
 
@@ -795,7 +808,7 @@ impl<'a> ClassProperties<'a> {
                 let value = Expression::new_binary_expression(SPAN, get_call, operator, value, ctx);
 
                 // `_classPrivateFieldSet2(_prop, object, _classPrivateFieldGet2(_prop, object) + value)`
-                *expr = self.create_private_setter(
+                self.create_private_setter(
                     &field.name,
                     class_binding,
                     set_binding,
@@ -803,7 +816,7 @@ impl<'a> ClassProperties<'a> {
                     value,
                     span,
                     ctx,
-                );
+                )
             } else if let Some(operator) = operator.to_logical_operator() {
                 // `object.#prop &&= value`
                 // -> `_classPrivateFieldGet2(_prop, object) && _classPrivateFieldSet2(_prop, object, value)`
@@ -828,13 +841,14 @@ impl<'a> ClassProperties<'a> {
                     SPAN,
                     ctx,
                 );
+
                 // `_classPrivateFieldGet2(_prop, object) && _classPrivateFieldSet2(_prop, object, value)`
-                *expr = Expression::new_logical_expression(span, get_call, operator, set_call, ctx);
+                Expression::new_logical_expression(span, get_call, operator, set_call, ctx)
             } else {
                 // The above covers all types of `AssignmentOperator`
                 unreachable!();
             }
-        }
+        });
     }
 
     /// Transform update expression (`++` or `--`) where argument is private field.
@@ -924,16 +938,23 @@ impl<'a> ClassProperties<'a> {
         };
 
         if self.private_fields_as_properties {
-            let prop_binding = self.classes_stack.find_private_prop(&field_expr.field).prop_binding;
             // `object.#prop++` -> `_classPrivateFieldLooseBase(object, _prop)[_prop]++`
-            let object = field_expr.object.take_in(ctx);
-            let replacement = Self::create_private_field_member_expr_loose(
-                object,
-                prop_binding,
-                field_expr.span,
-                ctx,
-            );
-            update_expr.argument = SimpleAssignmentTarget::from(replacement);
+            update_expr.argument.replace_with(|argument| {
+                let SimpleAssignmentTarget::PrivateFieldExpression(field_expr) = argument else {
+                    unreachable!()
+                };
+
+                let prop_binding =
+                    self.classes_stack.find_private_prop(&field_expr.field).prop_binding;
+                let field_expr = field_expr.unbox();
+                let replacement = Self::create_private_field_member_expr_loose(
+                    field_expr.object,
+                    prop_binding,
+                    field_expr.span,
+                    ctx,
+                );
+                SimpleAssignmentTarget::from(replacement)
+            });
             return;
         }
 
@@ -1023,74 +1044,77 @@ impl<'a> ClassProperties<'a> {
             let UpdateExpression { span, prefix, .. } = **update_expr;
             update_expr.span = SPAN;
             update_expr.argument = temp_binding.create_read_write_simple_target(ctx);
-            let update_expr = expr.take_in(ctx);
+            expr.replace_with(|update_expr| {
+                if prefix {
+                    // Source = `++object.#prop` (prefix `++`)
 
-            if prefix {
-                // Source = `++object.#prop` (prefix `++`)
-
-                // `(_object$prop = _assertClassBrand(Class, object, _prop)._, ++_object$prop)`
-                let mut value = Expression::new_sequence_expression(
-                    SPAN,
-                    ArenaVec::from_array_in([assignment, update_expr], ctx),
-                    ctx,
-                );
-
-                // If no shortcut, wrap in `_assertClassBrand(Class, object, <value>)`
-                if let Some(class_ident) = class_ident {
-                    value = self.create_assert_class_brand(class_ident, object, value, SPAN, ctx);
-                }
-
-                // `_prop._ = <value>`
-                *expr = Expression::new_assignment_expression(
-                    span,
-                    AssignmentOperator::Assign,
-                    Self::create_underscore_member_expr_target(prop_ident2, SPAN, ctx),
-                    value,
-                    ctx,
-                );
-            } else {
-                // Source = `object.#prop++` (postfix `++`)
-
-                // `_object$prop2 = _object$prop++`
-                let temp_binding2 = VarDeclarationsStore::create_uid_var(&temp_var_name_base, ctx);
-                let assignment2 = create_assignment(&temp_binding2, update_expr, SPAN, ctx);
-
-                // `(_object$prop = _assertClassBrand(Class, object, _prop)._, _object$prop2 = _object$prop++, _object$prop)`
-                let mut value = Expression::new_sequence_expression(
-                    SPAN,
-                    ArenaVec::from_array_in(
-                        [assignment, assignment2, temp_binding.create_read_expression(ctx)],
+                    // `(_object$prop = _assertClassBrand(Class, object, _prop)._, ++_object$prop)`
+                    let mut value = Expression::new_sequence_expression(
+                        SPAN,
+                        ArenaVec::from_array_in([assignment, update_expr], ctx),
                         ctx,
-                    ),
-                    ctx,
-                );
+                    );
 
-                // If no shortcut, wrap in `_assertClassBrand(Class, object, <value>)`
-                if let Some(class_ident) = class_ident {
-                    value = self.create_assert_class_brand(class_ident, object, value, SPAN, ctx);
-                }
+                    // If no shortcut, wrap in `_assertClassBrand(Class, object, <value>)`
+                    if let Some(class_ident) = class_ident {
+                        value =
+                            self.create_assert_class_brand(class_ident, object, value, SPAN, ctx);
+                    }
 
-                // `_prop._ = <value>`
-                let assignment3 = Expression::new_assignment_expression(
-                    SPAN,
-                    AssignmentOperator::Assign,
-                    Self::create_underscore_member_expr_target(prop_ident2, SPAN, ctx),
-                    value,
-                    ctx,
-                );
-
-                // `(_prop._ = <value>, _object$prop2)`
-                // TODO(improve-on-babel): Final `_object$prop2` is only needed if this expression
-                // is consumed (i.e. not in an `ExpressionStatement`)
-                *expr = Expression::new_sequence_expression(
-                    span,
-                    ArenaVec::from_array_in(
-                        [assignment3, temp_binding2.create_read_expression(ctx)],
+                    // `_prop._ = <value>`
+                    Expression::new_assignment_expression(
+                        span,
+                        AssignmentOperator::Assign,
+                        Self::create_underscore_member_expr_target(prop_ident2, SPAN, ctx),
+                        value,
                         ctx,
-                    ),
-                    ctx,
-                );
-            }
+                    )
+                } else {
+                    // Source = `object.#prop++` (postfix `++`)
+
+                    // `_object$prop2 = _object$prop++`
+                    let temp_binding2 =
+                        VarDeclarationsStore::create_uid_var(&temp_var_name_base, ctx);
+                    let assignment2 = create_assignment(&temp_binding2, update_expr, SPAN, ctx);
+
+                    // `(_object$prop = _assertClassBrand(Class, object, _prop)._, _object$prop2 = _object$prop++, _object$prop)`
+                    let mut value = Expression::new_sequence_expression(
+                        SPAN,
+                        ArenaVec::from_array_in(
+                            [assignment, assignment2, temp_binding.create_read_expression(ctx)],
+                            ctx,
+                        ),
+                        ctx,
+                    );
+
+                    // If no shortcut, wrap in `_assertClassBrand(Class, object, <value>)`
+                    if let Some(class_ident) = class_ident {
+                        value =
+                            self.create_assert_class_brand(class_ident, object, value, SPAN, ctx);
+                    }
+
+                    // `_prop._ = <value>`
+                    let assignment3 = Expression::new_assignment_expression(
+                        SPAN,
+                        AssignmentOperator::Assign,
+                        Self::create_underscore_member_expr_target(prop_ident2, SPAN, ctx),
+                        value,
+                        ctx,
+                    );
+
+                    // `(_prop._ = <value>, _object$prop2)`
+                    // TODO(improve-on-babel): Final `_object$prop2` is only needed if this expression
+                    // is consumed (i.e. not in an `ExpressionStatement`)
+                    Expression::new_sequence_expression(
+                        span,
+                        ArenaVec::from_array_in(
+                            [assignment3, temp_binding2.create_read_expression(ctx)],
+                            ctx,
+                        ),
+                        ctx,
+                    )
+                }
+            });
         } else {
             // Clone as borrow restrictions.
             // TODO: Try to find a way to avoid this.
@@ -1126,64 +1150,65 @@ impl<'a> ClassProperties<'a> {
             let UpdateExpression { span, prefix, .. } = **update_expr;
             update_expr.span = SPAN;
             update_expr.argument = temp_binding.create_read_write_simple_target(ctx);
-            let update_expr = expr.take_in(ctx);
-
-            if prefix {
-                // Source = `++object.#prop` (prefix `++`)
-                // `(_object$prop = _classPrivateFieldGet(_prop, object), ++_object$prop)`
-                let value = Expression::new_sequence_expression(
-                    SPAN,
-                    ArenaVec::from_array_in([assignment, update_expr], ctx),
-                    ctx,
-                );
-                // `_classPrivateFieldSet(_prop, object, <value>)`
-                *expr = self.create_private_setter(
-                    &private_name,
-                    class_binding.as_ref(),
-                    set_binding.as_ref(),
-                    object1,
-                    value,
-                    span,
-                    ctx,
-                );
-            } else {
-                // Source = `object.#prop++` (postfix `++`)
-                // `_object$prop2 = _object$prop++`
-                let temp_binding2 = VarDeclarationsStore::create_uid_var(&temp_var_name_base, ctx);
-                let assignment2 = create_assignment(&temp_binding2, update_expr, SPAN, ctx);
-
-                // `(_object$prop = _classPrivateFieldGet(_prop, object), _object$prop2 = _object$prop++, _object$prop)`
-                let value = Expression::new_sequence_expression(
-                    SPAN,
-                    ArenaVec::from_array_in(
-                        [assignment, assignment2, temp_binding.create_read_expression(ctx)],
+            expr.replace_with(|update_expr| {
+                if prefix {
+                    // Source = `++object.#prop` (prefix `++`)
+                    // `(_object$prop = _classPrivateFieldGet(_prop, object), ++_object$prop)`
+                    let value = Expression::new_sequence_expression(
+                        SPAN,
+                        ArenaVec::from_array_in([assignment, update_expr], ctx),
                         ctx,
-                    ),
-                    ctx,
-                );
-
-                // `_classPrivateFieldSet(_prop, object, <value>)`
-                let set_call = self.create_private_setter(
-                    &private_name,
-                    class_binding.as_ref(),
-                    set_binding.as_ref(),
-                    object1,
-                    value,
-                    span,
-                    ctx,
-                );
-                // `(_classPrivateFieldSet(_prop, object, <value>), _object$prop2)`
-                // TODO(improve-on-babel): Final `_object$prop2` is only needed if this expression
-                // is consumed (i.e. not in an `ExpressionStatement`)
-                *expr = Expression::new_sequence_expression(
-                    span,
-                    ArenaVec::from_array_in(
-                        [set_call, temp_binding2.create_read_expression(ctx)],
+                    );
+                    // `_classPrivateFieldSet(_prop, object, <value>)`
+                    self.create_private_setter(
+                        &private_name,
+                        class_binding.as_ref(),
+                        set_binding.as_ref(),
+                        object1,
+                        value,
+                        span,
                         ctx,
-                    ),
-                    ctx,
-                );
-            }
+                    )
+                } else {
+                    // Source = `object.#prop++` (postfix `++`)
+                    // `_object$prop2 = _object$prop++`
+                    let temp_binding2 =
+                        VarDeclarationsStore::create_uid_var(&temp_var_name_base, ctx);
+                    let assignment2 = create_assignment(&temp_binding2, update_expr, SPAN, ctx);
+
+                    // `(_object$prop = _classPrivateFieldGet(_prop, object), _object$prop2 = _object$prop++, _object$prop)`
+                    let value = Expression::new_sequence_expression(
+                        SPAN,
+                        ArenaVec::from_array_in(
+                            [assignment, assignment2, temp_binding.create_read_expression(ctx)],
+                            ctx,
+                        ),
+                        ctx,
+                    );
+
+                    // `_classPrivateFieldSet(_prop, object, <value>)`
+                    let set_call = self.create_private_setter(
+                        &private_name,
+                        class_binding.as_ref(),
+                        set_binding.as_ref(),
+                        object1,
+                        value,
+                        span,
+                        ctx,
+                    );
+                    // `(_classPrivateFieldSet(_prop, object, <value>), _object$prop2)`
+                    // TODO(improve-on-babel): Final `_object$prop2` is only needed if this expression
+                    // is consumed (i.e. not in an `ExpressionStatement`)
+                    Expression::new_sequence_expression(
+                        span,
+                        ArenaVec::from_array_in(
+                            [set_call, temp_binding2.create_read_expression(ctx)],
+                            ctx,
+                        ),
+                        ctx,
+                    )
+                }
+            });
         }
     }
 
@@ -1385,8 +1410,9 @@ impl<'a> ClassProperties<'a> {
             // `o?.Foo.#self.self?.self.unicorn;` -> `(result ? void 0 : object)?.self.unicorn`
             //  ^^^^^^^^^^^^^^^^^ the object has transformed, if the current member is optional,
             //                    then we need to wrap it to a conditional expression
-            let owned_object = object.take_in(ctx);
-            *object = Self::wrap_conditional_check(result, owned_object, ctx);
+            object.replace_with(|owned_object| {
+                Self::wrap_conditional_check(result, owned_object, ctx)
+            });
             None
         } else {
             Some(result)
@@ -1580,7 +1606,7 @@ impl<'a> ClassProperties<'a> {
             if is_optional_callee {
                 // `o?.Foo.#self?.getSelf?.().#x;` -> `(_ref$getSelf = (_ref2 = _ref = o === null || o === void 0 ?
                 //              ^^ is optional         void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._)`
-                *object = Self::wrap_conditional_check(result, object.take_in(ctx), ctx);
+                object.replace_with(|object| Self::wrap_conditional_check(result, object, ctx));
                 let (assignment, context) = self.duplicate_object(object.take_in(ctx), ctx);
                 *object = assignment;
                 context
@@ -1592,7 +1618,7 @@ impl<'a> ClassProperties<'a> {
                 //                        and then use it as a first argument of `_ref.call`.
                 let (assignment, context) = self.duplicate_object(object.take_in(ctx), ctx);
                 *object = assignment;
-                *callee = Self::wrap_conditional_check(result, callee.take_in(ctx), ctx);
+                callee.replace_with(|callee| Self::wrap_conditional_check(result, callee, ctx));
                 context
             }
         } else {
@@ -1722,17 +1748,20 @@ impl<'a> ClassProperties<'a> {
         if let Some((result, chain_expr)) =
             self.transform_chain_expression_impl(&mut unary_expr.argument, ctx)
         {
-            *expr = Expression::new_conditional_expression(
-                unary_expr.span,
-                result,
-                Expression::new_boolean_literal(SPAN, true, ctx),
-                {
-                    // We still need this unary expr, but it needs to be used as the alternative of the conditional
-                    unary_expr.argument = chain_expr;
-                    expr.take_in(ctx)
-                },
-                ctx,
-            );
+            let span = unary_expr.span;
+
+            // We still need this unary expr, but it needs to be used as the alternative of the conditional
+            unary_expr.argument = chain_expr;
+
+            expr.replace_with(|expr| {
+                Expression::new_conditional_expression(
+                    span,
+                    result,
+                    Expression::new_boolean_literal(SPAN, true, ctx),
+                    expr,
+                    ctx,
+                )
+            });
         }
     }
 
@@ -1880,11 +1909,12 @@ impl<'a> ClassProperties<'a> {
         expr: &mut Expression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        let Expression::PrivateInExpression(private_in) = expr.take_in(ctx) else {
-            unreachable!();
-        };
-
-        *expr = self.transform_private_in_expression_impl(private_in, ctx);
+        expr.replace_with(|expr| {
+            let Expression::PrivateInExpression(private_in) = expr else {
+                unreachable!();
+            };
+            self.transform_private_in_expression_impl(private_in, ctx)
+        });
     }
 
     fn transform_private_in_expression_impl(

--- a/crates/oxc_transformer/src/es2022/class_properties/super_converter.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/super_converter.rs
@@ -1,7 +1,7 @@
 //! ES2022: Class Properties
 //! Transform of `super` expressions.
 
-use oxc_allocator::{ArenaBox, ArenaVec, TakeIn};
+use oxc_allocator::{ArenaBox, ArenaVec, ReplaceWith, TakeIn};
 use oxc_ast::ast::*;
 use oxc_span::SPAN;
 use oxc_traverse::ast_operations::get_var_name_from_node;
@@ -207,15 +207,19 @@ impl<'a> ClassPropertiesSuperConverter<'a, '_> {
         expr: &mut Expression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        let Expression::AssignmentExpression(assign_expr) = expr.take_in(ctx) else {
-            unreachable!()
-        };
-        let AssignmentExpression { span, operator, right: value, left, .. } = assign_expr.unbox();
-        let AssignmentTarget::StaticMemberExpression(member) = left else { unreachable!() };
-        let property =
-            Expression::new_string_literal(member.property.span, member.property.name, None, ctx);
-        *expr =
-            self.transform_super_assignment_expression_impl(span, operator, property, value, ctx);
+        expr.replace_with(|expr| {
+            let Expression::AssignmentExpression(assign_expr) = expr else { unreachable!() };
+            let AssignmentExpression { span, operator, right: value, left, .. } =
+                assign_expr.unbox();
+            let AssignmentTarget::StaticMemberExpression(member) = left else { unreachable!() };
+            let property = Expression::new_string_literal(
+                member.property.span,
+                member.property.name,
+                None,
+                ctx,
+            );
+            self.transform_super_assignment_expression_impl(span, operator, property, value, ctx)
+        });
     }
 
     /// Transform assignment expression where the left-hand side is a computed member expression
@@ -235,14 +239,14 @@ impl<'a> ClassPropertiesSuperConverter<'a, '_> {
         expr: &mut Expression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        let Expression::AssignmentExpression(assign_expr) = expr.take_in(ctx) else {
-            unreachable!()
-        };
-        let AssignmentExpression { span, operator, right: value, left, .. } = assign_expr.unbox();
-        let AssignmentTarget::ComputedMemberExpression(member) = left else { unreachable!() };
-        let property = member.unbox().expression.into_inner_expression();
-        *expr =
-            self.transform_super_assignment_expression_impl(span, operator, property, value, ctx);
+        expr.replace_with(|expr| {
+            let Expression::AssignmentExpression(assign_expr) = expr else { unreachable!() };
+            let AssignmentExpression { span, operator, right: value, left, .. } =
+                assign_expr.unbox();
+            let AssignmentTarget::ComputedMemberExpression(member) = left else { unreachable!() };
+            let property = member.unbox().expression.into_inner_expression();
+            self.transform_super_assignment_expression_impl(span, operator, property, value, ctx)
+        });
     }
 
     /// Transform assignment expression where the left-hand side is a member expression with `super`
@@ -370,25 +374,29 @@ impl<'a> ClassPropertiesSuperConverter<'a, '_> {
         expr: &mut Expression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        let Expression::UpdateExpression(mut update_expr) = expr.take_in(ctx) else {
-            unreachable!()
-        };
-        let SimpleAssignmentTarget::StaticMemberExpression(member) = &mut update_expr.argument
-        else {
-            unreachable!()
-        };
+        expr.replace_with(|expr| {
+            let Expression::UpdateExpression(mut update_expr) = expr else { unreachable!() };
+            let SimpleAssignmentTarget::StaticMemberExpression(member) = &mut update_expr.argument
+            else {
+                unreachable!()
+            };
 
-        let temp_var_name_base = get_var_name_from_node(member.as_ref());
+            let temp_var_name_base = get_var_name_from_node(member.as_ref());
 
-        let property =
-            Expression::new_string_literal(member.property.span, member.property.name, None, ctx);
+            let property = Expression::new_string_literal(
+                member.property.span,
+                member.property.name,
+                None,
+                ctx,
+            );
 
-        *expr = self.transform_super_update_expression_impl(
-            &temp_var_name_base,
-            update_expr,
-            property,
-            ctx,
-        );
+            self.transform_super_update_expression_impl(
+                &temp_var_name_base,
+                update_expr,
+                property,
+                ctx,
+            )
+        });
     }
 
     /// Transform update expression (`++` or `--`) where argument is a computed member expression
@@ -433,24 +441,25 @@ impl<'a> ClassPropertiesSuperConverter<'a, '_> {
         expr: &mut Expression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        let Expression::UpdateExpression(mut update_expr) = expr.take_in(ctx) else {
-            unreachable!()
-        };
-        let SimpleAssignmentTarget::ComputedMemberExpression(member) = &mut update_expr.argument
-        else {
-            unreachable!()
-        };
+        expr.replace_with(|expr| {
+            let Expression::UpdateExpression(mut update_expr) = expr else { unreachable!() };
+            let SimpleAssignmentTarget::ComputedMemberExpression(member) =
+                &mut update_expr.argument
+            else {
+                unreachable!()
+            };
 
-        let temp_var_name_base = get_var_name_from_node(member.as_ref());
+            let temp_var_name_base = get_var_name_from_node(member.as_ref());
 
-        let property = member.expression.get_inner_expression_mut().take_in(ctx);
+            let property = member.expression.get_inner_expression_mut().take_in(ctx);
 
-        *expr = self.transform_super_update_expression_impl(
-            &temp_var_name_base,
-            update_expr,
-            property,
-            ctx,
-        );
+            self.transform_super_update_expression_impl(
+                &temp_var_name_base,
+                update_expr,
+                property,
+                ctx,
+            )
+        });
     }
 
     /// Transform update expression (`++` or `--`) where argument is a member expression with `super`.

--- a/crates/oxc_transformer/src/es2026/explicit_resource_management.rs
+++ b/crates/oxc_transformer/src/es2026/explicit_resource_management.rs
@@ -37,7 +37,7 @@ use std::mem;
 
 use rustc_hash::FxHashMap;
 
-use oxc_allocator::{Address, ArenaBox, ArenaVec, GetAddress, TakeIn};
+use oxc_allocator::{Address, ArenaBox, ArenaVec, GetAddress, ReplaceWith, TakeIn};
 use oxc_ast::{ast::*, builder::NONE};
 use oxc_ecmascript::BoundNames;
 use oxc_semantic::{NodeId, ScopeFlags, ScopeId, SymbolFlags, SymbolId};
@@ -140,10 +140,10 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a> {
                     for_of_init_symbol_id,
                 );
 
-                let old_body = for_of_stmt.body.take_in(ctx);
-                let new_body = ArenaVec::from_array_in([using_stmt, old_body], ctx);
-                for_of_stmt.body =
-                    Statement::new_block_statement_with_scope_id(SPAN, new_body, scope_id, ctx);
+                for_of_stmt.body.replace_with(|old_body| {
+                    let new_body = ArenaVec::from_array_in([using_stmt, old_body], ctx);
+                    Statement::new_block_statement_with_scope_id(SPAN, new_body, scope_id, ctx)
+                });
                 return;
             }
 
@@ -168,11 +168,10 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a> {
                 for_of_init_symbol_id,
             );
 
-            let old_body = for_of_stmt.body.take_in(ctx);
-
-            let new_body = ArenaVec::from_array_in([using_stmt, old_body], ctx);
-            for_of_stmt.body =
-                Statement::new_block_statement_with_scope_id(SPAN, new_body, scope_id, ctx);
+            for_of_stmt.body.replace_with(|old_body| {
+                let new_body = ArenaVec::from_array_in([using_stmt, old_body], ctx);
+                Statement::new_block_statement_with_scope_id(SPAN, new_body, scope_id, ctx)
+            });
         }
     }
 
@@ -381,224 +380,235 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a> {
             return;
         }
 
-        let program_body = program.body.take_in(ctx);
+        program.body.replace_with(|program_body| {
+            let (mut program_body, inner_block): (
+                ArenaVec<'a, Statement<'a>>,
+                ArenaVec<'a, Statement<'a>>,
+            ) = program_body.into_iter().fold(
+                (ArenaVec::new_in(ctx), ArenaVec::new_in(ctx)),
+                |(mut program_body, mut inner_block), mut stmt| {
+                    let address = stmt.address();
+                    match stmt {
+                        Statement::FunctionDeclaration(_)
+                        | Statement::ImportDeclaration(_)
+                        | Statement::ExportAllDeclaration(_) => {
+                            program_body.push(stmt);
+                        }
+                        Statement::ExportDefaultDeclaration(ref mut export_default_decl) => {
+                            let (var_id, span) = match &mut export_default_decl.declaration {
+                                ExportDefaultDeclarationKind::ClassDeclaration(class_decl)
+                                    if class_decl.id.is_some() =>
+                                {
+                                    Self::preserve_class_expression_name(class_decl, ctx)
+                                }
+                                ExportDefaultDeclarationKind::FunctionDeclaration(_) => {
+                                    program_body.push(stmt);
+                                    return (program_body, inner_block);
+                                }
+                                _ => (
+                                    ctx.generate_binding_in_current_scope(
+                                        static_ident!("_default"),
+                                        SymbolFlags::FunctionScopedVariable,
+                                    ),
+                                    SPAN,
+                                ),
+                            };
 
-        let (mut program_body, inner_block): (
-            ArenaVec<'a, Statement<'a>>,
-            ArenaVec<'a, Statement<'a>>,
-        ) = program_body.into_iter().fold(
-            (ArenaVec::new_in(ctx), ArenaVec::new_in(ctx)),
-            |(mut program_body, mut inner_block), mut stmt| {
-                let address = stmt.address();
-                match stmt {
-                    Statement::FunctionDeclaration(_)
-                    | Statement::ImportDeclaration(_)
-                    | Statement::ExportAllDeclaration(_) => {
-                        program_body.push(stmt);
-                    }
-                    Statement::ExportDefaultDeclaration(ref mut export_default_decl) => {
-                        let (var_id, span) = match &mut export_default_decl.declaration {
-                            ExportDefaultDeclarationKind::ClassDeclaration(class_decl)
-                                if class_decl.id.is_some() =>
-                            {
-                                Self::preserve_class_expression_name(class_decl, ctx)
-                            }
-                            ExportDefaultDeclarationKind::FunctionDeclaration(_) => {
-                                program_body.push(stmt);
+                            let decl = mem::replace(
+                                &mut export_default_decl.declaration,
+                                ExportDefaultDeclarationKind::new_null_literal(SPAN, ctx),
+                            );
+
+                            let expr = match decl {
+                                ExportDefaultDeclarationKind::FunctionDeclaration(decl) => {
+                                    Expression::FunctionExpression(decl)
+                                }
+                                ExportDefaultDeclarationKind::ClassDeclaration(mut decl) => {
+                                    decl.r#type = ClassType::ClassExpression;
+                                    Expression::ClassExpression(decl)
+                                }
+                                _ => decl.into_expression(),
+                            };
+
+                            inner_block.push(Statement::new_variable_declaration(
+                                span,
+                                VariableDeclarationKind::Var,
+                                ArenaVec::from_value_in(
+                                    VariableDeclarator::new(
+                                        span,
+                                        VariableDeclarationKind::Var,
+                                        var_id.create_spanned_binding_pattern(span, ctx),
+                                        NONE,
+                                        Some(expr),
+                                        false,
+                                        ctx,
+                                    ),
+                                    ctx,
+                                ),
+                                false,
+                                ctx,
+                            ));
+
+                            program_body.push(Statement::new_export_named_declaration(
+                                SPAN,
+                                None,
+                                ArenaVec::from_value_in(
+                                    ExportSpecifier::new(
+                                        SPAN,
+                                        ModuleExportName::IdentifierReference(
+                                            var_id.create_read_reference(ctx),
+                                        ),
+                                        ModuleExportName::new_identifier_name(SPAN, "default", ctx),
+                                        ImportOrExportKind::Value,
+                                        ctx,
+                                    ),
+                                    ctx,
+                                ),
+                                None,
+                                ImportOrExportKind::Value,
+                                NONE,
+                                ctx,
+                            ));
+                        }
+                        Statement::ExportNamedDeclaration(export_named_declaration) => {
+                            if export_named_declaration.declaration.is_none() {
+                                program_body.push(Statement::ExportNamedDeclaration(
+                                    export_named_declaration,
+                                ));
                                 return (program_body, inner_block);
                             }
-                            _ => (
-                                ctx.generate_binding_in_current_scope(
-                                    static_ident!("_default"),
-                                    SymbolFlags::FunctionScopedVariable,
-                                ),
-                                SPAN,
-                            ),
-                        };
 
-                        let decl = mem::replace(
-                            &mut export_default_decl.declaration,
-                            ExportDefaultDeclarationKind::new_null_literal(SPAN, ctx),
-                        );
-
-                        let expr = match decl {
-                            ExportDefaultDeclarationKind::FunctionDeclaration(decl) => {
-                                Expression::FunctionExpression(decl)
-                            }
-                            ExportDefaultDeclarationKind::ClassDeclaration(mut decl) => {
-                                decl.r#type = ClassType::ClassExpression;
-                                Expression::ClassExpression(decl)
-                            }
-                            _ => decl.into_expression(),
-                        };
-
-                        inner_block.push(Statement::new_variable_declaration(
-                            span,
-                            VariableDeclarationKind::Var,
-                            ArenaVec::from_value_in(
-                                VariableDeclarator::new(
-                                    span,
-                                    VariableDeclarationKind::Var,
-                                    var_id.create_spanned_binding_pattern(span, ctx),
-                                    NONE,
-                                    Some(expr),
-                                    false,
-                                    ctx,
-                                ),
-                                ctx,
-                            ),
-                            false,
-                            ctx,
-                        ));
-
-                        program_body.push(Statement::new_export_named_declaration(
-                            SPAN,
-                            None,
-                            ArenaVec::from_value_in(
-                                ExportSpecifier::new(
-                                    SPAN,
-                                    ModuleExportName::IdentifierReference(
-                                        var_id.create_read_reference(ctx),
-                                    ),
-                                    ModuleExportName::new_identifier_name(SPAN, "default", ctx),
-                                    ImportOrExportKind::Value,
-                                    ctx,
-                                ),
-                                ctx,
-                            ),
-                            None,
-                            ImportOrExportKind::Value,
-                            NONE,
-                            ctx,
-                        ));
-                    }
-                    Statement::ExportNamedDeclaration(ref mut export_named_declaration) => {
-                        let Some(ref mut decl) = export_named_declaration.declaration else {
-                            program_body.push(stmt);
-                            return (program_body, inner_block);
-                        };
-                        if matches!(
-                            decl,
-                            Declaration::FunctionDeclaration(_)
+                            let decl = export_named_declaration.declaration.as_ref().unwrap();
+                            if matches!(
+                                decl,
+                                Declaration::FunctionDeclaration(_)
                                 | Declaration::TSTypeAliasDeclaration(_)
                                 | Declaration::TSInterfaceDeclaration(_)
                                 | Declaration::TSEnumDeclaration(_)
                                 | Declaration::TSModuleDeclaration(_)
                                 // Note: `TSGlobalDeclaration` cannot be exported
                                 | Declaration::TSImportEqualsDeclaration(_)
-                        ) {
-                            program_body.push(stmt);
+                            ) {
+                                program_body.push(Statement::ExportNamedDeclaration(
+                                    export_named_declaration,
+                                ));
 
-                            return (program_body, inner_block);
-                        }
-
-                        let export_specifiers = match decl.take_in(ctx) {
-                            Declaration::ClassDeclaration(class_decl) => {
-                                let class_binding = class_decl.id.as_ref().unwrap();
-                                let class_binding_name = class_binding.name;
-
-                                let class_binding_reference =
-                                    BoundIdentifier::from_binding_ident(class_binding)
-                                        .create_read_reference(ctx);
-
-                                inner_block.push(Self::transform_class_decl(class_decl, ctx));
-
-                                let local =
-                                    ModuleExportName::IdentifierReference(class_binding_reference);
-                                let exported = ModuleExportName::new_identifier_name(
-                                    SPAN,
-                                    class_binding_name,
-                                    ctx,
-                                );
-                                ArenaVec::from_value_in(
-                                    ExportSpecifier::new(
-                                        SPAN,
-                                        local,
-                                        exported,
-                                        ImportOrExportKind::Value,
-                                        ctx,
-                                    ),
-                                    ctx,
-                                )
+                                return (program_body, inner_block);
                             }
-                            Declaration::VariableDeclaration(mut var_decl) => {
-                                var_decl.kind = VariableDeclarationKind::Var;
-                                let mut export_specifiers = ArenaVec::new_in(ctx);
 
-                                for decl in &mut var_decl.declarations {
-                                    decl.kind = VariableDeclarationKind::Var;
+                            let export_kind = export_named_declaration.export_kind;
+
+                            let decl = export_named_declaration.unbox().declaration.unwrap();
+                            let export_specifiers = match decl {
+                                Declaration::ClassDeclaration(class_decl) => {
+                                    let class_binding = class_decl.id.as_ref().unwrap();
+                                    let class_binding_name = class_binding.name;
+
+                                    let class_binding_reference =
+                                        BoundIdentifier::from_binding_ident(class_binding)
+                                            .create_read_reference(ctx);
+
+                                    inner_block.push(Self::transform_class_decl(class_decl, ctx));
+
+                                    let local = ModuleExportName::IdentifierReference(
+                                        class_binding_reference,
+                                    );
+                                    let exported = ModuleExportName::new_identifier_name(
+                                        SPAN,
+                                        class_binding_name,
+                                        ctx,
+                                    );
+                                    ArenaVec::from_value_in(
+                                        ExportSpecifier::new(
+                                            SPAN,
+                                            local,
+                                            exported,
+                                            ImportOrExportKind::Value,
+                                            ctx,
+                                        ),
+                                        ctx,
+                                    )
                                 }
+                                Declaration::VariableDeclaration(mut var_decl) => {
+                                    var_decl.kind = VariableDeclarationKind::Var;
+                                    let mut export_specifiers = ArenaVec::new_in(ctx);
 
-                                var_decl.bound_names(&mut |ident| {
-                                    *ctx.scoping_mut().symbol_flags_mut(ident.symbol_id()) =
-                                        SymbolFlags::FunctionScopedVariable;
+                                    for decl in &mut var_decl.declarations {
+                                        decl.kind = VariableDeclarationKind::Var;
+                                    }
 
-                                    export_specifiers.push(ExportSpecifier::new(
-                                        SPAN,
-                                        ModuleExportName::IdentifierReference(
-                                            BoundIdentifier::from_binding_ident(ident)
-                                                .create_read_reference(ctx),
-                                        ),
-                                        ModuleExportName::new_identifier_name(
-                                            SPAN, ident.name, ctx,
-                                        ),
-                                        ImportOrExportKind::Value,
-                                        ctx,
-                                    ));
-                                });
-                                inner_block.push(Statement::VariableDeclaration(var_decl));
-                                export_specifiers
+                                    var_decl.bound_names(&mut |ident| {
+                                        *ctx.scoping_mut().symbol_flags_mut(ident.symbol_id()) =
+                                            SymbolFlags::FunctionScopedVariable;
+
+                                        export_specifiers.push(ExportSpecifier::new(
+                                            SPAN,
+                                            ModuleExportName::IdentifierReference(
+                                                BoundIdentifier::from_binding_ident(ident)
+                                                    .create_read_reference(ctx),
+                                            ),
+                                            ModuleExportName::new_identifier_name(
+                                                SPAN, ident.name, ctx,
+                                            ),
+                                            ImportOrExportKind::Value,
+                                            ctx,
+                                        ));
+                                    });
+                                    inner_block.push(Statement::VariableDeclaration(var_decl));
+                                    export_specifiers
+                                }
+                                _ => unreachable!(),
+                            };
+
+                            program_body.push(Statement::new_export_named_declaration(
+                                SPAN,
+                                None,
+                                export_specifiers,
+                                None,
+                                export_kind,
+                                NONE,
+                                ctx,
+                            ));
+                        }
+                        Statement::ClassDeclaration(class_decl) => {
+                            inner_block.push(Self::transform_class_decl(class_decl, ctx));
+                        }
+                        Statement::VariableDeclaration(ref mut var_declaration) => {
+                            if var_declaration.kind == VariableDeclarationKind::Using {
+                                self.top_level_using.insert(address, false);
+                            } else if var_declaration.kind == VariableDeclarationKind::AwaitUsing {
+                                self.top_level_using.insert(address, true);
                             }
-                            _ => unreachable!(),
-                        };
+                            var_declaration.kind = VariableDeclarationKind::Var;
 
-                        program_body.push(Statement::new_export_named_declaration(
-                            SPAN,
-                            None,
-                            export_specifiers,
-                            None,
-                            export_named_declaration.export_kind,
-                            NONE,
-                            ctx,
-                        ));
-                    }
-                    Statement::ClassDeclaration(class_decl) => {
-                        inner_block.push(Self::transform_class_decl(class_decl, ctx));
-                    }
-                    Statement::VariableDeclaration(ref mut var_declaration) => {
-                        if var_declaration.kind == VariableDeclarationKind::Using {
-                            self.top_level_using.insert(address, false);
-                        } else if var_declaration.kind == VariableDeclarationKind::AwaitUsing {
-                            self.top_level_using.insert(address, true);
+                            for decl in &mut var_declaration.declarations {
+                                decl.kind = VariableDeclarationKind::Var;
+                                decl.id.bound_names(&mut |c| {
+                                    *ctx.scoping_mut().symbol_flags_mut(c.symbol_id()) =
+                                        SymbolFlags::FunctionScopedVariable;
+                                });
+                            }
+
+                            inner_block.push(stmt);
                         }
-                        var_declaration.kind = VariableDeclarationKind::Var;
-
-                        for decl in &mut var_declaration.declarations {
-                            decl.kind = VariableDeclarationKind::Var;
-                            decl.id.bound_names(&mut |c| {
-                                *ctx.scoping_mut().symbol_flags_mut(c.symbol_id()) =
-                                    SymbolFlags::FunctionScopedVariable;
-                            });
-                        }
-
-                        inner_block.push(stmt);
+                        _ => inner_block.push(stmt),
                     }
-                    _ => inner_block.push(stmt),
-                }
 
-                (program_body, inner_block)
-            },
-        );
+                    (program_body, inner_block)
+                },
+            );
 
-        let block_scope_id = ctx.insert_scope_below_statements(&inner_block, ScopeFlags::empty());
-        program_body.push(Statement::new_block_statement_with_scope_id(
-            SPAN,
-            inner_block,
-            block_scope_id,
-            ctx,
-        ));
+            let block_scope_id =
+                ctx.insert_scope_below_statements(&inner_block, ScopeFlags::empty());
+            program_body.push(Statement::new_block_statement_with_scope_id(
+                SPAN,
+                inner_block,
+                block_scope_id,
+                ctx,
+            ));
 
-        std::mem::swap(&mut program.body, &mut program_body);
+            program_body
+        });
     }
 }
 
@@ -742,45 +752,48 @@ impl<'a> ExplicitResourceManagement<'a> {
 
         let callee = helper_load(Helper::UsingCtx, ctx);
 
-        let block = {
-            let vec = ArenaVec::from_array_in(
-                [
-                    Statement::new_variable_declaration(
-                        SPAN,
-                        VariableDeclarationKind::Var,
-                        ArenaVec::from_value_in(
-                            VariableDeclarator::new(
-                                SPAN,
-                                VariableDeclarationKind::Var,
-                                using_ctx.create_binding_pattern(ctx),
-                                NONE,
-                                Some(Expression::new_call_expression(
+        stmt.replace_with(|stmt| {
+            let block = {
+                let vec = ArenaVec::from_array_in(
+                    [
+                        Statement::new_variable_declaration(
+                            SPAN,
+                            VariableDeclarationKind::Var,
+                            ArenaVec::from_value_in(
+                                VariableDeclarator::new(
                                     SPAN,
-                                    callee,
+                                    VariableDeclarationKind::Var,
+                                    using_ctx.create_binding_pattern(ctx),
                                     NONE,
-                                    ArenaVec::new_in(ctx),
+                                    Some(Expression::new_call_expression(
+                                        SPAN,
+                                        callee,
+                                        NONE,
+                                        ArenaVec::new_in(ctx),
+                                        false,
+                                        ctx,
+                                    )),
                                     false,
                                     ctx,
-                                )),
-                                false,
+                                ),
                                 ctx,
                             ),
+                            false,
                             ctx,
                         ),
-                        false,
-                        ctx,
-                    ),
-                    stmt.take_in(ctx),
-                ],
-                ctx,
-            );
+                        stmt,
+                    ],
+                    ctx,
+                );
 
-            BlockStatement::new_with_scope_id(SPAN, vec, block_stmt_sid, ctx)
-        };
+                BlockStatement::new_with_scope_id(SPAN, vec, block_stmt_sid, ctx)
+            };
 
-        let catch = Self::create_catch_clause(&using_ctx, current_scope_id, ctx);
-        let finally = Self::create_finally_block(&using_ctx, current_scope_id, needs_await, ctx);
-        *stmt = Statement::new_try_statement(span, block, Some(catch), Some(finally), ctx);
+            let catch = Self::create_catch_clause(&using_ctx, current_scope_id, ctx);
+            let finally =
+                Self::create_finally_block(&using_ctx, current_scope_id, needs_await, ctx);
+            Statement::new_try_statement(span, block, Some(catch), Some(finally), ctx)
+        });
     }
 
     /// Transforms:

--- a/crates/oxc_transformer/src/jsx/jsx_impl.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_impl.rs
@@ -88,7 +88,7 @@
 //!
 //! * Babel plugin implementation: <https://github.com/babel/babel/tree/v7.26.2/packages/babel-helper-builder-react-jsx>
 
-use oxc_allocator::{ArenaBox, ArenaStringBuilder, ArenaVec, GetAllocator, TakeIn};
+use oxc_allocator::{ArenaBox, ArenaStringBuilder, ArenaVec, GetAllocator, ReplaceWith};
 use oxc_ast::{
     ast::*,
     builder::{AstBuilder, NONE},
@@ -551,11 +551,11 @@ impl<'a> Traverse<'a, TransformState<'a>> for JsxImpl<'a> {
         if !expr.is_jsx() {
             return;
         }
-        *expr = match expr.take_in(ctx) {
+        expr.replace_with(|expr| match expr {
             Expression::JSXElement(e) => self.transform_jsx_element(e, ctx),
             Expression::JSXFragment(e) => self.transform_jsx(e.span, None, e.unbox().children, ctx),
             _ => unreachable!(),
-        };
+        });
     }
 }
 

--- a/crates/oxc_transformer/src/jsx/refresh.rs
+++ b/crates/oxc_transformer/src/jsx/refresh.rs
@@ -8,7 +8,8 @@ use hmac_sha1_compact::Hash as Sha1;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use oxc_allocator::{
-    ArenaStringBuilder, ArenaVec, CloneIn, GetAddress, GetAllocator, TakeIn, UnstableAddress,
+    ArenaStringBuilder, ArenaVec, CloneIn, GetAddress, GetAllocator, ReplaceWith, TakeIn,
+    UnstableAddress,
 };
 use oxc_ast::{
     ast::*,
@@ -271,15 +272,17 @@ impl<'a> Traverse<'a, TransformState<'a>> for ReactRefresh<'a> {
         }
 
         let span = expr.span();
-        arguments.insert(0, Argument::from(expr.take_in(ctx)));
-        *expr = Expression::new_call_expression(
-            span,
-            binding.create_read_expression(ctx),
-            NONE,
-            arguments,
-            false,
-            ctx,
-        );
+        expr.replace_with(|expr| {
+            arguments.insert(0, Argument::from(expr));
+            Expression::new_call_expression(
+                span,
+                binding.create_read_expression(ctx),
+                NONE,
+                arguments,
+                false,
+                ctx,
+            )
+        });
     }
 
     fn exit_function(&mut self, func: &mut Function<'a>, ctx: &mut TraverseCtx<'a>) {
@@ -544,13 +547,15 @@ impl<'a> ReactRefresh<'a> {
         }
 
         if !is_variable_declarator {
-            *expr = Expression::new_assignment_expression(
-                SPAN,
-                AssignmentOperator::Assign,
-                self.create_registration(Str::from_str_in(inferred_name, ctx), ctx),
-                expr.take_in(ctx),
-                ctx,
-            );
+            expr.replace_with(|expr| {
+                Expression::new_assignment_expression(
+                    SPAN,
+                    AssignmentOperator::Assign,
+                    self.create_registration(Str::from_str_in(inferred_name, ctx), ctx),
+                    expr,
+                    ctx,
+                )
+            });
         }
 
         true

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -7,7 +7,7 @@
 
 use std::path::Path;
 
-use oxc_allocator::{Allocator, ArenaVec, TakeIn};
+use oxc_allocator::{Allocator, ArenaVec, ReplaceWith};
 use oxc_ast::{ast::*, builder::AstBuilder};
 use oxc_diagnostics::Diagnostics;
 #[cfg(feature = "react_compiler")]
@@ -645,11 +645,13 @@ impl<'a> Traverse<'a, TransformState<'a>> for TransformerImpl<'a> {
             // };
             // ```
             for stmt in statements.iter_mut().rev() {
-                let Statement::ExpressionStatement(expr_stmt) = stmt else {
+                if !matches!(stmt, Statement::ExpressionStatement(_)) {
                     continue;
-                };
-                let expression = Some(expr_stmt.expression.take_in(ctx));
-                *stmt = Statement::new_return_statement(SPAN, expression, ctx);
+                }
+                stmt.replace_with(|stmt| {
+                    let Statement::ExpressionStatement(expr_stmt) = stmt else { unreachable!() };
+                    Statement::new_return_statement(SPAN, Some(expr_stmt.unbox().expression), ctx)
+                });
                 return;
             }
             unreachable!("At least one statement should be expression statement")

--- a/crates/oxc_transformer/src/plugins/styled_components.rs
+++ b/crates/oxc_transformer/src/plugins/styled_components.rs
@@ -63,7 +63,7 @@ use std::{
 use rustc_hash::FxHasher;
 use serde::Deserialize;
 
-use oxc_allocator::{ArenaVec, TakeIn};
+use oxc_allocator::{ArenaVec, ReplaceWith, TakeIn};
 use oxc_ast::{
     ast::*,
     builder::{AstBuilder, NONE},
@@ -460,12 +460,12 @@ impl<'a> StyledComponents<'a> {
             self.add_properties(&mut properties, ctx);
             let object = ObjectExpression::boxed(SPAN, properties, ctx);
             let arguments = ArenaVec::from_value_in(Argument::ObjectExpression(object), ctx);
-            let object = expr.take_in(ctx);
-            let property = IdentifierName::new(SPAN, "withConfig", ctx);
-            let callee =
-                Expression::new_static_member_expression(SPAN, object, property, false, ctx);
-            let call = Expression::new_call_expression(SPAN, callee, NONE, arguments, false, ctx);
-            *expr = call;
+            expr.replace_with(|object| {
+                let property = IdentifierName::new(SPAN, "withConfig", ctx);
+                let callee =
+                    Expression::new_static_member_expression(SPAN, object, property, false, ctx);
+                Expression::new_call_expression(SPAN, callee, NONE, arguments, false, ctx)
+            });
         } else {
             return false;
         }

--- a/crates/oxc_transformer/src/plugins/tagged_template_transform.rs
+++ b/crates/oxc_transformer/src/plugins/tagged_template_transform.rs
@@ -40,7 +40,7 @@
 
 use std::iter;
 
-use oxc_allocator::{ArenaVec, TakeIn};
+use oxc_allocator::{ArenaVec, ReplaceWith};
 use oxc_ast::{ast::*, builder::NONE};
 use oxc_semantic::SymbolFlags;
 use oxc_span::SPAN;
@@ -83,16 +83,18 @@ impl<'a> TaggedTemplateTransform {
             return;
         }
 
-        let Expression::TaggedTemplateExpression(tagged) = expr.take_in(ctx) else {
-            unreachable!();
-        };
+        expr.replace_with(|expr| {
+            let Expression::TaggedTemplateExpression(tagged) = expr else {
+                unreachable!();
+            };
 
-        let TaggedTemplateExpression { span, tag, quasi: template_lit, type_arguments, .. } =
-            tagged.unbox();
+            let TaggedTemplateExpression { span, tag, quasi: template_lit, type_arguments, .. } =
+                tagged.unbox();
 
-        let binding = self.create_top_level_binding(ctx);
-        let arguments = self.transform_template_literal(&binding, template_lit, ctx);
-        *expr = Expression::new_call_expression(span, tag, type_arguments, arguments, false, ctx);
+            let binding = self.create_top_level_binding(ctx);
+            let arguments = self.transform_template_literal(&binding, template_lit, ctx);
+            Expression::new_call_expression(span, tag, type_arguments, arguments, false, ctx)
+        });
     }
 
     /// Check if the template literal contains a `</script` tag; note it is case-insensitive.

--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{ArenaVec, TakeIn};
+use oxc_allocator::{ArenaVec, ReplaceWith, TakeIn};
 use oxc_ast::ast::*;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_semantic::{Reference, SymbolFlags};
@@ -246,10 +246,9 @@ impl<'a> Traverse<'a, TransformState<'a>> for TypeScriptAnnotations<'a> {
             .retain(|elem| !matches!(elem, ClassElement::PropertyDefinition(prop) if prop.declare));
     }
 
-    fn enter_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
+    fn enter_expression(&mut self, expr: &mut Expression<'a>, _ctx: &mut TraverseCtx<'a>) {
         if expr.is_typescript_syntax() {
-            let inner_expr = expr.get_inner_expression_mut();
-            *expr = inner_expr.take_in(ctx);
+            expr.replace_with(Expression::into_inner_expression);
         }
     }
 
@@ -412,8 +411,9 @@ impl<'a> Traverse<'a, TransformState<'a>> for TypeScriptAnnotations<'a> {
                 _ => None,
             };
             if let Some(span) = consequent_span {
-                let consequent = stmt.consequent.take_in(ctx);
-                stmt.consequent = Self::create_block_with_statement(consequent, span, ctx);
+                stmt.consequent.replace_with(|consequent| {
+                    Self::create_block_with_statement(consequent, span, ctx)
+                });
             }
 
             let alternate_span = match &stmt.alternate {

--- a/crates/oxc_transformer/src/typescript/class.rs
+++ b/crates/oxc_transformer/src/typescript/class.rs
@@ -1,6 +1,6 @@
 use rustc_hash::FxHashSet;
 
-use oxc_allocator::{ArenaVec, TakeIn};
+use oxc_allocator::{ArenaVec, ReplaceWith, TakeIn};
 use oxc_ast::{ast::*, builder::NONE};
 use oxc_semantic::{ScopeFlags, ScopeId};
 use oxc_span::SPAN;
@@ -533,16 +533,16 @@ impl<'a> TypeScript<'a> {
         if let Some(key) = key.as_expression_mut() {
             // If the key is already an expression, we need to create a new expression sequence
             // to insert the assignments into.
-            let original_key = key.take_in(ctx);
-            let new_key = Expression::new_sequence_expression(
-                SPAN,
-                ArenaVec::from_iter_in(
-                    assignments.split_off(0).into_iter().chain(std::iter::once(original_key)),
+            key.replace_with(|original_key| {
+                Expression::new_sequence_expression(
+                    SPAN,
+                    ArenaVec::from_iter_in(
+                        assignments.split_off(0).into_iter().chain(std::iter::once(original_key)),
+                        ctx,
+                    ),
                     ctx,
-                ),
-                ctx,
-            );
-            *key = new_key;
+                )
+            });
         }
     }
 

--- a/crates/oxc_transformer/src/typescript/namespace.rs
+++ b/crates/oxc_transformer/src/typescript/namespace.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{ArenaBox, ArenaVec, TakeIn};
+use oxc_allocator::{ArenaBox, ArenaVec, ReplaceWith, TakeIn};
 use oxc_ast::{ast::*, builder::NONE};
 use oxc_ecmascript::BoundNames;
 use oxc_span::{SPAN, Span};
@@ -475,20 +475,22 @@ impl<'a> TypeScriptNamespace {
                     return;
                 };
                 if let Some(init) = &mut declarator.init {
-                    declarator.init = Some(Expression::new_assignment_expression(
-                        SPAN,
-                        AssignmentOperator::Assign,
-                        SimpleAssignmentTarget::new_static_member_expression(
+                    init.replace_with(|init| {
+                        Expression::new_assignment_expression(
                             SPAN,
-                            binding.create_read_expression(ctx),
-                            IdentifierName::new(SPAN, property_name, ctx),
-                            false,
+                            AssignmentOperator::Assign,
+                            SimpleAssignmentTarget::new_static_member_expression(
+                                SPAN,
+                                binding.create_read_expression(ctx),
+                                IdentifierName::new(SPAN, property_name, ctx),
+                                false,
+                                ctx,
+                            )
+                            .into(),
+                            init,
                             ctx,
                         )
-                        .into(),
-                        init.take_in(ctx),
-                        ctx,
-                    ));
+                    });
                 }
             });
             return ArenaVec::from_value_in(Statement::VariableDeclaration(var_decl), ctx);

--- a/crates/oxc_transformer_plugins/src/module_runner_transform.rs
+++ b/crates/oxc_transformer_plugins/src/module_runner_transform.rs
@@ -50,7 +50,7 @@ use std::iter;
 use itoa::Buffer as ItoaBuffer;
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use oxc_allocator::{Allocator, ArenaBox, ArenaVec, GetAllocator, TakeIn};
+use oxc_allocator::{Allocator, ArenaBox, ArenaVec, GetAllocator, ReplaceWith};
 use oxc_ast::{ast::*, builder::NONE};
 use oxc_ecmascript::BoundNames;
 use oxc_semantic::{ReferenceFlags, ScopeFlags, Scoping, SymbolFlags, SymbolId};
@@ -245,26 +245,28 @@ impl<'a> ModuleRunnerTransform<'a> {
     /// Transform `import(source, ...arguments)` to `__vite_ssr_dynamic_import__(source, ...arguments)`.
     #[inline]
     fn transform_dynamic_import(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
-        let Expression::ImportExpression(import_expr) = expr.take_in(ctx) else {
-            unreachable!();
-        };
+        expr.replace_with(|expr| {
+            let Expression::ImportExpression(import_expr) = expr else {
+                unreachable!();
+            };
 
-        let ImportExpression { span, source, options, .. } = import_expr.unbox();
+            let ImportExpression { span, source, options, .. } = import_expr.unbox();
 
-        if let Expression::StringLiteral(source) = &source {
-            self.dynamic_deps.insert(source.value.to_string());
-        }
+            if let Expression::StringLiteral(source) = &source {
+                self.dynamic_deps.insert(source.value.to_string());
+            }
 
-        let flags = ReferenceFlags::Read;
-        let callee = ctx.create_unbound_ident_expr(
-            SPAN,
-            static_ident!("__vite_ssr_dynamic_import__"),
-            flags,
-        );
-        let arguments = options.into_iter().map(Argument::from);
-        let arguments =
-            ArenaVec::from_iter_in(iter::once(Argument::from(source)).chain(arguments), ctx);
-        *expr = Expression::new_call_expression(span, callee, NONE, arguments, false, ctx);
+            let flags = ReferenceFlags::Read;
+            let callee = ctx.create_unbound_ident_expr(
+                SPAN,
+                static_ident!("__vite_ssr_dynamic_import__"),
+                flags,
+            );
+            let arguments = options.into_iter().map(Argument::from);
+            let arguments =
+                ArenaVec::from_iter_in(iter::once(Argument::from(source)).chain(arguments), ctx);
+            Expression::new_call_expression(span, callee, NONE, arguments, false, ctx)
+        });
     }
 
     /// Transform `import.meta` to `__vite_ssr_import_meta__`.

--- a/crates/oxc_transformer_plugins/src/replace_global_defines.rs
+++ b/crates/oxc_transformer_plugins/src/replace_global_defines.rs
@@ -2,7 +2,7 @@ use std::{cmp::Ordering, sync::Arc};
 
 use rustc_hash::FxHashSet;
 
-use oxc_allocator::{Address, Allocator, ArenaBox, GetAddress, TakeIn, UnstableAddress};
+use oxc_allocator::{Address, Allocator, ArenaBox, GetAddress, ReplaceWith, UnstableAddress};
 use oxc_ast::ast::*;
 use oxc_ast_visit::{VisitMut, walk_mut};
 use oxc_diagnostics::{Diagnostics, OxcDiagnostic};
@@ -290,7 +290,7 @@ impl<'a> VisitMut<'a> for ReplaceGlobalDefines<'a> {
         // leaving an invalid `ChainExpression` with no optional elements.
         // Unwrap it to a plain expression to produce a valid AST.
         if matches!(expr, Expression::ChainExpression(_)) {
-            self.unwrap_chain_expression_if_no_optional(expr);
+            Self::unwrap_chain_expression_if_no_optional(expr);
         }
     }
 
@@ -830,7 +830,7 @@ impl<'a> ReplaceGlobalDefines<'a> {
     /// If `expr` is a `ChainExpression` whose chain no longer contains any
     /// `optional: true` markers (because a define replacement removed them),
     /// unwrap it to a plain expression.
-    fn unwrap_chain_expression_if_no_optional(&self, expr: &mut Expression<'a>) {
+    fn unwrap_chain_expression_if_no_optional(expr: &mut Expression<'a>) {
         let Expression::ChainExpression(chain) = &*expr else { return };
 
         // Check the chain element's optional flag and get the first object/callee to walk.
@@ -878,9 +878,10 @@ impl<'a> ReplaceGlobalDefines<'a> {
         }
 
         // No optional markers remain — unwrap the chain to a plain expression.
-        let chain_expr = expr.take_in(&self.allocator);
-        let Expression::ChainExpression(chain) = chain_expr else { unreachable!() };
-        *expr = Expression::from(chain.unbox().expression);
+        expr.replace_with(|chain_expr| {
+            let Expression::ChainExpression(chain) = chain_expr else { unreachable!() };
+            Expression::from(chain.unbox().expression)
+        });
     }
 
     pub fn is_dot_define<'b>(

--- a/tasks/track_memory_allocations/allocs_transformer.snap
+++ b/tasks/track_memory_allocations/allocs_transformer.snap
@@ -1,16 +1,16 @@
 File                       | File size      || Sys allocs     | Sys reallocs   || Arena allocs   | Arena reallocs 
 ---------------------------------------------------------------------------------------------------------------------------
-checker.ts                 | 2.92 MB        ||             20 |              0 ||           4400 |              5
+checker.ts                 | 2.92 MB        ||             20 |              0 ||           1959 |              5
 
-App.tsx                    | 415.34 kB      ||             25 |              2 ||            719 |             17
+App.tsx                    | 415.34 kB      ||             25 |              2 ||            618 |             17
 
-RadixUIAdoptionSection.jsx | 2.52 kB        ||             21 |              2 ||            259 |             13
+RadixUIAdoptionSection.jsx | 2.52 kB        ||             21 |              2 ||            258 |             13
 
 pdf.mjs                    | 567.30 kB      ||             15 |              0 ||              2 |              0
 
 antd.js                    | 6.69 MB        ||             15 |              0 ||              2 |              0
 
-binder.ts                  | 193.08 kB      ||             17 |              0 ||            379 |              0
+binder.ts                  | 193.08 kB      ||             17 |              0 ||            154 |              0
 
-kitchen-sink.tsx           | 732.90 kB      ||            184 |              3 ||           6689 |            280
+kitchen-sink.tsx           | 732.90 kB      ||            184 |              3 ||           6132 |            280
 


### PR DESCRIPTION
Replace `take_in` with `replace_with` in as many places as possible in transformer. See #24012 for explanation of the advantage of `replace_with`.

This has only a minimal perf effect according to Codspeed benchmarks (1% improvement). But it does cut the number of arena allocations on TS files by 50%, so reduces memory usage.