### PR TITLE
fix(semantic): resolve symbols in `TSConditionalType` correctly

### DIFF
--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -731,19 +731,20 @@ fn get_module_instance_state_for_alias_target<'a>(
 
 impl<'a> Binder<'a> for TSTypeParameter<'a> {
     fn bind(&self, builder: &mut SemanticBuilder<'a>) {
-        let scope_id = if matches!(builder.ancestry().parent_kind(), AstKind::TSInferType(_)) {
-            builder.active_ts_conditional_scope_id()
+        let symbol_id = if matches!(builder.ancestry().parent_kind(), AstKind::TSInferType(_))
+            && let Some(symbol_id) =
+                builder.declare_ts_infer_type_parameter(self.name.span, self.name.name)
+        {
+            symbol_id
         } else {
-            None
+            builder.declare_symbol(
+                self.name.span,
+                self.name.name,
+                SymbolFlags::TypeParameter,
+                SymbolFlags::TypeParameterExcludes,
+            )
         };
 
-        let symbol_id = builder.declare_symbol_on_scope(
-            self.name.span,
-            self.name.name,
-            scope_id.unwrap_or(builder.current_scope_id),
-            SymbolFlags::TypeParameter,
-            SymbolFlags::TypeParameterExcludes,
-        );
         self.name.symbol_id.set(Some(symbol_id));
     }
 }

--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -732,10 +732,7 @@ fn get_module_instance_state_for_alias_target<'a>(
 impl<'a> Binder<'a> for TSTypeParameter<'a> {
     fn bind(&self, builder: &mut SemanticBuilder<'a>) {
         let scope_id = if matches!(builder.ancestry().parent_kind(), AstKind::TSInferType(_)) {
-            builder
-                .scoping
-                .scope_ancestors(builder.current_scope_id)
-                .find(|scope_id| builder.scoping.scope_flags(*scope_id).is_ts_conditional())
+            builder.active_ts_conditional_scope_id()
         } else {
             None
         };

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -102,6 +102,9 @@ pub struct SemanticBuilder<'a> {
     /// Tracks the start index in the flat unresolved references list.
     unresolved_references_checkpoint: usize,
 
+    /// Conditional scopes that should receive `infer T` bindings while walking an `extends` type.
+    active_ts_conditional_scope_ids: SmallVec<[ScopeId; 2]>,
+
     unused_labels: UnusedLabels<'a>,
     #[cfg(feature = "jsdoc")]
     jsdoc: JSDocBuilder<'a>,
@@ -161,6 +164,7 @@ impl<'a> SemanticBuilder<'a> {
             scoping,
             unresolved_references: UnresolvedReferences::new(),
             unresolved_references_checkpoint: 0,
+            active_ts_conditional_scope_ids: SmallVec::new(),
             unused_labels: UnusedLabels::default(),
             #[cfg(feature = "jsdoc")]
             jsdoc: JSDocBuilder::default(),
@@ -734,6 +738,10 @@ impl<'a> SemanticBuilder<'a> {
             }
         }
         self.unresolved_references.truncate(write_idx);
+    }
+
+    pub(crate) fn active_ts_conditional_scope_id(&self) -> Option<ScopeId> {
+        self.active_ts_conditional_scope_ids.last().copied()
     }
 
     pub(crate) fn add_redeclare_variable(
@@ -2574,6 +2582,56 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         }
         self.visit_ts_type(&decl.type_annotation);
         self.leave_scope();
+        self.leave_node(kind);
+    }
+
+    fn visit_ts_conditional_type(&mut self, ty: &TSConditionalType<'a>) {
+        let kind = AstKind::TSConditionalType(self.alloc(ty));
+        self.enter_node(kind);
+        self.visit_span(&ty.span);
+        self.visit_ts_type(&ty.check_type);
+
+        let parent_scope_id = self.current_scope_id;
+        self.enter_scope(ScopeFlags::TsConditional, &ty.scope_id);
+        let conditional_scope_id = self.current_scope_id;
+
+        // Match TypeScript's resolver: `infer` declarations are collected on the conditional type
+        // node, but those locals are visible only from the true branch.
+        //
+        // ```ts
+        // type C<T> = T extends (a: infer B) => B ? B : never;
+        // //                         ^^^^^^^    ^   ^
+        // //                         declare    |   |
+        // //                                    |   visible: true_type sees `infer B`
+        // //                                    not visible: still inside extends_type
+        // ```
+        //
+        // Operationally this means the conditional scope has two roles:
+        //
+        // ```text
+        // parent scope
+        //   |- extends_type        references start here
+        //   |    \- infer B  --->  declarations are deposited in conditional scope
+        //   |
+        //   \- conditional scope   true_type references start here
+        //        \- B
+        // ```
+        //
+        // So we create the conditional scope now, keep it on
+        // `active_ts_conditional_scope_ids` as the binding target for `infer`, but restore
+        // `current_scope_id` to the parent while walking `extends_type`. After that, walking
+        // `true_type` from the conditional scope makes normal reference resolution find `infer B`.
+        // `false_type` is visited after leaving the conditional scope, so it cannot see `B`.
+        self.current_scope_id = parent_scope_id;
+        self.active_ts_conditional_scope_ids.push(conditional_scope_id);
+        self.visit_ts_type(&ty.extends_type);
+        let popped = self.active_ts_conditional_scope_ids.pop();
+        debug_assert_eq!(popped, Some(conditional_scope_id));
+
+        self.current_scope_id = conditional_scope_id;
+        self.visit_ts_type(&ty.true_type);
+        self.leave_scope();
+        self.visit_ts_type(&ty.false_type);
         self.leave_node(kind);
     }
 

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -2684,12 +2684,38 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         param.bind(self);
         self.visit_span(&param.span);
         self.visit_binding_identifier(&param.name);
