### PR TITLE
feat(linter/eslint/no-inner-declarations): add `namespaces` option

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -147,6 +147,7 @@ export type AllowKind =
  */
 export type NoInnerDeclarationsConfig = "functions" | "both";
 export type BlockScopedFunctions = "allow" | "disallow";
+export type Namespaces = "allow" | "disallow";
 export type NoMagicNumbersNumber = number | string;
 export type NoRestrictedImportsConfigEnum = string | RestrictedPath | NoRestrictedImportsConfig;
 export type PossiblePaths = string | RestrictedPath;
@@ -3132,6 +3133,10 @@ export interface NoInnerDeclarationsOptions {
    * Controls whether function declarations in nested blocks are allowed in strict mode (ES6+ behavior).
    */
   blockScopedFunctions?: BlockScopedFunctions;
+  /**
+   * Controls whether declarations directly inside TypeScript namespace or module bodies are allowed.
+   */
+  namespaces?: Namespaces;
 }
 export interface NoInvalidRegexpConfig {
   /**

--- a/crates/oxc_linter/src/rules/eslint/no_inner_declarations.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_inner_declarations.rs
@@ -30,6 +30,9 @@ struct NoInnerDeclarationsOptions {
     /// Controls whether function declarations in nested blocks are allowed in strict mode (ES6+ behavior).
     #[schemars(with = "BlockScopedFunctions")]
     block_scoped_functions: Option<BlockScopedFunctions>,
+    /// Controls whether declarations directly inside TypeScript namespace or module bodies are allowed.
+    #[schemars(with = "Namespaces")]
+    namespaces: Option<Namespaces>,
 }
 
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
@@ -39,6 +42,16 @@ enum BlockScopedFunctions {
     #[default]
     Allow,
     /// Disallow function declarations in nested blocks regardless of strict mode.
+    Disallow,
+}
+
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+enum Namespaces {
+    /// Allow declarations directly inside TypeScript namespace or module bodies.
+    Allow,
+    /// Disallow declarations directly inside TypeScript namespace or module bodies.
+    #[default]
     Disallow,
 }
 
@@ -91,6 +104,8 @@ impl Rule for NoInnerDeclarations {
             },
         );
 
+        // Options follow the mode string, matching ESLint's positional schema
+        // `[("functions" | "both"), { … }]`.
         let block_scoped_functions = if value.is_array() && !value.is_null() {
             value
                 .get(1)
@@ -105,7 +120,15 @@ impl Rule for NoInnerDeclarations {
             None
         };
 
-        Ok(Self(config, NoInnerDeclarationsOptions { block_scoped_functions }))
+        let namespaces =
+            value.get(1).and_then(|v| v.get("namespaces")).and_then(serde_json::Value::as_str).map(
+                |value| match value {
+                    "allow" => Namespaces::Allow,
+                    _ => Namespaces::Disallow,
+                },
+            );
+
+        Ok(Self(config, NoInnerDeclarationsOptions { block_scoped_functions, namespaces }))
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
@@ -115,7 +138,7 @@ impl Rule for NoInnerDeclarations {
                     return;
                 }
 
-                check_rule(node, ctx);
+                check_rule(node, ctx, self.1.namespaces == Some(Namespaces::Allow));
             }
             AstKind::Function(func) => {
                 if !func.is_function_declaration() {
@@ -139,17 +162,35 @@ impl Rule for NoInnerDeclarations {
                     }
                 }
 
-                check_rule(node, ctx);
+                check_rule(node, ctx, self.1.namespaces == Some(Namespaces::Allow));
             }
             _ => {}
         }
     }
 }
 
-fn check_rule<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) {
+fn check_rule<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>, allow_namespaces: bool) {
     let parent_node = ctx.nodes().parent_node(node.id());
-    if matches!(
-        parent_node.kind(),
+    let parent_kind = parent_node.kind();
+
+    // A declaration may be wrapped in `export`; look through it to find the real enclosing scope.
+    let enclosing = if matches!(
+        parent_kind,
+        AstKind::ExportNamedDeclaration(_) | AstKind::ExportDefaultDeclaration(_)
+    ) {
+        ctx.nodes().parent_node(parent_node.id()).kind()
+    } else {
+        parent_kind
+    };
+
+    // Declarations directly inside a TS namespace/module body (exported or not) are governed
+    // by the `namespaces` option.
+    if matches!(enclosing, AstKind::TSModuleBlock(_)) {
+        if allow_namespaces {
+            return;
+        }
+    } else if matches!(
+        parent_kind,
         AstKind::Program(_)
             | AstKind::FunctionBody(_)
             | AstKind::StaticBlock(_)
@@ -255,6 +296,27 @@ fn test() {
             "const C = class { method() { if(test) { function somethingElse() { } } } }",
             Some(serde_json::json!(["functions", { "blockScopedFunctions": "allow" }])),
         ), // { "ecmaVersion": 2022 }
+        // `namespaces: "allow"` exempts declarations directly in a TS namespace/module body
+        (
+            "namespace N { function foo() {} }",
+            Some(serde_json::json!(["both", { "namespaces": "allow" }])),
+        ),
+        (
+            "namespace N { var x = 1; }",
+            Some(serde_json::json!(["both", { "namespaces": "allow" }])),
+        ),
+        (
+            "module M { function foo() {} }",
+            Some(serde_json::json!(["both", { "namespaces": "allow" }])),
+        ),
+        (
+            "namespace N { export function bar() {} }",
+            Some(serde_json::json!(["both", { "namespaces": "allow" }])),
+        ),
+        (
+            "namespace N { function foo() {} }",
+            Some(serde_json::json!(["functions", { "namespaces": "allow" }])),
+        ),
     ];
 
     let fail = vec![
@@ -328,9 +390,18 @@ fn test() {
              console.log('foo called'); } }",
             Some(serde_json::json!(["both"])),
         ), // { "ecmaVersion": 2022 }
+        // `namespaces` default (disallow); nested blocks inside a namespace still report
+        ("namespace N { function foo() {} }", Some(serde_json::json!(["both"]))),
+        ("namespace N { var x = 1; }", Some(serde_json::json!(["both"]))),
+        // an exported declaration inside a namespace is still governed by `namespaces`
+        ("namespace N { export function bar() {} }", Some(serde_json::json!(["both"]))),
+        (
+            "namespace N { if (x) { function foo() {} } }",
+            Some(serde_json::json!(["both", { "namespaces": "allow" }])),
+        ),
     ];
 
     Tester::new(NoInnerDeclarations::NAME, NoInnerDeclarations::PLUGIN, pass, fail)
-        .change_rule_path_extension("mjs")
+        .change_rule_path_extension("mts")
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/snapshots/eslint_no_inner_declarations.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_inner_declarations.snap
@@ -3,175 +3,175 @@ source: crates/oxc_linter/src/tester.rs
 ---
 
   ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
-   ╭─[no_inner_declarations.mjs:1:13]
+   ╭─[no_inner_declarations.mts:1:13]
  1 │ if (test) { function doSomething() { } }
    ·             ────────
    ╰────
   help: Move function declaration to program root
 
   ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
-   ╭─[no_inner_declarations.mjs:1:10]
+   ╭─[no_inner_declarations.mts:1:10]
  1 │ if (foo) var a; 
    ·          ───
    ╰────
   help: Move variable declaration to program root
 
   ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
-   ╭─[no_inner_declarations.mjs:1:30]
+   ╭─[no_inner_declarations.mts:1:30]
  1 │ if (foo) /* some comments */ var a; 
    ·                              ───
    ╰────
   help: Move variable declaration to program root
 
   ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
-   ╭─[no_inner_declarations.mjs:1:11]
+   ╭─[no_inner_declarations.mts:1:11]
  1 │ if (foo){ function f(){ if(bar){ var a; } } }
    ·           ────────
    ╰────
   help: Move function declaration to program root
 
   ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
-   ╭─[no_inner_declarations.mjs:1:34]
+   ╭─[no_inner_declarations.mts:1:34]
  1 │ if (foo){ function f(){ if(bar){ var a; } } }
    ·                                  ───
    ╰────
   help: Move variable declaration to function body root
 
   ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
-   ╭─[no_inner_declarations.mjs:1:10]
+   ╭─[no_inner_declarations.mts:1:10]
  1 │ if (foo) function f(){ if(bar) var a; }
    ·          ────────
    ╰────
   help: Move function declaration to program root
 
   ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
-   ╭─[no_inner_declarations.mjs:1:32]
+   ╭─[no_inner_declarations.mts:1:32]
  1 │ if (foo) function f(){ if(bar) var a; }
    ·                                ───
    ╰────
   help: Move variable declaration to function body root
 
   ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
-   ╭─[no_inner_declarations.mjs:1:12]
+   ╭─[no_inner_declarations.mts:1:12]
  1 │ if (foo) { var fn = function(){} } 
    ·            ───
    ╰────
   help: Move variable declaration to program root
 
   ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
-   ╭─[no_inner_declarations.mjs:1:11]
+   ╭─[no_inner_declarations.mts:1:11]
  1 │ if (foo)  function f(){} 
    ·           ────────
    ╰────
   help: Move function declaration to program root
 
   ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
-   ╭─[no_inner_declarations.mjs:1:27]
+   ╭─[no_inner_declarations.mts:1:27]
  1 │ function bar() { if (foo) function f(){}; }
    ·                           ────────
    ╰────
   help: Move function declaration to function body root
 
   ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
-   ╭─[no_inner_declarations.mjs:1:27]
+   ╭─[no_inner_declarations.mts:1:27]
  1 │ function bar() { if (foo) var a; }
    ·                           ───
    ╰────
   help: Move variable declaration to function body root
 
   ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
-   ╭─[no_inner_declarations.mjs:1:12]
+   ╭─[no_inner_declarations.mts:1:12]
  1 │ if (foo) { var a; }
    ·            ───
    ╰────
   help: Move variable declaration to program root
 
   ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
-   ╭─[no_inner_declarations.mjs:1:31]
+   ╭─[no_inner_declarations.mts:1:31]
  1 │ function doSomething() { do { function somethingElse() { } } while (test); }
    ·                               ────────
    ╰────
   help: Move function declaration to function body root
 
   ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
-   ╭─[no_inner_declarations.mjs:1:27]
+   ╭─[no_inner_declarations.mts:1:27]
  1 │ (function() { if (test) { function doSomething() { } } }());
    ·                           ────────
    ╰────
   help: Move function declaration to function body root
 
   ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
-   ╭─[no_inner_declarations.mjs:1:16]
+   ╭─[no_inner_declarations.mts:1:16]
  1 │ while (test) { var foo; }
    ·                ───
    ╰────
   help: Move variable declaration to program root
 
   ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
-   ╭─[no_inner_declarations.mjs:1:38]
+   ╭─[no_inner_declarations.mts:1:38]
  1 │ function doSomething() { if (test) { var foo = 42; } }
    ·                                      ───
    ╰────
   help: Move variable declaration to function body root
 
   ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
-   ╭─[no_inner_declarations.mjs:1:27]
+   ╭─[no_inner_declarations.mts:1:27]
  1 │ (function() { if (test) { var foo; } }());
    ·                           ───
    ╰────
   help: Move variable declaration to function body root
 
   ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
-   ╭─[no_inner_declarations.mjs:1:41]
+   ╭─[no_inner_declarations.mts:1:41]
  1 │ const doSomething = () => { if (test) { var foo = 42; } }
    ·                                         ───
    ╰────
   help: Move variable declaration to program root
 
   ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
-   ╭─[no_inner_declarations.mjs:1:33]
+   ╭─[no_inner_declarations.mts:1:33]
  1 │ class C { method() { if(test) { var foo; } } }
    ·                                 ───
    ╰────
   help: Move variable declaration to function body root
 
   ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
-   ╭─[no_inner_declarations.mjs:1:32]
+   ╭─[no_inner_declarations.mts:1:32]
  1 │ class C { static { if (test) { var foo; } } }
    ·                                ───
    ╰────
   help: Move variable declaration to class static block body root
 
   ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
-   ╭─[no_inner_declarations.mjs:1:32]
+   ╭─[no_inner_declarations.mts:1:32]
  1 │ class C { static { if (test) { function foo() {} } } }
    ·                                ────────
    ╰────
   help: Move function declaration to class static block body root
 
   ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
-   ╭─[no_inner_declarations.mjs:1:51]
+   ╭─[no_inner_declarations.mts:1:51]
  1 │ class C { static { if (test) { if (anotherTest) { var foo; } } } }
    ·                                                   ───
    ╰────
   help: Move variable declaration to class static block body root
 
   ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
-   ╭─[no_inner_declarations.mjs:1:13]
+   ╭─[no_inner_declarations.mts:1:13]
  1 │ if (test) { function doSomething() { } }
    ·             ────────
    ╰────
   help: Move function declaration to program root
 
   ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
-   ╭─[no_inner_declarations.mjs:1:13]
+   ╭─[no_inner_declarations.mts:1:13]
  1 │ if (test) { function doSomething() { } }
    ·             ────────
    ╰────
   help: Move function declaration to program root
 
   ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
-   ╭─[no_inner_declarations.mjs:2:26]
+   ╭─[no_inner_declarations.mts:2:26]
  1 │ 'use strict'
  2 │              if (test) { function doSomething() { } }
    ·                          ────────
@@ -179,7 +179,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move function declaration to program root
 
   ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
-   ╭─[no_inner_declarations.mjs:2:26]
+   ╭─[no_inner_declarations.mts:2:26]
  1 │ 'use strict'
  2 │              if (test) { function doSomething() { } }
    ·                          ────────
@@ -187,7 +187,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move function declaration to program root
 
   ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
-   ╭─[no_inner_declarations.mjs:2:16]
+   ╭─[no_inner_declarations.mts:2:16]
  1 │ function foo() {'use strict'
  2 │              { function bar() { } } }
    ·                ────────
@@ -195,7 +195,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move function declaration to function body root
 
   ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
-   ╭─[no_inner_declarations.mjs:2:16]
+   ╭─[no_inner_declarations.mts:2:16]
  1 │ function foo() {'use strict'
  2 │              { function bar() { } } }
    ·                ────────
@@ -203,7 +203,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move function declaration to function body root
 
   ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
-   ╭─[no_inner_declarations.mjs:2:19]
+   ╭─[no_inner_declarations.mts:2:19]
  1 │ function doSomething() { 'use strict'
  2 │              do { function somethingElse() { } } while (test); }
    ·                   ────────
@@ -211,9 +211,37 @@ source: crates/oxc_linter/src/tester.rs
   help: Move function declaration to function body root
 
   ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
-   ╭─[no_inner_declarations.mjs:1:3]
+   ╭─[no_inner_declarations.mts:1:3]
  1 │ { function foo () {'use strict'
    ·   ────────
  2 │              console.log('foo called'); } }
+   ╰────
+  help: Move function declaration to program root
+
+  ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
+   ╭─[no_inner_declarations.mts:1:15]
+ 1 │ namespace N { function foo() {} }
+   ·               ────────
+   ╰────
+  help: Move function declaration to program root
+
+  ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
+   ╭─[no_inner_declarations.mts:1:15]
+ 1 │ namespace N { var x = 1; }
+   ·               ───
+   ╰────
+  help: Move variable declaration to program root
+
+  ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
+   ╭─[no_inner_declarations.mts:1:22]
+ 1 │ namespace N { export function bar() {} }
+   ·                      ────────
+   ╰────
+  help: Move function declaration to program root
+
+  ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
+   ╭─[no_inner_declarations.mts:1:24]
+ 1 │ namespace N { if (x) { function foo() {} } }
+   ·                        ────────
    ╰────
   help: Move function declaration to program root

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -13036,6 +13036,26 @@
       },
       "additionalProperties": false
     },
