### PR TITLE
test(react_compiler): render code for lint output-mode fixtures

### DIFF
--- a/crates/oxc_react_compiler/src/lib.rs
+++ b/crates/oxc_react_compiler/src/lib.rs
@@ -42,7 +42,7 @@ use prefilter::{has_react_like_functions, has_resource_management_declarations};
 
 // Re-exported so integrations needn't depend on the upstream `react_compiler` crates.
 pub use crate::react_compiler::entrypoint::plugin_options::{
-    CompilerTarget, DynamicGatingConfig, GatingConfig, PluginOptions,
+    CompilerOutputMode, CompilerTarget, DynamicGatingConfig, GatingConfig, PluginOptions,
 };
 pub use crate::react_compiler_hir::environment_config::EnvironmentConfig;
 

--- a/crates/oxc_react_compiler/tests/snapshot.rs
+++ b/crates/oxc_react_compiler/tests/snapshot.rs
@@ -30,7 +30,8 @@ use oxc_react_compiler::react_compiler_hir::type_config::{
 };
 use oxc_react_compiler::react_compiler_utils::FxIndexMap;
 use oxc_react_compiler::{
-    DynamicGatingConfig, EnvironmentConfig, GatingConfig, PluginOptions, transform,
+    CompilerOutputMode, DynamicGatingConfig, EnvironmentConfig, GatingConfig, PluginOptions,
+    transform,
 };
 use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
