### PR TITLE
fix(minifier): bound if-fold recursion and logical-join chain length

### DIFF
--- a/crates/oxc_minifier/src/peephole/minimize_for_statement.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_for_statement.rs
@@ -9,18 +9,41 @@ use super::PeepholeOptimizations;
 impl<'a> PeepholeOptimizations {
     /// `mangleFor`: <https://github.com/evanw/esbuild/blob/v0.24.2/internal/js_ast/js_parser.go#L9801>
     pub fn minimize_for_statement(for_stmt: &mut ForStatement<'a>, ctx: &mut TraverseCtx<'a>) {
+        // Greedily pull leading `if (c) break;` guards into the for-test in one
+        // pass — pulling one per pass would need a pass per guard and never
+        // converge on a long run. Stop once the test's `&&` spine reaches the cap
+        // so the run can't rebuild an expression deep enough to overflow. The cap
+        // check is idempotent: a later pass re-enters with the test already at the
+        // cap and pulls nothing, so any leftover guards stay in the body — correct
+        // and terminal.
+        loop {
+            if for_stmt.test.as_ref().is_some_and(Self::logical_expression_count_exceeded) {
+                return;
+            }
+            if !Self::pull_leading_break_into_for_test(for_stmt, ctx) {
+                return;
+            }
+        }
+    }
+
+    /// Pull a single leading `if (c) break;` (or `if (x) y(); else break;`) guard
+    /// from the loop body into the for-test, returning `true` when one was pulled.
+    fn pull_leading_break_into_for_test(
+        for_stmt: &mut ForStatement<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> bool {
         // Get the first statement in the loop
         let mut first = &for_stmt.body;
         if let Statement::BlockStatement(block_stmt) = first {
             if let Some(b) = block_stmt.body.first() {
                 first = b;
             } else {
-                return;
+                return false;
             }
         }
 
         let Statement::IfStatement(if_stmt) = first else {
-            return;
+            return false;
         };
         // "for (;;) if (x) break;" => "for (; !x;) ;"
         // "for (; a;) if (x) break;" => "for (; a && !x;) ;"
@@ -28,7 +51,7 @@ impl<'a> PeepholeOptimizations {
         // "for (; a;) if (x) break; else y();" => "for (; a && !x;) y();"
         if let Some(Statement::BreakStatement(break_stmt)) = if_stmt.consequent.get_one_child() {
             if break_stmt.label.is_some() {
-                return;
+                return false;
             }
 
             let span = for_stmt.body.span();
@@ -64,7 +87,7 @@ impl<'a> PeepholeOptimizations {
             let alternate = if_stmt.alternate.take();
             let new_body = Self::drop_first_statement(span, body, alternate, ctx);
             ctx.replace_statement(&mut for_stmt.body, new_body);
-            return;
+            return true;
         }
         // "for (;;) if (x) y(); else break;" => "for (; x;) y();"
         // "for (; a;) if (x) y(); else break;" => "for (; a && x;) y();"
@@ -72,7 +95,7 @@ impl<'a> PeepholeOptimizations {
             if_stmt.alternate.as_ref().and_then(|stmt| stmt.get_one_child())
         {
             if break_stmt.label.is_some() {
-                return;
+                return false;
             }
 
             let span = for_stmt.body.span();
@@ -103,7 +126,9 @@ impl<'a> PeepholeOptimizations {
             let consequent = if_stmt.consequent.take_in(ctx);
             let new_body = Self::drop_first_statement(span, body, Some(consequent), ctx);
             ctx.replace_statement(&mut for_stmt.body, new_body);
+            return true;
         }
+        false
     }
 
     fn drop_first_statement(

--- a/crates/oxc_minifier/src/peephole/minimize_if_statement.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_if_statement.rs
@@ -25,10 +25,13 @@ impl<'a> PeepholeOptimizations {
                     // "if (a) b();" => "a && b();"
                     e => (LogicalOperator::And, e),
                 };
-                let a = e.take_in(ctx);
-                let b = expr_stmt.expression.take_in(ctx);
-                let expr = Self::join_with_left_associative_op(if_stmt.span, op, a, b, ctx);
-                return Some(Statement::new_expression_statement(if_stmt.span, expr, ctx));
+                // Don't extend a logical chain that is already at the cap.
+                if !Self::logical_expression_count_exceeded(e) {
+                    let a = e.take_in(ctx);
+                    let b = expr_stmt.expression.take_in(ctx);
+                    let expr = Self::join_with_left_associative_op(if_stmt.span, op, a, b, ctx);
+                    return Some(Statement::new_expression_statement(if_stmt.span, expr, ctx));
+                }
             } else if let Some(Statement::ExpressionStatement(alternate_expr_stmt)) =
                 &mut if_stmt.alternate
             {
@@ -57,10 +60,13 @@ impl<'a> PeepholeOptimizations {
                     // "if (a) {} else b();" => "a || b();"
                     e => (LogicalOperator::Or, e),
                 };
