### PR TITLE
test(react_compiler): supply the snap test module type provider

### DIFF
--- a/crates/oxc_react_compiler/tests/snapshot.rs
+++ b/crates/oxc_react_compiler/tests/snapshot.rs
@@ -20,9 +20,15 @@ use convert_case::{Case, Casing};
 use oxc_allocator::Allocator;
 use oxc_codegen::Codegen;
 use oxc_parser::Parser;
+use oxc_react_compiler::react_compiler_hir::Effect;
 use oxc_react_compiler::react_compiler_hir::environment_config::{
     ExhaustiveEffectDepsMode, ExternalFunctionConfig, InstrumentationConfig,
 };
+use oxc_react_compiler::react_compiler_hir::type_config::{
+    BuiltInTypeRef, FunctionTypeConfig, HookTypeConfig, ObjectTypeConfig, TypeConfig,
+    TypeReferenceConfig, ValueKind,
+};
+use oxc_react_compiler::react_compiler_utils::FxIndexMap;
 use oxc_react_compiler::{
     DynamicGatingConfig, EnvironmentConfig, GatingConfig, PluginOptions, transform,
 };
@@ -102,6 +108,10 @@ fn parse_pragma(source: &str) -> (SourceType, PluginOptions) {
         panic_threshold: "all_errors".to_string(),
         ..PluginOptions::default()
     };
+    // Mirror the snap runner's test `moduleTypeProvider`; unlisted modules fall back to
+    // oxc's default provider, so only the `error.invalid-{type-provider,known-incompatible}-*`
+    // fixtures (which import these magic modules) are affected.
+    options.environment.module_type_provider = Some(test_module_type_provider());
 
     let mut is_script = false;
     // Fixture headers are normalised to the canonical `@key:value` / bare `@key` shape,
