### PR TITLE
fix(codegen): preserve inline leading comments in value positions

### DIFF
--- a/crates/oxc_codegen/src/binary_expr_visitor.rs
+++ b/crates/oxc_codegen/src/binary_expr_visitor.rs
@@ -5,12 +5,16 @@
 use std::ops::Not;
 
 use oxc_ast::ast::{BinaryExpression, Expression, LogicalExpression};
+use oxc_span::GetSpan;
 use oxc_syntax::{
     operator::{BinaryOperator, LogicalOperator},
     precedence::{GetPrecedence, Precedence},
 };
 
-use crate::{Codegen, Context, Operator, cjs_module_lexer, r#gen::GenExpr};
+use crate::{
+    Codegen, Context, Operator, cjs_module_lexer,
+    r#gen::{GenExpr, is_pife_arrow_or_function},
+};
 
 #[derive(Clone, Copy)]
 pub enum Binaryish<'a> {
@@ -230,6 +234,12 @@ impl<'a> BinaryExpressionVisitor<'a> {
         self.operator.r#gen(p);
         p.print_soft_space();
         let right = self.e.right();
+        // Preserve a leading comment on the right operand, e.g. a coverage-ignore
+        // comment: `a ?? /* c */ b`, `a && /* c */ b`. Skip `pife`
+        // arrows/functions — they print the comment inside their own `(` wrap.
+        if !is_pife_arrow_or_function(right) {
+            p.print_inline_leading_comments(right.span().start);
+        }
         if !cjs_module_lexer::try_print_equality_string(p, self.operator, right) {
             right.gen_expr(p, self.right_precedence, self.ctx);
         }

--- a/crates/oxc_codegen/src/comment.rs
+++ b/crates/oxc_codegen/src/comment.rs
@@ -168,6 +168,21 @@ impl Codegen<'_> {
         }
     }
 
+    /// Print leading comments that sit inline before an expression in a value
+    /// position — e.g. `a ?? /* c */ b`, `key: /* c */ v`, `` `${/* c */ x}` ``.
+    ///
+    /// Only block comments are emitted here. A line comment would force a
+    /// newline and re-anchor to a different node on the next parse, which breaks
+    /// codegen idempotency once a pass (e.g. the minifier) folds statements into
+    /// a single expression. Leaving line comments in place matches the previous
+    /// behavior, where such comments were dropped at these positions.
+    #[inline]
+    pub(crate) fn print_inline_leading_comments(&mut self, start: u32) {
+        if self.comments.get(&start).is_some_and(|comments| comments.iter().all(|c| !c.is_line())) {
+            self.print_leading_comments_anchored_to_self(start);
+        }
+    }
+
     /// Whether a legal-comment orphan with `attached_to < end` is still
     /// pending. Used by block emitters to keep an empty body multi-line.
     #[inline]
@@ -267,7 +282,10 @@ impl Codegen<'_> {
                     }
                 }
             }
-        } else {
+        } else if matches!(self.last_byte(), None | Some(b'\n')) {
+            // Only indent at the start of a line. An inline comment in a value
+            // position (e.g. `a ?? /* c */ b` nested inside an indented block)
+            // must not insert stray indentation mid-line.
             self.print_indent();
         }
         self.print_comment(first);

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -1789,6 +1789,13 @@ impl Gen for ObjectProperty<'_> {
             }
             p.print_colon();
             p.print_soft_space();
+            // Preserve a leading comment on the value (e.g. a coverage-ignore
+            // comment surviving JSX-prop lowering: `{ key: /* c */ () => … }`).
+            // Skip `pife` arrows/functions — they print the comment inside their
+            // own `(` wrap.
+            if !is_pife_arrow_or_function(&self.value) {
+                p.print_inline_leading_comments(self.value.span().start);
+            }
         }
 
         self.value.print_expr(p, Precedence::Comma, Context::empty());
@@ -1998,6 +2005,12 @@ impl GenExpr for ConditionalExpression<'_> {
             p.print_soft_space();
             p.print_ascii_byte(b'?');
             p.print_soft_space();
+            // Skip when the consequent is a `pife` arrow/function — its own
+            // gen_expr prints the leading comment inside its `(` wrap so the
+            // source position `? ( /* c */ arrow )` is preserved.
+            if !is_pife_arrow_or_function(&self.consequent) {
+                p.print_inline_leading_comments(self.consequent.span().start);
+            }
             self.consequent.print_expr(p, Precedence::Yield, Context::empty());
             p.print_soft_space();
             p.print_colon();
@@ -2015,7 +2028,7 @@ impl GenExpr for ConditionalExpression<'_> {
 
 /// `true` if `expr` is a `pife`-marked arrow or function expression — its
 /// own `gen_expr` adds a `(` wrap and prints leading comments inside it.