@@ -50,6 +51,12 @@ fn snapshots() {
 /// Parse, analyse, compile, and render the compiled program + diagnostics.
 fn run_fixture(source: &str) -> String {
     let (source_type, options) = parse_pragma(source);
+    // In lint output mode the compiler validates without rewriting the program, so
+    // `changed` is always false. Upstream's `snap` runner still emits the (unmodified)
+    // code in that mode alongside the reported findings, so mirror that here rather
+    // than collapsing to "No changes." — otherwise every lint fixture would look like a
+    // bail-out even though the compiler ran to completion.
+    let lint_mode = CompilerOutputMode::from_opts(&options) == CompilerOutputMode::Lint;
 
     let allocator = Allocator::default();
     let parsed = Parser::new(&allocator, source, source_type).parse();
@@ -73,12 +80,13 @@ fn run_fixture(source: &str) -> String {
     // Mirror the upstream `snap` runner, which always re-emits the program as
     // `## Code` unless a hard error turns the output into `## Error`. So when the
     // compiler cleanly declines to change anything (e.g. `@expectNothingCompiled`,
-    // or a file with no React-like functions), echo the reprinted source rather
-    // than the `No changes.` marker. The marker is kept only when an error was
-    // reported (parse failure or a compile diagnostic), where upstream emits no
-    // code — and echoing a parse-recovered AST would be misleading.
+    // or a file with no React-like functions), or when a lint-mode run reports
+    // findings without rewriting the program, echo the reprinted source rather than
+    // the `No changes.` marker. The marker is kept only when a non-lint run reports
+    // an error (parse failure or compile diagnostic), where upstream emits no code —
+    // and echoing a parse-recovered AST would be misleading.
     let clean = parsed.diagnostics.is_empty() && result.diagnostics.as_slice().is_empty();
-    if result.changed || clean {
+    if result.changed || clean || lint_mode {
         out.push_str(&Codegen::new().build(&program).code);
     } else {
         out.push_str("No changes.");

--- a/crates/oxc_react_compiler/tests/snapshots/effect-derived-computations__derived-state-conditionally-in-effect.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/effect-derived-computations__derived-state-conditionally-in-effect.snap
@@ -6,4 +6,23 @@ Diagnostics:
 
 OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] EffectDerivationsOfState: You might not need an effect. Derive values in render, not effects.", labels: One([LabeledSpan { label: Some("This should be computed during render, not in an effect"), span: SourceSpan { offset: SourceOffset(263), length: 13 }, primary: false }]), help: Some("Using an effect triggers an additional render which can hurt performance and user experience, potentially briefly showing stale values to the user\n\nThis setState call is setting a derived value that depends on the following reactive sources:\n\nProps: [value]\n\nData Flow Tree:\n└── value (Prop)\n\nSee: https://react.dev/learn/you-might-not-need-an-effect#updating-state-based-on-props-or-state"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
 
-No changes.
+// @validateNoDerivedComputationsInEffects_exp @loggerTestOnly @outputMode:"lint"
+import { useEffect, useState } from "react";
+function Component({ value, enabled }) {
+	const [localValue, setLocalValue] = useState("");
+	useEffect(() => {
+		if (enabled) {
+			setLocalValue(value);
+		} else {
+			setLocalValue("disabled");
+		}
+	}, [value, enabled]);
+	return <div>{localValue}</div>;
+}
+export const FIXTURE_ENTRYPOINT = {
+	fn: Component,
+	params: [{
+		value: "test",
+		enabled: true
+	}]
+};

--- a/crates/oxc_react_compiler/tests/snapshots/effect-derived-computations__derived-state-from-default-props.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/effect-derived-computations__derived-state-from-default-props.snap
@@ -6,4 +6,17 @@ Diagnostics:
 
 OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] EffectDerivationsOfState: You might not need an effect. Derive values in render, not effects.", labels: One([LabeledSpan { label: Some("This should be computed during render, not in an effect"), span: SourceSpan { offset: SourceOffset(295), length: 12 }, primary: false }]), help: Some("Using an effect triggers an additional render which can hurt performance and user experience, potentially briefly showing stale values to the user\n\nThis setState call is setting a derived value that depends on the following reactive sources:\n\nProps: [input]\n\nData Flow Tree:\n└── input (Prop)\n\nSee: https://react.dev/learn/you-might-not-need-an-effect#updating-state-based-on-props-or-state"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
 
-No changes.
+// @validateNoDerivedComputationsInEffects_exp @loggerTestOnly @outputMode:"lint"
+import { useEffect, useState } from "react";
+export default function Component({ input = "empty" }) {
+	const [currInput, setCurrInput] = useState(input);
+	const localConst = "local const";
+	useEffect(() => {
+		setCurrInput(input + localConst);
+	}, [input, localConst]);
+	return <div>{currInput}</div>;
+}
+export const FIXTURE_ENTRYPOINT = {
+	fn: Component,
+	params: [{ input: "test" }]
+};

--- a/crates/oxc_react_compiler/tests/snapshots/effect-derived-computations__derived-state-from-local-state-in-effect.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/effect-derived-computations__derived-state-from-local-state-in-effect.snap
@@ -6,4 +6,14 @@ Diagnostics:
 
 OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] EffectDerivationsOfState: You might not need an effect. Derive values in render, not effects.", labels: One([LabeledSpan { label: Some("This should be computed during render, not in an effect"), span: SourceSpan { offset: SourceOffset(256), length: 8 }, primary: false }]), help: Some("Using an effect triggers an additional render which can hurt performance and user experience, potentially briefly showing stale values to the user\n\nThis setState call is setting a derived value that depends on the following reactive sources:\n\nState: [count]\n\nData Flow Tree:\n└── count (State)\n\nSee: https://react.dev/learn/you-might-not-need-an-effect#updating-state-based-on-props-or-state"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
 
-No changes.
+// @validateNoDerivedComputationsInEffects_exp @loggerTestOnly @outputMode:"lint"
+import { useEffect, useState } from "react";
+function Component({ shouldChange }) {
+	const [count, setCount] = useState(0);
+	useEffect(() => {
+		if (shouldChange) {
+			setCount(count + 1);
+		}
+	}, [count]);
+	return <div>{count}</div>;
+}

--- a/crates/oxc_react_compiler/tests/snapshots/effect-derived-computations__derived-state-from-prop-local-state-and-component-scope.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/effect-derived-computations__derived-state-from-prop-local-state-and-component-scope.snap
@@ -6,4 +6,25 @@ Diagnostics:
 
 OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] EffectDerivationsOfState: You might not need an effect. Derive values in render, not effects.", labels: One([LabeledSpan { label: Some("This should be computed during render, not in an effect"), span: SourceSpan { offset: SourceOffset(316), length: 11 }, primary: false }]), help: Some("Using an effect triggers an additional render which can hurt performance and user experience, potentially briefly showing stale values to the user\n\nThis setState call is setting a derived value that depends on the following reactive sources:\n\nProps: [firstName]\nState: [lastName]\n\nData Flow Tree:\n├── firstName (Prop)\n└── lastName (State)\n\nSee: https://react.dev/learn/you-might-not-need-an-effect#updating-state-based-on-props-or-state"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
 
-No changes.
+// @validateNoDerivedComputationsInEffects_exp @loggerTestOnly @outputMode:"lint"
+import { useEffect, useState } from "react";
+function Component({ firstName }) {
+	const [lastName, setLastName] = useState("Doe");
+	const [fullName, setFullName] = useState("John");
+	const middleName = "D.";
+	useEffect(() => {
+		setFullName(firstName + " " + middleName + " " + lastName);
+	}, [
+		firstName,
+		middleName,
+		lastName
+	]);
+	return <div>
+      <input value={lastName} onChange={(e) => setLastName(e.target.value)} />
+      <div>{fullName}</div>
+    </div>;
+}
+export const FIXTURE_ENTRYPOINT = {
+	fn: Component,
+	params: [{ firstName: "John" }]
+};

--- a/crates/oxc_react_compiler/tests/snapshots/effect-derived-computations__derived-state-from-prop-setter-ternary.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/effect-derived-computations__derived-state-from-prop-setter-ternary.snap
@@ -6,4 +6,11 @@ Diagnostics:
 
 OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] EffectDerivationsOfState: You might not need an effect. Derive values in render, not effects.", labels: One([LabeledSpan { label: Some("This should be computed during render, not in an effect"), span: SourceSpan { offset: SourceOffset(168), length: 10 }, primary: false }]), help: Some("Using an effect triggers an additional render which can hurt performance and user experience, potentially briefly showing stale values to the user\n\nThis setState call is setting a derived value that depends on the following reactive sources:\n\nProps: [value]\n\nData Flow Tree:\n└── value (Prop)\n\nSee: https://react.dev/learn/you-might-not-need-an-effect#updating-state-based-on-props-or-state"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
 
