### PR TITLE
fix(semantic): resolve parameter initializer references after traversal

### DIFF
--- a/crates/oxc_minifier/tests/mangler/mod.rs
+++ b/crates/oxc_minifier/tests/mangler/mod.rs
@@ -375,6 +375,84 @@ fn reserved_names() {
     );
 }
 
+/// A reference in a parameter initializer must bind to a hoisted declaration in the
+/// *enclosing* function's body, even when an outer binding shares the name. The semantic
+/// builder used to eagerly resolve such references against ancestor scopes before the
+/// enclosing body's hoisted declarations were bound, capturing the reference to the wrong
+/// (outer) symbol and miscompiling — surfaced as mangler idempotency failures in
+/// monitor-oxc on ts-api-utils / typescript / vuetify.
+#[test]
+fn parameter_initializer_sees_enclosing_body_declarations() {
+    let options = &MangleOptions::default();
+
+    // `r = s` must follow the hoisted `function s` at the end of `m`'s body,
+    // not the top-level `s`.
+    test(
+        "function s() { return 'outer'; }
+         function m() {
+             const a = (r = s) => r();
+             return a();
+             function s() { return 'inner'; }
+         }",
+        "function s() { return 'outer'; }
+         function m() {
+             const e = (e = t) => e();
+             return e();
+             function t() { return 'inner'; }
+         }",
+        options,
+    );
+
+    // Same with a `const` declared after the arrow (bound later in the traversal,
+    // TDZ at runtime until initialized, but lexically the nearest binding).
+    test(
+        "const s = 'outer';
+         function m() {
+             const a = (r = s) => r;
+             const s = 'inner';
+             return a();
+         }",
+        "const s = 'outer';
+         function m() {
+             const e = (e = t) => e;
+             const t = 'inner';
+             return e();
+         }",
+        options,
+    );
+}
+
+/// Re-mangling output containing parameter initializers that reference hoisted
+/// enclosing-body declarations must be a fixed point.
+#[test]
+fn parameter_initializer_mangle_is_idempotent() {
+    let options = &MangleOptions::default();
+
+    let cases = [
+        "function s() { return 'outer'; }
+         function m() {
+             const a = (r = s) => r();
+             return a();
+             function s() { return 'inner'; }
+         }",
+        "const s = 'outer';
+         function m() {
+             const a = (r = s) => r;
+             const s = 'inner';
+             return a();
+         }",
+    ];
+
+    for case in cases {
+        let pass1 = mangle(case, options);
+        let pass2 = mangle(&pass1, options);
+        assert_eq!(
+            pass1, pass2,
+            "\nIdempotency failure for:\n{case}\nPass 1:\n{pass1}\nPass 2:\n{pass2}"
+        );
+    }
+}
+
 /// Annex B.3.2.1: In sloppy mode, function declarations inside blocks have var-like hoisting.
 /// The mangler must not assign the same name to such a function and an outer `var` binding.
 #[test]

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -600,8 +600,9 @@ impl<'a> SemanticBuilder<'a> {
         name: Ident<'a>,
         reference: Reference,
     ) -> ReferenceId {
+        let scope_id = reference.scope_id();
         let reference_id = self.scoping.create_reference(reference);
-        self.unresolved_references.push(name, reference_id);
+        self.unresolved_references.push(name, reference_id, scope_id);
         reference_id
     }
 
