### PR TITLE
fix(react_compiler): lower fbt/fbs macros to runtime form

### DIFF
--- a/crates/oxc_react_compiler/src/fbt.rs
+++ b/crates/oxc_react_compiler/src/fbt.rs
@@ -1,0 +1,557 @@
+//! fbt/fbs macro lowering.
+//!
+//! Ports (a subset of) Meta's `babel-plugin-fbt` + `babel-plugin-fbt-runtime`,
+//! which upstream run *after* the React Compiler in the fixture test harness
+//! (see `RunReactCompilerBabelPlugin.ts`: `plugins: [reactCompiler,
+//! 'babel-plugin-fbt', 'babel-plugin-fbt-runtime']`). Those plugins lower
+//! `fbt(...)` / `<fbt>` / `fbt.param(...)` / `<fbt:param>` macros into their
+//! runtime form:
+//!
+//! ```js
+//! fbt._("Hello {user name}", [fbt._param("user name", props.name)], { hk: "2zEDKF" })
+//! ```
+//!
+//! This module runs on the compiled oxc `Program`, mirroring that ordering.
+//!
+//! ## Scope
+//!
+//! Implemented: the "single leaf" case — plain text with `fbt.param` /
+//! `<fbt:param>` interpolations (no string variations), for both the call form
+//! (`fbt(text, desc)`, incl. template-literal / string-concat / array text) and
+//! the JSX form (`<fbt desc>...</fbt>`), for both the `fbt` and `fbs` modules.
+//!
+//! Not yet implemented (left untransformed, matching prior behaviour): string
+//! variations (`fbt.plural` / `<fbt:plural>`, `fbt.enum` / `<fbt:enum>`,
+//! `fbt.pronoun`, and `number`/`gender` param options — all of which build a
+//! `jsfbt` *table*) and implicit-param subtrees (non-fbt JSX elements nested
+//! directly inside `<fbt>`, lowered to `fbt._implicitParam`).
+
+use oxc_allocator::{CloneIn, GetAllocator, Vec as ArenaVec};
+use oxc_ast::ast::{
+    Argument, ArrayExpressionElement, Expression, IdentifierName, JSXAttributeItem,
+    JSXAttributeName, JSXAttributeValue, JSXChild, JSXElement, JSXElementName, JSXExpression,
+    ObjectPropertyKind, Program, PropertyKey, PropertyKind, Statement,
+    TSTypeParameterInstantiation,
+};
+use oxc_ast::builder::AstBuilder;
+use oxc_ast_visit::{VisitMut, walk_mut};
+use oxc_span::SPAN;
+use oxc_syntax::operator::BinaryOperator;
+
+/// Lower `fbt`/`fbs` macros in `program` to their runtime `fbt._(...)` form.
+///
+/// No-op when the module never imports `fbt`/`fbs` from `"fbt"`.
+pub fn transform_fbt<'a>(ast: &AstBuilder<'a>, program: &mut Program<'a>) {
+    let (fbt, fbs) = collect_fbt_modules(program);
+    if !fbt && !fbs {
+        return;
+    }
+    let mut visitor = FbtVisitor { ast, fbt, fbs };
+    visitor.visit_program(program);
+}
+
+/// Which of the `fbt` / `fbs` names are bound to the `"fbt"` module in this file.
+fn collect_fbt_modules(program: &Program) -> (bool, bool) {
+    let (mut fbt, mut fbs) = (false, false);
+    for stmt in &program.body {
+        let Statement::ImportDeclaration(import) = stmt else { continue };
+        if import.source.value != "fbt" {
+            continue;
+        }
+        let Some(specifiers) = &import.specifiers else { continue };
+        for spec in specifiers {
+            match spec.local().name.as_str() {
+                "fbt" => fbt = true,
+                "fbs" => fbs = true,
+                _ => {}
+            }
+        }
+    }
+    (fbt, fbs)
+}
+
+struct FbtVisitor<'a, 'b> {
+    ast: &'b AstBuilder<'a>,
+    fbt: bool,
+    fbs: bool,
+}
+
+impl<'a> VisitMut<'a> for FbtVisitor<'a, '_> {
+    fn visit_expression(&mut self, expr: &mut Expression<'a>) {
+        // Lower innermost macros first so a nested `fbt(...)` inside a param value
+        // is already in runtime form when the enclosing macro clones it.
+        walk_mut::walk_expression(self, expr);
+        if let Some(replacement) = self.try_lower(expr) {
+            *expr = replacement;
+        }
+    }
+}
+
+/// A piece of an fbt string: literal text, or an interpolated `fbt.param`.
+enum Part<'a> {
+    Text(String),
+    Param { name: String, value: Expression<'a> },
+}
+
+impl<'a> FbtVisitor<'a, '_> {
+    /// If `expr` is an `fbt(...)` call or `<fbt>` element (or `fbs`), return its
+    /// lowered runtime form. `None` means "leave untouched" (not fbt, or a case
+    /// this port does not handle).
+    fn try_lower(&self, expr: &Expression<'a>) -> Option<Expression<'a>> {
+        match expr {
+            Expression::CallExpression(call) => {
+                let module = self.callee_module(&call.callee)?;
+                self.lower_call(module, &call.arguments)
+            }
+            Expression::JSXElement(el) => {
+                let module = self.element_module(el)?;
+                self.lower_jsx(module, el)
+            }
+            _ => None,
+        }
+    }
+
+    /// Module name if `callee` is a bare `fbt` / `fbs` identifier.
+    fn callee_module(&self, callee: &Expression<'a>) -> Option<&'static str> {
+        let Expression::Identifier(id) = callee else { return None };
+        self.module_for(id.name.as_str())
+    }
+
+    /// Module name if `el`'s tag is a bare `fbt` / `fbs` identifier.
+    fn element_module(&self, el: &JSXElement<'a>) -> Option<&'static str> {
+        let JSXElementName::Identifier(id) = &el.opening_element.name else { return None };
+        self.module_for(id.name.as_str())
+    }
+
+    fn module_for(&self, name: &str) -> Option<&'static str> {
+        match name {
+            "fbt" if self.fbt => Some("fbt"),
+            "fbs" if self.fbs => Some("fbs"),
+            _ => None,
+        }
+    }
+
+    fn lower_call(
+        &self,
+        module: &str,
+        args: &ArenaVec<'a, Argument<'a>>,
+    ) -> Option<Expression<'a>> {
+        let text_arg = args.first()?.as_expression()?;
+        let desc_arg = args.get(1)?.as_expression()?;
+        let mut parts = Vec::new();
+        self.collect_call_parts(text_arg, &mut parts)?;
+        let desc = normalize_spaces(&expand_string_concat(desc_arg)?).trim().to_string();
+        Some(self.build_runtime_call(module, parts, &desc))
+    }
+
+    fn lower_jsx(&self, module: &str, el: &JSXElement<'a>) -> Option<Expression<'a>> {
+        let desc = self.jsx_description(el)?;
+        let mut parts = Vec::new();
+        self.collect_jsx_children(&el.children, &mut parts)?;
+        Some(self.build_runtime_call(module, parts, &desc))
+    }
+
+    // --- call-form text extraction ------------------------------------------
+
+    fn collect_call_parts(&self, expr: &Expression<'a>, out: &mut Vec<Part<'a>>) -> Option<()> {
+        match expr {
+            Expression::StringLiteral(s) => out.push(Part::Text(s.value.as_str().to_string())),
+            Expression::TemplateLiteral(tpl) => {
+                for (i, quasi) in tpl.quasis.iter().enumerate() {
+                    if let Some(cooked) = &quasi.value.cooked {
+                        out.push(Part::Text(cooked.as_str().to_string()));
+                    }
+                    if let Some(expr) = tpl.expressions.get(i) {
+                        self.collect_construct(expr, out)?;
+                    }
+                }
+            }
+            Expression::BinaryExpression(bin) if bin.operator == BinaryOperator::Addition => {
+                self.collect_call_parts(&bin.left, out)?;
+                self.collect_call_parts(&bin.right, out)?;
+            }
+            Expression::ArrayExpression(arr) => {
+                for el in &arr.elements {
+                    self.collect_call_parts(el.as_expression()?, out)?;
+                }
+            }
+            Expression::ParenthesizedExpression(paren) => {
+                self.collect_call_parts(&paren.expression, out)?;
+            }
+            Expression::CallExpression(_) => self.collect_construct(expr, out)?,
+            _ => return None,
+        }
+        Some(())
+    }
+
+    /// Extract one `fbt.param(name, value)` construct. Anything else (plural,
+    /// enum, pronoun, variation params) aborts the whole lowering.
+    fn collect_construct(&self, expr: &Expression<'a>, out: &mut Vec<Part<'a>>) -> Option<()> {
+        let Expression::CallExpression(call) = expr else { return None };
+        let name = self.member_construct_name(&call.callee)?;
+        if name != "param" {
+            return None;
+        }
+        let arg0 = call.arguments.first()?.as_expression()?;
+        let Expression::StringLiteral(name_lit) = arg0 else { return None };
+        let value = call.arguments.get(1)?.as_expression()?;
+        if let Some(opts) = call.arguments.get(2).and_then(Argument::as_expression) {
+            if object_has_variation(opts) {
+                return None;
+            }
+        }
+        out.push(Part::Param {
+            name: name_lit.value.as_str().to_string(),
+            value: value.clone_in(self.ast.allocator()),
+        });
+        Some(())
+    }
+
+    /// Construct name for a `fbt.param` / `fbt.plural` / ... member callee.
+    fn member_construct_name(&self, callee: &Expression<'a>) -> Option<&str> {
+        let Expression::StaticMemberExpression(member) = callee else { return None };
+        let Expression::Identifier(obj) = &member.object else { return None };
+        self.module_for(obj.name.as_str())?;
+        Some(member.property.name.as_str())
+    }
+
+    fn is_construct_call(&self, expr: &Expression<'a>) -> bool {
+        matches!(expr, Expression::CallExpression(call)
+            if self.member_construct_name(&call.callee).is_some())
+    }
+
+    // --- JSX-form text extraction -------------------------------------------
+
+    fn collect_jsx_children(
+        &self,
+        children: &ArenaVec<'a, JSXChild<'a>>,
+        out: &mut Vec<Part<'a>>,
+    ) -> Option<()> {
+        for child in children {
+            match child {
+                JSXChild::Text(text) => {
+                    let value = text.value.as_str();
+                    // filterEmptyNodes: drop whitespace-only text nodes.
+                    if !is_whitespace_only(value) {
+                        out.push(Part::Text(value.to_string()));
+                    }
+                }
+                JSXChild::ExpressionContainer(container) => match &container.expression {
+                    JSXExpression::EmptyExpression(_) => {}
+                    _ => {
+                        let expr = container.expression.as_expression()?;
+                        if self.is_construct_call(expr) {
+                            self.collect_construct(expr, out)?;
+                        } else {
+                            out.push(Part::Text(expand_string_concat(expr)?));
+                        }
+                    }
+                },
+                JSXChild::Element(el) => self.collect_jsx_element_child(el, out)?,
+                _ => return None,
+            }
+        }
+        Some(())
+    }
+
+    fn collect_jsx_element_child(
+        &self,
+        el: &JSXElement<'a>,
+        out: &mut Vec<Part<'a>>,
+    ) -> Option<()> {
+        // Only namespaced `fbt:param` is handled. Plain elements would become
+        // implicit params; `fbt:plural`/`fbt:enum` build tables — both abort.
+        let JSXElementName::NamespacedName(name) = &el.opening_element.name else { return None };
+        self.module_for(name.namespace.name.as_str())?;
+        if name.name.name.as_str() != "param" {
+            return None;
+        }
+        let (param_name, value) = self.extract_jsx_param(el)?;
+        out.push(Part::Param { name: param_name, value });
+        Some(())
+    }
+
+    /// Extract the `(name, value)` of a `<fbt:param name="...">{value}</fbt:param>`.
+    fn extract_jsx_param(&self, el: &JSXElement<'a>) -> Option<(String, Expression<'a>)> {
+        let mut param_name = None;
+        for attr in &el.opening_element.attributes {
+            let JSXAttributeItem::Attribute(attr) = attr else { return None };
+            let JSXAttributeName::Identifier(id) = &attr.name else { return None };
+            match id.name.as_str() {
+                "name" => {
+                    let Some(JSXAttributeValue::StringLiteral(lit)) = &attr.value else {
+                        return None;
+                    };
+                    let raw = lit.value.as_str();
+                    // Multi-line name attributes are space-normalized upstream.
+                    param_name = Some(if raw.contains('\n') {
+                        normalize_spaces(raw)
+                    } else {
+                        raw.to_string()
+                    });
+                }
+                // Any variation option (`number`, `gender`) builds a table: abort.
+                "number" | "gender" => return None,
+                _ => {}
+            }
+        }
+        let param_name = param_name?;
+
+        // The value is the single expression-container or element child.
+        let mut value = None;
+        for child in &el.children {
+            match child {
+                JSXChild::Text(text) => {
+                    // `<fbt:param> </fbt:param>` is equivalent to `{' '}`.
+                    if text.value.as_str() == " " && value.is_none() && el.children.len() == 1 {
+                        value = Some(self.string_expr(" "));
+                    } else if !is_whitespace_only(text.value.as_str()) {
+                        return None;
+                    }
+                }
+                JSXChild::ExpressionContainer(container) => {
+                    if value.is_some() {
+                        return None;
+                    }
+                    let expr = container.expression.as_expression()?;
+                    value = Some(expr.clone_in(self.ast.allocator()));
+                }
+                JSXChild::Element(inner) => {
+                    if value.is_some() {
+                        return None;
+                    }
+                    value = Some(Expression::JSXElement(inner.clone_in(self.ast.allocator())));
+                }
+                _ => return None,
+            }
+        }
+        Some((param_name, value?))
+    }
+
+    fn jsx_description(&self, el: &JSXElement<'a>) -> Option<String> {
+        for attr in &el.opening_element.attributes {
+            let JSXAttributeItem::Attribute(attr) = attr else { continue };
+            let JSXAttributeName::Identifier(id) = &attr.name else { continue };
+            if id.name.as_str() != "desc" {
+                continue;
+            }
+            let raw = match attr.value.as_ref()? {
+                JSXAttributeValue::StringLiteral(lit) => lit.value.as_str().to_string(),
+                JSXAttributeValue::ExpressionContainer(container) => {
+                    expand_string_concat(container.expression.as_expression()?)?
+                }
+                _ => return None,
+            };
+            return Some(normalize_spaces(&raw).trim().to_string());
+        }
+        None
+    }
+
+    // --- runtime call construction ------------------------------------------
+
+    fn build_runtime_call(&self, module: &str, parts: Vec<Part<'a>>, desc: &str) -> Expression<'a> {
+        let ast = self.ast;
+        let mut text = String::new();
+        let mut runtime_params = ArenaVec::new_in(ast);
+        for part in parts {
+            match part {
+                Part::Text(piece) => text.push_str(&piece),
+                Part::Param { name, value } => {
+                    text.push('{');
+                    text.push_str(&name);
+                    text.push('}');
+                    let mut param_args = ArenaVec::new_in(ast);
+                    param_args.push(Argument::from(self.string_expr(&name)));
+                    param_args.push(Argument::from(value));
+                    runtime_params.push(ArrayExpressionElement::from(
+                        self.member_call(module, "_param", param_args),
+                    ));
+                }
+            }
+        }
+        let text = normalize_spaces(&text).trim().to_string();
+        let hk = fbt_hash_key(&text, desc);
+
+        let mut call_args = ArenaVec::new_in(ast);
+        call_args.push(Argument::from(self.string_expr(&text)));
+        // 2nd arg: the params array, or `null` when there are none.
+        if runtime_params.is_empty() {
+            call_args.push(Argument::from(Expression::new_null_literal(SPAN, ast)));
+        } else {
+            call_args.push(Argument::from(Expression::new_array_expression(
+                SPAN,
+                runtime_params,
+                ast,
+            )));
+        }
+        // 3rd arg: `{ hk: "<hash>" }`.
+        let hk_key = PropertyKey::new_static_identifier(SPAN, self.atom("hk"), ast);
+        let hk_prop = ObjectPropertyKind::new_object_property(
+            SPAN,
+            PropertyKind::Init,
+            hk_key,
+            self.string_expr(&hk),
+            false,
+            false,
+            false,
+            ast,
+        );
+        let mut options = ArenaVec::new_in(ast);
+        options.push(hk_prop);
+        call_args.push(Argument::from(Expression::new_object_expression(SPAN, options, ast)));
+
+        self.member_call(module, "_", call_args)
+    }
+
+    /// `<module>.<method>(<args>)`, e.g. `fbt._param(...)`.
+    fn member_call(
+        &self,
+        module: &str,
+        method: &str,
+        args: ArenaVec<'a, Argument<'a>>,
+    ) -> Expression<'a> {
+        let ast = self.ast;
+        let callee = Expression::new_static_member_expression(
+            SPAN,
+            Expression::new_identifier(SPAN, self.atom(module), ast),
+            IdentifierName::new(SPAN, self.atom(method), ast),
+            false,
+            ast,
+        );
+        Expression::new_call_expression(
+            SPAN,
+            callee,
+            None::<oxc_allocator::Box<TSTypeParameterInstantiation>>,
+            args,
+            false,
+            ast,
+        )
+    }
+
+    fn string_expr(&self, value: &str) -> Expression<'a> {
+        Expression::new_string_literal(SPAN, self.atom(value), None, self.ast)
+    }
+
+    fn atom(&self, s: &str) -> &'a str {
+        oxc_allocator::StringBuilder::from_str_in(s, self.ast.allocator()).into_str()
+    }
+}
+
+/// `true` when `obj` is `{ number: ... }` or `{ gender: ... }` (a variation).
+fn object_has_variation(obj: &Expression) -> bool {
+    let Expression::ObjectExpression(obj) = obj else { return false };
+    obj.properties.iter().any(|prop| {
+        let ObjectPropertyKind::ObjectProperty(prop) = prop else { return false };
+        matches!(prop.key.static_name().as_deref(), Some("number" | "gender"))
+    })
+}
+
+/// Concatenate a static-string expression (string / no-expression template /
+/// `+` concatenation). `None` for anything dynamic.
+fn expand_string_concat(expr: &Expression) -> Option<String> {
+    match expr {
+        Expression::StringLiteral(s) => Some(s.value.as_str().to_string()),
+        Expression::TemplateLiteral(tpl) if tpl.expressions.is_empty() => {
+            let mut out = String::new();
+            for quasi in &tpl.quasis {
+                if let Some(cooked) = &quasi.value.cooked {
+                    out.push_str(cooked.as_str());
+                }
+            }
+            Some(out)
+        }
+        Expression::BinaryExpression(bin) if bin.operator == BinaryOperator::Addition => {
+            Some(expand_string_concat(&bin.left)? + &expand_string_concat(&bin.right)?)
+        }
+        Expression::ParenthesizedExpression(paren) => expand_string_concat(&paren.expression),
+        _ => None,
+    }
+}
+
+fn is_whitespace_only(s: &str) -> bool {
+    !s.is_empty() && s.chars().all(char::is_whitespace)
+}
+
+/// Collapse runs of whitespace (except U+00A0) to a single space.
+/// Mirrors `FbtUtil.normalizeSpaces`: `value.replace(/[^\S ]+/g, ' ')`.
+fn normalize_spaces(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    let mut in_ws = false;
+    for c in value.chars() {
+        if c.is_whitespace() && c != '\u{00A0}' {
+            if !in_ws {
+                out.push(' ');
+                in_ws = true;
+            }
+        } else {
+            out.push(c);
+            in_ws = false;
+        }
+    }
+    out
+}
+
+/// `fbtHashKey`: base62 of the Jenkins hash of `JSON.stringify(text) + '|' + desc`.
+///
+/// This is the single-leaf (no token aliases) path of upstream `fbtJenkinsHash`.
+fn fbt_hash_key(text: &str, desc: &str) -> String {
+    let mut key = json_stringify_str(text);
+    key.push('|');
+    key.push_str(desc);
+    uint_to_base62(jenkins_hash(&key))
+}
+
+/// `jenkinsHash` over the UTF-8 bytes of `s` (matches upstream `toUtf8`).
+fn jenkins_hash(s: &str) -> u32 {
+    let mut hash: u32 = 0;
+    for &byte in s.as_bytes() {
+        hash = hash.wrapping_add(u32::from(byte));
+        hash = hash.wrapping_add(hash << 10);
+        hash ^= hash >> 6;
+    }
+    hash = hash.wrapping_add(hash << 3);
+    hash ^= hash >> 11;
+    hash = hash.wrapping_add(hash << 15);
+    hash
+}
+
+const BASE_N_SYMBOLS: &[u8; 62] = b"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+fn uint_to_base62(mut number: u32) -> String {
+    let mut out = Vec::new();
+    loop {
+        out.push(BASE_N_SYMBOLS[(number % 62) as usize]);
+        number /= 62;
+        if number == 0 {
+            break;
+        }
+    }
+    out.reverse();
+    // SAFETY: all bytes come from the ASCII `BASE_N_SYMBOLS` table.
+    String::from_utf8(out).unwrap()
+}
+
+/// `JSON.stringify` for a single string, matching JS semantics: escape the
+/// standard control characters and `"` / `\`, keep every other char (incl.
+/// non-ASCII) verbatim.
+fn json_stringify_str(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '\u{08}' => out.push_str("\\b"),
+            '\u{0C}' => out.push_str("\\f"),
+            c if (c as u32) < 0x20 => {
+                out.push_str(&format!("\\u{:04x}", c as u32));
+            }
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}

