### PR TITLE
feat(linter): add promise/no-native rule

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4518,6 +4518,12 @@ impl RuleRunner for crate::rules::promise::no_multiple_resolved::NoMultipleResol
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::promise::no_native::NoNative {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::IdentifierReference]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::promise::no_nesting::NoNesting {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -406,6 +406,7 @@ pub use crate::rules::promise::avoid_new::AvoidNew as PromiseAvoidNew;
 pub use crate::rules::promise::catch_or_return::CatchOrReturn as PromiseCatchOrReturn;
 pub use crate::rules::promise::no_callback_in_promise::NoCallbackInPromise as PromiseNoCallbackInPromise;
 pub use crate::rules::promise::no_multiple_resolved::NoMultipleResolved as PromiseNoMultipleResolved;
+pub use crate::rules::promise::no_native::NoNative as PromiseNoNative;
 pub use crate::rules::promise::no_nesting::NoNesting as PromiseNoNesting;
 pub use crate::rules::promise::no_new_statics::NoNewStatics as PromiseNoNewStatics;
 pub use crate::rules::promise::no_promise_in_callback::NoPromiseInCallback as PromiseNoPromiseInCallback;
@@ -1564,6 +1565,7 @@ pub enum RuleEnum {
     PromiseCatchOrReturn(PromiseCatchOrReturn),
     PromiseNoCallbackInPromise(PromiseNoCallbackInPromise),
     PromiseNoMultipleResolved(PromiseNoMultipleResolved),
+    PromiseNoNative(PromiseNoNative),
     PromiseNoNesting(PromiseNoNesting),
     PromiseNoNewStatics(PromiseNoNewStatics),
     PromiseNoPromiseInCallback(PromiseNoPromiseInCallback),
@@ -2498,7 +2500,8 @@ const PROMISE_AVOID_NEW_ID: usize = PROMISE_ALWAYS_RETURN_ID + 1usize;
 const PROMISE_CATCH_OR_RETURN_ID: usize = PROMISE_AVOID_NEW_ID + 1usize;
 const PROMISE_NO_CALLBACK_IN_PROMISE_ID: usize = PROMISE_CATCH_OR_RETURN_ID + 1usize;
 const PROMISE_NO_MULTIPLE_RESOLVED_ID: usize = PROMISE_NO_CALLBACK_IN_PROMISE_ID + 1usize;
-const PROMISE_NO_NESTING_ID: usize = PROMISE_NO_MULTIPLE_RESOLVED_ID + 1usize;
+const PROMISE_NO_NATIVE_ID: usize = PROMISE_NO_MULTIPLE_RESOLVED_ID + 1usize;
+const PROMISE_NO_NESTING_ID: usize = PROMISE_NO_NATIVE_ID + 1usize;
 const PROMISE_NO_NEW_STATICS_ID: usize = PROMISE_NO_NESTING_ID + 1usize;
 const PROMISE_NO_PROMISE_IN_CALLBACK_ID: usize = PROMISE_NO_NEW_STATICS_ID + 1usize;
 const PROMISE_NO_RETURN_IN_FINALLY_ID: usize = PROMISE_NO_PROMISE_IN_CALLBACK_ID + 1usize;
@@ -3472,6 +3475,7 @@ impl RuleEnum {
             Self::PromiseCatchOrReturn(_) => PROMISE_CATCH_OR_RETURN_ID,
             Self::PromiseNoCallbackInPromise(_) => PROMISE_NO_CALLBACK_IN_PROMISE_ID,
             Self::PromiseNoMultipleResolved(_) => PROMISE_NO_MULTIPLE_RESOLVED_ID,
+            Self::PromiseNoNative(_) => PROMISE_NO_NATIVE_ID,
             Self::PromiseNoNesting(_) => PROMISE_NO_NESTING_ID,
             Self::PromiseNoNewStatics(_) => PROMISE_NO_NEW_STATICS_ID,
             Self::PromiseNoPromiseInCallback(_) => PROMISE_NO_PROMISE_IN_CALLBACK_ID,
@@ -4432,6 +4436,7 @@ impl RuleEnum {
             Self::PromiseCatchOrReturn(_) => PromiseCatchOrReturn::NAME,
             Self::PromiseNoCallbackInPromise(_) => PromiseNoCallbackInPromise::NAME,
             Self::PromiseNoMultipleResolved(_) => PromiseNoMultipleResolved::NAME,
+            Self::PromiseNoNative(_) => PromiseNoNative::NAME,
             Self::PromiseNoNesting(_) => PromiseNoNesting::NAME,
             Self::PromiseNoNewStatics(_) => PromiseNoNewStatics::NAME,
             Self::PromiseNoPromiseInCallback(_) => PromiseNoPromiseInCallback::NAME,
@@ -5432,6 +5437,7 @@ impl RuleEnum {
             Self::PromiseCatchOrReturn(_) => PromiseCatchOrReturn::CATEGORY,
             Self::PromiseNoCallbackInPromise(_) => PromiseNoCallbackInPromise::CATEGORY,
             Self::PromiseNoMultipleResolved(_) => PromiseNoMultipleResolved::CATEGORY,
+            Self::PromiseNoNative(_) => PromiseNoNative::CATEGORY,
             Self::PromiseNoNesting(_) => PromiseNoNesting::CATEGORY,
             Self::PromiseNoNewStatics(_) => PromiseNoNewStatics::CATEGORY,
             Self::PromiseNoPromiseInCallback(_) => PromiseNoPromiseInCallback::CATEGORY,
@@ -6403,6 +6409,7 @@ impl RuleEnum {
             Self::PromiseCatchOrReturn(_) => PromiseCatchOrReturn::FIX,
             Self::PromiseNoCallbackInPromise(_) => PromiseNoCallbackInPromise::FIX,
             Self::PromiseNoMultipleResolved(_) => PromiseNoMultipleResolved::FIX,
+            Self::PromiseNoNative(_) => PromiseNoNative::FIX,
             Self::PromiseNoNesting(_) => PromiseNoNesting::FIX,
             Self::PromiseNoNewStatics(_) => PromiseNoNewStatics::FIX,
             Self::PromiseNoPromiseInCallback(_) => PromiseNoPromiseInCallback::FIX,
@@ -7578,6 +7585,7 @@ impl RuleEnum {
             Self::PromiseCatchOrReturn(_) => PromiseCatchOrReturn::documentation(),
             Self::PromiseNoCallbackInPromise(_) => PromiseNoCallbackInPromise::documentation(),
             Self::PromiseNoMultipleResolved(_) => PromiseNoMultipleResolved::documentation(),
+            Self::PromiseNoNative(_) => PromiseNoNative::documentation(),
             Self::PromiseNoNesting(_) => PromiseNoNesting::documentation(),
             Self::PromiseNoNewStatics(_) => PromiseNoNewStatics::documentation(),
             Self::PromiseNoPromiseInCallback(_) => PromiseNoPromiseInCallback::documentation(),
@@ -9795,6 +9803,8 @@ impl RuleEnum {
                 PromiseNoMultipleResolved::config_schema(generator)
                     .or_else(|| PromiseNoMultipleResolved::schema(generator))
             }
+            Self::PromiseNoNative(_) => PromiseNoNative::config_schema(generator)
+                .or_else(|| PromiseNoNative::schema(generator)),
             Self::PromiseNoNesting(_) => PromiseNoNesting::config_schema(generator)
                 .or_else(|| PromiseNoNesting::schema(generator)),
             Self::PromiseNoNewStatics(_) => PromiseNoNewStatics::config_schema(generator)
@@ -10887,6 +10897,7 @@ impl RuleEnum {
             Self::PromiseCatchOrReturn(_) => "promise",
             Self::PromiseNoCallbackInPromise(_) => "promise",
             Self::PromiseNoMultipleResolved(_) => "promise",
+            Self::PromiseNoNative(_) => "promise",
             Self::PromiseNoNesting(_) => "promise",
             Self::PromiseNoNewStatics(_) => "promise",
             Self::PromiseNoPromiseInCallback(_) => "promise",
@@ -13290,6 +13301,9 @@ impl RuleEnum {
             Self::PromiseNoMultipleResolved(_) => Ok(Self::PromiseNoMultipleResolved(
                 PromiseNoMultipleResolved::from_configuration(value)?,
             )),
+            Self::PromiseNoNative(_) => {
+                Ok(Self::PromiseNoNative(PromiseNoNative::from_configuration(value)?))
+            }
             Self::PromiseNoNesting(_) => {
                 Ok(Self::PromiseNoNesting(PromiseNoNesting::from_configuration(value)?))
             }
@@ -14436,6 +14450,7 @@ impl RuleEnum {
             Self::PromiseCatchOrReturn(rule) => rule.to_configuration(),
             Self::PromiseNoCallbackInPromise(rule) => rule.to_configuration(),
             Self::PromiseNoMultipleResolved(rule) => rule.to_configuration(),
+            Self::PromiseNoNative(rule) => rule.to_configuration(),
             Self::PromiseNoNesting(rule) => rule.to_configuration(),
             Self::PromiseNoNewStatics(rule) => rule.to_configuration(),
             Self::PromiseNoPromiseInCallback(rule) => rule.to_configuration(),
@@ -15281,6 +15296,7 @@ impl RuleEnum {
             Self::PromiseCatchOrReturn(rule) => rule.run(node, ctx),
             Self::PromiseNoCallbackInPromise(rule) => rule.run(node, ctx),
             Self::PromiseNoMultipleResolved(rule) => rule.run(node, ctx),
+            Self::PromiseNoNative(rule) => rule.run(node, ctx),
             Self::PromiseNoNesting(rule) => rule.run(node, ctx),
             Self::PromiseNoNewStatics(rule) => rule.run(node, ctx),
             Self::PromiseNoPromiseInCallback(rule) => rule.run(node, ctx),
@@ -16136,6 +16152,7 @@ impl RuleEnum {
             Self::PromiseCatchOrReturn(rule) => rule.run_once(ctx),
             Self::PromiseNoCallbackInPromise(rule) => rule.run_once(ctx),
             Self::PromiseNoMultipleResolved(rule) => rule.run_once(ctx),
+            Self::PromiseNoNative(rule) => rule.run_once(ctx),
             Self::PromiseNoNesting(rule) => rule.run_once(ctx),
             Self::PromiseNoNewStatics(rule) => rule.run_once(ctx),
             Self::PromiseNoPromiseInCallback(rule) => rule.run_once(ctx),
@@ -17100,6 +17117,7 @@ impl RuleEnum {
             Self::PromiseCatchOrReturn(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::PromiseNoCallbackInPromise(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::PromiseNoMultipleResolved(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::PromiseNoNative(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::PromiseNoNesting(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::PromiseNoNewStatics(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::PromiseNoPromiseInCallback(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -17964,6 +17982,7 @@ impl RuleEnum {
             Self::PromiseCatchOrReturn(rule) => rule.should_run(ctx),
             Self::PromiseNoCallbackInPromise(rule) => rule.should_run(ctx),
             Self::PromiseNoMultipleResolved(rule) => rule.should_run(ctx),
+            Self::PromiseNoNative(rule) => rule.should_run(ctx),
             Self::PromiseNoNesting(rule) => rule.should_run(ctx),
             Self::PromiseNoNewStatics(rule) => rule.should_run(ctx),
             Self::PromiseNoPromiseInCallback(rule) => rule.should_run(ctx),
@@ -19130,6 +19149,7 @@ impl RuleEnum {
             Self::PromiseCatchOrReturn(_) => PromiseCatchOrReturn::IS_TSGOLINT_RULE,
             Self::PromiseNoCallbackInPromise(_) => PromiseNoCallbackInPromise::IS_TSGOLINT_RULE,
             Self::PromiseNoMultipleResolved(_) => PromiseNoMultipleResolved::IS_TSGOLINT_RULE,
+            Self::PromiseNoNative(_) => PromiseNoNative::IS_TSGOLINT_RULE,
             Self::PromiseNoNesting(_) => PromiseNoNesting::IS_TSGOLINT_RULE,
             Self::PromiseNoNewStatics(_) => PromiseNoNewStatics::IS_TSGOLINT_RULE,
             Self::PromiseNoPromiseInCallback(_) => PromiseNoPromiseInCallback::IS_TSGOLINT_RULE,
@@ -20178,6 +20198,7 @@ impl RuleEnum {
             Self::PromiseCatchOrReturn(_) => PromiseCatchOrReturn::VERSION,
             Self::PromiseNoCallbackInPromise(_) => PromiseNoCallbackInPromise::VERSION,
             Self::PromiseNoMultipleResolved(_) => PromiseNoMultipleResolved::VERSION,
+            Self::PromiseNoNative(_) => PromiseNoNative::VERSION,
             Self::PromiseNoNesting(_) => PromiseNoNesting::VERSION,
             Self::PromiseNoNewStatics(_) => PromiseNoNewStatics::VERSION,
             Self::PromiseNoPromiseInCallback(_) => PromiseNoPromiseInCallback::VERSION,
@@ -21223,6 +21244,7 @@ impl RuleEnum {
             Self::PromiseCatchOrReturn(_) => PromiseCatchOrReturn::HAS_CONFIG,
             Self::PromiseNoCallbackInPromise(_) => PromiseNoCallbackInPromise::HAS_CONFIG,
             Self::PromiseNoMultipleResolved(_) => PromiseNoMultipleResolved::HAS_CONFIG,
+            Self::PromiseNoNative(_) => PromiseNoNative::HAS_CONFIG,
             Self::PromiseNoNesting(_) => PromiseNoNesting::HAS_CONFIG,
             Self::PromiseNoNewStatics(_) => PromiseNoNewStatics::HAS_CONFIG,
             Self::PromiseNoPromiseInCallback(_) => PromiseNoPromiseInCallback::HAS_CONFIG,
@@ -22203,6 +22225,7 @@ impl RuleEnum {
             Self::PromiseCatchOrReturn(_) => PromiseCatchOrReturn::INFO,
             Self::PromiseNoCallbackInPromise(_) => PromiseNoCallbackInPromise::INFO,
             Self::PromiseNoMultipleResolved(_) => PromiseNoMultipleResolved::INFO,
+            Self::PromiseNoNative(_) => PromiseNoNative::INFO,
             Self::PromiseNoNesting(_) => PromiseNoNesting::INFO,
             Self::PromiseNoNewStatics(_) => PromiseNoNewStatics::INFO,
             Self::PromiseNoPromiseInCallback(_) => PromiseNoPromiseInCallback::INFO,
@@ -23058,6 +23081,7 @@ impl RuleEnum {
             Self::PromiseCatchOrReturn(rule) => rule.types_info(),
             Self::PromiseNoCallbackInPromise(rule) => rule.types_info(),
             Self::PromiseNoMultipleResolved(rule) => rule.types_info(),
+            Self::PromiseNoNative(rule) => rule.types_info(),
             Self::PromiseNoNesting(rule) => rule.types_info(),
             Self::PromiseNoNewStatics(rule) => rule.types_info(),
             Self::PromiseNoPromiseInCallback(rule) => rule.types_info(),
@@ -23900,6 +23924,7 @@ impl RuleEnum {
             Self::PromiseCatchOrReturn(rule) => rule.run_info(),
             Self::PromiseNoCallbackInPromise(rule) => rule.run_info(),
             Self::PromiseNoMultipleResolved(rule) => rule.run_info(),
+            Self::PromiseNoNative(rule) => rule.run_info(),
             Self::PromiseNoNesting(rule) => rule.run_info(),
             Self::PromiseNoNewStatics(rule) => rule.run_info(),
             Self::PromiseNoPromiseInCallback(rule) => rule.run_info(),
@@ -24870,6 +24895,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::PromiseCatchOrReturn(PromiseCatchOrReturn::default()),
         RuleEnum::PromiseNoCallbackInPromise(PromiseNoCallbackInPromise::default()),
         RuleEnum::PromiseNoMultipleResolved(PromiseNoMultipleResolved::default()),
+        RuleEnum::PromiseNoNative(PromiseNoNative::default()),
         RuleEnum::PromiseNoNesting(PromiseNoNesting::default()),
         RuleEnum::PromiseNoNewStatics(PromiseNoNewStatics::default()),
         RuleEnum::PromiseNoPromiseInCallback(PromiseNoPromiseInCallback::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -748,6 +748,7 @@ pub(crate) mod promise {
     pub mod catch_or_return;
     pub mod no_callback_in_promise;
     pub mod no_multiple_resolved;
+    pub mod no_native;
     pub mod no_nesting;
     pub mod no_new_statics;
     pub mod no_promise_in_callback;

--- a/crates/oxc_linter/src/rules/promise/no_native.rs
+++ b/crates/oxc_linter/src/rules/promise/no_native.rs
@@ -1,0 +1,83 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_native_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("\"Promise\" is not defined")
+        .with_help(
+            "Bring your own `Promise` into scope first (e.g. `var Promise = require('bluebird')`) so the code still runs where there is no native one.",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoNative;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Requires a `Promise` to be brought into scope explicitly — via an import
+    /// or an assignment — before it is used, rather than leaning on the native
+    /// global.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Ancient ES5 engines (looking at you, IE11) ship no native `Promise`, so
+    /// reaching for the global there throws at runtime. Declaring your own keeps
+    /// the code portable and makes the polyfill obvious to the next reader.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```javascript
+    /// new Promise(function (resolve, reject) {});
+    /// var x = Promise.resolve("good");
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// var Promise = require("bluebird");
+    /// var x = Promise.resolve("good");
+    /// ```
+    NoNative,
+    promise,
+    restriction,
+    version = "1.71.0",
+    short_description = "Require creating a `Promise` constructor before using it in an ES5 environment.",
+);
+
+impl Rule for NoNative {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::IdentifierReference(ident) = node.kind() else {
+            return;
+        };
+
+        if ident.name == "Promise" && ctx.is_reference_to_global_variable(ident) {
+            ctx.diagnostic(no_native_diagnostic(ident.span));
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        r#"var Promise = null; function x() { return Promise.resolve("hi"); }"#,
+        r#"var Promise = window.Promise || require("bluebird"); var x = Promise.reject();"#,
+        r#"import Promise from "bluebird"; var x = Promise.reject();"#,
+        "function foo(Promise) { return Promise.resolve(); }",
+    ];
+
+    let fail = vec![
+        "new Promise(function (resolve, reject) {})",
+        "Promise.resolve()",
+        r#"Promise.reject(new Error("oops"))"#,
+        "var x = Promise.all([a, b]);",
+    ];
+
+    Tester::new(NoNative::NAME, NoNative::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/promise_no_native.snap
+++ b/crates/oxc_linter/src/snapshots/promise_no_native.snap
@@ -1,0 +1,31 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ promise(no-native): "Promise" is not defined
+   ╭─[no_native.tsx:1:5]
+ 1 │ new Promise(function (resolve, reject) {})
+   ·     ───────
+   ╰────
+  help: Bring your own `Promise` into scope first (e.g. `var Promise = require('bluebird')`) so the code still runs where there is no native one.
+
+  ⚠ promise(no-native): "Promise" is not defined
+   ╭─[no_native.tsx:1:1]
+ 1 │ Promise.resolve()
+   · ───────
+   ╰────
+  help: Bring your own `Promise` into scope first (e.g. `var Promise = require('bluebird')`) so the code still runs where there is no native one.
+
+  ⚠ promise(no-native): "Promise" is not defined
+   ╭─[no_native.tsx:1:1]
+ 1 │ Promise.reject(new Error("oops"))
+   · ───────
+   ╰────
+  help: Bring your own `Promise` into scope first (e.g. `var Promise = require('bluebird')`) so the code still runs where there is no native one.
+
+  ⚠ promise(no-native): "Promise" is not defined
+   ╭─[no_native.tsx:1:9]
+ 1 │ var x = Promise.all([a, b]);
+   ·         ───────
+   ╰────
+  help: Bring your own `Promise` into scope first (e.g. `var Promise = require('bluebird')`) so the code still runs where there is no native one.


### PR DESCRIPTION
Implements `promise/no-native`, the one `eslint-plugin-promise` rule oxlint was still missing (the plugin's other 16 rules are already ported).

## What it does

Flags any reference to the `Promise` global that wasn't brought into scope first. It nudges code targeting an ES5 engine (no native `Promise`) toward declaring or importing its own polyfill instead of throwing at runtime.

```js
// bad
new Promise((resolve, reject) => {});
var x = Promise.resolve("good");

// good
var Promise = require("bluebird");
var x = Promise.resolve("good");
```

## Implementation

Matches every `IdentifierReference` named `Promise` and reports it when `ctx.is_reference_to_global_variable` says it resolves to the global — so a local `var` / `import` / function parameter named `Promise` shadows the check and is left alone. Same behaviour as the upstream rule (its valid/invalid cases are covered in the tests, plus a parameter-shadowing case).

Category is `restriction` (opt-in), matching the upstream default (not in `recommended`).

Ran `cargo lintgen`; `cargo test -p oxc_linter`, `cargo fmt --check` and `cargo clippy` are all green.
