### PR TITLE
test(coverage): reimplement test262 runtime execution

### DIFF
--- a/tasks/coverage/snapshots/runtime.snap
+++ b/tasks/coverage/snapshots/runtime.snap
@@ -1,0 +1,3035 @@
+commit: de8e621c
+
+runtime Summary:
+AST Parsed     : 18277/18277 (100.00%)
+Positive Passed: 17279/18277 (94.54%)
+minify Error: tasks/coverage/test262/test/language/computed-property-names/class/static/generator-prototype.js
+Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/computed-property-names/class/static/getter-prototype.js
+Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/computed-property-names/class/static/method-prototype.js
+Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/computed-property-names/class/static/setter-prototype.js
+Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
+
+codegen Error: tasks/coverage/test262/test/language/eval-code/direct/var-env-func-init-global-update-configurable.js
+Test262Error: f descriptor should be enumerable; f descriptor should be writable
+
+codegen Error: tasks/coverage/test262/test/language/eval-code/direct/var-env-var-init-global-exstng.js
+Test262Error: x descriptor should not be configurable
+
+codegen Error: tasks/coverage/test262/test/language/eval-code/indirect/var-env-func-init-global-update-configurable.js
+Test262Error: f descriptor should be enumerable; f descriptor should be writable
+
+codegen Error: tasks/coverage/test262/test/language/eval-code/indirect/var-env-var-init-global-exstng.js
+Test262Error: x descriptor should not be configurable
+
+minify Error: tasks/coverage/test262/test/language/expressions/arrow-function/dstr/ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/arrow-function/dstr/ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/arrow-function/dstr/ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/arrow-function/dstr/dflt-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/arrow-function/dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/arrow-function/dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/arrow-function/dstr/dflt-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/arrow-function/dstr/dflt-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/arrow-function/dstr/dflt-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/arrow-function/dstr/obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/arrow-function/dstr/obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/arrow-function/dstr/obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/assignment/dstr/array-elem-init-fn-name-class.js
+Test262Error: Expected true but got false
+
+minify Error: tasks/coverage/test262/test/language/expressions/assignment/dstr/array-elem-init-fn-name-fn.js
+Test262Error: Expected true but got false
+
+minify Error: tasks/coverage/test262/test/language/expressions/assignment/dstr/array-elem-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/assignment/dstr/obj-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/assignment/dstr/obj-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/assignment/dstr/obj-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/assignment/dstr/obj-prop-elem-init-evaluation.js
+Test262Error: value of `x` Expected SameValue(«undefined», «true») to be true
+
+minify Error: tasks/coverage/test262/test/language/expressions/assignment/dstr/obj-prop-elem-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/assignment/dstr/obj-prop-elem-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/assignment/dstr/obj-prop-elem-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/assignment/dstr/obj-prop-elem-init-let.js
+Test262Error: Expected a ReferenceError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/expressions/assignment/dstr/obj-prop-elem-init-yield-expr.js
+Test262Error: Expected SameValue(«true», «false») to be true
+
+minify Error: tasks/coverage/test262/test/language/expressions/assignment/fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/assignment/fn-name-fn.js
+Test262Error: Expected true but got false
+
+minify Error: tasks/coverage/test262/test/language/expressions/assignment/fn-name-gen.js
+Test262Error: Expected true but got false
+
+codegen Error: tasks/coverage/test262/test/language/expressions/assignment/fn-name-lhs-cover.js
+Test262Error: name descriptor value should be ; name value should be 
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-arrow-function/forbidden-ext/b1/async-arrow-function-forbidden-ext-direct-access-prop-arguments.js
+Test262Error: Expected SameValue(«true», «false») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-arrow-function/forbidden-ext/b1/async-arrow-function-forbidden-ext-direct-access-prop-caller.js
+Test262Error: Expected SameValue(«true», «false») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-arrow-function/prototype.js
+Test262Error: Expected SameValue(«function () { [native code] }», «[object AsyncFunction]») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-function/forbidden-ext/b1/async-func-expr-named-forbidden-ext-direct-access-prop-arguments.js
+Test262Error: Expected SameValue(«true», «false») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-function/forbidden-ext/b1/async-func-expr-named-forbidden-ext-direct-access-prop-caller.js
+Test262Error: Expected SameValue(«true», «false») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-function/forbidden-ext/b1/async-func-expr-nameless-forbidden-ext-direct-access-prop-arguments.js
+Test262Error: Expected SameValue(«true», «false») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-function/forbidden-ext/b1/async-func-expr-nameless-forbidden-ext-direct-access-prop-caller.js
+Test262Error: Expected SameValue(«true», «false») to be true
+
+minify Error: tasks/coverage/test262/test/language/expressions/async-function/name.js
+Test262Error: name descriptor value should be func; name value should be func
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-function/named-reassign-fn-name-in-body-in-arrow.js
+Test262Error: Expected SameValue(«1», «function BindingIdentifier() {
+		return _BindingIdentifier.apply(this, arguments);
+	}») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-function/named-reassign-fn-name-in-body-in-eval.js
+Test262Error: Expected SameValue(«1», «function BindingIdentifier() {
+		return _BindingIdentifier.apply(this, arguments);
+	}») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-function/named-reassign-fn-name-in-body.js
+Test262Error: Expected SameValue(«1», «function BindingIdentifier() {
+		return _BindingIdentifier.apply(this, arguments);
+	}») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-function/named-strict-error-reassign-fn-name-in-body-in-arrow.js
+Test262Error: Expected SameValue(«0», «1») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-function/named-strict-error-reassign-fn-name-in-body-in-eval.js
+Test262Error: Expected SameValue(«0», «1») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-function/named-strict-error-reassign-fn-name-in-body.js
+Test262Error: Expected SameValue(«0», «1») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-generator/default-proto.js
+Test262Error: fn.prototype is undefined Expected SameValue(«[object Object]», «[object Object]») to be true
+
+minify Error: tasks/coverage/test262/test/language/expressions/async-generator/dstr/ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/async-generator/dstr/ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/async-generator/dstr/ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/async-generator/dstr/dflt-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/async-generator/dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/async-generator/dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/async-generator/dstr/dflt-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/async-generator/dstr/dflt-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/async-generator/dstr/dflt-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/async-generator/dstr/named-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/async-generator/dstr/named-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/async-generator/dstr/named-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/async-generator/dstr/named-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/async-generator/dstr/named-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/async-generator/dstr/named-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/async-generator/dstr/named-dflt-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/async-generator/dstr/named-dflt-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/async-generator/dstr/named-dflt-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/async-generator/dstr/named-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/async-generator/dstr/named-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/async-generator/dstr/named-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/async-generator/dstr/obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/async-generator/dstr/obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/async-generator/dstr/obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-generator/forbidden-ext/b1/async-gen-func-expr-forbidden-ext-direct-access-prop-arguments.js
+Test262Error: Expected SameValue(«true», «false») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-generator/forbidden-ext/b1/async-gen-func-expr-forbidden-ext-direct-access-prop-caller.js
+Test262Error: Expected SameValue(«true», «false») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-generator/forbidden-ext/b1/async-gen-named-func-expr-forbidden-ext-direct-access-prop-arguments.js
+Test262Error: Expected SameValue(«true», «false») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-generator/forbidden-ext/b1/async-gen-named-func-expr-forbidden-ext-direct-access-prop-caller.js
+Test262Error: Expected SameValue(«true», «false») to be true
+
+codegen Error: tasks/coverage/test262/test/language/expressions/async-generator/generator-created-after-decl-inst.js
+Test262Error: Expected SameValue(«[object AsyncGenerator]», «[object AsyncGenerator]») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/async-generator/name.js
+Test262Error: name descriptor value should be func; name value should be func
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-generator/named-no-strict-reassign-fn-name-in-body-in-arrow.js
+Test262Error: Expected SameValue(«1», «function BindingIdentifier() {
+		return _BindingIdentifier.apply(this, arguments);
+	}») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-generator/named-no-strict-reassign-fn-name-in-body-in-eval.js
+Test262Error: Expected SameValue(«1», «function BindingIdentifier() {
+		return _BindingIdentifier.apply(this, arguments);
+	}») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-generator/named-no-strict-reassign-fn-name-in-body.js
+Test262Error: Expected SameValue(«1», «function BindingIdentifier() {
+		return _BindingIdentifier.apply(this, arguments);
+	}») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-generator/named-strict-error-reassign-fn-name-in-body-in-arrow.js
+Test262Error: Expected SameValue(«0», «1») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-generator/named-strict-error-reassign-fn-name-in-body-in-eval.js
+Test262Error: Expected SameValue(«0», «1») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-generator/named-strict-error-reassign-fn-name-in-body.js
+Test262Error: Expected SameValue(«0», «1») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-generator/named-yield-star-async-next.js
+Test262Error: Expected SameValue(«"get next done (1)"», «"get next value (1)"») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-generator/named-yield-star-async-return.js
+Test262Error: Expected SameValue(«"get return"», «"get next"») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-generator/named-yield-star-async-throw.js
+Test262Error: Expected SameValue(«"get throw"», «"get next"») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-generator/named-yield-star-next-call-done-get-abrupt.js
+Timed out.
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-generator/named-yield-star-next-call-returns-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-generator/named-yield-star-next-get-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-generator/named-yield-star-next-non-object-ignores-then.js
+Timed out.
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-generator/named-yield-star-next-then-get-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-generator/named-yield-star-next-then-returns-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-generator/named-yield-star-sync-throw.js
+throw-arg-1
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-generator/yield-star-async-next.js
+Test262Error: Expected SameValue(«"get next done (1)"», «"get next value (1)"») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-generator/yield-star-async-return.js
+Test262Error: Expected SameValue(«"get return"», «"get next"») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-generator/yield-star-async-throw.js
+Test262Error: Expected SameValue(«"get throw"», «"get next"») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-generator/yield-star-next-call-done-get-abrupt.js
+Timed out.
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-generator/yield-star-next-call-returns-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-generator/yield-star-next-get-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-generator/yield-star-next-non-object-ignores-then.js
+Timed out.
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-generator/yield-star-next-then-get-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-generator/yield-star-next-then-returns-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/async-generator/yield-star-sync-throw.js
+throw-arg-1
+
+transform Error: tasks/coverage/test262/test/language/expressions/await/await-monkey-patched-promise.js
+Test262Error: Monkey-patched "then" on native promises should not be called. Expected SameValue(«1», «0») to be true
+
+codegen Error: tasks/coverage/test262/test/language/expressions/call/eval-spread.js
+Test262Error: Expected SameValue(«"local"», «1») to be true
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/accessor-name-inst/computed-err-to-prop-key.js
+Test262Error: `get` accessor Expected a TypeError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/accessor-name-static/computed-err-to-prop-key.js
+Test262Error: `get` accessor Expected a TypeError to be thrown but no exception was thrown at all
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/async-gen-method/yield-star-async-next.js
+Test262Error: Expected SameValue(«"get next done (1)"», «"get next value (1)"») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/async-gen-method/yield-star-async-return.js
+Test262Error: Expected SameValue(«"get return"», «"get next"») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/async-gen-method/yield-star-async-throw.js
+Test262Error: Expected SameValue(«"get throw"», «"get next"») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/async-gen-method/yield-star-next-call-done-get-abrupt.js
+Timed out.
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/async-gen-method/yield-star-next-call-returns-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/async-gen-method/yield-star-next-get-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/async-gen-method/yield-star-next-non-object-ignores-then.js
+Timed out.
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/async-gen-method/yield-star-next-then-get-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/async-gen-method/yield-star-next-then-returns-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/async-gen-method/yield-star-sync-throw.js
+throw-arg-1
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/async-gen-method-static/yield-star-async-next.js
+Test262Error: Expected SameValue(«"get next done (1)"», «"get next value (1)"») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/async-gen-method-static/yield-star-async-return.js
+Test262Error: Expected SameValue(«"get return"», «"get next"») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/async-gen-method-static/yield-star-async-throw.js
+Test262Error: Expected SameValue(«"get throw"», «"get next"») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/async-gen-method-static/yield-star-next-call-done-get-abrupt.js
+Timed out.
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/async-gen-method-static/yield-star-next-call-returns-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/async-gen-method-static/yield-star-next-get-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/async-gen-method-static/yield-star-next-non-object-ignores-then.js
+Timed out.
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/async-gen-method-static/yield-star-next-then-get-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/async-gen-method-static/yield-star-next-then-returns-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/async-gen-method-static/yield-star-sync-throw.js
+throw-arg-1
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-dflt-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-dflt-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-dflt-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-static-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-static-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-static-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-static-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-static-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-static-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-dflt-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-dflt-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-dflt-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-static-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-static-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-static-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-static-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-static-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-static-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-dflt-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-dflt-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-dflt-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-static-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-static-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-static-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-static-dflt-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-static-dflt-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-static-dflt-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-static-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-static-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-static-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/meth-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/meth-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/meth-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/meth-dflt-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/meth-dflt-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/meth-dflt-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/meth-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/meth-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/meth-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/meth-static-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/meth-static-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/meth-static-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/meth-static-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/meth-static-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/meth-static-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/meth-static-dflt-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/meth-static-dflt-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/meth-static-dflt-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/meth-static-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/meth-static-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/meth-static-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-dflt-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-dflt-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-dflt-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-static-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-static-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-static-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-static-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-static-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-static-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-dflt-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-dflt-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-dflt-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-static-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-static-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-static-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-static-dflt-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-static-dflt-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-static-dflt-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-static-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-static-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-static-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/arrow-body-derived-cls-direct-eval-err-contains-supercall-1.js
+Test262Error: Expected a SyntaxError but got a ReferenceError
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/arrow-body-derived-cls-direct-eval-err-contains-supercall-2.js
+Test262Error: Expected a SyntaxError but got a ReferenceError
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/arrow-body-derived-cls-direct-eval-err-contains-supercall.js
+Test262Error: Expected a SyntaxError but got a ReferenceError
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/arrow-body-direct-eval-err-contains-arguments.js
+Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/arrow-body-direct-eval-err-contains-newtarget.js
+Test262Error: Expected SameValue(«class {
+	constructor() {
+		babelHelpers.defineProperty(this, "x", eval("executed = true; () => new.target;"));
+	}
+}», «undefined») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/arrow-body-private-derived-cls-direct-eval-err-contains-supercall-1.js
+Test262Error: Expected a SyntaxError but got a TypeError
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/arrow-body-private-derived-cls-direct-eval-err-contains-supercall-2.js
+Test262Error: Expected a SyntaxError but got a TypeError
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/arrow-body-private-derived-cls-direct-eval-err-contains-supercall.js
+Test262Error: Expected a SyntaxError but got a TypeError
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/arrow-body-private-direct-eval-err-contains-arguments.js
+Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/async-gen-private-method/yield-star-async-next.js
+Test262Error: Expected SameValue(«"get next done (1)"», «"get next value (1)"») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/async-gen-private-method/yield-star-async-return.js
+Test262Error: Expected SameValue(«"get return"», «"get next"») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/async-gen-private-method/yield-star-async-throw.js
+Test262Error: Expected SameValue(«"get throw"», «"get next"») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/async-gen-private-method/yield-star-next-call-done-get-abrupt.js
+Timed out.
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/async-gen-private-method/yield-star-next-call-returns-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/async-gen-private-method/yield-star-next-get-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/async-gen-private-method/yield-star-next-non-object-ignores-then.js
+Timed out.
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/async-gen-private-method/yield-star-next-then-get-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/async-gen-private-method/yield-star-next-then-returns-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/async-gen-private-method/yield-star-sync-throw.js
+throw-arg-1
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/async-gen-private-method-static/yield-star-async-next.js
+Test262Error: Expected SameValue(«"get next done (1)"», «"get next value (1)"») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/async-gen-private-method-static/yield-star-async-return.js
+Test262Error: Expected SameValue(«"get return"», «"get next"») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/async-gen-private-method-static/yield-star-async-throw.js
+Test262Error: Expected SameValue(«"get throw"», «"get next"») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/async-gen-private-method-static/yield-star-next-call-done-get-abrupt.js
+Timed out.
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/async-gen-private-method-static/yield-star-next-call-returns-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/async-gen-private-method-static/yield-star-next-get-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/async-gen-private-method-static/yield-star-next-non-object-ignores-then.js
+Timed out.
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/async-gen-private-method-static/yield-star-next-then-get-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/async-gen-private-method-static/yield-star-next-then-returns-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/async-gen-private-method-static/yield-star-sync-throw.js
+throw-arg-1
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/class-name-static-initializer-anonymous.js
+Test262Error: Expected SameValue(«"_Class"», «"C"») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/class-name-static-initializer-default-export.js
+Test262Error: Expected SameValue(«"_Class"», «"default"») to be true
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/elements/class-name-static-initializer-expr.js
+Test262Error: Expected SameValue(«"expr"», «"C"») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/computed-name-toprimitive-symbol.js
+TypeError: Cannot convert a Symbol value to a string
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/derived-cls-direct-eval-err-contains-supercall-1.js
+Test262Error: Expected a SyntaxError but got a ReferenceError
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/derived-cls-direct-eval-err-contains-supercall-2.js
+Test262Error: Expected a SyntaxError but got a ReferenceError
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/derived-cls-direct-eval-err-contains-supercall.js
+Test262Error: Expected a SyntaxError but got a ReferenceError
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/direct-eval-err-contains-arguments.js
+Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/direct-eval-err-contains-newtarget.js
+Test262Error: Expected SameValue(«class {
+	constructor() {
+		babelHelpers.defineProperty(this, "x", eval("executed = true; new.target;"));
+	}
+}», «undefined») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/evaluation-error/computed-name-toprimitive-err.js
+Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/evaluation-error/computed-name-toprimitive-returns-noncallable.js
+Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/evaluation-error/computed-name-toprimitive-returns-nonobject.js
+Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/evaluation-error/computed-name-tostring-err.js
+Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/evaluation-error/computed-name-valueof-err.js
+Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/elements/fields-computed-name-static-propname-prototype.js
+Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/nested-derived-cls-direct-eval-err-contains-supercall-1.js
+Test262Error: Expected a SyntaxError but got a ReferenceError
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/nested-derived-cls-direct-eval-err-contains-supercall-2.js
+Test262Error: Expected a SyntaxError but got a ReferenceError
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/nested-derived-cls-direct-eval-err-contains-supercall.js
+Test262Error: Expected a SyntaxError but got a ReferenceError
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/nested-direct-eval-err-contains-arguments.js
+Test262Error: Expected a SyntaxError but got a TypeError
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/nested-direct-eval-err-contains-newtarget.js
+Test262Error: Expected SameValue(«class {
+	constructor() {
+		babelHelpers.defineProperty(this, "x", eval("executed = true; new.target;"));
+	}
+}», «undefined») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/nested-private-derived-cls-direct-eval-err-contains-supercall-1.js
+Test262Error: Expected a SyntaxError but got a ReferenceError
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/nested-private-derived-cls-direct-eval-err-contains-supercall-2.js
+Test262Error: Expected a SyntaxError but got a ReferenceError
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/nested-private-derived-cls-direct-eval-err-contains-supercall.js
+Test262Error: Expected a SyntaxError but got a ReferenceError
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/nested-private-direct-eval-err-contains-arguments.js
+Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/private-async-generator-method-name.js
+Test262Error: Expected SameValue(«"_method"», «"#method"») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/private-async-method-name.js
+Test262Error: Expected SameValue(«"_method"», «"#method"») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/private-derived-cls-direct-eval-err-contains-supercall-1.js
+Test262Error: Expected a SyntaxError but got a ReferenceError
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/private-derived-cls-direct-eval-err-contains-supercall-2.js
+Test262Error: Expected a SyntaxError but got a ReferenceError
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/private-derived-cls-direct-eval-err-contains-supercall.js
+Test262Error: Expected a SyntaxError but got a ReferenceError
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/private-direct-eval-err-contains-arguments.js
+Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/private-generator-method-name.js
+Test262Error: Expected SameValue(«"_method"», «"#method"») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/private-methods/prod-private-async-generator.js
+Test262Error: function name inside constructor Expected SameValue(«"_m"», «"#m"») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/private-methods/prod-private-async-method.js
+Test262Error: function name inside constructor Expected SameValue(«"_m"», «"#m"») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/private-methods/prod-private-generator.js
+Test262Error: function name inside constructor Expected SameValue(«"_m"», «"#m"») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/private-methods/prod-private-method.js
+Test262Error: function name inside constructor Expected SameValue(«"_m"», «"#m"») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/private-static-async-generator-method-name.js
+Test262Error: Expected SameValue(«"_method"», «"#method"») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/private-static-async-method-name.js
+Test262Error: Expected SameValue(«"_method"», «"#method"») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/private-static-generator-method-name.js
+Test262Error: Expected SameValue(«"_method"», «"#method"») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/private-static-method-name.js
+Test262Error: Expected SameValue(«"_method"», «"#method"») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/static-field-anonymous-function-name.js
+Test262Error: Expected SameValue(«"_"», «"#field"») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/elements/static-field-init-with-this.js
+Test262Error: Expected SameValue(«"undefinedtest"», «"test262test"») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/class/heritage-async-arrow-function.js
+Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/expressions/class/name.js
+Test262Error: name descriptor value should be cls; name value should be cls
+
+transform Error: tasks/coverage/test262/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-add.js
+Test262Error: The expression should evaluate to the result Expected SameValue(«undefined», «3») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-bitand.js
+Test262Error: The expression should evaluate to the result Expected SameValue(«undefined», «0») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-bitor.js
+Test262Error: The expression should evaluate to the result Expected SameValue(«undefined», «15») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-bitxor.js
+Test262Error: The expression should evaluate to the result Expected SameValue(«undefined», «257») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-div.js
+Test262Error: The expression should evaluate to the result Expected SameValue(«undefined», «0.5») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-exp.js
+Test262Error: The expression should evaluate to the result Expected SameValue(«undefined», «1000») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-lshift.js
+Test262Error: The expression should evaluate to the result Expected SameValue(«undefined», «96») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-mod.js
+Test262Error: The expression should evaluate to the result Expected SameValue(«undefined», «1») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-mult.js
+Test262Error: The expression should evaluate to the result Expected SameValue(«undefined», «6») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-rshift.js
+Test262Error: The expression should evaluate to the result Expected SameValue(«undefined», «3») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-srshift.js
+Test262Error: The expression should evaluate to the result Expected SameValue(«undefined», «3») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-sub.js
+Test262Error: The expression should evaluate to the result Expected SameValue(«undefined», «1») to be true
+
+minify Error: tasks/coverage/test262/test/language/expressions/does-not-equals/S11.9.2_A7.8.js
+Test262Error: #7: (1 != {valueOf: function() {throw "error"}, toString: function() {return 1}}) throw "error"
+
+minify Error: tasks/coverage/test262/test/language/expressions/equals/coerce-symbol-to-prim-err.js
+Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/expressions/equals/coerce-symbol-to-prim-invocation.js
+Test262Error: method invoked exactly once Expected SameValue(«0», «1») to be true
+
+minify Error: tasks/coverage/test262/test/language/expressions/equals/coerce-symbol-to-prim-return-obj.js
+Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/expressions/equals/get-symbol-to-prim-err.js
+Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all
+
+transform Error: tasks/coverage/test262/test/language/expressions/exponentiation/bigint-negative-exponent-throws.js
+Test262Error: (-1n) ** -1n throws RangeError Expected a RangeError but got a TypeError
+
+minify Error: tasks/coverage/test262/test/language/expressions/function/dstr/ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/function/dstr/ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/function/dstr/ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/function/dstr/dflt-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/function/dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/function/dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/function/dstr/dflt-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/function/dstr/dflt-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/function/dstr/dflt-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/function/dstr/obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/function/dstr/obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/function/dstr/obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/function/name.js
+Test262Error: name descriptor value should be func; name value should be func
+
+minify Error: tasks/coverage/test262/test/language/expressions/generators/dstr/ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/generators/dstr/ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/generators/dstr/ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/generators/dstr/dflt-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/generators/dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/generators/dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/generators/dstr/dflt-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/generators/dstr/dflt-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/generators/dstr/dflt-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/generators/dstr/obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/generators/dstr/obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/generators/dstr/obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+codegen Error: tasks/coverage/test262/test/language/expressions/generators/generator-created-after-decl-inst.js
+Test262Error: Expected SameValue(«[object Generator]», «[object Generator]») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/generators/name.js
+Test262Error: name descriptor value should be func; name value should be func
+
+minify Error: tasks/coverage/test262/test/language/expressions/greater-than/S11.8.2_A2.3_T1.js
+Test262Error: #1.3: Failed with: Test262Error: #1.1: Should have thrown
+
+minify Error: tasks/coverage/test262/test/language/expressions/greater-than/bigint-and-symbol.js
+Test262Error: 3n > Symbol("2") throws TypeError Expected a TypeError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/expressions/less-than/bigint-and-symbol.js
+Test262Error: 3n < Symbol("2") throws TypeError Expected a TypeError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/expressions/less-than-or-equal/S11.8.3_A2.3_T1.js
+Test262Error: #1.3: Failed with: Test262Error: #1.1: Should have thrown
+
+transform Error: tasks/coverage/test262/test/language/expressions/logical-assignment/left-hand-side-private-reference-accessor-property-and.js
+Test262Error: The expression should evaluate to the result Expected SameValue(«undefined», «false») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/logical-assignment/left-hand-side-private-reference-accessor-property-nullish.js
+Test262Error: The expression should evaluate to the result Expected SameValue(«undefined», «1») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/logical-assignment/left-hand-side-private-reference-accessor-property-or.js
+Test262Error: The expression should evaluate to the result Expected SameValue(«undefined», «true») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/logical-assignment/left-hand-side-private-reference-method-and.js
+Test262Error: PutValue throws when storing the result in a method private reference Expected a TypeError to be thrown but no exception was thrown at all
+
+transform Error: tasks/coverage/test262/test/language/expressions/logical-assignment/left-hand-side-private-reference-method-short-circuit-nullish.js
+Test262Error: The right-hand side should not be evaluated
+
+transform Error: tasks/coverage/test262/test/language/expressions/logical-assignment/left-hand-side-private-reference-method-short-circuit-or.js
+Test262Error: The right-hand side should not be evaluated
+
+codegen Error: tasks/coverage/test262/test/language/expressions/object/__proto__-permitted-dup-shorthand.js
+Test262Error: Expected SameValue(«[object Object]», «2») to be true
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/accessor-name-computed-err-to-prop-key.js
+Test262Error: `get` accessor Expected a TypeError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/dstr/async-gen-meth-dflt-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/dstr/async-gen-meth-dflt-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/dstr/async-gen-meth-dflt-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/dstr/async-gen-meth-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/dstr/async-gen-meth-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/dstr/async-gen-meth-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/dstr/gen-meth-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/dstr/gen-meth-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/dstr/gen-meth-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/dstr/gen-meth-dflt-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/dstr/gen-meth-dflt-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/dstr/gen-meth-dflt-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/dstr/gen-meth-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/dstr/gen-meth-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/dstr/gen-meth-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/dstr/meth-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/dstr/meth-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/dstr/meth-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/dstr/meth-dflt-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/dstr/meth-dflt-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/dstr/meth-dflt-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/dstr/meth-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/dstr/meth-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/dstr/meth-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+transform Error: tasks/coverage/test262/test/language/expressions/object/dstr/object-rest-proxy-gopd-not-called-on-excluded-keys.js
+Test262Error: Actual [excludedString, 0, includedString, 1, Symbol(included_symbol)] and expected [Symbol(included_symbol), includedString, 1] should have the same contents. 
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/fn-name-class.js
+Test262Error: Expected true but got false
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/fn-name-fn.js
+Test262Error: Expected true but got false
+
+minify Error: tasks/coverage/test262/test/language/expressions/object/fn-name-gen.js
+Test262Error: Expected true but got false
+
+transform Error: tasks/coverage/test262/test/language/expressions/object/method-definition/async-gen-yield-star-async-next.js
+Test262Error: Expected SameValue(«"get next done (1)"», «"get next value (1)"») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/object/method-definition/async-gen-yield-star-async-return.js
+Test262Error: Expected SameValue(«"get return"», «"get next"») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/object/method-definition/async-gen-yield-star-async-throw.js
+Test262Error: Expected SameValue(«"get throw"», «"get next"») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/object/method-definition/async-gen-yield-star-next-call-done-get-abrupt.js
+Timed out.
+
+transform Error: tasks/coverage/test262/test/language/expressions/object/method-definition/async-gen-yield-star-next-call-returns-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/object/method-definition/async-gen-yield-star-next-get-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/object/method-definition/async-gen-yield-star-next-non-object-ignores-then.js
+Timed out.
+
+transform Error: tasks/coverage/test262/test/language/expressions/object/method-definition/async-gen-yield-star-next-then-get-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/object/method-definition/async-gen-yield-star-next-then-returns-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/expressions/object/method-definition/async-gen-yield-star-sync-throw.js
+throw-arg-1
+
+transform Error: tasks/coverage/test262/test/language/expressions/object/object-spread-proxy-get-not-called-on-dontenum-keys.js
+Test262Error: Actual [dontEnumString, 0, enumerableString, 1, Symbol(dont_enum_symbol), Symbol(enumerable_symbol)] and expected [Symbol(dont_enum_symbol), dontEnumString, 0, Symbol(enumerable_symbol), enumerableString, 1] should have the same contents. 
+
+transform Error: tasks/coverage/test262/test/language/expressions/object/object-spread-proxy-no-excluded-keys.js
+TypeError: Cannot read properties of undefined (reading 'enumerable')
+
+transform Error: tasks/coverage/test262/test/language/expressions/object/object-spread-proxy-ownkeys-returned-keys-order.js
+TypeError: Cannot read properties of undefined (reading 'enumerable')
+
+minify Error: tasks/coverage/test262/test/language/expressions/optional-chaining/member-expression.js
+Test262Error: Expected SameValue(«"a"», «""») to be true
+
+codegen Error: tasks/coverage/test262/test/language/expressions/super/prop-expr-getsuperbase-before-topropertykey-getvalue.js
+Test262Error: Expected SameValue(«"bad"», «"ok"») to be true
+
+codegen Error: tasks/coverage/test262/test/language/expressions/super/prop-expr-getsuperbase-before-topropertykey-putvalue-compound-assign.js
+Test262Error: Expected SameValue(«0», «2») to be true
+
+codegen Error: tasks/coverage/test262/test/language/expressions/super/prop-expr-getsuperbase-before-topropertykey-putvalue-increment.js
+Test262Error: Expected SameValue(«0», «2») to be true
+
+codegen Error: tasks/coverage/test262/test/language/expressions/super/prop-expr-getsuperbase-before-topropertykey-putvalue.js
+Test262Error: Expected SameValue(«"bad"», «"ok"») to be true
+
+minify Error: tasks/coverage/test262/test/language/function-code/block-decl-onlystrict.js
+TypeError: Cannot read properties of undefined (reading 'constructor')
+
+minify Error: tasks/coverage/test262/test/language/function-code/switch-case-decl-onlystrict.js
+TypeError: Cannot read properties of undefined (reading 'constructor')
+
+minify Error: tasks/coverage/test262/test/language/function-code/switch-dflt-decl-onlystrict.js
+TypeError: Cannot read properties of undefined (reading 'constructor')
+
+minify Error: tasks/coverage/test262/test/language/global-code/block-decl-strict.js
+Test262Error: Expected a ReferenceError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/global-code/switch-case-decl-strict.js
+Test262Error: Expected a ReferenceError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/global-code/switch-dflt-decl-strict.js
+Test262Error: Expected a ReferenceError to be thrown but no exception was thrown at all
+
+codegen Error: tasks/coverage/test262/test/language/import/import-attributes/text-empty.js
+SyntaxError: The requested module './text-empty_FIXTURE' does not provide an export named 'default'
+
+codegen Error: tasks/coverage/test262/test/language/import/import-attributes/text-javascript.js
+SyntaxError: Unexpected token '{'
+
+codegen Error: tasks/coverage/test262/test/language/import/import-attributes/text-self.js
+SyntaxError: The requested module './text-self.js' does not provide an export named 'default'
+
+codegen Error: tasks/coverage/test262/test/language/import/import-attributes/text-string.js
+SyntaxError: Unexpected identifier 'string'
+
+codegen Error: tasks/coverage/test262/test/language/import/import-attributes/text-via-namespace.js
+Test262Error: Expected SameValue(«0», «1») to be true
+
+codegen Error: tasks/coverage/test262/test/language/import/import-bytes/bytes-from-empty.js
+SyntaxError: The requested module './bytes-from-empty_FIXTURE.bin' does not provide an export named 'default'
+
+codegen Error: tasks/coverage/test262/test/language/import/import-bytes/bytes-from-js.js
+SyntaxError: The requested module './bytes-from-js_FIXTURE.js' does not provide an export named 'default'
+
+codegen Error: tasks/coverage/test262/test/language/import/import-bytes/bytes-from-json.js
+Test262Error: Expected true but got false
+
+codegen Error: tasks/coverage/test262/test/language/import/import-bytes/bytes-from-png.js
+SyntaxError: Invalid or unexpected token
+
+codegen Error: tasks/coverage/test262/test/language/import/import-bytes/bytes-from-txt.js
+SyntaxError: Unexpected identifier 'World'
+
+transform Error: tasks/coverage/test262/test/language/statements/async-function/forbidden-ext/b1/async-func-decl-forbidden-ext-direct-access-prop-arguments.js
+Test262Error: Expected SameValue(«true», «false») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/async-function/forbidden-ext/b1/async-func-decl-forbidden-ext-direct-access-prop-caller.js
+Test262Error: Expected SameValue(«true», «false») to be true
+
+minify Error: tasks/coverage/test262/test/language/statements/async-generator/dstr/ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/async-generator/dstr/ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/async-generator/dstr/ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/async-generator/dstr/dflt-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/async-generator/dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/async-generator/dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/async-generator/dstr/dflt-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/async-generator/dstr/dflt-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/async-generator/dstr/dflt-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/async-generator/dstr/obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/async-generator/dstr/obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/async-generator/dstr/obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+transform Error: tasks/coverage/test262/test/language/statements/async-generator/forbidden-ext/b1/async-gen-func-decl-forbidden-ext-direct-access-prop-arguments.js
+Test262Error: Expected SameValue(«true», «false») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/async-generator/forbidden-ext/b1/async-gen-func-decl-forbidden-ext-direct-access-prop-caller.js
+Test262Error: Expected SameValue(«true», «false») to be true
+
+codegen Error: tasks/coverage/test262/test/language/statements/async-generator/generator-created-after-decl-inst.js
+Test262Error: Expected SameValue(«[object AsyncGenerator]», «[object AsyncGenerator]») to be false
+
+transform Error: tasks/coverage/test262/test/language/statements/async-generator/return-undefined-implicit-and-explicit.js
+Test262Error: Actual [tick 1, tick 2, g1 ret, g2 ret, g3 ret, g4 ret] and expected [tick 1, g1 ret, g2 ret, tick 2, g3 ret, g4 ret] should have the same contents. Ticks for implicit and explicit return undefined
+
+transform Error: tasks/coverage/test262/test/language/statements/async-generator/yield-star-async-from-sync-iterator-inaccessible.js
+TypeError: Cannot convert undefined or null to object
+
+transform Error: tasks/coverage/test262/test/language/statements/async-generator/yield-star-async-next.js
+Test262Error: Expected SameValue(«"get next done (1)"», «"get next value (1)"») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/async-generator/yield-star-async-return.js
+Test262Error: Expected SameValue(«"get return"», «"get next"») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/async-generator/yield-star-async-throw.js
+Test262Error: Expected SameValue(«"get throw"», «"get next"») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/async-generator/yield-star-next-call-done-get-abrupt.js
+Timed out.
+
+transform Error: tasks/coverage/test262/test/language/statements/async-generator/yield-star-next-call-returns-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/async-generator/yield-star-next-get-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/async-generator/yield-star-next-non-object-ignores-then.js
+Timed out.
+
+transform Error: tasks/coverage/test262/test/language/statements/async-generator/yield-star-next-then-get-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/async-generator/yield-star-next-then-returns-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/async-generator/yield-star-normal-notdone-iter-value-throws.js
+Timed out.
+
+transform Error: tasks/coverage/test262/test/language/statements/async-generator/yield-star-promise-not-unwrapped.js
+Test262Error: .throw should not be accessed
+
+transform Error: tasks/coverage/test262/test/language/statements/async-generator/yield-star-return-notdone-iter-value-throws.js
+Timed out.
+
+transform Error: tasks/coverage/test262/test/language/statements/async-generator/yield-star-return-then-getter-ticks.js
+Test262Error: Actual [start, get return, tick 1, get then, tick 2, tick 3] and expected [start, tick 1, get then, tick 2, get return, get then, tick 3] should have the same contents. Ticks for return with thenable getter
+
+transform Error: tasks/coverage/test262/test/language/statements/async-generator/yield-star-sync-throw.js
+throw-arg-1
+
+transform Error: tasks/coverage/test262/test/language/statements/async-generator/yield-star-throw-notdone-iter-value-throws.js
+Timed out.
+
+minify Error: tasks/coverage/test262/test/language/statements/class/accessor-name-inst/computed-err-to-prop-key.js
+Test262Error: `get` accessor Expected a TypeError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/statements/class/accessor-name-static/computed-err-to-prop-key.js
+Test262Error: `get` accessor Expected a TypeError to be thrown but no exception was thrown at all
+
+transform Error: tasks/coverage/test262/test/language/statements/class/async-gen-method/yield-star-async-next.js
+Test262Error: Expected SameValue(«"get next done (1)"», «"get next value (1)"») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/async-gen-method/yield-star-async-return.js
+Test262Error: Expected SameValue(«"get return"», «"get next"») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/async-gen-method/yield-star-async-throw.js
+Test262Error: Expected SameValue(«"get throw"», «"get next"») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/async-gen-method/yield-star-next-call-done-get-abrupt.js
+Timed out.
+
+transform Error: tasks/coverage/test262/test/language/statements/class/async-gen-method/yield-star-next-call-returns-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/async-gen-method/yield-star-next-get-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/async-gen-method/yield-star-next-non-object-ignores-then.js
+Timed out.
+
+transform Error: tasks/coverage/test262/test/language/statements/class/async-gen-method/yield-star-next-then-get-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/async-gen-method/yield-star-next-then-returns-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/async-gen-method/yield-star-sync-throw.js
+throw-arg-1
+
+transform Error: tasks/coverage/test262/test/language/statements/class/async-gen-method-static/yield-star-async-next.js
+Test262Error: Expected SameValue(«"get next done (1)"», «"get next value (1)"») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/async-gen-method-static/yield-star-async-return.js
+Test262Error: Expected SameValue(«"get return"», «"get next"») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/async-gen-method-static/yield-star-async-throw.js
+Test262Error: Expected SameValue(«"get throw"», «"get next"») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/async-gen-method-static/yield-star-next-call-done-get-abrupt.js
+Timed out.
+
+transform Error: tasks/coverage/test262/test/language/statements/class/async-gen-method-static/yield-star-next-call-returns-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/async-gen-method-static/yield-star-next-get-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/async-gen-method-static/yield-star-next-non-object-ignores-then.js
+Timed out.
+
+transform Error: tasks/coverage/test262/test/language/statements/class/async-gen-method-static/yield-star-next-then-get-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/async-gen-method-static/yield-star-next-then-returns-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/async-gen-method-static/yield-star-sync-throw.js
+throw-arg-1
+
+minify Error: tasks/coverage/test262/test/language/statements/class/definition/constructable-but-no-prototype.js
+Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/statements/class/definition/getters-non-configurable-err.js
+Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/statements/class/definition/invalid-extends.js
+Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/statements/class/definition/prototype-getter.js
+Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/statements/class/definition/prototype-setter.js
+Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/statements/class/definition/setters-non-configurable-err.js
+Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-dflt-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-dflt-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-dflt-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-static-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-static-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-static-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-static-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-static-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-static-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-dflt-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-dflt-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-dflt-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-static-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-static-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-static-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-static-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-static-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-static-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-dflt-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-dflt-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-dflt-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-static-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-static-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-static-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-static-dflt-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-static-dflt-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-static-dflt-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-static-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-static-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-static-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/meth-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/meth-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/meth-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/meth-dflt-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/meth-dflt-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/meth-dflt-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/meth-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/meth-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/meth-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/meth-static-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/meth-static-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/meth-static-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/meth-static-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/meth-static-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/meth-static-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/meth-static-dflt-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/meth-static-dflt-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/meth-static-dflt-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/meth-static-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/meth-static-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/meth-static-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-dflt-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-dflt-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-dflt-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-static-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-static-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-static-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-static-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-static-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-static-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-meth-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-meth-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-meth-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-meth-dflt-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-meth-dflt-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-meth-dflt-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-meth-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-meth-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-meth-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-meth-static-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-meth-static-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-meth-static-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-meth-static-dflt-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-meth-static-dflt-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-meth-static-dflt-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-meth-static-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-meth-static-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/class/dstr/private-meth-static-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/arrow-body-derived-cls-direct-eval-err-contains-supercall-1.js
+Test262Error: Expected a SyntaxError but got a ReferenceError
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/arrow-body-derived-cls-direct-eval-err-contains-supercall-2.js
+Test262Error: Expected a SyntaxError but got a ReferenceError
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/arrow-body-derived-cls-direct-eval-err-contains-supercall.js
+Test262Error: Expected a SyntaxError but got a ReferenceError
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/arrow-body-direct-eval-err-contains-arguments.js
+Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/arrow-body-direct-eval-err-contains-newtarget.js
+Test262Error: Expected SameValue(«class C {
+	constructor() {
+		babelHelpers.defineProperty(this, "x", eval("executed = true; () => new.target;"));
+	}
+}», «undefined») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/arrow-body-private-derived-cls-direct-eval-err-contains-supercall-1.js
+Test262Error: Expected a SyntaxError but got a TypeError
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/arrow-body-private-derived-cls-direct-eval-err-contains-supercall-2.js
+Test262Error: Expected a SyntaxError but got a TypeError
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/arrow-body-private-derived-cls-direct-eval-err-contains-supercall.js
+Test262Error: Expected a SyntaxError but got a TypeError
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/arrow-body-private-direct-eval-err-contains-arguments.js
+Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/async-gen-private-method/yield-star-async-next.js
+Test262Error: Expected SameValue(«"get next done (1)"», «"get next value (1)"») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/async-gen-private-method/yield-star-async-return.js
+Test262Error: Expected SameValue(«"get return"», «"get next"») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/async-gen-private-method/yield-star-async-throw.js
+Test262Error: Expected SameValue(«"get throw"», «"get next"») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/async-gen-private-method/yield-star-next-call-done-get-abrupt.js
+Timed out.
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/async-gen-private-method/yield-star-next-call-returns-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/async-gen-private-method/yield-star-next-get-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/async-gen-private-method/yield-star-next-non-object-ignores-then.js
+Timed out.
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/async-gen-private-method/yield-star-next-then-get-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/async-gen-private-method/yield-star-next-then-returns-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/async-gen-private-method/yield-star-sync-throw.js
+throw-arg-1
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/async-gen-private-method-static/yield-star-async-next.js
+Test262Error: Expected SameValue(«"get next done (1)"», «"get next value (1)"») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/async-gen-private-method-static/yield-star-async-return.js
+Test262Error: Expected SameValue(«"get return"», «"get next"») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/async-gen-private-method-static/yield-star-async-throw.js
+Test262Error: Expected SameValue(«"get throw"», «"get next"») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/async-gen-private-method-static/yield-star-next-call-done-get-abrupt.js
+Timed out.
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/async-gen-private-method-static/yield-star-next-call-returns-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/async-gen-private-method-static/yield-star-next-get-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/async-gen-private-method-static/yield-star-next-non-object-ignores-then.js
+Timed out.
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/async-gen-private-method-static/yield-star-next-then-get-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/async-gen-private-method-static/yield-star-next-then-returns-abrupt.js
+Test262Error: reject reason Expected SameValue(«TypeError: The iterator does not provide a 'throw' method.», «[object Object]») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/async-gen-private-method-static/yield-star-sync-throw.js
+throw-arg-1
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/class-field-on-frozen-objects.js
+Test262Error: Frozen objects can't be changed Expected a TypeError to be thrown but no exception was thrown at all
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/computed-name-toprimitive-symbol.js
+TypeError: Cannot convert a Symbol value to a string
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/derived-cls-direct-eval-err-contains-supercall-1.js
+Test262Error: Expected a SyntaxError but got a ReferenceError
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/derived-cls-direct-eval-err-contains-supercall-2.js
+Test262Error: Expected a SyntaxError but got a ReferenceError
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/derived-cls-direct-eval-err-contains-supercall.js
+Test262Error: Expected a SyntaxError but got a ReferenceError
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/direct-eval-err-contains-arguments.js
+Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/direct-eval-err-contains-newtarget.js
+Test262Error: Expected SameValue(«class C {
+	constructor() {
+		babelHelpers.defineProperty(this, "x", eval("executed = true; new.target;"));
+	}
+}», «undefined») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/evaluation-error/computed-name-toprimitive-err.js
+Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/evaluation-error/computed-name-toprimitive-returns-noncallable.js
+Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/evaluation-error/computed-name-toprimitive-returns-nonobject.js
+Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/evaluation-error/computed-name-tostring-err.js
+Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/evaluation-error/computed-name-valueof-err.js
+Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/statements/class/elements/fields-computed-name-static-computed-var-propname-prototype.js
+Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/statements/class/elements/fields-computed-name-static-propname-prototype.js
+Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/nested-derived-cls-direct-eval-err-contains-supercall-1.js
+Test262Error: Expected a SyntaxError but got a ReferenceError
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/nested-derived-cls-direct-eval-err-contains-supercall-2.js
+Test262Error: Expected a SyntaxError but got a ReferenceError
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/nested-derived-cls-direct-eval-err-contains-supercall.js
+Test262Error: Expected a SyntaxError but got a ReferenceError
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/nested-direct-eval-err-contains-arguments.js
+Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/nested-direct-eval-err-contains-newtarget.js
+Test262Error: Expected SameValue(«class C {
+	constructor() {
+		babelHelpers.defineProperty(this, "x", eval("executed = true; new.target;"));
+	}
+}», «undefined») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/nested-private-derived-cls-direct-eval-err-contains-supercall-1.js
+Test262Error: Expected a SyntaxError but got a ReferenceError
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/nested-private-derived-cls-direct-eval-err-contains-supercall-2.js
+Test262Error: Expected a SyntaxError but got a ReferenceError
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/nested-private-derived-cls-direct-eval-err-contains-supercall.js
+Test262Error: Expected a SyntaxError but got a ReferenceError
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/nested-private-direct-eval-err-contains-arguments.js
+Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/statements/class/elements/private-accessor-is-visible-in-computed-properties.js
+SyntaxError: Private field '#f' must be declared in an enclosing class
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/private-async-generator-method-name.js
+Test262Error: Expected SameValue(«"_method"», «"#method"») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/private-async-method-name.js
+Test262Error: Expected SameValue(«"_method"», «"#method"») to be true
+
+codegen Error: tasks/coverage/test262/test/language/statements/class/elements/private-class-field-on-nonextensible-objects.js
+Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/private-derived-cls-direct-eval-err-contains-supercall-1.js
+Test262Error: Expected a SyntaxError but got a ReferenceError
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/private-derived-cls-direct-eval-err-contains-supercall-2.js
+Test262Error: Expected a SyntaxError but got a ReferenceError
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/private-derived-cls-direct-eval-err-contains-supercall.js
+Test262Error: Expected a SyntaxError but got a ReferenceError
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/private-direct-eval-err-contains-arguments.js
+Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/statements/class/elements/private-field-is-visible-in-computed-properties.js
+SyntaxError: Private field '#f' must be declared in an enclosing class
+
+minify Error: tasks/coverage/test262/test/language/statements/class/elements/private-field-with-initialized-id-is-visible-in-computed-properties.js
+SyntaxError: Private field '#f' must be declared in an enclosing class
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/private-generator-method-name.js
+Test262Error: Expected SameValue(«"_method"», «"#method"») to be true
+
+minify Error: tasks/coverage/test262/test/language/statements/class/elements/private-method-double-initialisation-get-and-set.js
+Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/statements/class/elements/private-method-double-initialisation-get.js
+Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/statements/class/elements/private-method-double-initialisation-set.js
+Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/statements/class/elements/private-method-double-initialisation.js
+Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/statements/class/elements/private-method-is-visible-in-computed-properties.js
+SyntaxError: Private field '#m' must be declared in an enclosing class
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/private-methods/prod-private-async-generator.js
+Test262Error: function name inside constructor Expected SameValue(«"_m"», «"#m"») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/private-methods/prod-private-async-method.js
+Test262Error: function name inside constructor Expected SameValue(«"_m"», «"#m"») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/private-methods/prod-private-generator.js
+Test262Error: function name inside constructor Expected SameValue(«"_m"», «"#m"») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/private-methods/prod-private-method.js
+Test262Error: function name inside constructor Expected SameValue(«"_m"», «"#m"») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/private-static-async-generator-method-name.js
+Test262Error: Expected SameValue(«"_method"», «"#method"») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/private-static-async-method-name.js
+Test262Error: Expected SameValue(«"_method"», «"#method"») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/private-static-generator-method-name.js
+Test262Error: Expected SameValue(«"_method"», «"#method"») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/private-static-method-name.js
+Test262Error: Expected SameValue(«"_method"», «"#method"») to be true
+
+minify Error: tasks/coverage/test262/test/language/statements/class/elements/privatefieldadd-typeerror.js
+Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/static-field-anonymous-function-name.js
+Test262Error: Expected SameValue(«"_"», «"#field"») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/class/elements/static-field-init-with-this.js
+Test262Error: Expected SameValue(«"undefinedtest"», «"test262test"») to be true
+
+minify Error: tasks/coverage/test262/test/language/statements/class/name-binding/in-extends-expression-assigned.js
+Test262Error: Expected a ReferenceError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/statements/class/name-binding/in-extends-expression-grouped.js
+Test262Error: Expected a ReferenceError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/statements/class/static-method-gen-non-configurable-err.js
+Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/statements/class/static-method-non-configurable-err.js
+Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/statements/class/subclass/builtin-objects/Proxy/no-prototype-throws.js
+Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
+
+codegen Error: tasks/coverage/test262/test/language/statements/class/subclass/private-class-field-on-nonextensible-return-override.js
+Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/statements/class/subclass/superclass-arrow-function.js
+Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
+
+transform Error: tasks/coverage/test262/test/language/statements/class/subclass/superclass-async-function.js
+TypeError: Cannot redefine property: prototype
+
+transform Error: tasks/coverage/test262/test/language/statements/class/subclass/superclass-async-generator-function.js
+Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/statements/class/subclass/superclass-generator-function.js
+Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/statements/const/block-local-use-before-initialization-in-prior-statement.js
+Test262Error: Expected a ReferenceError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/statements/const/dstr/ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/const/dstr/ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/const/dstr/ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/const/dstr/obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/const/dstr/obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/const/dstr/obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/const/fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/const/fn-name-fn.js
+Test262Error: Expected true but got false
+
+minify Error: tasks/coverage/test262/test/language/statements/const/fn-name-gen.js
+Test262Error: Expected true but got false
+
+minify Error: tasks/coverage/test262/test/language/statements/const/function-local-use-before-initialization-in-prior-statement.js
+Test262Error: Expected a ReferenceError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/statements/for/dstr/const-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for/dstr/const-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for/dstr/const-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for/dstr/const-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for/dstr/const-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for/dstr/const-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for/dstr/let-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for/dstr/let-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for/dstr/let-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for/dstr/let-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for/dstr/let-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for/dstr/let-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for/dstr/var-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for/dstr/var-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for/dstr/var-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for/dstr/var-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for/dstr/var-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for/dstr/var-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+transform Error: tasks/coverage/test262/test/language/statements/for-await-of/async-from-sync-iterator-continuation-abrupt-completion-get-constructor.js
+Test262Error: Actual [start, tick 1, catch, tick 2] and expected [start, tick 1, tick 2, catch] should have the same contents. 
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-init-fn-name-class.js
+Test262Error: Expected true but got false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-init-fn-name-fn.js
+Test262Error: Expected true but got false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+transform Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-init-yield-ident-valid.js
+Test262Error: Expected SameValue(«undefined», «4») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-nested-array-yield-ident-valid.js
+Test262Error: Expected SameValue(«undefined», «22») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-nested-obj-yield-ident-valid.js
+Test262Error: Expected SameValue(«undefined», «2») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-target-yield-valid.js
+Test262Error: Expected SameValue(«undefined», «33») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-array-rest-nested-array-yield-ident-valid.js
+Test262Error: Expected SameValue(«undefined», «86») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-array-rest-nested-obj-yield-ident-valid.js
+Test262Error: Expected SameValue(«undefined», «2») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-array-rest-yield-ident-valid.js
+TypeError: Cannot read properties of undefined (reading 'length')
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-obj-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-obj-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFnexp"», «"xFnexp"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-obj-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+transform Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-obj-id-init-yield-ident-valid.js
+Test262Error: Expected SameValue(«undefined», «3») to be true
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-obj-prop-elem-init-evaluation.js
+Test262Error: value of `x` Expected SameValue(«undefined», «true») to be true
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-obj-prop-elem-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-obj-prop-elem-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFnexp"», «"xFnexp"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-obj-prop-elem-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+transform Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-obj-prop-elem-init-yield-ident-valid.js
+Test262Error: Expected SameValue(«undefined», «4») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-obj-prop-elem-target-yield-ident-valid.js
+Test262Error: Expected SameValue(«undefined», «23») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-obj-prop-nested-array-yield-ident-valid.js
+Test262Error: Expected SameValue(«undefined», «22») to be true
+
+transform Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-obj-prop-nested-obj-yield-ident-valid.js
+Test262Error: Expected SameValue(«undefined», «2») to be true
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-decl-dstr-array-elem-init-fn-name-class.js
+Test262Error: Expected true but got false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-decl-dstr-array-elem-init-fn-name-fn.js
+Test262Error: Expected true but got false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-decl-dstr-array-elem-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-decl-dstr-obj-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-decl-dstr-obj-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFnexp"», «"xFnexp"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-decl-dstr-obj-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-decl-dstr-obj-prop-elem-init-evaluation.js
+Test262Error: value of `x` Expected SameValue(«undefined», «true») to be true
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-decl-dstr-obj-prop-elem-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-decl-dstr-obj-prop-elem-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFnexp"», «"xFnexp"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-decl-dstr-obj-prop-elem-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-decl-dstr-obj-prop-elem-init-yield-expr.js
+Timed out.
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+transform Error: tasks/coverage/test262/test/language/statements/for-await-of/ticks-with-async-iter-resolved-promise-and-constructor-lookup-two.js
+Test262Error: Actual [pre, constructor, constructor, tick 1, loop, constructor, constructor, tick 2, post] and expected [pre, constructor, tick 1, loop, constructor, tick 2, post] should have the same contents. Ticks and constructor lookups
+
+transform Error: tasks/coverage/test262/test/language/statements/for-await-of/ticks-with-async-iter-resolved-promise-and-constructor-lookup.js
+Test262Error: Actual [pre, constructor, tick 1, loop, constructor, tick 2, post] and expected [pre, tick 1, loop, tick 2, post] should have the same contents. Ticks and constructor lookups
+
+transform Error: tasks/coverage/test262/test/language/statements/for-await-of/ticks-with-sync-iter-resolved-promise-and-constructor-lookup.js
+Test262Error: Actual [pre, constructor, constructor, constructor, constructor, tick 1, tick 2, loop, constructor, constructor, constructor, tick 3, tick 4, post] and expected [pre, constructor, constructor, tick 1, tick 2, loop, constructor, tick 3, tick 4, post] should have the same contents. Ticks and constructor lookups
+
+minify Error: tasks/coverage/test262/test/language/statements/for-in/scope-body-lex-open.js
+Test262Error: Expected a ReferenceError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/statements/for-in/scope-head-lex-close.js
+Test262Error: Expected a ReferenceError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/statements/for-in/scope-head-lex-open.js
+Test262Error: Expected a ReferenceError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/statements/for-of/dstr/array-elem-init-fn-name-class.js
+Test262Error: Expected true but got false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-of/dstr/array-elem-init-fn-name-fn.js
+Test262Error: Expected true but got false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-of/dstr/array-elem-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-of/dstr/const-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-of/dstr/const-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-of/dstr/const-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-of/dstr/const-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-of/dstr/const-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-of/dstr/const-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-of/dstr/let-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-of/dstr/let-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-of/dstr/let-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-of/dstr/let-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-of/dstr/let-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-of/dstr/let-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-of/dstr/obj-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-of/dstr/obj-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-of/dstr/obj-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-of/dstr/obj-prop-elem-init-evaluation.js
+Test262Error: value of `x` Expected SameValue(«undefined», «true») to be true
+
+minify Error: tasks/coverage/test262/test/language/statements/for-of/dstr/obj-prop-elem-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-of/dstr/obj-prop-elem-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-of/dstr/obj-prop-elem-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-of/dstr/obj-prop-elem-init-let.js
+Test262Error: Expected a ReferenceError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/statements/for-of/dstr/obj-prop-elem-init-yield-expr.js
+Test262Error: Expected SameValue(«true», «false») to be true
+
+minify Error: tasks/coverage/test262/test/language/statements/for-of/dstr/var-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-of/dstr/var-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-of/dstr/var-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-of/dstr/var-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-of/dstr/var-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-of/dstr/var-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/for-of/scope-body-lex-open.js
+Test262Error: Expected a ReferenceError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/statements/for-of/scope-head-lex-close.js
+Test262Error: Expected a ReferenceError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/statements/for-of/scope-head-lex-open.js
+Test262Error: Expected a ReferenceError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/statements/function/dstr/ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/function/dstr/ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/function/dstr/ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/function/dstr/dflt-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/function/dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/function/dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/function/dstr/dflt-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/function/dstr/dflt-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/function/dstr/dflt-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/function/dstr/obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/function/dstr/obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/function/dstr/obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/generators/dstr/ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/generators/dstr/ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/generators/dstr/ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/generators/dstr/dflt-ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/generators/dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/generators/dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/generators/dstr/dflt-obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/generators/dstr/dflt-obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/generators/dstr/dflt-obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/generators/dstr/obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/generators/dstr/obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/generators/dstr/obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+codegen Error: tasks/coverage/test262/test/language/statements/generators/generator-created-after-decl-inst.js
+Test262Error: Expected SameValue(«[object Generator]», «[object Generator]») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/let/block-local-use-before-initialization-in-prior-statement.js
+Test262Error: Expected a ReferenceError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/statements/let/dstr/ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/let/dstr/ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/let/dstr/ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/let/dstr/obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/let/dstr/obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/let/dstr/obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/let/fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/let/fn-name-fn.js
+Test262Error: Expected true but got false
+
+minify Error: tasks/coverage/test262/test/language/statements/let/fn-name-gen.js
+Test262Error: Expected true but got false
+
+minify Error: tasks/coverage/test262/test/language/statements/let/function-local-use-before-initialization-in-prior-statement.js
+Test262Error: Expected a ReferenceError to be thrown but no exception was thrown at all
+
+minify Error: tasks/coverage/test262/test/language/statements/try/dstr/ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/try/dstr/ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/try/dstr/ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/try/dstr/obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/try/dstr/obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/try/dstr/obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/variable/dstr/ary-ptrn-elem-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/variable/dstr/ary-ptrn-elem-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/variable/dstr/ary-ptrn-elem-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/variable/dstr/obj-ptrn-id-init-fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/variable/dstr/obj-ptrn-id-init-fn-name-fn.js
+Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/variable/dstr/obj-ptrn-id-init-fn-name-gen.js
+Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/variable/fn-name-class.js
+Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+minify Error: tasks/coverage/test262/test/language/statements/variable/fn-name-fn.js
+Test262Error: Expected true but got false
+
+minify Error: tasks/coverage/test262/test/language/statements/variable/fn-name-gen.js
+Test262Error: Expected true but got false
+

