### PR TITLE
fix(transformer): migrate babel loose options

### DIFF
--- a/tasks/transform_conformance/update_fixtures.mjs
+++ b/tasks/transform_conformance/update_fixtures.mjs
@@ -35,6 +35,7 @@ const CLASS_PLUGINS = [
   "transform-private-methods",
   "transform-private-property-in-object",
 ];
+const OPTIONAL_CHAINING_PLUGIN = "transform-optional-chaining";
 
 const PACKAGES_PATH = pathJoin(import.meta.dirname, "../coverage/babel/packages");
 
@@ -137,8 +138,60 @@ function updateOptions(options) {
   }
 
   filter("presets", FILTER_OUT_PRESETS);
+  if (migrateDeprecatedLooseOptions(options)) {
+    hasChangedOptions = true;
+  }
   filter("plugins", FILTER_OUT_PLUGINS);
   if (ensureAllClassPluginsEnabled(options)) {
+    hasChangedOptions = true;
+  }
+
+  return hasChangedOptions;
+}
+
+// Babel 8 deprecates plugin-level `loose` options in favor of top-level assumptions.
+// Keep these generated fixture updates aligned with Babel's migration docs:
+// https://babeljs.io/docs/assumptions/
+function migrateDeprecatedLooseOptions(options) {
+  const { plugins } = options;
+  if (!plugins) return false;
+
+  let hasChangedOptions = false;
+
+  for (let index = 0; index < plugins.length; index++) {
+    const plugin = plugins[index];
+    if (!Array.isArray(plugin)) continue;
+
+    const pluginName = getName(plugin);
+    const pluginOptions = plugin[1];
+    if (!pluginOptions || !Object.hasOwn(pluginOptions, "loose")) continue;
+
+    if (CLASS_PLUGINS.includes(pluginName)) {
+      if (pluginOptions.loose) {
+        options.assumptions ??= {};
+        options.assumptions.setPublicClassFields ??= true;
+        options.assumptions.constantSuper ??= true;
+        if (
+          !Object.hasOwn(options.assumptions, "privateFieldsAsProperties") &&
+          !Object.hasOwn(options.assumptions, "privateFieldsAsSymbols")
+        ) {
+          options.assumptions.privateFieldsAsProperties = true;
+        }
+      }
+    } else if (pluginName === OPTIONAL_CHAINING_PLUGIN) {
+      if (pluginOptions.loose) {
+        options.assumptions ??= {};
+        options.assumptions.noDocumentAll ??= true;
+        options.assumptions.pureGetters ??= true;
+      }
+    } else {
+      continue;
+    }
+
+    delete pluginOptions.loose;
+    if (Object.keys(pluginOptions).length === 0) {
+      plugins[index] = pluginName;
+    }
     hasChangedOptions = true;
   }
 


### PR DESCRIPTION
## Summary

Migrates deprecated Babel `loose` plugin options in `tasks/transform_conformance/update_fixtures.mjs` before fixture regeneration runs.

The updater was copying `loose: true` into class-feature plugins and passing Babel 7-style options through to Babel 8. Babel then emitted repeated migration warnings in the conformance job. This converts those options to Babel 8 assumptions instead:

- class feature plugins: `setPublicClassFields` + `privateFieldsAsProperties`
- optional chaining: `noDocumentAll` + `pureGetters`

No warnings are suppressed; unexpected Babel warnings and transform errors still surface normally.