--- a/crates/oxc_react_compiler/src/lib.rs
+++ b/crates/oxc_react_compiler/src/lib.rs
@@ -2,6 +2,7 @@ use oxc_allocator::{Allocator, ArenaVec};
 
 pub mod convert_scope;
 pub mod diagnostics;
+pub mod fbt;
 pub mod prefilter;
 pub mod scope;
 
@@ -150,6 +151,9 @@ fn compile<'a>(
     let compiled = program_ast.map(|mut compiled: Program<'a>| {
         compiled.source_type = program.source_type;
         preserve_comments(&mut compiled, program, allocator);
+        // Lower `fbt`/`fbs` macros, mirroring upstream running `babel-plugin-fbt`
+        // (+ `-runtime`) after the compiler on the fixture harness.
+        crate::fbt::transform_fbt(&ast_builder, &mut compiled);
         compiled
     });
 

--- a/crates/oxc_react_compiler/tests/snapshots/fbt-scope-range-identifier-sync.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/fbt-scope-range-identifier-sync.snap
@@ -26,7 +26,7 @@ function Component(t0) {
 			const otherSize = selectedColor?.matchingProducts?.filter((product) => product.id != null && product.tags?.get("bridge") === selectedProduct?.tags?.get("bridge")).find((product_0) => product_0.tags?.get("size") !== selectedProduct?.tags?.get("size"));
 			const otherFrameSize = otherSize?.tags?.get("size");
 			if (otherSize?.id != null && otherFrameSize != null && rxIds.includes(otherSize.id)) {
-				t1 = <div>{fbt(`Only available in ${fbt.param("frame size", otherFrameSize)} size`, "Badge text")}</div>;
+				t1 = <div>{fbt._("Only available in {frame size} size", [fbt._param("frame size", otherFrameSize)], { hk: "4sIu3a" })}</div>;
 				break bb0;
 			}
 		}