+
+        // `infer` type parameters are declared before their constraints are resolved, and the
+        // constraint is allowed to see that just-declared type parameter.
+        //
+        // ```ts
+        // type Outer = string;
+        // type C<T> = T extends infer U extends U ? U : never;
+        // //                       ^^^^^^^ ^         ^
+        // //                       declare |         |
+        // //                               |         true_type sees `infer U`
+        // //                               constraint also sees `infer U`, not `Outer`
+        // ```
+        //
+        // TypeScript resolves the constraint `U` to the inferred `U`; the checker then reports
+        // "Type parameter 'U' has a circular constraint." If we kept resolving the constraint from
+        // the parent scope used for the surrounding `extends_type`, it would incorrectly bind to an
+        // outer `U` (or remain unresolved). Temporarily resolving the constraint/default from the
+        // active conditional scope preserves that self-reference while the rest of `extends_type`
+        // remains unable to see conditional `infer` locals.
+        let saved_scope_id = self.current_scope_id;
+        if matches!(self.ancestry().parent_kind(), AstKind::TSInferType(_))
+            && let Some(scope_id) = self.active_ts_conditional_scope_id()
+        {
+            self.current_scope_id = scope_id;
+        }
         if let Some(constraint) = &param.constraint {
             self.visit_ts_type(constraint);
         }
         if let Some(default) = &param.default {
             self.visit_ts_type(default);
         }
+        self.current_scope_id = saved_scope_id;
         self.leave_node(kind);
     }
 

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -2595,15 +2595,16 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         self.enter_scope(ScopeFlags::TsConditional, &ty.scope_id);
         let conditional_scope_id = self.current_scope_id;
 
-        // Match TypeScript's resolver: `infer` declarations are collected on the conditional type
+        // `infer` declarations are collected on the conditional type
         // node, but those locals are visible only from the true branch.
         //
         // ```ts
         // type C<T> = T extends (a: infer B) => B ? B : never;
-        // //                         ^^^^^^^    ^   ^
-        // //                         declare    |   |
-        // //                                    |   visible: true_type sees `infer B`
-        // //                                    not visible: still inside extends_type
+        // //                        ─┬─────     ┬   ┬   ─┬───
+        // //                         │          │   │    ╰ not visible
+        // //                         │          │   ╰ visible: true_type sees `infer B`
+        // //                         │          ╰ not visible: still inside extends_type
+        // //                         ╰ `B` declared here
         // ```
         //
         // Operationally this means the conditional scope has two roles:

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -2685,24 +2685,6 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         self.visit_span(&param.span);
         self.visit_binding_identifier(&param.name);
 
-        // `infer` type parameters are declared before their constraints are resolved, and the
-        // constraint is allowed to see that just-declared type parameter.
-        //
-        // ```ts
-        // type Outer = string;
-        // type C<T> = T extends infer U extends U ? U : never;
-        // //                       ^^^^^^^ ^         ^
-        // //                       declare |         |
-        // //                               |         true_type sees `infer U`
-        // //                               constraint also sees `infer U`, not `Outer`
-        // ```
-        //
-        // TypeScript resolves the constraint `U` to the inferred `U`; the checker then reports
-        // "Type parameter 'U' has a circular constraint." If we kept resolving the constraint from
-        // the parent scope used for the surrounding `extends_type`, it would incorrectly bind to an
-        // outer `U` (or remain unresolved). Temporarily resolving the constraint/default from the
-        // active conditional scope preserves that self-reference while the rest of `extends_type`
-        // remains unable to see conditional `infer` locals.
         let saved_scope_id = self.current_scope_id;
         if matches!(self.ancestry().parent_kind(), AstKind::TSInferType(_))
             && let Some(scope_id) = self.active_ts_conditional_scope_id()

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -104,6 +104,8 @@ pub struct SemanticBuilder<'a> {
 
     /// Conditional scopes that should receive `infer T` bindings while walking an `extends` type.
     active_ts_conditional_scope_ids: SmallVec<[ScopeId; 2]>,
