### PR TITLE
refactor(react_compiler): borrow semantic in compile pipeline

### DIFF
--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -7,7 +7,7 @@ use std::{
     sync::Arc,
 };
 
-use oxc_allocator::ArenaBox;
+use oxc_allocator::{Allocator, ArenaBox};
 use oxc_diagnostics::{OxcDiagnostic, Severity};
 use oxc_parser::Token;
 use oxc_semantic::Semantic;
@@ -146,6 +146,8 @@ pub struct ContextHost<'a> {
     /// A file can have multiple script entries.
     /// Some rules (like vue) need the information of the other entries.
     pub(super) sub_hosts: Vec<ContextSubHost<'a>>,
+    /// Allocator that owns the parsed AST and related semantic data.
+    pub(super) allocator: &'a Allocator,
     /// The current index which will be linted.
     current_sub_host_index: Cell<usize>,
     /// Diagnostics reported by the linter.
@@ -181,6 +183,7 @@ impl<'a> ContextHost<'a> {
     pub fn new<P: AsRef<Path>>(
         file_path: P,
         sub_hosts: Vec<ContextSubHost<'a>>,
+        allocator: &'a Allocator,
         options: LintOptions,
         config: Arc<LintConfig>,
     ) -> Self {
@@ -196,6 +199,7 @@ impl<'a> ContextHost<'a> {
 
         Self {
             sub_hosts,
+            allocator,
             current_sub_host_index: Cell::new(0),
             diagnostics: RefCell::new(Vec::with_capacity(DIAGNOSTICS_INITIAL_CAPACITY)),
             fix: options.fix,
@@ -210,6 +214,12 @@ impl<'a> ContextHost<'a> {
     /// The current [`ContextSubHost`]
     pub fn current_sub_host(&self) -> &ContextSubHost<'a> {
         &self.sub_hosts[self.current_sub_host_index.get()]
+    }
+
+    /// Allocator that owns the parsed AST and semantic data.
+    #[inline]
+    pub fn allocator(&self) -> &'a Allocator {
+        self.allocator
     }
 
     /// Get mutable reference to the current [`ContextSubHost`]

--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -4,6 +4,7 @@ use std::{borrow::Cow, ffi::OsStr, ops::Deref, path::Path, rc::Rc};
 
 use javascript_globals::{GLOBALS, GLOBALS_BUILTIN, GLOBALS_ES2026};
 
+use oxc_allocator::Allocator;
 use oxc_ast::ast::IdentifierReference;
 use oxc_cfg::ControlFlowGraph;
 use oxc_diagnostics::{OxcDiagnostic, Severity};
@@ -106,6 +107,12 @@ impl<'a> LintContext<'a> {
     #[inline]
     pub fn semantic(&self) -> &Semantic<'a> {
         self.parent.semantic()
+    }
+
+    /// Allocator that owns the parsed AST and semantic data.
+    #[inline]
+    pub fn allocator(&self) -> &'a Allocator {
+        self.parent.allocator()
     }
 
     #[inline]

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -367,7 +367,8 @@ impl Linter {
         let ResolvedLinterState { rules, config, external_rules } = self.config.resolve(path);
         let mut timing_recorder = TIMINGS.then(|| RuleTimingRecorder::with_capacity(rules.len()));
 
-        let mut ctx_host = Rc::new(ContextHost::new(path, context_sub_hosts, self.options, config));
+        let mut ctx_host =
+            Rc::new(ContextHost::new(path, context_sub_hosts, allocator, self.options, config));
 
         #[cfg(debug_assertions)]
         let mut current_diagnostic_index = 0;

--- a/crates/oxc_linter/src/rules/react/react_compiler.rs
+++ b/crates/oxc_linter/src/rules/react/react_compiler.rs
@@ -124,7 +124,7 @@ impl Rule for ReactCompiler {
         let program = ctx.nodes().program();
         let options = react_compiler_options(ctx.file_path().to_str().map(ToString::to_string));
 
-        let result = oxc_react_compiler::lint(program, options);
+        let result = oxc_react_compiler::lint(program, ctx.semantic(), ctx.allocator(), options);
 
         let diagnostics = result.diagnostics.into_vec();
         let diagnostics = if self.report_all_bailouts {

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -377,6 +377,7 @@ mod test {
                     0,
                     ContextSubHostOptions::default(),
                 )],
+                &allocator,
                 LintOptions::default(),
                 Arc::default(),
             ))

--- a/crates/oxc_linter/src/utils/regex.rs
+++ b/crates/oxc_linter/src/utils/regex.rs
@@ -272,6 +272,7 @@ mod test {
                 0,
                 ContextSubHostOptions::default(),
             )],
+            &allocator,
             LintOptions::default(),
             Arc::default(),
         ))

