### PR TITLE
refactor(react_compiler): remove unused js options

### DIFF
--- a/crates/oxc_linter/src/rules/react/react_compiler.rs
+++ b/crates/oxc_linter/src/rules/react/react_compiler.rs
@@ -14,9 +14,8 @@ use crate::{
 /// The compiler options `eslint-plugin-react-compiler` lints with — `lint`
 /// output mode plus validations that are off by default in the compiler.
 /// Mirrors `COMPILER_OPTIONS` in the plugin's `src/shared/RunReactCompiler.ts`.
-fn react_compiler_options(filename: Option<String>) -> PluginOptions {
+fn react_compiler_options() -> PluginOptions {
     PluginOptions {
-        filename,
         output_mode: Some("lint".to_string()),
         // Don't emit errors on Flow suppressions — Flow already gave a signal.
         // Suppressed lines are filtered in `run_once` instead (like the eslint
@@ -122,7 +121,7 @@ impl Rule for ReactCompiler {
 
     fn run_once(&self, ctx: &LintContext) {
         let program = ctx.nodes().program();
-        let options = react_compiler_options(ctx.file_path().to_str().map(ToString::to_string));
+        let options = react_compiler_options();
 
         let result = oxc_react_compiler::lint(program, ctx.semantic(), ctx.allocator(), options);
 

--- a/crates/oxc_react_compiler/src/lib.rs
+++ b/crates/oxc_react_compiler/src/lib.rs
@@ -57,10 +57,6 @@ impl Default for PluginOptions {
     /// `PluginOptions { ..Default::default() }`.
     fn default() -> Self {
         PluginOptions {
-            should_compile: true,
-            enable_reanimated: false,
-            is_dev: false,
-            filename: None,
             compilation_mode: "infer".to_string(),
             panic_threshold: "none".to_string(),
             target: CompilerTarget::Version("19".to_string()),

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/imports.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/imports.rs
@@ -30,11 +30,6 @@ pub struct NonLocalImportSpecifier {
 /// Equivalent to ProgramContext class in Imports.ts.
 pub struct ProgramContext {
     pub opts: PluginOptions,
-    pub filename: Option<String>,
-    /// The source filename from the parser's sourceFilename option.
-    /// This is the filename stored on AST node `loc.filename` fields,
-    /// which may differ from `filename` (e.g., no path prefix).
-    source_filename: Option<String>,
     pub code: Option<String>,
     pub react_runtime_module: String,
     pub suppressions: Vec<SuppressionRange>,
@@ -65,7 +60,6 @@ pub struct ProgramContext {
 impl ProgramContext {
     pub fn new(
         opts: PluginOptions,
-        filename: Option<String>,
         code: Option<String>,
         suppressions: Vec<SuppressionRange>,
         has_module_scope_opt_out: bool,
@@ -74,8 +68,6 @@ impl ProgramContext {
         let debug_enabled = opts.debug;
         Self {
             opts,
-            filename,
-            source_filename: None,
             code,
             react_runtime_module,
             suppressions,
@@ -91,18 +83,6 @@ impl ProgramContext {
             known_referenced_names: FxHashSet::default(),
             imports: FxHashMap::default(),
         }
-    }
-
-    /// Set the source filename (from AST node loc.filename).
-    pub fn set_source_filename(&mut self, filename: Option<String>) {
-        if self.source_filename.is_none() {
-            self.source_filename = filename;
-        }
-    }
-
-    /// Get the source filename for logger events.
-    pub fn source_filename(&self) -> Option<String> {
-        self.source_filename.clone()
     }
 
     /// Check if a function at the given start position has already been compiled.

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
@@ -114,7 +114,6 @@ pub fn compile_fn<'a>(
         CompilerOutputMode::Lint => OutputMode::Lint,
     };
     env.code = context.code.clone();
-    env.filename = context.filename.clone();
     env.instrument_fn_name = context.instrument_fn_name.clone();
     env.instrument_gating_name = context.instrument_gating_name.clone();
     env.hook_guard_name = context.hook_guard_name.clone();

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/plugin_options.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/plugin_options.rs
@@ -25,18 +25,9 @@ pub struct DynamicGatingConfig {
     pub source: String,
 }
 
-/// Serializable plugin options, pre-resolved by the JS shim.
-/// JS-only values (sources function, logger, etc.) are resolved before
-/// being sent to Rust.
+/// Serializable plugin options.
 #[derive(Debug, Clone)]
 pub struct PluginOptions {
-    // Pre-resolved by JS
-    pub should_compile: bool,
-    pub enable_reanimated: bool,
-    pub is_dev: bool,
-    pub filename: Option<String>,
-
-    // Pass-through options
     pub compilation_mode: String,
     pub panic_threshold: String,
     pub target: CompilerTarget,

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -2875,16 +2875,6 @@ pub fn compile_program<'a, 'p>(
         });
     }
 
-    // Check if we should compile this file at all (pre-resolved by JS shim)
-    if !options.should_compile {
-        return CompileResult::Success {
-            ast: None,
-            diagnostics: Diagnostics::new(),
-            ordered_log: early_ordered_log,
-            renames: Vec::new(),
-        };
-    }
-
     let program = oxc_program;
 
     // Check for existing runtime imports (file already compiled)
@@ -2931,18 +2921,12 @@ pub fn compile_program<'a, 'p>(
     // Create program context
     let mut context = ProgramContext::new(
         options.clone(),
-        options.filename.clone(),
         // Source text feeds the line-offset table (diagnostic line/col) and the fast
         // refresh hash. The oxc front-end derives locations from it on demand.
         Some(program.source_text.to_string()),
         suppressions,
         has_module_scope_opt_out,
     );
-
-    // The source filename only fed logger event source locations. The oxc AST
-    // carries no per-node filename (the Babel bridge set it to `None` too), so
-    // leave it unset; it never affects compiled output or diagnostics.
-    context.set_source_filename(None);
 
     // Initialize known referenced names from scope bindings for UID collision detection
     context.init_from_scope(&scope);

--- a/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
@@ -66,9 +66,6 @@ pub struct Environment<'a> {
     // Source file code (for fast refresh hash computation)
     pub code: Option<String>,
 
-    // Source file name (for instrumentation)
-    pub filename: Option<String>,
-
     // Pre-resolved import local names for instrumentation/hook guards.
     // Set by the program-level code before compilation.
     pub instrument_fn_name: Option<String>,
@@ -184,7 +181,6 @@ impl<'a> Environment<'a> {
             fn_type: ReactFunctionType::Other,
             output_mode: OutputMode::Client,
             code: None,
-            filename: None,
             instrument_fn_name: None,
             instrument_gating_name: None,
             hook_guard_name: None,
@@ -231,7 +227,6 @@ impl<'a> Environment<'a> {
             fn_type,
             output_mode: self.output_mode,
             code: self.code.clone(),
-            filename: self.filename.clone(),
             instrument_fn_name: self.instrument_fn_name.clone(),
             instrument_gating_name: self.instrument_gating_name.clone(),
             hook_guard_name: self.hook_guard_name.clone(),

--- a/crates/oxc_react_compiler/tests/transform.rs
+++ b/crates/oxc_react_compiler/tests/transform.rs
@@ -10,9 +10,7 @@ use oxc_span::SourceType;
 use oxc_react_compiler::{PluginOptions, TransformResult, transform};
 
 fn options() -> PluginOptions {
-    // The upstream options type is constructed typed (it has no `Deserialize`);
-    // only `filename` differs from the compiler's standard defaults.
-    PluginOptions { filename: Some("Component.jsx".to_string()), ..PluginOptions::default() }
+    PluginOptions::default()
 }
 
 /// Parse `source_text` then run the compiler in place, returning the


### PR DESCRIPTION
Removes unused upstream JS option fields from Oxc's React Compiler options and deletes the dead filename plumbing they carried through the compile environment.

Stacked on #24063.

AI-assisted.