### PR TITLE
fix(npm): preserve config docs in defineConfig

### DIFF
--- a/apps/oxfmt/src-js/index.ts
+++ b/apps/oxfmt/src-js/index.ts
@@ -58,7 +58,7 @@ export type TailwindcssOptions = SortTailwindcssConfig;
 /**
  * Define an oxfmt configuration with type inference.
  */
-export function defineConfig<T extends OxfmtConfig>(config: T): T {
+export function defineConfig<T extends OxfmtConfig>(config: T & OxfmtConfig): T {
   return config;
 }
 

--- a/apps/oxlint/src-js/package/config.ts
+++ b/apps/oxlint/src-js/package/config.ts
@@ -36,12 +36,65 @@ export interface OxlintConfig extends Oxlintrc {
 
 export type { OxlintOverride };
 
+interface OxlintConfigContext {
+  /**
+   * Configure an entire category of rules all at once.
+   *
+   * Rules enabled or disabled this way will be overwritten by individual rules in the `rules` field.
+   */
+  categories?: FullOxlintrc["categories"];
+  /**
+   * Environments enable and disable collections of global variables.
+   */
+  env?: FullOxlintrc["env"];
+  /**
+   * Configuration files that this configuration extends.
+   */
+  extends?: OxlintConfig[];
+  /**
+   * Enabled or disabled specific global variables.
+   */
+  globals?: FullOxlintrc["globals"];
+  /**
+   * Globs to ignore during linting. These are resolved from the configuration file path.
+   */
+  ignorePatterns?: FullOxlintrc["ignorePatterns"];
+  /**
+   * JS plugins, allows usage of ESLint plugins with Oxlint.
+   */
+  jsPlugins?: FullOxlintrc["jsPlugins"];
+  /**
+   * Oxlint config options.
+   */
+  options?: FullOxlintrc["options"];
+  /**
+   * Add, remove, or otherwise reconfigure rules for specific files or groups of files.
+   */
+  overrides?: FullOxlintrc["overrides"];
+  /**
+   * Enabled built-in plugins for Oxlint.
+   *
+   * Setting this field will overwrite the base set of plugins.
+   */
+  plugins?: FullOxlintrc["plugins"];
+  /**
+   * Configure linter rules.
+   *
+   * See Oxlint Rules for the list of rules.
+   */
+  rules?: FullOxlintrc["rules"];
+  /**
+   * Plugin-specific configuration for both built-in and custom plugins.
+   */
+  settings?: FullOxlintrc["settings"];
+}
+
 /**
  * Define an Oxlint configuration with type inference.
  *
  * @param config - Oxlint configuration
  * @returns Config unchanged
  */
-export function defineConfig<T extends OxlintConfig>(config: T): T {
+export function defineConfig<T extends OxlintConfig>(config: T & OxlintConfigContext): T {
   return config;
 }


### PR DESCRIPTION
## Summary

- preserve editor hover documentation for `oxfmt` `defineConfig` object properties
- preserve editor hover documentation for top-level `oxlint` `defineConfig` object properties
- keep `defineConfig` as an identity helper at runtime while improving the contextual type used by TypeScript services

## Why

`defineConfig<T extends Config>(config: T): T` keeps literal inference, but once an object property is written, TypeScript quick info is based on the inferred object property and loses the JSDoc from the config interface. Intersecting the parameter with a documented config context keeps the literal return type while giving editors a documented contextual type for hover and completion details.

For `oxlint`, the public `OxlintConfig` still extends the `$schema`/`extends`-stripped config type. A separate internal context type is used for the helper parameter so top-level config property docs are available without changing the exported config shape.

## Validation

- `pnpm fmt apps/oxfmt/src-js/index.ts apps/oxlint/src-js/package/config.ts`
- `pnpm lint apps/oxfmt/src-js/index.ts apps/oxlint/src-js/package/config.ts`
- `pnpm --filter oxfmt-app build-js`
- `pnpm exec tsc --noEmit --pretty false --skipLibCheck --target ES2022 --moduleResolution Bundler --module ESNext src-js/package/config.ts` from `apps/oxlint`
- verified with TypeScript language service that `oxfmt` and `oxlint` config property hover docs are present

`pnpm --filter oxlint-app build-js` was not completed locally because the current Node.js v22.20.0 runtime does not provide `RegExp.escape`, which is used by `apps/oxlint/tsdown_plugins/inline_search.ts`.

## AI usage

This PR was prepared with assistance from OpenAI Codex. I reviewed the diff and validation results before submitting.
