### PR TITLE
fix(linter/jest/prefer-ending-with-an-expect): validate config patterns

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -2392,6 +2392,7 @@ export interface PreferEndingWithAnExpectConfig {
   additionalTestBlockFunctions?: string[];
   /**
    * A list of function names that should be treated as assertion functions.
+   * Default: `["expect"]`
    */
   assertFunctionNames?: string[];
 }

--- a/crates/oxc_linter/src/rules/jest/prefer_ending_with_an_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_ending_with_an_expect.rs
@@ -1,3 +1,4 @@
+use lazy_regex::Regex;
 use oxc_ast::{
     AstKind,
     ast::{Argument, Expression, FunctionBody, Statement},
@@ -11,7 +12,7 @@ use serde::Deserialize;
 
 use crate::{
     context::LintContext,
-    rule::Rule,
+    rule::{DefaultRuleConfig, Rule},
     rules::PossibleJestNode,
     utils::{
         JestGeneralFnKind, convert_pattern, get_node_name, matches_assert_function_name,
@@ -34,7 +35,20 @@ pub struct PreferEndingWithAnExpectConfig {
     /// An array of function names that should also be treated as test blocks.
     additional_test_block_functions: Vec<CompactStr>,
     /// A list of function names that should be treated as assertion functions.
-    assert_function_names: Vec<CompactStr>,
+    /// Default: `["expect"]`
+    #[serde(deserialize_with = "deserialize_assert_function_names")]
+    #[schemars(with = "Vec<String>")]
+    assert_function_names: Vec<Regex>,
+}
+
+fn deserialize_assert_function_names<'de, D>(deserializer: D) -> Result<Vec<Regex>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Vec::<CompactStr>::deserialize(deserializer)?
+        .into_iter()
+        .map(|pattern| Regex::new(&convert_pattern(&pattern)).map_err(serde::de::Error::custom))
+        .collect()
 }
 
 impl std::ops::Deref for PreferEndingWithAnExpect {
@@ -46,9 +60,12 @@ impl std::ops::Deref for PreferEndingWithAnExpect {
 }
 
 impl Default for PreferEndingWithAnExpectConfig {
+    #[expect(clippy::trivial_regex)]
     fn default() -> Self {
         Self {
-            assert_function_names: vec!["expect".into()],
+            assert_function_names: vec![
+                Regex::new("expect").expect("default assertion pattern should be valid"),
+            ],
             additional_test_block_functions: vec![],
         }
     }
@@ -158,29 +175,8 @@ declare_oxc_lint!(
 
 impl Rule for PreferEndingWithAnExpect {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        let config = value.get(0);
-
-        let assert_function_names = config
-            .and_then(|config| config.get("assertFunctionNames"))
-            .and_then(serde_json::Value::as_array)
-            .map(|v| {
-                v.iter()
-                    .filter_map(serde_json::Value::as_str)
-                    .map(convert_pattern)
-                    .collect::<Vec<_>>()
-            })
-            .unwrap_or(vec!["expect".into()]);
-
-        let additional_test_block_functions = config
-            .and_then(|config| config.get("additionalTestBlockFunctions"))
-            .and_then(serde_json::Value::as_array)
-            .map(|v| v.iter().filter_map(serde_json::Value::as_str).map(CompactStr::from).collect())
-            .unwrap_or_default();
-
-        Ok(Self(Box::new(PreferEndingWithAnExpectConfig {
-            additional_test_block_functions,
-            assert_function_names,
-        })))
+        serde_json::from_value::<DefaultRuleConfig<PreferEndingWithAnExpectConfig>>(value)
+            .map(|config| Self(Box::new(config.into_inner())))
     }
 
     fn run_on_jest_node<'a, 'c>(
@@ -341,12 +337,7 @@ fn test() {
             Some(serde_json::json!([{ "assertFunctionNames": ["td.verify"] }])),
         ),
         (r#"it("should pass", async () => expect(true).toBeDefined())"#, None),
-        (
-            r#"it("should pass", () => expect(true).toBeDefined())"#,
-            Some(
-                serde_json::json!([ { "assertFunctionNames": "undefined", "additionalTestBlockFunctions": "undefined", }, ]),
-            ),
-        ),
+        (r#"it("should pass", () => expect(true).toBeDefined())"#, Some(serde_json::json!([{}]))),
         (r#"it("should pass", () => { expect(true).toBeDefined() })"#, None),
         (r#"it("should pass", function () { expect(true).toBeDefined() })"#, None),
         (

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -320,8 +320,8 @@ pub fn is_equality_matcher(matcher: &KnownMemberExpressionProperty) -> bool {
 }
 
 /// Checks if node names returned by getNodeName matches any of the given star patterns
-pub fn matches_assert_function_name(name: &str, patterns: &[CompactStr]) -> bool {
-    patterns.iter().any(|pattern| Regex::new(pattern).unwrap().is_match(name))
+pub fn matches_assert_function_name(name: &str, patterns: &[Regex]) -> bool {
+    patterns.iter().any(|pattern| pattern.is_match(name))
 }
 
 pub fn convert_pattern(pattern: &str) -> CompactStr {

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -16903,15 +16903,12 @@
           "markdownDescription": "An array of function names that should also be treated as test blocks."
         },
         "assertFunctionNames": {
-          "description": "A list of function names that should be treated as assertion functions.",
-          "default": [
-            "expect"
-          ],
+          "description": "A list of function names that should be treated as assertion functions.\nDefault: `[\"expect\"]`",
           "type": "array",
           "items": {
             "type": "string"
           },
-          "markdownDescription": "A list of function names that should be treated as assertion functions."
+          "markdownDescription": "A list of function names that should be treated as assertion functions.\nDefault: `[\"expect\"]`"
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Summary

- deserialize rule options through `DefaultRuleConfig`
- convert and validate configured assertion function patterns during deserialization
- propagate invalid regex configuration errors instead of panicking at lint runtime

Closes [oxc-project/oxc#23644](https://github.com/oxc-project/oxc/pull/23644)
