### PR TITLE
feat(minifier): drop unused arguments to stable functions

### DIFF
--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -372,7 +372,10 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
                 Statement::ForStatement(_) => Self::try_fold_for(stmt, ctx),
                 Statement::TryStatement(_) => Self::try_fold_try(stmt, ctx),
                 Statement::LabeledStatement(_) => Self::try_fold_labeled(stmt, ctx),
-                Statement::FunctionDeclaration(_) => {
+                Statement::FunctionDeclaration(function) => {
+                    if Self::record_function_declaration_dead_arguments(function, ctx) {
+                        ctx.state.request_revisit();
+                    }
                     Self::remove_unused_function_declaration(stmt, ctx);
                 }
                 Statement::ClassDeclaration(_) => {
@@ -454,6 +457,9 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
         ctx: &mut TraverseCtx<'a>,
     ) {
         if ctx.is_tree_shake_only() {
+            if Self::record_const_arrow_dead_arguments(decl, ctx) {
+                ctx.state.request_revisit();
+            }
             return;
         }
         Self::substitute_variable_declaration(decl, ctx);

--- a/crates/oxc_minifier/src/peephole/normalize.rs
+++ b/crates/oxc_minifier/src/peephole/normalize.rs
@@ -109,12 +109,20 @@ impl<'a> Traverse<'a> for Normalize {
         decl: &mut VariableDeclaration<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
+        if ctx.is_tree_shake_only() {
+            PeepholeOptimizations::record_const_arrow_dead_arguments(decl, ctx);
+        }
         if self.options.convert_const_to_let {
             Self::convert_const_to_let(decl, ctx);
         }
     }
 
     fn exit_statement(&mut self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
+        if ctx.is_tree_shake_only()
+            && let Statement::FunctionDeclaration(function) = stmt
+        {
+            PeepholeOptimizations::record_function_declaration_dead_arguments(function, ctx);
+        }
         match stmt {
             Statement::WhileStatement(_) if self.options.convert_while_to_fors => {
                 Self::convert_while_to_for(stmt, ctx);

--- a/crates/oxc_minifier/src/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/src/peephole/remove_dead_code.rs
@@ -4,6 +4,10 @@ use oxc_ast::ast::*;
 use oxc_ast_visit::VisitJs;
 use oxc_ecmascript::{constant_evaluation::ConstantEvaluation, side_effects::MayHaveSideEffects};
 use oxc_span::GetSpan;
+use oxc_syntax::{
+    scope::{ScopeFlags, ScopeId},
+    symbol::SymbolId,
+};
 
 use crate::{TraverseCtx, keep_var::KeepVar, symbol_metadata::FunctionSummary};
 
@@ -499,35 +503,141 @@ impl<'a> PeepholeOptimizations {
             return;
         }
         let Some(symbol_id) = id.and_then(|id| id.symbol_id.get()) else { return };
+        if !Self::has_stable_function_binding(symbol_id, ctx) {
+            // Discard a summary from an earlier pass. Removing a write or the
+            // last direct eval can make the binding safe again later.
+            ctx.state.symbols.clear_function_summary(symbol_id);
+            return;
+        }
+        ctx.state.symbols.set_function_summary(
+            symbol_id,
+            if body.is_empty() {
+                FunctionSummary::SideEffectFreeReturnsUndefined
+            } else {
+                FunctionSummary::SideEffectFree
+            },
+        );
+    }
+
+    fn has_stable_function_binding(symbol_id: SymbolId, ctx: &TraverseCtx<'a>) -> bool {
         let binding_scope_id = ctx.scoping().symbol_scope_id(symbol_id);
         let binding_scope_flags = ctx.scoping().scope_flags(binding_scope_id);
         // Redeclarations are span-only in semantic and create no references,
         // so the read-only-reference check below cannot see them. A different
-        // declaration of the same symbol may be impure and win at runtime.
+        // declaration of the same symbol may win at runtime.
         if !ctx.scoping().symbol_redeclarations(symbol_id).is_empty() {
-            ctx.state.symbols.clear_function_summary(symbol_id);
-            return;
+            return false;
         }
         // Direct eval and Script global properties can replace the binding
-        // without producing a resolved write reference. Discard any summary
-        // from an earlier pass; removing the last eval may make the binding
-        // safe later, while Script roots are rejected again on every pass.
+        // without producing a resolved write reference.
         if binding_scope_flags.contains_direct_eval()
             || (ctx.source_type().is_script() && binding_scope_id == ctx.scoping().root_scope_id())
         {
-            ctx.state.symbols.clear_function_summary(symbol_id);
-            return;
+            return false;
         }
-        if ctx.scoping().get_resolved_references(symbol_id).all(|r| r.flags().is_read_only()) {
-            ctx.state.symbols.set_function_summary(
-                symbol_id,
-                if body.is_empty() {
-                    FunctionSummary::SideEffectFreeReturnsUndefined
-                } else {
-                    FunctionSummary::SideEffectFree
-                },
-            );
+        ctx.scoping().get_resolved_references(symbol_id).all(|r| r.flags().is_read_only())
+    }
+
+    /// Record conservative dead-parameter summaries for immutable local arrows.
+    ///
+    /// Normalize seeds the map before the first peephole pass. Later passes
+    /// refresh it after reference pruning exposes newly unused parameters, so
+    /// chains of calls converge without making results depend on reinvoking DCE.
+    /// Facts are monotone: DCE removes references but never adds parameter uses.
+    pub fn record_const_arrow_dead_arguments(
+        declaration: &VariableDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> bool {
+        if declaration.kind != VariableDeclarationKind::Const {
+            return false;
         }
+        let mut changed = false;
+        for declarator in &declaration.declarations {
+            let BindingPattern::BindingIdentifier(id) = &declarator.id else { continue };
+            let Some(Expression::ArrowFunctionExpression(function)) = &declarator.init else {
+                continue;
+            };
+            let Some(symbol_id) = id.symbol_id.get() else { continue };
+            let Some(scope_id) = function.scope_id.get() else { continue };
+            if ctx.scoping().scope_flags(scope_id).contains_direct_eval() {
+                continue;
+            }
+            if let Some(prefix) = Self::dead_trailing_parameter_prefix(&function.params, ctx) {
+                changed |= ctx.state.symbols.record_dead_argument_prefix(symbol_id, prefix);
+            }
+        }
+        changed
+    }
+
+    /// Record dead-parameter summaries for stable strict function declarations.
+    ///
+    /// Strict mode prevents external observation through `function.arguments`.
+    /// A reference to the function's own `arguments` object remains observable
+    /// independently of parameter-symbol liveness and therefore rejects the
+    /// summary.
+    pub fn record_function_declaration_dead_arguments(
+        function: &Function<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> bool {
+        let Some(id) = &function.id else { return false };
+        let Some(symbol_id) = id.symbol_id.get() else { return false };
+        let Some(scope_id) = function.scope_id.get() else { return false };
+        let scope_flags = ctx.scoping().scope_flags(scope_id);
+        if function.body.is_none()
+            || !scope_flags.is_strict_mode()
+            || scope_flags.contains_direct_eval()
+        {
+            return false;
+        }
+        let Some(prefix) = Self::dead_trailing_parameter_prefix(&function.params, ctx) else {
+            return false;
+        };
+        if Self::function_uses_arguments(scope_id, ctx)
+            || !Self::has_stable_function_binding(symbol_id, ctx)
+        {
+            return false;
+        }
+        ctx.state.symbols.record_dead_argument_prefix(symbol_id, prefix)
+    }
+
+    fn function_uses_arguments(function_scope_id: ScopeId, ctx: &TraverseCtx<'a>) -> bool {
+        let Some(references) = ctx.scoping().root_unresolved_references().get("arguments") else {
+            return false;
+        };
+        references.iter().any(|&reference_id| {
+            let reference_scope_id = ctx.scoping().get_reference(reference_id).scope_id();
+            ctx.scoping().scope_ancestors(reference_scope_id).find(|&scope_id| {
+                let flags = ctx.scoping().scope_flags(scope_id);
+                flags.is_function() && !flags.is_arrow()
+            }) == Some(function_scope_id)
+        })
+    }
+
+    fn dead_trailing_parameter_prefix(
+        params: &FormalParameters<'a>,
+        ctx: &TraverseCtx<'a>,
+    ) -> Option<usize> {
+        if params.rest.is_some()
+            || !params
+                .items
+                .iter()
+                .all(|param| param.pattern.is_binding_identifier() && param.initializer.is_none())
+        {
+            return None;
+        }
+
+        let mut prefix = params.items.len();
+        while prefix > 0 {
+            let BindingPattern::BindingIdentifier(id) = &params.items[prefix - 1].pattern else {
+                break;
+            };
+            let Some(symbol_id) = id.symbol_id.get() else { break };
+            if !ctx.scoping().symbol_is_unused(symbol_id) {
+                break;
+            }
+            prefix -= 1;
+        }
+        (prefix < params.items.len()).then_some(prefix)
     }
 
     pub fn remove_dead_code_call_expression(expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
@@ -546,8 +656,53 @@ impl<'a> PeepholeOptimizations {
                 exprs.push(Expression::new_void_0(e.span, ctx));
                 let new_expr = Expression::new_sequence_expression(e.span, exprs, ctx);
                 ctx.replace_expression(expr, new_expr);
+                return;
             }
         }
+
+        if !ctx.is_tree_shake_only() {
+            return;
+        }
+        let Expression::Identifier(ident) = &e.callee else { return };
+        let reference_id = ident.reference_id();
+        let reference = ctx.scoping().get_reference(reference_id);
+        let Some(symbol_id) = reference.symbol_id() else { return };
+        let Some(prefix) = ctx.state.symbols.dead_argument_prefix(symbol_id) else { return };
+        if Self::reference_may_be_dynamically_shadowed(reference.scope_id(), ctx) {
+            return;
+        }
+        if e.arguments.len() <= prefix
+            || e.arguments.iter().any(|argument| matches!(argument, Argument::SpreadElement(_)))
+        {
+            return;
+        }
+
+        while e.arguments.len() > prefix {
+            let Some(argument) = e.arguments.last_mut().and_then(Argument::as_expression_mut)
+            else {
+                return;
+            };
+            // Reuse unused-expression analysis so hidden effects and derived-
+            // constructor `this` before `super()` remain observable.
+            if !Self::remove_unused_expression(argument, ctx) {
+                break;
+            }
+            let dropped = e.arguments.pop().unwrap().into_expression();
+            ctx.drop_expression(&dropped);
+        }
+    }
+
+    /// A `with` object or sloppy direct eval can dynamically replace a statically
+    /// resolved identifier.
+    pub(super) fn reference_may_be_dynamically_shadowed(
+        reference_scope_id: ScopeId,
+        ctx: &TraverseCtx<'a>,
+    ) -> bool {
+        ctx.scoping().scope_ancestors(reference_scope_id).any(|scope_id| {
+            ctx.scoping()
+                .scope_flags(scope_id)
+                .intersects(ScopeFlags::With | ScopeFlags::DirectEval)
+        })
     }
 
     /// Whether the indirect access should be kept.

--- a/crates/oxc_minifier/src/symbol_state.rs
+++ b/crates/oxc_minifier/src/symbol_state.rs
@@ -20,6 +20,7 @@ use crate::{
 /// The fields stay separate because they have different storage and reset
 /// contracts:
 /// - `values` is dense scratch rebuilt for each peephole pass;
+/// - `dead_argument_prefixes` is sparse monotone DCE metadata retained across passes;
 /// - `persistent` is sparse metadata retained across passes;
 /// - `liveness` is stable observability metadata plus optional graph results.
 pub struct SymbolState<'a> {
@@ -28,6 +29,8 @@ pub struct SymbolState<'a> {
     /// Sized once from `Scoping::symbols_len()`; no minifier pass mints new
     /// symbols, so indexed writes intentionally panic if that contract changes.
     values: IndexVec<SymbolId, Option<SymbolValue<'a>>>,
+    /// Monotone DCE summaries for stable local functions with dead trailing parameters.
+    dead_argument_prefixes: FxHashMap<SymbolId, u32>,
     persistent: FxHashMap<SymbolId, PersistentSymbolMetadata>,
     liveness: Option<SymbolLiveness<'a>>,
 }
@@ -43,6 +46,7 @@ impl<'a> SymbolState<'a> {
         values.resize_with(scoping.symbols_len(), || None);
         Self {
             values,
+            dead_argument_prefixes: FxHashMap::default(),
             persistent: FxHashMap::default(),
             liveness: SymbolLiveness::new_if_enabled(source_type, options, scoping, allocator),
         }
@@ -82,6 +86,30 @@ impl<'a> SymbolState<'a> {
         self.persistent
             .get(&symbol_id)
             .map_or(FunctionSummary::Unknown, PersistentSymbolMetadata::function_summary)
+    }
+
+    /// Record a dead-argument prefix, returning whether the reusable fact changed.
+    pub fn record_dead_argument_prefix(&mut self, symbol_id: SymbolId, prefix: usize) -> bool {
+        let prefix = u32::try_from(prefix).expect("function parameter count must fit in u32");
+        match self.dead_argument_prefixes.entry(symbol_id) {
+            std::collections::hash_map::Entry::Occupied(mut entry) => {
+                if *entry.get() == prefix {
+                    false
+                } else {
+                    debug_assert!(prefix < *entry.get(), "dead argument prefix must be monotone");
+                    entry.insert(prefix);
+                    true
+                }
+            }
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(prefix);
+                true
+            }
+        }
+    }
+
+    pub fn dead_argument_prefix(&self, symbol_id: SymbolId) -> Option<usize> {
+        self.dead_argument_prefixes.get(&symbol_id).map(|&prefix| prefix as usize)
     }
 
     pub fn record_member_write_effect(&mut self, symbol_id: SymbolId, effect: MemberWriteEffect) {

--- a/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
+++ b/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
@@ -1056,3 +1056,105 @@ fn dce_keeps_implicitly_observable_bindings() {
         options,
     );
 }
+
+// https://github.com/oxc-project/oxc/issues/23866
+#[test]
+fn dce_drops_dead_trailing_const_arrow_arguments() {
+    test(
+        "const foo = async (assets) => ({}); export default await foo({ bar: 'baz' })",
+        "const foo = async (assets) => ({}); export default await foo()",
+    );
+
+    // Dropping the argument also removes a nested dynamic import that would
+    // otherwise keep an unnecessary chunk alive in Rolldown.
+    test(
+        "const foo = async (assets) => ({}); export default await foo({ image: () => import('./image.js') })",
+        "const foo = async (assets) => ({}); export default await foo()",
+    );
+    test(
+        "export const foo = async (unused) => bar(); foo({ image: () => import('./image.js') })",
+        "export const foo = async (unused) => bar(); foo()",
+    );
+    test(
+        "const foo = (unused) => { bar() }; foo(1); foo(2)",
+        "const foo = (unused) => { bar() }; foo(); foo()",
+    );
+    test(
+        "const call = () => foo(1); const foo = (unused) => bar(); call()",
+        "const call = () => foo(); const foo = (unused) => bar(); call()",
+    );
+}
+
+#[test]
+fn dce_cascades_dead_trailing_const_arrow_arguments() {
+    test(
+        "const leaf = (value, unused) => value; const middle = (value, unused) => leaf(value, unused); const outer = (value, unused) => middle(value, unused); consume(outer(1, 2))",
+        "const leaf = (value, unused) => value; const middle = (value, unused) => leaf(value); const outer = (value, unused) => middle(value); consume(outer(1))",
+    );
+
+    // Propagate parameter liveness through the chain, but preserve an argument
+    // whose evaluation remains observable at the outermost call.
+    test(
+        "const leaf = (value, unused) => value; const middle = (value, unused) => leaf(value, unused); const outer = (value, unused) => middle(value, unused); consume(outer(1, sideEffect()))",
+        "const leaf = (value, unused) => value; const middle = (value, unused) => leaf(value); const outer = (value, unused) => middle(value); consume(outer(1, sideEffect()))",
+    );
+
+    // Revisit calls that precede the declaration whose summary became stronger.
+    test(
+        "const leaf = (value, unused) => value; const outer = (value, unused) => middle(value, unused); consume(outer(1, 2)); const middle = (value, unused) => leaf(value, unused)",
+        "const leaf = (value, unused) => value; const outer = (value, unused) => middle(value); consume(outer(1)); const middle = (value, unused) => leaf(value)",
+    );
+}
+
+// https://github.com/oxc-project/oxc/issues/23866#issuecomment-5102502151
+#[test]
+fn dce_drops_dead_trailing_function_declaration_arguments() {
+    test(
+        "const __DEV__ = false; function computed(getterOrOptions, debugOptions) { const cRef = { value: getterOrOptions }; if (__DEV__ && debugOptions) { cRef.onTrack = debugOptions.onTrack; cRef.onTrigger = debugOptions.onTrigger } return cRef } consume(computed(123, { onTrack: () => {} }))",
+        "function computed(getterOrOptions, debugOptions) { return { value: getterOrOptions } } consume(computed(123))",
+    );
+
+    // A normal function can observe its actual arguments independently of its
+    // parameter bindings.
+    test_same("function foo(unused) { consume(arguments.length) } foo(1)");
+    test_same("function foo(unused) { return () => arguments.length } consume(foo(1))");
+
+    // A nested normal function owns a different arguments object.
+    test(
+        "function foo(unused) { return function () { consume(arguments.length) } } consume(foo(1))",
+        "function foo(unused) { return function () { consume(arguments.length) } } consume(foo())",
+    );
+
+    // Direct eval can observe a parameter even when static references cannot.
+    test_same("function foo(unused) { eval('consume(unused)') } foo(1)");
+
+    // A written binding no longer proves which function a direct call invokes.
+    test_same("function foo(unused) { bar() } foo = replacement; foo(1)");
+
+    // Sloppy functions expose their current arguments through `foo.arguments`.
+    test_same_source_type("function foo(unused) { bar() } consume(foo(1))", SourceType::cjs());
+}
+
+#[test]
+fn dce_keeps_observable_trailing_const_arrow_arguments() {
+    test_same("const foo = (unused) => bar(); foo(sideEffect())");
+    test_same("let foo = (unused) => bar(); foo(1); foo = replacement");
+    test_same("const foo = (unused) => eval(\"unused\"); consume(foo(1))");
+    test_same("const foo = (a, b) => bar(b); foo(1, 2)");
+    test_same("const foo = (unused = sideEffect()) => bar(); foo(1)");
+    test_same("const foo = ({ unused }) => bar(); foo(value)");
+    test_same("const foo = (...args) => bar(args); foo(1)");
+    test_same("const foo = function(unused) { return arguments.length }; consume(foo(1))");
+    test_same("const foo = (unused) => bar(); foo(...values)");
+    test_same(
+        "class Base {} class Derived extends Base { constructor() { const foo = (unused) => bar(); foo(this); super() } } consume(new Derived())",
+    );
+    test_same_source_type(
+        "function outer(object) { const foo = (unused) => bar(); with (object) foo(1) } outer(source)",
+        SourceType::cjs().with_script(true),
+    );
+    test_same_source_type(
+        "const foo = (unused) => bar(); function outer() { eval(\"var foo = function(value) { return value }\"); consume(foo(1)) } outer()",
+        SourceType::cjs(),
+    );
+}


### PR DESCRIPTION
Unused arguments to locally known functions remain in DCE output. In Rolldown,
an otherwise removable object can contain a dynamic import or production-only
Vue debug options and keep unnecessary code alive.

Monitor Oxc also exposed an idempotency problem with a one-time parameter
summary. Removing an argument from a leaf call can make the forwarding
parameter of its caller unused. The old implementation stopped there, so a
second DCE invocation changed the output again.

DCE now seeds conservative dead-parameter summaries during Normalize and
refreshes them as references are pruned. DCE only removes parameter uses, so
each summary can only strengthen and the existing peephole loop converges in a
single invocation. This reuses the existing summary map and revisit signal; it
does not add another state collection for the cascade.

The scope remains conservative. Direct identifier calls to `const` arrows with
simple parameters are supported. Function declarations are supported only when
the function is strict, its binding cannot be reassigned, redeclared, or
dynamically replaced, and neither the body nor a nested arrow observes its
`arguments` object. Sloppy declarations, function expressions, default or
destructured parameters, rest parameters, direct eval, dynamic `with`
shadowing, spreads, and observable argument evaluation remain unchanged.

## Example

Input:

```js
const foo = async (assets) => ({});
export default await foo({
  image: () => import("./image.js"),
});
```

Before:

```js
const foo = async (assets) => ({});
export default await foo({
  image: () => import("./image.js"),
});
```

After:

```js
const foo = async (assets) => ({});
export default await foo();
```

The Vue-style strict function declaration reported in
[#23866](https://github.com/oxc-project/oxc/issues/23866#issuecomment-5102502151)
is covered by a regression test that removes its production-only debug options.

Verified with the full `oxc_minifier` suite (645 integration tests passed, 36
ignored), cascading and source-order idempotency regressions, Clippy with
warnings denied, formatting, and `just minsize`. Full-compression size,
iteration, and allocation snapshots are unchanged.

Closes #23866

Implemented with AI assistance (OpenAI Codex). The contributor remains
responsible for reviewing, understanding, and submitting these changes under
the repository AI usage policy.