@@ -273,4 +283,98 @@ fn json_strings(value: &str) -> Vec<String> {
 fn json_source(value: &str) -> Option<String> {
     let parts = json_strings(value);
     parts.iter().position(|s| s == "source").and_then(|i| parts.get(i + 1).cloned())
+}
+
+/// The upstream snap runner's test `moduleTypeProvider` (`shared-runtime-type-provider`),
+/// limited to the magic modules the corpus imports to exercise type-config /
+/// known-incompatible-library validation. These configs are intentionally invalid or
+/// flagged, so the `error.invalid-type-provider-*` / `error.invalid-known-incompatible-*`
+/// fixtures produce diagnostics instead of compiling.
+fn test_module_type_provider() -> FxIndexMap<String, TypeConfig> {
+    FxIndexMap::from_iter([
+        (
+            "ReactCompilerKnownIncompatibleTest".to_string(),
+            object([
+                (
+                    "useKnownIncompatible",
+                    hook(
+                        type_ref(),
+                        Some(Vec::new()),
+                        incompat("useKnownIncompatible is known to be incompatible"),
+                    ),
+                ),
+                (
+                    "useKnownIncompatibleIndirect",
+                    hook(
+                        object([(
+                            "incompatible",
+                            incompatible_fn(
+                                "useKnownIncompatibleIndirect returns an incompatible() function that is known incompatible",
+                            ),
+                        )]),
+                        Some(Vec::new()),
+                        None,
+                    ),
+                ),
+                (
+                    "knownIncompatible",
+                    incompatible_fn("useKnownIncompatible is known to be incompatible"),
+                ),
+            ]),
+        ),
+        (
+            "ReactCompilerTest".to_string(),
+            object([
+                ("useHookNotTypedAsHook", type_ref()),
+                ("notAhookTypedAsHook", hook(type_ref(), None, None)),
+            ]),
+        ),
+        ("useDefaultExportNotTypedAsHook".to_string(), object([("default", type_ref())])),
+    ])
+}
+
+fn object(properties: impl IntoIterator<Item = (&'static str, TypeConfig)>) -> TypeConfig {
+    let properties = properties.into_iter().map(|(name, config)| (name.to_string(), config));
+    TypeConfig::Object(ObjectTypeConfig { properties: Some(properties.collect()) })
+}
+
+fn type_ref() -> TypeConfig {
+    TypeConfig::TypeReference(TypeReferenceConfig { name: BuiltInTypeRef::Any })
+}
+
+fn hook(
+    return_type: TypeConfig,
+    positional_params: Option<Vec<Effect>>,
+    known_incompatible: Option<String>,
+) -> TypeConfig {
+    let rest_param = positional_params.as_ref().map(|_| Effect::Read);
+    TypeConfig::Hook(HookTypeConfig {
+        positional_params,
+        rest_param,
+        return_type: Box::new(return_type),
+        return_value_kind: None,
+        no_alias: None,
+        aliasing: None,
+        known_incompatible,
+    })
+}
+
+fn incompatible_fn(message: &str) -> TypeConfig {
+    TypeConfig::Function(FunctionTypeConfig {
+        positional_params: Vec::new(),
+        rest_param: Some(Effect::Read),
+        callee_effect: Effect::Read,
+        return_type: Box::new(type_ref()),
+        return_value_kind: ValueKind::Mutable,
+        no_alias: None,
+        mutable_only_if_operands_are_mutable: None,
+        impure: None,
+        canonical_name: None,
+        aliasing: None,
+        known_incompatible: Some(message.to_string()),
+    })
+}
+
+fn incompat(message: &str) -> Option<String> {
+    Some(message.to_string())
 }

--- a/crates/oxc_react_compiler/tests/snapshots/error.invalid-known-incompatible-function.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/error.invalid-known-incompatible-function.snap
@@ -2,17 +2,9 @@
 source: crates/oxc_react_compiler/tests/snapshot.rs
 input_file: crates/oxc_react_compiler/fixtures/error.invalid-known-incompatible-function.js
 ---
-import { c as _c } from "react/compiler-runtime";
-import { knownIncompatible } from "ReactCompilerKnownIncompatibleTest";
-function Component() {
-	const $ = _c(1);
-	knownIncompatible();
-	let t0;
-	if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-		t0 = <div>Error</div>;
-		$[0] = t0;
-	} else {
-		t0 = $[0];
-	}
-	return t0;
-}
+Diagnostics:
+
+OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] Unexpected error: Compilation Skipped: Use of incompatible library. This API returns functions which cannot be memoized without leading to stale UI. To prevent this, by default React Compiler will skip memoizing this component/hook. However, you may see issues if values from this API are passed to other components/hooks that are memoized. (4:15)", labels: One([LabeledSpan { label: None, span: SourceSpan { offset: SourceOffset(71), length: 87 }, primary: false }]), help: None, note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
+OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] IncompatibleLibrary: Use of incompatible library", labels: One([LabeledSpan { label: Some("useKnownIncompatible is known to be incompatible"), span: SourceSpan { offset: SourceOffset(109), length: 17 }, primary: false }]), help: Some("This API returns functions which cannot be memoized without leading to stale UI. To prevent this, by default React Compiler will skip memoizing this component/hook. However, you may see issues if values from this API are passed to other components/hooks that are memoized"), note: None, severity: Warning, code: OxcCode { scope: None, number: None }, url: None } }
+
+No changes.

--- a/crates/oxc_react_compiler/tests/snapshots/error.invalid-known-incompatible-hook-return-property.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/error.invalid-known-incompatible-hook-return-property.snap
@@ -2,26 +2,9 @@
 source: crates/oxc_react_compiler/tests/snapshot.rs
 input_file: crates/oxc_react_compiler/fixtures/error.invalid-known-incompatible-hook-return-property.js
 ---
