### PR TITLE
feat(type_checker): parse project tsconfig via oxc_resolver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2628,6 +2628,7 @@ dependencies = [
  "oxc_ast_visit",
  "oxc_diagnostics",
  "oxc_parser",
+ "oxc_resolver",
  "oxc_semantic",
  "oxc_span",
 ]

--- a/crates/oxc_type_checker/Cargo.toml
+++ b/crates/oxc_type_checker/Cargo.toml
@@ -38,6 +38,7 @@ test = false
 oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }
 oxc_diagnostics = { workspace = true }
+oxc_resolver = { workspace = true }
 oxc_semantic = { workspace = true }
 oxc_span = { workspace = true }
 

--- a/crates/oxc_type_checker/src/execute/tsc.rs
+++ b/crates/oxc_type_checker/src/execute/tsc.rs
@@ -6,7 +6,7 @@ use std::{
     process::ExitCode,
 };
 
-use crate::tsoptions::{TypeCheckCommand, parse_command_line};
+use crate::tsoptions::{TypeCheckCommand, parse_command_line, parse_config_file};
 
 /// Run the type checker from the command line.
 ///
@@ -32,11 +32,21 @@ fn tsc_compilation(command: &TypeCheckCommand) -> ExitCode {
     };
 
     match resolve_config_file(command, &cwd) {
-        // A resolved config file. Later steps will parse it and type check the project.
-        Ok(Some(config_file)) => {
-            println!("project: {}", config_file.display());
-            ExitCode::SUCCESS
-        }
+        // A resolved config file: parse it (resolving `extends`) via `oxc_resolver`. Later
+        // steps will expand its file globs and type check the project.
+        Ok(Some(config_file)) => match parse_config_file(&config_file) {
+            Ok(tsconfig) => {
+                println!("project: {}", config_file.display());
+                println!("  files:   {:?}", tsconfig.files);
+                println!("  include: {:?}", tsconfig.include);
+                println!("  exclude: {:?}", tsconfig.exclude);
+                ExitCode::SUCCESS
+            }
+            Err(message) => {
+                eprintln!("{message}");
+                ExitCode::FAILURE
+            }
+        },
         // Source files were given without a config file. Later steps will type check them
         // directly as root files.
         Ok(None) => {

--- a/crates/oxc_type_checker/src/tsoptions/mod.rs
+++ b/crates/oxc_type_checker/src/tsoptions/mod.rs
@@ -3,5 +3,7 @@
 //! Command-line and (later) `tsconfig.json` option parsing.
 
 mod commandlineparser;
+mod tsconfigparsing;
 
 pub use commandlineparser::{TypeCheckCommand, parse_command_line};
+pub use tsconfigparsing::parse_config_file;

--- a/crates/oxc_type_checker/src/tsoptions/tsconfigparsing.rs
+++ b/crates/oxc_type_checker/src/tsoptions/tsconfigparsing.rs
@@ -1,0 +1,25 @@
+//! Port of typescript-go's `internal/tsoptions/tsconfigparsing.go`.
+//!
+//! Reads and parses a `tsconfig.json`. The JSONC parse and the `extends`/`references`
+//! search are delegated to `oxc_resolver`.
+
+use std::{path::Path, sync::Arc};
+
+use oxc_resolver::{ResolveOptions, Resolver, TsConfig};
+
+/// Parse the `tsconfig.json` at `config_file`, resolving its `extends` chain.
+///
+/// Mirrors tsgo's `GetParsedCommandLineOfConfigFile`, but delegates the JSONC parse and the
+/// `extends`/`references` search to `oxc_resolver`. `config_file` may be a path to a config
+/// file or to a directory (in which case `tsconfig.json` is assumed).
+///
+/// Expanding `files`/`include`/`exclude` into the concrete root file list is a later step.
+///
+/// # Errors
+///
+/// Returns the `oxc_resolver` error text when the file is missing, or when the tsconfig (or
+/// any config it `extends`) is invalid.
+pub fn parse_config_file(config_file: &Path) -> Result<Arc<TsConfig>, String> {
+    let resolver = Resolver::new(ResolveOptions::default());
+    resolver.resolve_tsconfig(config_file).map_err(|error| error.to_string())
+}


### PR DESCRIPTION
## Summary

Next step in porting [`typescript-go`](https://github.com/microsoft/typescript-go) into `oxc_type_checker`, following [#24102](https://github.com/oxc-project/oxc/pull/24102).

After resolving a project to its config-file path (tsc `-p` semantics), `oxcheck` now **parses that `tsconfig.json`** by delegating to `oxc_resolver`'s `resolve_tsconfig`, which:

- resolves the `extends` chain,
- tolerates JSONC (comments / trailing commas),
- normalizes `include`/`exclude` to absolute paths.

New `src/tsoptions/tsconfigparsing.rs` (mirrors tsgo's `internal/tsoptions/tsconfigparsing.go`) wraps it as `parse_config_file`; `execute::tsc_compilation` parses after the path is resolved and prints `files`/`include`/`exclude`.

## Try it

```console
$ cargo run -p oxc_type_checker --bin oxcheck -- -p apps/oxfmt
project: /abs/apps/oxfmt/tsconfig.json
  files:   None
  include: Some(["/abs/apps/oxfmt/scripts", "/abs/apps/oxfmt/conformance/*.ts", ...])
  exclude: Some(["/abs/apps/oxfmt/test/**/fixtures"])
```

`extends` is honored (a child inherits `include` from its base while keeping its own `exclude`); an invalid tsconfig exits non-zero. The tsc-style `-p` resolution and the TS5042/5058/5081 errors are unchanged — they short-circuit before parsing.

## Scope

Expanding `files`/`include`/`exclude` globs into the concrete root file list is the next step. `oxc_resolver` parse errors currently print as its raw `ResolveError`; tsc-styled diagnostics remain deferred.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
