### PR TITLE
fix(minifier): remove stale pure_functions entries for redeclared symbols

### DIFF
--- a/crates/oxc_minifier/src/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/src/peephole/remove_dead_code.rs
@@ -499,6 +499,15 @@ impl<'a> PeepholeOptimizations {
             return;
         }
         let Some(symbol_id) = id.and_then(|id| id.symbol_id.get()) else { return };
+        // Redeclarations are span-only in oxc_semantic and create no references, so
+        // they're invisible to the read-only-refs check below. The runtime-winning
+        // declaration may be an impure one that never reaches this function, so a
+        // "pure" fact recorded for another declaration of the same symbol cannot be
+        // trusted and must not survive.
+        if !ctx.scoping().symbol_redeclarations(symbol_id).is_empty() {
+            ctx.state.pure_functions.remove(&symbol_id);
+            return;
+        }
         if ctx.scoping().get_resolved_references(symbol_id).all(|r| r.flags().is_read_only()) {
             ctx.state.pure_functions.insert(
                 symbol_id,

--- a/crates/oxc_minifier/tests/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_dead_code.rs
@@ -1,6 +1,8 @@
+use oxc_span::SourceType;
+
 use crate::{
     CompressOptions, CompressOptionsUnused, default_options, test, test_options, test_same,
-    test_same_options,
+    test_same_options, test_same_options_source_type,
 };
 
 #[track_caller]
@@ -260,4 +262,32 @@ fn remove_empty_function() {
 
     test_same_options("function* foo({}) {} foo()", &options);
     test_options("var foo = function*({}) {}; foo()", "(function*({}) {})()", &options);
+}
+
+#[test]
+fn redeclared_pure_function_is_not_folded_var() {
+    // `var foo` redeclarations are span-only in oxc_semantic and create no references,
+    // so the read-only-refs gate on the first declarator can't see the second one.
+    // Whichever declaration wins at runtime (here, the `if` branch, when truthy) may
+    // be impure, so a stale "pure" fact recorded for an earlier declarator must not
+    // survive to fold the call.
+    test_same("var foo = (u) => {}; if (g) var foo = (a) => { console.log(a); }; foo('x');");
+}
+
+#[test]
+fn redeclared_pure_function_is_not_folded_function_declaration() {
+    // Duplicate `function` declarations are legal in sloppy scripts (SyntaxError in
+    // modules); the second declaration wins at runtime.
+    test_same_options_source_type(
+        "function foo(u) {} function foo(a) { console.log(a); } foo('x');",
+        SourceType::cjs().with_script(true),
+        &default_options(),
+    );
+}
+
+#[test]
+fn non_redeclared_pure_function_still_folds() {
+    // Regression guard for `redeclared_pure_function_is_not_folded`: a single,
+    // un-redeclared pure function must still fold as before.
+    test("const foo = (u) => {}; foo(1)", "const foo = (u) => {};");
 }


### PR DESCRIPTION
Redeclarations of a symbol (e.g. a conditionally-redeclared `var`, or duplicate `function` declarations in a sloppy script) are span-only in `oxc_semantic` and create no references, so the read-only-refs check in `try_save_pure_function` can't see them. If an earlier declaration is pure but a later, runtime-winning redeclaration is not, the stale `pure_functions` entry survived and caused call sites to be folded away, silently dropping the impure declaration's side effects.

## Example

```js
var foo = (u) => {};
if (g) var foo = (a) => { console.log(a); };
foo('x');
```

Before (miscompiled — `foo('x')` deleted, so `console.log` never runs when `g` is truthy):

```js
var foo = (u) => {};
if (g) var foo = (a) => {
	console.log(a);
};
```

After: the call is preserved. Covered by new regression tests for both the conditional-`var` (module) and duplicate-`function`-declaration (sloppy script) shapes.
