### PR TITLE
feat(linter/eslint/no-constant-binary-expression): check relational comparisons

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1114,7 +1114,7 @@ export interface DummyRuleMap {
   "no-cond-assign"?: RuleNoConfig | [AllowWarnDeny, NoCondAssignConfig];
   "no-console"?: RuleNoConfig | [AllowWarnDeny, NoConsoleConfig];
   "no-const-assign"?: RuleNoConfig;
-  "no-constant-binary-expression"?: RuleNoConfig;
+  "no-constant-binary-expression"?: RuleNoConfig | [AllowWarnDeny, NoConstantBinaryExpressionConfig];
   "no-constant-condition"?: RuleNoConfig | [AllowWarnDeny, NoConstantCondition];
   "no-constructor-return"?: RuleNoConfig;
   "no-continue"?: RuleNoConfig;
@@ -2912,6 +2912,9 @@ export interface NoConsoleConfig {
    * ```
    */
   allow?: string[];
+}
+export interface NoConstantBinaryExpressionConfig {
+  checkRelationalComparisons?: boolean;
 }
 export interface NoConstantCondition {
   /**

--- a/crates/oxc_linter/src/rules/eslint/no_constant_binary_expression.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constant_binary_expression.rs
@@ -3,18 +3,32 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use oxc_syntax::operator::{AssignmentOperator, BinaryOperator, LogicalOperator, UnaryOperator};
+use schemars::JsonSchema;
+use serde::Deserialize;
 
 use crate::{
     AstNode,
     ast_util::{self, IsConstant},
     context::LintContext,
-    rule::Rule,
+    rule::{DefaultRuleConfig, Rule},
 };
 
 /// `https://eslint.org/docs/latest/rules/no-constant-binary-expression`
 /// Original Author: Jordan Eldredge <https://jordaneldredge.com>
-#[derive(Debug, Default, Clone)]
-pub struct NoConstantBinaryExpression;
+#[derive(Debug, Default, Clone, Deserialize)]
+pub struct NoConstantBinaryExpression(NoConstantBinaryExpressionConfig);
+
+#[derive(Debug, Clone, Copy, JsonSchema, Deserialize)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct NoConstantBinaryExpressionConfig {
+    check_relational_comparisons: bool,
+}
+
+impl Default for NoConstantBinaryExpressionConfig {
+    fn default() -> Self {
+        Self { check_relational_comparisons: true }
+    }
+}
 
 declare_oxc_lint!(
     /// ### What it does
@@ -25,6 +39,8 @@ declare_oxc_lint!(
     ///
     /// Comparisons which will always evaluate to true or false and logical expressions (`||`, `&&`, `??`) which either always
     /// short-circuit or never short-circuit are both likely indications of programmer error.
+    /// By default, this rule also reports relational comparisons
+    /// (`<`, `<=`, `>`, `>=`) where both sides are literal values.
     ///
     /// These errors are especially common in complex expressions where operator precedence is easy to misjudge.
     ///
@@ -57,6 +73,7 @@ declare_oxc_lint!(
     NoConstantBinaryExpression,
     eslint,
     correctness,
+    config = NoConstantBinaryExpressionConfig,
     version = "0.0.3",
     short_description = "Disallow expressions where the operation doesn't affect the value.",
 );
@@ -89,7 +106,17 @@ fn constant_both_always_new(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
+fn constant_relational_comparison(operator: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Unexpected constant relational comparison")
+        .with_help(format!("Both sides of the {operator} are literal values"))
+        .with_label(span)
+}
+
 impl Rule for NoConstantBinaryExpression {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::LogicalExpression(expr) => match expr.operator {
@@ -147,6 +174,14 @@ impl Rule for NoConstantBinaryExpression {
                 {
                     ctx.diagnostic(constant_both_always_new(expr.span));
                 }
+
+                if self.0.check_relational_comparisons
+                    && operator.is_compare()
+                    && Self::is_static_literal(left, ctx)
+                    && Self::is_static_literal(right, ctx)
+                {
+                    ctx.diagnostic(constant_relational_comparison(operator.as_str(), expr.span));
+                }
             }
             _ => {}
         }
@@ -154,6 +189,25 @@ impl Rule for NoConstantBinaryExpression {
 }
 
 impl NoConstantBinaryExpression {
+    fn is_static_literal<'a>(expr: &Expression<'a>, ctx: &LintContext<'a>) -> bool {
+        match expr.get_inner_expression() {
+            Expression::UnaryExpression(unary_expr)
+                if matches!(
+                    unary_expr.operator,
+                    UnaryOperator::UnaryNegation
+                        | UnaryOperator::UnaryPlus
+                        | UnaryOperator::BitwiseNot
+                ) =>
+            {
+                unary_expr.argument.get_inner_expression().is_literal()
+            }
+            Expression::Identifier(ident) => {
+                ident.name == "undefined" && ctx.is_reference_to_global_variable(ident)
+            }
+            expr => expr.is_literal() || expr.is_no_substitution_template(),
+        }
+    }
+
     ///  Test if an AST node has a statically knowable constant nullishness. Meaning,
     /// it will always resolve to a constant value of either: `null`, `undefined`
     /// or not `null` _or_ `undefined`. An expression that can vary between those
@@ -380,9 +434,13 @@ impl NoConstantBinaryExpression {
 
 #[test]
 fn test() {
-    use crate::tester::Tester;
+    use crate::tester::{TestCase, Tester};
 
-    let pass = vec![
+    let check_relational_comparisons = Some(serde_json::json!([{
+        "checkRelationalComparisons": true
+    }]));
+
+    let mut pass = vec![
         // While this _would_ be a constant condition in React, ESLint has a policy of not attributing any specific behavior to JSX.
         "<p /> && foo",
         "<></> && foo",
@@ -423,9 +481,38 @@ fn test() {
         "foo ?? null ?? bar",
         "a ?? (doSomething(), undefined) ?? b",
         "a ?? (something = null) ?? b",
-    ];
+    ]
+    .into_iter()
+    .map(Into::into)
+    .collect::<Vec<TestCase>>();
 
-    let fail = vec![
+    pass.extend(
+        [
+            ("5 < 10", Some(serde_json::json!([{ "checkRelationalComparisons": false }]))),
+            ("5 <= 10", Some(serde_json::json!([{ "checkRelationalComparisons": false }]))),
+            ("10 > 5", Some(serde_json::json!([{ "checkRelationalComparisons": false }]))),
+            ("10 >= 5", Some(serde_json::json!([{ "checkRelationalComparisons": false }]))),
+            ("'a' < 'b'", Some(serde_json::json!([{ "checkRelationalComparisons": false }]))),
+            ("undefined >= 5", Some(serde_json::json!([{ "checkRelationalComparisons": false }]))),
+            ("`` < ``", Some(serde_json::json!([{ "checkRelationalComparisons": false }]))),
+            ("1n < 2n", Some(serde_json::json!([{ "checkRelationalComparisons": false }]))),
+            ("null >= 5", Some(serde_json::json!([{ "checkRelationalComparisons": false }]))),
+            ("x < 5", check_relational_comparisons.clone()),
+            ("5 < x", check_relational_comparisons.clone()),
+            ("x > y", check_relational_comparisons.clone()),
+            ("x >= undefined", check_relational_comparisons.clone()),
+            ("`${x}` < 5", check_relational_comparisons.clone()),
+            ("5 > `${x}`", check_relational_comparisons.clone()),
+            ("~x < 10", check_relational_comparisons.clone()),
+            ("-x >= 5", check_relational_comparisons.clone()),
+            ("x < /a/", check_relational_comparisons.clone()),
+            ("/a/ >= x", check_relational_comparisons.clone()),
+        ]
+        .into_iter()
+        .map(Into::into),
+    );
+
+    let mut fail = vec![
         // Error messages
         "[] && greeting",
         "[] || greeting",
@@ -663,7 +750,36 @@ fn test() {
         "window.abc && false && anything",
         "window.abc || true || anything",
         "window.abc ?? 'non-nullish' ?? anything",
-    ];
+    ]
+    .into_iter()
+    .map(Into::into)
+    .collect::<Vec<TestCase>>();
+
+    fail.extend(
+        [
+            ("5 < 10", None),
+            ("5 <= 10", None),
+            ("10 > 5", None),
+            ("10 >= 5", None),
+            ("'a' < 'b'", None),
+            ("true >= false", check_relational_comparisons.clone()),
+            ("undefined < 5", None),
+            ("5 > undefined", None),
+            ("`` < ``", None),
+            ("`` >= 5", check_relational_comparisons.clone()),
+            ("`foo` < `bar`", check_relational_comparisons.clone()),
+            ("1n < 2n", None),
+            ("null >= 5", None),
+            ("-5 < 10", check_relational_comparisons.clone()),
+            ("10 >= +5", check_relational_comparisons.clone()),
+            ("~5 <= 10", check_relational_comparisons.clone()),
+            ("~1 > ~2", check_relational_comparisons.clone()),
+            ("/a/ < /b/", check_relational_comparisons.clone()),
+            ("/a/ >= /b/", check_relational_comparisons),
+        ]
+        .into_iter()
+        .map(Into::into),
+    );
 
     Tester::new(NoConstantBinaryExpression::NAME, NoConstantBinaryExpression::PLUGIN, pass, fail)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/snapshots/eslint_no_constant_binary_expression.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_constant_binary_expression.snap
@@ -1548,3 +1548,136 @@ source: crates/oxc_linter/src/tester.rs
    · ───────────────────────────────────────
    ╰────
   help: This expression always evaluates to the constant on the left-hand side
+
+  ⚠ eslint(no-constant-binary-expression): Unexpected constant relational comparison
+   ╭─[no_constant_binary_expression.tsx:1:1]
+ 1 │ 5 < 10
+   · ──────
+   ╰────
+  help: Both sides of the < are literal values
+
+  ⚠ eslint(no-constant-binary-expression): Unexpected constant relational comparison
+   ╭─[no_constant_binary_expression.tsx:1:1]
+ 1 │ 5 <= 10
+   · ───────
+   ╰────
+  help: Both sides of the <= are literal values
+
+  ⚠ eslint(no-constant-binary-expression): Unexpected constant relational comparison
+   ╭─[no_constant_binary_expression.tsx:1:1]
+ 1 │ 10 > 5
+   · ──────
+   ╰────
+  help: Both sides of the > are literal values
+
+  ⚠ eslint(no-constant-binary-expression): Unexpected constant relational comparison
+   ╭─[no_constant_binary_expression.tsx:1:1]
+ 1 │ 10 >= 5
+   · ───────
+   ╰────
+  help: Both sides of the >= are literal values
+
+  ⚠ eslint(no-constant-binary-expression): Unexpected constant relational comparison
+   ╭─[no_constant_binary_expression.tsx:1:1]
+ 1 │ 'a' < 'b'
+   · ─────────
+   ╰────
+  help: Both sides of the < are literal values
+
+  ⚠ eslint(no-constant-binary-expression): Unexpected constant relational comparison
+   ╭─[no_constant_binary_expression.tsx:1:1]
+ 1 │ true >= false
+   · ─────────────
+   ╰────
+  help: Both sides of the >= are literal values
+
+  ⚠ eslint(no-constant-binary-expression): Unexpected constant relational comparison
+   ╭─[no_constant_binary_expression.tsx:1:1]
+ 1 │ undefined < 5
+   · ─────────────
+   ╰────
+  help: Both sides of the < are literal values
+
+  ⚠ eslint(no-constant-binary-expression): Unexpected constant relational comparison
+   ╭─[no_constant_binary_expression.tsx:1:1]
+ 1 │ 5 > undefined
+   · ─────────────
+   ╰────
+  help: Both sides of the > are literal values
+
+  ⚠ eslint(no-constant-binary-expression): Unexpected constant relational comparison
+   ╭─[no_constant_binary_expression.tsx:1:1]
+ 1 │ `` < ``
+   · ───────
+   ╰────
+  help: Both sides of the < are literal values
+
+  ⚠ eslint(no-constant-binary-expression): Unexpected constant relational comparison
+   ╭─[no_constant_binary_expression.tsx:1:1]
+ 1 │ `` >= 5
+   · ───────
+   ╰────
+  help: Both sides of the >= are literal values
+
+  ⚠ eslint(no-constant-binary-expression): Unexpected constant relational comparison
+   ╭─[no_constant_binary_expression.tsx:1:1]
+ 1 │ `foo` < `bar`
+   · ─────────────
+   ╰────
+  help: Both sides of the < are literal values
+
+  ⚠ eslint(no-constant-binary-expression): Unexpected constant relational comparison
+   ╭─[no_constant_binary_expression.tsx:1:1]
+ 1 │ 1n < 2n
+   · ───────
+   ╰────
+  help: Both sides of the < are literal values
+
+  ⚠ eslint(no-constant-binary-expression): Unexpected constant relational comparison
+   ╭─[no_constant_binary_expression.tsx:1:1]
+ 1 │ null >= 5
+   · ─────────
+   ╰────
+  help: Both sides of the >= are literal values
+
+  ⚠ eslint(no-constant-binary-expression): Unexpected constant relational comparison
+   ╭─[no_constant_binary_expression.tsx:1:1]
+ 1 │ -5 < 10
+   · ───────
+   ╰────
+  help: Both sides of the < are literal values
+
+  ⚠ eslint(no-constant-binary-expression): Unexpected constant relational comparison
+   ╭─[no_constant_binary_expression.tsx:1:1]
+ 1 │ 10 >= +5
+   · ────────
+   ╰────
+  help: Both sides of the >= are literal values
+
+  ⚠ eslint(no-constant-binary-expression): Unexpected constant relational comparison
+   ╭─[no_constant_binary_expression.tsx:1:1]
+ 1 │ ~5 <= 10
+   · ────────
+   ╰────
+  help: Both sides of the <= are literal values
+
+  ⚠ eslint(no-constant-binary-expression): Unexpected constant relational comparison
+   ╭─[no_constant_binary_expression.tsx:1:1]
+ 1 │ ~1 > ~2
+   · ───────
+   ╰────
+  help: Both sides of the > are literal values
+
+  ⚠ eslint(no-constant-binary-expression): Unexpected constant relational comparison
+   ╭─[no_constant_binary_expression.tsx:1:1]
+ 1 │ /a/ < /b/
+   · ─────────
+   ╰────
+  help: Both sides of the < are literal values
+
+  ⚠ eslint(no-constant-binary-expression): Unexpected constant relational comparison
+   ╭─[no_constant_binary_expression.tsx:1:1]
+ 1 │ /a/ >= /b/
+   · ──────────
+   ╰────
+  help: Both sides of the >= are literal values

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -4441,7 +4441,24 @@
           "$ref": "#/definitions/RuleNoConfig"
         },
         "no-constant-binary-expression": {
-          "$ref": "#/definitions/RuleNoConfig"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleNoConfig"
+            },
+            {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/AllowWarnDeny"
+                },
+                {
+                  "$ref": "#/definitions/NoConstantBinaryExpressionConfig"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          ]
         },
         "no-constant-condition": {
           "anyOf": [
@@ -13407,6 +13424,16 @@
             "type": "string"
           },
           "markdownDescription": "The `allow` option permits the given list of console methods to be used as exceptions to\nthis rule.\n\nSay the option was configured as `{ \"allow\": [\"info\"] }` then the rule would behave as\nfollows:\n\nExample of **incorrect** code for this option:\n```javascript\nconsole.log('foo');\n```\n\nExample of **correct** code for this option:\n```javascript\nconsole.info('foo');\n```"
+        }
+      },
+      "additionalProperties": false
+    },
+    "NoConstantBinaryExpressionConfig": {
+      "type": "object",
+      "properties": {
+        "checkRelationalComparisons": {
+          "default": true,
+          "type": "boolean"
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Summary

- add `checkRelationalComparisons` support to `no-constant-binary-expression`
- default the Oxc option to `true` and allow explicit opt-out with `false`
- port the ESLint relational comparison test cases into the existing rule fixture
