### PR TITLE
perf(rust): return impl ExactSizeIterator from slice-backed accessors

### DIFF
--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -531,7 +531,7 @@ impl<'a> Codegen<'a> {
     }
 
     #[inline]
-    fn current_class_ids(&self) -> impl Iterator<Item = ClassId> {
+    fn current_class_ids(&self) -> impl ExactSizeIterator<Item = ClassId> {
         self.class_stack.iter().rev().copied()
     }
 

--- a/crates/oxc_formatter_core/src/source_text.rs
+++ b/crates/oxc_formatter_core/src/source_text.rs
@@ -40,12 +40,12 @@ impl<'a> SourceText<'a> {
 
     // Byte slicing
     /// Get bytes from position to end
-    fn bytes_from(&self, position: u32) -> impl Iterator<Item = u8> {
+    fn bytes_from(&self, position: u32) -> impl ExactSizeIterator<Item = u8> {
         self.text.as_bytes()[position as usize..].iter().copied()
     }
 
     /// Get bytes from start to position in reverse
-    pub fn bytes_to(&self, position: u32) -> impl Iterator<Item = u8> {
+    pub fn bytes_to(&self, position: u32) -> impl ExactSizeIterator<Item = u8> {
         self.text.as_bytes()[..position as usize].iter().copied().rev()
     }
 

--- a/crates/oxc_minifier/src/traverse_context/ancestry.rs
+++ b/crates/oxc_minifier/src/traverse_context/ancestry.rs
@@ -112,7 +112,7 @@ impl<'a> TraverseAncestry<'a> {
     /// Get iterator over ancestors, starting with parent and working up.
     ///
     /// Last `Ancestor` returned will be `Program`. `Ancestor::None` is not included in iteration.
-    pub fn ancestors<'t>(&'t self) -> impl Iterator<Item = Ancestor<'a, 't>> {
+    pub fn ancestors<'t>(&'t self) -> impl ExactSizeIterator<Item = Ancestor<'a, 't>> {
         // SAFETY: Stack always has at least 1 entry
         let stack_without_first = unsafe { self.stack.get_unchecked(1..) };
         stack_without_first.iter().rev().map(|&ancestor| {

--- a/crates/oxc_minifier/src/traverse_context/mod.rs
+++ b/crates/oxc_minifier/src/traverse_context/mod.rs
@@ -167,7 +167,7 @@ impl<'a, State> TraverseCtx<'a, State> {
     ///
     /// Shortcut for `ctx.ancestry.ancestors`.
     #[inline]
-    pub fn ancestors<'t>(&'t self) -> impl Iterator<Item = Ancestor<'a, 't>> {
+    pub fn ancestors<'t>(&'t self) -> impl ExactSizeIterator<Item = Ancestor<'a, 't>> {
         self.ancestry.ancestors()
     }
 

--- a/crates/oxc_semantic/src/class/table.rs
+++ b/crates/oxc_semantic/src/class/table.rs
@@ -65,14 +65,14 @@ impl<'a> ClassTable<'a> {
         self.declarations.raw.len()
     }
 
-    pub fn iter_enumerated(&self) -> impl Iterator<Item = (ClassId, &NodeId)> + '_ {
+    pub fn iter_enumerated(&self) -> impl ExactSizeIterator<Item = (ClassId, &NodeId)> + '_ {
         self.declarations.iter_enumerated()
     }
 
     pub fn iter_private_identifiers(
         &self,
         class_id: ClassId,
-    ) -> impl Iterator<Item = &PrivateIdentifierReference<'_>> + '_ {
+    ) -> impl ExactSizeIterator<Item = &PrivateIdentifierReference<'_>> + '_ {
         self.private_identifier_references[class_id].iter()
     }
 

--- a/crates/oxc_semantic/src/multi_index_vec.rs
+++ b/crates/oxc_semantic/src/multi_index_vec.rs
@@ -220,7 +220,7 @@ macro_rules! multi_index_vec {
             }
 
             /// Iterate over all valid indices.
-            $vis fn iter_ids(&self) -> impl Iterator<Item = $idx> {
+            $vis fn iter_ids(&self) -> impl ExactSizeIterator<Item = $idx> {
                 let len = self.len as usize;
                 // SAFETY: Valid indices are `0..len`, and by invariant `len <= Idx::MAX + 1`.
                 (0..len).map(|i| unsafe { <$idx as ::oxc_index::Idx>::from_usize_unchecked(i) })

--- a/crates/oxc_semantic/src/node/nodes.rs
+++ b/crates/oxc_semantic/src/node/nodes.rs
@@ -38,12 +38,12 @@ pub struct AstNodes<'a> {
 
 impl<'a> AstNodes<'a> {
     /// Iterate over all [`AstNode`]s in this AST.
-    pub fn iter(&self) -> impl Iterator<Item = &AstNode<'a>> + '_ {
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = &AstNode<'a>> + '_ {
         self.nodes.iter()
     }
 
     /// Iterate over all [`AstNode`]s with their [`NodeId`].
-    pub fn iter_enumerated(&self) -> impl Iterator<Item = (NodeId, &AstNode<'a>)> + '_ {
+    pub fn iter_enumerated(&self) -> impl ExactSizeIterator<Item = (NodeId, &AstNode<'a>)> + '_ {
         self.nodes.iter_enumerated()
     }
 

--- a/crates/oxc_semantic/src/scoping.rs
+++ b/crates/oxc_semantic/src/scoping.rs
@@ -309,12 +309,14 @@ impl Scoping {
     }
 
     /// Iterate all symbol names in insertion order.
-    pub fn symbol_names(&self) -> impl Iterator<Item = &str> + '_ {
+    pub fn symbol_names(&self) -> impl ExactSizeIterator<Item = &str> + '_ {
         self.cell.borrow_dependent().symbol_names.iter().map(Ident::as_str)
     }
 
     /// Iterate resolved reference ID lists for each symbol.
-    pub fn resolved_references(&self) -> impl Iterator<Item = &ArenaVec<'_, ReferenceId>> + '_ {
+    pub fn resolved_references(
+        &self,
+    ) -> impl ExactSizeIterator<Item = &ArenaVec<'_, ReferenceId>> + '_ {
         self.cell.borrow_dependent().resolved_references.iter()
     }
 
@@ -324,7 +326,7 @@ impl Scoping {
     /// scope.
     ///
     /// [`ScopeTree::iter_bindings_in`]: crate::scoping::Scoping::iter_bindings_in
-    pub fn symbol_ids(&self) -> impl Iterator<Item = SymbolId> + '_ {
+    pub fn symbol_ids(&self) -> impl ExactSizeIterator<Item = SymbolId> + '_ {
         self.symbol_table.iter_ids()
     }
 
@@ -702,7 +704,7 @@ impl Scoping {
     }
 
     /// Iterate all scope IDs from the root scope through all descendants.
-    pub fn scope_descendants_from_root(&self) -> impl Iterator<Item = ScopeId> + '_ {
+    pub fn scope_descendants_from_root(&self) -> impl ExactSizeIterator<Item = ScopeId> + '_ {
         self.scope_table.iter_ids()
     }
 
@@ -862,13 +864,16 @@ impl Scoping {
     /// If you only want bindings in a specific scope, use [`iter_bindings_in`].
     ///
     /// [`iter_bindings_in`]: Scoping::iter_bindings_in
-    pub fn iter_bindings(&self) -> impl Iterator<Item = (ScopeId, &Bindings<'_>)> + '_ {
+    pub fn iter_bindings(&self) -> impl ExactSizeIterator<Item = (ScopeId, &Bindings<'_>)> + '_ {
         self.cell.borrow_dependent().bindings.iter_enumerated()
     }
 
     /// Iterate over bindings declared inside a scope.
     #[inline]
-    pub fn iter_bindings_in(&self, scope_id: ScopeId) -> impl Iterator<Item = SymbolId> + '_ {
+    pub fn iter_bindings_in(
+        &self,
+        scope_id: ScopeId,
+    ) -> impl ExactSizeIterator<Item = SymbolId> + '_ {
         self.cell.borrow_dependent().bindings[scope_id].values().copied()
     }
 

--- a/crates/oxc_traverse/src/context/ancestry.rs
+++ b/crates/oxc_traverse/src/context/ancestry.rs
@@ -112,7 +112,7 @@ impl<'a> TraverseAncestry<'a> {
     /// Get iterator over ancestors, starting with parent and working up.
     ///
     /// Last `Ancestor` returned will be `Program`. `Ancestor::None` is not included in iteration.
-    pub fn ancestors<'t>(&'t self) -> impl Iterator<Item = Ancestor<'a, 't>> {
+    pub fn ancestors<'t>(&'t self) -> impl ExactSizeIterator<Item = Ancestor<'a, 't>> {
         // SAFETY: Stack always has at least 1 entry
         let stack_without_first = unsafe { self.stack.get_unchecked(1..) };
         stack_without_first.iter().rev().map(|&ancestor| {

--- a/crates/oxc_traverse/src/context/mod.rs
+++ b/crates/oxc_traverse/src/context/mod.rs
@@ -159,7 +159,7 @@ impl<'a, State> TraverseCtx<'a, State> {
     ///
     /// Shortcut for `ctx.ancestry.ancestors`.
     #[inline]
-    pub fn ancestors<'t>(&'t self) -> impl Iterator<Item = Ancestor<'a, 't>> {
+    pub fn ancestors<'t>(&'t self) -> impl ExactSizeIterator<Item = Ancestor<'a, 't>> {
         self.ancestry.ancestors()
     }
 


### PR DESCRIPTION
These slice/`Vec`/`IndexVec`-backed accessors are already `ExactSizeIterator` internally (`slice::iter().map(..)` / `.copied()` / `.rev()`, `iter_enumerated()`, `HashMap::values()`, `(0..len).map(..)`) — the `impl Iterator` return type just erased it.

Widening to `impl ExactSizeIterator` lets callers pre-size collections from the known length:

```rust
let mut v = Vec::with_capacity(scoping.symbol_ids().len());
v.extend(scoping.symbol_ids().filter_map(..));
```

instead of growing a `Vec` through reallocs, and lets callers call `.len()` directly.

Backward-compatible: `ExactSizeIterator: Iterator`, so existing callers are unaffected.

Two ordering details make it compile:
- The `multi_index_vec!` `iter_ids` (`(0..len).map(..)`) is widened first so the bound propagates to `SymbolTable`/`ScopeTable`, which is what lets `symbol_ids`/`scope_descendants_from_root` widen.
- The delegating `TraverseCtx::ancestors` is widened after its `TraverseAncestry::ancestors` source — an opaque `impl Iterator` only re-exposes `ExactSizeIterator` if the inner signature declares it.

Widened accessors:
- **oxc_semantic**: `Scoping::{symbol_names, resolved_references, symbol_ids, scope_descendants_from_root, iter_bindings, iter_bindings_in}`, `AstNodes::{iter, iter_enumerated}`, `ClassTable::{iter_enumerated, iter_private_identifiers}`, `multi_index_vec!` `iter_ids`
- **oxc_traverse** / **oxc_minifier**: `TraverseAncestry::ancestors`, `TraverseCtx::ancestors`
- **oxc_formatter_core**: `SourceText::{bytes_from, bytes_to}`
- **oxc_codegen**: `Codegen::current_class_ids`