-No changes.
+// @validateNoDerivedComputationsInEffects_exp @outputMode:"lint"
+function Component({ value }) {
+	const [checked, setChecked] = useState("");
+	useEffect(() => {
+		setChecked(value === "" ? [] : value.split(","));
+	}, [value]);
+	return <div>{checked}</div>;
+}

--- a/crates/oxc_react_compiler/tests/snapshots/effect-derived-computations__derived-state-from-prop-with-side-effect.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/effect-derived-computations__derived-state-from-prop-with-side-effect.snap
@@ -6,4 +6,17 @@ Diagnostics:
 
 OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] EffectDerivationsOfState: You might not need an effect. Derive values in render, not effects.", labels: One([LabeledSpan { label: Some("This should be computed during render, not in an effect"), span: SourceSpan { offset: SourceOffset(233), length: 13 }, primary: false }]), help: Some("Using an effect triggers an additional render which can hurt performance and user experience, potentially briefly showing stale values to the user\n\nThis setState call is setting a derived value that depends on the following reactive sources:\n\nProps: [value]\n\nData Flow Tree:\n└── value (Prop)\n\nSee: https://react.dev/learn/you-might-not-need-an-effect#updating-state-based-on-props-or-state"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
 
-No changes.
+// @validateNoDerivedComputationsInEffects_exp @loggerTestOnly @outputMode:"lint"
+import { useEffect, useState } from "react";
+function Component({ value }) {
+	const [localValue, setLocalValue] = useState("");
+	useEffect(() => {
+		setLocalValue(value);
+		document.title = `Value: ${value}`;
+	}, [value]);
+	return <div>{localValue}</div>;
+}
+export const FIXTURE_ENTRYPOINT = {
+	fn: Component,
+	params: [{ value: "test" }]
+};

--- a/crates/oxc_react_compiler/tests/snapshots/effect-derived-computations__effect-contains-local-function-call.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/effect-derived-computations__effect-contains-local-function-call.snap
@@ -6,4 +6,20 @@ Diagnostics:
 
 OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] EffectDerivationsOfState: You might not need an effect. Derive values in render, not effects.", labels: One([LabeledSpan { label: Some("This should be computed during render, not in an effect"), span: SourceSpan { offset: SourceOffset(298), length: 8 }, primary: false }]), help: Some("Using an effect triggers an additional render which can hurt performance and user experience, potentially briefly showing stale values to the user\n\nThis setState call is setting a derived value that depends on the following reactive sources:\n\nProps: [propValue]\n\nData Flow Tree:\n└── propValue (Prop)\n\nSee: https://react.dev/learn/you-might-not-need-an-effect#updating-state-based-on-props-or-state"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
 
-No changes.
+// @validateNoDerivedComputationsInEffects_exp @loggerTestOnly @outputMode:"lint"
+import { useEffect, useState } from "react";
+function Component({ propValue }) {
+	const [value, setValue] = useState(null);
+	function localFunction() {
+		console.log("local function");
+	}
+	useEffect(() => {
+		setValue(propValue);
+		localFunction();
+	}, [propValue]);
+	return <div>{value}</div>;
+}
+export const FIXTURE_ENTRYPOINT = {
+	fn: Component,
+	params: [{ propValue: "test" }]
+};

--- a/crates/oxc_react_compiler/tests/snapshots/effect-derived-computations__effect-used-in-dep-array-still-errors.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/effect-derived-computations__effect-used-in-dep-array-still-errors.snap
@@ -6,4 +6,11 @@ Diagnostics:
 
 OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] EffectDerivationsOfState: You might not need an effect. Derive values in render, not effects.", labels: One([LabeledSpan { label: Some("This should be computed during render, not in an effect"), span: SourceSpan { offset: SourceOffset(169), length: 4 }, primary: false }]), help: Some("Using an effect triggers an additional render which can hurt performance and user experience, potentially briefly showing stale values to the user\n\nThis setState call is setting a derived value that depends on the following reactive sources:\n\nProps: [prop]\n\nData Flow Tree:\n└── prop (Prop)\n\nSee: https://react.dev/learn/you-might-not-need-an-effect#updating-state-based-on-props-or-state"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
 
-No changes.
+// @validateNoDerivedComputationsInEffects_exp @loggerTestOnly @outputMode:"lint"
+function Component({ prop }) {
+	const [s, setS] = useState(0);
+	useEffect(() => {
+		setS(prop);
+	}, [prop, setS]);
+	return <div>{prop}</div>;
+}

--- a/crates/oxc_react_compiler/tests/snapshots/effect-derived-computations__function-expression-mutation-edge-case.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/effect-derived-computations__function-expression-mutation-edge-case.snap
@@ -6,4 +6,28 @@ Diagnostics:
 
 OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] EffectDerivationsOfState: You might not need an effect. Derive values in render, not effects.", labels: One([LabeledSpan { label: Some("This should be computed during render, not in an effect"), span: SourceSpan { offset: SourceOffset(682), length: 6 }, primary: false }]), help: Some("Using an effect triggers an additional render which can hurt performance and user experience, potentially briefly showing stale values to the user\n\nThis setState call is setting a derived value that depends on the following reactive sources:\n\nState: [foo, bar]\n\nData Flow Tree:\n└── newData\n    ├── foo (State)\n    └── bar (State)\n\nSee: https://react.dev/learn/you-might-not-need-an-effect#updating-state-based-on-props-or-state"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
 