--- a/crates/oxc_react_compiler/examples/react_compiler.rs
+++ b/crates/oxc_react_compiler/examples/react_compiler.rs
@@ -17,6 +17,7 @@ use std::path::Path;
 use oxc_allocator::Allocator;
 use oxc_codegen::Codegen;
 use oxc_parser::Parser;
+use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
 
 use oxc_react_compiler::{PluginOptions, transform};
@@ -38,7 +39,13 @@ fn main() {
     let allocator = Allocator::default();
     let mut program = Parser::new(&allocator, &source_text, source_type).parse().program;
 
-    let result = transform(&mut program, &allocator, PluginOptions::default());
+    let mut result = {
+        let semantic = SemanticBuilder::new().with_build_nodes(true).build(&program).semantic;
+        transform(&program, &semantic, &allocator, PluginOptions::default())
+    };
+    if let Some(compiled) = result.program.take() {
+        program = compiled;
+    }
 
     if !result.diagnostics.is_empty() {
         println!("Diagnostics:\n");

--- a/crates/oxc_react_compiler/src/lib.rs
+++ b/crates/oxc_react_compiler/src/lib.rs
@@ -48,7 +48,7 @@ pub use crate::react_compiler_hir::environment_config::EnvironmentConfig;
 
 use oxc_ast::ast::Program;
 use oxc_diagnostics::Diagnostics;
-use oxc_semantic::SemanticBuilder;
+use oxc_semantic::Semantic;
 use oxc_span::GetSpan;
 use rustc_hash::FxHashSet;
 
@@ -79,9 +79,16 @@ impl Default for PluginOptions {
 }
 
 #[derive(Default)]
-pub struct TransformResult {
-    /// Whether `program` was rewritten. `false` means the compiler made no
-    /// changes — no React-like functions, a bail-out, or nothing to memoize.
+pub struct TransformResult<'a> {
+    /// The rewritten program, when the compiler memoized something.
+    ///
+    /// Callers that want in-place behavior should replace their original
+    /// `Program` with this value after the borrowed `Semantic` has gone out of
+    /// scope.
+    pub program: Option<Program<'a>>,
+    /// Whether `program` contains a rewritten program. `false` means the
+    /// compiler made no changes — no React-like functions, a bail-out, or
+    /// nothing to memoize.
     pub changed: bool,
     /// Errors and warnings produced by the compile. Errors (e.g. Rules of Hooks
     /// violations) are hard problems in the source; the program is still left
@@ -94,30 +101,29 @@ pub struct LintResult {
     pub diagnostics: Diagnostics,
 }
 
-/// Run the React Compiler on a pre-parsed program, rewriting `program` in place
-/// when it memoizes something. Builds the semantic model internally.
+/// Run the React Compiler on a pre-parsed program, returning a rewritten
+/// program when it memoizes something.
 ///
-/// Must run **first**, on the pristine AST, before any other transform.
+/// Must run **first**, on the pristine AST, before any other transform. The
+/// borrowed `semantic` must have been built from that same pristine AST with
+/// `SemanticBuilder::with_build_nodes(true)`.
 pub fn transform<'a>(
-    program: &mut Program<'a>,
+    program: &Program<'a>,
+    semantic: &Semantic<'_>,
     allocator: &'a Allocator,
     options: PluginOptions,
-) -> TransformResult {
-    let (compiled, diagnostics) = compile(program, allocator, options);
-    let changed = compiled.is_some();
-    if let Some(compiled) = compiled {
-        *program = compiled;
-    }
-    TransformResult { changed, diagnostics }
+) -> TransformResult<'a> {
+    let (program, diagnostics) = compile(program, semantic, allocator, options);
+    let changed = program.is_some();
+    TransformResult { program, changed, diagnostics }
 }
 
 /// Shared compile pipeline behind [`transform`] and [`lint`]. Borrows `program`
 /// (so `lint` can stay read-only) and returns the compiled OXC program — `None`
 /// when nothing was compiled — together with diagnostics and logger events.
-/// Containing the semantic borrow inside this call is what lets `transform`
-/// write the result back into its `&mut program` afterwards.
 fn compile<'a>(
     program: &Program<'a>,
+    semantic: &Semantic<'_>,
     allocator: &'a Allocator,
     options: PluginOptions,
 ) -> (Option<Program<'a>>, Diagnostics) {
@@ -133,12 +139,10 @@ fn compile<'a>(
         return (None, Diagnostics::default());
     }
 
