### PR TITLE
chore(deps): update Rust dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,9 +46,9 @@ checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "autocfg"
@@ -262,7 +262,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -645,7 +645,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1445,7 +1445,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2942,9 +2942,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
@@ -3105,7 +3105,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3200,7 +3200,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3484,7 +3484,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3955,7 +3955,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,56 +170,56 @@ serde = "1" # Serialization framework
 serde_json = "1" # JSON serialization
 syn = { version = "2", default-features = false } # Rust parser for macros
 unicode-id-start = "1" # Unicode identifier validation
-unicode-segmentation = "1.12.0" # Unicode grapheme segmentation
+unicode-segmentation = "1.13.3" # Unicode grapheme segmentation
 
 #
-javascript-globals = "1.5.0" # JavaScript global definitions
-json-strip-comments = "3.1.0" # Strip JSON comments
-oxc-browserslist = "3.0.0" # Browser compatibility queries
+javascript-globals = "1.5.1" # JavaScript global definitions
+json-strip-comments = "3.1.1" # Strip JSON comments
+oxc-browserslist = "3.0.9" # Browser compatibility queries
 oxc_index = { version = "5.0.0", features = ["nonmax", "serde"] } # Type-safe indices
-oxc_resolver = "11.16.3" # Module resolution
+oxc_resolver = "11.23.0" # Module resolution
 oxc_sourcemap = "8.0.2" # Source map generation
 
 #
 allocator-api2 = "=0.2.21" # Allocator trait
 oxc-graphql-parser = "0.0.4" # GraphQL parser (direct AST; apollo-parser 0.8.6 fork with opt-in 2025 descriptions + legacy fragment variables)
 base64 = "0.22.1" # Base64 encoding
-bitflags = "2.10.0" # Bitflag types
-bpaf = "0.9.20" # CLI parser
-compact_str = "0.9.0" # Compact string type
-console = "0.16.2" # Terminal utilities
+bitflags = "2.13.0" # Bitflag types
+bpaf = "0.9.26" # CLI parser
+compact_str = "0.9.1" # Compact string type
+console = "0.16.4" # Terminal utilities
 constcat = "0.6.1" # Const string concatenation
 convert_case = "0.11.0" # Case conversion
 cow-utils = "0.1.3" # Copy-on-write utilities
-criterion2 = { version = "3.0.2", default-features = false } # Benchmarking
-dragonbox_ecma = "0.1.0" # Fast float formatting
+criterion2 = { version = "3.0.4", default-features = false } # Benchmarking
+dragonbox_ecma = "0.1.12" # Fast float formatting
 encoding_rs = "0.8.35" # Character encoding
 encoding_rs_io = "0.1.7" # Encoding I/O
-fast-glob = "1.0.0" # Fast glob matching
-flate2 = "1.1.8" # Compression
-futures = "0.3.31" # Async utilities
-handlebars = "6.4.0" # Template engine
-hashbrown = { version = "0.17.0", default-features = false } # Fast hash map
+fast-glob = "1.0.1" # Fast glob matching
+flate2 = "1.1.9" # Compression
+futures = "0.3.32" # Async utilities
+handlebars = "6.4.2" # Template engine
+hashbrown = { version = "0.17.1", default-features = false } # Fast hash map
 hmac-sha1-compact = "1.1.7" # Self-contained, zero-dependency SHA-1
 hmac-sha256 = "1" # Self-contained, zero-dependency SHA-256 (react_compiler reactive-scope cache keys)
 humansize = "2.1.3" # Human-readable sizes
-ignore = "0.4.25" # Gitignore matching
-insta = "1.43.2" # Snapshot testing
+ignore = "0.4.27" # Gitignore matching
+insta = "1.48.0" # Snapshot testing
 itertools = "0.15.0" # Iterator utilities
-itoa = "1.0.17" # Integer to string
+itoa = "1.0.18" # Integer to string
 language-tags = "0.3.2" # Language tag parsing
-lazy-regex = "3.5.1" # Lazy regex compilation
+lazy-regex = "3.6.0" # Lazy regex compilation
 markdown = "1.0.0" # Markdown parsing
