### PR TITLE
fix(formatter_css): align SCSS output to Prettier 3.9.1

### DIFF
--- a/apps/oxfmt/conformance/run.ts
+++ b/apps/oxfmt/conformance/run.ts
@@ -254,6 +254,8 @@ const categories: Category[] = [
         NOTE_NOT_INDENT,
         "logn-expr line-break position",
       ].join("\n"),
+      "externals/gitlab/stylesheets/framework/variables_overrides.scss":
+        "Allowed (semantics): Prettier adds a trailing comma to non-comma-list map-item parens (`1: ($spacer * 0.5)` → 1-element list); we keep them inline. See crates/oxc_formatter_css/AGENTS.md",
     },
   },
 ];

--- a/apps/oxfmt/conformance/snapshots/conformance.snap.md
+++ b/apps/oxfmt/conformance/snapshots/conformance.snap.md
@@ -310,7 +310,7 @@
 | [externals/gitlab/stylesheets/components/content_editor.scss](diffs/scss/externals__gitlab__stylesheets__components__content_editor.scss.md) |  |
 | [externals/gitlab/stylesheets/framework/diffs.scss](diffs/scss/externals__gitlab__stylesheets__framework__diffs.scss.md) | Allowed: media-query operator spacing; Prettier can't space arithmetic ops (prettier/prettier#1811) |
 | [externals/gitlab/stylesheets/framework/sidebar.scss](diffs/scss/externals__gitlab__stylesheets__framework__sidebar.scss.md) | Allowed (layout-only): wrapped :not() selector-arg indent (prettier/prettier#16165)<br>logn-expr line-break position |
-| [externals/gitlab/stylesheets/framework/variables_overrides.scss](diffs/scss/externals__gitlab__stylesheets__framework__variables_overrides.scss.md) |  |
+| [externals/gitlab/stylesheets/framework/variables_overrides.scss](diffs/scss/externals__gitlab__stylesheets__framework__variables_overrides.scss.md) | Allowed (semantics): Prettier adds a trailing comma to non-comma-list map-item parens (`1: ($spacer * 0.5)` → 1-element list); we keep them inline. See crates/oxc_formatter_css/AGENTS.md |
 | [externals/gitlab/stylesheets/highlight/conflict_colors.scss](diffs/scss/externals__gitlab__stylesheets__highlight__conflict_colors.scss.md) | Allowed: Prettier drops blank lines in SCSS maps with paren values; ours preserves (prettier/prettier#16824) |
 | [externals/gitlab/stylesheets/highlight/white_base.scss](diffs/scss/externals__gitlab__stylesheets__highlight__white_base.scss.md) | Allowed (layout-only): wrapped :not() selector-arg indent (prettier/prettier#16165) |
 | [externals/gitlab/stylesheets/page_bundles/_ide_theme_overrides.scss](diffs/scss/externals__gitlab__stylesheets__page_bundles___ide_theme_overrides.scss.md) |  |
@@ -333,7 +333,7 @@
 | :--- | :--- |
 | [externals/gitlab/stylesheets/framework/diffs.scss](diffs/scss/externals__gitlab__stylesheets__framework__diffs.scss.md) | Allowed: media-query operator spacing; Prettier can't space arithmetic ops (prettier/prettier#1811) |
 | [externals/gitlab/stylesheets/framework/sidebar.scss](diffs/scss/externals__gitlab__stylesheets__framework__sidebar.scss.md) | Allowed (layout-only): wrapped :not() selector-arg indent (prettier/prettier#16165)<br>logn-expr line-break position |
-| [externals/gitlab/stylesheets/framework/variables_overrides.scss](diffs/scss/externals__gitlab__stylesheets__framework__variables_overrides.scss.md) |  |
+| [externals/gitlab/stylesheets/framework/variables_overrides.scss](diffs/scss/externals__gitlab__stylesheets__framework__variables_overrides.scss.md) | Allowed (semantics): Prettier adds a trailing comma to non-comma-list map-item parens (`1: ($spacer * 0.5)` → 1-element list); we keep them inline. See crates/oxc_formatter_css/AGENTS.md |
 | [externals/gitlab/stylesheets/highlight/conflict_colors.scss](diffs/scss/externals__gitlab__stylesheets__highlight__conflict_colors.scss.md) | Allowed: Prettier drops blank lines in SCSS maps with paren values; ours preserves (prettier/prettier#16824) |
 | [externals/gitlab/stylesheets/page_bundles/_ide_theme_overrides.scss](diffs/scss/externals__gitlab__stylesheets__page_bundles___ide_theme_overrides.scss.md) |  |
 | [externals/gitlab/stylesheets/page_bundles/editor.scss](diffs/scss/externals__gitlab__stylesheets__page_bundles__editor.scss.md) | Allowed: media-query operator spacing; Prettier can't space arithmetic ops (prettier/prettier#1811) |

--- a/apps/oxfmt/conformance/snapshots/diffs/scss/externals__gitlab__stylesheets__framework__variables_overrides.scss.md
+++ b/apps/oxfmt/conformance/snapshots/diffs/scss/externals__gitlab__stylesheets__framework__variables_overrides.scss.md
@@ -1,5 +1,7 @@
 # externals/gitlab/stylesheets/framework/variables_overrides.scss
 
+> Allowed (semantics): Prettier adds a trailing comma to non-comma-list map-item parens (`1: ($spacer * 0.5)` → 1-element list); we keep them inline. See crates/oxc_formatter_css/AGENTS.md
+
 ## Option 1
 
 `````json
@@ -12,19 +14,48 @@
 ===================================================================
 --- prettier
 +++ oxfmt
-@@ -43,9 +43,11 @@
+@@ -40,33 +40,17 @@
+ $headings-font-weight: $gl-font-weight-bold;
+ $spacer: $grid-size;
+ $spacers: (
    0: 0,
-   1: (
-     $spacer * 0.5,
-   ),
--  2: ($spacer),
-+  2: (
-+    $spacer,
-+  ),
-   3: (
-     $spacer * 2,
-   ),
-   4: (
+-  1: (
+-    $spacer * 0.5,
+-  ),
++  1: ($spacer * 0.5),
+   2: ($spacer),
+-  3: (
+-    $spacer * 2,
+-  ),
+-  4: (
+-    $spacer * 3,
+-  ),
+-  5: (
+-    $spacer * 4,
+-  ),
+-  6: (
+-    $spacer * 5,
+-  ),
+-  7: (
+-    $spacer * 6,
+-  ),
+-  8: (
+-    $spacer * 7,
+-  ),
+-  9: (
+-    $spacer * 8,
+-  ),
++  3: ($spacer * 2),
++  4: ($spacer * 3),
++  5: ($spacer * 4),
++  6: ($spacer * 5),
++  7: ($spacer * 6),
++  8: ($spacer * 7),
++  9: ($spacer * 8),
+ );
+ $pagination-color: $gl-text-color;
+ $tooltip-padding-y: 0.5rem;
+ $tooltip-padding-x: 0.75rem;
 
 `````
 
@@ -74,33 +105,15 @@ $headings-font-weight: $gl-font-weight-bold;
 $spacer: $grid-size;
 $spacers: (
   0: 0,
-  1: (
-    $spacer * 0.5,
-  ),
-  2: (
-    $spacer,
-  ),
-  3: (
-    $spacer * 2,
-  ),
-  4: (
-    $spacer * 3,
-  ),
-  5: (
-    $spacer * 4,
-  ),
-  6: (
-    $spacer * 5,
-  ),
-  7: (
-    $spacer * 6,
-  ),
-  8: (
-    $spacer * 7,
-  ),
-  9: (
-    $spacer * 8,
-  ),
+  1: ($spacer * 0.5),
+  2: ($spacer),
+  3: ($spacer * 2),
+  4: ($spacer * 3),
+  5: ($spacer * 4),
+  6: ($spacer * 5),
+  7: ($spacer * 6),
+  8: ($spacer * 7),
+  9: ($spacer * 8),
 );
 $pagination-color: $gl-text-color;
 $tooltip-padding-y: 0.5rem;
@@ -248,19 +261,48 @@ $b-table-sort-icon-bg-not-sorted: "";
 ===================================================================
 --- prettier
 +++ oxfmt
-@@ -42,9 +42,11 @@
+@@ -39,33 +39,17 @@
+ $headings-font-weight: $gl-font-weight-bold;
+ $spacer: $grid-size;
+ $spacers: (
    0: 0,
-   1: (
-     $spacer * 0.5,
-   ),
--  2: ($spacer),
-+  2: (
-+    $spacer,
-+  ),
-   3: (
-     $spacer * 2,
-   ),
-   4: (
+-  1: (
+-    $spacer * 0.5,
+-  ),
++  1: ($spacer * 0.5),
+   2: ($spacer),
+-  3: (
+-    $spacer * 2,
+-  ),
+-  4: (
+-    $spacer * 3,
+-  ),
+-  5: (
+-    $spacer * 4,
+-  ),
+-  6: (
+-    $spacer * 5,
+-  ),
+-  7: (
+-    $spacer * 6,
+-  ),
+-  8: (
+-    $spacer * 7,
+-  ),
+-  9: (
+-    $spacer * 8,
+-  ),
++  3: ($spacer * 2),
++  4: ($spacer * 3),
++  5: ($spacer * 4),
++  6: ($spacer * 5),
++  7: ($spacer * 6),
++  8: ($spacer * 7),
++  9: ($spacer * 8),
+ );
+ $pagination-color: $gl-text-color;
+ $tooltip-padding-y: 0.5rem;
+ $tooltip-padding-x: 0.75rem;
 
 `````
 
@@ -309,33 +351,15 @@ $headings-font-weight: $gl-font-weight-bold;
 $spacer: $grid-size;
 $spacers: (
   0: 0,
-  1: (
-    $spacer * 0.5,
-  ),
-  2: (
-    $spacer,
-  ),
-  3: (
-    $spacer * 2,
-  ),
-  4: (
-    $spacer * 3,
-  ),
-  5: (
-    $spacer * 4,
-  ),
-  6: (
-    $spacer * 5,
-  ),
-  7: (
-    $spacer * 6,
-  ),
-  8: (
-    $spacer * 7,
-  ),
-  9: (
-    $spacer * 8,
-  ),
+  1: ($spacer * 0.5),
+  2: ($spacer),
+  3: ($spacer * 2),
+  4: ($spacer * 3),
+  5: ($spacer * 4),
+  6: ($spacer * 5),
+  7: ($spacer * 6),
+  8: ($spacer * 7),
+  9: ($spacer * 8),
 );
 $pagination-color: $gl-text-color;
 $tooltip-padding-y: 0.5rem;

--- a/crates/oxc_formatter_css/AGENTS.md
+++ b/crates/oxc_formatter_css/AGENTS.md
@@ -12,6 +12,8 @@ Prettier compatible CSS/SCSS/Less formatter (`oxfmt`'s Tier 1 backend), using th
     tolerates `${}` placeholders and `TopLevelDeclaration`
 - The canonical reference is Prettier's `src/language-css/printer-postcss.js`
   - port its layout decisions, do not invent new ones
+  - ONE exception: never reproduce output that changes program semantics
+    - See "Known divergences" section
 
 ### Forked parser
 
@@ -146,28 +148,42 @@ NOT covered: `$(var)` interpolation (`margin-$(dir): 10px`, `.icon.is-$(network)
 
 ### Known divergences
 
-Deliberate divergences from Prettier (impact does not justify the matching cost):
+Deliberate divergences from Prettier. Two admission reasons:
 
-- Less: `func(x, + 20px)` unary gluing
-  - Prettier prints `+20px`; `oxc-css-parser` ASTs `, +` as a comma-left binary operation, so matching is ad-hoc for a torture-test-only shape
-- Less: Nested math in a function arg / multi-value shorthand
-  - Prettier's fill fit-check breaks INSIDE the wide chunk; our core `fill` (biome semantics) breaks the SEPARATOR instead.
-  - Principled fix is the shared core-fill fit-check change (needs JS-conformance impact experiment first)
+1. Prettier's output would change program semantics (formatting must never do that)
+2. The impact does not justify the matching cost
+
+Notable divergences are:
+
 - Broken `:not(...)` selector args indent at +2
   - Prettier lands at +4 (arg) / +2 (`)`)
   - Layout-only, rare trigger (selector longer than line width)
-- Selector-position Sass interpolation normalizes inner spaces (`#{ $name }` → `#{$name}`)
-  - We normalize BOTH positions for output consistency
-  - Prettier keeps SELECTOR interpolation verbatim
-- `@warn` / `@error` prelude strings re-quote per `singleQuote` option (`@error "x"` → `@error 'x'`)
-  - `oxc-css-parser` parses them as `SassExpr`, so they go through the structured printer (see `at_rule.rs`)
-  - Prettier keeps them as a raw string verbatim
-- A function call directly after a `//` comment in nested-args position
-  - Prettier double-indents it
-  - We print the normal indent (prettier/prettier#19427)
 - A declaration swallowed by a `;`-less css-in-js placeholder (`${m}\ncolor: red`)
   - We parse it structurally and FORMAT it (spacing/hex/number normalization)
   - Prettier keeps it verbatim, postcss swallows the run as an opaque prelude string it can't format, so `color   :   red` / `#FFFFFF` survive unformatted
+- SCSS: Selector-position Sass interpolation normalizes inner spaces (`#{ $name }` → `#{$name}`)
+  - We normalize BOTH positions for output consistency
+  - Prettier keeps SELECTOR interpolation verbatim
+- SCSS: `@warn` / `@error` prelude strings re-quote per `singleQuote` option (`@error "x"` → `@error 'x'`)
+  - `oxc-css-parser` parses them as `SassExpr`, so they go through the structured printer (see `at_rule.rs`)
+  - Prettier keeps them as a raw string verbatim
+- SCSS: A function call directly after a `//` comment in nested-args position
+  - Prettier double-indents it
+  - We print the normal indent (prettier/prettier#19427)
+- SCSS: The map-item break (one element per line + trailing comma) applies ONLY to parens whose contents are already a comma-separated list (semantics)
+  - `(x,)` is a single-element list in Sass, so the added comma is a semantic no-op for a comma list and NOWHERE else
+  - Prettier 3.9.1 changes `key: ($a + $b)` from a number to a list,
+    restructures `key: (a b)` (2-element space list → nested 1-element list),
+    and emits non-compiling output for `key: 2 * ($a + $b)` inside `$var:` declarations (dart-sass: `Undefined operation "2 * (3px,)"`)
+  - Prettier's own #18530 (math siblings in args) / #19091 (single-node scalars) fixed subsets of this;
+    we extend the same rule to every non-comma-list, so these stay inline
+- SCSS: A map whose FIRST item is preceded by a block comment always breaks one-per-line
+  - Prettier stops treating it as a map item (the comment becomes `groups[0]`, so `isKeyValuePairInParenGroupNode` fails) and inlines it when it fits: `$b: (/* c */ a: 1);`
+  - We reproduce the map-item-ness loss for the trailing comma (dropped, like Prettier)
+    - But keep the forced break; matching the inline layout needs comment support in the soft map path
+- SCSS: Consecutive `//` comments in a comment-only map indent uniformly
+  - Prettier misaligns the second one with a stray extra leading space (`   // b`), an artifact of its `join(line)` separator printing before the deferred `lineSuffix` flushes
+  - A meaningless glitch (may well be fixed upstream); we print the normal indent
 - SCSS: A `;`-less custom-property rule block followed by another declaration (`--p: {color:red;} /* <- no semi */ --q: blue;`)
   - SCSS output: we treat it as two separate declarations: format the inner block, add the missing `;`, and format `--q` normally
   - Prettier behavior: keeps the whole run verbatim, postcss swallows everything past the `}` as an opaque prelude string until a source `;`
@@ -177,6 +193,11 @@ Deliberate divergences from Prettier (impact does not justify the matching cost)
     - Each mode is internally consistent with what its parser produces
   - The value syntax `--p: { ... }` itself is valid CSS, but its only intended consumer was the `@apply --p;` at-rule from the dropped CSS Apply Rule proposal
     - With no consumer, real-world usage is near zero, so the cross-mode behavior difference is theoretical
+- Less: `func(x, + 20px)` unary gluing
+  - Prettier prints `+20px`; `oxc-css-parser` ASTs `, +` as a comma-left binary operation, so matching is ad-hoc for a torture-test-only shape
+- Less: Nested math in a function arg / multi-value shorthand
+  - Prettier's fill fit-check breaks INSIDE the wide chunk; our core `fill` (biome semantics) breaks the SEPARATOR instead.
+  - Principled fix is the shared core-fill fit-check change (needs JS-conformance impact experiment first)
 - Less: Value-position `@{var}` interpolation
   - `oxc-css-parser` rejects it matching `lessc`; Prettier (postcss) accepts and prints verbatim
 - Less: Lookup with whitespace inside (`@config   [   option1]`)
@@ -200,8 +221,11 @@ Fixtures are grouped per language (`format/{css,scss,less}/`; test modules mirro
 Unit tests in `tests/fixtures/mod.rs` cover parse-error `Err` semantics (`parse_error_is_err`).
 Fixtures under `embedded/` route through `format_to_ir` instead of `format()`; the `embedded_debug` example formats files the same way for quick comparison.
 
-Every expected output must be verified against Prettier (3.8.4, the current submodule).
-`npx prettier@3.8.4 --parser <variant>` at both `--print-width 80` and `100` (the harness snapshots both).
+Every expected output must be verified against Prettier (3.9.1, the current submodule).
+`npx prettier@3.9.1 --parser <variant>` at both `--print-width 80` and `100` (the harness snapshots both).
+
+Exception: a fixture may pin an entry from "Known divergences" (e.g. `map-item-parens.scss`);
+its comments must say which lines deviate from Prettier and why.
 
 ```sh
 cargo test -p oxc_formatter_css
@@ -220,7 +244,7 @@ cargo run -p oxc_prettier_conformance
 cargo run -p oxc_prettier_conformance -- --filter css/atrule
 ```
 
-At the current version (v3.8.4), the divergences of two files has been confirmed in the SCSS conformance, but this is intentional.
+At the current version (v3.9.1), the divergences of three files (`scss/comments/4878.scss`, `scss/map/function-argument/functional-argument.scss`, `scss/variables/apply-rule.scss`) have been confirmed in the SCSS conformance, but these are intentional (see "Known divergences").
 
 ### Embedded conformance (`apps/oxfmt`)
 

--- a/crates/oxc_formatter_css/src/print/scss.rs
+++ b/crates/oxc_formatter_css/src/print/scss.rs
@@ -14,8 +14,8 @@ use oxc_css_parser::{
 use oxc_formatter_core::{
     Buffer,
     builders::{
-        dedent, empty_line, group, hard_line_break, if_group_breaks, indent, soft_line_break,
-        soft_line_break_or_space, space, text,
+        dedent, empty_line, expand_parent, group, hard_line_break, if_group_breaks, indent,
+        soft_line_break, soft_line_break_or_space, space, text,
     },
     write,
 };
@@ -145,8 +145,10 @@ pub(super) fn write_sass_map<'a>(
 ) {
     if map.items.is_empty() {
         // A map with no items may still hold comments (`(\n  // c\n)`).
-        // Keep them inside the parens, one line each, instead of leaking
-        // them past `)` as a trailing declaration comment (Prettier #18535).
+        // Keep them inside the parens instead of leaking them past `)` as a trailing declaration comment.
+        // Block comments stay inline when they fit (`$map: (/* c */);`);
+        // a `//` comment glues to the current line but forces the `)` onto its own line,
+        // like Prettier's `lineSuffix` + `lineSuffixBoundary` (Prettier #18535).
         let r_paren = to_span(map.span()).end.saturating_sub(1);
         let tail: Vec<comments::CssComment> = f.context().comments().take_before(r_paren).to_vec();
         if tail.is_empty() {
@@ -154,17 +156,32 @@ pub(super) fn write_sass_map<'a>(
             return;
         }
         let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+            write!(f, soft_line_break());
             for (i, &comment) in tail.iter().enumerate() {
-                if i == 0 || comment.inline || tail[i - 1].inline {
-                    write!(f, hard_line_break());
-                } else {
-                    // Block comments are fill items: they join when they fit
-                    write!(f, " ");
+                if i > 0 {
+                    if tail[i - 1].inline {
+                        // Prettier leaves a stray leading space here
+                        // (`   // b`, the `join(line)` separator prints before the deferred `lineSuffix` flushes);
+                        write!(f, hard_line_break());
+                    } else {
+                        write!(f, space());
+                    }
                 }
                 comments::write_single_comment(comment, f);
+                if comment.inline {
+                    write!(f, expand_parent());
+                }
             }
         });
-        write!(f, ["(", indent(&body), hard_line_break(), ")"]);
+        write!(
+            f,
+            group(&format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                write!(f, "(");
+                write!(f, indent(&body));
+                write!(f, soft_line_break());
+                write!(f, ")");
+            }))
+        );
         return;
     }
     // Maps break only in "map item" positions
@@ -228,6 +245,7 @@ pub(super) fn write_sass_map<'a>(
         write!(f, hard_line_break());
         let source = f.context().source_text();
         let mut last_item_block_with_comment = false;
+        let mut first_item_has_leading_comment = false;
         for (i, item) in map.items.iter().enumerate() {
             if i > 0 {
                 write!(f, ",");
@@ -275,6 +293,9 @@ pub(super) fn write_sass_map<'a>(
                 } else {
                     write!(f, " ");
                 }
+            }
+            if i == 0 {
+                first_item_has_leading_comment = had_leading_comment;
             }
             let key_is_block = matches!(
                 item.key,
@@ -347,7 +368,13 @@ pub(super) fn write_sass_map<'a>(
             .any(|c| c.span.start >= last_item_end && value::comment_is_own_line(c, source));
         // Prettier drops the trailing comma after a comment-preceded block value
         // (the pair doc isn't the plain dedent shape).
-        let printed_comma = (trailing && !last_item_block_with_comment) || has_ownline_tail;
+        // A comment before the FIRST item also drops it:
+        // the comment becomes `groups[0]` of the paren group,
+        // so `isKeyValuePairInParenGroupNode` no longer sees a key-value pair
+        // and the group stops being an SCSS map item.
+        let printed_comma =
+            (trailing && !last_item_block_with_comment && !first_item_has_leading_comment)
+                || has_ownline_tail;
         if printed_comma {
             write!(f, ",");
         }
@@ -362,7 +389,7 @@ pub(super) fn write_sass_map<'a>(
                 && ctx.in_args
                 && f.context().comments().peek().is_some_and(|c| c.span.start > source_comma_start);
             if !next_slot {
-                value::flush_same_line_comments(to_span(last.span()).end, f);
+                value::flush_same_line_comments(to_span(last.span()).end, r_paren, f);
             }
         }
         // Own-line comments before `)`: same-line runs stay glued
@@ -559,6 +586,9 @@ pub(super) fn write_sass_include<'a>(include: &SassInclude<'a>, f: &mut CssForma
     write!(f, text(source.text_for(&name_span)));
     if let Some(arguments) = &include.arguments {
         let args = &arguments.args;
+        // Same first-argument gate as `write_function` (which see), over typed args
+        let first_arg_is_kw =
+            args.first().is_some_and(|a| matches!(a, ComponentValue::SassKeywordArgument(_)));
         let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
             let source = f.context().source_text();
             write!(f, soft_line_break());
@@ -583,8 +613,13 @@ pub(super) fn write_sass_include<'a>(include: &SassInclude<'a>, f: &mut CssForma
                         write!(f, soft_line_break_or_space());
                     }
                 }
-                let arg_ctx =
-                    ValueContext { map_break: true, in_args: true, ..ValueContext::default() };
+                let arg_ctx = ValueContext {
+                    map_break: true,
+                    in_args: true,
+                    paren_break: first_arg_is_kw
+                        && matches!(arg, ComponentValue::SassKeywordArgument(_)),
+                    ..ValueContext::default()
+                };
                 write_top_level_value(arg, arg_ctx, f);
             }
         });
@@ -814,6 +849,8 @@ fn write_sass_module_config<'a>(config: &SassModuleConfig<'a>, f: &mut CssFormat
             }
             let span = to_span(item.variable.span());
             write!(f, [text(source.text_for(&span)), ":", space()]);
+            // No first-argument gate here (cf. `write_function`):
+            // config items are structurally always `$var: value` pairs, so the gate holds by construction.
             let item_ctx =
                 ValueContext { paren_break: true, map_break: true, ..ValueContext::default() };
             write_top_level_value(&item.value, item_ctx, f);

--- a/crates/oxc_formatter_css/src/print/value.rs
+++ b/crates/oxc_formatter_css/src/print/value.rs
@@ -407,9 +407,9 @@ pub(super) struct ValueContext<'a> {
     pub no_break: bool,
     /// SCSS map printed in key position: stays inline (Prettier's `isKey`).
     pub map_key: bool,
-    /// A parenthesized comma list here breaks one item per line
-    /// (only as a direct map-item value,
-    /// `isSCSSMapItemNode` needs key-value pairs in the group or its grandparent).
+    /// A parenthesized COMMA list here breaks one item per line with a trailing comma
+    /// (only as a direct map-item value, `isSCSSMapItemNode` needs key-value pairs in the group or its grandparent;
+    /// non-comma-list contents never take the break, the comma would change their meaning).
     pub paren_break: bool,
     /// SCSS maps here always break (`$var:` values, function args, map items).
     pub map_break: bool,
@@ -648,7 +648,13 @@ pub(super) fn flush_value_comments(upper_bound: u32, f: &mut CssFormatter<'_, '_
 
 /// Emits pending comments that sit on the same line as the just-printed
 /// content ending at `prev_end` (` // c` / ` /* c */`), up to `upper_bound`.
-fn flush_same_line_comments_before(prev_end: u32, upper_bound: u32, f: &mut CssFormatter<'_, '_>) {
+/// Container tails pass their own end as the bound,
+/// so a same-line comment belonging to a FOLLOWING statement is never pulled inside.
+pub(super) fn flush_same_line_comments(
+    prev_end: u32,
+    upper_bound: u32,
+    f: &mut CssFormatter<'_, '_>,
+) {
     loop {
         let Some(comment) = f.context().comments().peek() else { return };
         let source = f.context().source_text();
@@ -666,12 +672,6 @@ fn flush_same_line_comments_before(prev_end: u32, upper_bound: u32, f: &mut CssF
             return;
         }
     }
-}
-
-/// Unbounded variant (used at container tails where everything pending
-/// belongs to the container).
-pub(super) fn flush_same_line_comments(prev_end: u32, f: &mut CssFormatter<'_, '_>) {
-    flush_same_line_comments_before(prev_end, u32::MAX, f);
 }
 
 /// Emits pending comments before `upper_bound` as ` /* c */` suffixes
@@ -1238,16 +1238,22 @@ pub(super) fn write_component_value<'a>(
         ComponentValue::SassMap(map) => scss::write_sass_map(map, ctx, f),
         ComponentValue::SassList(list) => scss::write_sass_list(list, ctx, f),
         ComponentValue::SassParenthesizedExpression(paren) => {
-            // `$var: ((a, b), (c, d))` / map item values: one item per line
-            if ctx.paren_break {
-                // Map-item values always break (`isSCSSMapItemNode`),
+            // `$var: ((a, b), (c, d))` / map item values: one item per line.
+            // ONLY a comma-separated list takes this break:
+            // the trailing comma is a semantic no-op there and NOWHERE else.
+            // NOTE: `(x,)` is a single-element list in Sass,
+            // so adding it to `($a + $b)` / `(a b)` / `(-$a)` changes the value
+            // and `2 * ($a + $b,)` fails to compile.
+            // (Prettier 3.9.1 does all of these; #19091 exempted single-node scalars only)
+            if ctx.paren_break
+                && let ComponentValue::SassList(list) = &*paren.expr
+                && list.comma_spans.is_some()
+            {
+                // Comma-list map-item values always break (`isSCSSMapItemNode`),
                 // with a trailing comma per option.
                 let inner_ctx = ValueContext { paren_break: false, ..ctx };
                 let trailing = f.options().allow_trailing_comma();
-                let elements: &[ComponentValue<'a>] = match &*paren.expr {
-                    ComponentValue::SassList(list) if list.comma_spans.is_some() => &list.elements,
-                    expr => std::slice::from_ref(expr),
-                };
+                let elements = &list.elements;
                 let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
                     write!(f, hard_line_break());
                     for (i, el) in elements.iter().enumerate() {
@@ -1281,7 +1287,9 @@ pub(super) fn write_component_value<'a>(
                         }
                         write_component_value(el, inner_ctx, f);
                     }
-                    if trailing && (ctx.map_key || ctx.paren_break) {
+                    // `ctx.paren_break` cannot be set here,
+                    // a comma list with it takes the hard-break branch above.
+                    if trailing && ctx.map_key {
                         write!(f, if_group_breaks(&text(",")));
                     }
                 } else {
@@ -1337,6 +1345,9 @@ pub(super) fn write_component_value<'a>(
                 write_component_value(&kw.value, ctx, f);
                 return;
             }
+            // Only a value that IS the paren group is a map item;
+            // a paren nested in a math expression (`$foo: 2 * ($bar + $baz)`) never breaks (Prettier #18530).
+            let ctx = ValueContext { paren_break: false, ..ctx };
             // `$name: value` may break after the colon when too long
             let pair = format_with(move |f: &mut CssFormatter<'_, 'a>| {
                 let mut filler = f.fill();
@@ -1985,6 +1996,14 @@ pub(super) fn write_function<'a>(
         no_leading_softline: false,
         ..ctx
     };
+    // A keyword argument's paren-group value is a map item
+    // ONLY when the call's FIRST argument is a key-value pair
+    // (Prettier's `isKeyValuePairInParenGroupNode` checks `groups[0]` alone):
+    // `func($k: (1, 2), a)` breaks, `func(a, $k: (1, 2))` does not.
+    let is_kw_arg = |g: &[ComponentValue<'a>]| {
+        g.len() == 1 && matches!(g[0], ComponentValue::SassKeywordArgument(_))
+    };
+    let first_arg_is_kw = groups.first().is_some_and(|g| is_kw_arg(g));
     let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
         let source = f.context().source_text();
         write!(f, soft_line_break());
@@ -2010,7 +2029,9 @@ pub(super) fn write_function<'a>(
                     write!(f, soft_line_break_or_space());
                 }
             }
-            write_arg_group(group_values, ctx, f);
+            let arg_ctx =
+                ValueContext { paren_break: first_arg_is_kw && is_kw_arg(group_values), ..ctx };
+            write_arg_group(group_values, arg_ctx, f);
         }
         if has_trailing_comma {
             write!(f, ",");

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/map-comment-only.scss
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/map-comment-only.scss
@@ -1,6 +1,7 @@
-// A map whose only content is a comment keeps the comment INSIDE the parens,
-// one per line — it must not leak past `)` (Prettier#18535, fixed on main;
-// 3.8.4 misprints it as `$map: () // comment`).
+// A map whose only content is a comment keeps the comment INSIDE the parens —
+// it must not leak past `)` (Prettier#18535, 3.8.4 misprints it as
+// `$map: () // comment`). Block comments stay inline when they fit;
+// a `//` comment forces the `)` onto its own line (Prettier's `lineSuffixBoundary`).
 $inline: (
   // comment
 );
@@ -12,7 +13,9 @@ $multi: (
   // b
 );
 // Regression guards: a truly empty map stays `()`, and a map WITH items still
-// renders its leading comment normally.
+// renders its leading comment normally. A comment before the FIRST item makes
+// the group `groups[0]` a non-key-value pair in Prettier, so the map stops
+// being an SCSS map item and loses its trailing comma.
 $empty: ();
 $with-items: (
   // comment

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/map-comment-only.scss.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/map-comment-only.scss.snap
@@ -2,9 +2,10 @@
 source: crates/oxc_formatter_css/tests/fixtures/mod.rs
 ---
 ==================== Input ====================
-// A map whose only content is a comment keeps the comment INSIDE the parens,
-// one per line — it must not leak past `)` (Prettier#18535, fixed on main;
-// 3.8.4 misprints it as `$map: () // comment`).
+// A map whose only content is a comment keeps the comment INSIDE the parens —
+// it must not leak past `)` (Prettier#18535, 3.8.4 misprints it as
+// `$map: () // comment`). Block comments stay inline when they fit;
+// a `//` comment forces the `)` onto its own line (Prettier's `lineSuffixBoundary`).
 $inline: (
   // comment
 );
@@ -16,7 +17,9 @@ $multi: (
   // b
 );
 // Regression guards: a truly empty map stays `()`, and a map WITH items still
-// renders its leading comment normally.
+// renders its leading comment normally. A comment before the FIRST item makes
+// the group `groups[0]` a non-key-value pair in Prettier, so the map stops
+// being an SCSS map item and loses its trailing comma.
 $empty: ();
 $with-items: (
   // comment
@@ -27,49 +30,51 @@ $with-items: (
 ------------------
 { printWidth: 80 }
 ------------------
-// A map whose only content is a comment keeps the comment INSIDE the parens,
-// one per line — it must not leak past `)` (Prettier#18535, fixed on main;
-// 3.8.4 misprints it as `$map: () // comment`).
+// A map whose only content is a comment keeps the comment INSIDE the parens —
+// it must not leak past `)` (Prettier#18535, 3.8.4 misprints it as
+// `$map: () // comment`). Block comments stay inline when they fit;
+// a `//` comment forces the `)` onto its own line (Prettier's `lineSuffixBoundary`).
 $inline: (
   // comment
 );
-$block: (
-  /* block */
-);
+$block: (/* block */);
 $multi: (
   // a
   // b
 );
 // Regression guards: a truly empty map stays `()`, and a map WITH items still
-// renders its leading comment normally.
+// renders its leading comment normally. A comment before the FIRST item makes
+// the group `groups[0]` a non-key-value pair in Prettier, so the map stops
+// being an SCSS map item and loses its trailing comma.
 $empty: ();
 $with-items: (
   // comment
-  a: 1,
+  a: 1
 );
 
 -------------------
 { printWidth: 100 }
 -------------------
-// A map whose only content is a comment keeps the comment INSIDE the parens,
-// one per line — it must not leak past `)` (Prettier#18535, fixed on main;
-// 3.8.4 misprints it as `$map: () // comment`).
+// A map whose only content is a comment keeps the comment INSIDE the parens —
+// it must not leak past `)` (Prettier#18535, 3.8.4 misprints it as
+// `$map: () // comment`). Block comments stay inline when they fit;
+// a `//` comment forces the `)` onto its own line (Prettier's `lineSuffixBoundary`).
 $inline: (
   // comment
 );
-$block: (
-  /* block */
-);
+$block: (/* block */);
 $multi: (
   // a
   // b
 );
 // Regression guards: a truly empty map stays `()`, and a map WITH items still
-// renders its leading comment normally.
+// renders its leading comment normally. A comment before the FIRST item makes
+// the group `groups[0]` a non-key-value pair in Prettier, so the map stops
+// being an SCSS map item and loses its trailing comma.
 $empty: ();
 $with-items: (
   // comment
-  a: 1,
+  a: 1
 );
 
 ===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/map-item-parens.scss
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/map-item-parens.scss
@@ -1,0 +1,34 @@
+// `isSCSSMapItemNode` (Prettier#18530/#19091, released in 3.9) with our
+// semantic-safety extension (see "Known divergences" in AGENTS.md):
+// a paren group breaks one-element-per-line with a trailing comma ONLY when
+// - it is a keyword argument's direct value and the call's FIRST argument is a
+//   key-value pair (Prettier checks `groups[0]` alone), or a map item value, AND
+// - its contents are ALREADY a comma-separated list, the only case where the
+//   added comma is a semantic no-op (`(x,)` is a single-element list in Sass).
+@include container($foo: ($bar, $baz));
+@include first-not-kv(a, $k: (1, 2));
+@include first-kv($k: (1, 2), a);
+.a {
+  color: fn(a, $k: (1, 2));
+  border-color: fn($k: (1, 2), a);
+}
+// Non-comma-list contents NEVER take the break: Prettier 3.9.1 still listifies
+// `($bar + $baz)` / `(a b)` / `(-$a)` and emits non-compiling output for
+// `key: 2 * ($a + $b)` (`Undefined operation "2 * (3px,)"`), so these stay
+// inline as a deliberate divergence.
+@include container($foo: 2 * ($bar + $baz));
+@include container($foo: ($bar + $baz));
+@include container($foo: (value));
+.b {
+  background-color: rgba($color: (#808080), $alpha: 0.9);
+}
+$map: (
+  scalar-fn: (fn(1, 2)),
+  scalar-nested: ((value)),
+  space-list: (a b),
+  math: ($x + $y),
+  math-sibling: 2 * ($x + $y),
+  signed: (-$a),
+  interpolation: (#{$a}),
+  comma-list: (a, b),
+);

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/map-item-parens.scss.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/map-item-parens.scss.snap
@@ -1,0 +1,157 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// `isSCSSMapItemNode` (Prettier#18530/#19091, released in 3.9) with our
+// semantic-safety extension (see "Known divergences" in AGENTS.md):
+// a paren group breaks one-element-per-line with a trailing comma ONLY when
+// - it is a keyword argument's direct value and the call's FIRST argument is a
+//   key-value pair (Prettier checks `groups[0]` alone), or a map item value, AND
+// - its contents are ALREADY a comma-separated list, the only case where the
+//   added comma is a semantic no-op (`(x,)` is a single-element list in Sass).
+@include container($foo: ($bar, $baz));
+@include first-not-kv(a, $k: (1, 2));
+@include first-kv($k: (1, 2), a);
+.a {
+  color: fn(a, $k: (1, 2));
+  border-color: fn($k: (1, 2), a);
+}
+// Non-comma-list contents NEVER take the break: Prettier 3.9.1 still listifies
+// `($bar + $baz)` / `(a b)` / `(-$a)` and emits non-compiling output for
+// `key: 2 * ($a + $b)` (`Undefined operation "2 * (3px,)"`), so these stay
+// inline as a deliberate divergence.
+@include container($foo: 2 * ($bar + $baz));
+@include container($foo: ($bar + $baz));
+@include container($foo: (value));
+.b {
+  background-color: rgba($color: (#808080), $alpha: 0.9);
+}
+$map: (
+  scalar-fn: (fn(1, 2)),
+  scalar-nested: ((value)),
+  space-list: (a b),
+  math: ($x + $y),
+  math-sibling: 2 * ($x + $y),
+  signed: (-$a),
+  interpolation: (#{$a}),
+  comma-list: (a, b),
+);
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// `isSCSSMapItemNode` (Prettier#18530/#19091, released in 3.9) with our
+// semantic-safety extension (see "Known divergences" in AGENTS.md):
+// a paren group breaks one-element-per-line with a trailing comma ONLY when
+// - it is a keyword argument's direct value and the call's FIRST argument is a
+//   key-value pair (Prettier checks `groups[0]` alone), or a map item value, AND
+// - its contents are ALREADY a comma-separated list, the only case where the
+//   added comma is a semantic no-op (`(x,)` is a single-element list in Sass).
+@include container(
+  $foo: (
+    $bar,
+    $baz,
+  )
+);
+@include first-not-kv(a, $k: (1, 2));
+@include first-kv(
+  $k: (
+    1,
+    2,
+  ),
+  a
+);
+.a {
+  color: fn(a, $k: (1, 2));
+  border-color: fn(
+    $k: (
+      1,
+      2,
+    ),
+    a
+  );
+}
+// Non-comma-list contents NEVER take the break: Prettier 3.9.1 still listifies
+// `($bar + $baz)` / `(a b)` / `(-$a)` and emits non-compiling output for
+// `key: 2 * ($a + $b)` (`Undefined operation "2 * (3px,)"`), so these stay
+// inline as a deliberate divergence.
+@include container($foo: 2 * ($bar + $baz));
+@include container($foo: ($bar + $baz));
+@include container($foo: (value));
+.b {
+  background-color: rgba($color: (#808080), $alpha: 0.9);
+}
+$map: (
+  scalar-fn: (fn(1, 2)),
+  scalar-nested: ((value)),
+  space-list: (a b),
+  math: ($x + $y),
+  math-sibling: 2 * ($x + $y),
+  signed: (-$a),
+  interpolation: (#{$a}),
+  comma-list: (
+    a,
+    b,
+  ),
+);
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// `isSCSSMapItemNode` (Prettier#18530/#19091, released in 3.9) with our
+// semantic-safety extension (see "Known divergences" in AGENTS.md):
+// a paren group breaks one-element-per-line with a trailing comma ONLY when
+// - it is a keyword argument's direct value and the call's FIRST argument is a
+//   key-value pair (Prettier checks `groups[0]` alone), or a map item value, AND
+// - its contents are ALREADY a comma-separated list, the only case where the
+//   added comma is a semantic no-op (`(x,)` is a single-element list in Sass).
+@include container(
+  $foo: (
+    $bar,
+    $baz,
+  )
+);
+@include first-not-kv(a, $k: (1, 2));
+@include first-kv(
+  $k: (
+    1,
+    2,
+  ),
+  a
+);
+.a {
+  color: fn(a, $k: (1, 2));
+  border-color: fn(
+    $k: (
+      1,
+      2,
+    ),
+    a
+  );
+}
+// Non-comma-list contents NEVER take the break: Prettier 3.9.1 still listifies
+// `($bar + $baz)` / `(a b)` / `(-$a)` and emits non-compiling output for
+// `key: 2 * ($a + $b)` (`Undefined operation "2 * (3px,)"`), so these stay
+// inline as a deliberate divergence.
+@include container($foo: 2 * ($bar + $baz));
+@include container($foo: ($bar + $baz));
+@include container($foo: (value));
+.b {
+  background-color: rgba($color: (#808080), $alpha: 0.9);
+}
+$map: (
+  scalar-fn: (fn(1, 2)),
+  scalar-nested: ((value)),
+  space-list: (a b),
+  math: ($x + $y),
+  math-sibling: 2 * ($x + $y),
+  signed: (-$a),
+  interpolation: (#{$a}),
+  comma-list: (
+    a,
+    b,
+  ),
+);
+
+===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/map-tail-comment.scss
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/map-tail-comment.scss
@@ -1,0 +1,12 @@
+// The tail flush of a map must stay bounded by its own `)`: the `//` comment
+// glued to `$second`'s last item must not be pulled into `$first`'s output
+// (it is not own-line, so the unbounded same-line flush used to steal it).
+$first: (
+  a: 1,
+  // own comment
+  b: 2,
+);
+$second: (
+  a: 1,
+  b: 2, // stays here
+);

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/map-tail-comment.scss.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/map-tail-comment.scss.snap
@@ -1,0 +1,51 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// The tail flush of a map must stay bounded by its own `)`: the `//` comment
+// glued to `$second`'s last item must not be pulled into `$first`'s output
+// (it is not own-line, so the unbounded same-line flush used to steal it).
+$first: (
+  a: 1,
+  // own comment
+  b: 2,
+);
+$second: (
+  a: 1,
+  b: 2, // stays here
+);
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// The tail flush of a map must stay bounded by its own `)`: the `//` comment
+// glued to `$second`'s last item must not be pulled into `$first`'s output
+// (it is not own-line, so the unbounded same-line flush used to steal it).
+$first: (
+  a: 1,
+  // own comment
+  b: 2,
+);
+$second: (
+  a: 1,
+  b: 2, // stays here
+);
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// The tail flush of a map must stay bounded by its own `)`: the `//` comment
+// glued to `$second`'s last item must not be pulled into `$first`'s output
+// (it is not own-line, so the unbounded same-line flush used to steal it).
+$first: (
+  a: 1,
+  // own comment
+  b: 2,
+);
+$second: (
+  a: 1,
+  b: 2, // stays here
+);
+
+===================== End =====================

--- a/tasks/prettier_conformance/snapshots/prettier.scss.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.scss.snap.md
@@ -1,15 +1,11 @@
-scss compatibility: 83/90 (92.22%), 7 files skipped
+scss compatibility: 87/90 (96.67%), 7 files skipped
 
 # Failed
 
 | Spec path | Failed or Passed | Match ratio |
 | :-------- | :--------------: | :---------: |
 | scss/comments/4878.scss | 💥 | 89.39% |
-| scss/map/3235.scss | 💥💥 | 97.40% |
-| scss/map/comment.scss | 💥💥 | 91.67% |
-| scss/map/key-values.scss | 💥💥 | 92.45% |
 | scss/map/function-argument/functional-argument.scss | 💥 | 96.00% |
-| scss/math/7419.scss | 💥💥 | 50.00% |
 | scss/variables/apply-rule.scss | 💥 | 87.88% |
 
 # Skipped (parse error, TODO: should be ignored or supported)


### PR DESCRIPTION
Part of #23923

Addressed these changes:

- https://github.com/prettier/prettier/blob/79f6cdfd9873a91be9b25c9c6a41d26dcd9a6656/changelog_unreleased/scss/18530.md
- https://github.com/prettier/prettier/blob/79f6cdfd9873a91be9b25c9c6a41d26dcd9a6656/changelog_unreleased/scss/18535.md
- https://github.com/prettier/prettier/blob/79f6cdfd9873a91be9b25c9c6a41d26dcd9a6656/changelog_unreleased/scss/19091.md

and also fixed minor formatting diffs regarding to trailing comment in map.

```scss
$m: (
  a: 1,
  b: 2, // THIS
);
```