-    let semantic = SemanticBuilder::new().with_build_nodes(true).build(program).semantic;
-
     // The codegen back-end builds oxc nodes directly via this `AstBuilder`, and the
     // compiled program is spliced/returned as an arena-allocated `Program<'a>`.
     let ast_builder = oxc_ast::builder::AstBuilder::new(allocator);
-    let scope_info = convert_scope_info(&semantic, program);
+    let scope_info = convert_scope_info(semantic, program);
     // Function discovery and lowering both walk the oxc `Program` directly.
     let result = compile_program(&ast_builder, program, scope_info, options);
 
@@ -192,12 +196,18 @@ fn preserve_comments<'a>(
 
 /// Lint a pre-parsed program — like [`transform`] but read-only: it collects
 /// diagnostics without rewriting the program.
-pub fn lint(program: &Program, options: PluginOptions) -> LintResult {
+///
+/// The borrowed `semantic` must have been built from `program` with
+/// `SemanticBuilder::with_build_nodes(true)`.
+pub fn lint<'a>(
+    program: &Program<'a>,
+    semantic: &Semantic<'_>,
+    allocator: &'a Allocator,
+    options: PluginOptions,
+) -> LintResult {
     let mut options = options;
     options.no_emit = true;
 
-    // `no_emit` produces no program; a local arena for the conversion suffices.
-    let allocator = Allocator::default();
-    let (_program, diagnostics) = compile(program, &allocator, options);
+    let (_program, diagnostics) = compile(program, semantic, allocator, options);
     LintResult { diagnostics }
 }

--- a/crates/oxc_react_compiler/tests/transform.rs
+++ b/crates/oxc_react_compiler/tests/transform.rs
@@ -22,9 +22,15 @@ fn transform_source<'a>(
     source_type: SourceType,
     allocator: &'a Allocator,
     options: PluginOptions,
-) -> (Program<'a>, TransformResult) {
+) -> (Program<'a>, TransformResult<'a>) {
     let mut program = Parser::new(allocator, source_text, source_type).parse().program;
-    let result = transform(&mut program, allocator, options);
+    let mut result = {
+        let semantic = SemanticBuilder::new().with_build_nodes(true).build(&program).semantic;
+        transform(&program, &semantic, allocator, options)
+    };
+    if let Some(compiled) = result.program.take() {
+        program = compiled;
+    }
     (program, result)
 }
 

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -228,10 +228,14 @@ impl<'a> Transformer<'a> {
         let Some(options) = self.react_compiler.take() else {
             return (scoping, Diagnostics::new());
         };
-        let result = react_compiler_transform(program, self.allocator, options);
+        let mut result = {
+            let semantic = SemanticBuilder::new().with_build_nodes(true).build(program).semantic;
+            react_compiler_transform(program, &semantic, self.allocator, options)
+        };
         if !result.changed {
             return (scoping, result.diagnostics);
         }
+        *program = result.program.take().expect("changed result should include a program");
         let scoping =
             SemanticBuilder::new().with_enum_eval(true).build(program).semantic.into_scoping();
         (scoping, result.diagnostics)

--- a/tasks/benchmark/benches/react_compiler.rs
+++ b/tasks/benchmark/benches/react_compiler.rs
@@ -2,6 +2,7 @@ use oxc_allocator::Allocator;
 use oxc_benchmark::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use oxc_parser::{Parser, ParserReturn};
 use oxc_react_compiler::{PluginOptions, transform};
+use oxc_semantic::SemanticBuilder;
 use oxc_tasks_common::TestFiles;
 
 fn bench_react_compiler(criterion: &mut Criterion) {
@@ -28,7 +29,17 @@ fn bench_react_compiler(criterion: &mut Criterion) {
                 let ParserReturn { mut program, .. } =
                     Parser::new(&allocator, source_text, source_type).parse();
 
-                runner.run(|| transform(&mut program, &allocator, options.clone()));
+                runner.run(|| {
+                    let mut result = {
+                        let semantic =
+                            SemanticBuilder::new().with_build_nodes(true).build(&program).semantic;
+                        transform(&program, &semantic, &allocator, options.clone())
+                    };
+                    if let Some(compiled) = result.program.take() {
+                        program = compiled;
+                    }
+                    result
+                });
             });
         });
     }


### PR DESCRIPTION
Borrow existing semantic data and caller allocator in React Compiler transform/lint paths to avoid hidden rebuild/allocation work.

Transform now returns the compiled program so callers can install it after the semantic borrow ends.

AI-assisted.