### PR TITLE
perf(react_compiler): cache control-test identifiers in reactive inference

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_places.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_places.rs
@@ -59,6 +59,13 @@ pub fn infer_reactive_places(
     // Compute control dominators
     let post_dominators = compute_post_dominator_tree(func, env.next_block_id().0, false)?;
 
+    // The post-dominator frontier of a block — and therefore the set of terminal
+    // test identifiers that control it — depends only on the CFG and the
+    // post-dominator tree, both fixed for the whole fixpoint. Cache the flattened
+    // test-identifier list per block instead of re-walking the CFG on every
+    // `is_reactive_controlled_block` call in every iteration.
+    let mut control_test_cache: FxHashMap<BlockId, Box<[IdentifierId]>> = FxHashMap::default();
+
     // Collect block IDs for iteration
     let block_ids: Vec<BlockId> = func.body.blocks.keys().copied().collect();
 
@@ -73,8 +80,13 @@ pub fn infer_reactive_places(
     loop {
         for block_id in &block_ids {
             let block = func.body.blocks.get(block_id).unwrap();
-            let has_reactive_control =
-                is_reactive_controlled_block(block.id, func, &post_dominators, &mut reactive_map);
+            let has_reactive_control = is_reactive_controlled_block(
+                block.id,
+                func,
+                &post_dominators,
+                &mut reactive_map,
+                &mut control_test_cache,
+            );
 
             // Process phi nodes
             let block = func.body.blocks.get(block_id).unwrap();
@@ -103,6 +115,7 @@ pub fn infer_reactive_places(
                             func,
                             &post_dominators,
                             &mut reactive_map,
+                            &mut control_test_cache,
                         ) {
                             reactive_map.mark_reactive(phi.place.identifier);
                             break;
@@ -364,32 +377,31 @@ fn is_reactive_controlled_block(
     func: &HirFunction,
     post_dominators: &PostDominator,
     reactive_map: &mut ReactivityMap,
+    control_test_cache: &mut FxHashMap<BlockId, Box<[IdentifierId]>>,
 ) -> bool {
-    let frontier = post_dominator_frontier(func, post_dominators, block_id);
-    for frontier_block_id in &frontier {
-        let control_block = func.body.blocks.get(frontier_block_id).unwrap();
-        match &control_block.terminal {
-            Terminal::If { test, .. } | Terminal::Branch { test, .. } => {
-                if reactive_map.is_reactive(test.identifier) {
-                    return true;
+    let tests = control_test_cache.entry(block_id).or_insert_with(|| {
+        let frontier = post_dominator_frontier(func, post_dominators, block_id);
+        let mut tests: Vec<IdentifierId> = Vec::new();
+        for frontier_block_id in &frontier {
+            let control_block = func.body.blocks.get(frontier_block_id).unwrap();
+            match &control_block.terminal {
+                Terminal::If { test, .. } | Terminal::Branch { test, .. } => {
+                    tests.push(test.identifier);
                 }
-            }
-            Terminal::Switch { test, cases, .. } => {
-                if reactive_map.is_reactive(test.identifier) {
-                    return true;
-                }
-                for case in cases {
-                    if let Some(ref case_test) = case.test {
-                        if reactive_map.is_reactive(case_test.identifier) {
-                            return true;
+                Terminal::Switch { test, cases, .. } => {
+                    tests.push(test.identifier);
+                    for case in cases {
+                        if let Some(ref case_test) = case.test {
+                            tests.push(case_test.identifier);
                         }
                     }
                 }
+                _ => {}
             }
-            _ => {}
         }
-    }
-    false
+        tests.into_boxed_slice()
+    });
+    tests.iter().any(|&test_id| reactive_map.is_reactive(test_id))
 }
 
 // =============================================================================

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_places.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_places.rs
@@ -134,15 +134,12 @@ pub fn infer_reactive_places(
 
                 let value = &instr.value;
 
-                // Check if any operand is reactive
+                // Check if any operand is reactive. The place list is reused for
+                // the mutable-operand pass below instead of visiting twice.
                 let mut has_reactive_input = false;
-                let operands: Vec<IdentifierId> =
-                    visitors::each_instruction_value_operand(value, env)
-                        .into_iter()
-                        .map(|p| p.identifier)
-                        .collect();
-                for &op_id in &operands {
-                    let reactive = reactive_map.is_reactive(op_id);
+                let operand_places = visitors::each_instruction_value_operand(value, env);
+                for op_place in &operand_places {
+                    let reactive = reactive_map.is_reactive(op_place.identifier);
                     has_reactive_input = has_reactive_input || reactive;
                 }
 
@@ -171,21 +168,16 @@ pub fn infer_reactive_places(
 
                 if has_reactive_input {
                     // Mark lvalues reactive (unless stable)
-                    let lvalue_ids: Vec<IdentifierId> = visitors::each_instruction_lvalue(instr)
-                        .into_iter()
-                        .map(|p| p.identifier)
-                        .collect();
-                    for lvalue_id in lvalue_ids {
-                        if stable_sidemap.is_stable(lvalue_id) {
+                    for lvalue in &visitors::each_instruction_lvalue(instr) {
+                        if stable_sidemap.is_stable(lvalue.identifier) {
                             continue;
                         }
-                        reactive_map.mark_reactive(lvalue_id);
+                        reactive_map.mark_reactive(lvalue.identifier);
                     }
                 }
 
                 if has_reactive_input || has_reactive_control {
                     // Mark mutable operands reactive
-                    let operand_places = visitors::each_instruction_value_operand(value, env);
                     for op_place in &operand_places {
                         match op_place.effect {
                             Effect::Capture


### PR DESCRIPTION
## What

`is_reactive_controlled_block` recomputed the post-dominator frontier — a full backward CFG walk allocating several hash sets — on every call: once per block per fixpoint iteration, plus once per phi-operand predecessor for not-yet-reactive phis. The frontier depends only on the CFG and the post-dominator tree, both fixed for the whole pass; only the reactivity of the controlling test identifiers changes between iterations. Independently, the fixpoint visited each instruction's operands twice per iteration — once to test reactivity, once to mark mutable operands — collecting identifier vectors it immediately discarded.

## Change

- Memoize the flattened frontier test-identifier list per block (`FxHashMap<BlockId, Box<[IdentifierId]>>`), computed on first use; `is_reactive_controlled_block` reduces to a reactivity membership check over that list.
- Call `each_instruction_value_operand` once per instruction and reuse the returned place list for both the reactive-input test and the mutable-operand marking; iterate lvalues directly instead of collecting them into an intermediate vector.

## Impact

cal.com corpus (5,063 files), `react/react-compiler` rule only, `--threads=1`:

| Metric | Base (dade03eb6b) | PR | Δ |
| --- | --- | --- | --- |
| instructions:u | 62,736,961,372 | 61,950,337,369 | −1.25% |
| wall time (median of 3) | 7.148 s | 7.116 s | −0.45% |

## Verification

- Byte-identity: 4/4 full-output diffs identical (rule-only and `reportAllBailouts:true` configs × cal.com and excalidraw corpora, `--threads=1`).
- Transform differential: 1438/1438 corpus files produce identical `react_compiler` example output (base vs PR).
- `cargo test -p oxc_react_compiler`: 15/15 pass.
- `cargo clippy -p oxc_react_compiler --all-targets` clean; `cargo fmt --check` clean.

Whether a block is reactively controlled is a pure OR over an invariant set of test identifiers (fixed by the CFG and post-dominator tree), so reactivity output is unchanged by construction.

AI-assisted.