### PR TITLE
fix(react_compiler): drop stray empty statement from catch bindings

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
@@ -710,8 +710,16 @@ fn ox_codegen_block_no_reset<'a, 'h>(
                 };
                 if let Some(ref label) = term_stmt.label {
                     if !label.implicit {
+                        // Collapse a labeled block that wraps a single statement
+                        // (`bb0: { switch {} }` -> `bb0: switch {}`). A `try` is the
+                        // exception: the reference output always keeps the braces around a
+                        // labeled `try` (`bb0: { try {} catch {} }`, never `bb0: try`), as
+                        // the catch-binding declaration originally padded the block.
                         let inner = match stmt {
-                            oxc::Statement::BlockStatement(mut bs) if bs.body.len() == 1 => {
+                            oxc::Statement::BlockStatement(mut bs)
+                                if bs.body.len() == 1
+                                    && !matches!(bs.body[0], oxc::Statement::TryStatement(_)) =>
+                            {
                                 bs.body.pop().unwrap()
                             }
                             other => other,
@@ -1428,7 +1436,13 @@ fn ox_codegen_instruction_nullable<'a, 'h>(
             | InstructionValue::Destructure { .. }
             | InstructionValue::DeclareLocal { .. }
             | InstructionValue::DeclareContext { .. } => {
-                return ox_codegen_store_or_declare(cx, instr, value);
+                // `emit_store` returns an empty statement for `InstructionKind::Catch`
+                // declarations: the catch parameter is emitted from the `Try` terminal's
+                // handler binding, so the declaration itself has no textual form. Drop it
+                // (like the other instruction paths below) so it does not surface as a
+                // stray `;` at the top of the labeled block wrapping the `try`.
+                let stmt = ox_codegen_store_or_declare(cx, instr, value)?;
+                return Ok(stmt.filter(|s| !matches!(s, oxc::Statement::EmptyStatement(_))));
             }
             InstructionValue::StartMemoize { .. } | InstructionValue::FinishMemoize { .. } => {
                 return Ok(None);

--- a/crates/oxc_react_compiler/tests/snapshots/error.bug-invariant-local-or-context-references.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/error.bug-invariant-local-or-context-references.snap
@@ -17,7 +17,6 @@ const bar = () => {
 };
 export const useFoot = () => {
 	const [, setState] = useState(null);
-	;
 	try {
 		const { data } = bar();
 		setState({

--- a/crates/oxc_react_compiler/tests/snapshots/propagate-scope-deps-hir-fork__try-catch-try-value-modified-in-catch-escaping.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/propagate-scope-deps-hir-fork__try-catch-try-value-modified-in-catch-escaping.snap
@@ -9,7 +9,6 @@ function Component(props) {
 	const $ = _c(3);
 	let x;
 	if ($[0] !== props.e || $[1] !== props.y) {
-		;
 		try {
 			const y = [];
 			y.push(props.y);

--- a/crates/oxc_react_compiler/tests/snapshots/propagate-scope-deps-hir-fork__try-catch-try-value-modified-in-catch.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/propagate-scope-deps-hir-fork__try-catch-try-value-modified-in-catch.snap
@@ -11,7 +11,6 @@ function Component(props) {
 	if ($[0] !== props.e || $[1] !== props.y) {
 		t0 = Symbol.for("react.early_return_sentinel");
 		bb0: {
-			;
 			try {
 				const y = [];
 				y.push(props.y);

--- a/crates/oxc_react_compiler/tests/snapshots/repro-for-in-in-try.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/repro-for-in-in-try.snap
@@ -12,7 +12,6 @@ function Foo(t0) {
 		t1 = Symbol.for("react.early_return_sentinel");
 		bb0: {
 			keys = [];
-			;
 			try {
 				for (const key in obj) {
 					keys.push(key);

--- a/crates/oxc_react_compiler/tests/snapshots/repro-for-loop-in-try.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/repro-for-loop-in-try.snap
@@ -12,7 +12,6 @@ function Foo(t0) {
 		t1 = Symbol.for("react.early_return_sentinel");
 		bb0: {
 			results = [];
-			;
 			try {
 				for (let i = 0; i < items.length; i++) {
 					results.push(items[i]);

--- a/crates/oxc_react_compiler/tests/snapshots/repro-for-of-in-try.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/repro-for-of-in-try.snap
@@ -12,7 +12,6 @@ function Foo(t0) {
 		t1 = Symbol.for("react.early_return_sentinel");
 		bb0: {
 			items = [];
-			;
 			try {
 				for (const [key, value] of Object.entries(obj)) {
 					items.push(`${key}: ${value}`);

--- a/crates/oxc_react_compiler/tests/snapshots/repro-nested-try-catch-in-usememo.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/repro-nested-try-catch-in-usememo.snap
@@ -8,7 +8,6 @@ import { useMemo } from "react";
 function useFoo(text) {
 	const $ = _c(2);
 	let t0;
-	;
 	try {
 		let formattedText;
 		try {

--- a/crates/oxc_react_compiler/tests/snapshots/repro-unreachable-code-early-return-in-useMemo.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/repro-unreachable-code-early-return-in-useMemo.snap
@@ -15,7 +15,6 @@ function Component(t0) {
 			t1 = null;
 			break bb0;
 		}
-		;
 		try {
 			let t3;
 			if ($[0] !== value) {

--- a/crates/oxc_react_compiler/tests/snapshots/try-catch-alias-try-values.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/try-catch-alias-try-values.snap
@@ -10,7 +10,6 @@ function Component(props) {
 	if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
 		let y;
 		x = [];
-		;
 		try {
 			throwInput(x);
 		} catch (t0) {

--- a/crates/oxc_react_compiler/tests/snapshots/try-catch-logical-expression.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/try-catch-logical-expression.snap
@@ -4,7 +4,6 @@ input_file: crates/oxc_react_compiler/fixtures/try-catch-logical-expression.js
 ---
 function Component(props) {
 	let result;
-	;
 	try {
 		result = props.cond && props.foo && props.items.length;
 	} catch (t0) {

--- a/crates/oxc_react_compiler/tests/snapshots/try-catch-ternary-expression.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/try-catch-ternary-expression.snap
@@ -4,7 +4,6 @@ input_file: crates/oxc_react_compiler/fixtures/try-catch-ternary-expression.js
 ---
 function Component(props) {
 	let result;
-	;
 	try {
 		result = props.cond ? props.a : props.fallback.value;
 	} catch (t0) {

--- a/crates/oxc_react_compiler/tests/snapshots/try-catch-try-immediately-returns.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/try-catch-try-immediately-returns.snap
@@ -4,7 +4,6 @@ input_file: crates/oxc_react_compiler/fixtures/try-catch-try-immediately-returns
 ---
 function Component(props) {
 	let x;
-	;
 	return 42;
 }
 export const FIXTURE_ENTRYPOINT = {

--- a/crates/oxc_react_compiler/tests/snapshots/try-catch-try-immediately-throws-after-constant-propagation.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/try-catch-try-immediately-throws-after-constant-propagation.snap
@@ -4,7 +4,6 @@ input_file: crates/oxc_react_compiler/fixtures/try-catch-try-immediately-throws-
 ---
 function Component(props) {
 	let x;
-	;
 	return 42;
 }
 export const FIXTURE_ENTRYPOINT = {

--- a/crates/oxc_react_compiler/tests/snapshots/try-catch-try-value-modified-in-catch-escaping.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/try-catch-try-value-modified-in-catch-escaping.snap
@@ -8,7 +8,6 @@ function Component(props) {
 	const $ = _c(3);
 	let x;
 	if ($[0] !== props.e || $[1] !== props.y) {
-		;
 		try {
 			const y = [];
 			y.push(props.y);

--- a/crates/oxc_react_compiler/tests/snapshots/try-catch-try-value-modified-in-catch.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/try-catch-try-value-modified-in-catch.snap
@@ -10,7 +10,6 @@ function Component(props) {
 	if ($[0] !== props.e || $[1] !== props.y) {
 		t0 = Symbol.for("react.early_return_sentinel");
 		bb0: {
-			;
 			try {
 				const y = [];
 				y.push(props.y);

--- a/crates/oxc_react_compiler/tests/snapshots/try-catch-with-catch-param.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/try-catch-with-catch-param.snap
@@ -12,7 +12,6 @@ function Component(props) {
 		t0 = Symbol.for("react.early_return_sentinel");
 		bb0: {
 			x = [];
-			;
 			try {
 				throwInput(x);
 			} catch (t1) {

--- a/crates/oxc_react_compiler/tests/snapshots/try-catch-within-function-expression-returns-caught-value.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/try-catch-within-function-expression-returns-caught-value.snap
@@ -9,7 +9,6 @@ function Component(props) {
 	let t0;
 	if ($[0] !== props) {
 		const callback = () => {
-			;
 			try {
 				throwInput([props.value]);
 			} catch (t1) {

--- a/crates/oxc_react_compiler/tests/snapshots/try-catch-within-function-expression.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/try-catch-within-function-expression.snap
@@ -16,7 +16,6 @@ function Component(props) {
 	return t0;
 }
 function _temp() {
-	;
 	try {
 		return [];
 	} catch (t0) {

--- a/crates/oxc_react_compiler/tests/snapshots/try-catch-within-object-method-returns-caught-value.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/try-catch-within-object-method-returns-caught-value.snap
@@ -9,7 +9,6 @@ function Component(props) {
 	let t0;
 	if ($[0] !== props) {
 		const object = { foo() {
-			;
 			try {
 				throwInput([props.value]);
 			} catch (t1) {

--- a/crates/oxc_react_compiler/tests/snapshots/try-catch-within-object-method.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/try-catch-within-object-method.snap
@@ -8,7 +8,6 @@ function Component(props) {
 	let t0;
 	if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
 		const object = { foo() {
-			;
 			try {
 				return [];
 			} catch (t1) {


### PR DESCRIPTION
## Root cause

A `try`/`catch` with a catch parameter lowers the catch binding to a `DeclareLocal` (and a `StoreLocal` in the handler) with `InstructionKind::Catch`. In `emit_store` these codegen to an **empty statement** — a faithful port of the fork's `emitStore` (`case InstructionKind.Catch: return t.emptyStatement()`) — because the catch parameter itself is emitted separately, from the `Try` terminal's `handler_binding`, so the declaration has no textual form.

oxc's other instruction paths drop such empty statements (`ox_codegen_instruction_nullable` filters `EmptyStatement` -> `None`), but the `StoreLocal`/`DeclareLocal`/`DeclareContext`/`Destructure` path returned the result of `ox_codegen_store_or_declare` **directly**, so the catch declaration's empty statement was pushed into the block. It surfaced as a stray `;`:

```js
bb0: {
  x = [];
  ;          // <- stray, from the catch `DeclareLocal`
  try { ... } catch (t1) { ... }
}
```

and, when the `try` was optimized away entirely, as a bare `;` in the function body (`let x; ; return 42;`). The reference goldens (`*.expect.md`) never contain such a `;`.

## Fix

`crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs`:

1. **Drop the empty statement** from the store/declare path in `ox_codegen_instruction_nullable`, consistent with the other instruction paths.
2. Removing it turned a labeled block that wrapped only a `try` into a single-statement block, which tripped the labeled-block single-statement **unwrap** and dropped the braces (`bb0: try {}` instead of `bb0: { try {} catch {} }`). Restrict the unwrap so a labeled `try` keeps its braces — matching the reference output, which always brace-wraps a labeled `try` (the catch declaration originally padded the block to two statements). Other single statements (`if`/`for`/`switch`/`while`, nested labels such as `bb1: bb2: switch`) still unwrap as before.

## Fixtures changed

20 snapshots updated, each removing exactly one stray `;` (braces and everything else preserved). ~29 `try`/`catch` fixtures now match the fork golden at the compiled-component level. The change also cleaned two non-`try-catch`-named fixtures that embed a `try` (`repro-unreachable-code-early-return-in-useMemo`, `error.bug-invariant-local-or-context-references`). The whole-suite diff vs `main` is 20 files, all `-1` line; no snapshot regressed.

## Remaining work (out of scope, pre-existing)

The still-diverging `try`/`catch` fixtures differ only by codegen formatting / error handling unrelated to the stray `;`:

- Prettier-style formatting: inline vs multi-line object/array literals and `FIXTURE_ENTRYPOINT` params, multi-line vs inline JSX (`try-catch-multiple-value-blocks`, `try-catch-within-object-method*`), directive-comment placement (`propagate-scope-deps-hir-fork__*`, `repro-nested-try-catch-in-usememo`).
- `finally` clauses and invalid-JSX-in-`catch` fixtures (`error.todo*`, `invalid-jsx-*`, `fault-tolerance__error.try-finally-*`) where oxc's error/`## Error` behavior diverges from the fork.
