### PR TITLE
fix(mangler): keep names of destructured exported bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2124,6 +2124,7 @@ dependencies = [
  "oxc_allocator",
  "oxc_ast",
  "oxc_data_structures",
+ "oxc_ecmascript",
  "oxc_index",
  "oxc_parser",
  "oxc_semantic",

--- a/crates/oxc_mangler/Cargo.toml
+++ b/crates/oxc_mangler/Cargo.toml
@@ -23,6 +23,7 @@ test = true
 oxc_allocator = { workspace = true, features = ["bitset"] }
 oxc_ast = { workspace = true }
 oxc_data_structures = { workspace = true, features = ["inline_string"] }
+oxc_ecmascript = { workspace = true }
 oxc_index = { workspace = true }
 oxc_semantic = { workspace = true }
 oxc_span = { workspace = true }

--- a/crates/oxc_mangler/src/lib.rs
+++ b/crates/oxc_mangler/src/lib.rs
@@ -10,6 +10,7 @@ use base54::base54;
 use oxc_allocator::{Allocator, ArenaHashSet, ArenaVec, BitSet};
 use oxc_ast::ast::{Declaration, Program, Statement};
 use oxc_data_structures::inline_string::InlineString;
+use oxc_ecmascript::BoundNames;
 use oxc_semantic::{AstNodes, Reference, Scoping, Semantic, SemanticBuilder, Stats, SymbolId};
 use oxc_span::SourceType;
 use oxc_str::{CompactStr, Ident, Str};
@@ -843,12 +844,13 @@ fn collect_exported_symbols<'a>(
         let Statement::ExportNamedDeclaration(v) = statement else { continue };
         let Some(decl) = &v.declaration else { continue };
         if let Declaration::VariableDeclaration(decl) = decl {
-            for decl in &decl.declarations {
-                if let Some(id) = decl.id.get_binding_identifier() {
-                    exported_names.insert(id.name.as_arena_str());
-                    exported_symbols.set_bit(id.symbol_id().index());
-                }
-            }
+            // Use `bound_names` rather than `get_binding_identifier`: a destructuring
+            // pattern (`export const { find } = x`) exports every bound name, and
+            // renaming any of them would rename the export.
+            decl.bound_names(&mut |id| {
+                exported_names.insert(id.name.as_arena_str());
+                exported_symbols.set_bit(id.symbol_id().index());
+            });
         } else if let Some(id) = decl.id() {
             exported_names.insert(id.name.as_arena_str());
             exported_symbols.set_bit(id.symbol_id().index());

--- a/crates/oxc_minifier/tests/mangler/mod.rs
+++ b/crates/oxc_minifier/tests/mangler/mod.rs
@@ -276,6 +276,40 @@ fn shadowed_fn_expr_mangle_is_idempotent() {
     }
 }
 
+/// Destructured bindings in `export const/let/var` define the module's export names —
+/// they must never be renamed (`export const { find } = x` exports `find`; renaming the
+/// binding renames the export). Surfaced by monitor-oxc: mangled `css-tree` lost its
+/// `find` export and broke `import { find } from "css-tree"` at runtime.
+#[test]
+fn destructured_exports_keep_names() {
+    let options = MangleOptions::default();
+
+    test(
+        "import syntax from 's';
+         export const { tokenize, parse, find } = syntax;",
+        "import e from 's';
+         export const { tokenize, parse, find } = e;",
+        options,
+    );
+
+    test(
+        "import syntax from 's';
+         export const [first, second, ...rest] = syntax;",
+        "import e from 's';
+         export const [first, second, ...rest] = e;",
+        options,
+    );
+
+    // Renamed destructuring and nested patterns: only the bound names are exported.
+    test(
+        "import syntax from 's';
+         export const { a: renamed, b: { nested = 1 } } = syntax;",
+        "import e from 's';
+         export const { a: renamed, b: { nested = 1 } } = e;",
+        options,
+    );
+}
+
 /// Annex B.3.2.1: In sloppy mode, function declarations inside blocks have var-like hoisting.
 /// The mangler must not assign the same name to such a function and an outer `var` binding.
 #[test]


### PR DESCRIPTION
`collect_exported_symbols` resolved each exported variable declarator with `get_binding_identifier`, which returns `None` for destructuring patterns — so the bindings of `export const { … } = …` were never marked as exported and got mangled, **renaming the module's named exports**. Collect the declarator's `bound_names` instead, which covers object / array patterns, nesting, defaults and rest elements.

Surfaced by the monitor-oxc mangler runtime test (previously masked by the idempotency failures fixed in #24033): mangled `css-tree` lost its `find` export and `@asamuzakjp/dom-selector` failed with `SyntaxError: The requested module 'css-tree' does not provide an export named 'find'` ([failing run](https://github.com/oxc-project/monitor-oxc/actions/runs/28562614557/job/84683456673)). The same export shape appears in commander, csso, colorette, ansis and `@actions/io`, so those were broken too.

## Example

```js
import syntax from "./syntax/index.js";
export const { tokenize, parse, find } = syntax;
```

Before:

```js
import e from "./syntax/index.js";
export const { tokenize: t, parse: n, find: s } = e; // exports `t`, `n`, `s`
```

After:

```js
import e from "./syntax/index.js";
export const { tokenize, parse, find } = e;
```

Verified end-to-end by mangling every file in `css-tree@3.2.1` and exercising `import { find, parse, generate, walk } from "css-tree"` in node.