### PR TITLE
feat(oxlint): auto-discover .mjs/.cjs/.mts/.cts config files

### DIFF
--- a/apps/oxfmt/src/core/config/mod.rs
+++ b/apps/oxfmt/src/core/config/mod.rs
@@ -40,7 +40,7 @@ use super::{
 const OXFMT_CONFIG_FILE_NAMES: ConfigFileNames = ConfigFileNames {
     json: ".oxfmtrc.json",
     jsonc: ".oxfmtrc.jsonc",
-    js: "oxfmt.config.ts",
+    js: &["oxfmt.config.ts"],
     vite: "vite.config.ts",
 };
 

--- a/apps/oxlint/src/config_loader.rs
+++ b/apps/oxlint/src/config_loader.rs
@@ -15,7 +15,7 @@ use oxc_linter::{
 };
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 
-use crate::{DEFAULT_JSONC_OXLINTRC_NAME, DEFAULT_OXLINTRC_NAME, DEFAULT_TS_OXLINTRC_NAME};
+use crate::{DEFAULT_JS_OXLINTRC_NAMES, DEFAULT_JSONC_OXLINTRC_NAME, DEFAULT_OXLINTRC_NAME};
 use crate::{VITE_CONFIG_NAME, vp_version};
 
 const GIT_DIR: &str = ".git";
@@ -34,7 +34,7 @@ pub struct JsConfigResult {
 const OXLINT_CONFIG_FILE_NAMES: ConfigFileNames = ConfigFileNames {
     json: DEFAULT_OXLINTRC_NAME,
     jsonc: DEFAULT_JSONC_OXLINTRC_NAME,
-    js: DEFAULT_TS_OXLINTRC_NAME,
+    js: DEFAULT_JS_OXLINTRC_NAMES,
     vite: VITE_CONFIG_NAME,
 };
 

--- a/apps/oxlint/src/lib.rs
+++ b/apps/oxlint/src/lib.rs
@@ -59,7 +59,18 @@ static GLOBAL: mimalloc_safe::MiMalloc = mimalloc_safe::MiMalloc;
 
 const DEFAULT_OXLINTRC_NAME: &str = ".oxlintrc.json";
 const DEFAULT_JSONC_OXLINTRC_NAME: &str = ".oxlintrc.jsonc";
-const DEFAULT_TS_OXLINTRC_NAME: &str = "oxlint.config.ts";
+/// JS/TS config file names discovered automatically, mirroring the extensions
+/// accepted by an explicit `--config` (`.js`, `.mjs`, `.cjs`, `.ts`, `.mts`, `.cts`).
+///
+/// `oxlint.config.ts` is listed first so it stays the primary/documented name.
+const DEFAULT_JS_OXLINTRC_NAMES: &[&str] = &[
+    "oxlint.config.ts",
+    "oxlint.config.mts",
+    "oxlint.config.cts",
+    "oxlint.config.mjs",
+    "oxlint.config.cjs",
+    "oxlint.config.js",
+];
 /// Vite config file that may contain oxlint config under a `.lint` field.
 const VITE_CONFIG_NAME: &str = "vite.config.ts";
 

--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -951,10 +951,15 @@ mod test_watchers {
             let patterns =
                 Tester::new("fixtures/lsp/watchers/default", json!({})).get_watcher_patterns();
 
-            assert_eq!(patterns.len(), 3);
+            assert_eq!(patterns.len(), 8);
             assert_eq!(patterns[0], "**/.oxlintrc.json".to_string());
             assert_eq!(patterns[1], "**/.oxlintrc.jsonc".to_string());
             assert_eq!(patterns[2], "**/oxlint.config.ts".to_string());
+            assert_eq!(patterns[3], "**/oxlint.config.mts".to_string());
+            assert_eq!(patterns[4], "**/oxlint.config.cts".to_string());
+            assert_eq!(patterns[5], "**/oxlint.config.mjs".to_string());
+            assert_eq!(patterns[6], "**/oxlint.config.cjs".to_string());
+            assert_eq!(patterns[7], "**/oxlint.config.js".to_string());
         }
 
         #[test]
@@ -967,10 +972,15 @@ mod test_watchers {
             )
             .get_watcher_patterns();
 
-            assert_eq!(patterns.len(), 3);
+            assert_eq!(patterns.len(), 8);
             assert_eq!(patterns[0], "**/.oxlintrc.json".to_string());
             assert_eq!(patterns[1], "**/.oxlintrc.jsonc".to_string());
             assert_eq!(patterns[2], "**/oxlint.config.ts".to_string());
+            assert_eq!(patterns[3], "**/oxlint.config.mts".to_string());
+            assert_eq!(patterns[4], "**/oxlint.config.cts".to_string());
+            assert_eq!(patterns[5], "**/oxlint.config.mjs".to_string());
+            assert_eq!(patterns[6], "**/oxlint.config.cjs".to_string());
+            assert_eq!(patterns[7], "**/oxlint.config.js".to_string());
         }
 
         #[test]
@@ -992,12 +1002,15 @@ mod test_watchers {
             let patterns = Tester::new("fixtures/lsp/watchers/linter_extends", json!({}))
                 .get_watcher_patterns();
 
-            // The `.oxlintrc.json` extends `./lint.json` -> 4 watchers (json, jsonc, ts, lint.json)
-            assert_eq!(patterns.len(), 4);
+            // The `.oxlintrc.json` extends `./lint.json` -> 9 watchers
+            // (json, jsonc, the 6 JS/TS config variants, and lint.json)
+            assert_eq!(patterns.len(), 9);
             assert_eq!(patterns[0], "**/.oxlintrc.json".to_string());
             assert_eq!(patterns[1], "**/.oxlintrc.jsonc".to_string());
             assert_eq!(patterns[2], "**/oxlint.config.ts".to_string());
-            assert_eq!(patterns[3], "lint.json".to_string());
+            assert_eq!(patterns[3], "**/oxlint.config.mts".to_string());
+            assert_eq!(patterns[7], "**/oxlint.config.js".to_string());
+            assert_eq!(patterns[8], "lint.json".to_string());
         }
 
         #[test]
@@ -1025,11 +1038,12 @@ mod test_watchers {
             )
             .get_watcher_patterns();
 
-            assert_eq!(patterns.len(), 4);
+            assert_eq!(patterns.len(), 9);
             assert_eq!(patterns[0], "**/.oxlintrc.json".to_string());
             assert_eq!(patterns[1], "**/.oxlintrc.jsonc".to_string());
             assert_eq!(patterns[2], "**/oxlint.config.ts".to_string());
-            assert_eq!(patterns[3], "**/tsconfig*.json".to_string());
+            assert_eq!(patterns[7], "**/oxlint.config.js".to_string());
+            assert_eq!(patterns[8], "**/tsconfig*.json".to_string());
         }
     }
 
