### PR TITLE
perf(linter): dispatch react_perf rules only on JSXAttribute nodes

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2914,23 +2914,27 @@ impl RuleRunner for crate::rules::react::void_dom_elements_no_children::VoidDomE
 }
 
 impl RuleRunner for crate::rules::react_perf::jsx_no_jsx_as_prop::JsxNoJsxAsProp {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
-    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Unknown;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXAttribute]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
 impl RuleRunner for crate::rules::react_perf::jsx_no_new_array_as_prop::JsxNoNewArrayAsProp {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
-    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Unknown;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXAttribute]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
 impl RuleRunner for crate::rules::react_perf::jsx_no_new_function_as_prop::JsxNoNewFunctionAsProp {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
-    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Unknown;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXAttribute]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
 impl RuleRunner for crate::rules::react_perf::jsx_no_new_object_as_prop::JsxNoNewObjectAsProp {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
-    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Unknown;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXAttribute]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
 impl RuleRunner for crate::rules::unicorn::catch_error_name::CatchErrorName {

--- a/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
+++ b/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
@@ -81,12 +81,6 @@ impl Rule for NoConfusingSetTimeout {
     fn run_once(&self, ctx: &LintContext) {
         let scopes = ctx.scoping();
         let symbol_table = ctx.scoping();
-        let possible_nodes = collect_possible_jest_call_node(ctx);
-        let id_to_jest_node_map =
-            possible_nodes.iter().fold(FxHashMap::default(), |mut acc, cur| {
-                acc.insert(cur.node.id(), cur);
-                acc
-            });
 
         let mut jest_reference_id_list: Vec<(ReferenceId, Span)> = vec![];
         let mut reported_unordered_set_timeouts = FxHashSet::default();
@@ -103,6 +97,19 @@ impl Rule for NoConfusingSetTimeout {
                 ctx,
             );
         }
+
+        // Every diagnostic this rule can report requires at least one `jest.setTimeout`
+        // reference (collected above), so skip the rest of the analysis if there are none.
+        if jest_reference_id_list.is_empty() {
+            return;
+        }
+
+        let possible_nodes = collect_possible_jest_call_node(ctx);
+        let id_to_jest_node_map =
+            possible_nodes.iter().fold(FxHashMap::default(), |mut acc, cur| {
+                acc.insert(cur.node.id(), cur);
+                acc
+            });
 
         for reference_id_list in scopes.root_unresolved_references_ids() {
             handle_jest_set_time_out(

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_jsx_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_jsx_as_prop.rs
@@ -5,7 +5,12 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::SymbolId;
 use oxc_span::{GetSpan, Span};
 
-use crate::utils::{NativeAllowList, ReactPerfConfig, ReactPerfRule};
+use crate::{
+    AstNode, LintContext,
+    context::ContextHost,
+    rule::{DefaultRuleConfig, Rule},
+    utils::{NativeAllowList, ReactPerfConfig, ReactPerfRule, run_react_perf_rule},
+};
 
 #[derive(Debug, Default, Clone, Deserialize)]
 pub struct JsxNoJsxAsProp(Box<ReactPerfConfig>);
@@ -52,6 +57,23 @@ declare_oxc_lint!(
     version = "0.2.3",
     short_description = "Prevent JSX elements that are local to the current method from being used as values of JSX props.",
 );
+
+impl Rule for JsxNoJsxAsProp {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::JSXAttribute(attr) = node.kind() else {
+            return;
+        };
+        run_react_perf_rule(self, attr, node, ctx);
+    }
+
+    fn should_run(&self, ctx: &ContextHost) -> bool {
+        ctx.source_type().is_jsx()
+    }
+}
 
 impl ReactPerfRule for JsxNoJsxAsProp {
     const MESSAGE: &'static str = "JSX attribute values should not contain other JSX.";

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_new_array_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_new_array_as_prop.rs
@@ -6,10 +6,13 @@ use oxc_semantic::SymbolId;
 use oxc_span::{GetSpan, Span};
 
 use crate::{
+    AstNode, LintContext,
     ast_util::is_method_call,
+    context::ContextHost,
+    rule::{DefaultRuleConfig, Rule},
     utils::{
         NativeAllowList, ReactPerfConfig, ReactPerfRule, find_initialized_binding,
-        is_constructor_matching_name,
+        is_constructor_matching_name, run_react_perf_rule,
     },
 };
 
@@ -60,6 +63,23 @@ declare_oxc_lint!(
     version = "0.2.3",
     short_description = "Prevent arrays that are local to the current method from being used as values of JSX props.",
 );
+
+impl Rule for JsxNoNewArrayAsProp {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::JSXAttribute(attr) = node.kind() else {
+            return;
+        };
+        run_react_perf_rule(self, attr, node, ctx);
+    }
+
+    fn should_run(&self, ctx: &ContextHost) -> bool {
+        ctx.source_type().is_jsx()
+    }
+}
 
 impl ReactPerfRule for JsxNoNewArrayAsProp {
     const MESSAGE: &'static str =

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_new_function_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_new_function_as_prop.rs
@@ -8,7 +8,15 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::SymbolId;
 use oxc_span::{GetSpan, Span};
 
-use crate::utils::{NativeAllowList, ReactPerfConfig, ReactPerfRule, is_constructor_matching_name};
+use crate::{
+    AstNode, LintContext,
+    context::ContextHost,
+    rule::{DefaultRuleConfig, Rule},
+    utils::{
+        NativeAllowList, ReactPerfConfig, ReactPerfRule, is_constructor_matching_name,
+        run_react_perf_rule,
+    },
+};
 
 #[derive(Debug, Default, Clone, Deserialize)]
 pub struct JsxNoNewFunctionAsProp(Box<ReactPerfConfig>);
@@ -54,6 +62,23 @@ declare_oxc_lint!(
     version = "0.2.3",
     short_description = "Prevent functions that are local to the current method from being used as values of JSX props.",
 );
+
+impl Rule for JsxNoNewFunctionAsProp {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::JSXAttribute(attr) = node.kind() else {
+            return;
+        };
+        run_react_perf_rule(self, attr, node, ctx);
+    }
+
+    fn should_run(&self, ctx: &ContextHost) -> bool {
+        ctx.source_type().is_jsx()
+    }
+}
 
 impl ReactPerfRule for JsxNoNewFunctionAsProp {
     const MESSAGE: &'static str =

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_new_object_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_new_object_as_prop.rs
@@ -6,10 +6,13 @@ use oxc_semantic::SymbolId;
 use oxc_span::{GetSpan, Span};
 
 use crate::{
+    AstNode, LintContext,
     ast_util::is_method_call,
+    context::ContextHost,
+    rule::{DefaultRuleConfig, Rule},
     utils::{
         NativeAllowList, ReactPerfConfig, ReactPerfRule, find_initialized_binding,
-        is_constructor_matching_name,
+        is_constructor_matching_name, run_react_perf_rule,
     },
 };
 
@@ -61,6 +64,23 @@ declare_oxc_lint!(
     version = "0.2.3",
     short_description = "Prevent objects that are local to the current method from being used as values of JSX props.",
 );
+
+impl Rule for JsxNoNewObjectAsProp {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::JSXAttribute(attr) = node.kind() else {
+            return;
+        };
+        run_react_perf_rule(self, attr, node, ctx);
+    }
+
+    fn should_run(&self, ctx: &ContextHost) -> bool {
+        ctx.source_type().is_jsx()
+    }
+}
 
 impl ReactPerfRule for JsxNoNewObjectAsProp {
     const MESSAGE: &'static str =

--- a/crates/oxc_linter/src/utils/react_perf.rs
+++ b/crates/oxc_linter/src/utils/react_perf.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use oxc_ast::{
     AstKind,
-    ast::{BindingIdentifier, BindingPattern, Expression, JSXAttributeValue},
+    ast::{BindingIdentifier, BindingPattern, Expression, JSXAttribute, JSXAttributeValue},
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_semantic::SymbolId;
@@ -11,12 +11,7 @@ use oxc_str::CompactStr;
 use schemars::JsonSchema;
 use serde::Deserialize;
 
-use crate::{
-    AstNode, LintContext,
-    context::ContextHost,
-    rule::{DefaultRuleConfig, Rule},
-    utils::is_react_component_name,
-};
+use crate::{AstNode, LintContext, utils::is_react_component_name};
 
 #[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
@@ -96,93 +91,87 @@ pub trait ReactPerfRule: Sized + Default + fmt::Debug {
     ) -> Option<(/* decl */ Span, /* init */ Option<Span>)>;
 }
 
-impl<R> Rule for R
-where
-    R: ReactPerfRule + serde::de::DeserializeOwned,
-{
-    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+/// Shared `run` implementation for all `react_perf` rules.
+///
+/// Callers (the rules' `Rule::run` implementations) are expected to have already
+/// matched `node.kind()` against [`AstKind::JSXAttribute`] and pass the attribute in,
+/// so that the linter can dispatch these rules only to `JSXAttribute` nodes.
+pub fn run_react_perf_rule<'a, R: ReactPerfRule>(
+    rule: &R,
+    attr: &JSXAttribute<'a>,
+    node: &AstNode<'a>,
+    ctx: &LintContext<'a>,
+) {
+    // new objects/arrays/etc created at the root scope do not get
+    // re-created on each render and thus do not affect performance.
+    if node.scope_id() == ctx.scoping().root_scope_id() {
+        return;
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        // new objects/arrays/etc created at the root scope do not get
-        // re-created on each render and thus do not affect performance.
-        if node.scope_id() == ctx.scoping().root_scope_id() {
-            return;
-        }
+    // look for JSX attributes whose values are expressions (foo={bar}) (as opposed to
+    // spreads ({...foo}) or just boolean attributes) (<div foo />)
+    let Some(JSXAttributeValue::ExpressionContainer(container)) = attr.value.as_ref() else {
+        return;
+    };
+    let Some(expr) = container.expression.as_expression() else {
+        return;
+    };
 
-        // look for JSX attributes whose values are expressions (foo={bar}) (as opposed to
-        // spreads ({...foo}) or just boolean attributes) (<div foo />)
-        let AstKind::JSXAttribute(attr) = node.kind() else {
-            return;
-        };
-        let Some(JSXAttributeValue::ExpressionContainer(container)) = attr.value.as_ref() else {
-            return;
-        };
-        let Some(expr) = container.expression.as_expression() else {
-            return;
-        };
-
-        // skip native elements (lowercase-first-letter tags like `div`) that are
-        // exempted by the `nativeAllowList` configuration.
-        if !matches!(self.native_allow_list(), NativeAllowList::None)
-            && let AstKind::JSXOpeningElement(opening) = ctx.nodes().parent_kind(node.id())
-            && let Some(tag_name) = opening.name.get_identifier_name()
-            && !is_react_component_name(&tag_name)
-        {
-            match self.native_allow_list() {
-                NativeAllowList::All(_) => return,
-                NativeAllowList::List(names) => {
-                    if let Some(attr_name) = attr.name.as_identifier()
-                        && names.iter().any(|n| n.as_str().eq_ignore_ascii_case(&attr_name.name))
-                    {
-                        return;
-                    }
+    // skip native elements (lowercase-first-letter tags like `div`) that are
+    // exempted by the `nativeAllowList` configuration.
+    if !matches!(rule.native_allow_list(), NativeAllowList::None)
+        && let AstKind::JSXOpeningElement(opening) = ctx.nodes().parent_kind(node.id())
+        && let Some(tag_name) = opening.name.get_identifier_name()
+        && !is_react_component_name(&tag_name)
+    {
+        match rule.native_allow_list() {
+            NativeAllowList::All(_) => return,
+            NativeAllowList::List(names) => {
+                if let Some(attr_name) = attr.name.as_identifier()
+                    && names.iter().any(|n| n.as_str().eq_ignore_ascii_case(&attr_name.name))
+                {
+                    return;
                 }
-                NativeAllowList::None => {}
             }
-        }
-
-        // strip parenthesis and TS type casting expressions
-        let expr = expr.get_inner_expression();
-        // When expr is a violation, this fn will report the appropriate
-        // diagnostic and return true.
-        if let Some(attr_span) = self.check_for_violation_on_expr(expr) {
-            ctx.diagnostic(react_perf_inline_diagnostic(Self::MESSAGE, attr_span));
-            return;
-        }
-
-        // check for new objects/arrays/etc declared within the render function,
-        // which is effectively the same as passing a new object/array/etc
-        // directly as a prop.
-        let Expression::Identifier(ident) = expr else {
-            return;
-        };
-        let Some(symbol_id) = ctx.scoping().get_reference(ident.reference_id()).symbol_id() else {
-            return;
-        };
-        // Symbols declared at the root scope won't (or, at least, shouldn't) be
-        // re-assigned inside component render functions, so we can safely
-        // ignore them.
-        if ctx.scoping().symbol_scope_id(symbol_id) == ctx.scoping().root_scope_id() {
-            return;
-        }
-
-        let declaration_node = ctx.nodes().get_node(ctx.scoping().symbol_declaration(symbol_id));
-        if let Some((decl_span, init_span)) =
-            self.check_for_violation_on_ast_kind(&declaration_node.kind(), symbol_id)
-        {
-            ctx.diagnostic(react_perf_reference_diagnostic(
-                Self::MESSAGE,
-                ident.span,
-                decl_span,
-                init_span,
-            ));
+            NativeAllowList::None => {}
         }
     }
 
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_jsx()
+    // strip parenthesis and TS type casting expressions
+    let expr = expr.get_inner_expression();
+    // When expr is a violation, this fn will report the appropriate
+    // diagnostic and return true.
+    if let Some(attr_span) = rule.check_for_violation_on_expr(expr) {
+        ctx.diagnostic(react_perf_inline_diagnostic(R::MESSAGE, attr_span));
+        return;
+    }
+
+    // check for new objects/arrays/etc declared within the render function,
+    // which is effectively the same as passing a new object/array/etc
+    // directly as a prop.
+    let Expression::Identifier(ident) = expr else {
+        return;
+    };
+    let Some(symbol_id) = ctx.scoping().get_reference(ident.reference_id()).symbol_id() else {
+        return;
+    };
+    // Symbols declared at the root scope won't (or, at least, shouldn't) be
+    // re-assigned inside component render functions, so we can safely
+    // ignore them.
+    if ctx.scoping().symbol_scope_id(symbol_id) == ctx.scoping().root_scope_id() {
+        return;
+    }
+
+    let declaration_node = ctx.nodes().get_node(ctx.scoping().symbol_declaration(symbol_id));
+    if let Some((decl_span, init_span)) =
+        rule.check_for_violation_on_ast_kind(&declaration_node.kind(), symbol_id)
+    {
+        ctx.diagnostic(react_perf_reference_diagnostic(
+            R::MESSAGE,
+            ident.span,
+            decl_span,
+            init_span,
+        ));
     }
 }
 


### PR DESCRIPTION
### What this PR does

The four `react_perf` rules (`jsx-no-new-object-as-prop`, `jsx-no-new-array-as-prop`, `jsx-no-new-function-as-prop`, `jsx-no-jsx-as-prop`) received their `Rule` implementation from a blanket `impl<R> Rule for R where R: ReactPerfRule` in `utils/react_perf.rs`. Because the `run` body lived outside the rule files, `oxc_linter_codegen` could not detect the node types they match and generated `NODE_TYPES: None` — so all four rules ran on **every AST node** of every JSX/TSX file, even though they only ever act on `AstKind::JSXAttribute`.

This PR replaces the blanket impl with per-rule `Rule` impls whose `run` starts with the `let AstKind::JSXAttribute(..) = node.kind() else { return; }` pattern that codegen detects, delegating the shared logic to a `run_react_perf_rule` helper. The generated runners now carry `NODE_TYPES: [JSXAttribute]`, and with `vue/max_props` being the only remaining `NODE_TYPES: None` rule (gated to `.vue` files), the "run on any node" bucket is empty for typical configurations.

On `kitchen-sink.tsx` this removes ~133k wasted `run` invocations per rule per lint (2.66M over 20 iterations; the rules dropped from ~17% of instrumented rule time to ~0.4%).

A second commit adds an early exit to `jest/no-confusing-set-timeout`: every diagnostic it can report requires at least one `jest.setTimeout` reference, so the rule now collects those references first and skips building the possible-jest-node map and a second full pass over all references when there are none (the common case outside test setup files).

### Benchmarks (local, Apple Silicon)

Retired instruction counts for `Linter::run` only (deterministic, measured via `proc_pid_rusage`, `ConfigStoreBuilder::all()` like the criterion bench):

| bench file | main | this PR | Δ |
|---|---|---|---|
| kitchen-sink.tsx | 350.4M | 324.6M | **−7.4%** |
| App.tsx | 224.1M | 215.0M | −4.1% |
| binder.ts | 60.1M | 59.3M | −1.4% |
| RadixUIAdoptionSection.jsx | 10.21M | 10.10M | −1.1% |
| react.development.js | 29.7M | 29.6M | −0.4% |

Wall-time (criterion, idle machine, back-to-back runs): kitchen-sink −4.9%, App.tsx −3.0%. CodSpeed should give the authoritative numbers.

Also evaluated and rejected: a chunked rule-major dispatch reorder (running each rule over batches of its matching nodes to make the `RuleEnum` dispatch branch predictable) — it measured 3–5% *slower* due to lost data-cache locality on node data, so it is not included.

### Testing

- All `oxc_linter` tests pass; in debug mode the `Tester` also asserts the optimized (type-bucketed) and unoptimized paths produce identical diagnostics for these rules.
- `cargo lintgen` regenerated `rule_runner_impls.rs` (included); rerunning it is a no-op.
- `oxlint` CLI tests pass (except `lint::suppression::test_fixing_only_ts_go_errors`, which also fails on `main` in my environment — missing tsgolint binary).

### Disclosure

This PR was developed with the assistance of an AI coding agent (Grok), per the repo's AI usage policy. I have reviewed, tested, and take responsibility for the changes.