+    /// Current `infer T` type parameters whose constraints may refer to themselves.
+    active_ts_infer_constraint_symbol_ids: SmallVec<[(Ident<'a>, SymbolId, ScopeId); 2]>,
 
     unused_labels: UnusedLabels<'a>,
     #[cfg(feature = "jsdoc")]
@@ -165,6 +167,7 @@ impl<'a> SemanticBuilder<'a> {
             unresolved_references: UnresolvedReferences::new(),
             unresolved_references_checkpoint: 0,
             active_ts_conditional_scope_ids: SmallVec::new(),
+            active_ts_infer_constraint_symbol_ids: SmallVec::new(),
             unused_labels: UnusedLabels::default(),
             #[cfg(feature = "jsdoc")]
             jsdoc: JSDocBuilder::default(),
@@ -659,6 +662,27 @@ impl<'a> SemanticBuilder<'a> {
         false
     }
 
+    fn walk_up_resolve_reference_until_scope(
+        &mut self,
+        name: Ident<'a>,
+        reference_id: ReferenceId,
+        stop_scope_id: ScopeId,
+    ) -> bool {
+        let mut scope_id = Some(self.scoping.references[reference_id].scope_id());
+        while let Some(sid) = scope_id {
+            if sid == stop_scope_id {
+                return false;
+            }
+            if let Some(symbol_id) = self.scoping.get_binding(sid, name)
+                && self.try_resolve_reference(reference_id, symbol_id)
+            {
+                return true;
+            }
+            scope_id = self.scoping.scope_parent_id(sid);
+        }
+        false
+    }
+
     /// Try to resolve a reference to a symbol. Returns `true` if resolved.
     fn try_resolve_reference(&mut self, reference_id: ReferenceId, symbol_id: SymbolId) -> bool {
         let symbol_flags = self.scoping.symbol_flags(symbol_id);
@@ -742,6 +766,14 @@ impl<'a> SemanticBuilder<'a> {
 
     pub(crate) fn active_ts_conditional_scope_id(&self) -> Option<ScopeId> {
         self.active_ts_conditional_scope_ids.last().copied()
+    }
+
+    fn active_ts_infer_constraint_symbol_id(&self, name: Ident<'a>) -> Option<(SymbolId, ScopeId)> {
+        self.active_ts_infer_constraint_symbol_ids.iter().rev().find_map(
+            |&(symbol_name, symbol_id, stop_scope_id)| {
+                (symbol_name == name).then_some((symbol_id, stop_scope_id))
+            },
+        )
     }
 
     pub(crate) fn add_redeclare_variable(
@@ -2685,11 +2717,31 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         self.visit_span(&param.span);
         self.visit_binding_identifier(&param.name);
 
-        let saved_scope_id = self.current_scope_id;
-        if matches!(self.ancestry().parent_kind(), AstKind::TSInferType(_))
-            && let Some(scope_id) = self.active_ts_conditional_scope_id()
-        {
-            self.current_scope_id = scope_id;
+        // Conditional `infer` bindings are declared in the conditional scope, but `extends_type`
+        // references are resolved from the surrounding scope. The only exception is the current
+        // inferred type parameter's own constraint:
+        //
+        // `T extends infer U extends U ? U : never`
+        //            declared here ^         ^ true type sees conditional scope
+        //                    constraint ^ resolves only to this just-declared `U`
+        //
+        // Sibling inferred parameters are intentionally hidden from each other, matching TypeScript:
+        // `T extends [infer A, infer B extends A] ? B : never`
+        //                                  ^ unresolved; does not see sibling `A`
+        let infer_constraint_symbol_id =
+            if matches!(self.ancestry().parent_kind(), AstKind::TSInferType(_))
+                && self.active_ts_conditional_scope_id().is_some()
+            {
+                param
+                    .name
+                    .symbol_id
+                    .get()
+                    .map(|symbol_id| (param.name.name, symbol_id, self.current_scope_id))
+            } else {
+                None
+            };
+        if let Some(symbol) = infer_constraint_symbol_id {
+            self.active_ts_infer_constraint_symbol_ids.push(symbol);
         }
         if let Some(constraint) = &param.constraint {
             self.visit_ts_type(constraint);
@@ -2697,7 +2749,9 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         if let Some(default) = &param.default {
             self.visit_ts_type(default);
         }
-        self.current_scope_id = saved_scope_id;
+        if infer_constraint_symbol_id.is_some() {
+            self.active_ts_infer_constraint_symbol_ids.pop();
+        }
         self.leave_node(kind);
     }
 
@@ -2867,6 +2921,22 @@ impl<'a> SemanticBuilder<'a> {
         let flags = self.resolve_reference_usages();
         let reference =
             Reference::new(self.node_store.current_node_id, self.current_scope_id, flags);
+        if let Some((symbol_id, stop_scope_id)) =
+            self.active_ts_infer_constraint_symbol_id(ident.name)
+        {
+            let reference_id = self.scoping.create_reference(reference);
+            if self.walk_up_resolve_reference_until_scope(ident.name, reference_id, stop_scope_id) {
+                ident.reference_id.set(Some(reference_id));
+                return;
+            }
+            if self.try_resolve_reference(reference_id, symbol_id) {
+                ident.reference_id.set(Some(reference_id));
+                return;
+            }
+            self.unresolved_references.push(ident.name, reference_id);
+            ident.reference_id.set(Some(reference_id));
+            return;
+        }
         let reference_id = self.declare_reference(ident.name, reference);
         ident.reference_id.set(Some(reference_id));
     }

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -102,10 +102,8 @@ pub struct SemanticBuilder<'a> {
     /// Tracks the start index in the flat unresolved references list.
     unresolved_references_checkpoint: usize,
 
-    /// Conditional scopes that should receive `infer T` bindings while walking an `extends` type.
-    active_ts_conditional_scope_ids: SmallVec<[ScopeId; 2]>,
-    /// Current `infer T` type parameters whose constraints may refer to themselves.
-    active_ts_infer_constraint_symbol_ids: SmallVec<[(Ident<'a>, SymbolId, ScopeId); 2]>,
+    /// Conditional scopes collecting pending `infer T` bindings while walking an `extends` type.
+    active_ts_conditional_scopes: SmallVec<[TsConditionalScope<'a>; 2]>,
 
     unused_labels: UnusedLabels<'a>,
     #[cfg(feature = "jsdoc")]
@@ -131,6 +129,17 @@ pub struct SemanticBuilder<'a> {
 
     #[cfg(feature = "cfg")]
     ast_node_records: Vec<NodeId>,
+}
+
+#[derive(Clone, Copy)]
+struct TsInferBinding<'a> {
+    name: Ident<'a>,
+    symbol_id: SymbolId,
+}
+
+struct TsConditionalScope<'a> {
+    scope_id: ScopeId,
+    pending_infer_bindings: SmallVec<[TsInferBinding<'a>; 2]>,
 }
 
 /// Data returned by [`SemanticBuilder::build`].
@@ -166,8 +175,7 @@ impl<'a> SemanticBuilder<'a> {
             scoping,
             unresolved_references: UnresolvedReferences::new(),
             unresolved_references_checkpoint: 0,
-            active_ts_conditional_scope_ids: SmallVec::new(),
-            active_ts_infer_constraint_symbol_ids: SmallVec::new(),
+            active_ts_conditional_scopes: SmallVec::new(),
             unused_labels: UnusedLabels::default(),
             #[cfg(feature = "jsdoc")]
             jsdoc: JSDocBuilder::default(),
@@ -662,27 +670,6 @@ impl<'a> SemanticBuilder<'a> {
         false
     }
 
-    fn walk_up_resolve_reference_until_scope(
-        &mut self,
-        name: Ident<'a>,
-        reference_id: ReferenceId,
-        stop_scope_id: ScopeId,
-    ) -> bool {
-        let mut scope_id = Some(self.scoping.references[reference_id].scope_id());
-        while let Some(sid) = scope_id {
-            if sid == stop_scope_id {
-                return false;
-            }
-            if let Some(symbol_id) = self.scoping.get_binding(sid, name)
-                && self.try_resolve_reference(reference_id, symbol_id)
-            {
-                return true;
-            }
-            scope_id = self.scoping.scope_parent_id(sid);
-        }
-        false
-    }
-
     /// Try to resolve a reference to a symbol. Returns `true` if resolved.
     fn try_resolve_reference(&mut self, reference_id: ReferenceId, symbol_id: SymbolId) -> bool {
         let symbol_flags = self.scoping.symbol_flags(symbol_id);
@@ -764,16 +751,70 @@ impl<'a> SemanticBuilder<'a> {
         self.unresolved_references.truncate(write_idx);
     }
 
-    pub(crate) fn active_ts_conditional_scope_id(&self) -> Option<ScopeId> {
-        self.active_ts_conditional_scope_ids.last().copied()
+    fn resolve_references_for_current_scope_matching_name(&mut self, target_name: Ident<'a>) {
+        let checkpoint = self.unresolved_references_checkpoint;
+        let end = self.unresolved_references.len();
+        if end <= checkpoint {
+            return;
+        }
+        let mut write_idx = checkpoint;
+        for read_idx in checkpoint..end {
+            let (name, reference_id) = self.unresolved_references.get(read_idx);
+            if name == target_name && self.walk_up_resolve_reference(name, reference_id) {
+                continue;
+            }
+            if write_idx != read_idx {
+                self.unresolved_references.set(write_idx, name, reference_id);
+            }
+            write_idx += 1;
+        }
+        self.unresolved_references.truncate(write_idx);
     }
 
-    fn active_ts_infer_constraint_symbol_id(&self, name: Ident<'a>) -> Option<(SymbolId, ScopeId)> {
-        self.active_ts_infer_constraint_symbol_ids.iter().rev().find_map(
-            |&(symbol_name, symbol_id, stop_scope_id)| {
-                (symbol_name == name).then_some((symbol_id, stop_scope_id))
-            },
-        )
+    pub(crate) fn active_ts_conditional_scope_id(&self) -> Option<ScopeId> {
+        self.active_ts_conditional_scopes.last().map(|scope| scope.scope_id)
+    }
+
+    pub(crate) fn declare_ts_infer_type_parameter(
+        &mut self,
+        span: Span,
+        name: Ident<'a>,
+    ) -> Option<SymbolId> {
+        let frame_index = self.active_ts_conditional_scopes.len().checked_sub(1)?;
+        let conditional_scope_id = self.active_ts_conditional_scopes[frame_index].scope_id;
+
+        if let Some(symbol_id) = self.active_ts_conditional_scopes[frame_index]
+            .pending_infer_bindings
+            .iter()
+            .find_map(|binding| (binding.name == name).then_some(binding.symbol_id))
+        {
+            self.add_redeclare_variable(symbol_id, SymbolFlags::TypeParameter, span);
+            self.scoping.union_symbol_flag(symbol_id, SymbolFlags::TypeParameter);
+            return Some(symbol_id);
+        }
+
+        if let Some(symbol_id) = self.check_redeclaration(
+            conditional_scope_id,
+            span,
+            name,
+            SymbolFlags::TypeParameterExcludes,
+        ) {
+            self.add_redeclare_variable(symbol_id, SymbolFlags::TypeParameter, span);
+            self.scoping.union_symbol_flag(symbol_id, SymbolFlags::TypeParameter);
+            return Some(symbol_id);
+        }
+
+        let symbol_id = self.scoping.create_symbol(
+            span,
+            name,
+            SymbolFlags::TypeParameter,
+            conditional_scope_id,
+            self.node_store.current_node_id,
+        );
+        self.active_ts_conditional_scopes[frame_index]
+            .pending_infer_bindings
+            .push(TsInferBinding { name, symbol_id });
+        Some(symbol_id)
     }
 
     pub(crate) fn add_redeclare_variable(
@@ -2627,8 +2668,8 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         self.enter_scope(ScopeFlags::TsConditional, &ty.scope_id);
         let conditional_scope_id = self.current_scope_id;
 
-        // `infer` declarations are collected on the conditional type
-        // node, but those locals are visible only from the true branch.
+        // `infer` declarations are owned by the conditional type node, but those locals become
+        // normal bindings only after `extends_type` has been walked.
         //
         // ```ts
         // type C<T> = T extends (a: infer B) => B ? B : never;
@@ -2639,27 +2680,33 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         // //                         ╰ `B` declared here
         // ```
         //
-        // Operationally this means the conditional scope has two roles:
+        // Operationally this means the conditional scope is created before `extends_type`, but
+        // its `infer` bindings stay pending until just before `true_type`:
         //
         // ```text
         // parent scope
         //   |- extends_type        references start here
-        //   |    \- infer B  --->  declarations are deposited in conditional scope
+        //   |    \- infer B  --->  pending binding for conditional scope
         //   |
         //   \- conditional scope   true_type references start here
         //        \- B
         // ```
         //
-        // So we create the conditional scope now, keep it on
-        // `active_ts_conditional_scope_ids` as the binding target for `infer`, but restore
-        // `current_scope_id` to the parent while walking `extends_type`. After that, walking
-        // `true_type` from the conditional scope makes normal reference resolution find `infer B`.
-        // `false_type` is visited after leaving the conditional scope, so it cannot see `B`.
+        // Keeping the binding pending prevents sibling `infer` declarations from seeing each
+        // other in `extends_type`, while committing before `true_type` makes normal reference
+        // resolution find `infer B` there. `false_type` is visited after leaving the conditional
+        // scope, so it cannot see `B`.
         self.current_scope_id = parent_scope_id;
-        self.active_ts_conditional_scope_ids.push(conditional_scope_id);
+        self.active_ts_conditional_scopes.push(TsConditionalScope {
+            scope_id: conditional_scope_id,
+            pending_infer_bindings: SmallVec::new(),
+        });
         self.visit_ts_type(&ty.extends_type);
-        let popped = self.active_ts_conditional_scope_ids.pop();
-        debug_assert_eq!(popped, Some(conditional_scope_id));
+        let conditional_scope = self.active_ts_conditional_scopes.pop().unwrap();
+        debug_assert_eq!(conditional_scope.scope_id, conditional_scope_id);
+        for binding in conditional_scope.pending_infer_bindings {
+            self.scoping.add_binding(conditional_scope_id, binding.name, binding.symbol_id);
+        }
 
         self.current_scope_id = conditional_scope_id;
         self.visit_ts_type(&ty.true_type);
@@ -2717,9 +2764,8 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         self.visit_span(&param.span);
         self.visit_binding_identifier(&param.name);
 
-        // Conditional `infer` bindings are declared in the conditional scope, but `extends_type`
-        // references are resolved from the surrounding scope. The only exception is the current
-        // inferred type parameter's own constraint:
+        // Conditional `infer` bindings stay pending while `extends_type` is walked. The current
+        // inferred type parameter's own constraint gets a temporary self-binding:
         //
         // `T extends infer U extends U ? U : never`
         //            declared here ^         ^ true type sees conditional scope
@@ -2728,20 +2774,23 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         // Sibling inferred parameters are intentionally hidden from each other, matching TypeScript:
         // `T extends [infer A, infer B extends A] ? B : never`
         //                                  ^ unresolved; does not see sibling `A`
-        let infer_constraint_symbol_id =
+        let infer_constraint_binding =
             if matches!(self.ancestry().parent_kind(), AstKind::TSInferType(_))
                 && self.active_ts_conditional_scope_id().is_some()
             {
-                param
-                    .name
-                    .symbol_id
-                    .get()
-                    .map(|symbol_id| (param.name.name, symbol_id, self.current_scope_id))
+                param.name.symbol_id.get().map(|symbol_id| {
+                    let name = param.name.name;
+                    let displaced_symbol_id = self.scoping.get_binding(self.current_scope_id, name);
+                    self.scoping.add_binding(self.current_scope_id, name, symbol_id);
+                    (name, displaced_symbol_id)
+                })
             } else {
                 None
             };
-        if let Some(symbol) = infer_constraint_symbol_id {
-            self.active_ts_infer_constraint_symbol_ids.push(symbol);
+
+        let saved_checkpoint = self.unresolved_references_checkpoint;
+        if infer_constraint_binding.is_some() {
+            self.unresolved_references_checkpoint = self.unresolved_references.checkpoint();
         }
         if let Some(constraint) = &param.constraint {
             self.visit_ts_type(constraint);
@@ -2749,8 +2798,14 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         if let Some(default) = &param.default {
             self.visit_ts_type(default);
         }
-        if infer_constraint_symbol_id.is_some() {
-            self.active_ts_infer_constraint_symbol_ids.pop();
+        if let Some((name, displaced_symbol_id)) = infer_constraint_binding {
+            self.resolve_references_for_current_scope_matching_name(name);
+            self.unresolved_references_checkpoint = saved_checkpoint;
+            if let Some(displaced_symbol_id) = displaced_symbol_id {
+                self.scoping.add_binding(self.current_scope_id, name, displaced_symbol_id);
+            } else {
+                self.scoping.remove_binding(self.current_scope_id, name);
+            }
         }
         self.leave_node(kind);
     }
@@ -2921,22 +2976,6 @@ impl<'a> SemanticBuilder<'a> {
         let flags = self.resolve_reference_usages();
         let reference =
             Reference::new(self.node_store.current_node_id, self.current_scope_id, flags);
-        if let Some((symbol_id, stop_scope_id)) =
-            self.active_ts_infer_constraint_symbol_id(ident.name)
-        {
-            let reference_id = self.scoping.create_reference(reference);
-            if self.walk_up_resolve_reference_until_scope(ident.name, reference_id, stop_scope_id) {
-                ident.reference_id.set(Some(reference_id));
-                return;
-            }
-            if self.try_resolve_reference(reference_id, symbol_id) {
-                ident.reference_id.set(Some(reference_id));
-                return;
-            }
-            self.unresolved_references.push(ident.name, reference_id);
-            ident.reference_id.set(Some(reference_id));
-            return;
-        }
         let reference_id = self.declare_reference(ident.name, reference);
         ident.reference_id.set(Some(reference_id));
     }

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/infer-function-return-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/infer-function-return-type.snap
@@ -139,7 +139,7 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/infer-function-return-type
                     "id": 5,
                     "name": "U",
                     "node_id": 59,
-                    "scope_id": 9
+                    "scope_id": 8
                   },
                   {
                     "flags": "ReferenceFlags(Type)",
@@ -169,6 +169,60 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/infer-function-return-type
                 "name": "T",
                 "node_id": 54,
                 "scope_id": 8
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "children": [
+          {
+            "children": [],
+            "flags": "ScopeFlags(TsConditional)",
+            "id": 11,
+            "node": "TSConditionalType",
+            "symbols": [
+              {
+                "flags": "SymbolFlags(TypeParameter)",
+                "id": 14,
+                "name": "A",
+                "node": "TSTypeParameter(A)",
+                "references": []
+              },
+              {
+                "flags": "SymbolFlags(TypeParameter)",
+                "id": 15,
+                "name": "B",
+                "node": "TSTypeParameter(B)",
+                "references": [
+                  {
+                    "flags": "ReferenceFlags(Type)",
+                    "id": 9,
+                    "name": "B",
+                    "node_id": 81,
+                    "scope_id": 11
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "flags": "ScopeFlags(0x0)",
+        "id": 10,
+        "node": "TSTypeAliasDeclaration",
+        "symbols": [
+          {
+            "flags": "SymbolFlags(TypeParameter)",
+            "id": 13,
+            "name": "T",
+            "node": "TSTypeParameter(T)",
+            "references": [
+              {
+                "flags": "ReferenceFlags(Type)",
+                "id": 7,
+                "name": "T",
+                "node_id": 70,
+                "scope_id": 10
               }
             ]
           }
@@ -204,6 +258,13 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/infer-function-return-type
         "flags": "SymbolFlags(TypeAlias)",
         "id": 9,
         "name": "MyType3",
+        "node": "TSTypeAliasDeclaration",
+        "references": []
+      },
+      {
+        "flags": "SymbolFlags(TypeAlias)",
+        "id": 12,
+        "name": "MyType4",
         "node": "TSTypeAliasDeclaration",
         "references": []
       }

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/infer-function-return-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/infer-function-return-type.snap
@@ -112,6 +112,67 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/infer-function-return-type
             ]
           }
         ]
+      },
+      {
+        "children": [],
+        "flags": "ScopeFlags(0x0)",
+        "id": 7,
+        "node": "TSTypeAliasDeclaration",
+        "symbols": []
+      },
+      {
+        "children": [
+          {
+            "children": [],
+            "flags": "ScopeFlags(TsConditional)",
+            "id": 9,
+            "node": "TSConditionalType",
+            "symbols": [
+              {
+                "flags": "SymbolFlags(TypeParameter)",
+                "id": 11,
+                "name": "U",
+                "node": "TSTypeParameter(U)",
+                "references": [
+                  {
+                    "flags": "ReferenceFlags(Type)",
+                    "id": 5,
+                    "name": "U",
+                    "node_id": 59,
+                    "scope_id": 9
+                  },
+                  {
+                    "flags": "ReferenceFlags(Type)",
+                    "id": 6,
+                    "name": "U",
+                    "node_id": 61,
+                    "scope_id": 9
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "flags": "ScopeFlags(0x0)",
+        "id": 8,
+        "node": "TSTypeAliasDeclaration",
+        "symbols": [
+          {
+            "flags": "SymbolFlags(TypeParameter)",
+            "id": 10,
+            "name": "T",
+            "node": "TSTypeParameter(T)",
+            "references": [
+              {
+                "flags": "ReferenceFlags(Type)",
+                "id": 4,
+                "name": "T",
+                "node_id": 54,
+                "scope_id": 8
+              }
+            ]
+          }
+        ]
       }
     ],
     "flags": "ScopeFlags(Top)",
@@ -129,6 +190,20 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/infer-function-return-type
         "flags": "SymbolFlags(TypeAlias)",
         "id": 4,
         "name": "MyType2",
+        "node": "TSTypeAliasDeclaration",
+        "references": []
+      },
+      {
+        "flags": "SymbolFlags(TypeAlias)",
+        "id": 8,
+        "name": "U",
+        "node": "TSTypeAliasDeclaration",
+        "references": []
+      },
+      {
+        "flags": "SymbolFlags(TypeAlias)",
+        "id": 9,
+        "name": "MyType3",
         "node": "TSTypeAliasDeclaration",
         "references": []
       }

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/infer-function-return-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/infer-function-return-type.snap
@@ -1,0 +1,137 @@
+---
+source: crates/oxc_semantic/tests/main.rs
+input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/infer-function-return-type.ts
+---
+[
+  {
+    "children": [
+      {
+        "children": [
+          {
+            "children": [],
+            "flags": "ScopeFlags(TsConditional)",
+            "id": 2,
+            "node": "TSConditionalType",
+            "symbols": [
+              {
+                "flags": "SymbolFlags(TypeParameter)",
+                "id": 3,
+                "name": "B",
+                "node": "TSTypeParameter(B)",
+                "references": []
+              }
+            ]
+          },
+          {
+            "children": [],
+            "flags": "ScopeFlags(0x0)",
+            "id": 3,
+            "node": "TSFunctionType",
+            "symbols": [
+              {
+                "flags": "SymbolFlags(FunctionScopedVariable)",
+                "id": 2,
+                "name": "a",
+                "node": "FormalParameter(a)",
+                "references": []
+              }
+            ]
+          }
+        ],
+        "flags": "ScopeFlags(0x0)",
+        "id": 1,
+        "node": "TSTypeAliasDeclaration",
+        "symbols": [
+          {
+            "flags": "SymbolFlags(TypeParameter)",
+            "id": 1,
+            "name": "T",
+            "node": "TSTypeParameter(T)",
+            "references": [
+              {
+                "flags": "ReferenceFlags(Type)",
+                "id": 0,
+                "name": "T",
+                "node_id": 8,
+                "scope_id": 1
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "children": [
+          {
+            "children": [],
+            "flags": "ScopeFlags(TsConditional)",
+            "id": 5,
+            "node": "TSConditionalType",
+            "symbols": [
+              {
+                "flags": "SymbolFlags(TypeParameter)",
+                "id": 7,
+                "name": "B",
+                "node": "TSTypeParameter(B)",
+                "references": []
+              }
+            ]
+          },
+          {
+            "children": [],
+            "flags": "ScopeFlags(0x0)",
+            "id": 6,
+            "node": "TSFunctionType",
+            "symbols": [
+              {
+                "flags": "SymbolFlags(FunctionScopedVariable)",
+                "id": 6,
+                "name": "a",
+                "node": "FormalParameterRest",
+                "references": []
+              }
+            ]
+          }
+        ],
+        "flags": "ScopeFlags(0x0)",
+        "id": 4,
+        "node": "TSTypeAliasDeclaration",
+        "symbols": [
+          {
+            "flags": "SymbolFlags(TypeParameter)",
+            "id": 5,
+            "name": "T",
+            "node": "TSTypeParameter(T)",
+            "references": [
+              {
+                "flags": "ReferenceFlags(Type)",
+                "id": 2,
+                "name": "T",
+                "node_id": 29,
+                "scope_id": 4
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "flags": "ScopeFlags(Top)",
+    "id": 0,
+    "node": "Program",
+    "symbols": [
+      {
+        "flags": "SymbolFlags(TypeAlias)",
+        "id": 0,
+        "name": "MyType",
+        "node": "TSTypeAliasDeclaration",
+        "references": []
+      },
+      {
+        "flags": "SymbolFlags(TypeAlias)",
+        "id": 4,
+        "name": "MyType2",
+        "node": "TSTypeAliasDeclaration",
+        "references": []
+      }
+    ]
+  }
+]

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/infer-function-return-type.ts
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/infer-function-return-type.ts
@@ -1,2 +1,4 @@
 type MyType<T> = T extends (a: infer B) => B ? [] : [];
 type MyType2<T> = T extends (...a: infer B) => B ? [] : [];
+type U = string;
+type MyType3<T> = T extends infer U extends U ? U : [];

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/infer-function-return-type.ts
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/infer-function-return-type.ts
@@ -1,0 +1,2 @@
+type MyType<T> = T extends (a: infer B) => B ? [] : [];
+type MyType2<T> = T extends (...a: infer B) => B ? [] : [];

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/infer-function-return-type.ts
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/infer-function-return-type.ts
@@ -2,3 +2,4 @@ type MyType<T> = T extends (a: infer B) => B ? [] : [];
 type MyType2<T> = T extends (...a: infer B) => B ? [] : [];
 type U = string;
 type MyType3<T> = T extends infer U extends U ? U : [];
+type MyType4<T> = T extends [infer A, infer B extends A] ? B : [];

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional3.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional3.snap
@@ -8,23 +8,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
       {
         "children": [
           {
-            "children": [
-              {
-                "children": [],
-                "flags": "ScopeFlags(0x0)",
-                "id": 3,
-                "node": "TSFunctionType",
-                "symbols": [
-                  {
-                    "flags": "SymbolFlags(FunctionScopedVariable)",
-                    "id": 2,
-                    "name": "k",
-                    "node": "FormalParameter(k)",
-                    "references": []
-                  }
-                ]
-              }
-            ],
+            "children": [],
             "flags": "ScopeFlags(TsConditional)",
             "id": 2,
             "node": "TSConditionalType",
@@ -43,6 +27,21 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                     "scope_id": 2
                   }
                 ]
+              }
+            ]
+          },
+          {
+            "children": [],
+            "flags": "ScopeFlags(0x0)",
+            "id": 3,
+            "node": "TSFunctionType",
+            "symbols": [
+              {
+                "flags": "SymbolFlags(FunctionScopedVariable)",
+                "id": 2,
+                "name": "k",
+                "node": "FormalParameter(k)",
+                "references": []
               }
             ]
           }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional5.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional5.snap
@@ -8,39 +8,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
       {
         "children": [
           {
-            "children": [
-              {
-                "children": [
-                  {
-                    "children": [],
-                    "flags": "ScopeFlags(0x0)",
-                    "id": 4,
-                    "node": "TSFunctionType",
-                    "symbols": [
-                      {
-                        "flags": "SymbolFlags(FunctionScopedVariable)",
-                        "id": 3,
-                        "name": "arg2",
-                        "node": "FormalParameter(arg2)",
-                        "references": []
-                      }
-                    ]
-                  }
-                ],
-                "flags": "ScopeFlags(0x0)",
-                "id": 3,
-                "node": "TSFunctionType",
-                "symbols": [
-                  {
-                    "flags": "SymbolFlags(FunctionScopedVariable)",
-                    "id": 2,
-                    "name": "arg",
-                    "node": "FormalParameter(arg)",
-                    "references": []
-                  }
-                ]
-              }
-            ],
+            "children": [],
             "flags": "ScopeFlags(TsConditional)",
             "id": 2,
             "node": "TSConditionalType",
@@ -59,6 +27,37 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                     "scope_id": 2
                   }
                 ]
+              }
+            ]
+          },
+          {
+            "children": [
+              {
+                "children": [],
+                "flags": "ScopeFlags(0x0)",
+                "id": 4,
+                "node": "TSFunctionType",
+                "symbols": [
+                  {
+                    "flags": "SymbolFlags(FunctionScopedVariable)",
+                    "id": 3,
+                    "name": "arg2",
+                    "node": "FormalParameter(arg2)",
+                    "references": []
+                  }
+                ]
+              }
+            ],
+            "flags": "ScopeFlags(0x0)",
+            "id": 3,
+            "node": "TSFunctionType",
+            "symbols": [
+              {
+                "flags": "SymbolFlags(FunctionScopedVariable)",
+                "id": 2,
+                "name": "arg",
+                "node": "FormalParameter(arg)",
+                "references": []
               }
             ]
           }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/infer-type-constraint.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/infer-type-constraint.snap
@@ -75,7 +75,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "id": 1,
             "name": "X",
             "node_id": 22,
-            "scope_id": 2
+            "scope_id": 3
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/infer-type-constraint.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/infer-type-constraint.snap
@@ -75,7 +75,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "id": 1,
             "name": "X",
             "node_id": 22,
-            "scope_id": 3
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/integration/symbols.rs
+++ b/crates/oxc_semantic/tests/integration/symbols.rs
@@ -1,4 +1,4 @@
-use oxc_semantic::{Reference, SymbolFlags};
+use oxc_semantic::{Reference, ScopeFlags, SymbolFlags};
 
 use crate::util::SemanticTester;
 
@@ -261,6 +261,43 @@ fn test_ts_infer_type() {
 
     // type C is not referenced
     tester.has_symbol("C").has_number_of_references(0).test();
+}
+
+#[test]
+fn test_ts_conditional_infer_visibility() {
+    SemanticTester::ts("type T<A> = A extends (a: infer B) => B ? [] : [];")
+        .has_some_symbol("B")
+        .has_number_of_references(0)
+        .test();
+
+    SemanticTester::ts("type T<A> = A extends (...a: infer B) => B ? [] : [];")
+        .has_some_symbol("B")
+        .has_number_of_references(0)
+        .test();
+
+    let tester = SemanticTester::ts(
+        "
+        type U = string;
+        type T<A> = A extends infer U extends U ? U : never;
+        ",
+    );
+    let semantic = tester.build();
+    let scoping = semantic.scoping();
+    let outer_u = scoping.get_binding(scoping.root_scope_id(), "U".into()).unwrap();
+    assert_eq!(scoping.get_resolved_references(outer_u).count(), 0);
+
+    let infer_u_symbols = scoping
+        .iter_bindings()
+        .filter(|(scope_id, _)| scoping.scope_flags(*scope_id).contains(ScopeFlags::TsConditional))
+        .filter_map(|(_, bindings)| bindings.get("U").copied())
+        .collect::<Vec<_>>();
+    assert_eq!(infer_u_symbols.len(), 1);
+    assert_eq!(scoping.get_resolved_references(infer_u_symbols[0]).count(), 2);
+
+    let tester =
+        SemanticTester::ts("type T<T> = T extends [infer A, infer B extends A] ? B : never;");
+    tester.has_symbol("A").has_number_of_references(0).test();
+    tester.has_symbol("B").has_number_of_references(1).test();
 }
 
 #[test]


### PR DESCRIPTION
See code comments for what's going on here.

TypeScript resolver handling: https://github.com/microsoft/typescript/blob/5e4281fdf21da7c282ceaf016440992e1fad2565/src/compiler/utilities.ts#L11583-L11587