-No changes.
+// @validateNoDerivedComputationsInEffects_exp @loggerTestOnly @outputMode:"lint"
+function Component() {
+	const [foo, setFoo] = useState({});
+	const [bar, setBar] = useState(new Set());
+	/*
+	* isChanged is considered context of the effect's function expression,
+	* if we don't bail out of effect mutation derivation tracking, isChanged
+	* will inherit the sources of the effect's function expression.
+	*
+	* This is innacurate and with the multiple passes ends up causing an infinite loop.
+	*/
+	useEffect(() => {
+		let isChanged = false;
+		const newData = foo.map((val) => {
+			bar.someMethod(val);
+			isChanged = true;
+		});
+		if (isChanged) {
+			setFoo(newData);
+		}
+	}, [foo, bar]);
+	return <div>
+      {foo}, {bar}
+    </div>;
+}

--- a/crates/oxc_react_compiler/tests/snapshots/effect-derived-computations__invalid-derived-computation-in-effect.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/effect-derived-computations__invalid-derived-computation-in-effect.snap
@@ -6,4 +6,19 @@ Diagnostics:
 
 OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] EffectDerivationsOfState: You might not need an effect. Derive values in render, not effects.", labels: One([LabeledSpan { label: Some("This should be computed during render, not in an effect"), span: SourceSpan { offset: SourceOffset(362), length: 11 }, primary: false }]), help: Some("Using an effect triggers an additional render which can hurt performance and user experience, potentially briefly showing stale values to the user\n\nThis setState call is setting a derived value that depends on the following reactive sources:\n\nState: [firstName]\n\nData Flow Tree:\n└── firstName (State)\n\nSee: https://react.dev/learn/you-might-not-need-an-effect#updating-state-based-on-props-or-state"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
 
-No changes.
+// @validateNoDerivedComputationsInEffects_exp @loggerTestOnly @outputMode:"lint"
+import { useEffect, useState } from "react";
+function Component() {
+	const [firstName, setFirstName] = useState("Taylor");
+	const lastName = "Swift";
+	// 🔴 Avoid: redundant state and unnecessary Effect
+	const [fullName, setFullName] = useState("");
+	useEffect(() => {
+		setFullName(firstName + " " + lastName);
+	}, [firstName, lastName]);
+	return <div>{fullName}</div>;
+}
+export const FIXTURE_ENTRYPOINT = {
+	fn: Component,
+	params: []
+};

--- a/crates/oxc_react_compiler/tests/snapshots/effect-derived-computations__invalid-derived-state-from-computed-props.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/effect-derived-computations__invalid-derived-state-from-computed-props.snap
@@ -6,4 +6,25 @@ Diagnostics:
 
 OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] EffectDerivationsOfState: You might not need an effect. Derive values in render, not effects.", labels: One([LabeledSpan { label: Some("This should be computed during render, not in an effect"), span: SourceSpan { offset: SourceOffset(314), length: 15 }, primary: false }]), help: Some("Using an effect triggers an additional render which can hurt performance and user experience, potentially briefly showing stale values to the user\n\nThis setState call is setting a derived value that depends on the following reactive sources:\n\nProps: [props]\n\nData Flow Tree:\n└── computed\n    └── props (Prop)\n\nSee: https://react.dev/learn/you-might-not-need-an-effect#updating-state-based-on-props-or-state"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
 
-No changes.
+// @validateNoDerivedComputationsInEffects_exp @loggerTestOnly @outputMode:"lint"
+import { useEffect, useState } from "react";
+export default function Component(props) {
+	const [displayValue, setDisplayValue] = useState("");
+	useEffect(() => {
+		const computed = props.prefix + props.value + props.suffix;
+		setDisplayValue(computed);
+	}, [
+		props.prefix,
+		props.value,
+		props.suffix
+	]);
+	return <div>{displayValue}</div>;
+}
+export const FIXTURE_ENTRYPOINT = {
+	fn: Component,
+	params: [{
+		prefix: "[",
+		value: "test",
+		suffix: "]"
+	}]
+};

--- a/crates/oxc_react_compiler/tests/snapshots/effect-derived-computations__invalid-derived-state-from-destructured-props.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/effect-derived-computations__invalid-derived-state-from-destructured-props.snap
@@ -6,4 +6,19 @@ Diagnostics:
 
 OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] EffectDerivationsOfState: You might not need an effect. Derive values in render, not effects.", labels: One([LabeledSpan { label: Some("This should be computed during render, not in an effect"), span: SourceSpan { offset: SourceOffset(288), length: 11 }, primary: false }]), help: Some("Using an effect triggers an additional render which can hurt performance and user experience, potentially briefly showing stale values to the user\n\nThis setState call is setting a derived value that depends on the following reactive sources:\n\nProps: [props]\n\nData Flow Tree:\n└── props (Prop)\n\nSee: https://react.dev/learn/you-might-not-need-an-effect#updating-state-based-on-props-or-state"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
 