-fn is_pife_arrow_or_function(expr: &Expression<'_>) -> bool {
+pub fn is_pife_arrow_or_function(expr: &Expression<'_>) -> bool {
     match expr {
         Expression::ArrowFunctionExpression(arrow) => arrow.pife,
         Expression::FunctionExpression(func) => func.pife,
@@ -2313,6 +2326,13 @@ impl Gen for TemplateLiteral<'_> {
         p.print_str_escaping_script_close_tag(first_quasi.value.raw.as_str());
         for (expr, quasi) in self.expressions.iter().zip(remaining_quasis) {
             p.print_str("${");
+            // Preserve a leading comment on the substitution expression, e.g.
+            // a coverage-ignore comment: `` `${/* c */ () => …}` ``. Skip
+            // `pife` arrows/functions — they print the comment inside their
+            // own `(` wrap.
+            if !is_pife_arrow_or_function(expr) {
+                p.print_inline_leading_comments(expr.span().start);
+            }
             p.print_expression(expr);
             p.print_ascii_byte(b'}');
             p.add_source_mapping(quasi.span);

--- a/crates/oxc_codegen/tests/integration/comments.rs
+++ b/crates/oxc_codegen/tests/integration/comments.rs
@@ -71,10 +71,7 @@ fn unit() {
     test("console.log(<>{/*before*/ x}</>)", "console.log(<>{/*before*/ x}</>);\n");
     // https://lingui.dev/ref/macro#definemessage
     test("const message = /*i18n*/{};", "const message = (/*i18n*/ {});\n");
-    test(
-        "function foo() { return /*i18n*/ {} }",
-        "function foo() {\n\treturn (\t/*i18n*/ {});\n}\n",
-    );
+    test("function foo() { return /*i18n*/ {} }", "function foo() {\n\treturn (/*i18n*/ {});\n}\n");
 
     test_same("export { /** @deprecated */ parseAst } from \"rolldown/parseAst\";\n");
     test_same("export { /** @deprecated */ parseAst };\n");
@@ -290,6 +287,22 @@ catch (err) // v8 ignore next
   /* v8 ignore next */
   ...rest,
 }",
+            // Coverage comment after `??` (right operand of a logical expression)
+            // https://github.com/oxc-project/oxc/issues/23485
+            "const x = 1 ?? /* istanbul ignore next -- @preserve */ 0;",
+            // Coverage comment after `&&`
+            "if (a && /* istanbul ignore next -- @preserve */ b) {}",
+            // Coverage comment after `||`, nested inside an indented block
+            "function f() {\n  if (a || /* istanbul ignore next -- @preserve */ b) {}\n}",
+            // Coverage comment before a ConditionalExpression consequent
+            "const y = cond ? /* istanbul ignore next -- @preserve */ 1 : 2;",
+            // Coverage comment before a ConditionalExpression consequent inside an object property
+            "const obj = { a: cond ? /* istanbul ignore next -- @preserve */ 1 : 2 };",
+            // Coverage comment before an object property value
+            // (shape produced by lowering a JSX prop: `key={/* c */ () => …}`)
+            "const obj = { removeSelection: /* istanbul ignore next -- @preserve */ () => onUpdate(null) };",
+            // Coverage comment inside a template literal substitution
+            "const t = `${/* istanbul ignore next -- @preserve */ () => undefined}`;",
         ];
 
         snapshot("coverage", &cases);

--- a/crates/oxc_codegen/tests/integration/snapshots/coverage.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/coverage.snap
@@ -202,3 +202,42 @@ const obj = {
 	/* v8 ignore next */
 	...rest
 };
+
+########## 29
+const x = 1 ?? /* istanbul ignore next -- @preserve */ 0;
+----------
+const x = 1 ?? /* istanbul ignore next -- @preserve */ 0;
+
+########## 30
+if (a && /* istanbul ignore next -- @preserve */ b) {}
+----------
+if (a && /* istanbul ignore next -- @preserve */ b) {}
+
+########## 31
+function f() {
+  if (a || /* istanbul ignore next -- @preserve */ b) {}
+}
+----------
+function f() {
+	if (a || /* istanbul ignore next -- @preserve */ b) {}
+}
+
+########## 32
+const y = cond ? /* istanbul ignore next -- @preserve */ 1 : 2;
+----------
+const y = cond ? /* istanbul ignore next -- @preserve */ 1 : 2;
+
+########## 33
+const obj = { a: cond ? /* istanbul ignore next -- @preserve */ 1 : 2 };
+----------
+const obj = { a: cond ? /* istanbul ignore next -- @preserve */ 1 : 2 };
+
+########## 34
+const obj = { removeSelection: /* istanbul ignore next -- @preserve */ () => onUpdate(null) };
+----------
+const obj = { removeSelection: /* istanbul ignore next -- @preserve */ () => onUpdate(null) };
+
+########## 35
+const t = `${/* istanbul ignore next -- @preserve */ () => undefined}`;
+----------
+const t = `${/* istanbul ignore next -- @preserve */ () => undefined}`;


### PR DESCRIPTION
Emit leading block comments that sit inline before an expression in value positions — right operand of a logical/binary expression (`a ?? /* c */ b`), conditional consequent, object property value, and template literal substitution. This keeps coverage-ignore comments (e.g. `/* istanbul ignore next -- @preserve */`) from being dropped.

Only block comments are emitted; line comments would force a newline and break codegen idempotency. `pife` arrows/functions are skipped since they print the comment inside their own `(` wrap.

The code was written by Claude Code, I reviewed it but I am not fluent in rust and might have missed something.

This fixes most of the points addressed in #23485 with the exception of the issue already reported in #22048 as those comments do currently not survive the transformer.