### PR TITLE
fix(react_compiler): normalize snapshot fixture paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2315,6 +2315,7 @@ name = "oxc_react_compiler"
 version = "0.138.0"
 dependencies = [
  "convert_case",
+ "cow-utils",
  "hmac-sha256",
  "indexmap",
  "insta",

--- a/crates/oxc_react_compiler/Cargo.toml
+++ b/crates/oxc_react_compiler/Cargo.toml
@@ -56,6 +56,7 @@ oxc_parser = { workspace = true }
 # Snapshot testing of the compiler over the upstream fixture corpus (tests/snapshot.rs).
 insta = { workspace = true, features = ["glob"] }
 convert_case = { workspace = true }
+cow-utils = { workspace = true }
 
 # Catch usage of old `AstBuilder` APIs in tests, without affecting downstream consumers.
 # If we enabled `disable_old_builder` feature in main dependency, feature unification would

--- a/crates/oxc_react_compiler/tests/snapshot.rs
+++ b/crates/oxc_react_compiler/tests/snapshot.rs
@@ -14,9 +14,14 @@
 //! The snapshots are oxc's *own* golden output, so any change in compiler behaviour
 //! surfaces as a diff. Regenerate with `cargo insta accept` after reviewing.
 
-use std::{fs, path::Path};
+use std::{
+    ffi::OsStr,
+    fs,
+    path::{Component, Path, PathBuf},
+};
 
 use convert_case::{Case, Casing};
+use cow_utils::CowUtils;
 use oxc_allocator::Allocator;
 use oxc_codegen::Codegen;
 use oxc_parser::Parser;
@@ -41,11 +46,16 @@ fn snapshots() {
     let fixtures = concat!(env!("CARGO_MANIFEST_DIR"), "/fixtures");
     insta::glob!(fixtures, "**/*.{js,cjs,mjs,ts,cts,mts,jsx,tsx}", |path| {
         let source = fs::read_to_string(path).unwrap();
+        let source = normalize_newlines(&source);
         let snapshot = run_fixture(&source);
         insta::with_settings!({ prepend_module_to_snapshot => false, snapshot_suffix => "", omit_expression => true }, {
             insta::assert_snapshot!(snapshot_name(path), snapshot);
         });
     });
+}
+
+fn normalize_newlines(source: &str) -> String {
+    source.cow_replace("\r\n", "\n").cow_replace('\r', "\n").into_owned()
 }
 
 /// Parse, analyse, compile, and render the compiled program + diagnostics.
@@ -107,13 +117,31 @@ fn push_diagnostics(out: &mut String, label: &str, diagnostics: &[impl std::fmt:
     out.push('\n');
 }
 
-/// Snapshot name = fixture path under `fixtures/`, extension dropped and `/` → `__`
-/// so nested fixtures with the same basename don't collide.
+/// Snapshot name = fixture path under `fixtures/`, extension dropped and path
+/// separators replaced with `__`, so nested fixtures with the same basename
+/// don't collide.
 fn snapshot_name(path: &Path) -> String {
-    let full = path.to_string_lossy();
-    let rel = full.rsplit_once("/fixtures/").map_or(full.as_ref(), |(_, rel)| rel);
-    let stem = rel.rsplit_once('.').map_or(rel, |(stem, _ext)| stem);
-    stem.split('/').collect::<Vec<_>>().join("__")
+    let components = path.components().collect::<Vec<_>>();
+    let start = components
+        .iter()
+        .rposition(|component| {
+            matches!(component, Component::Normal(part) if *part == OsStr::new("fixtures"))
+        })
+        .map_or(0, |index| index + 1);
+
+    let mut rel = PathBuf::new();
+    for component in &components[start..] {
+        rel.push(component.as_os_str());
+    }
+    rel.set_extension("");
+
+    rel.components()
+        .filter_map(|component| match component {
+            Component::Normal(part) => Some(part.to_string_lossy()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("__")
 }
 
 /// Build the per-fixture `SourceType` + `PluginOptions` from the first-line pragmas.


### PR DESCRIPTION
## Summary

- Normalize React compiler snapshot names using path components instead of splitting on `/fixtures/`.
- Normalize fixture source newlines before parsing so diagnostic byte offsets are stable across Windows and Unix checkouts.
- Allow manually dispatched CI runs to execute the Windows cargo test job, without enabling it for normal pull requests.

## Root Cause

Windows `insta::glob!` passes fixture paths like `\?\E:\oxc\crates\oxc_react_compiler\fixtures\...`. The old string split only handled Unix `/fixtures/`, so Windows generated absolute-path snapshot names and treated every fixture as a new snapshot. After fixing that, Windows still differed because CRLF fixture checkout shifted diagnostic source offsets relative to LF snapshots.