--- a/tasks/coverage/src/load.rs
+++ b/tasks/coverage/src/load.rs
@@ -89,7 +89,7 @@ fn walk_and_read(
         .collect()
 }
 
-fn load_test262(filter: Option<&str>) -> Vec<Test262File> {
+pub fn load_test262(filter: Option<&str>) -> Vec<Test262File> {
     let skip_path = |path: &Path| {
         let s = path.to_string_lossy();
         let s = s.cow_replace('\\', "/");

--- a/tasks/coverage/src/main.rs
+++ b/tasks/coverage/src/main.rs
@@ -31,22 +31,24 @@ fn main() {
         .build_global()
         .unwrap();
 
-    // Load all test data once
-    let data = TestData::load(app_args.filter.as_deref());
+    // Load test data lazily: `runtime` and `transpiler` load their own inputs,
+    // so they must not require every fixture suite to be checked out
+    // (`run_all` also loads internally).
+    let load = || TestData::load(app_args.filter.as_deref());
 
     let task = command.as_deref().unwrap_or("default");
     match task {
-        "parser" => app_args.run_parser(&data),
-        "semantic" => app_args.run_semantic(&data),
-        "codegen" => app_args.run_codegen(&data),
-        "formatter" => app_args.run_formatter(&data),
-        "transformer" => app_args.run_transformer(&data),
+        "parser" => app_args.run_parser(&load()),
+        "semantic" => app_args.run_semantic(&load()),
+        "codegen" => app_args.run_codegen(&load()),
+        "formatter" => app_args.run_formatter(&load()),
+        "transformer" => app_args.run_transformer(&load()),
         "transpiler" => app_args.run_transpiler(),
-        "minifier" => app_args.run_minifier(&data),
+        "minifier" => app_args.run_minifier(&load()),
         "runtime" => app_args.run_runtime(),
-        "estree" => app_args.run_estree(&data),
-        "estree_tokens" => app_args.run_estree_tokens(&data),
-        "types" => app_args.run_types(&data),
+        "estree" => app_args.run_estree(&load()),
+        "estree_tokens" => app_args.run_estree_tokens(&load()),
+        "types" => app_args.run_types(&load()),
         "all" => {
             app_args.run_all();
             app_args.run_runtime();

--- a/tasks/coverage/src/runtime/mod.rs
+++ b/tasks/coverage/src/runtime/mod.rs
@@ -1,36 +1,382 @@
 //! Runtime tests - Test262 execution with Node.js
 //!
-//! These tests run generated code in a Node.js subprocess to verify correctness.
-//! Requires `node` to be installed and the runtime server to be running.
+//! Each eligible test262 case is run through three code-production pipelines
+//! (codegen only; transform; minify) and each result is executed in a Node.js
+//! server, verifying the test still passes. This catches semantic bugs in oxc's
+//! codegen, transformer, and minifier.
+//!
+//! To keep all cores busy, one Node.js server is started per core; each rayon
+//! worker sends its requests to a dedicated server.
+//!
+//! Requires `node` (>= 22) to be installed.
 
 mod test262_status;
 
-use std::process::{Command, Stdio};
+use std::{
+    num::NonZeroUsize,
+    path::Path,
+    process::{Child, Command, Stdio},
+    thread,
+    time::Duration,
+};
 
-use crate::workspace_root;
+use oxc::{
+    allocator::Allocator,
+    codegen::{Codegen, CodegenOptions},
+    minifier::{Minifier, MinifierOptions},
+    parser::Parser,
+    semantic::SemanticBuilder,
+    span::SourceType,
+    transformer::{HelperLoaderMode, TransformOptions, Transformer},
+};
+use oxc_tasks_common::agent;
+use rayon::prelude::*;
+use serde::Serialize;
 
-/// Run runtime tests
+use crate::{
+    CoverageResult, TEST262_PATH, Test262File, TestResult,
+    load::load_test262,
+    print_coverage, snapshot_results,
+    test262::{Phase, TestFlag},
+    workspace_root,
+};
+use test262_status::get_v8_test262_failure_paths;
+
+const HOST: &str = "http://localhost";
+const BASE_PORT: u16 = 32055;
+
+static SKIP_FEATURES: &[&str] = &[
+    // Node's version of V8 doesn't implement these
+    "hashbang",
+    "legacy-regexp",
+    "regexp-duplicate-named-groups",
+    "symbols-as-weakmap-keys",
+    "tail-call-optimization",
+    // We don't care about API-related things
+    "ArrayBuffer",
+    "change-array-by-copy",
+    "DataView",
+    "resizable-arraybuffer",
+    "ShadowRealm",
+    "cross-realm",
+    "SharedArrayBuffer",
+    "String.prototype.toWellFormed",
+    "Symbol.match",
+    "Symbol.replace",
+    "Symbol.unscopables",
+    "Temporal",
+    "TypedArray",
+    // Added in oxc
+    "Array.fromAsync",
+    "IsHTMLDDA",
+    "iterator-helpers",
+    "set-methods",
+    "array-grouping",
+    // stage 2
+    "Intl.DurationFormat",
+    // stage 3
+    "decorators",
+    "explicit-resource-management",
+    "source-phase-imports",
+    "import-defer",
+];
+
+static SKIP_INCLUDES: &[&str] = &[
+    // We don't preserve "toString()" on functions
+    "nativeFunctionMatcher.js",
+];
+
+static SKIP_TEST_CASES: &[&str] = &[
+    // node.js runtime error
+    "language/expressions/dynamic-import",
+    "language/global-code/decl-func.js",
+    "language/module-code",
+    // formerly S11.13.2_A5.10_T5
+    "language/expressions/compound-assignment/compound-assignment-operator-calls-putvalue-lref--v",
+    "language/expressions/postfix-increment/operator-x-postfix-increment-calls-putvalue-lhs-newvalue",
+    "language/expressions/postfix-decrement/operator-x-postfix-decrement-calls-putvalue-lhs-newvalue",
+    "language/expressions/prefix-increment/operator-prefix-increment-x-calls-putvalue-lhs-newvalue",
+    "language/expressions/prefix-decrement/operator-prefix-decrement-x-calls-putvalue-lhs-newvalue",
+];
+
+static SKIP_ESID: &[&str] = &["sec-privatefieldget", "sec-privatefieldset"];
+
+/// The JSON payload sent to the Node.js runtime server for each execution.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RunRequest<'a> {
+    code: String,
+    includes: &'a [Box<str>],
+    is_async: bool,
+    is_module: bool,
+    is_raw: bool,
+    import_dir: String,
+}
+
+/// Ensures every Node.js server subprocess is killed even if a test panics.
+struct ServerGuard(Vec<Child>);
+
+impl Drop for ServerGuard {
+    fn drop(&mut self) {
+        for child in &mut self.0 {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+/// Run runtime tests.
 ///
 /// # Panics
-/// Panics if the Node.js runtime server fails to start.
-pub fn run(_filter: Option<&str>, _detail: bool) {
-    let path = workspace_root().join("src/runtime/runtime.js").to_string_lossy().to_string();
+/// Panics if a Node.js runtime server fails to start or never becomes ready.
+pub fn run(filter: Option<&str>, detail: bool) {
+    let files = load_test262(filter);
 
-    println!("runtime Summary:");
-    println!("Starting Node.js runtime server...");
+    // Warm the V8 status list once (it may fetch over the network) before entering
+    // the parallel skip filter, so any failure surfaces deterministically.
+    let _ = get_v8_test262_failure_paths();
 
-    let mut runtime_process = Command::new("node")
-        .args(["--experimental-vm-modules", &path])
+    // One server per core keeps every core busy without over-subscribing them.
+    let num_servers = std::thread::available_parallelism().map_or(1, NonZeroUsize::get);
+
+    // A single agent, shared across the rayon threads and the readiness probes.
+    let http = agent();
+    let send = |port: u16, request: &RunRequest| -> Result<String, String> {
+        http.post(&format!("{HOST}:{port}/run"))
+            .send_json(request)
+            .map_err(|err| err.to_string())
+            .and_then(|mut res| res.body_mut().read_to_string().map_err(|err| err.to_string()))
+    };
+
+    // Start the Node.js servers and wait for each to accept requests.
+    let server = ServerGuard((0..num_servers).map(|i| spawn_server(server_port(i))).collect());
+    for i in 0..num_servers {
+        wait_for_server(&send, server_port(i));
+    }
+
+    // Each rayon worker talks to its own server (round-robined if there are more
+    // workers than servers); the three variants of a case share one server.
+    let mut results: Vec<CoverageResult> = files
+        .par_iter()
+        .filter(|&file| !skip_case(file))
+        .map(|file| {
+            let port = server_port(rayon::current_thread_index().unwrap_or(0) % num_servers);
+            run_case(file, port, &send)
+        })
+        .collect();
+
+    // Ask each server to shut down gracefully, then ensure the processes are gone.
+    for i in 0..num_servers {
+        let _ = http.delete(&format!("{HOST}:{}", server_port(i))).call();
+    }
+    drop(server);
+
+    // rayon collects out of order; sort so console output is deterministic.
+    // (`snapshot_results` sorts internally, so the snapshot is stable regardless.)
+    results.sort_by(|a, b| a.path.cmp(&b.path));
+
+    print_coverage("runtime", &results, detail || filter.is_some());
+    if filter.is_none() {
+        snapshot_results("runtime", Path::new(TEST262_PATH), &results);
+    }
+}
+
+/// Port for the `index`-th server. The count is bounded by the core count, so it
+/// always fits in a `u16`.
+fn server_port(index: usize) -> u16 {
+    BASE_PORT + u16::try_from(index).expect("server index fits in u16")
+}
+
+fn spawn_server(port: u16) -> Child {
+    let path = workspace_root().join("src/runtime/runtime.js");
+    Command::new("node")
+        .args(["--experimental-vm-modules"])
+        .arg(&path)
+        .env("PORT", port.to_string())
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
         .spawn()
-        .expect("Failed to start runtime.js - ensure Node.js is installed");
+        .expect("Failed to start runtime.js - ensure Node.js is installed")
+}
 
-    // TODO: Implement async test execution
-    // The runtime tests require async execution to communicate with the Node.js server
-    // For now, we just start the server and exit
-    println!("Runtime tests require async execution - not yet implemented in simplified runner");
+/// Poll a server until it answers a request, or panic after ~30s.
+fn wait_for_server(send: &impl Fn(u16, &RunRequest) -> Result<String, String>, port: u16) {
+    let probe = RunRequest {
+        code: String::new(),
+        includes: &[],
+        is_async: false,
+        is_module: false,
+        is_raw: true,
+        import_dir: String::new(),
+    };
+    for _ in 0..300 {
+        if send(port, &probe).is_ok() {
+            return;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    panic!("Runtime server on {HOST}:{port} did not become ready");
+}
 
-    let _ = runtime_process.kill();
-    let _ = runtime_process.wait();
+fn run_case(
+    file: &Test262File,
+    port: u16,
+    send: &impl Fn(u16, &RunRequest) -> Result<String, String>,
+) -> CoverageResult {
+    let result = run_variants(file, port, send);
+    CoverageResult { path: file.path.clone(), should_fail: false, result }
+}
+
+/// Run the three code-production variants in order, stopping at the first failure.
+fn run_variants(
+    file: &Test262File,
+    port: u16,
+    send: &impl Fn(u16, &RunRequest) -> Result<String, String>,
+) -> TestResult {
+    let code = get_code(file, false, false);
+    let result = run_test_code(file, "codegen", code, port, send);
+    if result != TestResult::Passed {
+        return result;
+    }
+
+    let code = get_code(file, true, false);
+    let result = run_test_code(file, "transform", code, port, send);
+    if result != TestResult::Passed {
+        return result;
+    }
+
+    let base_path = file.path.to_string_lossy();
+    let test262_path = base_path.trim_start_matches("test262/test/");
+
+    // Minifier does not conform to annexB.
+    if test262_path.starts_with("annexB") {
+        return TestResult::Passed;
+    }
+
+    // Unable to minify non-strict code, which may contain syntaxes the minifier does
+    // not support (e.g. `with`).
+    if file.meta.flags.contains(&TestFlag::NoStrict) {
+        return TestResult::Passed;
+    }
+
+    // None of the minifier conform to "fn-name-cover.js"
+    // `let xCover = (0, function() {});` xCover.name is ''
+    // `let xCover = function() {};` xCover.name is 'xCover'
+    // e.g. https://github.com/tc39/test262/blob/main/test/language/statements/let/fn-name-cover.js
+    if test262_path.ends_with("fn-name-cover.js") {
+        return TestResult::Passed;
+    }
+
+    let code = get_code(file, false, true);
+    run_test_code(file, "minify", code, port, send)
+}
+
+fn run_test_code(
+    file: &Test262File,
+    case: &'static str,
+    code: String,
+    port: u16,
+    send: &impl Fn(u16, &RunRequest) -> Result<String, String>,
+) -> TestResult {
+    let flags = &file.meta.flags;
+    let import_dir =
+        workspace_root().join(file.path.parent().unwrap()).to_string_lossy().into_owned();
+
+    let request = RunRequest {
+        code,
+        includes: file.meta.includes.as_ref(),
+        is_async: flags.contains(&TestFlag::Async),
+        is_module: flags.contains(&TestFlag::Module),
+        is_raw: flags.contains(&TestFlag::Raw),
+        import_dir,
+    };
+
+    match send(port, &request) {
+        Ok(output) => {
+            // A passing test produces no output. A runtime-phase negative test passes
+            // when it throws the expected error type.
+            let passed = output.is_empty()
+                || file.meta.negative.as_ref().is_some_and(|negative| {
+                    negative.phase.is_runtime() && output.starts_with(&*negative.error_type)
+                });
+            if passed { TestResult::Passed } else { TestResult::GenericError(case, output) }
+        }
+        Err(error) => TestResult::GenericError(case, error),
+    }
+}
+
+/// Produce the executable code for a single variant.
+///
+/// * `transform` runs the full transformer pipeline (down-levelling syntax).
+/// * `minify` runs the compressor (without mangling) and prints minified output.
+fn get_code(file: &Test262File, transform: bool, minify: bool) -> String {
+    let source_text = file.code.as_str();
+    let flags = &file.meta.flags;
+    let is_module = flags.contains(&TestFlag::Module);
+    let is_only_strict = flags.contains(&TestFlag::OnlyStrict);
+    let source_type = SourceType::cjs().with_script(!is_module).with_module(is_module);
+    let allocator = Allocator::default();
+    let mut program = Parser::new(&allocator, source_text, source_type).parse().program;
+
+    if transform {
+        let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
+        let mut options = TransformOptions::enable_all();
+        options.jsx.refresh = None;
+        options.helper_loader.mode = HelperLoaderMode::External;
+        options.typescript.only_remove_type_imports = true;
+        Transformer::new(&allocator, &file.path, &options)
+            .build_with_scoping(scoping, &mut program);
+    }
+
+    let scoping = if minify {
+        Minifier::new(MinifierOptions { mangle: None, ..MinifierOptions::default() })
+            .minify(&allocator, &mut program)
+            .scoping
+    } else {
+        None
+    };
+
+    let mut text = Codegen::new()
+        .with_options(if minify { CodegenOptions::minify() } else { CodegenOptions::default() })
+        .with_scoping(scoping)
+        .build(&program)
+        .code;
+    if is_only_strict {
+        text = format!("\"use strict\";\n{text}");
+    }
+    if is_module {
+        text = format!("{text}\n export {{}}");
+    }
+    text
+}
+
+/// Decide whether a case is ineligible for runtime execution.
+///
+/// These lists encode years of test262 triage and are ported verbatim from the
+/// original runner.
+fn skip_case(file: &Test262File) -> bool {
+    let base_path = file.path.to_string_lossy();
+    let test262_path = base_path.trim_start_matches("test262/test/");
+    let meta = &file.meta;
+    let includes = &meta.includes;
+    let features = &meta.features;
+
+    // Negative tests that fail at parse time can't produce runnable code.
+    meta.negative.as_ref().is_some_and(|negative| negative.phase == Phase::Parse)
+        || meta.esid.as_ref().is_some_and(|esid| SKIP_ESID.contains(&esid.as_ref()))
+        || base_path.contains("built-ins")
+        || base_path.contains("staging")
+        || base_path.contains("intl402")
+        || includes.iter().any(|include| SKIP_INCLUDES.contains(&include.as_ref()))
+        || features.iter().any(|feature| SKIP_FEATURES.contains(&feature.as_ref()))
+        || SKIP_TEST_CASES.iter().any(|path| test262_path.starts_with(path))
+        || get_v8_test262_failure_paths().iter().any(|path| {
+            if let Some(path) = path.strip_suffix('*') {
+                test262_path.starts_with(path)
+            } else {
+                test262_path.trim_end_matches(".js") == path
+            }
+        })
+        || file.code.contains("$262")
+        || file.code.contains("$DONOTEVALUATE()")
 }

--- a/tasks/coverage/src/runtime/runtime.js
+++ b/tasks/coverage/src/runtime/runtime.js
@@ -72,7 +72,7 @@ async function runCodeInHarness(options = {}) {
     };
 
     createContext(context);
-    if (!isRaw) runInContext(createHarnessForTest(includes), context);
+    if (!isRaw) getHarnessScript(includes).runInContext(context);
 
     if (isModule) {
       const module = new SourceTextModule(code, { context, importModuleDynamically });
@@ -128,6 +128,22 @@ function createHarnessForTest(includes) {
   return harness;
 }
 
+const harnessScriptCache = new Map();
+
+// Compile the harness once per distinct `includes` list and reuse the compiled
+// `vm.Script` across requests, instead of re-parsing assert.js + sta.js + the
+// includes + babelHelpers (~177 KB) on every execution. The cache key preserves
+// the original include order so the concatenated harness is byte-identical.
+function getHarnessScript(includes) {
+  const key = (includes || []).join(",");
+  let script = harnessScriptCache.get(key);
+  if (!script) {
+    script = new Script(createHarnessForTest(includes));
+    harnessScriptCache.set(key, script);
+  }
+  return script;
+}
+
 const server = createServer((req, res) => {
   if (req.method == "DELETE") {
     server.closeAllConnections();
@@ -171,4 +187,5 @@ process.on("unhandledRejection", () => {
 
 server.timeout = 3000;
 
-server.listen(32055, () => {});
+const port = process.env.PORT || 32055;
+server.listen(port, () => {});

--- a/tasks/coverage/src/runtime/test262_status.rs
+++ b/tasks/coverage/src/runtime/test262_status.rs
@@ -9,7 +9,6 @@ use crate::workspace_root;
 /// see <https://chromium.googlesource.com/v8/v8/+/refs/heads/main/test/test262/test262.status>
 ///
 /// # Panics
-#[expect(dead_code)]
 pub fn get_v8_test262_failure_paths() -> &'static Vec<String> {
     static STATUS: OnceLock<Vec<String>> = OnceLock::new();
     STATUS.get_or_init(|| {


### PR DESCRIPTION
## Summary

#18478 reduced the test262 runtime runner to a stub ("not yet implemented"), and since oxc's own CI never runs `cargo coverage runtime`, the transformer/minifier semantics coverage it provided has been dark — monitor-oxc's Test262 job (the only consumer) has been disabled since July 2025.

This restores execution on the simplified architecture: each eligible test262 case runs through codegen / transform / minify and executes in the Node runtime server, driven by rayon with blocking HTTP instead of the old tokio design. Skip lists and per-variant semantics are ported verbatim from the pre-#18478 runner.

- `main.rs` now loads `TestData` lazily, so `cargo coverage runtime` works with only the test262 fixtures checked out (which is how monitor-oxc CI invokes it).
- Execution is parallelized: one Node server per core with each rayon worker pinned to its own server, and the test262 harness is compiled once per distinct include list as a reusable `vm.Script` instead of re-parsed per request. Full suite: ~10s wall locally (~45s single-server).
- Results at test262 `de8e621c`: 17279/18277 positive tests pass (94.54%); `runtime.snap` is committed and byte-stable across repeated runs; clippy/fmt clean.
- monitor-oxc side: oxc-project/monitor-oxc#178 (must merge after this one).

Note: oxc CI still does not run the runtime suite, so `runtime.snap` can go stale and turn monitor-oxc's job red — the failure mode that led to the original "skip 262". Possible follow-ups: run it in conformance CI, or add a regression-only mode (fail on new failures, tolerate improvements).