+    "Namespaces": {
+      "oneOf": [
+        {
+          "description": "Allow declarations directly inside TypeScript namespace or module bodies.",
+          "type": "string",
+          "enum": [
+            "allow"
+          ],
+          "markdownDescription": "Allow declarations directly inside TypeScript namespace or module bodies."
+        },
+        {
+          "description": "Disallow declarations directly inside TypeScript namespace or module bodies.",
+          "type": "string",
+          "enum": [
+            "disallow"
+          ],
+          "markdownDescription": "Disallow declarations directly inside TypeScript namespace or module bodies."
+        }
+      ]
+    },
     "NativeAllowList": {
       "anyOf": [
         {
@@ -14116,6 +14136,16 @@
             }
           ],
           "markdownDescription": "Controls whether function declarations in nested blocks are allowed in strict mode (ES6+ behavior)."
+        },
+        "namespaces": {
+          "description": "Controls whether declarations directly inside TypeScript namespace or module bodies are allowed.",
+          "default": null,
+          "allOf": [
+            {
+              "$ref": "#/definitions/Namespaces"
+            }
+          ],
+          "markdownDescription": "Controls whether declarations directly inside TypeScript namespace or module bodies are allowed."
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
Adds a `namespaces` option to `eslint/no-inner-declarations`:

```json
["error", "both", { "namespaces": "allow" }]
```

With `namespaces: "allow"`, `function`/`var` declarations placed directly inside a TypeScript `namespace`/`module` body are no longer reported. Declarations nested inside blocks within a namespace (e.g. `namespace N { if (x) { function f() {} } }`) are still reported. The default (`disallow`) is unchanged.

Closes #21143
