### PR TITLE
chore(clippy): enable more restriction lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,17 @@ clone_on_ref_ptr = "warn"
 self_named_module_files = "warn" # "-Wclippy::mod_module_files"
 empty_drop = "warn"
 empty_structs_with_brackets = "warn"
+empty_enum_variants_with_brackets = "warn"
 exit = "warn"
+# Performance: avoid the intermediate `String` allocation of `s.push_str(&format!(..))`.
+format_push_string = "warn"
+# Casting a function item/pointer to a number is almost always a mistake (a missing call).
+fn_to_numeric_cast_any = "warn"
+unnecessary_self_imports = "warn"
+# `return Err(x)?` obscures a plain `return Err(x.into())`.
+try_err = "warn"
+# Don't name a type `Error` when it implements `std::error::Error`.
+error_impl_error = "warn"
 filetype_is_file = "warn"
 get_unwrap = "warn"
 rc_buffer = "warn"

--- a/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
@@ -11,9 +11,9 @@ use crate::react_compiler_diagnostics::ErrorCategory;
 
 use crate::react_compiler_hir::default_module_type_provider::default_module_type_provider;
 use crate::react_compiler_hir::environment_config::EnvironmentConfig;
+use crate::react_compiler_hir::globals;
 use crate::react_compiler_hir::globals::Global;
 use crate::react_compiler_hir::globals::GlobalRegistry;
-use crate::react_compiler_hir::globals::{self};
 use crate::react_compiler_hir::object_shape::BUILT_IN_MIXED_READONLY_ID;
 use crate::react_compiler_hir::object_shape::FunctionSignature;
 use crate::react_compiler_hir::object_shape::HookKind;

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/rename_variables.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/rename_variables.rs
@@ -29,8 +29,8 @@ use crate::react_compiler_hir::ReactiveTerminalStatement;
 use crate::react_compiler_hir::ReactiveValue;
 use crate::react_compiler_hir::environment::Environment;
 
+use crate::react_compiler_reactive_scopes::visitors;
 use crate::react_compiler_reactive_scopes::visitors::ReactiveFunctionVisitor;
-use crate::react_compiler_reactive_scopes::visitors::{self};
 
 // =============================================================================
 // Scopes


### PR DESCRIPTION
## What

Enable six additional clippy `restriction` lints. All are at **zero** violations across the workspace today (except `unnecessary_self_imports`, whose two hits are fixed inline), so they're pure regression-prevention.

| Lint | Rationale |
|---|---|
| `empty_enum_variants_with_brackets` | Consistency — mirrors the already-enabled `empty_structs_with_brackets` |
| `format_push_string` | Perf: forbids the throwaway `String` alloc of `push_str(&format!(..))` |
| `fn_to_numeric_cast_any` | Correctness: casting a fn item/pointer to a number is almost always a missing call |
| `unnecessary_self_imports` | Drops redundant `use path::{self}` (2 fixes in `oxc_react_compiler`) |
| `try_err` | `return Err(x)?` obscures a plain `return Err(x.into())` |
| `error_impl_error` | Don't name a type `Error` when it implements `std::error::Error` |

Verified green with `cargo lint -- -D warnings` across the full workspace.

## Considered but skipped

A full sweep of the `restriction` group surfaced three higher-count lints that were evaluated and intentionally left off, because enabling them would require ~400 `#[expect]` annotations or degrade code rather than improve it:

- `missing_asserts_for_indexing` — fires on code already guarded by `&&` short-circuits; the suggested `assert!` is redundant and converts graceful `false` returns into panics.
- `iter_over_hash_type` — 242 sites; oxc uses `FxHashMap` (fixed-seed, deterministic iteration), so most are order-independent and would only collect `#[expect]`.
- `let_underscore_must_use` — majority are `let _ = write!/writeln!(..)` (the standard idiom for infallible `String` writes) plus deliberate result-ignores.