### PR TITLE
feat(linter/unicorn/no-array-sort): add `allowAfterSpread` option

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -6094,6 +6094,16 @@ export interface NoArrayReverse {
 }
 export interface NoArraySort {
   /**
+   * When set to `true`, allows sorting a fresh array created by a spread, e.g. `[...iterable].sort()`.
+   * This avoids the double allocation of `toSorted()` when sorting an iterable such as a `Set`.
+   *
+   * Example of **correct** code for this rule with `allowAfterSpread` set to `true`:
+   * ```js
+   * const sorted = [...mySet].sort();
+   * ```
+   */
+  allowAfterSpread?: boolean;
+  /**
    * When set to `true` (default), allows `array.sort()` as an expression statement.
    * Set to `false` to forbid `Array#sort()` even if it's an expression statement.
    *

--- a/crates/oxc_linter/src/rules/unicorn/no_array_sort.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_sort.rs
@@ -35,11 +35,20 @@ pub struct NoArraySort {
     /// array.sort();
     /// ```
     allow_expression_statement: bool,
+
+    /// When set to `true`, allows sorting a fresh array created by a spread, e.g. `[...iterable].sort()`.
+    /// This avoids the double allocation of `toSorted()` when sorting an iterable such as a `Set`.
+    ///
+    /// Example of **correct** code for this rule with `allowAfterSpread` set to `true`:
+    /// ```js
+    /// const sorted = [...mySet].sort();
+    /// ```
+    allow_after_spread: bool,
 }
 
 impl Default for NoArraySort {
     fn default() -> Self {
-        Self { allow_expression_statement: true }
+        Self { allow_expression_statement: true, allow_after_spread: false }
     }
 }
 
@@ -126,6 +135,10 @@ impl Rule for NoArraySort {
             _ => false,
         };
 
+        if self.allow_after_spread && is_spread {
+            return;
+        }
+
         if self.allow_expression_statement && !is_spread {
             let parent = ctx.nodes().parent_node(node.id());
             let parent_is_expression_statement = match parent.kind() {
@@ -208,6 +221,14 @@ fn test() {
         (r#"Post.find({ published: true }).sort({ updatedAt: "desc" })"#, None),
         ("sorted = collection.sort(({field: 1}))", None),
         (r#"sorted = query.sort(("field"))"#, None),
+        ("sorted = [...mySet].sort()", Some(serde_json::json!([{ "allowAfterSpread": true }]))),
+        ("sorted = [...array].sort()", Some(serde_json::json!([{ "allowAfterSpread": true }]))),
+        ("sorted = [...array]?.sort()", Some(serde_json::json!([{ "allowAfterSpread": true }]))),
+        (
+            "sorted = [...array].sort(compareFn)",
+            Some(serde_json::json!([{ "allowAfterSpread": true }])),
+        ),
+        ("[...array].sort()", Some(serde_json::json!([{ "allowAfterSpread": true }]))),
     ];
 
     let fail = vec![
@@ -223,6 +244,8 @@ fn test() {
         ("array?.sort()", Some(serde_json::json!([{ "allowExpressionStatement": false }]))),
         ("[...array].sort()", Some(serde_json::json!([{ "allowExpressionStatement": false }]))),
         ("sorted = [...(0, array)].sort()", None),
+        ("sorted = array.sort()", Some(serde_json::json!([{ "allowAfterSpread": true }]))),
+        ("sorted = [...array].sort()", Some(serde_json::json!([{ "allowAfterSpread": false }]))),
     ];
 
     let fix = vec![

--- a/crates/oxc_linter/src/snapshots/unicorn_no_array_sort.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_array_sort.snap
@@ -85,3 +85,17 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ────
    ╰────
   help: `Array#sort()` mutates the original array. Use `Array#toSorted()` to return a new sorted array without modifying the original.
+
+  ⚠ unicorn(no-array-sort): Use `Array#toSorted()` instead of `Array#sort()`.
+   ╭─[no_array_sort.tsx:1:16]
+ 1 │ sorted = array.sort()
+   ·                ────
+   ╰────
+  help: `Array#sort()` mutates the original array. Use `Array#toSorted()` to return a new sorted array without modifying the original.
+
+  ⚠ unicorn(no-array-sort): Use `Array#toSorted()` instead of `Array#sort()`.
+   ╭─[no_array_sort.tsx:1:21]
+ 1 │ sorted = [...array].sort()
+   ·                     ────
+   ╰────
+  help: `Array#sort()` mutates the original array. Use `Array#toSorted()` to return a new sorted array without modifying the original.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -13185,6 +13185,12 @@
     "NoArraySort": {
       "type": "object",
       "properties": {
+        "allowAfterSpread": {
+          "description": "When set to `true`, allows sorting a fresh array created by a spread, e.g. `[...iterable].sort()`.\nThis avoids the double allocation of `toSorted()` when sorting an iterable such as a `Set`.\n\nExample of **correct** code for this rule with `allowAfterSpread` set to `true`:\n```js\nconst sorted = [...mySet].sort();\n```",
+          "default": false,
+          "type": "boolean",
+          "markdownDescription": "When set to `true`, allows sorting a fresh array created by a spread, e.g. `[...iterable].sort()`.\nThis avoids the double allocation of `toSorted()` when sorting an iterable such as a `Set`.\n\nExample of **correct** code for this rule with `allowAfterSpread` set to `true`:\n```js\nconst sorted = [...mySet].sort();\n```"
+        },
         "allowExpressionStatement": {
           "description": "When set to `true` (default), allows `array.sort()` as an expression statement.\nSet to `false` to forbid `Array#sort()` even if it's an expression statement.\n\nExample of **incorrect** code for this rule with `allowExpressionStatement` set to `false`:\n```js\narray.sort();\n```",
           "default": true,


### PR DESCRIPTION
Adds an `allowAfterSpread` option (default `false`) to `unicorn/no-array-sort`. When enabled, sorting a freshly-spread array (`[...iterable].sort()`) is allowed — it doesn't mutate an existing array and avoids the extra allocation `toSorted()` would incur when sorting a non-array iterable such as a `Set`.

`array.sort()` is still reported (not a spread), and `[...array].sort()` is still reported when the option is off.

Closes #20544
