### PR TITLE
perf(linter/jest/no-confusing-set-timeout): early exit fast path

### DIFF
--- a/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
+++ b/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
@@ -81,12 +81,6 @@ impl Rule for NoConfusingSetTimeout {
     fn run_once(&self, ctx: &LintContext) {
         let scopes = ctx.scoping();
         let symbol_table = ctx.scoping();
-        let possible_nodes = collect_possible_jest_call_node(ctx);
-        let id_to_jest_node_map =
-            possible_nodes.iter().fold(FxHashMap::default(), |mut acc, cur| {
-                acc.insert(cur.node.id(), cur);
-                acc
-            });
 
         let mut jest_reference_id_list: Vec<(ReferenceId, Span)> = vec![];
         let mut reported_unordered_set_timeouts = FxHashSet::default();
@@ -103,6 +97,17 @@ impl Rule for NoConfusingSetTimeout {
                 ctx,
             );
         }
+
+        if jest_reference_id_list.is_empty() {
+            return;
+        }
+
+        let possible_nodes = collect_possible_jest_call_node(ctx);
+        let id_to_jest_node_map =
+            possible_nodes.iter().fold(FxHashMap::default(), |mut acc, cur| {
+                acc.insert(cur.node.id(), cur);
+                acc
+            });
 
         for reference_id_list in scopes.root_unresolved_references_ids() {
             handle_jest_set_time_out(


### PR DESCRIPTION
### Summary

Extracts the Jest-only performance change from #24084.

Skips collecting possible Jest call nodes and the second full reference pass in `jest/no-confusing-set-timeout` when the file has no `jest.setTimeout` references. Every diagnostic emitted by this rule requires at least one `jest.setTimeout` reference, so this keeps behavior unchanged while avoiding work in the common case.

### Review

Reviewed #24084 and intentionally left out the separate `react_perf` dispatch changes so this PR contains only the Jest rule update.

Co-authored-by: Yagiz Nizipli <yagiz@nizipli.com>
