### PR TITLE
refactor(linter): remove custom react perf lint rule trait

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2915,22 +2915,22 @@ impl RuleRunner for crate::rules::react::void_dom_elements_no_children::VoidDomE
 
 impl RuleRunner for crate::rules::react_perf::jsx_no_jsx_as_prop::JsxNoJsxAsProp {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
-    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Unknown;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
 impl RuleRunner for crate::rules::react_perf::jsx_no_new_array_as_prop::JsxNoNewArrayAsProp {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
-    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Unknown;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
 impl RuleRunner for crate::rules::react_perf::jsx_no_new_function_as_prop::JsxNoNewFunctionAsProp {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
-    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Unknown;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
 impl RuleRunner for crate::rules::react_perf::jsx_no_new_object_as_prop::JsxNoNewObjectAsProp {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
-    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Unknown;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
 impl RuleRunner for crate::rules::unicorn::catch_error_name::CatchErrorName {

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_jsx_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_jsx_as_prop.rs
@@ -5,7 +5,15 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::SymbolId;
 use oxc_span::{GetSpan, Span};
 
-use crate::utils::{NativeAllowList, ReactPerfConfig, ReactPerfRule};
+use crate::{
+    AstNode, LintContext,
+    context::ContextHost,
+    rule::Rule,
+    utils::{
+        NativeAllowList, ReactPerfConfig, react_perf_from_configuration, run_react_perf_rule,
+        should_run_react_perf,
+    },
+};
 
 #[derive(Debug, Default, Clone, Deserialize)]
 pub struct JsxNoJsxAsProp(Box<ReactPerfConfig>);
@@ -53,25 +61,45 @@ declare_oxc_lint!(
     short_description = "Prevent JSX elements that are local to the current method from being used as values of JSX props.",
 );
 
-impl ReactPerfRule for JsxNoJsxAsProp {
+impl JsxNoJsxAsProp {
     const MESSAGE: &'static str = "JSX attribute values should not contain other JSX.";
 
     fn native_allow_list(&self) -> &NativeAllowList {
         self.0.native_allow_list()
     }
 
-    fn check_for_violation_on_expr(&self, expr: &Expression<'_>) -> Option<Span> {
+    fn check_for_violation_on_expr(expr: &Expression<'_>) -> Option<Span> {
         check_expression(expr)
     }
 
     fn check_for_violation_on_ast_kind(
-        &self,
         kind: &AstKind<'_>,
         _symbol_id: SymbolId,
     ) -> Option<(/* decl */ Span, /* init */ Option<Span>)> {
         let decl = kind.as_variable_declarator()?;
         let init_span = decl.init.as_ref().and_then(check_expression)?;
         Some((decl.id.span(), Some(init_span)))
+    }
+}
+
+impl Rule for JsxNoJsxAsProp {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        react_perf_from_configuration(value)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        run_react_perf_rule(
+            node,
+            ctx,
+            Self::MESSAGE,
+            self.native_allow_list(),
+            Self::check_for_violation_on_expr,
+            Self::check_for_violation_on_ast_kind,
+        );
+    }
+
+    fn should_run(&self, ctx: &ContextHost) -> bool {
+        should_run_react_perf(ctx)
     }
 }
 

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_new_array_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_new_array_as_prop.rs
@@ -6,10 +6,13 @@ use oxc_semantic::SymbolId;
 use oxc_span::{GetSpan, Span};
 
 use crate::{
+    AstNode, LintContext,
     ast_util::is_method_call,
+    context::ContextHost,
+    rule::Rule,
     utils::{
-        NativeAllowList, ReactPerfConfig, ReactPerfRule, find_initialized_binding,
-        is_constructor_matching_name,
+        NativeAllowList, ReactPerfConfig, find_initialized_binding, is_constructor_matching_name,
+        react_perf_from_configuration, run_react_perf_rule, should_run_react_perf,
     },
 };
 
@@ -61,7 +64,7 @@ declare_oxc_lint!(
     short_description = "Prevent arrays that are local to the current method from being used as values of JSX props.",
 );
 
-impl ReactPerfRule for JsxNoNewArrayAsProp {
+impl JsxNoNewArrayAsProp {
     const MESSAGE: &'static str =
         "JSX attribute values should not contain Arrays created in the same scope.";
 
@@ -69,12 +72,11 @@ impl ReactPerfRule for JsxNoNewArrayAsProp {
         self.0.native_allow_list()
     }
 
-    fn check_for_violation_on_expr(&self, expr: &Expression<'_>) -> Option<Span> {
+    fn check_for_violation_on_expr(expr: &Expression<'_>) -> Option<Span> {
         check_expression(expr)
     }
 
     fn check_for_violation_on_ast_kind(
-        &self,
         kind: &AstKind<'_>,
         symbol_id: SymbolId,
     ) -> Option<(/* decl */ Span, /* init */ Option<Span>)> {
@@ -92,6 +94,27 @@ impl ReactPerfRule for JsxNoNewArrayAsProp {
             }
             _ => None,
         }
+    }
+}
+
+impl Rule for JsxNoNewArrayAsProp {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        react_perf_from_configuration(value)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        run_react_perf_rule(
+            node,
+            ctx,
+            Self::MESSAGE,
+            self.native_allow_list(),
+            Self::check_for_violation_on_expr,
+            Self::check_for_violation_on_ast_kind,
+        );
+    }
+
+    fn should_run(&self, ctx: &ContextHost) -> bool {
+        should_run_react_perf(ctx)
     }
 }
 

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_new_function_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_new_function_as_prop.rs
@@ -8,7 +8,15 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::SymbolId;
 use oxc_span::{GetSpan, Span};
 
-use crate::utils::{NativeAllowList, ReactPerfConfig, ReactPerfRule, is_constructor_matching_name};
+use crate::{
+    AstNode, LintContext,
+    context::ContextHost,
+    rule::Rule,
+    utils::{
+        NativeAllowList, ReactPerfConfig, is_constructor_matching_name,
+        react_perf_from_configuration, run_react_perf_rule, should_run_react_perf,
+    },
+};
 
 #[derive(Debug, Default, Clone, Deserialize)]
 pub struct JsxNoNewFunctionAsProp(Box<ReactPerfConfig>);
@@ -55,7 +63,7 @@ declare_oxc_lint!(
     short_description = "Prevent functions that are local to the current method from being used as values of JSX props.",
 );
 
-impl ReactPerfRule for JsxNoNewFunctionAsProp {
+impl JsxNoNewFunctionAsProp {
     const MESSAGE: &'static str =
         "JSX attribute values should not contain functions created in the same scope.";
 
@@ -63,12 +71,11 @@ impl ReactPerfRule for JsxNoNewFunctionAsProp {
         self.0.native_allow_list()
     }
 
-    fn check_for_violation_on_expr(&self, expr: &Expression<'_>) -> Option<Span> {
+    fn check_for_violation_on_expr(expr: &Expression<'_>) -> Option<Span> {
         check_expression(expr)
     }
 
     fn check_for_violation_on_ast_kind(
-        &self,
         kind: &AstKind<'_>,
         _symbol_id: SymbolId,
     ) -> Option<(/* decl */ Span, /* init */ Option<Span>)> {
@@ -84,6 +91,27 @@ impl ReactPerfRule for JsxNoNewFunctionAsProp {
             AstKind::Function(f) => Some((f.id.as_ref().map_or(f.span, GetSpan::span), None)),
             _ => None,
         }
+    }
+}
+
+impl Rule for JsxNoNewFunctionAsProp {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        react_perf_from_configuration(value)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        run_react_perf_rule(
+            node,
+            ctx,
+            Self::MESSAGE,
+            self.native_allow_list(),
+            Self::check_for_violation_on_expr,
+            Self::check_for_violation_on_ast_kind,
+        );
+    }
+
+    fn should_run(&self, ctx: &ContextHost) -> bool {
+        should_run_react_perf(ctx)
     }
 }
 

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_new_object_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_new_object_as_prop.rs
@@ -6,10 +6,13 @@ use oxc_semantic::SymbolId;
 use oxc_span::{GetSpan, Span};
 
 use crate::{
+    AstNode, LintContext,
     ast_util::is_method_call,
+    context::ContextHost,
+    rule::Rule,
     utils::{
-        NativeAllowList, ReactPerfConfig, ReactPerfRule, find_initialized_binding,
-        is_constructor_matching_name,
+        NativeAllowList, ReactPerfConfig, find_initialized_binding, is_constructor_matching_name,
+        react_perf_from_configuration, run_react_perf_rule, should_run_react_perf,
     },
 };
 
@@ -62,7 +65,7 @@ declare_oxc_lint!(
     short_description = "Prevent objects that are local to the current method from being used as values of JSX props.",
 );
 
-impl ReactPerfRule for JsxNoNewObjectAsProp {
+impl JsxNoNewObjectAsProp {
     const MESSAGE: &'static str =
         "JSX attribute values should not contain objects created in the same scope.";
 
@@ -70,12 +73,11 @@ impl ReactPerfRule for JsxNoNewObjectAsProp {
         self.0.native_allow_list()
     }
 
-    fn check_for_violation_on_expr(&self, expr: &Expression<'_>) -> Option<Span> {
+    fn check_for_violation_on_expr(expr: &Expression<'_>) -> Option<Span> {
         check_expression(expr)
     }
 
     fn check_for_violation_on_ast_kind(
-        &self,
         kind: &AstKind<'_>,
         symbol_id: SymbolId,
     ) -> Option<(/* decl */ Span, /* init */ Option<Span>)> {
@@ -93,6 +95,27 @@ impl ReactPerfRule for JsxNoNewObjectAsProp {
             }
             _ => None,
         }
+    }
+}
+
+impl Rule for JsxNoNewObjectAsProp {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        react_perf_from_configuration(value)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        run_react_perf_rule(
+            node,
+            ctx,
+            Self::MESSAGE,
+            self.native_allow_list(),
+            Self::check_for_violation_on_expr,
+            Self::check_for_violation_on_ast_kind,
+        );
+    }
+
+    fn should_run(&self, ctx: &ContextHost) -> bool {
+        should_run_react_perf(ctx)
     }
 }
 

--- a/crates/oxc_linter/src/utils/react_perf.rs
+++ b/crates/oxc_linter/src/utils/react_perf.rs
@@ -1,5 +1,3 @@
-use std::fmt;
-
 use oxc_ast::{
     AstKind,
     ast::{BindingIdentifier, BindingPattern, Expression, JSXAttributeValue},
@@ -12,9 +10,7 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 
 use crate::{
-    AstNode, LintContext,
-    context::ContextHost,
-    rule::{DefaultRuleConfig, Rule},
+    AstNode, LintContext, context::ContextHost, rule::DefaultRuleConfig,
     utils::is_react_component_name,
 };
 
@@ -74,116 +70,100 @@ fn react_perf_reference_diagnostic(
     diagnostic.and_label(attr_span.label("And used here"))
 }
 
-pub trait ReactPerfRule: Sized + Default + fmt::Debug {
-    const MESSAGE: &'static str;
-
-    /// The `nativeAllowList` configuration for this rule.
-    fn native_allow_list(&self) -> &NativeAllowList;
-
-    /// Check if an [`Expression`] violates a react perf rule. If it does,
-    /// report the [`OxcDiagnostic`] and return `true`.
-    ///
-    /// [`OxcDiagnostic`]: oxc_diagnostics::OxcDiagnostic
-    fn check_for_violation_on_expr(&self, expr: &Expression<'_>) -> Option<Span>;
-    /// Check if a node of some [`AstKind`] violates a react perf rule. If it does,
-    /// report the [`OxcDiagnostic`] and return `true`.
-    ///
-    /// [`OxcDiagnostic`]: oxc_diagnostics::OxcDiagnostic
-    fn check_for_violation_on_ast_kind(
-        &self,
-        kind: &AstKind<'_>,
-        symbol_id: SymbolId,
-    ) -> Option<(/* decl */ Span, /* init */ Option<Span>)>;
+pub fn react_perf_from_configuration<T>(value: serde_json::Value) -> Result<T, serde_json::Error>
+where
+    T: Default + serde::de::DeserializeOwned,
+{
+    serde_json::from_value::<DefaultRuleConfig<T>>(value).map(DefaultRuleConfig::into_inner)
 }
 
-impl<R> Rule for R
-where
-    R: ReactPerfRule + serde::de::DeserializeOwned,
-{
-    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+pub fn run_react_perf_rule<'a>(
+    node: &AstNode<'a>,
+    ctx: &LintContext<'a>,
+    message: &'static str,
+    native_allow_list: &NativeAllowList,
+    check_for_violation_on_expr: impl Fn(&Expression<'_>) -> Option<Span>,
+    check_for_violation_on_ast_kind: impl Fn(
+        &AstKind<'_>,
+        SymbolId,
+    ) -> Option<(
+        /* decl */ Span,
+        /* init */ Option<Span>,
+    )>,
+) {
+    // new objects/arrays/etc created at the root scope do not get
+    // re-created on each render and thus do not affect performance.
+    if node.scope_id() == ctx.scoping().root_scope_id() {
+        return;
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        // new objects/arrays/etc created at the root scope do not get
-        // re-created on each render and thus do not affect performance.
-        if node.scope_id() == ctx.scoping().root_scope_id() {
-            return;
-        }
+    // look for JSX attributes whose values are expressions (foo={bar}) (as opposed to
+    // spreads ({...foo}) or just boolean attributes) (<div foo />)
+    let AstKind::JSXAttribute(attr) = node.kind() else {
+        return;
+    };
+    let Some(JSXAttributeValue::ExpressionContainer(container)) = attr.value.as_ref() else {
+        return;
+    };
+    let Some(expr) = container.expression.as_expression() else {
+        return;
+    };
 
-        // look for JSX attributes whose values are expressions (foo={bar}) (as opposed to
-        // spreads ({...foo}) or just boolean attributes) (<div foo />)
-        let AstKind::JSXAttribute(attr) = node.kind() else {
-            return;
-        };
-        let Some(JSXAttributeValue::ExpressionContainer(container)) = attr.value.as_ref() else {
-            return;
-        };
-        let Some(expr) = container.expression.as_expression() else {
-            return;
-        };
-
-        // skip native elements (lowercase-first-letter tags like `div`) that are
-        // exempted by the `nativeAllowList` configuration.
-        if !matches!(self.native_allow_list(), NativeAllowList::None)
-            && let AstKind::JSXOpeningElement(opening) = ctx.nodes().parent_kind(node.id())
-            && let Some(tag_name) = opening.name.get_identifier_name()
-            && !is_react_component_name(&tag_name)
-        {
-            match self.native_allow_list() {
-                NativeAllowList::All(_) => return,
-                NativeAllowList::List(names) => {
-                    if let Some(attr_name) = attr.name.as_identifier()
-                        && names.iter().any(|n| n.as_str().eq_ignore_ascii_case(&attr_name.name))
-                    {
-                        return;
-                    }
+    // skip native elements (lowercase-first-letter tags like `div`) that are
+    // exempted by the `nativeAllowList` configuration.
+    if !matches!(native_allow_list, NativeAllowList::None)
+        && let AstKind::JSXOpeningElement(opening) = ctx.nodes().parent_kind(node.id())
+        && let Some(tag_name) = opening.name.get_identifier_name()
+        && !is_react_component_name(&tag_name)
+    {
+        match native_allow_list {
+            NativeAllowList::All(_) => return,
+            NativeAllowList::List(names) => {
+                if let Some(attr_name) = attr.name.as_identifier()
+                    && names.iter().any(|n| n.as_str().eq_ignore_ascii_case(&attr_name.name))
+                {
+                    return;
                 }
-                NativeAllowList::None => {}
             }
-        }
-
-        // strip parenthesis and TS type casting expressions
-        let expr = expr.get_inner_expression();
-        // When expr is a violation, this fn will report the appropriate
-        // diagnostic and return true.
-        if let Some(attr_span) = self.check_for_violation_on_expr(expr) {
-            ctx.diagnostic(react_perf_inline_diagnostic(Self::MESSAGE, attr_span));
-            return;
-        }
-
-        // check for new objects/arrays/etc declared within the render function,
-        // which is effectively the same as passing a new object/array/etc
-        // directly as a prop.
-        let Expression::Identifier(ident) = expr else {
-            return;
-        };
-        let Some(symbol_id) = ctx.scoping().get_reference(ident.reference_id()).symbol_id() else {
-            return;
-        };
-        // Symbols declared at the root scope won't (or, at least, shouldn't) be
-        // re-assigned inside component render functions, so we can safely
-        // ignore them.
-        if ctx.scoping().symbol_scope_id(symbol_id) == ctx.scoping().root_scope_id() {
-            return;
-        }
-
-        let declaration_node = ctx.nodes().get_node(ctx.scoping().symbol_declaration(symbol_id));
-        if let Some((decl_span, init_span)) =
-            self.check_for_violation_on_ast_kind(&declaration_node.kind(), symbol_id)
-        {
-            ctx.diagnostic(react_perf_reference_diagnostic(
-                Self::MESSAGE,
-                ident.span,
-                decl_span,
-                init_span,
-            ));
+            NativeAllowList::None => {}
         }
     }
 
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_jsx()
+    // strip parenthesis and TS type casting expressions
+    let expr = expr.get_inner_expression();
+    // When expr is a violation, this fn will report the appropriate
+    // diagnostic and return true.
+    if let Some(attr_span) = check_for_violation_on_expr(expr) {
+        ctx.diagnostic(react_perf_inline_diagnostic(message, attr_span));
+        return;
     }
+
+    // check for new objects/arrays/etc declared within the render function,
+    // which is effectively the same as passing a new object/array/etc
+    // directly as a prop.
+    let Expression::Identifier(ident) = expr else {
+        return;
+    };
+    let Some(symbol_id) = ctx.scoping().get_reference(ident.reference_id()).symbol_id() else {
+        return;
+    };
+    // Symbols declared at the root scope won't (or, at least, shouldn't) be
+    // re-assigned inside component render functions, so we can safely
+    // ignore them.
+    if ctx.scoping().symbol_scope_id(symbol_id) == ctx.scoping().root_scope_id() {
+        return;
+    }
+
+    let declaration_node = ctx.nodes().get_node(ctx.scoping().symbol_declaration(symbol_id));
+    if let Some((decl_span, init_span)) =
+        check_for_violation_on_ast_kind(&declaration_node.kind(), symbol_id)
+    {
+        ctx.diagnostic(react_perf_reference_diagnostic(message, ident.span, decl_span, init_span));
+    }
+}
+
+pub fn should_run_react_perf(ctx: &ContextHost) -> bool {
+    ctx.source_type().is_jsx()
 }
 
 pub fn is_constructor_matching_name(callee: &Expression<'_>, name: &str) -> bool {


### PR DESCRIPTION
The rule trait here is convenient, but is inconsistent with the style and architecture of other linter rules. Removing this trait allows the linter codegen to understand this rule better, which enables performance optimizations not currently allowed with this style. It also makes these lint rules less "clean" but more consistent with every other lint rule that we have, which makes this easier to maintain in the long term.