-                let a = e.take_in(ctx);
-                let b = expr_stmt.expression.take_in(ctx);
-                let expr = Self::join_with_left_associative_op(if_stmt.span, op, a, b, ctx);
-                return Some(Statement::new_expression_statement(if_stmt.span, expr, ctx));
+                // Don't extend a logical chain that is already at the cap.
+                if !Self::logical_expression_count_exceeded(e) {
+                    let a = e.take_in(ctx);
+                    let b = expr_stmt.expression.take_in(ctx);
+                    let expr = Self::join_with_left_associative_op(if_stmt.span, op, a, b, ctx);
+                    return Some(Statement::new_expression_statement(if_stmt.span, expr, ctx));
+                }
             } else if let Some(stmt) = &mut if_stmt.alternate {
                 // "yes" is missing and "no" is not missing (and is not an expression)
                 match &mut if_stmt.test {
@@ -104,6 +110,11 @@ impl<'a> PeepholeOptimizations {
                 // "no" is missing
                 if let Statement::IfStatement(if2_stmt) = &mut if_stmt.consequent
                     && if2_stmt.alternate.is_none()
+                    // Don't collapse nested `if`s into an `&&` chain past the cap,
+                    // so deeply nested guards can't build an expression deep enough
+                    // to overflow. The nesting is left as-is: correct and terminal.
+                    && !Self::logical_expression_count_exceeded(&if_stmt.test)
+                    && !Self::logical_expression_count_exceeded(&if2_stmt.test)
                 {
                     // "if (a) if (b) return c;" => "if (a && b) return c;"
                     let a = if_stmt.test.take_in(ctx);

--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -30,6 +30,22 @@ fn dead_drop_mutates_ast(stmt: &Statement<'_>) -> bool {
             && decl.declarations.iter().all(|d| d.init.is_none() && d.type_annotation.is_none()))
 }
 
+/// Cap on how deep `optimize_implicit_jump` re-minimizes a drained tail within
+/// a single pass. The tail-guard fold (`if (c) return; REST` and the
+/// loop-`continue` form in `handle_if_statement`) recurses once per guard on
+/// the drained remainder, and a flat chain of such guards is not bounded by
+/// parse nesting, so generated code with a long run of them could otherwise
+/// overflow the stack. Beyond this depth the fold defers the remaining tail to
+/// the next global pass instead (still correct, just less folded).
+///
+/// Kept deliberately low: a `minimize_statements` frame is several KB, and the
+/// minifier runs on worker threads whose stacks can be ~2 MB (or smaller), so
+/// this recursion must stay within a fraction of that on top of the traversal
+/// already on the stack (empirically ~2000 levels overflow 8 MB, ~400 overflow
+/// 2 MB). 100 clears a 1 MB stack with margin and is far above any real guard
+/// chain, so real fixtures fold identically.
+const IF_FOLD_MAX_DEPTH: u32 = 100;
+
 impl<'a> PeepholeOptimizations {
     /// `mangleStmts`: <https://github.com/evanw/esbuild/blob/v0.24.2/internal/js_ast/js_parser.go#L8788>
     ///
@@ -48,7 +64,11 @@ impl<'a> PeepholeOptimizations {
     ///
     /// ## MinimizeExitPoints:
     /// <https://github.com/google/closure-compiler/blob/v20240609/src/com/google/javascript/jscomp/MinimizeExitPoints.java>
-    pub fn minimize_statements(stmts: &mut ArenaVec<'a, Statement<'a>>, ctx: &mut TraverseCtx<'a>) {
+    pub fn minimize_statements(
+        stmts: &mut ArenaVec<'a, Statement<'a>>,
+        ctx: &mut TraverseCtx<'a>,
+        depth: u32,
+    ) {
         let mut old_stmts = stmts.take_in(ctx);
         let mut is_control_flow_dead = false;
         let mut keep_var = KeepVar::new();
@@ -81,6 +101,7 @@ impl<'a> PeepholeOptimizations {
                 stmts,
                 &mut is_control_flow_dead,
                 ctx,
+                depth,
             )
             .is_break()
             {
@@ -359,6 +380,26 @@ impl<'a> PeepholeOptimizations {
         false
     }
 
+    /// `true` when the left spine of `expr` is already a `||`/`&&` chain at the
+    /// cap. The logical-join merges (the absorb-merge below and the joins in
+    /// `try_minimize_if`) fold a run of `if (x) <jump>` statements into a single
+    /// left-associative chain; without a stop the chain grows with the input
+    /// width, and building/printing a deep binary expression recurses on its
+    /// depth and overflows. Mirrors `conditional_expression_count_exceeded` for
+    /// ternaries; the cap is far above any real chain, so real code is untouched.
+    pub(crate) fn logical_expression_count_exceeded(expr: &Expression<'a>) -> bool {
+        let mut depth = 0u16;
+        let mut current = expr;
+        while let Expression::LogicalExpression(e) = current {
+            depth += 1;
+            if depth == 500 {
+                return true;
+            }
+            current = &e.left;
+        }
+        false
+    }
+
     fn minimize_statement(
         stmt: Statement<'a>,
         i: usize,
@@ -367,6 +408,7 @@ impl<'a> PeepholeOptimizations {
         is_control_flow_dead: &mut bool,
 
         ctx: &mut TraverseCtx<'a>,
+        depth: u32,
     ) -> ControlFlow<()> {
         match stmt {
             Statement::EmptyStatement(_) => (),
@@ -390,7 +432,7 @@ impl<'a> PeepholeOptimizations {
                 Self::handle_switch_statement(switch_stmt, result, ctx);
             }
             Statement::IfStatement(if_stmt) => {
-                if Self::handle_if_statement(i, stmts, if_stmt, result, ctx).is_break() {
+                if Self::handle_if_statement(i, stmts, if_stmt, result, ctx, depth).is_break() {
                     return ControlFlow::Break(());
                 }
             }
@@ -738,6 +780,7 @@ impl<'a> PeepholeOptimizations {
         result: &mut ArenaVec<'a, Statement<'a>>,
 
         ctx: &mut TraverseCtx<'a>,
+        depth: u32,
     ) -> ControlFlow<()> {
         Self::substitute_single_use_symbol_in_statement(&mut if_stmt.test, result, ctx, false);
 
@@ -756,6 +799,11 @@ impl<'a> PeepholeOptimizations {
                 if let Some(Statement::IfStatement(prev_if_stmt)) = result.last_mut()
                     && prev_if_stmt.alternate.is_none()
                     && Self::jump_stmts_look_the_same(&prev_if_stmt.consequent, &if_stmt.consequent)
+                    // Stop growing the `||` chain past the cap so a long run of
+                    // identical-jump guards can't build an expression deep enough
+                    // to overflow. The current guard is left as a fresh statement,
+                    // which starts a new chain.
+                    && !Self::logical_expression_count_exceeded(&prev_if_stmt.test)
                 {
                     // "if (a) break c; if (b) break c;" => "if (a || b) break c;"
                     // "if (a) continue c; if (b) continue c;" => "if (a || b) continue c;"
@@ -828,7 +876,14 @@ impl<'a> PeepholeOptimizations {
                             ArenaVec::from_iter_in(drained_stmts, ctx)
                         };
 
-                        Self::minimize_statements(&mut body, ctx);
+                        // Recurse to fold a nested guard chain in this pass, but
+                        // cap the depth: a flat chain becomes recursion depth and
+                        // is not bounded by parse nesting. Past the cap, leave the
+                        // tail unminimized (wrapped below) for the next global
+                        // pass — correct, just less folded, and it can't overflow.
+                        if depth < IF_FOLD_MAX_DEPTH {
+                            Self::minimize_statements(&mut body, ctx, depth + 1);
+                        }
                         let span = if body.is_empty() {
                             if_stmt.consequent.span()
                         } else {

--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -487,7 +487,7 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
         stmts: &mut ArenaVec<'a, Statement<'a>>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        Self::minimize_statements(stmts, ctx);
+        Self::minimize_statements(stmts, ctx, 0);
     }
 
     fn enter_statement(&mut self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {


### PR DESCRIPTION
## What

Fixes a stack overflow in the minifier on generated code with very long flat guard chains. This crash exists on `main` today:

```js
// 100k of these in one function body — minifier aborts with
// "thread 'main' has overflowed its stack"
function f() {
  if (g0()) return;
  if (g1()) return;
  // ... 100,000 more
  done();
}
```

The same happens with `if (c) break;` runs inside a loop. Flat statement runs are not limited by parse nesting, so a generated file can make these arbitrarily long.

## How

Three transforms turned flat statement width into unbounded recursion or expression depth. Each now has a bound, following the existing 500-deep ternary-chain cap (`conditional_expression_count_exceeded`):

- **If-fold recursion**: `handle_if_statement` re-minimizes the drained tail once per guard. Now capped at depth 100 (`IF_FOLD_MAX_DEPTH`); past the cap the rest is deferred to the next pass. 100 is chosen for worker threads: a frame is several KB and napi/rayon stacks can be 2 MB or less — 500 already overflows a 2 MB stack.
- **Logical-join merges**: `if (a) return; if (b) return;` => `if (a || b) return` grew one `||` chain per guard, and building or printing a ~10k-deep binary expression overflows on its own. New `logical_expression_count_exceeded` (cap 500) stops the merge; the next guard starts a fresh chain. Same guard added to the `&&`/`||` joins in `try_minimize_if`.
- **Break pulling**: `minimize_for_statement` pulled one leading `if (c) break;` into the for-test per pass, which now (with chunked chains) needed one pass per chunk and tripped the fixed-point loop's iteration guard. It now pulls all leading breaks in one pass, stopping at the same cap — and it refuses to pull when the test is already at the cap, so leftover guards stay in the body and the loop terminates.

Past a cap the output is still correct, just less folded. Real code never gets near the caps: minsize and allocation snapshots are byte-identical, and App.tsx still compresses in 2 iterations.

Out of scope: a single deep binary expression already written in the source (e.g. a 20k-term `&&` chain) still overflows on its own expression depth. That is a pre-existing limitation independent of the minifier's own folding.

Verified: 100k-guard return/break/block-guard stress files all exit 0, including on 1 MB and 2 MB stacks (`ulimit -s`); 546 minifier tests pass.

Implemented with Claude Code, reviewed and verified by me.