@@ -1080,11 +1094,12 @@ mod test_watchers {
                         "typeAware": true
                     }));
             assert!(watch_patterns.is_some());
-            assert_eq!(watch_patterns.as_ref().unwrap().len(), 4);
+            assert_eq!(watch_patterns.as_ref().unwrap().len(), 9);
             assert_eq!(watch_patterns.as_ref().unwrap()[0], "**/.oxlintrc.json".to_string());
             assert_eq!(watch_patterns.as_ref().unwrap()[1], "**/.oxlintrc.jsonc".to_string());
             assert_eq!(watch_patterns.as_ref().unwrap()[2], "**/oxlint.config.ts".to_string());
-            assert_eq!(watch_patterns.as_ref().unwrap()[3], "**/tsconfig*.json".to_string());
+            assert_eq!(watch_patterns.as_ref().unwrap()[7], "**/oxlint.config.js".to_string());
+            assert_eq!(watch_patterns.as_ref().unwrap()[8], "**/tsconfig*.json".to_string());
         }
     }
 }

--- a/crates/oxc_config/src/discovery.rs
+++ b/crates/oxc_config/src/discovery.rs
@@ -45,8 +45,11 @@ pub struct ConfigFileNames {
     pub json: &'static str,
     /// JSONC config file name, such as `.oxlintrc.jsonc`.
     pub jsonc: &'static str,
-    /// JavaScript or TypeScript config file name, such as `oxlint.config.ts`.
-    pub js: &'static str,
+    /// JavaScript or TypeScript config file names, such as `oxlint.config.ts`.
+    ///
+    /// Multiple names are supported so auto-discovery can find every JS/TS
+    /// extension variant (`.js`, `.mjs`, `.cjs`, `.ts`, `.mts`, `.cts`).
+    pub js: &'static [&'static str],
     /// Vite config file name used when Vite mode is enabled.
     pub vite: &'static str,
 }
