### PR TITLE
fix(formatter_css): keep selector value contain line-break without breaking line

### DIFF
--- a/crates/oxc_formatter_css/AGENTS.md
+++ b/crates/oxc_formatter_css/AGENTS.md
@@ -244,7 +244,3 @@ cargo run -p oxc_formatter_css --example embedded_debug file.scss               
 ## Roadmap (TODO: Follow Prettier main)
 
 The guiding axis is Prettier compatibility, matching what is in Prettier's unreleased changelog (main has them, next stable will).
-
-- [#18605](https://github.com/prettier/prettier/blob/main/changelog_unreleased/css/18605.md):
-  Don't break a selector when its attribute value contains an escaped literal newline (`foo="long\\<newline>continuation"`).
-  We currently break before the long span; Prettier main keeps the selector on one line.

--- a/crates/oxc_formatter_css/src/print/selector.rs
+++ b/crates/oxc_formatter_css/src/print/selector.rs
@@ -352,7 +352,7 @@ fn write_attribute_selector<'a>(attribute: &AttributeSelector<'a>, f: &mut CssFo
                 write!(f, [text(quote), text(source.text_for(&span)), text(quote)]);
             }
             AttributeSelectorValue::Str(InterpolableStr::Literal(str)) => {
-                value::write_str(str, f);
+                value::write_attribute_str(str, f);
             }
             // Interpolated string (`[x="#{$v}"]`):
             // re-quote the outer quotes per `singleQuote`, keep the `#{}` content verbatim.
@@ -365,7 +365,7 @@ fn write_attribute_selector<'a>(attribute: &AttributeSelector<'a>, f: &mut CssFo
             // so it re-quotes per `singleQuote` like the value-position handler.
             AttributeSelectorValue::LessEscapedStr(escaped) => {
                 write!(f, "~");
-                value::write_str(&escaped.str, f);
+                value::write_attribute_str(&escaped.str, f);
             }
             AttributeSelectorValue::Percentage(_)
             | AttributeSelectorValue::Number(_)

--- a/crates/oxc_formatter_css/src/print/value.rs
+++ b/crates/oxc_formatter_css/src/print/value.rs
@@ -117,6 +117,15 @@ pub(super) fn write_str<'a>(str: &Str<'a>, f: &mut CssFormatter<'_, 'a>) {
     write!(f, text(arena_cow_str(&printed, f)));
 }
 
+/// [`write_str`] for attribute-selector values.
+/// Prettier wraps the value in `replaceEndOfLine(..., literallineWithoutBreakParent)`:
+/// an escaped literal newline inside the value prints verbatim,
+/// but must not force a break in front of the selector.
+pub(super) fn write_attribute_str<'a>(str: &Str<'a>, f: &mut CssFormatter<'_, 'a>) {
+    let printed = print_string(str.raw, f.options());
+    write!(f, text(arena_cow_str(&printed, f)).without_expand_parent());
+}
+
 /// Prettier's `adjustNumbers(adjustStrings(...))` over a raw source slice:
 /// strings re-quote via `printString`,
 /// standalone numbers (not glued to a word part) get `printCssNumber` + lowercased/canonical unit;

--- a/tasks/prettier_conformance/snapshots/prettier.css.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.css.snap.md
@@ -1,10 +1,9 @@
-css compatibility: 147/150 (98.00%), 25 files skipped
+css compatibility: 148/150 (98.67%), 25 files skipped
 
 # Failed
 
 | Spec path | Failed or Passed | Match ratio |
 | :-------- | :--------------: | :---------: |
-| css/escaped-attribute/test.css | 💥 | 76.00% |
 | css/stylefmt-repo/at-media/at-media.css | 💥 | 90.48% |
 | css/stylefmt-repo/cssnext-example/cssnext-example.css | 💥 | 98.31% |
 


### PR DESCRIPTION
Part of #23923

```css
/* Input */
div span[foo="a long long long long long long long long\
long long long long attritbute value"] {
}

/* Before */
div
  span[foo="a long long long long long long long long\
long long long long attritbute value"] {
}

/* After */
div span[foo="a long long long long long long long long\
long long long long attritbute value"] {
}
```