-import { c as _c } from "react/compiler-runtime";
-import { useKnownIncompatibleIndirect } from "ReactCompilerKnownIncompatibleTest";
-function Component() {
-	const $ = _c(4);
-	const { incompatible } = useKnownIncompatibleIndirect();
-	let t0;
-	if ($[0] !== incompatible) {
-		t0 = incompatible();
-		$[0] = incompatible;
-		$[1] = t0;
-	} else {
-		t0 = $[1];
-	}
-	let t1;
-	if ($[2] !== t0) {
-		t1 = <div>{t0}</div>;
-		$[2] = t0;
-		$[3] = t1;
-	} else {
-		t1 = $[3];
-	}
-	return t1;
-}
+Diagnostics:
+
+OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] Unexpected error: Compilation Skipped: Use of incompatible library. This API returns functions which cannot be memoized without leading to stale UI. To prevent this, by default React Compiler will skip memoizing this component/hook. However, you may see issues if values from this API are passed to other components/hooks that are memoized. (5:15)", labels: One([LabeledSpan { label: None, span: SourceSpan { offset: SourceOffset(82), length: 119 }, primary: false }]), help: None, note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
+OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] IncompatibleLibrary: Use of incompatible library", labels: One([LabeledSpan { label: Some("useKnownIncompatibleIndirect returns an incompatible() function that is known incompatible"), span: SourceSpan { offset: SourceOffset(177), length: 12 }, primary: false }]), help: Some("This API returns functions which cannot be memoized without leading to stale UI. To prevent this, by default React Compiler will skip memoizing this component/hook. However, you may see issues if values from this API are passed to other components/hooks that are memoized"), note: None, severity: Warning, code: OxcCode { scope: None, number: None }, url: None } }
+
+No changes.

--- a/crates/oxc_react_compiler/tests/snapshots/error.invalid-known-incompatible-hook.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/error.invalid-known-incompatible-hook.snap
@@ -2,17 +2,9 @@
 source: crates/oxc_react_compiler/tests/snapshot.rs
 input_file: crates/oxc_react_compiler/fixtures/error.invalid-known-incompatible-hook.js
 ---
-import { c as _c } from "react/compiler-runtime";
-import { useKnownIncompatible } from "ReactCompilerKnownIncompatibleTest";
-function Component() {
-	const $ = _c(1);
-	useKnownIncompatible();
-	let t0;
-	if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-		t0 = <div>Error</div>;
-		$[0] = t0;
-	} else {
-		t0 = $[0];
-	}
-	return t0;
-}
+Diagnostics:
+
+OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] Unexpected error: Compilation Skipped: Use of incompatible library. This API returns functions which cannot be memoized without leading to stale UI. To prevent this, by default React Compiler will skip memoizing this component/hook. However, you may see issues if values from this API are passed to other components/hooks that are memoized. (4:15)", labels: One([LabeledSpan { label: None, span: SourceSpan { offset: SourceOffset(74), length: 90 }, primary: false }]), help: None, note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
+OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] IncompatibleLibrary: Use of incompatible library", labels: One([LabeledSpan { label: Some("useKnownIncompatible is known to be incompatible"), span: SourceSpan { offset: SourceOffset(112), length: 20 }, primary: false }]), help: Some("This API returns functions which cannot be memoized without leading to stale UI. To prevent this, by default React Compiler will skip memoizing this component/hook. However, you may see issues if values from this API are passed to other components/hooks that are memoized"), note: None, severity: Warning, code: OxcCode { scope: None, number: None }, url: None } }
+
+No changes.

--- a/crates/oxc_react_compiler/tests/snapshots/error.invalid-type-provider-hook-name-not-typed-as-hook-namespace.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/error.invalid-type-provider-hook-name-not-typed-as-hook-namespace.snap
@@ -2,7 +2,8 @@
 source: crates/oxc_react_compiler/tests/snapshot.rs
 input_file: crates/oxc_react_compiler/fixtures/error.invalid-type-provider-hook-name-not-typed-as-hook-namespace.js
 ---
-import ReactCompilerTest from "ReactCompilerTest";
-function Component() {
-	return ReactCompilerTest.useHookNotTypedAsHook();
-}
+Diagnostics:
+
+OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] Config: Invalid type configuration for module", labels: One([LabeledSpan { label: None, span: SourceSpan { offset: SourceOffset(84), length: 17 }, primary: false }]), help: Some("Expected type for object property 'useHookNotTypedAsHook' from module 'ReactCompilerTest' to be a hook based on the property name"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
+
+No changes.

--- a/crates/oxc_react_compiler/tests/snapshots/error.invalid-type-provider-hook-name-not-typed-as-hook.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/error.invalid-type-provider-hook-name-not-typed-as-hook.snap
@@ -2,7 +2,8 @@
 source: crates/oxc_react_compiler/tests/snapshot.rs
 input_file: crates/oxc_react_compiler/fixtures/error.invalid-type-provider-hook-name-not-typed-as-hook.js
 ---