@@ -43,7 +43,7 @@ function Component(t0) {
 	if (rxData.futureData.includes(selectedProduct?.id)) {
 		let t2;
 		if ($[6] === Symbol.for("react.memo_cache_sentinel")) {
-			t2 = <div>{fbt("Out of stock", "Badge text")}</div>;
+			t2 = <div>{fbt._("Out of stock", null, { hk: "M2wQM" })}</div>;
 			$[6] = t2;
 		} else {
 			t2 = $[6];
@@ -52,7 +52,7 @@ function Component(t0) {
 	}
 	let t2;
 	if ($[7] === Symbol.for("react.memo_cache_sentinel")) {
-		t2 = <div>{fbt("Not available", "Badge text")}</div>;
+		t2 = <div>{fbt._("Not available", null, { hk: "43mHFe" })}</div>;
 		$[7] = t2;
 	} else {
 		t2 = $[7];

--- a/crates/oxc_react_compiler/tests/snapshots/fbt__fbs-params.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/fbt__fbs-params.snap
@@ -8,9 +8,7 @@ function Component(props) {
 	const $ = _c(2);
 	let t0;
 	if ($[0] !== props.name) {
-		t0 = <div title={<fbs desc="Dialog to show to user">
-          Hello <fbs:param name="user name">{props.name}</fbs:param>
-        </fbs>}>Hover me</div>;
+		t0 = <div title={fbs._("Hello {user name}", [fbs._param("user name", props.name)], { hk: "2zEDKF" })}>Hover me</div>;
 		$[0] = props.name;
 		$[1] = t0;
 	} else {

--- a/crates/oxc_react_compiler/tests/snapshots/fbt__fbt-call-complex-param-value.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/fbt__fbt-call-complex-param-value.snap
@@ -9,7 +9,7 @@ function Component(props) {
 	const $ = _c(4);
 	let t0;
 	if ($[0] !== props.name) {
-		t0 = fbt(`Hello, ${fbt.param("(key) name", identity(props.name))}!`, "(description) Greeting");
+		t0 = fbt._("Hello, {(key) name}!", [fbt._param("(key) name", identity(props.name))], { hk: "2sOsn5" });
 		$[0] = props.name;
 		$[1] = t0;
 	} else {

--- a/crates/oxc_react_compiler/tests/snapshots/fbt__fbt-call.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/fbt__fbt-call.snap
@@ -8,7 +8,7 @@ function Component(props) {
 	const $ = _c(4);
 	let t0;
 	if ($[0] !== props.count) {
-		t0 = fbt(`${fbt.param("(key) count", props.count)} items`, "(description) Number of items");
+		t0 = fbt._("{(key) count} items", [fbt._param("(key) count", props.count)], { hk: "3yW91j" });
 		$[0] = props.count;
 		$[1] = t0;
 	} else {

--- a/crates/oxc_react_compiler/tests/snapshots/fbt__fbt-no-whitespace-btw-text-and-param.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/fbt__fbt-no-whitespace-btw-text-and-param.snap
@@ -10,9 +10,7 @@ function Component(t0) {
 	const { value } = t0;
 	let t1;
 	if ($[0] !== value) {
-		t1 = <fbt desc="descdesc">
-      Before text<fbt:param name="paramName">{value}</fbt:param>After text
-    </fbt>;
+		t1 = fbt._("Before text{paramName}After text", [fbt._param("paramName", value)], { hk: "aKEGX" });
 		$[0] = value;
 		$[1] = t1;
 	} else {

--- a/crates/oxc_react_compiler/tests/snapshots/fbt__fbt-param-with-newline.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/fbt__fbt-param-with-newline.snap
@@ -8,13 +8,7 @@ function Component(props) {
 	const $ = _c(2);
 	let t0;
 	if ($[0] !== props.name) {
-		const element = <fbt desc="Dialog to show to user">
-      Hello{" "}
-      <fbt:param name="a really long description
-      that got split into multiple lines">
-        {props.name}
-      </fbt:param>
-    </fbt>;
+		const element = fbt._("Hello {a really long description that got split into multiple lines}", [fbt._param("a really long description that got split into multiple lines", props.name)], { hk: "1euPUp" });
 		t0 = element.toString();
 		$[0] = props.name;
 		$[1] = t0;

--- a/crates/oxc_react_compiler/tests/snapshots/fbt__fbt-param-with-quotes.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/fbt__fbt-param-with-quotes.snap
@@ -8,9 +8,7 @@ function Component(props) {
 	const $ = _c(2);
 	let t0;
 	if ($[0] !== props.name) {
-		const element = <fbt desc="Dialog to show to user">
-      Hello <fbt:param name='"user" name'>{props.name}</fbt:param>
-    </fbt>;
+		const element = fbt._("Hello {\"user\" name}", [fbt._param("\"user\" name", props.name)], { hk: "S0vMe" });
 		t0 = element.toString();
 		$[0] = props.name;
 		$[1] = t0;

--- a/crates/oxc_react_compiler/tests/snapshots/fbt__fbt-param-with-unicode.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/fbt__fbt-param-with-unicode.snap
@@ -8,9 +8,7 @@ function Component(props) {
 	const $ = _c(2);
 	let t0;
 	if ($[0] !== props.name) {
-		const element = <fbt desc="Dialog to show to user">
-      Hello <fbt:param name="user name ☺">{props.name}</fbt:param>
-    </fbt>;
+		const element = fbt._("Hello {user name ☺}", [fbt._param("user name ☺", props.name)], { hk: "1En1lp" });
 		t0 = element.toString();
 		$[0] = props.name;
 		$[1] = t0;

--- a/crates/oxc_react_compiler/tests/snapshots/fbt__fbt-params-complex-param-value.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/fbt__fbt-params-complex-param-value.snap
@@ -8,9 +8,7 @@ function Component(props) {
 	const $ = _c(2);
 	let t0;
 	if ($[0] !== props.name) {
-		t0 = <fbt desc="Dialog to show to user">
-      Hello <fbt:param name="user name">{capitalize(props.name)}</fbt:param>
-    </fbt>;
+		t0 = fbt._("Hello {user name}", [fbt._param("user name", capitalize(props.name))], { hk: "2zEDKF" });
 		$[0] = props.name;
 		$[1] = t0;
 	} else {

--- a/crates/oxc_react_compiler/tests/snapshots/fbt__fbt-params.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/fbt__fbt-params.snap
@@ -8,9 +8,7 @@ function Component(props) {
 	const $ = _c(7);
 	let t0;
 	if ($[0] !== props.name) {
-		t0 = <fbt desc="Dialog to show to user">
-        Hello <fbt:param name="user name">{props.name}</fbt:param>
-      </fbt>;
+		t0 = fbt._("Hello {user name}", [fbt._param("user name", props.name)], { hk: "2zEDKF" });
 		$[0] = props.name;
 		$[1] = t0;
 	} else {
@@ -18,9 +16,7 @@ function Component(props) {
 	}
 	let t1;
 	if ($[2] !== props.actions) {
-		t1 = <fbt desc="Available actions|response">
-        <fbt:param name="actions|response">{props.actions}</fbt:param>
-      </fbt>;
+		t1 = fbt._("{actions|response}", [fbt._param("actions|response", props.actions)], { hk: "1cjfbg" });
 		$[2] = props.actions;
 		$[3] = t1;
 	} else {

--- a/crates/oxc_react_compiler/tests/snapshots/fbt__fbt-preserve-whitespace-two-subtrees.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/fbt__fbt-preserve-whitespace-two-subtrees.snap
@@ -47,16 +47,7 @@ function Foo(t0) {
 		} else {
 			t5 = $[12];
 		}
-		t1 = <fbt desc="Text that is displayed when two people accepts the user's pull request.">
-      <fbt:param name="user1">
-        {t3}
-      </fbt:param>
-      and
-      <fbt:param name="user2">
-        {t5}
-      </fbt:param>
-      accepted your PR!
-    </fbt>;
+		t1 = fbt._("{user1} and {user2} accepted your PR!", [fbt._param("user1", t3), fbt._param("user2", t5)], { hk: "2PxMie" });
 		$[0] = name1;
 		$[1] = name2;
 		$[2] = t1;

--- a/crates/oxc_react_compiler/tests/snapshots/fbt__fbt-preserve-whitespace.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/fbt__fbt-preserve-whitespace.snap
@@ -10,10 +10,7 @@ function Component(t0) {
 	const { value } = t0;
 	let t1;
 	if ($[0] !== value) {
-		t1 = <fbt desc="descdesc">
-      Before text
-      <fbt:param name="paramName">{value}</fbt:param>
-    </fbt>;
+		t1 = fbt._("Before text {paramName}", [fbt._param("paramName", value)], { hk: "3z5SVE" });
 		$[0] = value;
 		$[1] = t1;
 	} else {

--- a/crates/oxc_react_compiler/tests/snapshots/fbt__fbt-repro-invalid-mutable-range-destructured-prop.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/fbt__fbt-repro-invalid-mutable-range-destructured-prop.snap
@@ -11,9 +11,7 @@ function Component(t0) {
 	const { data } = t0;
 	let t1;
 	if ($[0] !== data.name) {
-		t1 = <fbt desc="user name">
-        <fbt:param name="name">{data.name ?? ""}</fbt:param>
-      </fbt>;
+		t1 = fbt._("{name}", [fbt._param("name", data.name ?? "")], { hk: "csQUH" });
 		$[0] = data.name;
 		$[1] = t1;
 	} else {

--- a/crates/oxc_react_compiler/tests/snapshots/fbt__fbt-single-space-btw-param-and-text.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/fbt__fbt-single-space-btw-param-and-text.snap
@@ -10,9 +10,7 @@ function Component(t0) {
 	const { value } = t0;
 	let t1;
 	if ($[0] !== value) {
-		t1 = <fbt desc="descdesc">
-      Before text <fbt:param name="paramName">{value}</fbt:param> after text
-    </fbt>;
+		t1 = fbt._("Before text {paramName} after text", [fbt._param("paramName", value)], { hk: "26pxNm" });
 		$[0] = value;
 		$[1] = t1;
 	} else {

--- a/crates/oxc_react_compiler/tests/snapshots/fbt__fbt-template-string-same-scope.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/fbt__fbt-template-string-same-scope.snap
@@ -13,7 +13,7 @@ export function Component(props) {
 	}
 	let t0;
 	if ($[0] !== count) {
-		t0 = fbt(`for ${fbt.param("count", count)} experiences`, "Label for the number of items", { project: "public" });
+		t0 = fbt._("for {count} experiences", [fbt._param("count", count)], { hk: "nmYpm" });
 		$[0] = count;
 		$[1] = t0;
 	} else {

--- a/crates/oxc_react_compiler/tests/snapshots/fbt__fbt-to-string.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/fbt__fbt-to-string.snap
@@ -8,9 +8,7 @@ function Component(props) {
 	const $ = _c(2);
 	let t0;
 	if ($[0] !== props.name) {
-		const element = <fbt desc="Dialog to show to user">
-      Hello <fbt:param name="user name">{props.name}</fbt:param>
-    </fbt>;
+		const element = fbt._("Hello {user name}", [fbt._param("user name", props.name)], { hk: "2zEDKF" });
 		t0 = element.toString();
 		$[0] = props.name;
 		$[1] = t0;

--- a/crates/oxc_react_compiler/tests/snapshots/fbt__fbt-whitespace-around-param-value.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/fbt__fbt-whitespace-around-param-value.snap
@@ -10,9 +10,7 @@ function Component(t0) {
 	const { value } = t0;
 	let t1;
 	if ($[0] !== value) {
-		t1 = <fbt desc="descdesc">
-      Before text <fbt:param name="paramName"> {value} </fbt:param> after text
-    </fbt>;
+		t1 = fbt._("Before text {paramName} after text", [fbt._param("paramName", value)], { hk: "26pxNm" });
 		$[0] = value;
 		$[1] = t1;
 	} else {

--- a/crates/oxc_react_compiler/tests/snapshots/fbt__fbt-whitespace-within-text.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/fbt__fbt-whitespace-within-text.snap
@@ -10,11 +10,7 @@ function Component(t0) {
 	const { value } = t0;
 	let t1;
 	if ($[0] !== value) {
-		t1 = <fbt desc="descdesc">
-      Before text <fbt:param name="paramName">{value}</fbt:param> after text
-      more text and more and more and more and more and more and more and more
-      and more and blah blah blah blah
-    </fbt>;
+		t1 = fbt._("Before text {paramName} after text more text and more and more and more and more and more and more and more and more and blah blah blah blah", [fbt._param("paramName", value)], { hk: "24ZPpO" });
 		$[0] = value;
 		$[1] = t1;
 	} else {

--- a/crates/oxc_react_compiler/tests/snapshots/fbt__fbtparam-text-must-use-expression-container.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/fbt__fbtparam-text-must-use-expression-container.snap
@@ -8,9 +8,7 @@ function Component(props) {
 	const $ = _c(1);
 	let t0;
 	if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-		t0 = <Foo value={<fbt desc="Description of the parameter">
-          <fbt:param name="value">{"0"}</fbt:param>%
-        </fbt>} />;
+		t0 = <Foo value={fbt._("{value}%", [fbt._param("value", "0")], { hk: "10F5Cc" })} />;
 		$[0] = t0;
 	} else {
 		t0 = $[0];

--- a/crates/oxc_react_compiler/tests/snapshots/fbt__fbtparam-with-jsx-fragment-value.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/fbt__fbtparam-with-jsx-fragment-value.snap
@@ -18,9 +18,7 @@ function Component(props) {
 		} else {
 			t2 = $[3];
 		}
-		t0 = <Foo value={<fbt desc="Description of the parameter">
-          <fbt:param name="value">{t2}</fbt:param>%
-        </fbt>} />;
+		t0 = <Foo value={fbt._("{value}%", [fbt._param("value", t2)], { hk: "10F5Cc" })} />;
 		$[0] = props.text;
 		$[1] = t0;
 	} else {

--- a/crates/oxc_react_compiler/tests/snapshots/fbt__lambda-with-fbt.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/fbt__lambda-with-fbt.snap
@@ -18,18 +18,13 @@ function Component() {
 }
 function _temp() {
 	if (!someCondition) {
-		return <fbt desc="My label">{"Purchase as a gift"}</fbt>;
+		return fbt._("Purchase as a gift", null, { hk: "1gHj4g" });
 	} else {
 		if (!iconOnly && showPrice && item?.current_gift_offer?.price?.formatted != null) {
-			return <fbt desc="Gift button's label">
-          {"Gift | "}
-          <fbt:param name="price">
-            {item?.current_gift_offer?.price?.formatted}
-          </fbt:param>
-        </fbt>;
+			return fbt._("Gift | {price}", [fbt._param("price", item?.current_gift_offer?.price?.formatted)], { hk: "3GTnGE" });
 		} else {
 			if (!iconOnly && !showPrice) {
-				return <fbt desc="Gift button's label">{"Gift"}</fbt>;
+				return fbt._("Gift", null, { hk: "3fqfrk" });
 			}
 		}
 	}

--- a/crates/oxc_react_compiler/tests/snapshots/fbt__repro-fbt-param-nested-fbt-jsx.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/fbt__repro-fbt-param-nested-fbt-jsx.snap
@@ -35,12 +35,7 @@ function Component(t0) {
 		} else {
 			t3 = $[6];
 		}
-		t1 = fbt([
-			"Name: ",
-			fbt.param("firstname", t2),
-			", ",
-			fbt.param("lastname", identity(fbt("(inner)" + fbt.param("lastname", t3), "Inner fbt value")))
-		], "Name");
+		t1 = fbt._("Name: {firstname}, {lastname}", [fbt._param("firstname", t2), fbt._param("lastname", identity(fbt._("(inner){lastname}", [fbt._param("lastname", t3)], { hk: "1Kdxyo" })))], { hk: "3AiIf8" });
 		$[0] = firstname;
 		$[1] = lastname;
 		$[2] = t1;

--- a/crates/oxc_react_compiler/tests/snapshots/fbt__repro-fbt-param-nested-fbt.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/fbt__repro-fbt-param-nested-fbt.snap
@@ -19,12 +19,7 @@ function Component(t0) {
 	const { firstname, lastname } = t0;
 	let t1;
 	if ($[0] !== firstname || $[1] !== lastname) {
-		t1 = fbt([
-			"Name: ",
-			fbt.param("firstname", identity(firstname)),
-			", ",
-			fbt.param("lastname", identity(fbt("(inner)" + fbt.param("lastname", identity(lastname)), "Inner fbt value")))
-		], "Name");
+		t1 = fbt._("Name: {firstname}, {lastname}", [fbt._param("firstname", identity(firstname)), fbt._param("lastname", identity(fbt._("(inner){lastname}", [fbt._param("lastname", identity(lastname))], { hk: "1Kdxyo" })))], { hk: "3AiIf8" });
 		$[0] = firstname;
 		$[1] = lastname;
 		$[2] = t1;

--- a/crates/oxc_react_compiler/tests/snapshots/method-call-scope-merge-mutable-range-sync.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/method-call-scope-merge-mutable-range-sync.snap
@@ -48,7 +48,7 @@ function Component(t0) {
 				break bb0;
 			}
 			t8 = store.id;
-			const t10 = fbt(`Directory: ${fbt.param("store URI", storeUri.replace("sftp://sftp.fb.com", ""))}`, "directory info");
+			const t10 = fbt._("Directory: {store URI}", [fbt._param("store URI", storeUri.replace("sftp://sftp.fb.com", ""))], { hk: "y1DI6" });
 			if ($[10] !== t10) {
 				t4 = <span>{t10}</span>;
 				$[10] = t10;
@@ -56,7 +56,7 @@ function Component(t0) {
 			} else {
 				t4 = $[11];
 			}
-			t5 = <span>{fbt(`Schema: ${fbt.param("schema", documentSchema)}`, "schema")},{" "}{fbt(`Geos: ${fbt.param("geos", licensedGeos.length)}`, "geos count")},{" "}</span>;
+			t5 = <span>{fbt._("Schema: {schema}", [fbt._param("schema", documentSchema)], { hk: "1Ua9F9" })},{" "}{fbt._("Geos: {geos}", [fbt._param("geos", licensedGeos.length)], { hk: "1PRSzD" })},{" "}</span>;
 			if ($[12] !== cwrSenderIds) {
 				t6 = cwrSenderIds != null && <span>Sender ID: {cwrSenderIds[0]}</span>;
 				$[12] = cwrSenderIds;

--- a/crates/oxc_react_compiler/tests/snapshots/preserve-existing-memoization-guarantees__lambda-with-fbt-preserve-memoization.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/preserve-existing-memoization-guarantees__lambda-with-fbt-preserve-memoization.snap
@@ -19,18 +19,13 @@ function Component() {
 }
 function _temp() {
 	if (!someCondition) {
-		return <fbt desc="My label">{"Purchase as a gift"}</fbt>;
+		return fbt._("Purchase as a gift", null, { hk: "1gHj4g" });
 	} else {
 		if (!iconOnly && showPrice && item?.current_gift_offer?.price?.formatted != null) {
-			return <fbt desc="Gift button's label">
-          {"Gift | "}
-          <fbt:param name="price">
-            {item?.current_gift_offer?.price?.formatted}
-          </fbt:param>
-        </fbt>;
+			return fbt._("Gift | {price}", [fbt._param("price", item?.current_gift_offer?.price?.formatted)], { hk: "3GTnGE" });
 		} else {
 			if (!iconOnly && !showPrice) {
-				return <fbt desc="Gift button's label">{"Gift"}</fbt>;
+				return fbt._("Gift", null, { hk: "3fqfrk" });
 			}
 		}
 	}

--- a/crates/oxc_react_compiler/tests/snapshots/repro-unmerged-fbt-call-merge-overlapping-reactive-scopes.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/repro-unmerged-fbt-call-merge-overlapping-reactive-scopes.snap
@@ -13,7 +13,7 @@ function Component(props) {
 			many: "bars",
 			showCount: "yes"
 		}), "The label text");
-		t0 = props.cond ? <Stringify description={<fbt desc="Some text">Text here</fbt>} label={label.toString()} /> : null;
+		t0 = props.cond ? <Stringify description={fbt._("Text here", null, { hk: "21YpZs" })} label={label.toString()} /> : null;
 		$[0] = props.cond;
 		$[1] = props.value.length;
 		$[2] = t0;


### PR DESCRIPTION
## Root cause

The React Compiler fixture harness runs `babel-plugin-fbt` and `babel-plugin-fbt-runtime` **after** the compiler ([`RunReactCompilerBabelPlugin.ts`](https://github.com/facebook/react/blob/main/compiler/packages/babel-plugin-react-compiler/src/Babel/RunReactCompilerBabelPlugin.ts): `plugins: [reactCompiler, 'babel-plugin-fbt', 'babel-plugin-fbt-runtime']`). Those plugins lower `fbt(...)` / `<fbt>` / `fbt.param(...)` / `<fbt:param>` macros into their runtime form:

```js
fbt._("Hello {user name}", [fbt._param("user name", props.name)], { hk: "2zEDKF" })
```

oxc ran neither plugin, so its compiled output kept the raw `fbt(...)` / `<fbt>` source and diverged from the fork on every fbt fixture.

## Fix

New post-codegen pass `crate::fbt::transform_fbt` (`crates/oxc_react_compiler/src/fbt.rs`), run on the compiled oxc `Program` right after `preserve_comments`, mirroring the upstream ordering. It ports the **single-leaf** subset of the two plugins:

- both the call form (`fbt(text, desc)` — template-literal, string-concat, and array text) and the JSX form (`<fbt desc>...</fbt>`);
- `fbt.param` / `<fbt:param>` interpolations, incl. nested `fbt(...)` inside a param value (bottom-up walk);
- both the `fbt` and `fbs` modules;
- the fbt whitespace rules (`normalizeSpaces` + `filterEmptyNodes` + trim);
- the `hk` hash key: a faithful reimplementation of upstream `fbtHashKey` (Jenkins hash of `JSON.stringify(text) + '|' + desc`, base62), producing **byte-identical** keys.

Gated on an `import ... from "fbt"` so non-fbt files are never touched.

## Fixtures changed

- **22 of the 31 `fbt/` fixtures** now emit the fork's `fbt._(...)` form with identical hash keys (diffs vs the fork golden are cosmetic codegen only — quote style, unicode escaping, indentation).
- **4 fbt-using fixtures outside the batch** also improved: `fbt-scope-range-identifier-sync`, `method-call-scope-merge-mutable-range-sync`, and `preserve-existing-memoization-guarantees/lambda-with-fbt-preserve-memoization` now fully match; `repro-unmerged-fbt-call-merge-overlapping-reactive-scopes` partially matches (its simple fbt lowers, its `fbt.plural` is deferred).
- The 5 `error.todo-*` fixtures already errored at the compiler level, matching the fork's `## Error` — untouched.

## Remaining work

Left untransformed (no regression — same as before this PR): string variations that build a jsfbt **table** — `fbt.plural` / `<fbt:plural>`, `fbt.enum` / `<fbt:enum>`, `fbt.pronoun`, and `number` / `gender` param options — plus implicit-param subtrees (non-fbt JSX nested directly inside `<fbt>`, lowered to `fbt._implicitParam`). These require porting the combinatorial `JSFbtBuilder` string-variation logic and are the 9 deferred `fbt/` fixtures.