### PR TITLE
perf(linter): only run react-perf rules on JSX attribute nodes

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2914,22 +2914,26 @@ impl RuleRunner for crate::rules::react::void_dom_elements_no_children::VoidDomE
 }
 
 impl RuleRunner for crate::rules::react_perf::jsx_no_jsx_as_prop::JsxNoJsxAsProp {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXAttribute]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
 impl RuleRunner for crate::rules::react_perf::jsx_no_new_array_as_prop::JsxNoNewArrayAsProp {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXAttribute]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
 impl RuleRunner for crate::rules::react_perf::jsx_no_new_function_as_prop::JsxNoNewFunctionAsProp {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXAttribute]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
 impl RuleRunner for crate::rules::react_perf::jsx_no_new_object_as_prop::JsxNoNewObjectAsProp {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXAttribute]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_jsx_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_jsx_as_prop.rs
@@ -88,8 +88,13 @@ impl Rule for JsxNoJsxAsProp {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::JSXAttribute(attr) = node.kind() else {
+            return;
+        };
+
         run_react_perf_rule(
-            node,
+            attr,
+            node.scope_id(),
             ctx,
             Self::MESSAGE,
             self.native_allow_list(),

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_new_array_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_new_array_as_prop.rs
@@ -103,8 +103,13 @@ impl Rule for JsxNoNewArrayAsProp {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::JSXAttribute(attr) = node.kind() else {
+            return;
+        };
+
         run_react_perf_rule(
-            node,
+            attr,
+            node.scope_id(),
             ctx,
             Self::MESSAGE,
             self.native_allow_list(),

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_new_function_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_new_function_as_prop.rs
@@ -100,8 +100,13 @@ impl Rule for JsxNoNewFunctionAsProp {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::JSXAttribute(attr) = node.kind() else {
+            return;
+        };
+
         run_react_perf_rule(
-            node,
+            attr,
+            node.scope_id(),
             ctx,
             Self::MESSAGE,
             self.native_allow_list(),

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_new_object_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_new_object_as_prop.rs
@@ -104,8 +104,13 @@ impl Rule for JsxNoNewObjectAsProp {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::JSXAttribute(attr) = node.kind() else {
+            return;
+        };
+
         run_react_perf_rule(
-            node,
+            attr,
+            node.scope_id(),
             ctx,
             Self::MESSAGE,
             self.native_allow_list(),

--- a/crates/oxc_linter/src/utils/react_perf.rs
+++ b/crates/oxc_linter/src/utils/react_perf.rs
@@ -1,17 +1,17 @@
 use oxc_ast::{
     AstKind,
-    ast::{BindingIdentifier, BindingPattern, Expression, JSXAttributeValue},
+    ast::{BindingIdentifier, BindingPattern, Expression, JSXAttribute, JSXAttributeValue},
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_semantic::SymbolId;
 use oxc_span::Span;
 use oxc_str::CompactStr;
+use oxc_syntax::scope::ScopeId;
 use schemars::JsonSchema;
 use serde::Deserialize;
 
 use crate::{
-    AstNode, LintContext, context::ContextHost, rule::DefaultRuleConfig,
-    utils::is_react_component_name,
+    LintContext, context::ContextHost, rule::DefaultRuleConfig, utils::is_react_component_name,
 };
 
 #[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
@@ -78,7 +78,8 @@ where
 }
 
 pub fn run_react_perf_rule<'a>(
-    node: &AstNode<'a>,
+    attr: &JSXAttribute<'a>,
+    scope_id: ScopeId,
     ctx: &LintContext<'a>,
     message: &'static str,
     native_allow_list: &NativeAllowList,
@@ -93,15 +94,12 @@ pub fn run_react_perf_rule<'a>(
 ) {
     // new objects/arrays/etc created at the root scope do not get
     // re-created on each render and thus do not affect performance.
-    if node.scope_id() == ctx.scoping().root_scope_id() {
+    if scope_id == ctx.scoping().root_scope_id() {
         return;
     }
 
     // look for JSX attributes whose values are expressions (foo={bar}) (as opposed to
     // spreads ({...foo}) or just boolean attributes) (<div foo />)
-    let AstKind::JSXAttribute(attr) = node.kind() else {
-        return;
-    };
     let Some(JSXAttributeValue::ExpressionContainer(container)) = attr.value.as_ref() else {
         return;
     };
@@ -112,7 +110,7 @@ pub fn run_react_perf_rule<'a>(
     // skip native elements (lowercase-first-letter tags like `div`) that are
     // exempted by the `nativeAllowList` configuration.
     if !matches!(native_allow_list, NativeAllowList::None)
-        && let AstKind::JSXOpeningElement(opening) = ctx.nodes().parent_kind(node.id())
+        && let AstKind::JSXOpeningElement(opening) = ctx.nodes().parent_kind(attr.node_id())
         && let Some(tag_name) = opening.name.get_identifier_name()
         && !is_react_component_name(&tag_name)
     {


### PR DESCRIPTION
Now that the react perf rules are not a special kind of lint rule, all we need to do is pull out the main node type check in order to opt-in to the AST node type optimizations in the linter codegen. In this case, the node type check is enforced by having the shared function accept the `JSXAttribute` instead of the `AstNode`, so it's impossible to _not_ check the AST node type in the `run` function first.

This improves performance by then allowing the linter runtime to skip these rules completely for files that don't contain any JSX attributes.