### PR TITLE
chore(linter): mark unicorn bad-comparison-sequence unsupported

### DIFF
--- a/tasks/lint_rules/src/unsupported-rules.json
+++ b/tasks/lint_rules/src/unsupported-rules.json
@@ -216,6 +216,7 @@
 
     "unicorn/no-named-default": "Implemented via `import/no-named-default`.",
     "unicorn/no-double-comparison": "Use `oxc/double-comparisons` instead.",
+    "unicorn/no-chained-comparison": "Use `oxc/bad-comparison-sequence` instead. TypeScript also reports errors for these comparisons.",
 
     "vue/no-lone-template": "Not currently possible, as it requires Vue template parsing.",
     "vue/no-v-html": "Not currently possible, as it requires Vue template parsing.",


### PR DESCRIPTION
## Summary
- mark `unicorn/bad-comparison-sequence` as unsupported in lint rule tracking
- point users to `oxc/bad-comparison-sequence` and note TypeScript also reports these comparisons