### PR TITLE
fix(linter/react/forbid-component-props): make allow/disallow lists optional in schema

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -4373,20 +4373,20 @@ export interface ForbidItemObject {
    * Component names for which this prop is **allowed** (all others are
    * forbidden).
    */
-  allowedFor: string[];
+  allowedFor?: string[];
   /**
    * Glob patterns for component names where the prop is **allowed**.
    */
-  allowedForPatterns: string[];
+  allowedForPatterns?: string[];
   /**
    * Component names for which this prop is **disallowed** (all others are
    * allowed).
    */
-  disallowedFor: string[];
+  disallowedFor?: string[];
   /**
    * Glob patterns for component names where the prop is **disallowed**.
    */
-  disallowedForPatterns: string[];
+  disallowedForPatterns?: string[];
   /**
    * Custom message to display.
    */

--- a/crates/oxc_linter/src/rules/react/forbid_component_props.rs
+++ b/crates/oxc_linter/src/rules/react/forbid_component_props.rs
@@ -93,13 +93,17 @@ pub struct ForbidItemObject {
     prop_name_pattern: Option<CompactStr>,
     /// Component names for which this prop is **allowed** (all others are
     /// forbidden).
+    #[serde(default)]
     allowed_for: Vec<CompactStr>,
     /// Glob patterns for component names where the prop is **allowed**.
+    #[serde(default)]
     allowed_for_patterns: Vec<CompactStr>,
     /// Component names for which this prop is **disallowed** (all others are
     /// allowed).
+    #[serde(default)]
     disallowed_for: Vec<CompactStr>,
     /// Glob patterns for component names where the prop is **disallowed**.
+    #[serde(default)]
     disallowed_for_patterns: Vec<CompactStr>,
     /// Custom message to display.
     message: Option<String>,

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -10914,15 +10914,10 @@
     },
     "ForbidItemObject": {
       "type": "object",
-      "required": [
-        "allowedFor",
-        "allowedForPatterns",
-        "disallowedFor",
-        "disallowedForPatterns"
-      ],
       "properties": {
         "allowedFor": {
           "description": "Component names for which this prop is **allowed** (all others are\nforbidden).",
+          "default": [],
           "type": "array",
           "items": {
             "type": "string"
@@ -10931,6 +10926,7 @@
         },
         "allowedForPatterns": {
           "description": "Glob patterns for component names where the prop is **allowed**.",
+          "default": [],
           "type": "array",
           "items": {
             "type": "string"
@@ -10939,6 +10935,7 @@
         },
         "disallowedFor": {
           "description": "Component names for which this prop is **disallowed** (all others are\nallowed).",
+          "default": [],
           "type": "array",
           "items": {
             "type": "string"
@@ -10947,6 +10944,7 @@
         },
         "disallowedForPatterns": {
           "description": "Glob patterns for component names where the prop is **disallowed**.",
+          "default": [],
           "type": "array",
           "items": {
             "type": "string"


### PR DESCRIPTION
`ForbidItemObject` derives `JsonSchema`, but its manual `Deserialize` impl already defaults the four allow/disallow `Vec` fields. Without `#[serde(default)]`, schemars marked them as `required` in the generated configuration schema, so editors/tooling wrongly required all four (`allowedFor`, `allowedForPatterns`, `disallowedFor`, `disallowedForPatterns`) whenever the object form of `react/forbid-component-props` was used.

Add `#[serde(default)]` to the four fields and regenerate the schema — the `required` array is dropped and each field gets `"default": []`.

Closes #23732
