### PR TITLE
fix(linter/unicorn/filename-case): keep digits attached in screamingSnakeCase

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/filename_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/filename_case.rs
@@ -224,10 +224,21 @@ enum CaseCheck {
 impl CaseCheck {
     fn convert(self, name: &str) -> String {
         match self {
-            CaseCheck::Convert(case) => Converter::new()
-                .remove_boundaries(&[Boundary::LowerDigit, Boundary::DigitLower])
-                .to_case(case)
-                .convert(name),
+            CaseCheck::Convert(case) => {
+                // SCREAMING_SNAKE_CASE keeps digits attached to their word (e.g. `V2_API`,
+                // `FOO2BAR`), so drop the upper/digit boundaries too.
+                let boundaries: &[Boundary] = if case == Case::UpperSnake {
+                    &[
+                        Boundary::LowerDigit,
+                        Boundary::DigitLower,
+                        Boundary::UpperDigit,
+                        Boundary::DigitUpper,
+                    ]
+                } else {
+                    &[Boundary::LowerDigit, Boundary::DigitLower]
+                };
+                Converter::new().remove_boundaries(boundaries).to_case(case).convert(name)
+            }
             CaseCheck::Lowercase => name.cow_to_lowercase().into_owned(),
         }
     }
@@ -461,6 +472,9 @@ fn test() {
         test_case("src/foo/FOO_BAR.test.js", "screamingSnakeCase"),
         test_case("src/foo/FOO_BAR.test_utils.js", "screamingSnakeCase"),
         test_case("src/foo/_FOO_BAR.js", "screamingSnakeCase"),
+        // digits stay attached to their word
+        test_case("src/foo/V2_API.js", "screamingSnakeCase"),
+        test_case("src/foo/FOO2BAR.js", "screamingSnakeCase"),
         test_case("", "lowercase"),
         test_case("", "screamingSnakeCase"),
         test_case("", "camelCase"),


### PR DESCRIPTION
Follow-up to #24045.

`screamingSnakeCase` removed only the lower/digit boundaries, so `convert_case` still split on the remaining upper/digit boundaries — `V2_API.js` and `FOO2BAR.js` were wrongly reported (converted to `V_2_API` / `FOO_2_BAR`). This drops the upper/digit boundaries for `SCREAMING_SNAKE_CASE` too, so digits stay attached to their word. Other cases are unchanged.