@@ -74,7 +77,9 @@ impl ConfigDiscovery {
             return vec![self.config_file_names.vite];
         }
 
-        vec![self.config_file_names.json, self.config_file_names.jsonc, self.config_file_names.js]
+        let mut names = vec![self.config_file_names.json, self.config_file_names.jsonc];
+        names.extend_from_slice(self.config_file_names.js);
+        names
     }
 
     /// Find the unique config file directly inside `dir` using a single `read_dir`.
@@ -108,7 +113,7 @@ impl ConfigDiscovery {
             let name_supported = if self.vite_plus_mode {
                 name == names.vite
             } else {
-                name == names.json || name == names.jsonc || name == names.js
+                name == names.json || name == names.jsonc || names.js.iter().any(|js| name == *js)
             };
             if !name_supported {
                 continue;
@@ -158,7 +163,7 @@ impl ConfigDiscovery {
         if file_name == self.config_file_names.jsonc {
             return Some(DiscoveredConfigFile::Jsonc(candidate.to_path_buf()));
         }
-        if file_name == self.config_file_names.js {
+        if self.config_file_names.js.iter().any(|js| file_name == *js) {
             return Some(DiscoveredConfigFile::Js(candidate.to_path_buf()));
         }
         None
@@ -259,7 +264,14 @@ mod test {
     const NAMES: ConfigFileNames = ConfigFileNames {
         json: ".oxlintrc.json",
         jsonc: ".oxlintrc.jsonc",
-        js: "oxlint.config.ts",
+        js: &[
+            "oxlint.config.js",
+            "oxlint.config.mjs",
+            "oxlint.config.cjs",
+            "oxlint.config.ts",
+            "oxlint.config.mts",
+            "oxlint.config.cts",
+        ],
         vite: "vite.config.ts",
     };
 
@@ -317,6 +329,35 @@ mod test {
 
         let found = discovery().find_unique_config_by_readdir(temp_dir.path(), false).unwrap();
         assert!(matches!(found, Some(DiscoveredConfigFile::Json(p)) if p == cfg_path));
+    }
+
+    #[test]
+    fn readdir_finds_each_js_config_extension() {
+        // Every configured JS/TS extension variant must be auto-discovered,
+        // not just `oxlint.config.ts`.
+        for name in NAMES.js {
+            let temp_dir = tempfile::tempdir().unwrap();
+            let cfg_path = temp_dir.path().join(name);
+            fs::write(&cfg_path, "export default {};").unwrap();
+
+            let found = discovery().find_unique_config_by_readdir(temp_dir.path(), false).unwrap();
+            assert!(
+                matches!(&found, Some(DiscoveredConfigFile::Js(p)) if *p == cfg_path),
+                "expected `{name}` to be discovered as a JS config, got {found:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn discover_config_file_recognizes_each_js_config_extension() {
+        for name in NAMES.js {
+            let candidate = Path::new("/project").join(name);
+            let found = discovery().discover_config_file(&candidate);
+            assert!(
+                matches!(&found, Some(DiscoveredConfigFile::Js(p)) if *p == candidate),
+                "expected `{name}` to be recognized as a JS config, got {found:?}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Config auto-discovery only looked for `oxlint.config.ts`, even though an explicit `--config` accepts `.js`, `.mjs`, `.cjs`, `.ts`, `.mts`, `.cts`.

The shared `ConfigFileNames.js` becomes a slice, and oxlint now lists all six `oxlint.config.*` variants (`.ts` first, so it stays the primary/documented name). The LSP watches every variant too.

`oxfmt` uses the same shared struct; its entry is kept as a behavior-preserving single-element slice here (still only `oxfmt.config.ts`) — adding the extra extensions there is a small follow-up.

Closes #20235
