### PR TITLE
refactor(react_compiler): remove transform_source and lint_source

### DIFF
--- a/crates/oxc_react_compiler/src/lib.rs
+++ b/crates/oxc_react_compiler/src/lib.rs
@@ -49,9 +49,8 @@ pub use crate::react_compiler_hir::environment_config::EnvironmentConfig;
 
 use oxc_ast::ast::Program;
 use oxc_diagnostics::Diagnostics;
-use oxc_parser::Parser;
 use oxc_semantic::SemanticBuilder;
-use oxc_span::{GetSpan, SourceType};
+use oxc_span::GetSpan;
 use rustc_hash::FxHashSet;
 
 /// [`PluginOptions`] with the compiler's standard defaults (it has no `Default`).
@@ -210,19 +209,6 @@ fn preserve_comments<'a>(
     compiled.source_text = source.source_text;
 }
 
-/// Convenience wrapper — parses source text then transforms it in place, returning
-/// the (possibly rewritten) program together with the result.
-pub fn transform_source<'a>(
-    source_text: &'a str,
-    source_type: SourceType,
-    allocator: &'a Allocator,
-    options: PluginOptions,
-) -> (Program<'a>, TransformResult) {
-    let mut program = Parser::new(allocator, source_text, source_type).parse().program;
-    let result = transform(&mut program, allocator, options);
-    (program, result)
-}
-
 /// Lint a pre-parsed program — like [`transform`] but read-only: it collects
 /// diagnostics without rewriting the program.
 pub fn lint(program: &Program, options: PluginOptions) -> LintResult {
@@ -233,15 +219,4 @@ pub fn lint(program: &Program, options: PluginOptions) -> LintResult {
     let allocator = Allocator::default();
     let (_program, diagnostics, _events) = compile(program, &allocator, options);
     LintResult { diagnostics }
-}
-
-/// Convenience wrapper — parses source text, runs semantic analysis, then lints.
-pub fn lint_source(
-    source_text: &str,
-    source_type: SourceType,
-    options: PluginOptions,
-) -> LintResult {
-    let allocator = Allocator::default();
-    let parsed = Parser::new(&allocator, source_text, source_type).parse();
-    lint(&parsed.program, options)
 }

--- a/crates/oxc_react_compiler/tests/transform.rs
+++ b/crates/oxc_react_compiler/tests/transform.rs
@@ -1,13 +1,13 @@
 //! End-to-end integration tests: oxc parse + semantic -> compile -> codegen.
 
 use oxc_allocator::Allocator;
-use oxc_ast::ast::{ModuleExportName, Statement};
+use oxc_ast::ast::{ModuleExportName, Program, Statement};
 use oxc_codegen::Codegen;
+use oxc_parser::Parser;
 use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
 
-use oxc_react_compiler::PluginOptions;
-use oxc_react_compiler::transform_source;
+use oxc_react_compiler::{PluginOptions, TransformResult, transform};
 
 fn options() -> PluginOptions {
     // The upstream options type is constructed typed (it has no `Deserialize`);
@@ -16,6 +16,19 @@ fn options() -> PluginOptions {
         filename: Some("Component.jsx".to_string()),
         ..oxc_react_compiler::default_plugin_options()
     }
+}
+
+/// Parse `source_text` then run the compiler in place, returning the
+/// (possibly rewritten) program together with the result.
+fn transform_source<'a>(
+    source_text: &'a str,
+    source_type: SourceType,
+    allocator: &'a Allocator,
+    options: PluginOptions,
+) -> (Program<'a>, TransformResult) {
+    let mut program = Parser::new(allocator, source_text, source_type).parse().program;
+    let result = transform(&mut program, allocator, options);
+    (program, result)
 }
 
 #[test]


### PR DESCRIPTION
Remove the `transform_source` and `lint_source` convenience wrappers from `oxc_react_compiler`'s public API.

- `lint_source` had no callers anywhere in the workspace.
- `transform_source` (parse-then-`transform`) was only used by the crate's own integration tests, so it moves into `tests/transform.rs` as a private helper — the 17 call sites are unchanged.
- Dropped the now-unused `oxc_parser::Parser` import in `lib.rs` and narrowed `oxc_span::{GetSpan, SourceType}` to `GetSpan`.

`transform`, `lint`, and `LintResult` are kept — they remain in use by the benchmark/example (`transform`) and the `react/react_compiler` linter rule (`lint`).