### PR TITLE
feat(linter/react): implement jsx-no-leaked-render rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -219,6 +219,7 @@ export type JsxCurlyBracePresenceConfig = JsxCurlyBracePresenceMode | JsxCurlyBr
 export type JsxCurlyBracePresenceMode = "always" | "never" | "ignore";
 export type JsxFilenameExtensionAllowMode = "always" | "as-needed";
 export type FragmentMode = "syntax" | "element";
+export type ValidStrategies = "coerce" | "ternary";
 export type EnforceDynamicLinksEnum = "always" | "never";
 export type IgnoreEnforceOption = "ignore" | "enforce";
 export type AllowedOrDisallowInFunc = "allowed" | "disallow-in-func";
@@ -1334,6 +1335,7 @@ export interface DummyRuleMap {
   "react/jsx-no-comment-textnodes"?: RuleNoConfig;
   "react/jsx-no-constructed-context-values"?: RuleNoConfig;
   "react/jsx-no-duplicate-props"?: RuleNoConfig;
+  "react/jsx-no-leaked-render"?: RuleNoConfig | [AllowWarnDeny, JsxNoLeakedRenderConfig];
   "react/jsx-no-literals"?: RuleNoConfig | [AllowWarnDeny, JsxNoLiteralsConfig];
   "react/jsx-no-script-url"?:
     | RuleNoConfig
@@ -4587,6 +4589,18 @@ export interface JsxMaxDepthConfig {
    * The maximum allowed depth of nested JSX elements and fragments.
    */
   max?: number;
+}
+export interface JsxNoLeakedRenderConfig {
+  /**
+   * Skip JSX attribute values (children of nested JSX inside attributes are
+   * still linted because each `JSXExpressionContainer` is its own node).
+   */
+  ignoreAttributes?: boolean;
+  /**
+   * Strategies the user accepts for guarding JSX expressions. The first entry
+   * determines the preferred fix when both strategies are valid.
+   */
+  validStrategies?: ValidStrategies[];
 }
 /**
  * The options shared between the top-level config and each `elementOverrides` entry.

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2657,6 +2657,12 @@ impl RuleRunner for crate::rules::react::jsx_no_duplicate_props::JsxNoDuplicateP
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::react::jsx_no_leaked_render::JsxNoLeakedRender {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXExpressionContainer]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::react::jsx_no_literals::JsxNoLiterals {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::JSXElement, AstType::JSXFragment]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -438,6 +438,7 @@ pub use crate::rules::react::jsx_max_depth::JsxMaxDepth as ReactJsxMaxDepth;
 pub use crate::rules::react::jsx_no_comment_textnodes::JsxNoCommentTextnodes as ReactJsxNoCommentTextnodes;
 pub use crate::rules::react::jsx_no_constructed_context_values::JsxNoConstructedContextValues as ReactJsxNoConstructedContextValues;
 pub use crate::rules::react::jsx_no_duplicate_props::JsxNoDuplicateProps as ReactJsxNoDuplicateProps;
+pub use crate::rules::react::jsx_no_leaked_render::JsxNoLeakedRender as ReactJsxNoLeakedRender;
 pub use crate::rules::react::jsx_no_literals::JsxNoLiterals as ReactJsxNoLiterals;
 pub use crate::rules::react::jsx_no_script_url::JsxNoScriptUrl as ReactJsxNoScriptUrl;
 pub use crate::rules::react::jsx_no_target_blank::JsxNoTargetBlank as ReactJsxNoTargetBlank;
@@ -1271,6 +1272,7 @@ pub enum RuleEnum {
     ReactJsxNoCommentTextnodes(ReactJsxNoCommentTextnodes),
     ReactJsxNoConstructedContextValues(ReactJsxNoConstructedContextValues),
     ReactJsxNoDuplicateProps(ReactJsxNoDuplicateProps),
+    ReactJsxNoLeakedRender(ReactJsxNoLeakedRender),
     ReactJsxNoLiterals(ReactJsxNoLiterals),
     ReactJsxNoScriptUrl(ReactJsxNoScriptUrl),
     ReactJsxNoTargetBlank(ReactJsxNoTargetBlank),
@@ -2168,7 +2170,8 @@ const REACT_JSX_NO_COMMENT_TEXTNODES_ID: usize = REACT_JSX_MAX_DEPTH_ID + 1usize
 const REACT_JSX_NO_CONSTRUCTED_CONTEXT_VALUES_ID: usize =
     REACT_JSX_NO_COMMENT_TEXTNODES_ID + 1usize;
 const REACT_JSX_NO_DUPLICATE_PROPS_ID: usize = REACT_JSX_NO_CONSTRUCTED_CONTEXT_VALUES_ID + 1usize;
-const REACT_JSX_NO_LITERALS_ID: usize = REACT_JSX_NO_DUPLICATE_PROPS_ID + 1usize;
+const REACT_JSX_NO_LEAKED_RENDER_ID: usize = REACT_JSX_NO_DUPLICATE_PROPS_ID + 1usize;
+const REACT_JSX_NO_LITERALS_ID: usize = REACT_JSX_NO_LEAKED_RENDER_ID + 1usize;
 const REACT_JSX_NO_SCRIPT_URL_ID: usize = REACT_JSX_NO_LITERALS_ID + 1usize;
 const REACT_JSX_NO_TARGET_BLANK_ID: usize = REACT_JSX_NO_SCRIPT_URL_ID + 1usize;
 const REACT_JSX_NO_UNDEF_ID: usize = REACT_JSX_NO_TARGET_BLANK_ID + 1usize;
@@ -3145,6 +3148,7 @@ impl RuleEnum {
                 REACT_JSX_NO_CONSTRUCTED_CONTEXT_VALUES_ID
             }
             Self::ReactJsxNoDuplicateProps(_) => REACT_JSX_NO_DUPLICATE_PROPS_ID,
+            Self::ReactJsxNoLeakedRender(_) => REACT_JSX_NO_LEAKED_RENDER_ID,
             Self::ReactJsxNoLiterals(_) => REACT_JSX_NO_LITERALS_ID,
             Self::ReactJsxNoScriptUrl(_) => REACT_JSX_NO_SCRIPT_URL_ID,
             Self::ReactJsxNoTargetBlank(_) => REACT_JSX_NO_TARGET_BLANK_ID,
@@ -4114,6 +4118,7 @@ impl RuleEnum {
             Self::ReactJsxNoCommentTextnodes(_) => ReactJsxNoCommentTextnodes::NAME,
             Self::ReactJsxNoConstructedContextValues(_) => ReactJsxNoConstructedContextValues::NAME,
             Self::ReactJsxNoDuplicateProps(_) => ReactJsxNoDuplicateProps::NAME,
+            Self::ReactJsxNoLeakedRender(_) => ReactJsxNoLeakedRender::NAME,
             Self::ReactJsxNoLiterals(_) => ReactJsxNoLiterals::NAME,
             Self::ReactJsxNoScriptUrl(_) => ReactJsxNoScriptUrl::NAME,
             Self::ReactJsxNoTargetBlank(_) => ReactJsxNoTargetBlank::NAME,
@@ -5099,6 +5104,7 @@ impl RuleEnum {
                 ReactJsxNoConstructedContextValues::CATEGORY
             }
             Self::ReactJsxNoDuplicateProps(_) => ReactJsxNoDuplicateProps::CATEGORY,
+            Self::ReactJsxNoLeakedRender(_) => ReactJsxNoLeakedRender::CATEGORY,
             Self::ReactJsxNoLiterals(_) => ReactJsxNoLiterals::CATEGORY,
             Self::ReactJsxNoScriptUrl(_) => ReactJsxNoScriptUrl::CATEGORY,
             Self::ReactJsxNoTargetBlank(_) => ReactJsxNoTargetBlank::CATEGORY,
@@ -6091,6 +6097,7 @@ impl RuleEnum {
             Self::ReactJsxNoCommentTextnodes(_) => ReactJsxNoCommentTextnodes::FIX,
             Self::ReactJsxNoConstructedContextValues(_) => ReactJsxNoConstructedContextValues::FIX,
             Self::ReactJsxNoDuplicateProps(_) => ReactJsxNoDuplicateProps::FIX,
+            Self::ReactJsxNoLeakedRender(_) => ReactJsxNoLeakedRender::FIX,
             Self::ReactJsxNoLiterals(_) => ReactJsxNoLiterals::FIX,
             Self::ReactJsxNoScriptUrl(_) => ReactJsxNoScriptUrl::FIX,
             Self::ReactJsxNoTargetBlank(_) => ReactJsxNoTargetBlank::FIX,
@@ -7159,6 +7166,7 @@ impl RuleEnum {
                 ReactJsxNoConstructedContextValues::documentation()
             }
             Self::ReactJsxNoDuplicateProps(_) => ReactJsxNoDuplicateProps::documentation(),
+            Self::ReactJsxNoLeakedRender(_) => ReactJsxNoLeakedRender::documentation(),
             Self::ReactJsxNoLiterals(_) => ReactJsxNoLiterals::documentation(),
             Self::ReactJsxNoScriptUrl(_) => ReactJsxNoScriptUrl::documentation(),
             Self::ReactJsxNoTargetBlank(_) => ReactJsxNoTargetBlank::documentation(),
@@ -8962,6 +8970,8 @@ impl RuleEnum {
             }
             Self::ReactJsxNoDuplicateProps(_) => ReactJsxNoDuplicateProps::config_schema(generator)
                 .or_else(|| ReactJsxNoDuplicateProps::schema(generator)),
+            Self::ReactJsxNoLeakedRender(_) => ReactJsxNoLeakedRender::config_schema(generator)
+                .or_else(|| ReactJsxNoLeakedRender::schema(generator)),
             Self::ReactJsxNoLiterals(_) => ReactJsxNoLiterals::config_schema(generator)
                 .or_else(|| ReactJsxNoLiterals::schema(generator)),
             Self::ReactJsxNoScriptUrl(_) => ReactJsxNoScriptUrl::config_schema(generator)
@@ -10629,6 +10639,7 @@ impl RuleEnum {
             Self::ReactJsxNoCommentTextnodes(_) => "react",
             Self::ReactJsxNoConstructedContextValues(_) => "react",
             Self::ReactJsxNoDuplicateProps(_) => "react",
+            Self::ReactJsxNoLeakedRender(_) => "react",
             Self::ReactJsxNoLiterals(_) => "react",
             Self::ReactJsxNoScriptUrl(_) => "react",
             Self::ReactJsxNoTargetBlank(_) => "react",
@@ -12383,6 +12394,9 @@ impl RuleEnum {
             Self::ReactJsxNoDuplicateProps(_) => Ok(Self::ReactJsxNoDuplicateProps(
                 ReactJsxNoDuplicateProps::from_configuration(value)?,
             )),
+            Self::ReactJsxNoLeakedRender(_) => {
+                Ok(Self::ReactJsxNoLeakedRender(ReactJsxNoLeakedRender::from_configuration(value)?))
+            }
             Self::ReactJsxNoLiterals(_) => {
                 Ok(Self::ReactJsxNoLiterals(ReactJsxNoLiterals::from_configuration(value)?))
             }
@@ -14190,6 +14204,7 @@ impl RuleEnum {
             Self::ReactJsxNoCommentTextnodes(rule) => rule.to_configuration(),
             Self::ReactJsxNoConstructedContextValues(rule) => rule.to_configuration(),
             Self::ReactJsxNoDuplicateProps(rule) => rule.to_configuration(),
+            Self::ReactJsxNoLeakedRender(rule) => rule.to_configuration(),
             Self::ReactJsxNoLiterals(rule) => rule.to_configuration(),
             Self::ReactJsxNoScriptUrl(rule) => rule.to_configuration(),
             Self::ReactJsxNoTargetBlank(rule) => rule.to_configuration(),
@@ -15038,6 +15053,7 @@ impl RuleEnum {
             Self::ReactJsxNoCommentTextnodes(rule) => rule.run(node, ctx),
             Self::ReactJsxNoConstructedContextValues(rule) => rule.run(node, ctx),
             Self::ReactJsxNoDuplicateProps(rule) => rule.run(node, ctx),
+            Self::ReactJsxNoLeakedRender(rule) => rule.run(node, ctx),
             Self::ReactJsxNoLiterals(rule) => rule.run(node, ctx),
             Self::ReactJsxNoScriptUrl(rule) => rule.run(node, ctx),
             Self::ReactJsxNoTargetBlank(rule) => rule.run(node, ctx),
@@ -15896,6 +15912,7 @@ impl RuleEnum {
             Self::ReactJsxNoCommentTextnodes(rule) => rule.run_once(ctx),
             Self::ReactJsxNoConstructedContextValues(rule) => rule.run_once(ctx),
             Self::ReactJsxNoDuplicateProps(rule) => rule.run_once(ctx),
+            Self::ReactJsxNoLeakedRender(rule) => rule.run_once(ctx),
             Self::ReactJsxNoLiterals(rule) => rule.run_once(ctx),
             Self::ReactJsxNoScriptUrl(rule) => rule.run_once(ctx),
             Self::ReactJsxNoTargetBlank(rule) => rule.run_once(ctx),
@@ -16825,6 +16842,7 @@ impl RuleEnum {
             Self::ReactJsxNoCommentTextnodes(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactJsxNoConstructedContextValues(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactJsxNoDuplicateProps(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::ReactJsxNoLeakedRender(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactJsxNoLiterals(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactJsxNoScriptUrl(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactJsxNoTargetBlank(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -17730,6 +17748,7 @@ impl RuleEnum {
             Self::ReactJsxNoCommentTextnodes(rule) => rule.should_run(ctx),
             Self::ReactJsxNoConstructedContextValues(rule) => rule.should_run(ctx),
             Self::ReactJsxNoDuplicateProps(rule) => rule.should_run(ctx),
+            Self::ReactJsxNoLeakedRender(rule) => rule.should_run(ctx),
             Self::ReactJsxNoLiterals(rule) => rule.should_run(ctx),
             Self::ReactJsxNoScriptUrl(rule) => rule.should_run(ctx),
             Self::ReactJsxNoTargetBlank(rule) => rule.should_run(ctx),
@@ -18751,6 +18770,7 @@ impl RuleEnum {
                 ReactJsxNoConstructedContextValues::IS_TSGOLINT_RULE
             }
             Self::ReactJsxNoDuplicateProps(_) => ReactJsxNoDuplicateProps::IS_TSGOLINT_RULE,
+            Self::ReactJsxNoLeakedRender(_) => ReactJsxNoLeakedRender::IS_TSGOLINT_RULE,
             Self::ReactJsxNoLiterals(_) => ReactJsxNoLiterals::IS_TSGOLINT_RULE,
             Self::ReactJsxNoScriptUrl(_) => ReactJsxNoScriptUrl::IS_TSGOLINT_RULE,
             Self::ReactJsxNoTargetBlank(_) => ReactJsxNoTargetBlank::IS_TSGOLINT_RULE,
@@ -19894,6 +19914,7 @@ impl RuleEnum {
                 ReactJsxNoConstructedContextValues::VERSION
             }
             Self::ReactJsxNoDuplicateProps(_) => ReactJsxNoDuplicateProps::VERSION,
+            Self::ReactJsxNoLeakedRender(_) => ReactJsxNoLeakedRender::VERSION,
             Self::ReactJsxNoLiterals(_) => ReactJsxNoLiterals::VERSION,
             Self::ReactJsxNoScriptUrl(_) => ReactJsxNoScriptUrl::VERSION,
             Self::ReactJsxNoTargetBlank(_) => ReactJsxNoTargetBlank::VERSION,
@@ -20928,6 +20949,7 @@ impl RuleEnum {
                 ReactJsxNoConstructedContextValues::HAS_CONFIG
             }
             Self::ReactJsxNoDuplicateProps(_) => ReactJsxNoDuplicateProps::HAS_CONFIG,
+            Self::ReactJsxNoLeakedRender(_) => ReactJsxNoLeakedRender::HAS_CONFIG,
             Self::ReactJsxNoLiterals(_) => ReactJsxNoLiterals::HAS_CONFIG,
             Self::ReactJsxNoScriptUrl(_) => ReactJsxNoScriptUrl::HAS_CONFIG,
             Self::ReactJsxNoTargetBlank(_) => ReactJsxNoTargetBlank::HAS_CONFIG,
@@ -21943,6 +21965,7 @@ impl RuleEnum {
             Self::ReactJsxNoCommentTextnodes(_) => ReactJsxNoCommentTextnodes::INFO,
             Self::ReactJsxNoConstructedContextValues(_) => ReactJsxNoConstructedContextValues::INFO,
             Self::ReactJsxNoDuplicateProps(_) => ReactJsxNoDuplicateProps::INFO,
+            Self::ReactJsxNoLeakedRender(_) => ReactJsxNoLeakedRender::INFO,
             Self::ReactJsxNoLiterals(_) => ReactJsxNoLiterals::INFO,
             Self::ReactJsxNoScriptUrl(_) => ReactJsxNoScriptUrl::INFO,
             Self::ReactJsxNoTargetBlank(_) => ReactJsxNoTargetBlank::INFO,
@@ -22839,6 +22862,7 @@ impl RuleEnum {
             Self::ReactJsxNoCommentTextnodes(rule) => rule.types_info(),
             Self::ReactJsxNoConstructedContextValues(rule) => rule.types_info(),
             Self::ReactJsxNoDuplicateProps(rule) => rule.types_info(),
+            Self::ReactJsxNoLeakedRender(rule) => rule.types_info(),
             Self::ReactJsxNoLiterals(rule) => rule.types_info(),
             Self::ReactJsxNoScriptUrl(rule) => rule.types_info(),
             Self::ReactJsxNoTargetBlank(rule) => rule.types_info(),
@@ -23684,6 +23708,7 @@ impl RuleEnum {
             Self::ReactJsxNoCommentTextnodes(rule) => rule.run_info(),
             Self::ReactJsxNoConstructedContextValues(rule) => rule.run_info(),
             Self::ReactJsxNoDuplicateProps(rule) => rule.run_info(),
+            Self::ReactJsxNoLeakedRender(rule) => rule.run_info(),
             Self::ReactJsxNoLiterals(rule) => rule.run_info(),
             Self::ReactJsxNoScriptUrl(rule) => rule.run_info(),
             Self::ReactJsxNoTargetBlank(rule) => rule.run_info(),
@@ -24619,6 +24644,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::ReactJsxNoCommentTextnodes(ReactJsxNoCommentTextnodes::default()),
         RuleEnum::ReactJsxNoConstructedContextValues(ReactJsxNoConstructedContextValues::default()),
         RuleEnum::ReactJsxNoDuplicateProps(ReactJsxNoDuplicateProps::default()),
+        RuleEnum::ReactJsxNoLeakedRender(ReactJsxNoLeakedRender::default()),
         RuleEnum::ReactJsxNoLiterals(ReactJsxNoLiterals::default()),
         RuleEnum::ReactJsxNoScriptUrl(ReactJsxNoScriptUrl::default()),
         RuleEnum::ReactJsxNoTargetBlank(ReactJsxNoTargetBlank::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -429,6 +429,7 @@ pub(crate) mod react {
     pub mod jsx_no_comment_textnodes;
     pub mod jsx_no_constructed_context_values;
     pub mod jsx_no_duplicate_props;
+    pub mod jsx_no_leaked_render;
     pub mod jsx_no_literals;
     pub mod jsx_no_script_url;
     pub mod jsx_no_target_blank;

--- a/crates/oxc_linter/src/rules/react/jsx_no_leaked_render.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_leaked_render.rs
@@ -1,0 +1,992 @@
+use std::borrow::Cow;
+
+use oxc_ast::{
+    AstKind,
+    ast::{ConditionalExpression, Expression, LogicalExpression},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+use oxc_syntax::operator::{LogicalOperator, UnaryOperator};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
+
+use crate::{
+    AstNode,
+    context::{ContextHost, LintContext},
+    rule::{DefaultRuleConfig, Rule},
+};
+
+/// Operands of an `&&` chain. Real-world JSX chains are nearly always 2–4
+/// operands, so this stays on the stack in the common case.
+type ChainOperands<'a, 'b> = SmallVec<[&'b Expression<'a>; 4]>;
+
+fn jsx_no_leaked_render_diagnostic(span: Span, help: &'static str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(
+        "Potential leaked value that might cause unintentionally rendered values or rendering crashes",
+    )
+    .with_help(help)
+    .with_label(span)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+struct JsxNoLeakedRenderConfig {
+    /// Strategies the user accepts for guarding JSX expressions. The first entry
+    /// determines the preferred fix when both strategies are valid.
+    valid_strategies: Vec<ValidStrategies>,
+    /// Skip JSX attribute values (children of nested JSX inside attributes are
+    /// still linted because each `JSXExpressionContainer` is its own node).
+    ignore_attributes: bool,
+}
+
+impl Default for JsxNoLeakedRenderConfig {
+    fn default() -> Self {
+        Self {
+            valid_strategies: vec![ValidStrategies::Ternary, ValidStrategies::Coerce],
+            ignore_attributes: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+enum ValidStrategies {
+    Coerce,
+    Ternary,
+}
+
+#[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct JsxNoLeakedRender(Box<JsxNoLeakedRenderConfig>);
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallow problematic leaked values from being rendered in JSX.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Using the `&&` short-circuit operator in JSX can render unintended values
+    /// such as `0`, `''`, or `NaN` directly into the DOM. In React Native this
+    /// can crash the application. Conditionally render with a ternary returning
+    /// `null` (`{x ? <Y/> : null}`) or coerce the gate to a boolean (`{!!x && <Y/>}`).
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```jsx
+    /// <div>{count && <Results/>}</div>
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    /// <div>{count ? <Results/> : null}</div>
+    /// <div>{!!count && <Results/>}</div>
+    /// ```
+    JsxNoLeakedRender,
+    react,
+    pedantic,
+    fix,
+    config = JsxNoLeakedRender,
+    version = "next",
+);
+
+impl Rule for JsxNoLeakedRender {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::JSXExpressionContainer(container) = node.kind() else { return };
+
+        let Some(expr) = container.expression.as_expression() else { return };
+
+        if self.0.ignore_attributes
+            && matches!(ctx.nodes().parent_kind(node.id()), AstKind::JSXAttribute(_))
+        {
+            return;
+        }
+
+        let strategies = &self.0.valid_strategies;
+        let allow_coerce = strategies.contains(&ValidStrategies::Coerce);
+        let allow_ternary = strategies.contains(&ValidStrategies::Ternary);
+        // The first strategy listed determines which fix shape we emit.
+        let prefer_coerce = strategies.first().copied() == Some(ValidStrategies::Coerce);
+
+        match expr.get_inner_expression() {
+            Expression::LogicalExpression(logical) if logical.operator == LogicalOperator::And => {
+                // React 18+ no longer renders empty strings as text, so an `'' && X`
+                // gate is harmless and is not reported under React 18+.
+                if let Expression::StringLiteral(s) = logical.left.get_inner_expression()
+                    && s.value.as_str().is_empty()
+                    && ctx.settings().react.version.is_some_and(|v| v.major() >= 18)
+                {
+                    return;
+                }
+
+                // When `coerce` is not in the user's strategies, every `&&` is a violation.
+                // Otherwise, only chains with a leakable non-final gate are violations.
+                if allow_coerce && !chain_has_leakable_gate(logical) {
+                    return;
+                }
+
+                let target_span = logical.span;
+                let (help, replacement) = if prefer_coerce {
+                    (
+                        "Coerce the gate of `&&` to a boolean using `!!`",
+                        build_coerce_from_logical(logical, ctx),
+                    )
+                } else {
+                    (
+                        "Use a ternary expression returning `null` instead of `&&`",
+                        build_ternary_from_logical(logical, ctx),
+                    )
+                };
+
+                ctx.diagnostic_with_fix(
+                    jsx_no_leaked_render_diagnostic(target_span, help),
+                    |fixer| fixer.replace(target_span, replacement),
+                );
+            }
+            Expression::ConditionalExpression(cond)
+                if allow_coerce && !allow_ternary && conditional_is_violation(cond) =>
+            {
+                let target_span = cond.span;
+                let replacement = build_coerce_from_conditional(cond, ctx);
+                ctx.diagnostic_with_fix(
+                    jsx_no_leaked_render_diagnostic(
+                        target_span,
+                        "Coerce the condition to a boolean using `!!` instead of a ternary",
+                    ),
+                    |fixer| fixer.replace(target_span, replacement),
+                );
+            }
+            _ => {}
+        }
+    }
+
+    fn should_run(&self, ctx: &ContextHost) -> bool {
+        ctx.source_type().is_jsx()
+    }
+}
+
+/// An expression is "safe" (its result is a definite boolean) if it is `!x`/`!!x`,
+/// a comparison/equality, or a boolean literal. Such operands do not need `!!` coercion.
+fn is_safe_boolean(expr: &Expression<'_>) -> bool {
+    match expr.get_inner_expression() {
+        Expression::UnaryExpression(u) => u.operator == UnaryOperator::LogicalNot,
+        Expression::BinaryExpression(b) => b.operator.is_compare() || b.operator.is_equality(),
+        Expression::BooleanLiteral(_) => true,
+        _ => false,
+    }
+}
+
+/// Collect the operands of an `&&` chain in source order. `a && b && c` parses
+/// as `(a && b) && c`, a left-leaning spine, so we descend into each node's
+/// `.left` while it is itself an `&&`, pushing the `.right` operands as we go and
+/// the innermost `.left` last, then reverse to get `[a, b, c]`. `get_inner_expression()`
+/// lets us flatten through parenthesized and TypeScript-wrapped `&&` nodes.
+///
+/// Kept iterative on purpose: a pathologically deep chain would overflow the
+/// stack under recursion, so we walk the spine with an explicit loop instead.
+fn collect_and_chain<'a, 'b>(logical: &'b LogicalExpression<'a>) -> ChainOperands<'a, 'b> {
+    let mut operands = ChainOperands::new();
+    let mut current = logical;
+    loop {
+        operands.push(&current.right);
+        match current.left.get_inner_expression() {
+            Expression::LogicalExpression(inner) if inner.operator == LogicalOperator::And => {
+                current = inner;
+            }
+            _ => {
+                operands.push(&current.left);
+                break;
+            }
+        }
+    }
+    operands.reverse();
+    operands
+}
+
+/// Returns true if the `&&` chain has at least one non-final gate that is leakable.
+/// The last operand is the rendered value, not a gate, so it is excluded.
+fn chain_has_leakable_gate(logical: &LogicalExpression<'_>) -> bool {
+    let operands = collect_and_chain(logical);
+    operands.split_last().is_some_and(|(_, gates)| gates.iter().any(|op| !is_safe_boolean(op)))
+}
+
+/// Render an `&&` chain coerce-form into `out`. When `coerce_last` is false, the
+/// final operand (the rendered value) is emitted verbatim — the typical `<chain> &&
+/// <rendered>` violation. When true, every operand is treated as a gate — used when
+/// the chain is the test of a ternary that we are rewriting.
+fn write_coerced_chain<'a>(
+    operands: &[&Expression<'a>],
+    ctx: &LintContext<'a>,
+    coerce_last: bool,
+    out: &mut String,
+) {
+    let last_idx = operands.len() - 1;
+    for (i, op) in operands.iter().enumerate() {
+        if i > 0 {
+            out.push_str(" && ");
+        }
+        let is_gate = coerce_last || i != last_idx;
+        if is_gate && !is_safe_boolean(op) {
+            out.push_str("!!");
+        }
+        out.push_str(ctx.source_range(op.span()));
+    }
+}
+
+/// Pre-size a fix-output buffer with room for the rewritten chain plus a small
+/// allowance for `!!` and ` && ` insertions.
+fn fix_buffer_for(span: Span, operand_count: usize) -> String {
+    String::with_capacity(span.size() as usize + operand_count * 4)
+}
+
+/// Build the coerce-form replacement for an `&&` chain expression: wrap each
+/// non-final leakable operand with `!!`, leave safe operands and the final
+/// (rendered) operand untouched.
+fn build_coerce_from_logical<'a>(logical: &LogicalExpression<'a>, ctx: &LintContext<'a>) -> String {
+    let operands = collect_and_chain(logical);
+    let mut out = fix_buffer_for(logical.span, operands.len());
+    write_coerced_chain(&operands, ctx, false, &mut out);
+    out
+}
+
+/// Build the ternary-form replacement for an `&&` chain expression. Splits the
+/// chain at the rightmost `&&` into `<test_chain> ? <rendered> : null`. If the
+/// test chain is `!!(x)`, strip the redundant `!!`.
+fn build_ternary_from_logical<'a>(
+    logical: &LogicalExpression<'a>,
+    ctx: &LintContext<'a>,
+) -> String {
+    let rendered = ctx.source_range(logical.right.span());
+    let test_text = ternary_test_text(&logical.left, ctx);
+    let mut out = fix_buffer_for(logical.span, 2);
+    out.push_str(&test_text);
+    out.push_str(" ? ");
+    out.push_str(rendered);
+    out.push_str(" : null");
+    out
+}
+
+/// Render the `test` part of a ternary fix. Strips a redundant outer `!!` and any
+/// surrounding parentheses left behind by stripping it. Returns borrowed source
+/// text in the common case; only allocates when stripping `!!`.
+fn ternary_test_text<'a>(test: &Expression<'a>, ctx: &LintContext<'a>) -> Cow<'a, str> {
+    if let Expression::UnaryExpression(outer) = test.without_parentheses()
+        && outer.operator == UnaryOperator::LogicalNot
+        && let Expression::UnaryExpression(inner) = outer.argument.without_parentheses()
+        && inner.operator == UnaryOperator::LogicalNot
+    {
+        let stripped = inner.argument.without_parentheses();
+        return Cow::Borrowed(ctx.source_range(stripped.span()));
+    }
+    Cow::Borrowed(ctx.source_range(test.span()))
+}
+
+/// Returns true when a `ConditionalExpression` inside a JSX expression container
+/// should be flagged under `coerce`-only strategy. Three cases:
+/// - `cond ? cons : null` (alternate is `null`)
+/// - `cond ? false : alt` (consequent is the literal `false`)
+/// - `<&&-chain> ? cons : alt` whose test has a leakable gate
+fn conditional_is_violation(cond: &ConditionalExpression<'_>) -> bool {
+    if matches!(&cond.alternate, Expression::NullLiteral(_)) {
+        return true;
+    }
+    if let Expression::BooleanLiteral(b) = &cond.consequent
+        && !b.value
+    {
+        return true;
+    }
+    if let Expression::LogicalExpression(logical) = cond.test.get_inner_expression()
+        && logical.operator == LogicalOperator::And
+        && chain_has_leakable_gate(logical)
+    {
+        return true;
+    }
+    false
+}
+
+/// Build the coerce-form replacement for a `ConditionalExpression` violation.
+/// - `cond ? cons : null`: `<maybe-coerced cond> && <cons>`.
+/// - `cond ? false : alt`: `!(<cond>) && <alt>` (parenthesizing the test to make
+///   `!` bind correctly when `cond` is non-trivial).
+/// - `<&&-chain> ? cons : alt`: rewrite test with each leakable gate coerced,
+///   keeping the `? cons : alt` shape.
+fn build_coerce_from_conditional<'a>(
+    cond: &ConditionalExpression<'a>,
+    ctx: &LintContext<'a>,
+) -> String {
+    // Case: alternate is `null` — collapse to `<coerced test> && <cons>`.
+    if matches!(&cond.alternate, Expression::NullLiteral(_)) {
+        return collapse_to_coerced_and(&cond.test, &cond.consequent, cond.span, ctx);
+    }
+    // Case: consequent is `false` — collapse to `!(<test>) && <alt>`.
+    if let Expression::BooleanLiteral(b) = &cond.consequent
+        && !b.value
+    {
+        let test_text = ctx.source_range(cond.test.span());
+        let alternate_text = ctx.source_range(cond.alternate.span());
+        let mut out = fix_buffer_for(cond.span, 2);
+        out.push('!');
+        out.push('(');
+        out.push_str(test_text);
+        out.push_str(") && ");
+        out.push_str(alternate_text);
+        return out;
+    }
+    // Case: test is an `&&` chain with leakable gates — rewrite test only.
+    if let Expression::LogicalExpression(logical) = cond.test.get_inner_expression()
+        && logical.operator == LogicalOperator::And
+    {
+        let operands = collect_and_chain(logical);
+        let consequent_text = ctx.source_range(cond.consequent.span());
+        let alternate_text = ctx.source_range(cond.alternate.span());
+        let mut out = fix_buffer_for(cond.span, operands.len() + 2);
+        write_coerced_chain(&operands, ctx, true, &mut out);
+        out.push_str(" ? ");
+        out.push_str(consequent_text);
+        out.push_str(" : ");
+        out.push_str(alternate_text);
+        return out;
+    }
+    // Fallback (shouldn't happen given `conditional_is_violation` filter): leave unchanged.
+    ctx.source_range(cond.span).to_owned()
+}
+
+/// Helper for the `cond ? cons : null` collapse case.
+fn collapse_to_coerced_and<'a>(
+    test: &Expression<'a>,
+    consequent: &Expression<'a>,
+    span: Span,
+    ctx: &LintContext<'a>,
+) -> String {
+    let consequent_text = ctx.source_range(consequent.span());
+    if let Expression::LogicalExpression(logical) = test.get_inner_expression()
+        && logical.operator == LogicalOperator::And
+    {
+        let operands = collect_and_chain(logical);
+        let mut out = fix_buffer_for(span, operands.len() + 1);
+        write_coerced_chain(&operands, ctx, true, &mut out);
+        out.push_str(" && ");
+        out.push_str(consequent_text);
+        return out;
+    }
+    let test_text = ctx.source_range(test.span());
+    let mut out = fix_buffer_for(span, 2);
+    if !is_safe_boolean(test) {
+        out.push_str("!!");
+    }
+    out.push_str(test_text);
+    out.push_str(" && ");
+    out.push_str(consequent_text);
+    out
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![];
+
+    let fail = vec![
+        ("
+                    const Example = () => {
+                      return (
+                        <>
+                          {0 && <Something/>}
+                          {'' && <Something/>}
+                          {NaN && <Something/>}
+                        </>
+                      )
+                    }
+                  ", None, Some(serde_json::json!({ "settings": { "react": { "version": "17.999.999" } } }))),
+        ("
+                    const Example = () => {
+                      return (
+                        <>
+                          {0 && <Something/>}
+                          {'' && <Something/>}
+                          {NaN && <Something/>}
+                        </>
+                      )
+                    }
+                  ", None, Some(serde_json::json!({ "settings": { "react": { "version": "18.0.0" } } }))),
+        ("
+                    const Component = ({ count, title }) => {
+                      return <div>{count && title}</div>
+                    }
+                  ", None, None),
+        ("
+                    const Component = ({ count }) => {
+                      return <div>{count && <span>There are {count} results</span>}</div>
+                    }
+                  ", None, None),
+        ("
+                    const Component = ({ elements }) => {
+                      return <div>{elements.length && <List elements={elements}/>}</div>
+                    }
+                  ", None, None),
+        ("
+                    const Component = ({ nestedCollection }) => {
+                      return <div>{nestedCollection.elements.length && <List elements={nestedCollection.elements}/>}</div>
+                    }
+                  ", None, None),
+        ("
+                    const Component = ({ elements }) => {
+                      return <div>{elements[0] && <List elements={elements}/>}</div>
+                    }
+                  ", None, None),
+        ("
+                    const Component = ({ numberA, numberB }) => {
+                      return <div>{(numberA || numberB) && <Results>{numberA+numberB}</Results>}</div>
+                    }
+                  ", None, None),
+        ("
+                    const Component = ({ numberA, numberB }) => {
+                      return <div>{(numberA || numberB) && <Results>{numberA+numberB}</Results>}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["coerce", "ternary"] }])), None),
+        ("
+                    const Component = ({ count, title }) => {
+                      return <div>{count && title}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["ternary"] }])), None),
+        ("
+                    const Component = ({ count }) => {
+                      return <div>{count && <span>There are {count} results</span>}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["ternary"] }])), None),
+        ("
+                    const Component = ({ elements }) => {
+                      return <div>{elements.length && <List elements={elements}/>}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["ternary"] }])), None),
+        ("
+                    const Component = ({ nestedCollection }) => {
+                      return <div>{nestedCollection.elements.length && <List elements={nestedCollection.elements}/>}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["ternary"] }])), None),
+        ("
+                    const Component = ({ elements }) => {
+                      return <div>{elements[0] && <List elements={elements}/>}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["ternary"] }])), None),
+        ("
+                    const Component = ({ numberA, numberB }) => {
+                      return <div>{(numberA || numberB) && <Results>{numberA+numberB}</Results>}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["ternary"] }])), None),
+        ("
+                    const Component = ({ someCondition, title }) => {
+                      return <div>{!someCondition && title}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["ternary"] }])), None),
+        ("
+                    const Component = ({ count, title }) => {
+                      return <div>{!!count && title}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["ternary"] }])), None),
+        ("
+                    const Component = ({ count, title }) => {
+                      return <div>{count > 0 && title}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["ternary"] }])), None),
+        ("
+                    const Component = ({ count, title }) => {
+                      return <div>{0 != count && title}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["ternary"] }])), None),
+        ("
+                    const Component = ({ count, total, title }) => {
+                      return <div>{count < total && title}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["ternary"] }])), None),
+        ("
+                    const Component = ({ count, title, somethingElse }) => {
+                      return <div>{!!(count && somethingElse) && title}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["ternary"] }])), None),
+        ("
+                    const Component = ({ count, title }) => {
+                      return <div>{count && title}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["coerce"] }])), None),
+        ("
+                    const Component = ({ count }) => {
+                      return <div>{count && <span>There are {count} results</span>}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["coerce"] }])), None),
+        ("
+                    const Component = ({ elements }) => {
+                      return <div>{elements.length && <List elements={elements}/>}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["coerce"] }])), None),
+        ("
+                    const Component = ({ nestedCollection }) => {
+                      return <div>{nestedCollection.elements.length && <List elements={nestedCollection.elements}/>}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["coerce"] }])), None),
+        ("
+                    const Component = ({ elements }) => {
+                      return <div>{elements[0] && <List elements={elements}/>}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["coerce"] }])), None),
+        ("
+                    const Component = ({ numberA, numberB }) => {
+                      return <div>{(numberA || numberB) && <Results>{numberA+numberB}</Results>}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["coerce"] }])), None),
+        ("
+                    const Component = ({ connection, hasError, hasErrorUpdate}) => {
+                      return <div>{connection && (hasError || hasErrorUpdate)}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["coerce"] }])), None),
+        ("
+                    const Component = ({ count, title }) => {
+                      return <div>{count ? title : null}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["coerce"] }])), None),
+        ("
+                    const Component = ({ count, title }) => {
+                      return <div>{!count ? title : null}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["coerce"] }])), None),
+        ("
+                    const Component = ({ count, somethingElse, title }) => {
+                      return <div>{count && somethingElse ? title : null}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["coerce"] }])), None),
+        ("
+                    const Component = ({ items, somethingElse, title }) => {
+                      return <div>{items.length > 0 && somethingElse && title}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["coerce"] }])), None),
+        ("
+                    const MyComponent = () => {
+                      const items = []
+                      const breakpoint = { phones: true }
+
+                      return <div>{items.length > 0 && breakpoint.phones && <span />}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["coerce", "ternary"] }])), None),
+        ("
+                    const MyComponent = () => {
+                      return <div>{maybeObject && (isFoo ? <Aaa /> : <Bbb />)}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["coerce"] }])), None),
+        ("
+                    const Component = ({ enabled, checked }) => {
+                      return <CheckBox checked={enabled && checked} />
+                    }
+                  ", None, None),
+        ("
+                    const MyComponent = () => {
+                      return <Something checked={isIndeterminate ? false : isChecked} />
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["coerce"] }])), None),
+        ("
+                    const MyComponent = () => {
+                      return <Something checked={cond && isIndeterminate ? false : isChecked} />
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["coerce"] }])), None),
+        ("
+                    const isOpen = 0;
+                    const Component = () => {
+                      return <Popover open={isOpen && items.length > 0} />
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["coerce"] }])), None),
+        ("
+                    const Component = ({ enabled }) => {
+                      return (
+                        <Foo bar={
+                          <Something>{enabled && <MuchWow />}</Something>
+                        } />
+                      )
+                    }
+                  ", Some(serde_json::json!([{ "ignoreAttributes": true }])), None)
+    ];
+
+    let fix = vec![
+        ("
+                    const Example = () => {
+                      return (
+                        <>
+                          {0 && <Something/>}
+                          {'' && <Something/>}
+                          {NaN && <Something/>}
+                        </>
+                      )
+                    }
+                  ", "
+                    const Example = () => {
+                      return (
+                        <>
+                          {0 ? <Something/> : null}
+                          {'' ? <Something/> : null}
+                          {NaN ? <Something/> : null}
+                        </>
+                      )
+                    }
+                  ", None, Some(serde_json::json!({ "settings": { "react": { "version": "17.999.999" } } }))),
+        ("
+                    const Example = () => {
+                      return (
+                        <>
+                          {0 && <Something/>}
+                          {'' && <Something/>}
+                          {NaN && <Something/>}
+                        </>
+                      )
+                    }
+                  ", "
+                    const Example = () => {
+                      return (
+                        <>
+                          {0 ? <Something/> : null}
+                          {'' && <Something/>}
+                          {NaN ? <Something/> : null}
+                        </>
+                      )
+                    }
+                  ", None, Some(serde_json::json!({ "settings": { "react": { "version": "18.0.0" } } }))),
+        ("
+                    const Component = ({ count, title }) => {
+                      return <div>{count && title}</div>
+                    }
+                  ", "
+                    const Component = ({ count, title }) => {
+                      return <div>{count ? title : null}</div>
+                    }
+                  ", None, None),
+        ("
+                    const Component = ({ count }) => {
+                      return <div>{count && <span>There are {count} results</span>}</div>
+                    }
+                  ", "
+                    const Component = ({ count }) => {
+                      return <div>{count ? <span>There are {count} results</span> : null}</div>
+                    }
+                  ", None, None),
+    ("
+                    const Component = ({ elements }) => {
+                      return <div>{elements.length && <List elements={elements}/>}</div>
+                    }
+                  ", "
+                    const Component = ({ elements }) => {
+                      return <div>{elements.length ? <List elements={elements}/> : null}</div>
+                    }
+                  ", None, None),
+    ("
+                    const Component = ({ nestedCollection }) => {
+                      return <div>{nestedCollection.elements.length && <List elements={nestedCollection.elements}/>}</div>
+                    }
+                  ", "
+                    const Component = ({ nestedCollection }) => {
+                      return <div>{nestedCollection.elements.length ? <List elements={nestedCollection.elements}/> : null}</div>
+                    }
+                  ", None, None),
+    ("
+                    const Component = ({ elements }) => {
+                      return <div>{elements[0] && <List elements={elements}/>}</div>
+                    }
+                  ", "
+                    const Component = ({ elements }) => {
+                      return <div>{elements[0] ? <List elements={elements}/> : null}</div>
+                    }
+                  ", None, None),
+    ("
+                    const Component = ({ numberA, numberB }) => {
+                      return <div>{(numberA || numberB) && <Results>{numberA+numberB}</Results>}</div>
+                    }
+                  ", "
+                    const Component = ({ numberA, numberB }) => {
+                      return <div>{(numberA || numberB) ? <Results>{numberA+numberB}</Results> : null}</div>
+                    }
+                  ", None, None),
+    ("
+                    const Component = ({ numberA, numberB }) => {
+                      return <div>{(numberA || numberB) && <Results>{numberA+numberB}</Results>}</div>
+                    }
+                  ", "
+                    const Component = ({ numberA, numberB }) => {
+                      return <div>{!!(numberA || numberB) && <Results>{numberA+numberB}</Results>}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["coerce", "ternary"] }])), None),
+    ("
+                    const Component = ({ count, title }) => {
+                      return <div>{count && title}</div>
+                    }
+                  ", "
+                    const Component = ({ count, title }) => {
+                      return <div>{count ? title : null}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["ternary"] }])), None),
+    ("
+                    const Component = ({ count }) => {
+                      return <div>{count && <span>There are {count} results</span>}</div>
+                    }
+                  ", "
+                    const Component = ({ count }) => {
+                      return <div>{count ? <span>There are {count} results</span> : null}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["ternary"] }])), None),
+    ("
+                    const Component = ({ elements }) => {
+                      return <div>{elements.length && <List elements={elements}/>}</div>
+                    }
+                  ", "
+                    const Component = ({ elements }) => {
+                      return <div>{elements.length ? <List elements={elements}/> : null}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["ternary"] }])), None),
+    ("
+                    const Component = ({ nestedCollection }) => {
+                      return <div>{nestedCollection.elements.length && <List elements={nestedCollection.elements}/>}</div>
+                    }
+                  ", "
+                    const Component = ({ nestedCollection }) => {
+                      return <div>{nestedCollection.elements.length ? <List elements={nestedCollection.elements}/> : null}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["ternary"] }])), None),
+    ("
+                    const Component = ({ elements }) => {
+                      return <div>{elements[0] && <List elements={elements}/>}</div>
+                    }
+                  ", "
+                    const Component = ({ elements }) => {
+                      return <div>{elements[0] ? <List elements={elements}/> : null}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["ternary"] }])), None),
+    ("
+                    const Component = ({ numberA, numberB }) => {
+                      return <div>{(numberA || numberB) && <Results>{numberA+numberB}</Results>}</div>
+                    }
+                  ", "
+                    const Component = ({ numberA, numberB }) => {
+                      return <div>{(numberA || numberB) ? <Results>{numberA+numberB}</Results> : null}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["ternary"] }])), None),
+    ("
+                    const Component = ({ someCondition, title }) => {
+                      return <div>{!someCondition && title}</div>
+                    }
+                  ", "
+                    const Component = ({ someCondition, title }) => {
+                      return <div>{!someCondition ? title : null}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["ternary"] }])), None),
+    ("
+                    const Component = ({ count, title }) => {
+                      return <div>{!!count && title}</div>
+                    }
+                  ", "
+                    const Component = ({ count, title }) => {
+                      return <div>{count ? title : null}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["ternary"] }])), None),
+    ("
+                    const Component = ({ count, title }) => {
+                      return <div>{count > 0 && title}</div>
+                    }
+                  ", "
+                    const Component = ({ count, title }) => {
+                      return <div>{count > 0 ? title : null}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["ternary"] }])), None),
+    ("
+                    const Component = ({ count, title }) => {
+                      return <div>{0 != count && title}</div>
+                    }
+                  ", "
+                    const Component = ({ count, title }) => {
+                      return <div>{0 != count ? title : null}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["ternary"] }])), None),
+    ("
+                    const Component = ({ count, total, title }) => {
+                      return <div>{count < total && title}</div>
+                    }
+                  ", "
+                    const Component = ({ count, total, title }) => {
+                      return <div>{count < total ? title : null}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["ternary"] }])), None),
+    ("
+                    const Component = ({ count, title, somethingElse }) => {
+                      return <div>{!!(count && somethingElse) && title}</div>
+                    }
+                  ", "
+                    const Component = ({ count, title, somethingElse }) => {
+                      return <div>{count && somethingElse ? title : null}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["ternary"] }])), None),
+    ("
+                    const Component = ({ count, title }) => {
+                      return <div>{count && title}</div>
+                    }
+                  ", "
+                    const Component = ({ count, title }) => {
+                      return <div>{!!count && title}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["coerce"] }])), None),
+    ("
+                    const Component = ({ count }) => {
+                      return <div>{count && <span>There are {count} results</span>}</div>
+                    }
+                  ", "
+                    const Component = ({ count }) => {
+                      return <div>{!!count && <span>There are {count} results</span>}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["coerce"] }])), None),
+    ("
+                    const Component = ({ elements }) => {
+                      return <div>{elements.length && <List elements={elements}/>}</div>
+                    }
+                  ", "
+                    const Component = ({ elements }) => {
+                      return <div>{!!elements.length && <List elements={elements}/>}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["coerce"] }])), None),
+    ("
+                    const Component = ({ nestedCollection }) => {
+                      return <div>{nestedCollection.elements.length && <List elements={nestedCollection.elements}/>}</div>
+                    }
+                  ", "
+                    const Component = ({ nestedCollection }) => {
+                      return <div>{!!nestedCollection.elements.length && <List elements={nestedCollection.elements}/>}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["coerce"] }])), None),
+    ("
+                    const Component = ({ elements }) => {
+                      return <div>{elements[0] && <List elements={elements}/>}</div>
+                    }
+                  ", "
+                    const Component = ({ elements }) => {
+                      return <div>{!!elements[0] && <List elements={elements}/>}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["coerce"] }])), None),
+    ("
+                    const Component = ({ numberA, numberB }) => {
+                      return <div>{(numberA || numberB) && <Results>{numberA+numberB}</Results>}</div>
+                    }
+                  ", "
+                    const Component = ({ numberA, numberB }) => {
+                      return <div>{!!(numberA || numberB) && <Results>{numberA+numberB}</Results>}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["coerce"] }])), None),
+    ("
+                    const Component = ({ connection, hasError, hasErrorUpdate}) => {
+                      return <div>{connection && (hasError || hasErrorUpdate)}</div>
+                    }
+                  ", "
+                    const Component = ({ connection, hasError, hasErrorUpdate}) => {
+                      return <div>{!!connection && (hasError || hasErrorUpdate)}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["coerce"] }])), None),
+    ("
+                    const Component = ({ count, title }) => {
+                      return <div>{count ? title : null}</div>
+                    }
+                  ", "
+                    const Component = ({ count, title }) => {
+                      return <div>{!!count && title}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["coerce"] }])), None),
+    ("
+                    const Component = ({ count, title }) => {
+                      return <div>{!count ? title : null}</div>
+                    }
+                  ", "
+                    const Component = ({ count, title }) => {
+                      return <div>{!count && title}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["coerce"] }])), None),
+    ("
+                    const Component = ({ count, somethingElse, title }) => {
+                      return <div>{count && somethingElse ? title : null}</div>
+                    }
+                  ", "
+                    const Component = ({ count, somethingElse, title }) => {
+                      return <div>{!!count && !!somethingElse && title}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["coerce"] }])), None),
+    ("
+                    const Component = ({ items, somethingElse, title }) => {
+                      return <div>{items.length > 0 && somethingElse && title}</div>
+                    }
+                  ", "
+                    const Component = ({ items, somethingElse, title }) => {
+                      return <div>{items.length > 0 && !!somethingElse && title}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["coerce"] }])), None),
+    ("
+                    const MyComponent = () => {
+                      const items = []
+                      const breakpoint = { phones: true }
+
+                      return <div>{items.length > 0 && breakpoint.phones && <span />}</div>
+                    }
+                  ", "
+                    const MyComponent = () => {
+                      const items = []
+                      const breakpoint = { phones: true }
+
+                      return <div>{items.length > 0 && !!breakpoint.phones && <span />}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["coerce", "ternary"] }])), None),
+    ("
+                    const MyComponent = () => {
+                      return <div>{maybeObject && (isFoo ? <Aaa /> : <Bbb />)}</div>
+                    }
+                  ", "
+                    const MyComponent = () => {
+                      return <div>{!!maybeObject && (isFoo ? <Aaa /> : <Bbb />)}</div>
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["coerce"] }])), None),
+    ("
+                    const Component = ({ enabled, checked }) => {
+                      return <CheckBox checked={enabled && checked} />
+                    }
+                  ", "
+                    const Component = ({ enabled, checked }) => {
+                      return <CheckBox checked={enabled ? checked : null} />
+                    }
+                  ", None, None),
+    ("
+                    const isOpen = 0;
+                    const Component = () => {
+                      return <Popover open={isOpen && items.length > 0} />
+                    }
+                  ", "
+                    const isOpen = 0;
+                    const Component = () => {
+                      return <Popover open={!!isOpen && items.length > 0} />
+                    }
+                  ", Some(serde_json::json!([{ "validStrategies": ["coerce"] }])), None),
+    ("
+                    const Component = ({ enabled }) => {
+                      return (
+                        <Foo bar={
+                          <Something>{enabled && <MuchWow />}</Something>
+                        } />
+                      )
+                    }
+                  ", "
+                    const Component = ({ enabled }) => {
+                      return (
+                        <Foo bar={
+                          <Something>{enabled ? <MuchWow /> : null}</Something>
+                        } />
+                      )
+                    }
+                  ", Some(serde_json::json!([{ "ignoreAttributes": true }])), None)
+    ];
+
+    Tester::new(JsxNoLeakedRender::NAME, JsxNoLeakedRender::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/react_jsx_no_leaked_render.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_no_leaked_render.snap
@@ -1,0 +1,381 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:5:28]
+ 4 │                         <>
+ 5 │                           {0 && <Something/>}
+   ·                            ─────────────────
+ 6 │                           {'' && <Something/>}
+   ╰────
+  help: Use a ternary expression returning `null` instead of `&&`
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:6:28]
+ 5 │                           {0 && <Something/>}
+ 6 │                           {'' && <Something/>}
+   ·                            ──────────────────
+ 7 │                           {NaN && <Something/>}
+   ╰────
+  help: Use a ternary expression returning `null` instead of `&&`
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:7:28]
+ 6 │                           {'' && <Something/>}
+ 7 │                           {NaN && <Something/>}
+   ·                            ───────────────────
+ 8 │                         </>
+   ╰────
+  help: Use a ternary expression returning `null` instead of `&&`
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:5:28]
+ 4 │                         <>
+ 5 │                           {0 && <Something/>}
+   ·                            ─────────────────
+ 6 │                           {'' && <Something/>}
+   ╰────
+  help: Use a ternary expression returning `null` instead of `&&`
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:7:28]
+ 6 │                           {'' && <Something/>}
+ 7 │                           {NaN && <Something/>}
+   ·                            ───────────────────
+ 8 │                         </>
+   ╰────
+  help: Use a ternary expression returning `null` instead of `&&`
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:36]
+ 2 │                     const Component = ({ count, title }) => {
+ 3 │                       return <div>{count && title}</div>
+   ·                                    ──────────────
+ 4 │                     }
+   ╰────
+  help: Use a ternary expression returning `null` instead of `&&`
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:36]
+ 2 │                     const Component = ({ count }) => {
+ 3 │                       return <div>{count && <span>There are {count} results</span>}</div>
+   ·                                    ───────────────────────────────────────────────
+ 4 │                     }
+   ╰────
+  help: Use a ternary expression returning `null` instead of `&&`
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:36]
+ 2 │                     const Component = ({ elements }) => {
+ 3 │                       return <div>{elements.length && <List elements={elements}/>}</div>
+   ·                                    ──────────────────────────────────────────────
+ 4 │                     }
+   ╰────
+  help: Use a ternary expression returning `null` instead of `&&`
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:36]
+ 2 │                     const Component = ({ nestedCollection }) => {
+ 3 │                       return <div>{nestedCollection.elements.length && <List elements={nestedCollection.elements}/>}</div>
+   ·                                    ────────────────────────────────────────────────────────────────────────────────
+ 4 │                     }
+   ╰────
+  help: Use a ternary expression returning `null` instead of `&&`
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:36]
+ 2 │                     const Component = ({ elements }) => {
+ 3 │                       return <div>{elements[0] && <List elements={elements}/>}</div>
+   ·                                    ──────────────────────────────────────────
+ 4 │                     }
+   ╰────
+  help: Use a ternary expression returning `null` instead of `&&`
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:36]
+ 2 │                     const Component = ({ numberA, numberB }) => {
+ 3 │                       return <div>{(numberA || numberB) && <Results>{numberA+numberB}</Results>}</div>
+   ·                                    ────────────────────────────────────────────────────────────
+ 4 │                     }
+   ╰────
+  help: Use a ternary expression returning `null` instead of `&&`
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:36]
+ 2 │                     const Component = ({ numberA, numberB }) => {
+ 3 │                       return <div>{(numberA || numberB) && <Results>{numberA+numberB}</Results>}</div>
+   ·                                    ────────────────────────────────────────────────────────────
+ 4 │                     }
+   ╰────
+  help: Coerce the gate of `&&` to a boolean using `!!`
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:36]
+ 2 │                     const Component = ({ count, title }) => {
+ 3 │                       return <div>{count && title}</div>
+   ·                                    ──────────────
+ 4 │                     }
+   ╰────
+  help: Use a ternary expression returning `null` instead of `&&`
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:36]
+ 2 │                     const Component = ({ count }) => {
+ 3 │                       return <div>{count && <span>There are {count} results</span>}</div>
+   ·                                    ───────────────────────────────────────────────
+ 4 │                     }
+   ╰────
+  help: Use a ternary expression returning `null` instead of `&&`
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:36]
+ 2 │                     const Component = ({ elements }) => {
+ 3 │                       return <div>{elements.length && <List elements={elements}/>}</div>
+   ·                                    ──────────────────────────────────────────────
+ 4 │                     }
+   ╰────
+  help: Use a ternary expression returning `null` instead of `&&`
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:36]
+ 2 │                     const Component = ({ nestedCollection }) => {
+ 3 │                       return <div>{nestedCollection.elements.length && <List elements={nestedCollection.elements}/>}</div>
+   ·                                    ────────────────────────────────────────────────────────────────────────────────
+ 4 │                     }
+   ╰────
+  help: Use a ternary expression returning `null` instead of `&&`
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:36]
+ 2 │                     const Component = ({ elements }) => {
+ 3 │                       return <div>{elements[0] && <List elements={elements}/>}</div>
+   ·                                    ──────────────────────────────────────────
+ 4 │                     }
+   ╰────
+  help: Use a ternary expression returning `null` instead of `&&`
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:36]
+ 2 │                     const Component = ({ numberA, numberB }) => {
+ 3 │                       return <div>{(numberA || numberB) && <Results>{numberA+numberB}</Results>}</div>
+   ·                                    ────────────────────────────────────────────────────────────
+ 4 │                     }
+   ╰────
+  help: Use a ternary expression returning `null` instead of `&&`
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:36]
+ 2 │                     const Component = ({ someCondition, title }) => {
+ 3 │                       return <div>{!someCondition && title}</div>
+   ·                                    ───────────────────────
+ 4 │                     }
+   ╰────
+  help: Use a ternary expression returning `null` instead of `&&`
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:36]
+ 2 │                     const Component = ({ count, title }) => {
+ 3 │                       return <div>{!!count && title}</div>
+   ·                                    ────────────────
+ 4 │                     }
+   ╰────
+  help: Use a ternary expression returning `null` instead of `&&`
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:36]
+ 2 │                     const Component = ({ count, title }) => {
+ 3 │                       return <div>{count > 0 && title}</div>
+   ·                                    ──────────────────
+ 4 │                     }
+   ╰────
+  help: Use a ternary expression returning `null` instead of `&&`
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:36]
+ 2 │                     const Component = ({ count, title }) => {
+ 3 │                       return <div>{0 != count && title}</div>
+   ·                                    ───────────────────
+ 4 │                     }
+   ╰────
+  help: Use a ternary expression returning `null` instead of `&&`
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:36]
+ 2 │                     const Component = ({ count, total, title }) => {
+ 3 │                       return <div>{count < total && title}</div>
+   ·                                    ──────────────────────
+ 4 │                     }
+   ╰────
+  help: Use a ternary expression returning `null` instead of `&&`
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:36]
+ 2 │                     const Component = ({ count, title, somethingElse }) => {
+ 3 │                       return <div>{!!(count && somethingElse) && title}</div>
+   ·                                    ───────────────────────────────────
+ 4 │                     }
+   ╰────
+  help: Use a ternary expression returning `null` instead of `&&`
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:36]
+ 2 │                     const Component = ({ count, title }) => {
+ 3 │                       return <div>{count && title}</div>
+   ·                                    ──────────────
+ 4 │                     }
+   ╰────
+  help: Coerce the gate of `&&` to a boolean using `!!`
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:36]
+ 2 │                     const Component = ({ count }) => {
+ 3 │                       return <div>{count && <span>There are {count} results</span>}</div>
+   ·                                    ───────────────────────────────────────────────
+ 4 │                     }
+   ╰────
+  help: Coerce the gate of `&&` to a boolean using `!!`
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:36]
+ 2 │                     const Component = ({ elements }) => {
+ 3 │                       return <div>{elements.length && <List elements={elements}/>}</div>
+   ·                                    ──────────────────────────────────────────────
+ 4 │                     }
+   ╰────
+  help: Coerce the gate of `&&` to a boolean using `!!`
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:36]
+ 2 │                     const Component = ({ nestedCollection }) => {
+ 3 │                       return <div>{nestedCollection.elements.length && <List elements={nestedCollection.elements}/>}</div>
+   ·                                    ────────────────────────────────────────────────────────────────────────────────
+ 4 │                     }
+   ╰────
+  help: Coerce the gate of `&&` to a boolean using `!!`
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:36]
+ 2 │                     const Component = ({ elements }) => {
+ 3 │                       return <div>{elements[0] && <List elements={elements}/>}</div>
+   ·                                    ──────────────────────────────────────────
+ 4 │                     }
+   ╰────
+  help: Coerce the gate of `&&` to a boolean using `!!`
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:36]
+ 2 │                     const Component = ({ numberA, numberB }) => {
+ 3 │                       return <div>{(numberA || numberB) && <Results>{numberA+numberB}</Results>}</div>
+   ·                                    ────────────────────────────────────────────────────────────
+ 4 │                     }
+   ╰────
+  help: Coerce the gate of `&&` to a boolean using `!!`
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:36]
+ 2 │                     const Component = ({ connection, hasError, hasErrorUpdate}) => {
+ 3 │                       return <div>{connection && (hasError || hasErrorUpdate)}</div>
+   ·                                    ──────────────────────────────────────────
+ 4 │                     }
+   ╰────
+  help: Coerce the gate of `&&` to a boolean using `!!`
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:36]
+ 2 │                     const Component = ({ count, title }) => {
+ 3 │                       return <div>{count ? title : null}</div>
+   ·                                    ────────────────────
+ 4 │                     }
+   ╰────
+  help: Coerce the condition to a boolean using `!!` instead of a ternary
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:36]
+ 2 │                     const Component = ({ count, title }) => {
+ 3 │                       return <div>{!count ? title : null}</div>
+   ·                                    ─────────────────────
+ 4 │                     }
+   ╰────
+  help: Coerce the condition to a boolean using `!!` instead of a ternary
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:36]
+ 2 │                     const Component = ({ count, somethingElse, title }) => {
+ 3 │                       return <div>{count && somethingElse ? title : null}</div>
+   ·                                    ─────────────────────────────────────
+ 4 │                     }
+   ╰────
+  help: Coerce the condition to a boolean using `!!` instead of a ternary
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:36]
+ 2 │                     const Component = ({ items, somethingElse, title }) => {
+ 3 │                       return <div>{items.length > 0 && somethingElse && title}</div>
+   ·                                    ──────────────────────────────────────────
+ 4 │                     }
+   ╰────
+  help: Coerce the gate of `&&` to a boolean using `!!`
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:6:36]
+ 5 │ 
+ 6 │                       return <div>{items.length > 0 && breakpoint.phones && <span />}</div>
+   ·                                    ─────────────────────────────────────────────────
+ 7 │                     }
+   ╰────
+  help: Coerce the gate of `&&` to a boolean using `!!`
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:36]
+ 2 │                     const MyComponent = () => {
+ 3 │                       return <div>{maybeObject && (isFoo ? <Aaa /> : <Bbb />)}</div>
+   ·                                    ──────────────────────────────────────────
+ 4 │                     }
+   ╰────
+  help: Coerce the gate of `&&` to a boolean using `!!`
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:49]
+ 2 │                     const Component = ({ enabled, checked }) => {
+ 3 │                       return <CheckBox checked={enabled && checked} />
+   ·                                                 ──────────────────
+ 4 │                     }
+   ╰────
+  help: Use a ternary expression returning `null` instead of `&&`
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:50]
+ 2 │                     const MyComponent = () => {
+ 3 │                       return <Something checked={isIndeterminate ? false : isChecked} />
+   ·                                                  ───────────────────────────────────
+ 4 │                     }
+   ╰────
+  help: Coerce the condition to a boolean using `!!` instead of a ternary
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:50]
+ 2 │                     const MyComponent = () => {
+ 3 │                       return <Something checked={cond && isIndeterminate ? false : isChecked} />
+   ·                                                  ───────────────────────────────────────────
+ 4 │                     }
+   ╰────
+  help: Coerce the condition to a boolean using `!!` instead of a ternary
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:4:45]
+ 3 │                     const Component = () => {
+ 4 │                       return <Popover open={isOpen && items.length > 0} />
+   ·                                             ──────────────────────────
+ 5 │                     }
+   ╰────
+  help: Coerce the gate of `&&` to a boolean using `!!`
+
+  ⚠ react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:5:39]
+ 4 │                         <Foo bar={
+ 5 │                           <Something>{enabled && <MuchWow />}</Something>
+   ·                                       ──────────────────────
+ 6 │                         } />
+   ╰────
+  help: Use a ternary expression returning `null` instead of `&&`

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -6664,6 +6664,26 @@
         "react/jsx-no-duplicate-props": {
           "$ref": "#/definitions/RuleNoConfig"
         },
+        "react/jsx-no-leaked-render": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleNoConfig"
+            },
+            {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/AllowWarnDeny"
+                },
+                {
+                  "$ref": "#/definitions/JsxNoLeakedRender"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          ]
+        },
         "react/jsx-no-literals": {
           "anyOf": [
             {
@@ -12077,6 +12097,33 @@
           "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "The maximum allowed depth of nested JSX elements and fragments."
+        }
+      },
+      "additionalProperties": false
+    },
+    "JsxNoLeakedRender": {
+      "$ref": "#/definitions/JsxNoLeakedRenderConfig"
+    },
+    "JsxNoLeakedRenderConfig": {
+      "type": "object",
+      "properties": {
+        "ignoreAttributes": {
+          "description": "Skip JSX attribute values (children of nested JSX inside attributes are\nstill linted because each `JSXExpressionContainer` is its own node).",
+          "default": false,
+          "type": "boolean",
+          "markdownDescription": "Skip JSX attribute values (children of nested JSX inside attributes are\nstill linted because each `JSXExpressionContainer` is its own node)."
+        },
+        "validStrategies": {
+          "description": "Strategies the user accepts for guarding JSX expressions. The first entry\ndetermines the preferred fix when both strategies are valid.",
+          "default": [
+            "ternary",
+            "coerce"
+          ],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ValidStrategies"
+          },
+          "markdownDescription": "Strategies the user accepts for guarding JSX expressions. The first entry\ndetermines the preferred fix when both strategies are valid."
         }
       },
       "additionalProperties": false
@@ -18739,6 +18786,13 @@
         }
       },
       "additionalProperties": false
+    },
+    "ValidStrategies": {
+      "type": "string",
+      "enum": [
+        "coerce",
+        "ternary"
+      ]
     },
     "ValidTypeof": {
       "type": "object",


### PR DESCRIPTION
Implements the eslint-plugin-react `jsx-no-leaked-render` rule with both `ternary` and `coerce` fix strategies, the `ignoreAttributes` option, and the React 18+ empty-string carve-out. Strategy order in the user's config determines the preferred fix.

Full disclosure: I did use Claude Code for the initial implementation of this rule, but I vetted the code myself and made some modifications before squashing it down into one commit for ease of review.

I think the `Rule` impl itself is pretty clean. The only aspect I'm not as sure about is the utility methods that I used. I tried to strike a balance of readability without sacrificing performance or code quality.