-memchr = "2.7.6" # Fast byte searching
+memchr = "2.8.2" # Fast byte searching
 miette = { package = "oxc-miette", version = "3.0.0", features = [
   "fancy-no-syscall",
 ] } # Error reporting
-mimalloc-safe = "0.1.62" # Fast allocator
+mimalloc-safe = "0.1.64" # Fast allocator
 nodejs-built-in-modules = "1.0.0" # Node.js built-in modules
 nonmax = "0.5.5" # Non-maximum numbers
 num-bigint = "0.4.6" # Big integers
 num-traits = "0.2.19" # Numeric traits
-papaya = "0.2.3" # Concurrent hash map
+papaya = "0.2.4" # Concurrent hash map
 percent-encoding = "2.3.2" # URL encoding
 petgraph = { version = "0.8.3", default-features = false } # Graph data structures
 phf = "0.14.0" # Perfect hash function
@@ -229,25 +229,25 @@ prettyplease = "0.2.37" # Rust code formatting
 project-root = "0.2.2" # Project root detection
 quickcheck = "1.1.0" # Property-based testing
 oxc-css-parser = "0.0.3" # CSS/SCSS/Less parser (raffia 0.12.3 fork: adds `template_placeholder` typed placeholders for css-in-js + valid-syntax coverage fixes (see crates/oxc_formatter_css/AGENTS.md))
-rand = "0.10.0" # Random number generation
-rayon = "1.11.0" # Data parallelism
+rand = "0.10.2" # Random number generation
+rayon = "1.12.0" # Data parallelism
 ropey = "1.6.1" # Rope text structure
-rust-lapper = "1.2.0" # Interval tree
+rust-lapper = "1.3.0" # Interval tree
 saphyr = "0.0.6" # YAML parser
 schemars = { package = "oxc-schemars", version = "0.9.1" } # JSON schema generation
 self_cell = "1.2.2" # Self-referential structs
 seq-macro = "0.3.6" # Sequence macros
 simdutf8 = { version = "0.1.5", features = ["aarch64_neon"] } # SIMD UTF-8 validation
-similar = "3.0.0" # Text diffing
+similar = "3.1.1" # Text diffing
 similar-asserts = "2.0.0" # Test diff assertions
-smallvec = { version = "1.15.1", features = ["union", "serde"] } # Stack-allocated vectors
-tempfile = "3.24.0" # Temporary files
-tokio = { version = "1.49.0", default-features = false } # Async runtime
-toml = { version = "1.0.0" }
+smallvec = { version = "1.15.2", features = ["union", "serde"] } # Stack-allocated vectors
+tempfile = "3.27.0" # Temporary files
+tokio = { version = "1.52.3", default-features = false } # Async runtime
+toml = { version = "1.1.2" }
 tower-lsp-server = "0.23.0" # LSP server framework
 tracing = "0.1.44"
-tracing-subscriber = "0.3.22" # Tracing implementation
-ureq = { version = "3.1.4", default-features = false } # HTTP client
+tracing-subscriber = "0.3.23" # Tracing implementation
+ureq = { version = "3.3.0", default-features = false } # HTTP client
 url = { version = "2.5.8" } # URL parsing
 walkdir = "2.5.0" # Directory traversal
 windows-sys = { version = "0.61.2" } # Windows API bindings
@@ -255,7 +255,7 @@ editorconfig-parser = "0.0.4"
 natord = "1.0.9"
 oxfmt = { path = "apps/oxfmt" }
 sort-package-json = "0.0.13"
-oxc-toml = "0.14.2"
+oxc-toml = "0.14.4"
 unicode-width = "0.2"
 website_common = { path = "tasks/website_common" }
 


### PR DESCRIPTION
Updates workspace Rust dependency requirements with compatible versions from `cargo upgrade -i`.

Keeps `oxc-graphql-parser` at `0.0.4` because `0.0.1` removes the AST API used by `oxc_formatter_graphql`.

Validated with `cargo check --workspace --locked`.