-No changes.
+// @validateNoDerivedComputationsInEffects_exp @loggerTestOnly @outputMode:"lint"
+import { useEffect, useState } from "react";
+export default function Component({ props }) {
+	const [fullName, setFullName] = useState(props.firstName + " " + props.lastName);
+	useEffect(() => {
+		setFullName(props.firstName + " " + props.lastName);
+	}, [props.firstName, props.lastName]);
+	return <div>{fullName}</div>;
+}
+export const FIXTURE_ENTRYPOINT = {
+	fn: Component,
+	params: [{ props: {
+		firstName: "John",
+		lastName: "Doe"
+	} }]
+};

--- a/crates/oxc_react_compiler/tests/snapshots/effect-derived-computations__usestate-derived-from-prop-no-show-in-data-flow-tree.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/effect-derived-computations__usestate-derived-from-prop-no-show-in-data-flow-tree.snap
@@ -6,4 +6,18 @@ Diagnostics:
 
 OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] EffectDerivationsOfState: You might not need an effect. Derive values in render, not effects.", labels: One([LabeledSpan { label: Some("This should be computed during render, not in an effect"), span: SourceSpan { offset: SourceOffset(462), length: 4 }, primary: false }]), help: Some("Using an effect triggers an additional render which can hurt performance and user experience, potentially briefly showing stale values to the user\n\nThis setState call is setting a derived value that depends on the following reactive sources:\n\nState: [second]\n\nData Flow Tree:\n└── second (State)\n\nSee: https://react.dev/learn/you-might-not-need-an-effect#updating-state-based-on-props-or-state"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
 
-No changes.
+// @validateNoDerivedComputationsInEffects_exp @loggerTestOnly @outputMode:"lint"
+function Component({ prop }) {
+	const [s, setS] = useState();
+	const [second, setSecond] = useState(prop);
+	/*
+	* `second` is a source of state. It will inherit the value of `prop` in
+	* the first render, but after that it will no longer be updated when
+	* `prop` changes. So we shouldn't consider `second` as being derived from
+	* `prop`
+	*/
+	useEffect(() => {
+		setS(second);
+	}, [second]);
+	return <div>{s}</div>;
+}

--- a/crates/oxc_react_compiler/tests/snapshots/error.todo-invalid-jsx-in-catch-in-outer-try-with-finally.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/error.todo-invalid-jsx-in-catch-in-outer-try-with-finally.snap
@@ -6,4 +6,19 @@ Diagnostics:
 
 OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] Todo: (BuildHIR::lowerStatement) Handle TryStatement without a catch clause", labels: One([LabeledSpan { label: None, span: SourceSpan { offset: SourceOffset(134), length: 158 }, primary: false }]), help: None, note: None, severity: Warning, code: OxcCode { scope: None, number: None }, url: None } }
 
-No changes.
+// @validateNoJSXInTryStatements @outputMode:"lint"
+import { identity } from "shared-runtime";
+function Component(props) {
+	let el;
+	try {
+		let value;
+		try {
+			value = identity(props.foo);
+		} catch {
+			el = <div value={value} />;
+		}
+	} finally {
+		console.log(el);
+	}
+	return el;
+}

--- a/crates/oxc_react_compiler/tests/snapshots/error.todo-invalid-jsx-in-try-with-finally.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/error.todo-invalid-jsx-in-try-with-finally.snap
@@ -6,4 +6,13 @@ Diagnostics:
 
 OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] Todo: (BuildHIR::lowerStatement) Handle TryStatement without a catch clause", labels: One([LabeledSpan { label: None, span: SourceSpan { offset: SourceOffset(92), length: 62 }, primary: false }]), help: None, note: None, severity: Warning, code: OxcCode { scope: None, number: None }, url: None } }
 
-No changes.
+// @validateNoJSXInTryStatements @outputMode:"lint"
+function Component(props) {
+	let el;
+	try {
+		el = <div />;
+	} finally {
+		console.log(el);
+	}
+	return el;
+}

--- a/crates/oxc_react_compiler/tests/snapshots/invalid-jsx-in-catch-in-outer-try-with-catch.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/invalid-jsx-in-catch-in-outer-try-with-catch.snap
@@ -6,4 +6,19 @@ Diagnostics:
 
 OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] ErrorBoundaries: Avoid constructing JSX within try/catch", labels: One([LabeledSpan { label: Some("Avoid constructing JSX within try/catch"), span: SourceSpan { offset: SourceOffset(241), length: 21 }, primary: false }]), help: Some("React does not immediately render components when JSX is rendered, so any errors from this component will not be caught by the try/catch. To catch errors in rendering a given component, wrap that component in an error boundary. (https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary)"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
 
-No changes.
+// @loggerTestOnly @validateNoJSXInTryStatements @outputMode:"lint"
+import { identity } from "shared-runtime";
+function Component(props) {
+	let el;
+	try {
+		let value;
+		try {
+			value = identity(props.foo);
+		} catch {
+			el = <div value={value} />;
+		}
+	} catch {
+		return null;
+	}
+	return el;
+}

