### PR TITLE
fix(ast_tools): suggest pnpm install for missing oxfmt

### DIFF
--- a/tasks/ast_tools/src/output/javascript.rs
+++ b/tasks/ast_tools/src/output/javascript.rs
@@ -52,7 +52,7 @@ fn format(source_text: &str) -> String {
         .arg(oxfmt_config_path)
         .arg(&tmp_file)
         .output()
-        .expect("Failed to run oxfmt (is it installed?)");
+        .expect("Failed to run oxfmt (do you need to run `pnpm i` to install it?)");
 
     // Read the formatted content
     let result = if output.status.success() {


### PR DESCRIPTION
When agents run `just ast`, and `oxfmt` is not installed, the agent often tries to build oxfmt from source instead of running `pnpm i`, this PR update the error msg to give the agent an actionable solution to the problem (run `pnpm i`)