@@ -631,24 +632,55 @@ impl<'a> SemanticBuilder<'a> {
     /// and reference creation is a simple Vec push instead of a hashmap insert.
     fn resolve_all_references(&mut self) {
         let refs = self.unresolved_references.take();
-        for (name, reference_id) in refs {
-            if !self.walk_up_resolve_reference(name, reference_id) {
+        for (name, reference_id, start_scope_id) in refs {
+            if !self.walk_up_resolve_reference(name, reference_id, start_scope_id) {
                 self.scoping.add_root_unresolved_reference(name, reference_id);
             }
         }
     }
 
-    /// Walk up the scope chain trying to resolve a reference.
+    /// Walk up the scope chain from `start_scope_id` trying to resolve a reference.
     /// Returns `true` if resolved.
     #[expect(clippy::inline_always, reason = "Hot path — called for every reference resolution")]
     #[inline(always)]
-    fn walk_up_resolve_reference(&mut self, name: Ident<'a>, reference_id: ReferenceId) -> bool {
-        let mut scope_id = Some(self.scoping.references[reference_id].scope_id());
+    fn walk_up_resolve_reference(
+        &mut self,
+        name: Ident<'a>,
+        reference_id: ReferenceId,
+        start_scope_id: ScopeId,
+    ) -> bool {
+        let mut scope_id = Some(start_scope_id);
         while let Some(sid) = scope_id {
             if let Some(symbol_id) = self.scoping.get_binding(sid, name)
                 && self.try_resolve_reference(reference_id, symbol_id)
             {
                 return true;
+            }
+            scope_id = self.scoping.scope_parent_id(sid);
+        }
+        false
+    }
+
+    /// Walk the scope chain trying to resolve a reference, checking the scopes from
+    /// `start` up to and including `last`. Returns `true` if resolved. Cold path —
+    /// only used for references in function / catch parameter regions; the hot path
+    /// is [`Self::walk_up_resolve_reference`].
+    fn resolve_reference_in_scope_range(
+        &mut self,
+        name: Ident<'a>,
+        reference_id: ReferenceId,
+        start: ScopeId,
+        last: ScopeId,
+    ) -> bool {
+        let mut scope_id = Some(start);
+        while let Some(sid) = scope_id {
+            if let Some(symbol_id) = self.scoping.get_binding(sid, name)
+                && self.try_resolve_reference(reference_id, symbol_id)
+            {
+                return true;
+            }
+            if sid == last {
+                return false;
             }
             scope_id = self.scoping.scope_parent_id(sid);
         }
@@ -704,32 +736,50 @@ impl<'a> SemanticBuilder<'a> {
         true
     }
 
-    /// Early-resolve references collected since the checkpoint by walking up the
-    /// full scope chain. Used for function parameters and catch parameters where
-    /// references must be resolved before entering the function body, to avoid
-    /// binding to variables declared inside the body (which share the same scope).
+    /// Early-resolve references collected since the checkpoint against the scopes
+    /// *inside* the current parameter region only — from each reference's walk-start
+    /// scope up to and including the current (function / catch) scope. Used for
+    /// function parameters and catch parameters where references must be resolved
+    /// before entering the body, to avoid binding to variables declared inside the
+    /// body (which share the same scope as the parameters).
     ///
-    /// Resolved references are removed. Unresolved references stay in the flat
-    /// list for later resolution by `resolve_all_references` (which handles
-    /// forward references to declarations not yet visited).
+    /// These scopes are complete at this point: nested scopes in parameter
+    /// initializers are fully visited, and the current scope holds exactly the
+    /// bindings a parameter reference may see (parameters, type parameters).
+    /// Ancestor scopes are NOT checked here — they are still being built, so a
+    /// binding that appears later in the source (a hoisted function, a `let` after
+    /// this statement) would be missed and the reference would wrongly bind to an
+    /// outer shadowed symbol.
+    ///
+    /// Instead, an unresolved reference's walk-start is bumped to the *parent*
+    /// scope: the final `resolve_all_references` walk then starts above this scope,
+    /// once every binding exists, keeping body bindings (added to the current scope
+    /// later) invisible to it. An enclosing parameter region re-processes it here
+    /// the same way (nested initializers do see the enclosing function's
+    /// parameters). The reference's own `scope_id` is never touched.
     fn resolve_references_for_current_scope(&mut self) {
-        // Process in-place using a retain-style write-cursor — no temporary
-        // `Vec`. Reads each `(name, reference_id)` by value out of the flat
-        // list (both fields are `Copy`), so calling `walk_up_resolve_reference`
-        // (which takes `&mut self`) doesn't conflict with the index read.
+        let Some(parent_scope_id) = self.scoping.scope_parent_id(self.current_scope_id) else {
+            return; // Unreachable: function / catch scopes always have a parent.
+        };
+
+        // Process in-place using a retain-style write-cursor, reading each entry by
+        // value out of the flat list (all fields are `Copy`), so calling
+        // `resolve_reference_in_scope_range` (which takes `&mut self`) doesn't
+        // conflict with the index read.
         let checkpoint = self.unresolved_references_checkpoint;
         let end = self.unresolved_references.len();
-        if end <= checkpoint {
-            return;
-        }
         let mut write_idx = checkpoint;
         for read_idx in checkpoint..end {
-            let (name, reference_id) = self.unresolved_references.get(read_idx);
-            if !self.walk_up_resolve_reference(name, reference_id) {
-                // Keep in the flat list — may resolve later via forward declarations.
-                if write_idx != read_idx {
-                    self.unresolved_references.set(write_idx, name, reference_id);
-                }
+            let (name, reference_id, start_scope_id) = self.unresolved_references.get(read_idx);
+            if !self.resolve_reference_in_scope_range(
+                name,
+                reference_id,
+                start_scope_id,
+                self.current_scope_id,
+            ) {
+                // Not visible in the parameter region — the final walk-up restarts
+                // from the parent scope.
+                self.unresolved_references.set(write_idx, name, reference_id, parent_scope_id);
                 write_idx += 1;
             }
         }

--- a/crates/oxc_semantic/src/unresolved_stack.rs
+++ b/crates/oxc_semantic/src/unresolved_stack.rs
@@ -1,5 +1,5 @@
 use oxc_str::Ident;
-use oxc_syntax::reference::ReferenceId;
+use oxc_syntax::{reference::ReferenceId, scope::ScopeId};
 
 /// Flat list of unresolved references collected during AST traversal.
 ///
@@ -7,8 +7,13 @@ use oxc_syntax::reference::ReferenceId;
 /// references are collected flat and resolved in a single pass after traversal (walk-up).
 /// This eliminates all hashmap drain+insert operations during scope exit.
 pub struct UnresolvedReferences<'a> {
-    /// Flat list of (name, reference_id) pairs collected during traversal.
-    references: Vec<(Ident<'a>, ReferenceId)>,
+    /// Flat list of `(name, reference_id, scope_id)` collected during traversal.
+    ///
+    /// `scope_id` is the scope the resolution walk starts from — the reference's own
+    /// scope, unless a function / catch parameter region bumped it to the region's
+    /// parent scope (see `SemanticBuilder::resolve_references_for_current_scope`).
+    /// The extra field is free: the tuple is 24 bytes with or without it (padding).
+    references: Vec<(Ident<'a>, ReferenceId, ScopeId)>,
 }
 
 impl<'a> UnresolvedReferences<'a> {
@@ -24,10 +29,11 @@ impl<'a> UnresolvedReferences<'a> {
         self.references.reserve_exact(additional);
     }
 
-    /// Push an unresolved reference to the flat list.
+    /// Push an unresolved reference to the flat list. `scope_id` is the scope the
+    /// resolution walk starts from — the scope the reference occurs in.
     #[inline]
-    pub(crate) fn push(&mut self, name: Ident<'a>, reference_id: ReferenceId) {
-        self.references.push((name, reference_id));
+    pub(crate) fn push(&mut self, name: Ident<'a>, reference_id: ReferenceId, scope_id: ScopeId) {
+        self.references.push((name, reference_id, scope_id));
     }
 
     /// Get the current length, used as a checkpoint for early resolution.
@@ -38,7 +44,7 @@ impl<'a> UnresolvedReferences<'a> {
 
     /// Take all collected references, leaving the list empty. O(1) pointer swap.
     #[inline]
-    pub(crate) fn take(&mut self) -> Vec<(Ident<'a>, ReferenceId)> {
+    pub(crate) fn take(&mut self) -> Vec<(Ident<'a>, ReferenceId, ScopeId)> {
         std::mem::take(&mut self.references)
     }
 
@@ -51,14 +57,14 @@ impl<'a> UnresolvedReferences<'a> {
     /// Read a reference by index, by value.
     ///
     /// Used by [`crate::SemanticBuilder::resolve_references_for_current_scope`]
-    /// to process the list in-place without allocating a temporary `Vec`. Both
-    /// `Ident<'a>` and `ReferenceId` are `Copy`, so this hands the caller an
-    /// owned pair that's detached from the underlying borrow.
+    /// to process the list in-place without allocating a temporary `Vec`. All
+    /// fields are `Copy`, so this hands the caller an owned tuple that's
+    /// detached from the underlying borrow.
     ///
     /// # Panics
     /// Panics if `idx >= self.len()`.
     #[inline]
-    pub(crate) fn get(&self, idx: usize) -> (Ident<'a>, ReferenceId) {
+    pub(crate) fn get(&self, idx: usize) -> (Ident<'a>, ReferenceId, ScopeId) {
         self.references[idx]
     }
 
@@ -68,8 +74,14 @@ impl<'a> UnresolvedReferences<'a> {
     /// # Panics
     /// Panics if `idx >= self.len()`.
     #[inline]
-    pub(crate) fn set(&mut self, idx: usize, name: Ident<'a>, reference_id: ReferenceId) {
-        self.references[idx] = (name, reference_id);
+    pub(crate) fn set(
+        &mut self,
+        idx: usize,
+        name: Ident<'a>,
+        reference_id: ReferenceId,
+        scope_id: ScopeId,
+    ) {
+        self.references[idx] = (name, reference_id, scope_id);
     }
 
     /// Truncate the list to `len`, removing references at the end.

--- a/crates/oxc_semantic/tests/integration/symbols.rs
+++ b/crates/oxc_semantic/tests/integration/symbols.rs
@@ -476,3 +476,75 @@ fn test_import_value_redeclaration_in_module() {
     // TypeScript should NOT report this error (declaration merging)
     SemanticTester::ts("import { Foo } from './foo.js'; var Foo;").has_root_symbol("Foo").test();
 }
+
+#[test]
+fn test_parameter_initializer_binds_to_hoisted_declaration() {
+    // `r = s` must bind to the `function s` hoisted in `m`'s body — the nearest
+    // binding on the arrow's scope chain — not the top-level `s`. The builder used
+    // to eagerly resolve parameter-initializer references against ancestor scopes
+    // before the enclosing body's hoisted declarations were bound, capturing the
+    // reference to the outer symbol.
+    let tester = SemanticTester::js(
+        "function s() { return 'outer'; }
+         function m() {
+             const a = (r = s) => r();
+             return a();
+             function s() { return 'inner'; }
+         }",
+    );
+    let semantic = tester.build();
+    let scoping = semantic.scoping();
+    let root_scope_id = scoping.root_scope_id();
+    let mut outer = None;
+    let mut inner = None;
+    for symbol_id in scoping.symbol_ids() {
+        if scoping.symbol_name(symbol_id) == "s" {
+            if scoping.symbol_scope_id(symbol_id) == root_scope_id {
+                outer = Some(symbol_id);
+            } else {
+                inner = Some(symbol_id);
+            }
+        }
+    }
+    assert_eq!(scoping.get_resolved_reference_ids(outer.unwrap()).len(), 0);
+    assert_eq!(scoping.get_resolved_reference_ids(inner.unwrap()).len(), 1);
+}
+
+#[test]
+fn test_parameter_initializer_does_not_bind_to_body_variable() {
+    // A parameter initializer must not see the function's own body declarations:
+    // `r = x` binds to the outer `x`, not the body `var x`.
+    // ... regardless of whether the outer declaration appears before or after the
+    // function in the source.
+    let sources = [
+        "var x = 1;
+         function m(r = x) {
+             var x = 2;
+             return r;
+         }",
+        "function m(r = x) {
+             var x = 2;
+             return r;
+         }
+         var x = 1;",
+    ];
+    for source in sources {
+        let tester = SemanticTester::js(source);
+        let semantic = tester.build();
+        let scoping = semantic.scoping();
+        let root_scope_id = scoping.root_scope_id();
+        let mut outer = None;
+        let mut body = None;
+        for symbol_id in scoping.symbol_ids() {
+            if scoping.symbol_name(symbol_id) == "x" {
+                if scoping.symbol_scope_id(symbol_id) == root_scope_id {
+                    outer = Some(symbol_id);
+                } else {
+                    body = Some(symbol_id);
+                }
+            }
+        }
+        assert_eq!(scoping.get_resolved_reference_ids(outer.unwrap()).len(), 1, "{source}");
+        assert_eq!(scoping.get_resolved_reference_ids(body.unwrap()).len(), 0, "{source}");
+    }
+}

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -176,7 +176,7 @@ Symbol reference IDs mismatch for "InMemoryTestWorkingCopyBackupService":
 after transform: SymbolId(19): [ReferenceId(43), ReferenceId(46), ReferenceId(165)]
 rebuilt        : SymbolId(15): [ReferenceId(75), ReferenceId(205)]
 Symbol reference IDs mismatch for "TestServiceAccessor":
-after transform: SymbolId(21): [ReferenceId(40), ReferenceId(155), ReferenceId(1), ReferenceId(71), ReferenceId(188)]
+after transform: SymbolId(21): [ReferenceId(1), ReferenceId(40), ReferenceId(71), ReferenceId(155), ReferenceId(188)]
 rebuilt        : SymbolId(17): [ReferenceId(99), ReferenceId(227)]
 Symbol reference IDs mismatch for "IWorkingCopyEditorService":
 after transform: SymbolId(32): [ReferenceId(21), ReferenceId(22), ReferenceId(355), ReferenceId(356)]
@@ -185,7 +185,7 @@ Symbol span mismatch for "TestWorkingCopyBackupTracker":
 after transform: SymbolId(39): Span { start: 3208, end: 3236 }
 rebuilt        : SymbolId(38): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "TestWorkingCopyBackupTracker":
-after transform: SymbolId(39): [ReferenceId(42), ReferenceId(154), ReferenceId(74), ReferenceId(215), ReferenceId(376), ReferenceId(378)]
+after transform: SymbolId(39): [ReferenceId(42), ReferenceId(74), ReferenceId(154), ReferenceId(215), ReferenceId(376), ReferenceId(378)]
 rebuilt        : SymbolId(38): [ReferenceId(23), ReferenceId(66), ReferenceId(102), ReferenceId(254)]
 Symbol span mismatch for "TestWorkingCopyBackupTracker":
 after transform: SymbolId(136): Span { start: 0, end: 0 }

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -2,7 +2,7 @@ commit: 7964e22f
 
 semantic_typescript Summary:
 AST Parsed     : 4720/4720 (100.00%)
-Positive Passed: 2644/4720 (56.02%)
+Positive Passed: 2643/4720 (56.00%)
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/2dArrays.ts
 Symbol reference IDs mismatch for "Cell":
 after transform: SymbolId(0): [ReferenceId(1)]
@@ -16,7 +16,7 @@ Bindings mismatch:
 after transform: ScopeId(0): ["console", "formatHost", "os", "process", "reportDiagnostic", "reportWatchStatusChanged", "ts", "watchMain"]
 rebuilt        : ScopeId(0): ["formatHost", "reportDiagnostic", "reportWatchStatusChanged", "ts", "watchMain"]
 Symbol reference IDs mismatch for "ts":
-after transform: SymbolId(3): [ReferenceId(30), ReferenceId(36), ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(8), ReferenceId(10), ReferenceId(11), ReferenceId(28), ReferenceId(33), ReferenceId(38)]
+after transform: SymbolId(3): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(8), ReferenceId(10), ReferenceId(11), ReferenceId(28), ReferenceId(30), ReferenceId(33), ReferenceId(36), ReferenceId(38)]
 rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(8), ReferenceId(10), ReferenceId(11), ReferenceId(27), ReferenceId(31), ReferenceId(35)]
 Reference symbol mismatch for "console":
 after transform: SymbolId(1) "console"
@@ -96,7 +96,7 @@ Bindings mismatch:
 after transform: ScopeId(0): ["console", "getAllTags", "getAnnotations", "getReturnTypeFromJSDoc", "getSomeOtherTags", "parseCommentsIntoDefinition", "parseSpecificTags", "ts"]
 rebuilt        : ScopeId(0): ["getAllTags", "getAnnotations", "getReturnTypeFromJSDoc", "getSomeOtherTags", "parseCommentsIntoDefinition", "parseSpecificTags", "ts"]
 Symbol reference IDs mismatch for "ts":
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(19), ReferenceId(33), ReferenceId(45), ReferenceId(64), ReferenceId(76), ReferenceId(79), ReferenceId(21), ReferenceId(25), ReferenceId(47), ReferenceId(48), ReferenceId(50), ReferenceId(52), ReferenceId(54), ReferenceId(55), ReferenceId(57), ReferenceId(59), ReferenceId(66), ReferenceId(67), ReferenceId(69), ReferenceId(73), ReferenceId(75), ReferenceId(77), ReferenceId(80), ReferenceId(82), ReferenceId(85), ReferenceId(88), ReferenceId(90), ReferenceId(96)]
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(19), ReferenceId(21), ReferenceId(25), ReferenceId(33), ReferenceId(45), ReferenceId(47), ReferenceId(48), ReferenceId(50), ReferenceId(52), ReferenceId(54), ReferenceId(55), ReferenceId(57), ReferenceId(59), ReferenceId(64), ReferenceId(66), ReferenceId(67), ReferenceId(69), ReferenceId(73), ReferenceId(75), ReferenceId(76), ReferenceId(77), ReferenceId(79), ReferenceId(80), ReferenceId(82), ReferenceId(85), ReferenceId(88), ReferenceId(90), ReferenceId(96)]
 rebuilt        : SymbolId(0): [ReferenceId(38), ReferenceId(39), ReferenceId(42), ReferenceId(44), ReferenceId(47), ReferenceId(53), ReferenceId(54), ReferenceId(56), ReferenceId(60), ReferenceId(62), ReferenceId(65), ReferenceId(68), ReferenceId(71), ReferenceId(73), ReferenceId(79)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/APISample_linter.ts
@@ -104,7 +104,7 @@ Bindings mismatch:
 after transform: ScopeId(0): ["console", "delint", "fileNames", "process", "readFileSync", "ts"]
 rebuilt        : ScopeId(0): ["delint", "fileNames", "ts"]
 Symbol reference IDs mismatch for "ts":
-after transform: SymbolId(3): [ReferenceId(0), ReferenceId(3), ReferenceId(40), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(11), ReferenceId(14), ReferenceId(15), ReferenceId(18), ReferenceId(23), ReferenceId(25), ReferenceId(28), ReferenceId(29), ReferenceId(32), ReferenceId(34), ReferenceId(37), ReferenceId(50), ReferenceId(54)]
+after transform: SymbolId(3): [ReferenceId(0), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(11), ReferenceId(14), ReferenceId(15), ReferenceId(18), ReferenceId(23), ReferenceId(25), ReferenceId(28), ReferenceId(29), ReferenceId(32), ReferenceId(34), ReferenceId(37), ReferenceId(40), ReferenceId(50), ReferenceId(54)]
 rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(11), ReferenceId(14), ReferenceId(19), ReferenceId(21), ReferenceId(24), ReferenceId(27), ReferenceId(29), ReferenceId(32), ReferenceId(44), ReferenceId(48)]
 Reference symbol mismatch for "console":
 after transform: SymbolId(1) "console"
@@ -221,7 +221,7 @@ rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/accessors_spec_section-4.5_inference.ts
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(4), ReferenceId(7), ReferenceId(9), ReferenceId(0)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(4), ReferenceId(7), ReferenceId(9)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/aliasInaccessibleModule.ts
@@ -417,7 +417,7 @@ Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "_defineProperty", "f", "t", "x"]
 rebuilt        : ScopeId(0): ["A", "B", "_defineProperty", "t", "x"]
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(4), ReferenceId(0)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(4)]
 rebuilt        : SymbolId(1): [ReferenceId(1)]
 Symbol reference IDs mismatch for "B":
 after transform: SymbolId(1): [ReferenceId(2), ReferenceId(3), ReferenceId(5)]
@@ -1903,7 +1903,7 @@ Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "Foo", "_defineProperty", "callme"]
 rebuilt        : ScopeId(0): ["Bar", "Foo", "_defineProperty"]
 Symbol reference IDs mismatch for "Bar":
-after transform: SymbolId(0): [ReferenceId(8), ReferenceId(6)]
+after transform: SymbolId(0): [ReferenceId(6), ReferenceId(8)]
 rebuilt        : SymbolId(1): []
 Symbol reference IDs mismatch for "Foo":
 after transform: SymbolId(5): [ReferenceId(1), ReferenceId(3), ReferenceId(4), ReferenceId(5)]
@@ -2315,7 +2315,7 @@ rebuilt        : ["fn", "x", "y"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collectionPatternNoError.ts
 Symbol reference IDs mismatch for "Message":
-after transform: SymbolId(3): [ReferenceId(6), ReferenceId(21), ReferenceId(0), ReferenceId(3), ReferenceId(4), ReferenceId(10)]
+after transform: SymbolId(3): [ReferenceId(0), ReferenceId(3), ReferenceId(4), ReferenceId(6), ReferenceId(10), ReferenceId(21)]
 rebuilt        : SymbolId(0): []
 Unresolved references mismatch:
 after transform: ["Array"]
@@ -3576,7 +3576,7 @@ Bindings mismatch:
 after transform: ScopeId(0): ["DEPS", "test"]
 rebuilt        : ScopeId(0): ["DEPS"]
 Symbol reference IDs mismatch for "DEPS":
-after transform: SymbolId(7): [ReferenceId(8), ReferenceId(6), ReferenceId(11), ReferenceId(15), ReferenceId(19), ReferenceId(22)]
+after transform: SymbolId(7): [ReferenceId(6), ReferenceId(8), ReferenceId(11), ReferenceId(15), ReferenceId(19), ReferenceId(22)]
 rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(7), ReferenceId(11), ReferenceId(15), ReferenceId(18)]
 Reference symbol mismatch for "test":
 after transform: SymbolId(1) "test"
@@ -4033,7 +4033,7 @@ rebuilt        : ["TabGroup"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/contextualTypingArrayOfLambdas.ts
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(2), ReferenceId(0), ReferenceId(1)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 rebuilt        : SymbolId(1): [ReferenceId(2), ReferenceId(5)]
 Symbol reference IDs mismatch for "B":
 after transform: SymbolId(1): [ReferenceId(3)]
@@ -4569,7 +4569,7 @@ Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "Y", "_defineProperty", "ctor", "f1", "f2", "f3", "f4", "foo", "goo", "x"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "Y", "_defineProperty", "f1", "f2", "f3", "f4", "foo", "goo"]
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(8): [ReferenceId(38), ReferenceId(36), ReferenceId(37)]
+after transform: SymbolId(8): [ReferenceId(36), ReferenceId(37), ReferenceId(38)]
 rebuilt        : SymbolId(9): [ReferenceId(30), ReferenceId(33)]
 Reference symbol mismatch for "x":
 after transform: SymbolId(17) "x"
@@ -4589,7 +4589,7 @@ rebuilt        : [ReferenceId(2), ReferenceId(5), ReferenceId(10), ReferenceId(1
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowInstanceofWithSymbolHasInstance.ts
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(12): [ReferenceId(49), ReferenceId(47), ReferenceId(48)]
+after transform: SymbolId(12): [ReferenceId(47), ReferenceId(48), ReferenceId(49)]
 rebuilt        : SymbolId(10): [ReferenceId(36), ReferenceId(39)]
 Unresolved reference IDs mismatch for "Promise":
 after transform: [ReferenceId(1), ReferenceId(20)]
@@ -4994,7 +4994,7 @@ Symbol span mismatch for "g":
 after transform: SymbolId(3): Span { start: 110, end: 111 }
 rebuilt        : SymbolId(1): Span { start: 176, end: 177 }
 Symbol reference IDs mismatch for "g":
-after transform: SymbolId(3): [ReferenceId(3), ReferenceId(1)]
+after transform: SymbolId(3): [ReferenceId(1), ReferenceId(3)]
 rebuilt        : SymbolId(1): []
 Symbol redeclarations mismatch for "g":
 after transform: SymbolId(3): [Span { start: 110, end: 111 }, Span { start: 143, end: 144 }, Span { start: 176, end: 177 }]
@@ -5203,10 +5203,10 @@ Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
 rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C":
-after transform: SymbolId(1): [ReferenceId(10), ReferenceId(0), ReferenceId(1), ReferenceId(11)]
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(10), ReferenceId(11)]
 rebuilt        : SymbolId(3): [ReferenceId(10)]
 Symbol reference IDs mismatch for "E":
-after transform: SymbolId(2): [ReferenceId(5), ReferenceId(2), ReferenceId(13)]
+after transform: SymbolId(2): [ReferenceId(2), ReferenceId(5), ReferenceId(13)]
 rebuilt        : SymbolId(4): [ReferenceId(2)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declInput.ts
@@ -5242,7 +5242,7 @@ Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
 rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "E":
-after transform: SymbolId(2): [ReferenceId(2), ReferenceId(0), ReferenceId(6)]
+after transform: SymbolId(2): [ReferenceId(0), ReferenceId(2), ReferenceId(6)]
 rebuilt        : SymbolId(4): [ReferenceId(2)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationAssertionNodeNotReusedWhenTypeNotEquivalent1.ts
@@ -5299,7 +5299,7 @@ rebuilt        : ["Symbol"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitClassMixinLocalClassDeclaration.ts
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(14): [ReferenceId(13), ReferenceId(14), ReferenceId(11)]
+after transform: SymbolId(14): [ReferenceId(11), ReferenceId(13), ReferenceId(14)]
 rebuilt        : SymbolId(2): [ReferenceId(1)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedNameCausesImportToBePainted.ts
@@ -5482,7 +5482,7 @@ Symbol span mismatch for "Point":
 after transform: SymbolId(0): Span { start: 17, end: 22 }
 rebuilt        : SymbolId(0): Span { start: 171, end: 176 }
 Symbol reference IDs mismatch for "Point":
-after transform: SymbolId(0): [ReferenceId(3), ReferenceId(6), ReferenceId(14), ReferenceId(0), ReferenceId(13), ReferenceId(15)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(3), ReferenceId(6), ReferenceId(13), ReferenceId(14), ReferenceId(15)]
 rebuilt        : SymbolId(0): [ReferenceId(4), ReferenceId(5)]
 Symbol redeclarations mismatch for "Point":
 after transform: SymbolId(0): [Span { start: 17, end: 22 }, Span { start: 171, end: 176 }]
@@ -5523,7 +5523,7 @@ rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitFirstTypeArgumentGenericFunctionType.ts
 Symbol reference IDs mismatch for "X":
-after transform: SymbolId(0): [ReferenceId(6), ReferenceId(9), ReferenceId(0), ReferenceId(2)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), ReferenceId(9)]
 rebuilt        : SymbolId(0): []
 Symbol reference IDs mismatch for "Y":
 after transform: SymbolId(12): [ReferenceId(12), ReferenceId(14), ReferenceId(16), ReferenceId(19)]
@@ -6051,7 +6051,7 @@ rebuilt        : ScopeId(0): ["o"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPromise.ts
 Symbol reference IDs mismatch for "bluebird":
-after transform: SymbolId(0): [ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(37), ReferenceId(39), ReferenceId(1), ReferenceId(12), ReferenceId(41), ReferenceId(60)]
+after transform: SymbolId(0): [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(37), ReferenceId(39), ReferenceId(41), ReferenceId(60)]
 rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(6), ReferenceId(23)]
 Symbol reference IDs mismatch for "func":
 after transform: SymbolId(15): [ReferenceId(28), ReferenceId(29)]
@@ -7537,7 +7537,7 @@ Symbol reference IDs mismatch for "B":
 after transform: SymbolId(3): [ReferenceId(1), ReferenceId(25)]
 rebuilt        : SymbolId(3): [ReferenceId(8)]
 Symbol reference IDs mismatch for "List":
-after transform: SymbolId(8): [ReferenceId(5), ReferenceId(9), ReferenceId(14), ReferenceId(7)]
+after transform: SymbolId(8): [ReferenceId(5), ReferenceId(7), ReferenceId(9), ReferenceId(14)]
 rebuilt        : SymbolId(5): [ReferenceId(10)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumLiteralsSubtypeReduction.ts
@@ -7596,7 +7596,7 @@ Symbol flags mismatch for "MyEnum":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "MyEnum":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(3), ReferenceId(6), ReferenceId(9), ReferenceId(2), ReferenceId(5), ReferenceId(8), ReferenceId(11), ReferenceId(25)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(9), ReferenceId(11), ReferenceId(25)]
 rebuilt        : SymbolId(0): [ReferenceId(7), ReferenceId(21), ReferenceId(23), ReferenceId(27), ReferenceId(29)]
 Symbol flags mismatch for "MyStringEnum":
 after transform: SymbolId(4): SymbolFlags(RegularEnum)
@@ -7814,7 +7814,7 @@ rebuilt        : ["M"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ClassTest8.ts
 Symbol reference IDs mismatch for "Vector":
-after transform: SymbolId(5): [ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(22), ReferenceId(23), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(28), ReferenceId(30), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(36)]
+after transform: SymbolId(5): [ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(28), ReferenceId(30), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(36)]
 rebuilt        : SymbolId(6): [ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(20), ReferenceId(22), ReferenceId(24), ReferenceId(25)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ExportAssignment4.ts
@@ -8540,7 +8540,7 @@ rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/exportVisibility.ts
 Symbol reference IDs mismatch for "Foo":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(0)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/extBaseClass1.ts
@@ -9328,7 +9328,7 @@ rebuilt        : ScopeId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericBaseClassLiteralProperty2.ts
 Symbol reference IDs mismatch for "CollectionItem2":
-after transform: SymbolId(0): [ReferenceId(4), ReferenceId(0), ReferenceId(3)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(3), ReferenceId(4)]
 rebuilt        : SymbolId(1): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericCallAtYieldExpressionInGenericCall2.ts
@@ -9549,7 +9549,7 @@ rebuilt        : ["ko", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericClasses4.ts
 Symbol reference IDs mismatch for "Vec2_T":
-after transform: SymbolId(0): [ReferenceId(4), ReferenceId(16), ReferenceId(19), ReferenceId(10), ReferenceId(12), ReferenceId(25), ReferenceId(27)]
+after transform: SymbolId(0): [ReferenceId(4), ReferenceId(10), ReferenceId(12), ReferenceId(16), ReferenceId(19), ReferenceId(25), ReferenceId(27)]
 rebuilt        : SymbolId(0): [ReferenceId(4), ReferenceId(10)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericClassesInModule.ts
@@ -10872,21 +10872,21 @@ rebuilt        : SymbolId(1): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/instanceAndStaticDeclarations1.ts
 Symbol reference IDs mismatch for "Point":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(9), ReferenceId(10), ReferenceId(15), ReferenceId(17)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(10), ReferenceId(9), ReferenceId(15), ReferenceId(17)]
 rebuilt        : SymbolId(2): [ReferenceId(13), ReferenceId(15)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/instanceOfAssignability.ts
 Symbol reference IDs mismatch for "Derived1":
-after transform: SymbolId(1): [ReferenceId(14), ReferenceId(23), ReferenceId(11), ReferenceId(21)]
+after transform: SymbolId(1): [ReferenceId(11), ReferenceId(14), ReferenceId(21), ReferenceId(23)]
 rebuilt        : SymbolId(1): [ReferenceId(15), ReferenceId(21)]
 Symbol reference IDs mismatch for "Derived2":
-after transform: SymbolId(2): [ReferenceId(19), ReferenceId(16), ReferenceId(25)]
+after transform: SymbolId(2): [ReferenceId(16), ReferenceId(19), ReferenceId(25)]
 rebuilt        : SymbolId(2): [ReferenceId(18), ReferenceId(24)]
 Symbol reference IDs mismatch for "Animal":
-after transform: SymbolId(3): [ReferenceId(27), ReferenceId(2)]
+after transform: SymbolId(3): [ReferenceId(2), ReferenceId(27)]
 rebuilt        : SymbolId(3): [ReferenceId(5)]
 Symbol reference IDs mismatch for "Mammal":
-after transform: SymbolId(4): [ReferenceId(28), ReferenceId(3)]
+after transform: SymbolId(4): [ReferenceId(3), ReferenceId(28)]
 rebuilt        : SymbolId(4): [ReferenceId(8)]
 Unresolved reference IDs mismatch for "Array":
 after transform: [ReferenceId(4), ReferenceId(5), ReferenceId(7), ReferenceId(32), ReferenceId(33), ReferenceId(35)]
@@ -12070,7 +12070,7 @@ rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/lambdaParameterWithTupleArgsHasCorrectAssignability.ts
 Symbol reference IDs mismatch for "GenericClass":
-after transform: SymbolId(5): [ReferenceId(10), ReferenceId(14), ReferenceId(12)]
+after transform: SymbolId(5): [ReferenceId(10), ReferenceId(12), ReferenceId(14)]
 rebuilt        : SymbolId(1): [ReferenceId(2)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/largeTupleTypes.ts
@@ -12341,7 +12341,7 @@ rebuilt        : ["chain"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/mappedTypePartialConstraints.ts
 Symbol reference IDs mismatch for "MyClass":
-after transform: SymbolId(1): [ReferenceId(5), ReferenceId(3)]
+after transform: SymbolId(1): [ReferenceId(3), ReferenceId(5)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 Unresolved references mismatch:
 after transform: ["Partial"]
@@ -13942,7 +13942,7 @@ rebuilt        : ["f"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/narrowByInstanceof.ts
 Symbol reference IDs mismatch for "Person":
-after transform: SymbolId(16): [ReferenceId(33), ReferenceId(28), ReferenceId(39)]
+after transform: SymbolId(16): [ReferenceId(28), ReferenceId(33), ReferenceId(39)]
 rebuilt        : SymbolId(11): [ReferenceId(19)]
 Symbol reference IDs mismatch for "Car":
 after transform: SymbolId(17): [ReferenceId(34)]
@@ -15349,13 +15349,13 @@ Symbol span mismatch for "m1":
 after transform: SymbolId(0): Span { start: 10, end: 12 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C1_public":
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(10), ReferenceId(12), ReferenceId(18), ReferenceId(20), ReferenceId(21), ReferenceId(28), ReferenceId(30), ReferenceId(36), ReferenceId(37), ReferenceId(40), ReferenceId(41), ReferenceId(48), ReferenceId(50), ReferenceId(6), ReferenceId(7), ReferenceId(11), ReferenceId(13), ReferenceId(24), ReferenceId(25), ReferenceId(29), ReferenceId(31), ReferenceId(44), ReferenceId(45), ReferenceId(49), ReferenceId(51), ReferenceId(71)]
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(6), ReferenceId(7), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(18), ReferenceId(20), ReferenceId(21), ReferenceId(24), ReferenceId(25), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(36), ReferenceId(37), ReferenceId(40), ReferenceId(41), ReferenceId(44), ReferenceId(45), ReferenceId(48), ReferenceId(49), ReferenceId(50), ReferenceId(51), ReferenceId(71)]
 rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(6), ReferenceId(7), ReferenceId(12), ReferenceId(13), ReferenceId(16), ReferenceId(17), ReferenceId(28), ReferenceId(29), ReferenceId(36), ReferenceId(37)]
 Symbol reference IDs mismatch for "C2_private":
-after transform: SymbolId(2): [ReferenceId(1), ReferenceId(4), ReferenceId(5), ReferenceId(14), ReferenceId(16), ReferenceId(19), ReferenceId(22), ReferenceId(23), ReferenceId(32), ReferenceId(34), ReferenceId(38), ReferenceId(39), ReferenceId(42), ReferenceId(43), ReferenceId(52), ReferenceId(54), ReferenceId(8), ReferenceId(9), ReferenceId(15), ReferenceId(17), ReferenceId(26), ReferenceId(27), ReferenceId(33), ReferenceId(35), ReferenceId(46), ReferenceId(47), ReferenceId(53), ReferenceId(55)]
+after transform: SymbolId(2): [ReferenceId(1), ReferenceId(4), ReferenceId(5), ReferenceId(8), ReferenceId(9), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(19), ReferenceId(22), ReferenceId(23), ReferenceId(26), ReferenceId(27), ReferenceId(32), ReferenceId(33), ReferenceId(34), ReferenceId(35), ReferenceId(38), ReferenceId(39), ReferenceId(42), ReferenceId(43), ReferenceId(46), ReferenceId(47), ReferenceId(52), ReferenceId(53), ReferenceId(54), ReferenceId(55)]
 rebuilt        : SymbolId(3): [ReferenceId(4), ReferenceId(5), ReferenceId(8), ReferenceId(9), ReferenceId(14), ReferenceId(15), ReferenceId(18), ReferenceId(19), ReferenceId(32), ReferenceId(33), ReferenceId(40), ReferenceId(41)]
 Symbol reference IDs mismatch for "C6_public":
-after transform: SymbolId(43): [ReferenceId(56), ReferenceId(57), ReferenceId(58), ReferenceId(61), ReferenceId(63), ReferenceId(65), ReferenceId(66), ReferenceId(68), ReferenceId(59), ReferenceId(60), ReferenceId(62), ReferenceId(64), ReferenceId(67), ReferenceId(69)]
+after transform: SymbolId(43): [ReferenceId(56), ReferenceId(57), ReferenceId(58), ReferenceId(59), ReferenceId(60), ReferenceId(61), ReferenceId(62), ReferenceId(63), ReferenceId(64), ReferenceId(65), ReferenceId(66), ReferenceId(67), ReferenceId(68), ReferenceId(69)]
 rebuilt        : SymbolId(40): [ReferenceId(46), ReferenceId(47), ReferenceId(48), ReferenceId(49), ReferenceId(50), ReferenceId(51)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyFunctionCannotNameParameterTypeDeclFile.ts
@@ -15385,10 +15385,10 @@ Bindings mismatch:
 after transform: ScopeId(142): ["_privateModule", "privateAmbientFunctionWithPrivateModuleParameterTypes", "privateAmbientFunctionWithPrivateParmeterTypes", "privateAmbientFunctionWithPublicParmeterTypes", "privateClass", "privateClassWithPrivateModuleParameterTypes", "privateClassWithWithPrivateParmeterTypes", "privateClassWithWithPublicParmeterTypes", "privateFunctionWithPrivateModuleParameterTypes", "privateFunctionWithPrivateParmeterTypes", "privateFunctionWithPublicParmeterTypes", "publicAmbientFunctionWithPrivateModuleParameterTypes", "publicAmbientFunctionWithPrivateParmeterTypes", "publicAmbientFunctionWithPublicParmeterTypes", "publicClass", "publicClassWithPrivateModuleParameterTypes", "publicClassWithWithPrivateParmeterTypes", "publicClassWithWithPublicParmeterTypes", "publicFunctionWithPrivateModuleParameterTypes", "publicFunctionWithPrivateParmeterTypes", "publicFunctionWithPublicParmeterTypes"]
 rebuilt        : ScopeId(82): ["_privateModule", "privateClass", "privateClassWithPrivateModuleParameterTypes", "privateClassWithWithPrivateParmeterTypes", "privateClassWithWithPublicParmeterTypes", "privateFunctionWithPrivateModuleParameterTypes", "privateFunctionWithPrivateParmeterTypes", "privateFunctionWithPublicParmeterTypes", "publicClass", "publicClassWithPrivateModuleParameterTypes", "publicClassWithWithPrivateParmeterTypes", "publicClassWithWithPublicParmeterTypes", "publicFunctionWithPrivateModuleParameterTypes", "publicFunctionWithPrivateParmeterTypes", "publicFunctionWithPublicParmeterTypes"]
 Symbol reference IDs mismatch for "privateClass":
-after transform: SymbolId(0): [ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(34), ReferenceId(35), ReferenceId(36), ReferenceId(37), ReferenceId(38), ReferenceId(39), ReferenceId(40), ReferenceId(48), ReferenceId(50), ReferenceId(52), ReferenceId(54), ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(34), ReferenceId(35), ReferenceId(36), ReferenceId(37), ReferenceId(38), ReferenceId(39), ReferenceId(40), ReferenceId(48), ReferenceId(50), ReferenceId(52), ReferenceId(54)]
 rebuilt        : SymbolId(0): []
 Symbol reference IDs mismatch for "publicClass":
-after transform: SymbolId(1): [ReferenceId(27), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(32), ReferenceId(33), ReferenceId(41), ReferenceId(42), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(46), ReferenceId(47), ReferenceId(49), ReferenceId(51), ReferenceId(53), ReferenceId(55), ReferenceId(1), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(57), ReferenceId(59), ReferenceId(69), ReferenceId(71)]
+after transform: SymbolId(1): [ReferenceId(1), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(27), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(32), ReferenceId(33), ReferenceId(41), ReferenceId(42), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(46), ReferenceId(47), ReferenceId(49), ReferenceId(51), ReferenceId(53), ReferenceId(55), ReferenceId(57), ReferenceId(59), ReferenceId(69), ReferenceId(71)]
 rebuilt        : SymbolId(1): []
 Symbol flags mismatch for "publicModule":
 after transform: SymbolId(94): SymbolFlags(ValueModule)
@@ -15397,10 +15397,10 @@ Symbol span mismatch for "publicModule":
 after transform: SymbolId(94): Span { start: 4746, end: 4758 }
 rebuilt        : SymbolId(58): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "privateClass":
-after transform: SymbolId(95): [ReferenceId(100), ReferenceId(101), ReferenceId(102), ReferenceId(103), ReferenceId(104), ReferenceId(105), ReferenceId(106), ReferenceId(114), ReferenceId(115), ReferenceId(116), ReferenceId(117), ReferenceId(118), ReferenceId(119), ReferenceId(120), ReferenceId(128), ReferenceId(130), ReferenceId(132), ReferenceId(134), ReferenceId(80), ReferenceId(82), ReferenceId(84), ReferenceId(90), ReferenceId(91), ReferenceId(92), ReferenceId(93), ReferenceId(94)]
+after transform: SymbolId(95): [ReferenceId(80), ReferenceId(82), ReferenceId(84), ReferenceId(90), ReferenceId(91), ReferenceId(92), ReferenceId(93), ReferenceId(94), ReferenceId(100), ReferenceId(101), ReferenceId(102), ReferenceId(103), ReferenceId(104), ReferenceId(105), ReferenceId(106), ReferenceId(114), ReferenceId(115), ReferenceId(116), ReferenceId(117), ReferenceId(118), ReferenceId(119), ReferenceId(120), ReferenceId(128), ReferenceId(130), ReferenceId(132), ReferenceId(134)]
 rebuilt        : SymbolId(60): []
 Symbol reference IDs mismatch for "publicClass":
-after transform: SymbolId(96): [ReferenceId(107), ReferenceId(108), ReferenceId(109), ReferenceId(110), ReferenceId(111), ReferenceId(112), ReferenceId(113), ReferenceId(121), ReferenceId(122), ReferenceId(123), ReferenceId(124), ReferenceId(125), ReferenceId(126), ReferenceId(127), ReferenceId(129), ReferenceId(131), ReferenceId(133), ReferenceId(135), ReferenceId(81), ReferenceId(83), ReferenceId(85), ReferenceId(86), ReferenceId(87), ReferenceId(88), ReferenceId(89), ReferenceId(95), ReferenceId(96), ReferenceId(97), ReferenceId(98), ReferenceId(99), ReferenceId(137), ReferenceId(139), ReferenceId(149), ReferenceId(151), ReferenceId(241)]
+after transform: SymbolId(96): [ReferenceId(81), ReferenceId(83), ReferenceId(85), ReferenceId(86), ReferenceId(87), ReferenceId(88), ReferenceId(89), ReferenceId(95), ReferenceId(96), ReferenceId(97), ReferenceId(98), ReferenceId(99), ReferenceId(107), ReferenceId(108), ReferenceId(109), ReferenceId(110), ReferenceId(111), ReferenceId(112), ReferenceId(113), ReferenceId(121), ReferenceId(122), ReferenceId(123), ReferenceId(124), ReferenceId(125), ReferenceId(126), ReferenceId(127), ReferenceId(129), ReferenceId(131), ReferenceId(133), ReferenceId(135), ReferenceId(137), ReferenceId(139), ReferenceId(149), ReferenceId(151), ReferenceId(241)]
 rebuilt        : SymbolId(61): [ReferenceId(13)]
 Symbol flags mismatch for "privateModule":
 after transform: SymbolId(189): SymbolFlags(ValueModule)
@@ -15409,13 +15409,13 @@ Symbol span mismatch for "privateModule":
 after transform: SymbolId(189): Span { start: 9967, end: 9980 }
 rebuilt        : SymbolId(118): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "privateModule":
-after transform: SymbolId(189): [ReferenceId(221), ReferenceId(222), ReferenceId(223), ReferenceId(224), ReferenceId(225), ReferenceId(226), ReferenceId(227), ReferenceId(233), ReferenceId(234), ReferenceId(235), ReferenceId(236), ReferenceId(237), ReferenceId(238), ReferenceId(239), ReferenceId(56), ReferenceId(58), ReferenceId(60), ReferenceId(61), ReferenceId(62), ReferenceId(63), ReferenceId(64), ReferenceId(65), ReferenceId(66), ReferenceId(67), ReferenceId(68), ReferenceId(70), ReferenceId(72), ReferenceId(73), ReferenceId(74), ReferenceId(75), ReferenceId(76), ReferenceId(77), ReferenceId(78), ReferenceId(79), ReferenceId(136), ReferenceId(138), ReferenceId(140), ReferenceId(141), ReferenceId(142), ReferenceId(143), ReferenceId(144), ReferenceId(145), ReferenceId(146), ReferenceId(147), ReferenceId(148), ReferenceId(150), ReferenceId(152), ReferenceId(153), ReferenceId(154), ReferenceId(155), ReferenceId(156), ReferenceId(157), ReferenceId(158), ReferenceId(159), ReferenceId(216), ReferenceId(218), ReferenceId(220), ReferenceId(228), ReferenceId(230), ReferenceId(232), ReferenceId(270), ReferenceId(271)]
+after transform: SymbolId(189): [ReferenceId(56), ReferenceId(58), ReferenceId(60), ReferenceId(61), ReferenceId(62), ReferenceId(63), ReferenceId(64), ReferenceId(65), ReferenceId(66), ReferenceId(67), ReferenceId(68), ReferenceId(70), ReferenceId(72), ReferenceId(73), ReferenceId(74), ReferenceId(75), ReferenceId(76), ReferenceId(77), ReferenceId(78), ReferenceId(79), ReferenceId(136), ReferenceId(138), ReferenceId(140), ReferenceId(141), ReferenceId(142), ReferenceId(143), ReferenceId(144), ReferenceId(145), ReferenceId(146), ReferenceId(147), ReferenceId(148), ReferenceId(150), ReferenceId(152), ReferenceId(153), ReferenceId(154), ReferenceId(155), ReferenceId(156), ReferenceId(157), ReferenceId(158), ReferenceId(159), ReferenceId(216), ReferenceId(218), ReferenceId(220), ReferenceId(221), ReferenceId(222), ReferenceId(223), ReferenceId(224), ReferenceId(225), ReferenceId(226), ReferenceId(227), ReferenceId(228), ReferenceId(230), ReferenceId(232), ReferenceId(233), ReferenceId(234), ReferenceId(235), ReferenceId(236), ReferenceId(237), ReferenceId(238), ReferenceId(239), ReferenceId(270), ReferenceId(271)]
 rebuilt        : SymbolId(118): [ReferenceId(66), ReferenceId(67)]
 Symbol reference IDs mismatch for "privateClass":
-after transform: SymbolId(190): [ReferenceId(180), ReferenceId(181), ReferenceId(182), ReferenceId(183), ReferenceId(184), ReferenceId(185), ReferenceId(186), ReferenceId(194), ReferenceId(195), ReferenceId(196), ReferenceId(197), ReferenceId(198), ReferenceId(199), ReferenceId(200), ReferenceId(208), ReferenceId(210), ReferenceId(212), ReferenceId(214), ReferenceId(160), ReferenceId(162), ReferenceId(164), ReferenceId(170), ReferenceId(171), ReferenceId(172), ReferenceId(173), ReferenceId(174)]
+after transform: SymbolId(190): [ReferenceId(160), ReferenceId(162), ReferenceId(164), ReferenceId(170), ReferenceId(171), ReferenceId(172), ReferenceId(173), ReferenceId(174), ReferenceId(180), ReferenceId(181), ReferenceId(182), ReferenceId(183), ReferenceId(184), ReferenceId(185), ReferenceId(186), ReferenceId(194), ReferenceId(195), ReferenceId(196), ReferenceId(197), ReferenceId(198), ReferenceId(199), ReferenceId(200), ReferenceId(208), ReferenceId(210), ReferenceId(212), ReferenceId(214)]
 rebuilt        : SymbolId(120): []
 Symbol reference IDs mismatch for "publicClass":
-after transform: SymbolId(191): [ReferenceId(187), ReferenceId(188), ReferenceId(189), ReferenceId(190), ReferenceId(191), ReferenceId(192), ReferenceId(193), ReferenceId(201), ReferenceId(202), ReferenceId(203), ReferenceId(204), ReferenceId(205), ReferenceId(206), ReferenceId(207), ReferenceId(209), ReferenceId(211), ReferenceId(213), ReferenceId(215), ReferenceId(161), ReferenceId(163), ReferenceId(165), ReferenceId(166), ReferenceId(167), ReferenceId(168), ReferenceId(169), ReferenceId(175), ReferenceId(176), ReferenceId(177), ReferenceId(178), ReferenceId(179), ReferenceId(217), ReferenceId(219), ReferenceId(229), ReferenceId(231), ReferenceId(257)]
+after transform: SymbolId(191): [ReferenceId(161), ReferenceId(163), ReferenceId(165), ReferenceId(166), ReferenceId(167), ReferenceId(168), ReferenceId(169), ReferenceId(175), ReferenceId(176), ReferenceId(177), ReferenceId(178), ReferenceId(179), ReferenceId(187), ReferenceId(188), ReferenceId(189), ReferenceId(190), ReferenceId(191), ReferenceId(192), ReferenceId(193), ReferenceId(201), ReferenceId(202), ReferenceId(203), ReferenceId(204), ReferenceId(205), ReferenceId(206), ReferenceId(207), ReferenceId(209), ReferenceId(211), ReferenceId(213), ReferenceId(215), ReferenceId(217), ReferenceId(219), ReferenceId(229), ReferenceId(231), ReferenceId(257)]
 rebuilt        : SymbolId(121): [ReferenceId(41)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyGloClass.ts
@@ -18425,7 +18425,7 @@ rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/specializedOverloadWithRestParameters.ts
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(2), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(0)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(5), ReferenceId(6)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 Symbol reference IDs mismatch for "Derived1":
 after transform: SymbolId(1): [ReferenceId(1), ReferenceId(4)]
@@ -19663,7 +19663,7 @@ rebuilt        : ScopeId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeParameterExtendingUnion1.ts
 Symbol reference IDs mismatch for "Animal":
-after transform: SymbolId(0): [ReferenceId(2), ReferenceId(0), ReferenceId(1)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 rebuilt        : SymbolId(1): [ReferenceId(1), ReferenceId(4)]
 Symbol reference IDs mismatch for "Cat":
 after transform: SymbolId(1): [ReferenceId(4)]
@@ -19693,7 +19693,7 @@ rebuilt        : ["f"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typePartameterConstraintInstantiatedWithDefaultWhenCheckingDefault.ts
 Symbol reference IDs mismatch for "Identity":
-after transform: SymbolId(4): [ReferenceId(10), ReferenceId(3), ReferenceId(12), ReferenceId(18), ReferenceId(26)]
+after transform: SymbolId(4): [ReferenceId(3), ReferenceId(10), ReferenceId(12), ReferenceId(18), ReferenceId(26)]
 rebuilt        : SymbolId(1): [ReferenceId(3)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typePredicateAcceptingPartialOfRefinedType.ts
@@ -19937,7 +19937,7 @@ rebuilt        : SymbolId(1): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeofObjectInference.ts
 Symbol reference IDs mismatch for "val":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(6), ReferenceId(4), ReferenceId(10), ReferenceId(15), ReferenceId(17), ReferenceId(22)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(4), ReferenceId(6), ReferenceId(10), ReferenceId(15), ReferenceId(17), ReferenceId(22)]
 rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(4), ReferenceId(7), ReferenceId(10)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeofStrictNull.ts
@@ -20245,7 +20245,7 @@ Symbol flags mismatch for "Enum":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "Enum":
-after transform: SymbolId(0): [ReferenceId(2), ReferenceId(6), ReferenceId(7), ReferenceId(9), ReferenceId(0), ReferenceId(19)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), ReferenceId(7), ReferenceId(9), ReferenceId(19)]
 rebuilt        : SymbolId(0): [ReferenceId(7)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/unionOfFunctionAndSignatureIsCallable.ts
@@ -21674,7 +21674,7 @@ rebuilt        : SymbolId(5): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock17.ts
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(4): [ReferenceId(7), ReferenceId(0), ReferenceId(1), ReferenceId(13)]
+after transform: SymbolId(4): [ReferenceId(0), ReferenceId(1), ReferenceId(7), ReferenceId(13)]
 rebuilt        : SymbolId(5): [ReferenceId(24)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/constructorImplementationWithDefaultValues.ts
@@ -21776,7 +21776,7 @@ rebuilt        : SymbolId(3): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameFieldDestructuredBinding.ts
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(3), ReferenceId(0)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(3)]
 rebuilt        : SymbolId(5): [ReferenceId(8)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameInLhsReceiverExpression.ts
@@ -21786,7 +21786,7 @@ rebuilt        : SymbolId(5): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticFieldDestructuredBinding.ts
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(12), ReferenceId(0), ReferenceId(25), ReferenceId(28)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(12), ReferenceId(25), ReferenceId(28)]
 rebuilt        : SymbolId(2): [ReferenceId(3), ReferenceId(16), ReferenceId(19)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/mixinAbstractClasses.ts
@@ -21826,7 +21826,7 @@ Bindings mismatch:
 after transform: ScopeId(0): ["Base", "Derived", "Thing1", "Thing2", "Thing3", "_defineProperty", "f1", "f2"]
 rebuilt        : ScopeId(0): ["Base", "Derived", "Printable", "Tagged", "Thing1", "Thing2", "Thing3", "_defineProperty", "f1", "f2"]
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(3): [ReferenceId(5), ReferenceId(1)]
+after transform: SymbolId(3): [ReferenceId(1), ReferenceId(5)]
 rebuilt        : SymbolId(1): [ReferenceId(3)]
 Symbol flags mismatch for "Printable":
 after transform: SymbolId(10): SymbolFlags(BlockScopedVariable | ConstVariable | Interface)
@@ -21855,7 +21855,7 @@ rebuilt        : SymbolId(12): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/mixinClassesAnonymous.ts
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(3): [ReferenceId(5), ReferenceId(1)]
+after transform: SymbolId(3): [ReferenceId(1), ReferenceId(5)]
 rebuilt        : SymbolId(1): [ReferenceId(3)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/mixinClassesMembers.ts
@@ -21968,7 +21968,7 @@ Bindings mismatch:
 after transform: ScopeId(0): ["ApiEnum", "ApiEnumMember", "ApiItem"]
 rebuilt        : ScopeId(0): ["ApiEnum", "ApiEnumMember", "ApiItem", "ApiItemContainerMixin"]
 Symbol reference IDs mismatch for "ApiItem":
-after transform: SymbolId(7): [ReferenceId(9), ReferenceId(22), ReferenceId(5), ReferenceId(7), ReferenceId(10), ReferenceId(11), ReferenceId(13), ReferenceId(25)]
+after transform: SymbolId(7): [ReferenceId(5), ReferenceId(7), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(13), ReferenceId(22), ReferenceId(25)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(5)]
 Symbol reference IDs mismatch for "ApiEnumMember":
 after transform: SymbolId(8): [ReferenceId(27)]
@@ -22046,7 +22046,7 @@ Symbol flags mismatch for "TestType":
 after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "TestType":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(0), ReferenceId(4), ReferenceId(6), ReferenceId(14)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(4), ReferenceId(6), ReferenceId(14)]
 rebuilt        : SymbolId(0): [ReferenceId(5), ReferenceId(7), ReferenceId(9)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnumPropertyAccess3.ts
@@ -23866,7 +23866,7 @@ rebuilt        : ["Factory", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames37_ES6.ts
 Symbol reference IDs mismatch for "Foo2":
-after transform: SymbolId(1): [ReferenceId(2), ReferenceId(0)]
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2)]
 rebuilt        : SymbolId(2): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames41_ES6.ts
@@ -24211,12 +24211,12 @@ rebuilt        : ["v"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern15.ts
 Symbol reference IDs mismatch for "Bar":
-after transform: SymbolId(0): [ReferenceId(3), ReferenceId(0)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(3)]
 rebuilt        : SymbolId(1): [ReferenceId(2)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern20.ts
 Symbol reference IDs mismatch for "Bar":
-after transform: SymbolId(0): [ReferenceId(5), ReferenceId(0)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(5)]
 rebuilt        : SymbolId(1): [ReferenceId(2)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern3.ts
@@ -28586,7 +28586,7 @@ Symbol flags mismatch for "Color":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "Color":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(5), ReferenceId(3), ReferenceId(10), ReferenceId(15), ReferenceId(23)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(3), ReferenceId(5), ReferenceId(10), ReferenceId(15), ReferenceId(23)]
 rebuilt        : SymbolId(0): [ReferenceId(7)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardFunction.ts
@@ -28594,13 +28594,13 @@ Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "D", "_defineProperty", "a", "acceptingBoolean", "acceptingTypeGuardFunction", "b", "f1", "f2", "isA", "isB", "isC", "isC_multipleParams", "obj", "retC", "subType", "union", "union2", "union3"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "D", "_defineProperty", "a", "b", "f1", "obj", "subType", "union", "union2", "union3"]
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(34), ReferenceId(39), ReferenceId(0), ReferenceId(5), ReferenceId(14), ReferenceId(19), ReferenceId(25)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(5), ReferenceId(14), ReferenceId(19), ReferenceId(25), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(34), ReferenceId(39)]
 rebuilt        : SymbolId(1): [ReferenceId(3)]
 Symbol reference IDs mismatch for "B":
 after transform: SymbolId(1): [ReferenceId(2), ReferenceId(6), ReferenceId(15), ReferenceId(43), ReferenceId(44)]
 rebuilt        : SymbolId(2): []
 Symbol reference IDs mismatch for "C":
-after transform: SymbolId(2): [ReferenceId(3), ReferenceId(4), ReferenceId(21), ReferenceId(28), ReferenceId(30), ReferenceId(32), ReferenceId(35), ReferenceId(10), ReferenceId(20), ReferenceId(26), ReferenceId(42)]
+after transform: SymbolId(2): [ReferenceId(3), ReferenceId(4), ReferenceId(10), ReferenceId(20), ReferenceId(21), ReferenceId(26), ReferenceId(28), ReferenceId(30), ReferenceId(32), ReferenceId(35), ReferenceId(42)]
 rebuilt        : SymbolId(3): []
 Reference symbol mismatch for "isC":
 after transform: SymbolId(7) "isC"
@@ -29258,6 +29258,17 @@ Symbol redeclarations mismatch for "f":
 after transform: SymbolId(0): [Span { start: 9, end: 10 }, Span { start: 38, end: 39 }]
 rebuilt        : SymbolId(0): []
 
+semantic Error: tasks/coverage/typescript/tests/cases/conformance/functions/functionParameterObjectRestAndInitializers.ts
+Symbol reference IDs mismatch for "a":
+after transform: SymbolId(1): [ReferenceId(0)]
+rebuilt        : SymbolId(6): []
+Reference symbol mismatch for "a":
+after transform: SymbolId(1) "a"
+rebuilt        : <None>
+Unresolved references mismatch:
+after transform: ["require"]
+rebuilt        : ["a", "require"]
+
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/functions/strictBindCallApply2.ts
 Symbol reference IDs mismatch for "fn":
 after transform: SymbolId(1): [ReferenceId(2), ReferenceId(3)]
@@ -29296,7 +29307,7 @@ Symbol flags mismatch for "Directive":
 after transform: SymbolId(12): SymbolFlags(RegularEnum | ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "Directive":
-after transform: SymbolId(12): [ReferenceId(14), ReferenceId(16), ReferenceId(64), ReferenceId(18), ReferenceId(51), ReferenceId(54), ReferenceId(93), ReferenceId(94), ReferenceId(108)]
+after transform: SymbolId(12): [ReferenceId(14), ReferenceId(16), ReferenceId(18), ReferenceId(51), ReferenceId(54), ReferenceId(64), ReferenceId(93), ReferenceId(94), ReferenceId(108)]
 rebuilt        : SymbolId(3): [ReferenceId(13), ReferenceId(15), ReferenceId(19), ReferenceId(20)]
 Symbol redeclarations mismatch for "Directive":
 after transform: SymbolId(12): [Span { start: 318, end: 327 }, Span { start: 381, end: 390 }]
@@ -29765,7 +29776,7 @@ Symbol span mismatch for "A":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "Point":
-after transform: SymbolId(1): [ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(0), ReferenceId(1), ReferenceId(8)]
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(8)]
 rebuilt        : SymbolId(2): [ReferenceId(3), ReferenceId(5)]
 Symbol flags mismatch for "B":
 after transform: SymbolId(4): SymbolFlags(ValueModule)
@@ -31182,7 +31193,7 @@ Symbol flags mismatch for "Choice":
 after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "Choice":
-after transform: SymbolId(0): [ReferenceId(15), ReferenceId(22), ReferenceId(59), ReferenceId(63), ReferenceId(64), ReferenceId(65), ReferenceId(68), ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(70), ReferenceId(72), ReferenceId(82), ReferenceId(83), ReferenceId(86), ReferenceId(87), ReferenceId(96), ReferenceId(99), ReferenceId(100), ReferenceId(103), ReferenceId(105), ReferenceId(109), ReferenceId(111), ReferenceId(122)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(15), ReferenceId(22), ReferenceId(59), ReferenceId(63), ReferenceId(64), ReferenceId(65), ReferenceId(68), ReferenceId(70), ReferenceId(72), ReferenceId(82), ReferenceId(83), ReferenceId(86), ReferenceId(87), ReferenceId(96), ReferenceId(99), ReferenceId(100), ReferenceId(103), ReferenceId(105), ReferenceId(109), ReferenceId(111), ReferenceId(122)]
 rebuilt        : SymbolId(0): [ReferenceId(7), ReferenceId(52), ReferenceId(54), ReferenceId(63), ReferenceId(64), ReferenceId(66), ReferenceId(67), ReferenceId(74), ReferenceId(78), ReferenceId(80), ReferenceId(83), ReferenceId(85)]
 Reference symbol mismatch for "g":
 after transform: SymbolId(21) "g"
@@ -31217,7 +31228,7 @@ Symbol flags mismatch for "Choice":
 after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "Choice":
-after transform: SymbolId(0): [ReferenceId(15), ReferenceId(22), ReferenceId(59), ReferenceId(63), ReferenceId(64), ReferenceId(65), ReferenceId(68), ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(70), ReferenceId(72), ReferenceId(82), ReferenceId(83), ReferenceId(86), ReferenceId(87), ReferenceId(96), ReferenceId(99), ReferenceId(100), ReferenceId(103), ReferenceId(105), ReferenceId(109), ReferenceId(111), ReferenceId(122)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(15), ReferenceId(22), ReferenceId(59), ReferenceId(63), ReferenceId(64), ReferenceId(65), ReferenceId(68), ReferenceId(70), ReferenceId(72), ReferenceId(82), ReferenceId(83), ReferenceId(86), ReferenceId(87), ReferenceId(96), ReferenceId(99), ReferenceId(100), ReferenceId(103), ReferenceId(105), ReferenceId(109), ReferenceId(111), ReferenceId(122)]
 rebuilt        : SymbolId(0): [ReferenceId(7), ReferenceId(52), ReferenceId(54), ReferenceId(63), ReferenceId(64), ReferenceId(66), ReferenceId(67), ReferenceId(74), ReferenceId(78), ReferenceId(80), ReferenceId(83), ReferenceId(85)]
 Reference symbol mismatch for "g":
 after transform: SymbolId(21) "g"
@@ -31255,7 +31266,7 @@ Symbol span mismatch for "FAILURE":
 after transform: SymbolId(65): Span { start: 2229, end: 2236 }
 rebuilt        : SymbolId(62): Span { start: 2256, end: 2263 }
 Symbol reference IDs mismatch for "FAILURE":
-after transform: SymbolId(65): [ReferenceId(66), ReferenceId(55), ReferenceId(58), ReferenceId(68)]
+after transform: SymbolId(65): [ReferenceId(55), ReferenceId(58), ReferenceId(66), ReferenceId(68)]
 rebuilt        : SymbolId(62): [ReferenceId(50), ReferenceId(54)]
 Symbol redeclarations mismatch for "FAILURE":
 after transform: SymbolId(65): [Span { start: 2229, end: 2236 }, Span { start: 2256, end: 2263 }]
@@ -31308,8 +31319,8 @@ Symbol flags mismatch for "E":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "E":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(4), ReferenceId(5), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(13), ReferenceId(30), ReferenceId(31), ReferenceId(35), ReferenceId(95)]
-rebuilt        : SymbolId(1): [ReferenceId(9), ReferenceId(13), ReferenceId(8), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(14), ReferenceId(15), ReferenceId(19), ReferenceId(44), ReferenceId(53), ReferenceId(57)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(13), ReferenceId(30), ReferenceId(31), ReferenceId(35), ReferenceId(95)]
+rebuilt        : SymbolId(1): [ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(19), ReferenceId(44), ReferenceId(53), ReferenceId(57)]
 Reference symbol mismatch for "g1":
 after transform: SymbolId(98) "g1"
 rebuilt        : <None>
@@ -31456,7 +31467,7 @@ Symbol flags mismatch for "Choice":
 after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "Choice":
-after transform: SymbolId(0): [ReferenceId(15), ReferenceId(22), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(48), ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(50), ReferenceId(52), ReferenceId(62), ReferenceId(63), ReferenceId(66), ReferenceId(67), ReferenceId(76), ReferenceId(79), ReferenceId(80), ReferenceId(83), ReferenceId(85), ReferenceId(89), ReferenceId(91), ReferenceId(99)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(15), ReferenceId(22), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(48), ReferenceId(50), ReferenceId(52), ReferenceId(62), ReferenceId(63), ReferenceId(66), ReferenceId(67), ReferenceId(76), ReferenceId(79), ReferenceId(80), ReferenceId(83), ReferenceId(85), ReferenceId(89), ReferenceId(91), ReferenceId(99)]
 rebuilt        : SymbolId(0): [ReferenceId(4), ReferenceId(31), ReferenceId(33), ReferenceId(42), ReferenceId(43), ReferenceId(45), ReferenceId(46), ReferenceId(53), ReferenceId(57), ReferenceId(59), ReferenceId(62), ReferenceId(64)]
 Reference symbol mismatch for "g":
 after transform: SymbolId(18) "g"
@@ -31491,7 +31502,7 @@ Symbol flags mismatch for "Choice":
 after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "Choice":
-after transform: SymbolId(0): [ReferenceId(15), ReferenceId(22), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(48), ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(50), ReferenceId(52), ReferenceId(62), ReferenceId(63), ReferenceId(66), ReferenceId(67), ReferenceId(76), ReferenceId(79), ReferenceId(80), ReferenceId(83), ReferenceId(85), ReferenceId(89), ReferenceId(91), ReferenceId(99)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(15), ReferenceId(22), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(48), ReferenceId(50), ReferenceId(52), ReferenceId(62), ReferenceId(63), ReferenceId(66), ReferenceId(67), ReferenceId(76), ReferenceId(79), ReferenceId(80), ReferenceId(83), ReferenceId(85), ReferenceId(89), ReferenceId(91), ReferenceId(99)]
 rebuilt        : SymbolId(0): [ReferenceId(4), ReferenceId(31), ReferenceId(33), ReferenceId(42), ReferenceId(43), ReferenceId(45), ReferenceId(46), ReferenceId(53), ReferenceId(57), ReferenceId(59), ReferenceId(62), ReferenceId(64)]
 Reference symbol mismatch for "g":
 after transform: SymbolId(18) "g"
@@ -31789,7 +31800,7 @@ rebuilt        : SymbolId(1): [ReferenceId(6)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/members/typesWithSpecializedCallSignatures.ts
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(4), ReferenceId(0), ReferenceId(1), ReferenceId(9), ReferenceId(13), ReferenceId(30)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(4), ReferenceId(9), ReferenceId(13), ReferenceId(30)]
 rebuilt        : SymbolId(1): [ReferenceId(2), ReferenceId(5)]
 Symbol reference IDs mismatch for "Derived1":
 after transform: SymbolId(1): [ReferenceId(2), ReferenceId(7), ReferenceId(11), ReferenceId(26)]
@@ -33043,7 +33054,7 @@ rebuilt        : [ReferenceId(12)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithConstraints2.ts
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(49), ReferenceId(50), ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(13), ReferenceId(16), ReferenceId(18), ReferenceId(19), ReferenceId(23), ReferenceId(26), ReferenceId(27), ReferenceId(29), ReferenceId(30), ReferenceId(33), ReferenceId(34), ReferenceId(39), ReferenceId(40)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(13), ReferenceId(16), ReferenceId(18), ReferenceId(19), ReferenceId(23), ReferenceId(26), ReferenceId(27), ReferenceId(29), ReferenceId(30), ReferenceId(33), ReferenceId(34), ReferenceId(39), ReferenceId(40), ReferenceId(49), ReferenceId(50)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 Symbol reference IDs mismatch for "B":
 after transform: SymbolId(1): [ReferenceId(12), ReferenceId(15), ReferenceId(17), ReferenceId(22), ReferenceId(42)]
@@ -33051,7 +33062,7 @@ rebuilt        : SymbolId(1): [ReferenceId(9), ReferenceId(14)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithConstraints3.ts
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(39), ReferenceId(0), ReferenceId(1), ReferenceId(12), ReferenceId(15), ReferenceId(18), ReferenceId(22), ReferenceId(26), ReferenceId(30)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(12), ReferenceId(15), ReferenceId(18), ReferenceId(22), ReferenceId(26), ReferenceId(30), ReferenceId(39)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 Symbol reference IDs mismatch for "B":
 after transform: SymbolId(1): [ReferenceId(13), ReferenceId(16), ReferenceId(17), ReferenceId(23), ReferenceId(36), ReferenceId(38), ReferenceId(46)]
@@ -33467,13 +33478,13 @@ Scope flags mismatch:
 after transform: ScopeId(29): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(32): ScopeFlags(Function)
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(14): [ReferenceId(47), ReferenceId(91), ReferenceId(92), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(27), ReferenceId(32), ReferenceId(113)]
+after transform: SymbolId(14): [ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(27), ReferenceId(32), ReferenceId(47), ReferenceId(91), ReferenceId(92), ReferenceId(113)]
 rebuilt        : SymbolId(15): [ReferenceId(3), ReferenceId(6)]
 Symbol flags mismatch for "Derived":
 after transform: SymbolId(15): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(16): SymbolFlags(Class)
 Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(15): [ReferenceId(48), ReferenceId(69), ReferenceId(70), ReferenceId(4), ReferenceId(30), ReferenceId(31), ReferenceId(116), ReferenceId(117)]
+after transform: SymbolId(15): [ReferenceId(4), ReferenceId(30), ReferenceId(31), ReferenceId(48), ReferenceId(69), ReferenceId(70), ReferenceId(116), ReferenceId(117)]
 rebuilt        : SymbolId(16): [ReferenceId(30), ReferenceId(31)]
 Symbol redeclarations mismatch for "Derived":
 after transform: SymbolId(15): [Span { start: 689, end: 696 }, Span { start: 845, end: 852 }]
@@ -33518,7 +33529,7 @@ rebuilt        : ["aOrB"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/instanceOf/narrowingConstrainedTypeVariable.ts
 Symbol reference IDs mismatch for "C":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(7), ReferenceId(3), ReferenceId(12)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(3), ReferenceId(7), ReferenceId(12)]
 rebuilt        : SymbolId(1): [ReferenceId(2), ReferenceId(6)]
 Symbol reference IDs mismatch for "D":
 after transform: SymbolId(6): [ReferenceId(8)]
@@ -33540,10 +33551,10 @@ rebuilt        : SymbolId(4): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/recursiveTypesUsedAsFunctionParameters.ts
 Symbol reference IDs mismatch for "List":
-after transform: SymbolId(0): [ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(24), ReferenceId(27), ReferenceId(1), ReferenceId(2), ReferenceId(18), ReferenceId(31)]
+after transform: SymbolId(0): [ReferenceId(1), ReferenceId(2), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(18), ReferenceId(24), ReferenceId(27), ReferenceId(31)]
 rebuilt        : SymbolId(1): []
 Symbol reference IDs mismatch for "MyList":
-after transform: SymbolId(2): [ReferenceId(16), ReferenceId(21), ReferenceId(29), ReferenceId(5), ReferenceId(6), ReferenceId(32)]
+after transform: SymbolId(2): [ReferenceId(5), ReferenceId(6), ReferenceId(16), ReferenceId(21), ReferenceId(29), ReferenceId(32)]
 rebuilt        : SymbolId(2): []
 Symbol span mismatch for "foo":
 after transform: SymbolId(4): Span { start: 129, end: 132 }
@@ -33705,10 +33716,10 @@ Bindings mismatch:
 after transform: ScopeId(0): ["Base", "Derived", "Derived2", "OtherDerived", "_defineProperty", "foo1", "foo11", "foo15", "foo16", "foo17", "foo18", "foo2", "foo3", "foo4", "foo5", "foo6", "r1", "r11", "r11a", "r11arg", "r11arg2", "r11b", "r15", "r15a", "r15arg", "r15arg2", "r15b", "r16", "r16a", "r16arg", "r16arg2", "r16b", "r17", "r17arg", "r18", "r18arg", "r1a", "r1arg", "r1arg2", "r1b", "r2", "r2a", "r2arg", "r2arg2", "r2b", "r3", "r3a", "r3arg", "r3arg2", "r3b", "r4", "r4a", "r4arg", "r4arg2", "r4b", "r5", "r5a", "r5arg", "r5arg2", "r5b", "r6", "r6a", "r6arg", "r6arg2", "r6b"]
 rebuilt        : ScopeId(0): ["Base", "Derived", "Derived2", "OtherDerived", "_defineProperty", "r1", "r11", "r11a", "r11arg", "r11arg2", "r11b", "r15", "r15a", "r15arg", "r15arg2", "r15b", "r16", "r16a", "r16arg", "r16arg2", "r16b", "r17", "r17arg", "r18", "r18arg", "r1a", "r1arg", "r1arg2", "r1b", "r2", "r2a", "r2arg", "r2arg2", "r2b", "r3", "r3a", "r3arg", "r3arg2", "r3b", "r4", "r4a", "r4arg", "r4arg2", "r4b", "r5", "r5a", "r5arg", "r5arg2", "r5b", "r6", "r6a", "r6arg", "r6arg2", "r6b"]
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(12), ReferenceId(19), ReferenceId(23), ReferenceId(31), ReferenceId(38), ReferenceId(44), ReferenceId(96), ReferenceId(101), ReferenceId(137), ReferenceId(141), ReferenceId(0), ReferenceId(2), ReferenceId(114), ReferenceId(118)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(12), ReferenceId(19), ReferenceId(23), ReferenceId(31), ReferenceId(38), ReferenceId(44), ReferenceId(96), ReferenceId(101), ReferenceId(114), ReferenceId(118), ReferenceId(137), ReferenceId(141)]
 rebuilt        : SymbolId(1): [ReferenceId(2), ReferenceId(8)]
 Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(1): [ReferenceId(14), ReferenceId(27), ReferenceId(35), ReferenceId(97), ReferenceId(103), ReferenceId(1)]
+after transform: SymbolId(1): [ReferenceId(1), ReferenceId(14), ReferenceId(27), ReferenceId(35), ReferenceId(97), ReferenceId(103)]
 rebuilt        : SymbolId(2): [ReferenceId(5)]
 Symbol reference IDs mismatch for "Derived2":
 after transform: SymbolId(2): [ReferenceId(41)]
@@ -33755,10 +33766,10 @@ Bindings mismatch:
 after transform: ScopeId(0): ["Base", "Derived", "Derived2", "OtherDerived", "_defineProperty", "foo1", "foo11", "foo15", "foo16", "foo17", "foo18", "foo2", "foo3", "foo4", "foo5", "foo6", "r1", "r11", "r11a", "r11arg", "r11arg2", "r11b", "r15", "r15a", "r15arg", "r15arg2", "r15b", "r16", "r16a", "r16arg", "r16arg2", "r16b", "r17", "r17arg", "r18", "r18arg", "r1a", "r1arg", "r1arg2", "r1b", "r2", "r2a", "r2arg", "r2arg2", "r2b", "r3", "r3a", "r3arg", "r3arg2", "r3b", "r4", "r4a", "r4arg", "r4arg2", "r4b", "r5", "r5a", "r5arg", "r5arg2", "r5b", "r6", "r6a", "r6arg", "r6arg2", "r6b"]
 rebuilt        : ScopeId(0): ["Base", "Derived", "Derived2", "OtherDerived", "_defineProperty", "r1", "r11", "r11a", "r11arg", "r11arg2", "r11b", "r15", "r15a", "r15arg", "r15arg2", "r15b", "r16", "r16a", "r16arg", "r16arg2", "r16b", "r17", "r17arg", "r18", "r18arg", "r1a", "r1arg", "r1arg2", "r1b", "r2", "r2a", "r2arg", "r2arg2", "r2b", "r3", "r3a", "r3arg", "r3arg2", "r3b", "r4", "r4a", "r4arg", "r4arg2", "r4b", "r5", "r5a", "r5arg", "r5arg2", "r5b", "r6", "r6a", "r6arg", "r6arg2", "r6b"]
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(12), ReferenceId(19), ReferenceId(23), ReferenceId(31), ReferenceId(38), ReferenceId(44), ReferenceId(0), ReferenceId(2), ReferenceId(96), ReferenceId(101), ReferenceId(114), ReferenceId(118), ReferenceId(137), ReferenceId(141)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(12), ReferenceId(19), ReferenceId(23), ReferenceId(31), ReferenceId(38), ReferenceId(44), ReferenceId(96), ReferenceId(101), ReferenceId(114), ReferenceId(118), ReferenceId(137), ReferenceId(141)]
 rebuilt        : SymbolId(1): [ReferenceId(2), ReferenceId(8)]
 Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(1): [ReferenceId(14), ReferenceId(27), ReferenceId(35), ReferenceId(1), ReferenceId(97), ReferenceId(103)]
+after transform: SymbolId(1): [ReferenceId(1), ReferenceId(14), ReferenceId(27), ReferenceId(35), ReferenceId(97), ReferenceId(103)]
 rebuilt        : SymbolId(2): [ReferenceId(5)]
 Symbol reference IDs mismatch for "Derived2":
 after transform: SymbolId(2): [ReferenceId(41)]
@@ -35461,7 +35472,7 @@ Symbol reference IDs mismatch for "One":
 after transform: SymbolId(0): [ReferenceId(5), ReferenceId(29)]
 rebuilt        : SymbolId(1): []
 Symbol reference IDs mismatch for "Two":
-after transform: SymbolId(1): [ReferenceId(33), ReferenceId(39), ReferenceId(40), ReferenceId(42), ReferenceId(43), ReferenceId(62), ReferenceId(63), ReferenceId(87), ReferenceId(88), ReferenceId(93), ReferenceId(94), ReferenceId(99), ReferenceId(100), ReferenceId(103), ReferenceId(104), ReferenceId(9)]
+after transform: SymbolId(1): [ReferenceId(9), ReferenceId(33), ReferenceId(39), ReferenceId(40), ReferenceId(42), ReferenceId(43), ReferenceId(62), ReferenceId(63), ReferenceId(87), ReferenceId(88), ReferenceId(93), ReferenceId(94), ReferenceId(99), ReferenceId(100), ReferenceId(103), ReferenceId(104)]
 rebuilt        : SymbolId(2): []
 Symbol reference IDs mismatch for "A":
 after transform: SymbolId(10): [ReferenceId(36), ReferenceId(37), ReferenceId(60), ReferenceId(64), ReferenceId(80), ReferenceId(84)]
@@ -36794,7 +36805,7 @@ Symbol reference IDs mismatch for "One":
 after transform: SymbolId(0): [ReferenceId(25)]
 rebuilt        : SymbolId(1): []
 Symbol reference IDs mismatch for "Two":
-after transform: SymbolId(1): [ReferenceId(29), ReferenceId(33), ReferenceId(34), ReferenceId(36), ReferenceId(37), ReferenceId(67), ReferenceId(68), ReferenceId(73), ReferenceId(74), ReferenceId(79), ReferenceId(80), ReferenceId(83), ReferenceId(84), ReferenceId(5)]
+after transform: SymbolId(1): [ReferenceId(5), ReferenceId(29), ReferenceId(33), ReferenceId(34), ReferenceId(36), ReferenceId(37), ReferenceId(67), ReferenceId(68), ReferenceId(73), ReferenceId(74), ReferenceId(79), ReferenceId(80), ReferenceId(83), ReferenceId(84)]
 rebuilt        : SymbolId(2): []
 Symbol reference IDs mismatch for "B":
 after transform: SymbolId(10): [ReferenceId(32), ReferenceId(35), ReferenceId(66), ReferenceId(72), ReferenceId(78), ReferenceId(82)]
@@ -37112,10 +37123,10 @@ rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesDifferingTypeParameterCounts.ts
 Symbol reference IDs mismatch for "B":
-after transform: SymbolId(0): [ReferenceId(18), ReferenceId(19), ReferenceId(28), ReferenceId(31), ReferenceId(33), ReferenceId(34), ReferenceId(36), ReferenceId(39), ReferenceId(42), ReferenceId(3)]
+after transform: SymbolId(0): [ReferenceId(3), ReferenceId(18), ReferenceId(19), ReferenceId(28), ReferenceId(31), ReferenceId(33), ReferenceId(34), ReferenceId(36), ReferenceId(39), ReferenceId(42)]
 rebuilt        : SymbolId(0): []
 Symbol reference IDs mismatch for "C":
-after transform: SymbolId(4): [ReferenceId(20), ReferenceId(21), ReferenceId(32), ReferenceId(41), ReferenceId(45), ReferenceId(7), ReferenceId(12)]
+after transform: SymbolId(4): [ReferenceId(7), ReferenceId(12), ReferenceId(20), ReferenceId(21), ReferenceId(32), ReferenceId(41), ReferenceId(45)]
 rebuilt        : SymbolId(2): []
 Symbol reference IDs mismatch for "a":
 after transform: SymbolId(21): [ReferenceId(24), ReferenceId(25), ReferenceId(35), ReferenceId(50)]
@@ -37207,10 +37218,10 @@ rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesDifferingTypeParameterNames.ts
 Symbol reference IDs mismatch for "B":
-after transform: SymbolId(0): [ReferenceId(15), ReferenceId(16), ReferenceId(25), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(3), ReferenceId(9)]
+after transform: SymbolId(0): [ReferenceId(3), ReferenceId(9), ReferenceId(15), ReferenceId(16), ReferenceId(25), ReferenceId(27), ReferenceId(29), ReferenceId(31)]
 rebuilt        : SymbolId(0): []
 Symbol reference IDs mismatch for "C":
-after transform: SymbolId(3): [ReferenceId(17), ReferenceId(18), ReferenceId(28), ReferenceId(34), ReferenceId(36), ReferenceId(6), ReferenceId(12)]
+after transform: SymbolId(3): [ReferenceId(6), ReferenceId(12), ReferenceId(17), ReferenceId(18), ReferenceId(28), ReferenceId(34), ReferenceId(36)]
 rebuilt        : SymbolId(2): [ReferenceId(0)]
 Symbol reference IDs mismatch for "a":
 after transform: SymbolId(12): [ReferenceId(21), ReferenceId(22), ReferenceId(30), ReferenceId(38)]
@@ -37299,10 +37310,10 @@ rebuilt        : SymbolId(31): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesOptionalParams.ts
 Symbol reference IDs mismatch for "B":
-after transform: SymbolId(0): [ReferenceId(22), ReferenceId(23), ReferenceId(32), ReferenceId(34), ReferenceId(36), ReferenceId(38), ReferenceId(6), ReferenceId(14)]
+after transform: SymbolId(0): [ReferenceId(6), ReferenceId(14), ReferenceId(22), ReferenceId(23), ReferenceId(32), ReferenceId(34), ReferenceId(36), ReferenceId(38)]
 rebuilt        : SymbolId(0): []
 Symbol reference IDs mismatch for "C":
-after transform: SymbolId(4): [ReferenceId(24), ReferenceId(25), ReferenceId(35), ReferenceId(41), ReferenceId(43), ReferenceId(10), ReferenceId(18)]
+after transform: SymbolId(4): [ReferenceId(10), ReferenceId(18), ReferenceId(24), ReferenceId(25), ReferenceId(35), ReferenceId(41), ReferenceId(43)]
 rebuilt        : SymbolId(3): [ReferenceId(0)]
 Symbol reference IDs mismatch for "a":
 after transform: SymbolId(16): [ReferenceId(28), ReferenceId(29), ReferenceId(37), ReferenceId(45)]
@@ -37391,10 +37402,10 @@ rebuilt        : SymbolId(34): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesOptionalParams2.ts
 Symbol reference IDs mismatch for "B":
-after transform: SymbolId(0): [ReferenceId(26), ReferenceId(27), ReferenceId(36), ReferenceId(38), ReferenceId(40), ReferenceId(42), ReferenceId(6), ReferenceId(16)]
+after transform: SymbolId(0): [ReferenceId(6), ReferenceId(16), ReferenceId(26), ReferenceId(27), ReferenceId(36), ReferenceId(38), ReferenceId(40), ReferenceId(42)]
 rebuilt        : SymbolId(0): []
 Symbol reference IDs mismatch for "C":
-after transform: SymbolId(5): [ReferenceId(28), ReferenceId(29), ReferenceId(39), ReferenceId(45), ReferenceId(47), ReferenceId(11), ReferenceId(21)]
+after transform: SymbolId(5): [ReferenceId(11), ReferenceId(21), ReferenceId(28), ReferenceId(29), ReferenceId(39), ReferenceId(45), ReferenceId(47)]
 rebuilt        : SymbolId(3): [ReferenceId(0)]
 Symbol reference IDs mismatch for "a":
 after transform: SymbolId(20): [ReferenceId(32), ReferenceId(33), ReferenceId(41), ReferenceId(49)]
@@ -37483,10 +37494,10 @@ rebuilt        : SymbolId(34): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesOptionalParams3.ts
 Symbol reference IDs mismatch for "B":
-after transform: SymbolId(0): [ReferenceId(26), ReferenceId(27), ReferenceId(36), ReferenceId(38), ReferenceId(40), ReferenceId(42), ReferenceId(6), ReferenceId(16)]
+after transform: SymbolId(0): [ReferenceId(6), ReferenceId(16), ReferenceId(26), ReferenceId(27), ReferenceId(36), ReferenceId(38), ReferenceId(40), ReferenceId(42)]
 rebuilt        : SymbolId(0): []
 Symbol reference IDs mismatch for "C":
-after transform: SymbolId(5): [ReferenceId(28), ReferenceId(29), ReferenceId(39), ReferenceId(45), ReferenceId(47), ReferenceId(11), ReferenceId(21)]
+after transform: SymbolId(5): [ReferenceId(11), ReferenceId(21), ReferenceId(28), ReferenceId(29), ReferenceId(39), ReferenceId(45), ReferenceId(47)]
 rebuilt        : SymbolId(3): [ReferenceId(0)]
 Symbol reference IDs mismatch for "a":
 after transform: SymbolId(20): [ReferenceId(32), ReferenceId(33), ReferenceId(41), ReferenceId(49)]
@@ -37575,10 +37586,10 @@ rebuilt        : SymbolId(34): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithNumericIndexers1.ts
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(23), ReferenceId(25), ReferenceId(1)]
+after transform: SymbolId(0): [ReferenceId(1), ReferenceId(3), ReferenceId(4), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(23), ReferenceId(25)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 Symbol reference IDs mismatch for "B":
-after transform: SymbolId(1): [ReferenceId(5), ReferenceId(6), ReferenceId(16), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(37), ReferenceId(2)]
+after transform: SymbolId(1): [ReferenceId(2), ReferenceId(5), ReferenceId(6), ReferenceId(16), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(37)]
 rebuilt        : SymbolId(1): [ReferenceId(1)]
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(2): [ReferenceId(7), ReferenceId(8), ReferenceId(18), ReferenceId(30), ReferenceId(40)]
@@ -37736,16 +37747,16 @@ rebuilt        : SymbolId(51): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithNumericIndexers2.ts
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(39), ReferenceId(0), ReferenceId(1), ReferenceId(7)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(7), ReferenceId(39)]
 rebuilt        : SymbolId(1): [ReferenceId(2)]
 Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(1): [ReferenceId(26), ReferenceId(50), ReferenceId(2), ReferenceId(4), ReferenceId(8), ReferenceId(9)]
+after transform: SymbolId(1): [ReferenceId(2), ReferenceId(4), ReferenceId(8), ReferenceId(9), ReferenceId(26), ReferenceId(50)]
 rebuilt        : SymbolId(2): []
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(2): [ReferenceId(10), ReferenceId(11), ReferenceId(22), ReferenceId(24), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33), ReferenceId(5)]
+after transform: SymbolId(2): [ReferenceId(5), ReferenceId(10), ReferenceId(11), ReferenceId(22), ReferenceId(24), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33)]
 rebuilt        : SymbolId(4): [ReferenceId(5)]
 Symbol reference IDs mismatch for "B":
-after transform: SymbolId(3): [ReferenceId(12), ReferenceId(13), ReferenceId(23), ReferenceId(35), ReferenceId(37), ReferenceId(40), ReferenceId(42), ReferenceId(44), ReferenceId(46), ReferenceId(6)]
+after transform: SymbolId(3): [ReferenceId(6), ReferenceId(12), ReferenceId(13), ReferenceId(23), ReferenceId(35), ReferenceId(37), ReferenceId(40), ReferenceId(42), ReferenceId(44), ReferenceId(46)]
 rebuilt        : SymbolId(5): [ReferenceId(6)]
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(4): [ReferenceId(14), ReferenceId(15), ReferenceId(25), ReferenceId(38), ReferenceId(49)]
@@ -37903,10 +37914,10 @@ rebuilt        : SymbolId(55): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithNumericIndexers3.ts
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(23), ReferenceId(25), ReferenceId(1)]
+after transform: SymbolId(0): [ReferenceId(1), ReferenceId(3), ReferenceId(4), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(23), ReferenceId(25)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 Symbol reference IDs mismatch for "B":
-after transform: SymbolId(1): [ReferenceId(5), ReferenceId(6), ReferenceId(16), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(37), ReferenceId(2)]
+after transform: SymbolId(1): [ReferenceId(2), ReferenceId(5), ReferenceId(6), ReferenceId(16), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(37)]
 rebuilt        : SymbolId(1): [ReferenceId(1)]
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(2): [ReferenceId(7), ReferenceId(8), ReferenceId(18), ReferenceId(30), ReferenceId(40)]
@@ -38135,10 +38146,10 @@ rebuilt        : SymbolId(22): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithPrivates.ts
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(23), ReferenceId(25), ReferenceId(1)]
+after transform: SymbolId(0): [ReferenceId(1), ReferenceId(3), ReferenceId(4), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(23), ReferenceId(25)]
 rebuilt        : SymbolId(1): [ReferenceId(4)]
 Symbol reference IDs mismatch for "B":
-after transform: SymbolId(1): [ReferenceId(5), ReferenceId(6), ReferenceId(16), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(37), ReferenceId(2)]
+after transform: SymbolId(1): [ReferenceId(2), ReferenceId(5), ReferenceId(6), ReferenceId(16), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(37)]
 rebuilt        : SymbolId(2): [ReferenceId(5)]
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(2): [ReferenceId(7), ReferenceId(8), ReferenceId(18), ReferenceId(30), ReferenceId(40)]
@@ -38296,10 +38307,10 @@ rebuilt        : SymbolId(52): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithPrivates2.ts
 Symbol reference IDs mismatch for "C":
-after transform: SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(7), ReferenceId(9), ReferenceId(15), ReferenceId(16), ReferenceId(1), ReferenceId(12)]
+after transform: SymbolId(0): [ReferenceId(1), ReferenceId(3), ReferenceId(4), ReferenceId(7), ReferenceId(9), ReferenceId(12), ReferenceId(15), ReferenceId(16)]
 rebuilt        : SymbolId(1): [ReferenceId(2), ReferenceId(4)]
 Symbol reference IDs mismatch for "D":
-after transform: SymbolId(2): [ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(17), ReferenceId(18), ReferenceId(14)]
+after transform: SymbolId(2): [ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(14), ReferenceId(17), ReferenceId(18)]
 rebuilt        : SymbolId(2): [ReferenceId(6)]
 Symbol span mismatch for "foo1":
 after transform: SymbolId(4): Span { start: 118, end: 122 }
@@ -38459,10 +38470,10 @@ rebuilt        : SymbolId(38): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithStringIndexers.ts
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(23), ReferenceId(25), ReferenceId(1)]
+after transform: SymbolId(0): [ReferenceId(1), ReferenceId(3), ReferenceId(4), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(23), ReferenceId(25)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 Symbol reference IDs mismatch for "B":
-after transform: SymbolId(1): [ReferenceId(5), ReferenceId(6), ReferenceId(16), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(37), ReferenceId(2)]
+after transform: SymbolId(1): [ReferenceId(2), ReferenceId(5), ReferenceId(6), ReferenceId(16), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(37)]
 rebuilt        : SymbolId(1): [ReferenceId(1)]
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(2): [ReferenceId(7), ReferenceId(8), ReferenceId(18), ReferenceId(30), ReferenceId(40)]
@@ -38620,16 +38631,16 @@ rebuilt        : SymbolId(51): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithStringIndexers2.ts
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(39), ReferenceId(0), ReferenceId(1), ReferenceId(7)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(7), ReferenceId(39)]
 rebuilt        : SymbolId(1): [ReferenceId(2)]
 Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(1): [ReferenceId(26), ReferenceId(50), ReferenceId(2), ReferenceId(4), ReferenceId(8), ReferenceId(9)]
+after transform: SymbolId(1): [ReferenceId(2), ReferenceId(4), ReferenceId(8), ReferenceId(9), ReferenceId(26), ReferenceId(50)]
 rebuilt        : SymbolId(2): []
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(2): [ReferenceId(10), ReferenceId(11), ReferenceId(22), ReferenceId(24), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33), ReferenceId(5)]
+after transform: SymbolId(2): [ReferenceId(5), ReferenceId(10), ReferenceId(11), ReferenceId(22), ReferenceId(24), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33)]
 rebuilt        : SymbolId(4): [ReferenceId(5)]
 Symbol reference IDs mismatch for "B":
-after transform: SymbolId(3): [ReferenceId(12), ReferenceId(13), ReferenceId(23), ReferenceId(35), ReferenceId(37), ReferenceId(40), ReferenceId(42), ReferenceId(44), ReferenceId(46), ReferenceId(6)]
+after transform: SymbolId(3): [ReferenceId(6), ReferenceId(12), ReferenceId(13), ReferenceId(23), ReferenceId(35), ReferenceId(37), ReferenceId(40), ReferenceId(42), ReferenceId(44), ReferenceId(46)]
 rebuilt        : SymbolId(5): [ReferenceId(6)]
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(4): [ReferenceId(14), ReferenceId(15), ReferenceId(25), ReferenceId(38), ReferenceId(49)]
@@ -38905,21 +38916,21 @@ rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithConstraintsTypeArgumentInference.ts
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(5), ReferenceId(12), ReferenceId(17), ReferenceId(56), ReferenceId(0), ReferenceId(2), ReferenceId(22), ReferenceId(29), ReferenceId(61), ReferenceId(90), ReferenceId(116), ReferenceId(120), ReferenceId(124)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(5), ReferenceId(12), ReferenceId(17), ReferenceId(22), ReferenceId(29), ReferenceId(56), ReferenceId(61), ReferenceId(90), ReferenceId(116), ReferenceId(120), ReferenceId(124)]
 rebuilt        : SymbolId(1): [ReferenceId(2)]
 Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(1): [ReferenceId(13), ReferenceId(18), ReferenceId(39), ReferenceId(47), ReferenceId(57), ReferenceId(1), ReferenceId(3), ReferenceId(23), ReferenceId(30), ReferenceId(52), ReferenceId(62), ReferenceId(91), ReferenceId(100), ReferenceId(108), ReferenceId(113), ReferenceId(117), ReferenceId(121), ReferenceId(125)]
+after transform: SymbolId(1): [ReferenceId(1), ReferenceId(3), ReferenceId(13), ReferenceId(18), ReferenceId(23), ReferenceId(30), ReferenceId(39), ReferenceId(47), ReferenceId(52), ReferenceId(57), ReferenceId(62), ReferenceId(91), ReferenceId(100), ReferenceId(108), ReferenceId(113), ReferenceId(117), ReferenceId(121), ReferenceId(125)]
 rebuilt        : SymbolId(2): [ReferenceId(5)]
 Symbol reference IDs mismatch for "Derived2":
-after transform: SymbolId(2): [ReferenceId(43), ReferenceId(48), ReferenceId(4), ReferenceId(53), ReferenceId(104), ReferenceId(109), ReferenceId(114)]
+after transform: SymbolId(2): [ReferenceId(4), ReferenceId(43), ReferenceId(48), ReferenceId(53), ReferenceId(104), ReferenceId(109), ReferenceId(114)]
 rebuilt        : SymbolId(4): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGenericSignatureArguments.ts
 Symbol reference IDs mismatch for "a":
-after transform: SymbolId(20): [ReferenceId(14), ReferenceId(21), ReferenceId(15), ReferenceId(22)]
+after transform: SymbolId(20): [ReferenceId(14), ReferenceId(15), ReferenceId(21), ReferenceId(22)]
 rebuilt        : SymbolId(16): [ReferenceId(6), ReferenceId(10)]
 Symbol reference IDs mismatch for "b":
-after transform: SymbolId(21): [ReferenceId(16), ReferenceId(19), ReferenceId(17), ReferenceId(20)]
+after transform: SymbolId(21): [ReferenceId(16), ReferenceId(17), ReferenceId(19), ReferenceId(20)]
 rebuilt        : SymbolId(17): [ReferenceId(7), ReferenceId(9)]
 Unresolved references mismatch:
 after transform: ["Date", "Object", "RegExp"]

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 1fb0b771
 
-Passed: 702/1165
+Passed: 701/1165
 
 # All Passed:
 * babel-plugin-transform-logical-assignment-operators
@@ -914,7 +914,7 @@ rebuilt        : ["o"]
 x Output mismatch
 
 
-# babel-plugin-transform-object-rest-spread (30/40)
+# babel-plugin-transform-object-rest-spread (29/40)
 * object-rest/for-x/input.js
 x Output mismatch
 
@@ -935,6 +935,47 @@ x Output mismatch
 
 * object-rest/object-ref-computed/input.js
 x Output mismatch
+
+* object-rest/parameters-object-rest-used-in-default/input.js
+Symbol reference IDs mismatch for "R":
+after transform: SymbolId(0): [ReferenceId(0)]
+rebuilt        : SymbolId(3): []
+Symbol reference IDs mismatch for "Y":
+after transform: SymbolId(2): [ReferenceId(1)]
+rebuilt        : SymbolId(6): []
+Symbol reference IDs mismatch for "R":
+after transform: SymbolId(6): [ReferenceId(2)]
+rebuilt        : SymbolId(10): []
+Symbol reference IDs mismatch for "R":
+after transform: SymbolId(7): [ReferenceId(3)]
+rebuilt        : SymbolId(16): []
+Symbol reference IDs mismatch for "R":
+after transform: SymbolId(13): [ReferenceId(6)]
+rebuilt        : SymbolId(20): []
+Symbol reference IDs mismatch for "R":
+after transform: SymbolId(15): [ReferenceId(7)]
+rebuilt        : SymbolId(23): []
+Reference symbol mismatch for "R":
+after transform: SymbolId(0) "R"
+rebuilt        : <None>
+Reference symbol mismatch for "Y":
+after transform: SymbolId(2) "Y"
+rebuilt        : <None>
+Reference symbol mismatch for "R":
+after transform: SymbolId(6) "R"
+rebuilt        : <None>
+Reference symbol mismatch for "R":
+after transform: SymbolId(7) "R"
+rebuilt        : <None>
+Reference symbol mismatch for "R":
+after transform: SymbolId(13) "R"
+rebuilt        : <None>
+Reference symbol mismatch for "R":
+after transform: SymbolId(15) "R"
+rebuilt        : <None>
+Unresolved references mismatch:
+after transform: ["b", "babelHelpers", "f", "q"]
+rebuilt        : ["R", "Y", "b", "babelHelpers", "f", "q"]
 
 * object-rest/symbol/input.js
 x Output mismatch

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -784,7 +784,7 @@ rebuilt        : ["Ambient", "Object", "babelHelpers", "dec"]
 
 * oxc/metadata/bound-type-reference/input.ts
 Symbol reference IDs mismatch for "BoundTypeReference":
-after transform: SymbolId(0): [ReferenceId(3), ReferenceId(1), ReferenceId(4), ReferenceId(5), ReferenceId(6)]
+after transform: SymbolId(0): [ReferenceId(1), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6)]
 rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(7), ReferenceId(9)]
 Symbol span mismatch for "Example":
 after transform: SymbolId(1): Span { start: 87, end: 94 }
@@ -911,7 +911,7 @@ Symbol flags mismatch for "StringEnum":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "StringEnum":
-after transform: SymbolId(0): [ReferenceId(21), ReferenceId(5), ReferenceId(27)]
+after transform: SymbolId(0): [ReferenceId(5), ReferenceId(21), ReferenceId(27)]
 rebuilt        : SymbolId(0): [ReferenceId(3)]
 Symbol flags mismatch for "TemplateStringEnum":
 after transform: SymbolId(3): SymbolFlags(RegularEnum)
@@ -923,7 +923,7 @@ Symbol flags mismatch for "NumberEnum":
 after transform: SymbolId(6): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "NumberEnum":
-after transform: SymbolId(6): [ReferenceId(22), ReferenceId(9), ReferenceId(23), ReferenceId(37)]
+after transform: SymbolId(6): [ReferenceId(9), ReferenceId(22), ReferenceId(23), ReferenceId(37)]
 rebuilt        : SymbolId(4): [ReferenceId(13), ReferenceId(53)]
 Symbol flags mismatch for "UnaryEnum":
 after transform: SymbolId(9): SymbolFlags(RegularEnum)


### PR DESCRIPTION
References in function / catch parameter initializers were early-resolved by walking up the full scope chain mid-traversal, while ancestor scopes were still being built. A binding declared later in an enclosing scope — a hoisted `function`, or a `let`/`const` after the statement — was not bound yet, so the reference permanently captured a same-named symbol further out that should have been shadowed. The mangler then renamed the declaration and the reference independently, miscompiling the program. This is the root cause of the monitor-oxc mangler idempotency failures on ts-api-utils / typescript / vuetify / storybook (all 13 failing files pass after this fix).

## Example

```js
function s() { return "outer"; }
function m() {
	const a = (r = s) => r();
	return a();
	function s() { return "inner"; }
}
console.log(m());
```

Before (mangled output — `r = e` points at the top-level function):

```js
function e() { return "outer"; }
function t() {
	const t = (t = e) => t();
	return t();
	function n() { return "inner"; }
}
console.log(t()); // prints "outer" — behavior changed
```

After:

```js
function e() { return "outer"; }
function t() {
	const e = (e = t) => e();
	return e();
	function t() { return "inner"; }
}
console.log(t()); // prints "inner" — matches source
```

## How

Each entry in the flat unresolved-references list now carries the scope its resolution walk starts from — the reference's own scope, initially. This is free: the tuple is 24 bytes with or without the extra `ScopeId` (padding), and no allocation profile changes.

The early resolution at a parameter-region boundary only checks the scopes *inside* the region — from the walk-start scope up to and including the function scope. Those are complete at that point: nested initializer scopes are fully visited, and the function scope holds exactly the parameters, so a match can never be a body binding. An unresolved reference just gets its walk-start bumped to the function's **parent** scope:

- The final resolution pass (unchanged in shape) then starts above the function scope once every binding exists — body bindings, added to the shared function scope later, stay invisible, per spec. This also fixes the reverse case, where such a reference used to fall back to a body `var`.
- Nested parameter regions need no special handling: the reference is still in the flat list, so the enclosing region's own boundary pass re-processes it (initializers *do* see the enclosing function's parameters).
- The reference's own `scope_id` is never touched, so liveness analyses (mangler slot reuse) stay exact.

## Conformance

Two snapshot entries change (one `semantic_typescript`, one Babel `object-rest-spread` fixture): the object-rest parameter transform relocates destructured parameters into the function body while keeping references to them in parameter initializers, so the rebuilt semantic — now spec-correct — no longer reproduces the transformer's retained symbol links. That transform output is already semantically broken JS (a known Babel limitation, e.g. `(_ref, a = R) => { let R = ... }`); the mismatch is now visible instead of accidentally hidden. TypeScript agrees: `function f(): X { type X = number; ... }` is `TS2304` in tsc, which this change also aligns with.

The remaining snapshot changes are reference-id *orderings* inside already-mismatching entries: parameter-region references now resolve in creation order.