--- a/crates/oxc_react_compiler/tests/snapshots/invalid-jsx-in-try-with-catch.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/invalid-jsx-in-try-with-catch.snap
@@ -6,4 +6,13 @@ Diagnostics:
 
 OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] ErrorBoundaries: Avoid constructing JSX within try/catch", labels: One([LabeledSpan { label: Some("Avoid constructing JSX within try/catch"), span: SourceSpan { offset: SourceOffset(123), length: 7 }, primary: false }]), help: Some("React does not immediately render components when JSX is rendered, so any errors from this component will not be caught by the try/catch. To catch errors in rendering a given component, wrap that component in an error boundary. (https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary)"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
 
-No changes.
+// @loggerTestOnly @validateNoJSXInTryStatements @outputMode:"lint"
+function Component(props) {
+	let el;
+	try {
+		el = <div />;
+	} catch {
+		return null;
+	}
+	return el;
+}

--- a/crates/oxc_react_compiler/tests/snapshots/invalid-setState-in-useEffect-namespace.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/invalid-setState-in-useEffect-namespace.snap
@@ -6,4 +6,12 @@ Diagnostics:
 
 OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] EffectSetState: Calling setState synchronously within an effect can trigger cascading renders", labels: One([LabeledSpan { label: Some("Avoid calling setState() directly within an effect"), span: SourceSpan { offset: SourceOffset(200), length: 8 }, primary: false }]), help: Some("Effects are intended to synchronize state between React and external systems such as manually updating the DOM, state management libraries, or other platform APIs. In general, the body of an effect should do one or both of the following:\n* Update external systems with the latest state from React.\n* Subscribe for updates from some external system, calling setState in a callback function when external state changes.\n\nCalling setState synchronously within an effect body causes cascading renders that can hurt performance, and is not recommended. (https://react.dev/learn/you-might-not-need-an-effect)"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
 
-No changes.
+// @loggerTestOnly @validateNoSetStateInEffects @outputMode:"lint"
+import * as React from "react";
+function Component() {
+	const [state, setState] = React.useState(0);
+	React.useEffect(() => {
+		setState((s) => s + 1);
+	});
+	return state;
+}

--- a/crates/oxc_react_compiler/tests/snapshots/invalid-setState-in-useEffect-new-expression-default-param.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/invalid-setState-in-useEffect-new-expression-default-param.snap
@@ -6,4 +6,13 @@ Diagnostics:
 
 OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] EffectSetState: Calling setState synchronously within an effect can trigger cascading renders", labels: One([LabeledSpan { label: Some("Avoid calling setState() directly within an effect"), span: SourceSpan { offset: SourceOffset(313), length: 8 }, primary: false }]), help: Some("Effects are intended to synchronize state between React and external systems such as manually updating the DOM, state management libraries, or other platform APIs. In general, the body of an effect should do one or both of the following:\n* Update external systems with the latest state from React.\n* Subscribe for updates from some external system, calling setState in a callback function when external state changes.\n\nCalling setState synchronously within an effect body causes cascading renders that can hurt performance, and is not recommended. (https://react.dev/learn/you-might-not-need-an-effect)"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
 
-No changes.
+// @loggerTestOnly @validateNoSetStateInEffects @outputMode:"lint"
+import { useEffect, useState } from "react";
+// Bug: NewExpression default param value should not prevent set-state-in-effect validation
+function Component({ value = new Number() }) {
+	const [state, setState] = useState(0);
+	useEffect(() => {
+		setState((s) => s + 1);
+	});
+	return state;
+}

--- a/crates/oxc_react_compiler/tests/snapshots/invalid-setState-in-useEffect-transitive.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/invalid-setState-in-useEffect-transitive.snap
@@ -6,4 +6,18 @@ Diagnostics:
 
 OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] EffectSetState: Calling setState synchronously within an effect can trigger cascading renders", labels: One([LabeledSpan { label: Some("Avoid calling setState() directly within an effect"), span: SourceSpan { offset: SourceOffset(284), length: 1 }, primary: false }]), help: Some("Effects are intended to synchronize state between React and external systems such as manually updating the DOM, state management libraries, or other platform APIs. In general, the body of an effect should do one or both of the following:\n* Update external systems with the latest state from React.\n* Subscribe for updates from some external system, calling setState in a callback function when external state changes.\n\nCalling setState synchronously within an effect body causes cascading renders that can hurt performance, and is not recommended. (https://react.dev/learn/you-might-not-need-an-effect)"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
 
-No changes.
+// @loggerTestOnly @validateNoSetStateInEffects @outputMode:"lint"
+import { useEffect, useState } from "react";
+function Component() {
+	const [state, setState] = useState(0);
+	const f = () => {
+		setState((s) => s + 1);
+	};
+	const g = () => {
+		f();
+	};
+	useEffect(() => {
+		g();
+	});
+	return state;
+}

--- a/crates/oxc_react_compiler/tests/snapshots/invalid-setState-in-useEffect-via-useEffectEvent.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/invalid-setState-in-useEffect-via-useEffectEvent.snap
@@ -6,4 +6,15 @@ Diagnostics:
 
 OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] EffectSetState: Calling setState synchronously within an effect can trigger cascading renders", labels: One([LabeledSpan { label: Some("Avoid calling setState() directly within an effect"), span: SourceSpan { offset: SourceOffset(286), length: 11 }, primary: false }]), help: Some("Effects are intended to synchronize state between React and external systems such as manually updating the DOM, state management libraries, or other platform APIs. In general, the body of an effect should do one or both of the following:\n* Update external systems with the latest state from React.\n* Subscribe for updates from some external system, calling setState in a callback function when external state changes.\n\nCalling setState synchronously within an effect body causes cascading renders that can hurt performance, and is not recommended. (https://react.dev/learn/you-might-not-need-an-effect)"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
 
-No changes.
+// @loggerTestOnly @validateNoSetStateInEffects @outputMode:"lint"
+import { useEffect, useEffectEvent, useState } from "react";
+function Component() {
+	const [state, setState] = useState(0);
+	const effectEvent = useEffectEvent(() => {
+		setState(true);
+	});
+	useEffect(() => {
+		effectEvent();
+	}, []);
+	return state;
+}

--- a/crates/oxc_react_compiler/tests/snapshots/invalid-setState-in-useEffect.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/invalid-setState-in-useEffect.snap
@@ -6,4 +6,12 @@ Diagnostics:
 
 OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] EffectSetState: Calling setState synchronously within an effect can trigger cascading renders", labels: One([LabeledSpan { label: Some("Avoid calling setState() directly within an effect"), span: SourceSpan { offset: SourceOffset(199), length: 8 }, primary: false }]), help: Some("Effects are intended to synchronize state between React and external systems such as manually updating the DOM, state management libraries, or other platform APIs. In general, the body of an effect should do one or both of the following:\n* Update external systems with the latest state from React.\n* Subscribe for updates from some external system, calling setState in a callback function when external state changes.\n\nCalling setState synchronously within an effect body causes cascading renders that can hurt performance, and is not recommended. (https://react.dev/learn/you-might-not-need-an-effect)"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
 
-No changes.
+// @loggerTestOnly @validateNoSetStateInEffects @outputMode:"lint"
+import { useEffect, useState } from "react";
+function Component() {
+	const [state, setState] = useState(0);
+	useEffect(() => {
+		setState((s) => s + 1);
+	});
+	return state;
+}

--- a/crates/oxc_react_compiler/tests/snapshots/static-components__invalid-conditionally-assigned-dynamically-constructed-component-in-render.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/static-components__invalid-conditionally-assigned-dynamically-constructed-component-in-render.snap
@@ -6,4 +6,13 @@ Diagnostics:
 
 OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] StaticComponents: Cannot create components during render", labels: Two([LabeledSpan { label: Some("This component is created during render"), span: SourceSpan { offset: SourceOffset(221), length: 9 }, primary: false }, LabeledSpan { label: Some("The component is created during render here"), span: SourceSpan { offset: SourceOffset(143), length: 17 }, primary: false }]), help: Some("Components created during render will reset their state each time they are created. Declare components outside of render"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
 