-import { useHookNotTypedAsHook } from "ReactCompilerTest";
-function Component() {
-	return useHookNotTypedAsHook();
-}
+Diagnostics:
+
+OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] Config: Invalid type configuration for module", labels: One([LabeledSpan { label: None, span: SourceSpan { offset: SourceOffset(90), length: 21 }, primary: false }]), help: Some("Expected type for object property 'useHookNotTypedAsHook' from module 'ReactCompilerTest' to be a hook based on the property name"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
+
+No changes.

--- a/crates/oxc_react_compiler/tests/snapshots/error.invalid-type-provider-hooklike-module-default-not-hook.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/error.invalid-type-provider-hooklike-module-default-not-hook.snap
@@ -2,16 +2,8 @@
 source: crates/oxc_react_compiler/tests/snapshot.rs
 input_file: crates/oxc_react_compiler/fixtures/error.invalid-type-provider-hooklike-module-default-not-hook.js
 ---
-import { c as _c } from "react/compiler-runtime";
-import foo from "useDefaultExportNotTypedAsHook";
-function Component() {
-	const $ = _c(1);
-	let t0;
-	if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-		t0 = <div>{foo()}</div>;
-		$[0] = t0;
-	} else {
-		t0 = $[0];
-	}
-	return t0;
-}
+Diagnostics:
+
+OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] Config: Invalid type configuration for module", labels: One([LabeledSpan { label: None, span: SourceSpan { offset: SourceOffset(89), length: 3 }, primary: false }]), help: Some("Expected type for `import ... from 'useDefaultExportNotTypedAsHook'` to be a hook based on the module name"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
+
+No changes.

--- a/crates/oxc_react_compiler/tests/snapshots/error.invalid-type-provider-nonhook-name-typed-as-hook.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/error.invalid-type-provider-nonhook-name-typed-as-hook.snap
@@ -2,16 +2,8 @@
 source: crates/oxc_react_compiler/tests/snapshot.rs
 input_file: crates/oxc_react_compiler/fixtures/error.invalid-type-provider-nonhook-name-typed-as-hook.js
 ---
-import { c as _c } from "react/compiler-runtime";
-import { notAhookTypedAsHook } from "ReactCompilerTest";
-function Component() {
-	const $ = _c(1);
-	let t0;
-	if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-		t0 = <div>{notAhookTypedAsHook()}</div>;
-		$[0] = t0;
-	} else {
-		t0 = $[0];
-	}
-	return t0;
-}
+Diagnostics:
+
+OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] Config: Invalid type configuration for module", labels: One([LabeledSpan { label: None, span: SourceSpan { offset: SourceOffset(94), length: 19 }, primary: false }]), help: Some("Expected type for object property 'useHookNotTypedAsHook' from module 'ReactCompilerTest' to be a hook based on the property name"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
+
+No changes.


### PR DESCRIPTION
Closes 7 of the 17 fixtures where oxc compiled but the upstream fork errors.

The `error.invalid-type-provider-*` (4) and `error.invalid-known-incompatible-*` (3) fixtures import magic modules — `ReactCompilerTest`, `ReactCompilerKnownIncompatibleTest`, `useDefaultExportNotTypedAsHook` — that the upstream snap runner maps to intentionally-invalid / incompatible type configs via its test `moduleTypeProvider` (`snap/src/sprout/shared-runtime-type-provider.ts`). oxc's snapshot harness installed no override, so these compiled silently instead of erroring.

This installs the same test configs through the existing `EnvironmentConfig::module_type_provider` field. Unlisted modules fall back to oxc's default provider, so **only these 7 fixtures change** — nothing else in the 1,734-fixture corpus is touched. The type-config and known-incompatible-library validations already exist in oxc (`infer_mutation_aliasing_effects.rs`); they simply never saw the configs.

All 7 now emit the fork's diagnostics and decline:
- 4 × `Config: Invalid type configuration for module`
- 3 × `Compilation Skipped: Use of incompatible library`

Verified: `CI=1 cargo test` green, `cargo clippy --all-features -D warnings` and `cargo fmt --check` clean, exactly 7 snapshots changed.