### PR TITLE
test(react_compiler): normalize fixture pragma headers to a single shape

### DIFF
--- a/crates/oxc_react_compiler/fixtures/fbt/error.todo-fbt-plural-in-expression-container.js
+++ b/crates/oxc_react_compiler/fixtures/fbt/error.todo-fbt-plural-in-expression-container.js
@@ -1,4 +1,4 @@
-// @compilationMode(infer)
+// @compilationMode:"infer"
 function Component(props) {
   return (
     <fbt desc="test">

--- a/crates/oxc_react_compiler/fixtures/immutable-hooks.js
+++ b/crates/oxc_react_compiler/fixtures/immutable-hooks.js
@@ -1,4 +1,4 @@
-// @enableAssumeHooksFollowRulesOfReact true
+// @enableAssumeHooksFollowRulesOfReact:true
 function Component(props) {
   const x = {};
   // In enableAssumeHooksFollowRulesOfReact mode hooks freeze their inputs and return frozen values

--- a/crates/oxc_react_compiler/fixtures/meta-isms/repro-cx-namespace-assigned-to-temporary.js
+++ b/crates/oxc_react_compiler/fixtures/meta-isms/repro-cx-namespace-assigned-to-temporary.js
@@ -1,4 +1,4 @@
-// @compilationMode:"infer" @enableAssumeHooksFollowRulesOfReact:false @customMacros(cx)
+// @compilationMode:"infer" @enableAssumeHooksFollowRulesOfReact:false @customMacros:"cx"
 import {identity} from 'shared-runtime';
 
 const DARK = 'dark';

--- a/crates/oxc_react_compiler/fixtures/no-cache-slots-no-import.js
+++ b/crates/oxc_react_compiler/fixtures/no-cache-slots-no-import.js
@@ -1,4 +1,4 @@
-// @compilationMode(all)
+// @compilationMode:"all"
 function useMyHook({a, b}) {
   return a + b;
 }

--- a/crates/oxc_react_compiler/fixtures/ref-current-aliased-no-added-to-dep.js
+++ b/crates/oxc_react_compiler/fixtures/ref-current-aliased-no-added-to-dep.js
@@ -1,4 +1,4 @@
-// @validateRefAccessDuringRender false
+// @validateRefAccessDuringRender:false
 function VideoTab() {
   const ref = useRef();
   const t = ref.current;

--- a/crates/oxc_react_compiler/fixtures/ref-current-field-not-added-to-dep.js
+++ b/crates/oxc_react_compiler/fixtures/ref-current-field-not-added-to-dep.js
@@ -1,4 +1,4 @@
-// @validateRefAccessDuringRender false
+// @validateRefAccessDuringRender:false
 function VideoTab() {
   const ref = useRef();
   let x = () => {

--- a/crates/oxc_react_compiler/fixtures/repro-bailout-nopanic-shouldnt-outline.js
+++ b/crates/oxc_react_compiler/fixtures/repro-bailout-nopanic-shouldnt-outline.js
@@ -1,4 +1,4 @@
-// @panicThreshold(none)
+// @panicThreshold:"none"
 'use no memo';
 
 function Foo() {

--- a/crates/oxc_react_compiler/fixtures/target-flag-meta-internal.js
+++ b/crates/oxc_react_compiler/fixtures/target-flag-meta-internal.js
@@ -1,4 +1,4 @@
-// @target="donotuse_meta_internal"
+// @target:"donotuse_meta_internal"
 
 function Component() {
   return <div>Hello world</div>;

--- a/crates/oxc_react_compiler/fixtures/target-flag.js
+++ b/crates/oxc_react_compiler/fixtures/target-flag.js
@@ -1,4 +1,4 @@
-// @target="18"
+// @target:"18"
 
 function Component() {
   return <div>Hello world</div>;

--- a/crates/oxc_react_compiler/tests/snapshot.rs
+++ b/crates/oxc_react_compiler/tests/snapshot.rs
@@ -107,15 +107,16 @@ fn parse_pragma(source: &str) -> (SourceType, PluginOptions) {
 
     let mut is_script = false;
     let first_line = source.lines().next().unwrap_or("");
-    // Mirror upstream `splitPragma`: each `@`-delimited entry splits at its first
-    // `:` into `key` + raw `value` (the value keeps internal spaces, e.g.
-    // `["use todo memo"]`); a colon-less entry is a bare flag whose key is its first
-    // space-delimited word (any trailing `word` is discarded, as upstream does).
+    // Every fixture header uses the canonical `@key:value` / bare `@key` shape (the
+    // corpus is normalised — no legacy `@key(value)`, `@key="value"`, or `@key value`
+    // forms), so each `@`-delimited entry either splits at its first `:` into key +
+    // raw value (the value keeps internal spaces, e.g. `["use todo memo"]`) or is a
+    // bare flag.
     for entry in first_line.split('@').skip(1) {
         let entry = entry.trim();
         let (key, value) = match entry.split_once(':') {
-            Some((k, v)) => (k, Some(v)),
-            None => (entry.split(' ').next().unwrap_or(""), None),
+            Some((key, value)) => (key, Some(value)),
+            None => (entry, None),
         };
         match key {
             "script" => is_script = true,

--- a/crates/oxc_react_compiler/tests/snapshots/fbt__error.todo-fbt-plural-in-expression-container.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/fbt__error.todo-fbt-plural-in-expression-container.snap
@@ -4,6 +4,6 @@ input_file: crates/oxc_react_compiler/fixtures/fbt/error.todo-fbt-plural-in-expr
 ---
 Diagnostics:
 
-OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] Todo: Support duplicate fbt tags", labels: Two([LabeledSpan { label: Some("Multiple `<fbt:plural>` tags found"), span: SourceSpan { offset: SourceOffset(95), length: 10 }, primary: false }, LabeledSpan { label: Some("Multiple `<fbt:plural>` tags found"), span: SourceSpan { offset: SourceOffset(291), length: 10 }, primary: false }]), help: Some("Support `<fbt>` tags with multiple `<fbt:plural>` values"), note: None, severity: Warning, code: OxcCode { scope: None, number: None }, url: None } }
+OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] Todo: Support duplicate fbt tags", labels: Two([LabeledSpan { label: Some("Multiple `<fbt:plural>` tags found"), span: SourceSpan { offset: SourceOffset(96), length: 10 }, primary: false }, LabeledSpan { label: Some("Multiple `<fbt:plural>` tags found"), span: SourceSpan { offset: SourceOffset(292), length: 10 }, primary: false }]), help: Some("Support `<fbt>` tags with multiple `<fbt:plural>` values"), note: None, severity: Warning, code: OxcCode { scope: None, number: None }, url: None } }
 
 No changes.

--- a/crates/oxc_react_compiler/tests/snapshots/immutable-hooks.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/immutable-hooks.snap
@@ -3,7 +3,7 @@ source: crates/oxc_react_compiler/tests/snapshot.rs
 input_file: crates/oxc_react_compiler/fixtures/immutable-hooks.js
 ---
 import { c as _c } from "react/compiler-runtime";
-// @enableAssumeHooksFollowRulesOfReact true
+// @enableAssumeHooksFollowRulesOfReact:true
 function Component(props) {
 	const $ = _c(3);
 	let t0;

--- a/crates/oxc_react_compiler/tests/snapshots/meta-isms__repro-cx-namespace-assigned-to-temporary.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/meta-isms__repro-cx-namespace-assigned-to-temporary.snap
@@ -3,7 +3,7 @@ source: crates/oxc_react_compiler/tests/snapshot.rs
 input_file: crates/oxc_react_compiler/fixtures/meta-isms/repro-cx-namespace-assigned-to-temporary.js
 ---
 import { c as _c } from "react/compiler-runtime";
-// @compilationMode:"infer" @enableAssumeHooksFollowRulesOfReact:false @customMacros(cx)
+// @compilationMode:"infer" @enableAssumeHooksFollowRulesOfReact:false @customMacros:"cx"
 import { identity } from "shared-runtime";
 const DARK = "dark";
 function Component() {

--- a/crates/oxc_react_compiler/tests/snapshots/no-cache-slots-no-import.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/no-cache-slots-no-import.snap
@@ -2,7 +2,7 @@
 source: crates/oxc_react_compiler/tests/snapshot.rs
 input_file: crates/oxc_react_compiler/fixtures/no-cache-slots-no-import.js
 ---
-// @compilationMode(all)
+// @compilationMode:"all"
 function useMyHook(t0) {
 	const { a, b } = t0;
 	return a + b;

--- a/crates/oxc_react_compiler/tests/snapshots/ref-current-aliased-no-added-to-dep.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/ref-current-aliased-no-added-to-dep.snap
@@ -3,7 +3,7 @@ source: crates/oxc_react_compiler/tests/snapshot.rs
 input_file: crates/oxc_react_compiler/fixtures/ref-current-aliased-no-added-to-dep.js
 ---
 import { c as _c } from "react/compiler-runtime";
-// @validateRefAccessDuringRender false
+// @validateRefAccessDuringRender:false
 function VideoTab() {
 	const $ = _c(1);
 	const ref = useRef();

--- a/crates/oxc_react_compiler/tests/snapshots/ref-current-field-not-added-to-dep.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/ref-current-field-not-added-to-dep.snap
@@ -3,7 +3,7 @@ source: crates/oxc_react_compiler/tests/snapshot.rs
 input_file: crates/oxc_react_compiler/fixtures/ref-current-field-not-added-to-dep.js
 ---
 import { c as _c } from "react/compiler-runtime";
-// @validateRefAccessDuringRender false
+// @validateRefAccessDuringRender:false
 function VideoTab() {
 	const $ = _c(1);
 	const ref = useRef();

--- a/crates/oxc_react_compiler/tests/snapshots/target-flag-meta-internal.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/target-flag-meta-internal.snap
@@ -3,7 +3,7 @@ source: crates/oxc_react_compiler/tests/snapshot.rs
 input_file: crates/oxc_react_compiler/fixtures/target-flag-meta-internal.js
 ---
 import { c as _c } from "react/compiler-runtime";
-// @target="donotuse_meta_internal"
+// @target:"donotuse_meta_internal"
 function Component() {
 	const $ = _c(1);
 	let t0;

--- a/crates/oxc_react_compiler/tests/snapshots/target-flag.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/target-flag.snap
@@ -3,7 +3,7 @@ source: crates/oxc_react_compiler/tests/snapshot.rs
 input_file: crates/oxc_react_compiler/fixtures/target-flag.js
 ---
 import { c as _c } from "react/compiler-runtime";
-// @target="18"
+// @target:"18"
 function Component() {
 	const $ = _c(1);
 	let t0;


### PR DESCRIPTION
The fixture corpus mixed the canonical `@key:value` pragma form with three legacy forms — `@key(value)`, `@key="value"`, and `@key value` — that upstream's `splitPragma` silently ignores or mis-reads. This rewrites the 9 affected fixtures to the canonical `@key:value` form so there is only one shape to parse, and drops the space-form tolerance from `parse_pragma` accordingly.

## Normalized headers

| fixture | before | after |
|---|---|---|
| `no-cache-slots-no-import` | `@compilationMode(all)` | `@compilationMode:"all"` |
| `repro-bailout-nopanic-shouldnt-outline` | `@panicThreshold(none)` | `@panicThreshold:"none"` |
| `fbt/error.todo-fbt-plural-in-expression-container` | `@compilationMode(infer)` | `@compilationMode:"infer"` |
| `meta-isms/repro-cx-namespace-assigned-to-temporary` | `@customMacros(cx)` | `@customMacros:"cx"` |
| `target-flag` | `@target="18"` | `@target:"18"` |
| `target-flag-meta-internal` | `@target="donotuse_meta_internal"` | `@target:"donotuse_meta_internal"` |
| `immutable-hooks` | `@enableAssumeHooksFollowRulesOfReact true` | `@enableAssumeHooksFollowRulesOfReact:true` |
| `ref-current-aliased-no-added-to-dep` | `@validateRefAccessDuringRender false` | `@validateRefAccessDuringRender:false` |
| `ref-current-field-not-added-to-dep` | `@validateRefAccessDuringRender false` | `@validateRefAccessDuringRender:false` |

## Behavior-preserving

Every regenerated snapshot differs only in the echoed header comment (codegen preserves the leading comment), plus one +1 byte-offset shift in the `fbt` diagnostic from the comment being one character longer. No compiled output changed, and no other fixture is affected by the parser simplification.