-No changes.
+// @loggerTestOnly @validateStaticComponents @outputMode:"lint"
+function Example(props) {
+	let Component;
+	if (props.cond) {
+		Component = createComponent();
+	} else {
+		Component = DefaultComponent;
+	}
+	return <Component />;
+}

--- a/crates/oxc_react_compiler/tests/snapshots/static-components__invalid-dynamically-construct-component-in-render.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/static-components__invalid-dynamically-construct-component-in-render.snap
@@ -6,4 +6,8 @@ Diagnostics:
 
 OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] StaticComponents: Cannot create components during render", labels: Two([LabeledSpan { label: Some("This component is created during render"), span: SourceSpan { offset: SourceOffset(139), length: 9 }, primary: false }, LabeledSpan { label: Some("The component is created during render here"), span: SourceSpan { offset: SourceOffset(110), length: 17 }, primary: false }]), help: Some("Components created during render will reset their state each time they are created. Declare components outside of render"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
 
-No changes.
+// @loggerTestOnly @validateStaticComponents @outputMode:"lint"
+function Example(props) {
+	const Component = createComponent();
+	return <Component />;
+}

--- a/crates/oxc_react_compiler/tests/snapshots/static-components__invalid-dynamically-constructed-component-function.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/static-components__invalid-dynamically-constructed-component-function.snap
@@ -6,4 +6,10 @@ Diagnostics:
 
 OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] StaticComponents: Cannot create components during render", labels: Two([LabeledSpan { label: Some("This component is created during render"), span: SourceSpan { offset: SourceOffset(149), length: 9 }, primary: false }, LabeledSpan { label: Some("The component is created during render here"), span: SourceSpan { offset: SourceOffset(92), length: 46 }, primary: false }]), help: Some("Components created during render will reset their state each time they are created. Declare components outside of render"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
 
-No changes.
+// @loggerTestOnly @validateStaticComponents @outputMode:"lint"
+function Example(props) {
+	function Component() {
+		return <div />;
+	}
+	return <Component />;
+}

