### PR TITLE
fix(linter): recognize `@effect/vitest` as a vitest import source

### DIFF
--- a/crates/oxc_linter/src/frameworks.rs
+++ b/crates/oxc_linter/src/frameworks.rs
@@ -95,7 +95,8 @@ pub fn is_jestlike_file(path: &Path) -> bool {
 #[cfg(not(test))]
 pub fn has_vitest_imports(module_record: &ModuleRecord) -> bool {
     module_record.import_entries.iter().any(|entry| {
-        entry.module_request.name() == "vitest" || entry.module_request.name() == "vite-plus/test"
+        let name = entry.module_request.name();
+        name == "vitest" || name == "vite-plus/test" || name == "@effect/vitest"
     })
 }
 

--- a/crates/oxc_linter/src/rules/vitest/prefer_expect_assertions.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_expect_assertions.rs
@@ -62,7 +62,8 @@ impl Rule for PreferExpectAssertions {
         // Resolve the file-level expect local name once (e.g. `"expect"` or `"e"`
         // for `import { expect as e }`). Per-callback vitest fixture overrides
         // are handled in `resolve_expect_source`.
-        let file_expect_prefix = resolve_expect_local_name(ctx, &["vitest", "vite-plus/test"]);
+        let file_expect_prefix =
+            resolve_expect_local_name(ctx, &["vitest", "vite-plus/test", "@effect/vitest"]);
 
         let mut covered_describe_ids: Vec<NodeId> = Vec::new();
 
@@ -221,6 +222,14 @@ fn test() {
         (
             r#"import { expect } from 'vite-plus/test';
             test("re-exported vitest global", () => {
+                expect.assertions(1);
+                expect(true).toBe(true);
+              });"#,
+            None,
+        ),
+        (
+            r#"import { expect } from '@effect/vitest';
+            test("re-exported effect vitest global", () => {
                 expect.assertions(1);
                 expect(true).toBe(true);
               });"#,
@@ -399,6 +408,11 @@ fn test() {
         (
             r#"import { expect as e } from 'vite-plus/test';
             test("re-exported missing", () => { e(true).toBe(true); });"#,
+            None,
+        ),
+        (
+            r#"import { expect as e } from '@effect/vitest';
+            test("re-exported effect missing", () => { e(true).toBe(true); });"#,
             None,
         ),
         (

--- a/crates/oxc_linter/src/snapshots/vitest_prefer_expect_assertions.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_prefer_expect_assertions.snap
@@ -231,6 +231,14 @@ source: crates/oxc_linter/src/tester.rs
   help: Add `e.hasAssertions()` or `e.assertions(<number>)` as the first statement in this test.
 
   ⚠ vitest(prefer-expect-assertions): This test should have either `e.assertions(<number of assertions>)` or `e.hasAssertions()` as its first expression.
+   ╭─[prefer_expect_assertions.tsx:2:13]
+ 1 │ import { expect as e } from '@effect/vitest';
+ 2 │             test("re-exported effect missing", () => { e(true).toBe(true); });
+   ·             ─────────────────────────────────────────────────────────────────
+   ╰────
+  help: Add `e.hasAssertions()` or `e.assertions(<number>)` as the first statement in this test.
+
+  ⚠ vitest(prefer-expect-assertions): This test should have either `e.assertions(<number of assertions>)` or `e.hasAssertions()` as its first expression.
    ╭─[prefer_expect_assertions.tsx:4:17]
  3 │                     beforeEach(() => { expect.hasAssertions(); });
  4 │ ╭─▶                 it('test', () => {

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -232,7 +232,7 @@ fn collect_ids_referenced_to_import<'a, 'c>(
 
                 if matches!(
                     import_decl.source.value.as_str(),
-                    "@jest/globals" | "vitest" | "vite-plus/test"
+                    "@jest/globals" | "vitest" | "vite-plus/test" | "@effect/vitest"
                 ) {
                     let original = find_original_name(import_decl, name);
                     let ret = reference_ids


### PR DESCRIPTION
`@effect/vitest` re-exports vitest's test API, so test files importing from it should be treated as vitest files. Add it alongside `vitest` and `vite-plus/test` in the three places that recognize vitest module specifiers:

- `has_vitest_imports` (framework detection / `FrameworkFlags::Vitest`)
- the jest/vitest imported-name resolver in `utils/jest.rs` (unblocks the shared jest/vitest rules for `@effect/vitest` imports)
- the `vitest/prefer-expect-assertions` expect-name resolver

Verified end-to-end: a test file importing `expect` from `@effect/vitest` now triggers `vitest/prefer-expect-assertions`.

Closes #23567
