### PR TITLE
fix(formatter): count combining marks toward printWidth like Prettier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1930,7 +1930,6 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "unicode-width",
 ]
 
 [[package]]
@@ -1943,6 +1942,7 @@ dependencies = [
  "oxc_span",
  "rustc-hash",
  "serde_json",
+ "unicode-segmentation",
  "unicode-width",
 ]
 

--- a/crates/oxc_formatter/Cargo.toml
+++ b/crates/oxc_formatter/Cargo.toml
@@ -37,7 +37,6 @@ itoa = { workspace = true }
 phf = { workspace = true, features = ["macros"] }
 rustc-hash = { workspace = true }
 smallvec = { workspace = true }
-unicode-width = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/oxc_formatter/src/print/template/mod.rs
+++ b/crates/oxc_formatter/src/print/template/mod.rs
@@ -1,12 +1,10 @@
 mod embed;
 
-use unicode_width::UnicodeWidthStr;
-
 use std::cmp;
 
 use oxc_allocator::{ArenaStringBuilder, ArenaVec};
 use oxc_ast::ast::*;
-use oxc_formatter_core::IndentWidth;
+use oxc_formatter_core::{IndentWidth, get_string_width};
 use oxc_span::{GetSpan, Span};
 
 use crate::{
@@ -537,7 +535,7 @@ struct EachTemplateColumn<'a> {
 
 impl<'a> EachTemplateColumn<'a> {
     fn new(text: &'a str, will_break: bool) -> Self {
-        let width = text.width();
+        let width = get_string_width(text);
 
         Self { text, width, will_break }
     }

--- a/crates/oxc_formatter/src/utils/string.rs
+++ b/crates/oxc_formatter/src/utils/string.rs
@@ -1,8 +1,6 @@
 use std::{borrow::Cow, ops::Deref};
 
-use unicode_width::UnicodeWidthStr;
-
-use oxc_formatter_core::{arena_cow_str, spec::normalize_string};
+use oxc_formatter_core::{arena_cow_str, get_string_width, spec::normalize_string};
 use oxc_span::SourceType;
 use oxc_syntax::identifier::is_identifier_name_patched;
 
@@ -77,7 +75,7 @@ impl Deref for CleanedStringLiteralText<'_> {
 
 impl CleanedStringLiteralText<'_> {
     pub fn width(&self) -> usize {
-        self.text.width()
+        get_string_width(&self.text)
     }
 }
 

--- a/crates/oxc_formatter/tests/fixtures/js/literal/issue-23863.js
+++ b/crates/oxc_formatter/tests/fixtures/js/literal/issue-23863.js
@@ -1,0 +1,6 @@
+// Combining marks must count toward printWidth, matching Prettier (oxc-project/oxc#23863).
+// The Tibetan subjoined letter U+0FB3 has zero `unicode-width` but Prettier counts it as 1,
+// so this property value is > 80 columns and the assignment breaks after `monthsShort:`.
+moment.defineLocale("bo", {
+  monthsShort: "ཟླ་1_ཟླ་2_ཟླ་3_ཟླ་4_ཟླ་5_ཟླ་6_ཟླ་7_ཟླ་8_ཟླ་9_ཟླ་10_ཟླ་11_ཟླ་12".split("_"),
+});

--- a/crates/oxc_formatter/tests/fixtures/js/literal/issue-23863.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/literal/issue-23863.js.snap
@@ -1,0 +1,34 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Combining marks must count toward printWidth, matching Prettier (oxc-project/oxc#23863).
+// The Tibetan subjoined letter U+0FB3 has zero `unicode-width` but Prettier counts it as 1,
+// so this property value is > 80 columns and the assignment breaks after `monthsShort:`.
+moment.defineLocale("bo", {
+  monthsShort: "ཟླ་1_ཟླ་2_ཟླ་3_ཟླ་4_ཟླ་5_ཟླ་6_ཟླ་7_ཟླ་8_ཟླ་9_ཟླ་10_ཟླ་11_ཟླ་12".split("_"),
+});
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Combining marks must count toward printWidth, matching Prettier (oxc-project/oxc#23863).
+// The Tibetan subjoined letter U+0FB3 has zero `unicode-width` but Prettier counts it as 1,
+// so this property value is > 80 columns and the assignment breaks after `monthsShort:`.
+moment.defineLocale("bo", {
+  monthsShort:
+    "ཟླ་1_ཟླ་2_ཟླ་3_ཟླ་4_ཟླ་5_ཟླ་6_ཟླ་7_ཟླ་8_ཟླ་9_ཟླ་10_ཟླ་11_ཟླ་12".split("_"),
+});
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Combining marks must count toward printWidth, matching Prettier (oxc-project/oxc#23863).
+// The Tibetan subjoined letter U+0FB3 has zero `unicode-width` but Prettier counts it as 1,
+// so this property value is > 80 columns and the assignment breaks after `monthsShort:`.
+moment.defineLocale("bo", {
+  monthsShort: "ཟླ་1_ཟླ་2_ཟླ་3_ཟླ་4_ཟླ་5_ཟླ་6_ཟླ་7_ཟླ་8_ཟླ་9_ཟླ་10_ཟླ་11_ཟླ་12".split("_"),
+});
+
+===================== End =====================

--- a/crates/oxc_formatter_core/Cargo.toml
+++ b/crates/oxc_formatter_core/Cargo.toml
@@ -23,6 +23,7 @@ oxc_span = { workspace = true }
 
 cow-utils = { workspace = true }
 rustc-hash = { workspace = true }
+unicode-segmentation = { workspace = true }
 unicode-width = { workspace = true }
 
 serde_json = { workspace = true, optional = true }

--- a/crates/oxc_formatter_core/src/format_element/mod.rs
+++ b/crates/oxc_formatter_core/src/format_element/mod.rs
@@ -8,11 +8,10 @@ use std::hash::{Hash, Hasher};
 use std::ptr;
 use std::{borrow::Cow, ops::Deref};
 
-use unicode_width::UnicodeWidthStr;
-
 use oxc_allocator::ArenaVec;
 
 use crate::IndentWidth;
+use crate::string_width::get_string_width;
 
 use self::tag::{LabelId, Tag, TagKind};
 
@@ -482,9 +481,8 @@ impl TextWidth {
 
     /// Calculates width from text, handling tabs, newlines, and Unicode.
     ///
-    /// NOTE: Uses `UnicodeWidthStr::width()` for accurate emoji sequence handling.
-    /// Counting by `char` can lead to incorrect widths for complex Unicode sequences.
-    /// e.g. "🗑️" (U+1F5D1 U+FE0F) is a single emoji with width 2, but counting chars gives width 1.
+    /// NOTE: Uses [`get_string_width`] so the result matches Prettier's `printWidth`
+    /// measurement (see that function for how it differs from `unicode_width`).
     #[expect(clippy::cast_possible_truncation)]
     pub fn from_text(text: &str, indent_width: IndentWidth) -> TextWidth {
         // Fast path for empty text
@@ -503,18 +501,18 @@ impl TextWidth {
         for (i, c) in text.char_indices() {
             match c {
                 '\t' => {
-                    width += text[segment_start..i].width() as u32;
+                    width += get_string_width(&text[segment_start..i]) as u32;
                     width += u32::from(indent_width.value());
                     segment_start = i + 1; // Skip the tab character
                 }
                 '\n' => {
-                    width += text[segment_start..i].width() as u32;
+                    width += get_string_width(&text[segment_start..i]) as u32;
                     return Self::multiline(width);
                 }
                 _ => {}
             }
         }
-        width += text[segment_start..].width() as u32;
+        width += get_string_width(&text[segment_start..]) as u32;
 
         Self::single(width)
     }
@@ -526,7 +524,7 @@ impl TextWidth {
         if is_all_printable_ascii(name) {
             return Self::single(name.len() as u32);
         }
-        Self::single(name.width() as u32)
+        Self::single(get_string_width(name) as u32)
     }
 
     /// Returns true if the text contains newlines.
@@ -666,9 +664,8 @@ mod tests {
 
     #[test]
     fn ascii_fast_path_is_byte_identical_to_slow_path() {
-        use unicode_width::UnicodeWidthStr;
-
-        // Reference: the original `from_text` scan, without the ASCII fast path.
+        // Reference: the `from_text` scan without the ASCII fast path, using the same
+        // Prettier-compatible width function as the real implementation.
         #[expect(clippy::cast_possible_truncation)]
         fn from_text_slow(text: &str, indent_width: IndentWidth) -> TextWidth {
             if text.is_empty() {
@@ -679,18 +676,18 @@ mod tests {
             for (i, c) in text.char_indices() {
                 match c {
                     '\t' => {
-                        width += text[segment_start..i].width() as u32;
+                        width += get_string_width(&text[segment_start..i]) as u32;
                         width += u32::from(indent_width.value());
                         segment_start = i + 1;
                     }
                     '\n' => {
-                        width += text[segment_start..i].width() as u32;
+                        width += get_string_width(&text[segment_start..i]) as u32;
                         return TextWidth::multiline(width);
                     }
                     _ => {}
                 }
             }
-            width += text[segment_start..].width() as u32;
+            width += get_string_width(&text[segment_start..]) as u32;
             TextWidth::single(width)
         }
 
@@ -727,7 +724,7 @@ mod tests {
             );
         }
 
-        // `from_non_whitespace_str` must equal an unconditional `UnicodeWidthStr::width`.
+        // `from_non_whitespace_str` must equal an unconditional `get_string_width`.
         let names = [
             "",
             "x",
@@ -743,7 +740,7 @@ mod tests {
         ];
         for &n in &names {
             #[expect(clippy::cast_possible_truncation)]
-            let expected = TextWidth::single(n.width() as u32);
+            let expected = TextWidth::single(get_string_width(n) as u32);
             debug_assert_eq!(
                 TextWidth::from_non_whitespace_str(n).0,
                 expected.0,

--- a/crates/oxc_formatter_core/src/lib.rs
+++ b/crates/oxc_formatter_core/src/lib.rs
@@ -31,6 +31,7 @@ mod simple_context;
 mod source_text;
 pub mod spec;
 mod state;
+mod string_width;
 mod text_range;
 mod traits;
 
@@ -68,6 +69,7 @@ pub use printer::{PrintResult, PrintWidth, Printed, Printer, PrinterOptions};
 pub(crate) use simple_context::SimpleFormatContext;
 pub use source_text::SourceText;
 pub use state::FormatState;
+pub use string_width::get_string_width;
 pub use text_range::TextRange;
 pub use traits::{FormatContext, FormatOptions};
 

--- a/crates/oxc_formatter_core/src/printer/mod.rs
+++ b/crates/oxc_formatter_core/src/printer/mod.rs
@@ -8,11 +8,11 @@ use std::num::NonZeroU8;
 
 use oxc_data_structures::code_buffer::{self, CodeBuffer};
 pub use printer_options::*;
-use unicode_width::UnicodeWidthChar;
 
 use crate::{
     ActualStart, BestFittingElement, Condition, DedentMode, FormatElement, GroupId, IndentStyle,
     InvalidDocumentError, LineMode, PrintError, PrintMode, Tag, TagKind, TextRange, TextWidth,
+    string_width::char_width,
 };
 
 use self::call_stack::{
@@ -775,7 +775,7 @@ impl<'a> Printer<'a> {
                 self.options.indent_width().value() as usize
             } else {
                 self.state.buffer.print_char(char);
-                char.width().unwrap_or(0)
+                char_width(char)
             };
 
             self.state.line_width += char_width;

--- a/crates/oxc_formatter_core/src/string_width.rs
+++ b/crates/oxc_formatter_core/src/string_width.rs
@@ -1,0 +1,171 @@
+//! Display-width measurement matching Prettier's `getStringWidth`.
+//!
+//! Prettier measures `printWidth` with a deliberately simple per-code-point rule
+//! (`src/utilities/get-string-width.js`): every code point counts as width 1, except
+//!
+//! - C0 / C1 control characters                  -> 0
+//! - combining diacritical marks `U+0300..=U+036F` -> 0
+//! - variation selectors `U+FE00..=U+FE0F`         -> 0
+//! - East Asian Wide / Fullwidth code points       -> 2
+//!
+//! and emoji grapheme clusters are collapsed to a single glyph (1 for the handful of
+//! "narrow" emoji, 2 otherwise) by an earlier emoji-regex pass.
+//!
+//! This intentionally differs from [`unicode_width`], whose `wcwidth`-style tables assign
+//! width 0 to *every* non-spacing mark (`Mn`/`Me`) and format character (`Cf`). Prettier only
+//! zeroes the three ranges above, so e.g. Tibetan / Arabic / Devanagari / Hebrew combining
+//! marks each count as 1. Measuring those as 0 makes lines that Prettier would break look like
+//! they fit, producing a formatting divergence (oxc issue #23863).
+//!
+//! We still lean on [`unicode_width`] for emoji clusters only: Prettier's emoji-regex step
+//! collapses a ZWJ sequence / flag / VS16 presentation to one glyph, which is exactly the
+//! grapheme-cluster width [`unicode_width`] computes.
+
+use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+/// Display width of a single code point, following Prettier's per-code-point rule.
+///
+/// Unlike [`unicode_width`], combining marks *outside* `U+0300..=U+036F` (and format
+/// characters) count as 1, matching Prettier. Emoji sequences are not handled here; use
+/// [`get_string_width`] for anything that may contain a multi-code-point grapheme cluster.
+///
+/// Kept crate-internal (the module is private); consumers go through [`get_string_width`].
+pub fn char_width(c: char) -> usize {
+    let cp = c as u32;
+    // C0 / C1 control characters.
+    if cp <= 0x1F || (0x7F..=0x9F).contains(&cp) {
+        return 0;
+    }
+    // Combining diacritical marks: the only combining block Prettier zeroes.
+    if (0x0300..=0x036F).contains(&cp) {
+        return 0;
+    }
+    // Variation selectors.
+    if (0xFE00..=0xFE0F).contains(&cp) {
+        return 0;
+    }
+    // East Asian Wide / Fullwidth -> 2, everything else (incl. non-`U+0300..=U+036F`
+    // combining marks, which `unicode_width` would zero) -> 1.
+    if UnicodeWidthChar::width(c) == Some(2) { 2 } else { 1 }
+}
+
+/// Display width of `text` as Prettier measures `printWidth`.
+///
+/// Tabs and newlines count as zero width (they are control characters); a caller that needs a
+/// tab expanded to `indent_width`, or the line width reset on each newline, must split on them
+/// first (as [`crate::format_element::TextWidth::from_text`] does). Grapheme segmentation is only
+/// used to keep emoji clusters collapsed; every other code point is summed via [`char_width`].
+pub fn get_string_width(text: &str) -> usize {
+    // Printable ASCII (no controls) has width == byte length.
+    if text.bytes().all(|b| matches!(b, 0x20..=0x7E)) {
+        return text.len();
+    }
+
+    let mut width = 0;
+    for cluster in text.graphemes(true) {
+        let mut chars = cluster.chars();
+        // `graphemes(true)` never yields an empty cluster, so `first` is always `Some`.
+        let Some(first) = chars.next() else { continue };
+        if chars.next().is_none() {
+            // Lone code point: the overwhelmingly common case, including every CJK ideograph
+            // and standalone emoji. Skips the emoji-cluster check.
+            width += char_width(first);
+        } else if is_emoji_cluster(cluster) {
+            // Prettier collapses emoji sequences to one glyph; `unicode_width` computes that
+            // collapsed width (1 narrow / 2 wide).
+            width += UnicodeWidthStr::width(cluster);
+        } else {
+            // A base character plus combining marks: Prettier counts each code point.
+            width += cluster.chars().map(char_width).sum::<usize>();
+        }
+    }
+    width
+}
+
+/// Whether a multi-code-point grapheme cluster is an emoji sequence Prettier collapses to a
+/// single glyph, as opposed to a base character carrying combining marks.
+///
+/// A variation selector (emoji presentation) or any scalar in the emoji planes (pictographs,
+/// regional-indicator flags, skin-tone modifiers) marks the cluster as emoji. Notably a bare
+/// ZWJ is *not* treated as an emoji signal, so combining sequences that use ZWJ purely as a
+/// text joiner (some Indic scripts) keep counting each code point.
+fn is_emoji_cluster(cluster: &str) -> bool {
+    cluster.chars().any(|c| {
+        let cp = c as u32;
+        (0xFE00..=0xFE0F).contains(&cp) || (0x1_F000..=0x1_FAFF).contains(&cp)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ascii_is_byte_length() {
+        assert_eq!(get_string_width(""), 0);
+        assert_eq!(get_string_width("abc"), 3);
+        assert_eq!(get_string_width("a b c"), 5);
+        assert_eq!(get_string_width("~!@#$%^&*()"), 11);
+    }
+
+    #[test]
+    fn east_asian_wide_counts_two() {
+        assert_eq!(get_string_width("你好"), 4);
+        assert_eq!(get_string_width("日本語"), 6);
+        // Fullwidth forms.
+        assert_eq!(get_string_width("ＡＢ"), 4);
+    }
+
+    #[test]
+    fn control_and_combining_diacriticals_are_zero() {
+        // C0 / C1 controls.
+        assert_eq!(char_width('\u{0007}'), 0);
+        assert_eq!(char_width('\u{0085}'), 0);
+        // Combining acute accent (in the zeroed block): "cafe\u{301}" == "café" == 4.
+        assert_eq!(get_string_width("cafe\u{301}"), 4);
+    }
+
+    #[test]
+    fn combining_marks_outside_the_zeroed_block_count_as_one() {
+        // The regression from oxc #23863: `unicode_width` zeroes these, Prettier counts them.
+        // Tibetan subjoined letter LA (U+0FB3), a non-spacing mark.
+        assert_eq!(char_width('\u{0FB3}'), 1);
+        // ཟླ་ = ZA (1) + subjoined LA (1) + tsheg (1) = 3.
+        assert_eq!(get_string_width("\u{0F5F}\u{0FB3}\u{0F0B}"), 3);
+        // Arabic letter meem + fatha (U+064E, non-spacing mark) = 2.
+        assert_eq!(get_string_width("\u{0645}\u{064E}"), 2);
+        // The full string from the issue.
+        let s = "ཟླ་1_ཟླ་2_ཟླ་3_ཟླ་4_ཟླ་5_ཟླ་6_ཟླ་7_ཟླ་8_ཟླ་9_ཟླ་10_ཟླ་11_ཟླ་12";
+        assert_eq!(get_string_width(s), 62);
+    }
+
+    #[test]
+    fn zwj_joining_non_emoji_is_counted() {
+        // A ZWJ between non-emoji is a text joiner, not an emoji sequence: e (1) + ZWJ (1) + b (1).
+        assert_eq!(get_string_width("e\u{200D}b"), 3);
+    }
+
+    #[test]
+    fn emoji_clusters_stay_collapsed() {
+        // Single emoji.
+        assert_eq!(get_string_width("👍"), 2);
+        // Emoji with variation selector.
+        assert_eq!(get_string_width("🗑️"), 2);
+        assert_eq!(get_string_width("⚠️"), 2);
+        // ZWJ sequence (family) collapses to one glyph.
+        assert_eq!(get_string_width("👨‍👩‍👧‍👦"), 2);
+        // Regional-indicator flag.
+        assert_eq!(get_string_width("🇯🇵"), 2);
+        // Skin-tone modifier.
+        assert_eq!(get_string_width("👍🏽"), 2);
+        // Emoji mixed with text.
+        assert_eq!(get_string_width("🗑️ DELETE"), 9);
+    }
+
+    #[test]
+    fn bare_narrow_symbol_without_presentation_selector_is_one() {
+        // Bare U+26A0 (no VS16) is a narrow symbol; Prettier counts it as 1.
+        assert_eq!(get_string_width("\u{26A0}"), 1);
+    }
+}


### PR DESCRIPTION
Closes #23863

## Problem

oxfmt kept a line on one line that Prettier breaks:

```tsx
// input
export default moment.defineLocale("bo", {
  monthsShort: "ཟླ་1_ཟླ་2_ཟླ་3_ཟླ་4_ཟླ་5_ཟླ་6_ཟླ་7_ཟླ་8_ཟླ་9_ཟླ་10_ཟླ་11_ཟླ་12".split("_"),
});
```

Display width was measured with `unicode-width`, whose `wcwidth`-style tables assign width **0** to every non-spacing combining mark. Prettier's [`getStringWidth`](https://github.com/prettier/prettier/blob/main/src/utilities/get-string-width.js) only zeroes three ranges — C0/C1 controls, combining diacriticals `U+0300..=U+036F`, and variation selectors `U+FE00..=U+FE0F` — and counts every other code point as 1 (2 for East Asian wide/fullwidth).

The 12 Tibetan subjoined letters (`U+0FB3`, a non-spacing mark) fall *outside* `U+0300..=U+036F`, so the line was undercounted:

| | width of the line |
| --- | --- |
| Prettier `getStringWidth` | **91** → exceeds 80 → breaks |
| oxc `unicode-width` | **79** → fits in 80 → stayed on one line |

This affects any combining marks outside `U+0300..=U+036F` — Tibetan, Arabic, Devanagari, Hebrew, etc.

## Fix

- New `oxc_formatter_core::get_string_width`, a Prettier-compatible per-code-point width. Emoji grapheme clusters (ZWJ sequences, flags, VS16 presentation) stay collapsed to one glyph via `unicode-width`, mirroring Prettier's emoji-regex step.
- Route every display-width measurement through it: `TextWidth::from_text` / `from_non_whitespace_str`, the printer's per-char path, and the consumer-side string-literal / template-column heuristics.
- Drop the now-unused `unicode-width` dependency from `oxc_formatter`.

The ASCII fast path is unchanged, so only non-ASCII text is affected.

## Verification

- Unit tests assert `get_string_width` against Prettier's real `getStringWidth` (Tibetan, Arabic, ZWJ, CJK, VS16, flags, ZWJ family emoji).
- Checked oxc output against Prettier's own recorded snapshots for the width-sensitive non-ASCII fixtures — `unicode/combining-characters.js`, `unicode/keys.js`, `method-chain/issue-11298.js`, `object-prop-break-in/short-keys.js` (where `古体诗:` breaks but `古今:` stays inline), `comments/emoji.js` — all match.
- Added regression fixture `js/literal/issue-23863.js`; all existing formatter/core tests pass unchanged.
