### PR TITLE
chore(rustfmt): standardize rustfmt config

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -7,6 +7,8 @@ use_small_heuristics = "Max"
 use_field_init_shorthand = true
 
 reorder_modules = true
+merge_derives = true
+remove_nested_parens = true
 
 # All unstable features that we wish for
 # unstable_features = true


### PR DESCRIPTION
Standardizes the Rustfmt config filename and options, then applies cargo fmt.
