### PR TITLE
fix(formatter_css): align CSS output to Prettier 3.9.1

### DIFF
--- a/crates/oxc_formatter_css/AGENTS.md
+++ b/crates/oxc_formatter_css/AGENTS.md
@@ -158,6 +158,15 @@ Notable divergences are:
 - Broken `:not(...)` selector args indent at +2
   - Prettier lands at +4 (arg) / +2 (`)`)
   - Layout-only, rare trigger (selector longer than line width)
+- `<general-enclosed>` media preludes (`@media (not all)`, `(screen and (color))` unparsable as `<media-condition>`) normalize whitespace fully
+  - Source gap → one space, paren inner edges tight
+  - Prettier only collapses space RUNS inside the unparsable paren, leaving `(not ( screen and ( color ) ))`
+    - We print `(not (screen and (color)))`
+  - Reproducing the half-normalization is pure tokenizer-artifact matching;
+    - Gap-based spacing never fuses tokens the source kept apart (`and (` can't become a function token `and(`)
+- `@custom-media` preludes always print structured (e.g. `--viewport-medium (width <= 50rem)`)
+  - With the name GLUED to the `(` (`--viewport-medium(width<=50rem)`)
+  - Prettier keeps the whole prelude verbatim (ONE `media-type` token)
 - A declaration swallowed by a `;`-less css-in-js placeholder (`${m}\ncolor: red`)
   - We parse it structurally and FORMAT it (spacing/hex/number normalization)
   - Prettier keeps it verbatim, postcss swallows the run as an opaque prelude string it can't format, so `color   :   red` / `#FFFFFF` survive unformatted
@@ -244,7 +253,10 @@ cargo run -p oxc_prettier_conformance
 cargo run -p oxc_prettier_conformance -- --filter css/atrule
 ```
 
-At the current version (v3.9.1), the divergences of three files (`scss/comments/4878.scss`, `scss/map/function-argument/functional-argument.scss`, `scss/variables/apply-rule.scss`) have been confirmed in the SCSS conformance, but these are intentional (see "Known divergences").
+At the current version (v3.9.1), the divergences of five files have been confirmed and are intentional (see "Known divergences"):
+
+- CSS: `css/stylefmt-repo/at-media/at-media.css`, `css/stylefmt-repo/cssnext-example/cssnext-example.css`
+- SCSS: `scss/comments/4878.scss`, `scss/map/function-argument/functional-argument.scss`, `scss/variables/apply-rule.scss`
 
 ### Embedded conformance (`apps/oxfmt`)
 

--- a/crates/oxc_formatter_css/src/print/at_rule.rs
+++ b/crates/oxc_formatter_css/src/print/at_rule.rs
@@ -12,7 +12,7 @@ use oxc_css_parser::{
         MediaCondition, MediaConditionKind, MediaFeature, MediaFeatureComparisonKind,
         MediaFeatureName, MediaInParens, MediaInParensKind, MediaQuery, MediaQueryList,
         NamespacePreludeUri, SassAtRootKind, SimpleBlock, SupportsCondition, SupportsConditionKind,
-        SupportsInParens, SupportsInParensKind, UnknownAtRulePrelude,
+        SupportsInParens, SupportsInParensKind, TokenSeq, UnknownAtRulePrelude,
     },
     token::{Token, TokenWithSpan},
 };
@@ -1536,17 +1536,46 @@ fn write_media_in_parens<'a>(in_parens: &MediaInParens<'a>, f: &mut CssFormatter
             let span = to_span(&interpolation.span);
             write!(f, text(f.context().source_text().text_for(&span)));
         }
-        // W3C `<general-enclosed>` forward-compat fallback: any prelude oxc-css-parser
-        // can't structure (e.g. `(max-width: $bp)` without `allow_postcss_simple_vars`)
-        // is preserved as a verbatim `TokenSeq` inside its own parens.
-        MediaInParensKind::GeneralEnclosed(seq) => write_general_enclosed(&seq.span, f),
+        // W3C `<general-enclosed>` forward-compat fallback:
+        // any prelude `oxc-css-parser` can't structure (e.g. `(not all)`, `(screen and (color))`)
+        // keeps its tokens with whitespace normalized.
+        MediaInParensKind::GeneralEnclosed(seq) => write_general_enclosed(seq, f),
     }
 }
 
-/// `<general-enclosed>` prints its `TokenSeq` verbatim inside its own parens.
-fn write_general_enclosed(span: &oxc_css_parser::Span, f: &mut CssFormatter<'_, '_>) {
-    let span = to_span(span);
-    write!(f, [text("("), text(f.context().source_text().text_for(&span)), text(")")]);
+/// `<general-enclosed>` prints its `TokenSeq` inside its own parens,
+/// tokens verbatim but whitespace normalized:
+/// a source gap becomes one space, paren inner edges stay tight, `:`/`,` space right only.
+/// Gap-based spacing never fuses tokens the source kept apart
+/// (`and (color)` can't collapse into a function token `and(`).
+/// NOTE: Deliberately more normalized than Prettier.
+fn write_general_enclosed<'a>(seq: &TokenSeq<'a>, f: &mut CssFormatter<'_, 'a>) {
+    let source = f.context().source_text();
+    write!(f, "(");
+    for (i, tok) in seq.tokens.iter().enumerate() {
+        if i > 0 {
+            let prev = &seq.tokens[i - 1];
+            let needs_space = match (&prev.token, &tok.token) {
+                (Token::LParen(_) | Token::LBracket(_), _)
+                | (
+                    _,
+                    Token::RParen(_)
+                    | Token::RBracket(_)
+                    | Token::Comma(_)
+                    | Token::Semicolon(_)
+                    | Token::Colon(_),
+                ) => false,
+                (Token::Comma(_) | Token::Colon(_), _) => true,
+                _ => to_span(prev.span()).end != to_span(tok.span()).start,
+            };
+            if needs_space {
+                write!(f, space());
+            }
+        }
+        let span = to_span(tok.span());
+        write!(f, text(source.text_for(&span)));
+    }
+    write!(f, ")");
 }
 
 fn write_media_feature_name<'a>(name: &MediaFeatureName<'a>, f: &mut CssFormatter<'_, 'a>) {
@@ -1688,7 +1717,7 @@ fn write_supports_in_parens<'a>(in_parens: &SupportsInParens<'a>, f: &mut CssFor
         SupportsInParensKind::Function(func) => {
             value::write_function(func, ValueContext::default(), f);
         }
-        SupportsInParensKind::GeneralEnclosed(seq) => write_general_enclosed(&seq.span, f),
+        SupportsInParensKind::GeneralEnclosed(seq) => write_general_enclosed(seq, f),
     }
 }
 

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/custom-media.css
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/custom-media.css
@@ -1,0 +1,8 @@
+/* `@custom-media` preludes always print structured: `--name <media-query-list>`.
+   Known divergence (see AGENTS.md): with the name GLUED to the `(` (line 1),
+   Prettier 3.9.1 keeps the whole prelude verbatim
+   (`--viewport-medium(width<=50rem)`, one postcss-media-query-parser token);
+   we print `--viewport-medium (width <= 50rem)` like the spaced form. */
+@custom-media --viewport-medium(width<=50rem);
+@custom-media --viewport-medium (width <= 50rem);
+@custom-media --modern (color), (hover);

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/custom-media.css.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/custom-media.css.snap
@@ -1,0 +1,39 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+/* `@custom-media` preludes always print structured: `--name <media-query-list>`.
+   Known divergence (see AGENTS.md): with the name GLUED to the `(` (line 1),
+   Prettier 3.9.1 keeps the whole prelude verbatim
+   (`--viewport-medium(width<=50rem)`, one postcss-media-query-parser token);
+   we print `--viewport-medium (width <= 50rem)` like the spaced form. */
+@custom-media --viewport-medium(width<=50rem);
+@custom-media --viewport-medium (width <= 50rem);
+@custom-media --modern (color), (hover);
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+/* `@custom-media` preludes always print structured: `--name <media-query-list>`.
+   Known divergence (see AGENTS.md): with the name GLUED to the `(` (line 1),
+   Prettier 3.9.1 keeps the whole prelude verbatim
+   (`--viewport-medium(width<=50rem)`, one postcss-media-query-parser token);
+   we print `--viewport-medium (width <= 50rem)` like the spaced form. */
+@custom-media --viewport-medium (width <= 50rem);
+@custom-media --viewport-medium (width <= 50rem);
+@custom-media --modern (color), (hover);
+
+-------------------
+{ printWidth: 100 }
+-------------------
+/* `@custom-media` preludes always print structured: `--name <media-query-list>`.
+   Known divergence (see AGENTS.md): with the name GLUED to the `(` (line 1),
+   Prettier 3.9.1 keeps the whole prelude verbatim
+   (`--viewport-medium(width<=50rem)`, one postcss-media-query-parser token);
+   we print `--viewport-medium (width <= 50rem)` like the spaced form. */
+@custom-media --viewport-medium (width <= 50rem);
+@custom-media --viewport-medium (width <= 50rem);
+@custom-media --modern (color), (hover);
+
+===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/media-general-enclosed.css
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/media-general-enclosed.css
@@ -1,0 +1,12 @@
+/* `<general-enclosed>` media preludes (unparsable as `<media-condition>`,
+   e.g. parenthesized `not all` or a media TYPE inside parens):
+   tokens kept, whitespace normalized (gap -> one space, paren edges tight).
+   Known divergence (see AGENTS.md): the nested query below prints
+   `(not (screen and (color)))`; Prettier 3.9.1 only collapses space runs
+   inside the unparsable paren and keeps `(not ( screen and ( color ) ))`. */
+@media (not all) and (monochrome) {
+}
+@media (   not     all    )    and     (   monochrome    ) {
+}
+@media (  not (   screen     and   (  color  )  )   ), print and (  color ) {
+}

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/media-general-enclosed.css.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/media-general-enclosed.css.snap
@@ -1,0 +1,51 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+/* `<general-enclosed>` media preludes (unparsable as `<media-condition>`,
+   e.g. parenthesized `not all` or a media TYPE inside parens):
+   tokens kept, whitespace normalized (gap -> one space, paren edges tight).
+   Known divergence (see AGENTS.md): the nested query below prints
+   `(not (screen and (color)))`; Prettier 3.9.1 only collapses space runs
+   inside the unparsable paren and keeps `(not ( screen and ( color ) ))`. */
+@media (not all) and (monochrome) {
+}
+@media (   not     all    )    and     (   monochrome    ) {
+}
+@media (  not (   screen     and   (  color  )  )   ), print and (  color ) {
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+/* `<general-enclosed>` media preludes (unparsable as `<media-condition>`,
+   e.g. parenthesized `not all` or a media TYPE inside parens):
+   tokens kept, whitespace normalized (gap -> one space, paren edges tight).
+   Known divergence (see AGENTS.md): the nested query below prints
+   `(not (screen and (color)))`; Prettier 3.9.1 only collapses space runs
+   inside the unparsable paren and keeps `(not ( screen and ( color ) ))`. */
+@media (not all) and (monochrome) {
+}
+@media (not all) and (monochrome) {
+}
+@media (not (screen and (color))), print and (color) {
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+/* `<general-enclosed>` media preludes (unparsable as `<media-condition>`,
+   e.g. parenthesized `not all` or a media TYPE inside parens):
+   tokens kept, whitespace normalized (gap -> one space, paren edges tight).
+   Known divergence (see AGENTS.md): the nested query below prints
+   `(not (screen and (color)))`; Prettier 3.9.1 only collapses space runs
+   inside the unparsable paren and keeps `(not ( screen and ( color ) ))`. */
+@media (not all) and (monochrome) {
+}
+@media (not all) and (monochrome) {
+}
+@media (not (screen and (color))), print and (color) {
+}
+
+===================== End =====================

--- a/tasks/prettier_conformance/snapshots/prettier.css.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.css.snap.md
@@ -4,7 +4,7 @@ css compatibility: 148/150 (98.67%), 25 files skipped
 
 | Spec path | Failed or Passed | Match ratio |
 | :-------- | :--------------: | :---------: |
-| css/stylefmt-repo/at-media/at-media.css | 💥 | 90.48% |
+| css/stylefmt-repo/at-media/at-media.css | 💥 | 95.24% |
 | css/stylefmt-repo/cssnext-example/cssnext-example.css | 💥 | 98.31% |
 
 # Skipped (parse error, TODO: should be ignored or supported)


### PR DESCRIPTION
Part of #23923

These changes were not listed in `changelog_unreleased`.