--- a/crates/oxc_react_compiler/tests/snapshots/static-components__invalid-dynamically-constructed-component-method-call.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/static-components__invalid-dynamically-constructed-component-method-call.snap
@@ -6,4 +6,8 @@ Diagnostics:
 
 OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] StaticComponents: Cannot create components during render", labels: Two([LabeledSpan { label: Some("This component is created during render"), span: SourceSpan { offset: SourceOffset(137), length: 9 }, primary: false }, LabeledSpan { label: Some("The component is created during render here"), span: SourceSpan { offset: SourceOffset(110), length: 15 }, primary: false }]), help: Some("Components created during render will reset their state each time they are created. Declare components outside of render"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
 
-No changes.
+// @loggerTestOnly @validateStaticComponents @outputMode:"lint"
+function Example(props) {
+	const Component = props.foo.bar();
+	return <Component />;
+}

--- a/crates/oxc_react_compiler/tests/snapshots/static-components__invalid-dynamically-constructed-component-new.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/static-components__invalid-dynamically-constructed-component-new.snap
@@ -6,4 +6,8 @@ Diagnostics:
 
 OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] StaticComponents: Cannot create components during render", labels: Two([LabeledSpan { label: Some("This component is created during render"), span: SourceSpan { offset: SourceOffset(144), length: 9 }, primary: false }, LabeledSpan { label: Some("The component is created during render here"), span: SourceSpan { offset: SourceOffset(110), length: 22 }, primary: false }]), help: Some("Components created during render will reset their state each time they are created. Declare components outside of render"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
 
-No changes.
+// @loggerTestOnly @validateStaticComponents @outputMode:"lint"
+function Example(props) {
+	const Component = new ComponentFactory();
+	return <Component />;
+}


### PR DESCRIPTION
## Summary

Resolves the `effect-derived-computations/` fidelity batch (21 fixtures) where oxc emitted `No changes.` while the fork produces `## Code`.

## Root cause

The batch header is `// @validateNoDerivedComputationsInEffects_exp @loggerTestOnly @outputMode:"lint"`. The original hypothesis was that oxc *aborts* on the `EffectDerivationsOfState` Error-severity diagnostic (`panic_threshold: "all_errors"`). That is **not** what happens — instrumenting `compile()` shows all 21 fixtures return `CompileResult::Success { ast: None }`, never `Error`:

- `validate_no_derived_computations_in_effects_exp` returns its findings, which the pipeline hands to `log_errors_as_events` (non-fatal), not `handle_error`.
- In lint output mode `process_fn` returns `Ok(None)` (lint never rewrites), so `transform` returns `program: None` / `changed: false`.

The real divergence is in the **snapshot harness**: it rendered any no-rewrite result as `No changes.`, so *every* `@outputMode:"lint"` fixture looked like a bail-out even though the compiler ran to completion and reported its findings. Upstream's `snap` runner instead emits the (unmodified) code in lint mode alongside the findings.

## Fix

- `tests/snapshot.rs`: in lint output mode, render the validated program's code instead of `No changes.` (the program is unchanged, matching the fork's lint `## Code`).
- `src/lib.rs`: re-export `CompilerOutputMode` so the harness detects lint mode canonically via `CompilerOutputMode::from_opts`.

No compiler logic changes — hence the `test(...)` scope; the compiler was already correct, the harness was misrepresenting lint output.

## Fixtures changed (46 lint-mode snapshots)

Verified each changed snapshot's code against the fork's `.expect.md` with a whitespace/trailing-comma-insensitive comparison.

**effect-derived-computations batch (21/21 — this PR's target):** all now match the fork's `## Code` and still emit the `EffectDerivationsOfState` diagnostic. 18 match modulo whitespace; 3 differ only by JSX-return parenthesization (`return <div>` vs `return (<div>)`), a pure oxc-codegen-vs-babel formatting difference.

**Other `@outputMode:"lint"` fixtures (25) — all improvements toward the fork:**
- 21 (setState, static-components, jsx-in-try-with-catch, `valid-*`, `use-memo-noemit`, `dynamic-gating-noemit`, `fn-name-no-leak`): now match the fork's `## Code`.
- 2 (`valid-setState-in-effect-from-ref-function-call`, `valid-setState-in-useEffect-controlled-by-ref-value`): match the fork's `## Code` except for compiler variable-rename suffixes (`ref_0`, `data_0`) that the fork applies to its lint output but oxc's harness does not — still a clear improvement over `No changes.`.
- 2 (`error.todo-invalid-jsx-in-try-with-finally`, `error.todo-invalid-jsx-in-catch-in-outer-try-with-finally`): the fork throws (`## Error`) on `try`/`finally` without a `catch`; oxc handles it, emitting a `Todo` **warning** and now showing the code. Pre-existing behavior divergence (oxc is more lenient here), surfaced by this change.

The `git diff --stat` is confined to these 46 lint-mode snapshots plus the two source files.

## Notes / follow-ups (out of this batch)

- `invalid-jsx-in-try-with-catch` and `invalid-jsx-in-catch-in-outer-try-with-catch` internally still `CompileResult::Error` (a separate fatal-in-lint-mode path in the JSX-in-try lowering). Because lint mode never rewrites, their emitted code + diagnostic still match the fork's `## Code`, but the latent abort is worth fixing in the JSX-in-try batch.
- Applying lint-mode variable renames in the harness (the `ref_0`/`data_0` gap) and oxc's `try`/`finally` handling vs the fork are separate items.
