### PR TITLE
refactor(react_compiler): gate HIR debug printing behind a `debug` feature

### DIFF
--- a/crates/oxc_react_compiler/Cargo.toml
+++ b/crates/oxc_react_compiler/Cargo.toml
@@ -27,6 +27,11 @@ description = "oxc integration for the Rust port of React Compiler"
 doctest = false
 test = false
 
+[features]
+# Compile in the HIR debug printer (`react_compiler::debug_print`). Off by default;
+# the runtime `PluginOptions::debug` flag only produces output when this is enabled.
+debug = []
+
 [dependencies]
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }

--- a/crates/oxc_react_compiler/src/react_compiler/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/mod.rs
@@ -1,4 +1,26 @@
+#[cfg(feature = "debug")]
 pub mod debug_print;
+
+/// No-op stand-in for [`debug_print`] when the `debug` feature is off, so the HIR
+/// debug-print call sites still compile without pulling in the ~600-line printer.
+/// (The runtime `PluginOptions::debug` flag only produces output with the feature on.)
+#[cfg(not(feature = "debug"))]
+pub mod debug_print {
+    use crate::react_compiler_hir::HirFunction;
+    use crate::react_compiler_hir::environment::Environment;
+    use crate::react_compiler_hir::print::PrintFormatter;
+
+    pub fn debug_hir<'h>(_hir: &HirFunction<'h>, _env: &Environment<'h>) -> String {
+        String::new()
+    }
+
+    pub fn format_hir_function_into<'h>(
+        _reactive_fmt: &mut PrintFormatter<'_, 'h>,
+        _func: &HirFunction<'h>,
+    ) {
+    }
+}
+
 pub mod entrypoint;
 
 // Re-export from new crates for backwards compatibility


### PR DESCRIPTION
Puts the HIR debug printer (`react_compiler::debug_print`, ~600 lines) behind a new off-by-default `debug` cargo feature, so it isn't compiled into normal builds.

### How
- `Cargo.toml`: add `[features]` with `debug = []`.
- `react_compiler/mod.rs`: `#[cfg(feature = "debug")]` on `pub mod debug_print;`, plus a `#[cfg(not(feature = "debug"))]` no-op stub module exposing the two entry points the pipeline calls (`debug_hir`, `format_hir_function_into`).

The printer is threaded through the vendored `pipeline.rs` at ~70 `if context.debug_enabled { … }` sites (plus a closure capture and a local formatter fn that are required pass arguments). Gating each site would scatter ~75 `#[cfg]` attributes through vendored code and fight re-syncability, so gating the module with a stub keeps `pipeline.rs`/`imports.rs` untouched while still compiling the printer out by default.

### Behavior
No change to default builds: nothing in the workspace sets `PluginOptions::debug`, so the printer was never triggered. To get HIR dumps, build with `--features oxc_react_compiler/debug` and set `PluginOptions::debug = true`.

### Verified
- Default build (stub) and `--features debug` (real printer) both compile clean.
- `oxc_react_compiler` tests pass in both modes (15/15); clippy clean in both.
- `oxc`, `oxc_linter`, `oxc_transformer` build with default features.