### PR TITLE
fix(react_compiler): memoize functions extracted by JSX outlining

### DIFF
--- a/crates/oxc_react_compiler/Cargo.toml
+++ b/crates/oxc_react_compiler/Cargo.toml
@@ -36,7 +36,9 @@ debug = []
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }
+oxc_codegen = { workspace = true }
 oxc_diagnostics = { workspace = true }
+oxc_parser = { workspace = true }
 oxc_semantic = { workspace = true }
 oxc_span = { workspace = true }
 oxc_syntax = { workspace = true }
@@ -48,11 +50,6 @@ indexmap = { workspace = true }
 rustc-hash = { workspace = true }
 
 [dev-dependencies]
-# The example and integration tests parse source and print the compiled program; the
-# library itself takes an already-parsed `Program` and never parses or codegens.
-oxc_codegen = { workspace = true }
-oxc_parser = { workspace = true }
-
 # Snapshot testing of the compiler over the upstream fixture corpus (tests/snapshot.rs).
 insta = { workspace = true, features = ["glob"] }
 convert_case = { workspace = true }

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
@@ -84,6 +84,12 @@ use crate::react_compiler_validation::validate_static_components;
 use crate::react_compiler_validation::validate_use_memo;
 use crate::scope::*;
 
+use oxc_allocator::Allocator;
+use oxc_codegen::Codegen;
+use oxc_parser::Parser;
+use oxc_semantic::SemanticBuilder;
+use oxc_span::SourceType;
+
 use super::compile_result::CodegenFunction;
 use super::compile_result::DebugLogEntry;
 use super::compile_result::OutlinedFunction;
@@ -778,6 +784,7 @@ pub fn compile_fn<'a>(
         if let Some(fn_type) = o.fn_type {
             let fn_name = outlined_codegen.id.as_ref().map(|id| id.name.to_string());
             match compile_outlined_fn(
+                ast,
                 outlined_codegen,
                 fn_name.as_deref(),
                 fn_type,
@@ -819,13 +826,16 @@ pub fn compile_fn<'a>(
     })
 }
 
-/// Compile an outlined function's codegen AST through the full pipeline.
+/// Re-compile an outlined function through the full pipeline so it is memoized.
 ///
-/// Creates a fresh Environment, builds a synthetic ScopeInfo with unique fake
-/// positions for identifier resolution, lowers from AST to HIR, then runs
-/// the full compilation pipeline. This mirrors the TS behavior where outlined
-/// functions are inserted into the program AST and re-compiled from scratch.
+/// The outlined codegen AST produced by the first pass is un-memoized (it comes
+/// from the outlined-codegen loop, not the full pipeline). Mirroring TS — which
+/// inserts the outlined function as a top-level `FunctionDeclaration` and compiles
+/// it again from scratch — we print the synthesized function to source, re-parse it
+/// (giving the AST real, unique spans, which the compiler uses as node identity),
+/// and run it back through [`compile_fn`] as its own component/hook.
 pub fn compile_outlined_fn<'a>(
+    ast: &oxc_ast::builder::AstBuilder<'a>,
     codegen_fn: CodegenFunction<'a>,
     fn_name: Option<&str>,
     fn_type: ReactFunctionType,
@@ -833,8 +843,75 @@ pub fn compile_outlined_fn<'a>(
     env_config: &EnvironmentConfig,
     context: &mut ProgramContext,
 ) -> Result<CodegenFunction<'a>, CompilerError> {
-    let _ = (fn_name, fn_type, mode, env_config, context);
-    Ok(codegen_fn)
+    // A `FunctionDeclaration` needs a name to be parseable; outlined functions always
+    // have one (`_temp`), but guard so a nameless input falls back to the un-memoized
+    // codegen rather than emitting invalid source.
+    if codegen_fn.id.is_none() {
+        return Ok(codegen_fn);
+    }
+
+    let source = emit_outlined_source(ast, codegen_fn);
+
+    // Re-parse in a fresh arena so the function gets real, unique spans. The parsed
+    // program (and its `Semantic`) borrow `source` and `outlined_alloc`, so both must
+    // outlive the `compile_fn` call below; declaration order keeps that invariant.
+    let outlined_alloc = Allocator::default();
+    let parsed = Parser::new(&outlined_alloc, &source, SourceType::tsx().with_module(true)).parse();
+    let semantic = SemanticBuilder::new().with_build_nodes(true).build(&parsed.program).semantic;
+    let scope_info = crate::convert_scope::convert_scope_info(&semantic, &parsed.program);
+
+    let Some(oxc_ast::ast::Statement::FunctionDeclaration(func)) = parsed.program.body.first()
+    else {
+        return Err(CompilerError::new());
+    };
+    let func_node = FunctionNode::Function(func);
+
+    // `compile_fn` derives `LineOffsets` from `context.code` to stamp HIR locations, so
+    // point it at the outlined source (cloned — `source` is still borrowed by the parse)
+    // for the duration of the re-compile, then restore the previous value.
+    let prev_code = context.code.replace(source.clone());
+    let result =
+        compile_fn(ast, &func_node, fn_name, &scope_info, fn_type, mode, env_config, context);
+    context.code = prev_code;
+    result
+}
+
+/// Print a synthesized outlined [`CodegenFunction`] as a standalone
+/// `FunctionDeclaration` source string, for re-parsing through the full pipeline.
+fn emit_outlined_source<'a>(
+    ast: &oxc_ast::builder::AstBuilder<'a>,
+    codegen_fn: CodegenFunction<'a>,
+) -> String {
+    use oxc_allocator::ArenaVec;
+    use oxc_ast::ast::{Function, FunctionType, Program, Statement};
+    use oxc_span::SPAN;
+
+    let CodegenFunction { id, params, body, generator, is_async, .. } = codegen_fn;
+    let func = Function::boxed(
+        SPAN,
+        FunctionType::FunctionDeclaration,
+        id,
+        generator,
+        is_async,
+        false,
+        None::<oxc_allocator::Box<oxc_ast::ast::TSTypeParameterDeclaration>>,
+        None::<oxc_allocator::Box<oxc_ast::ast::TSThisParameter>>,
+        params,
+        None::<oxc_allocator::Box<oxc_ast::ast::TSTypeAnnotation>>,
+        Some(body),
+        ast,
+    );
+    let program = Program::new(
+        SPAN,
+        SourceType::tsx(),
+        "",
+        ArenaVec::new_in(ast),
+        None,
+        ArenaVec::new_in(ast),
+        ArenaVec::from_value_in(Statement::FunctionDeclaration(func), ast),
+        ast,
+    );
+    Codegen::new().build(&program).code
 }
 
 /// Push a compiler error's per-detail diagnostics (validation / lint / telemetry

--- a/crates/oxc_react_compiler/tests/snapshots/jsx-outlining-child-stored-in-id.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/jsx-outlining-child-stored-in-id.snap
@@ -27,8 +27,26 @@ function Component(t0) {
 	return t1;
 }
 function _temp(t0) {
-	let { "i": i, "x": x } = t0;
-	return <Bar x={x}><Baz i={i} /></Bar>;
+	const $ = _c(5);
+	const { "i": i, "x": x } = t0;
+	let t1;
+	if ($[0] !== i) {
+		t1 = <Baz i={i} />;
+		$[0] = i;
+		$[1] = t1;
+	} else {
+		t1 = $[1];
+	}
+	let t2;
+	if ($[2] !== t1 || $[3] !== x) {
+		t2 = <Bar x={x}>{t1}</Bar>;
+		$[2] = t1;
+		$[3] = x;
+		$[4] = t2;
+	} else {
+		t2 = $[4];
+	}
+	return t2;
 }
 function Bar(t0) {
 	const $ = _c(3);

--- a/crates/oxc_react_compiler/tests/snapshots/jsx-outlining-dup-key-diff-value.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/jsx-outlining-dup-key-diff-value.snap
@@ -39,8 +39,35 @@ function Component(t0) {
 	return t2;
 }
 function _temp(t0) {
-	let { "i": i, "k": k, "x": x } = t0;
-	return <Bar x={x}><Baz i={i} /><Foo k={k} /></Bar>;
+	const $ = _c(8);
+	const { "i": i, "k": k, "x": x } = t0;
+	let t1;
+	if ($[0] !== i) {
+		t1 = <Baz i={i} />;
+		$[0] = i;
+		$[1] = t1;
+	} else {
+		t1 = $[1];
+	}
+	let t2;
+	if ($[2] !== k) {
+		t2 = <Foo k={k} />;
+		$[2] = k;
+		$[3] = t2;
+	} else {
+		t2 = $[3];
+	}
+	let t3;
+	if ($[4] !== t1 || $[5] !== t2 || $[6] !== x) {
+		t3 = <Bar x={x}>{t1}{t2}</Bar>;
+		$[4] = t1;
+		$[5] = t2;
+		$[6] = x;
+		$[7] = t3;
+	} else {
+		t3 = $[7];
+	}
+	return t3;
 }
 function Bar(t0) {
 	const $ = _c(3);

--- a/crates/oxc_react_compiler/tests/snapshots/jsx-outlining-dupe-attr-after-rename.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/jsx-outlining-dupe-attr-after-rename.snap
@@ -39,8 +39,44 @@ function Component(t0) {
 	return t2;
 }
 function _temp(t0) {
-	let { "k": k, "k1": k1, "k12": k12, "x": x } = t0;
-	return <Bar x={x}><Foo k={k} /><Foo k={k1} /><Baz k1={k12} /></Bar>;
+	const $ = _c(11);
+	const { "k": k, "k1": k1, "k12": k12, "x": x } = t0;
+	let t1;
+	if ($[0] !== k) {
+		t1 = <Foo k={k} />;
+		$[0] = k;
+		$[1] = t1;
+	} else {
+		t1 = $[1];
+	}
+	let t2;
+	if ($[2] !== k1) {
+		t2 = <Foo k={k1} />;
+		$[2] = k1;
+		$[3] = t2;
+	} else {
+		t2 = $[3];
+	}
+	let t3;
+	if ($[4] !== k12) {
+		t3 = <Baz k1={k12} />;
+		$[4] = k12;
+		$[5] = t3;
+	} else {
+		t3 = $[5];
+	}
+	let t4;
+	if ($[6] !== t1 || $[7] !== t2 || $[8] !== t3 || $[9] !== x) {
+		t4 = <Bar x={x}>{t1}{t2}{t3}</Bar>;
+		$[6] = t1;
+		$[7] = t2;
+		$[8] = t3;
+		$[9] = x;
+		$[10] = t4;
+	} else {
+		t4 = $[10];
+	}
+	return t4;
 }
 function Bar(t0) {
 	const $ = _c(3);

--- a/crates/oxc_react_compiler/tests/snapshots/jsx-outlining-dupe-key-dupe-component.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/jsx-outlining-dupe-key-dupe-component.snap
@@ -39,8 +39,35 @@ function Component(t0) {
 	return t2;
 }
 function _temp(t0) {
-	let { "k": k, "k1": k1, "x": x } = t0;
-	return <Bar x={x}><Foo k={k} /><Foo k={k1} /></Bar>;
+	const $ = _c(8);
+	const { "k": k, "k1": k1, "x": x } = t0;
+	let t1;
+	if ($[0] !== k) {
+		t1 = <Foo k={k} />;
+		$[0] = k;
+		$[1] = t1;
+	} else {
+		t1 = $[1];
+	}
+	let t2;
+	if ($[2] !== k1) {
+		t2 = <Foo k={k1} />;
+		$[2] = k1;
+		$[3] = t2;
+	} else {
+		t2 = $[3];
+	}
+	let t3;
+	if ($[4] !== t1 || $[5] !== t2 || $[6] !== x) {
+		t3 = <Bar x={x}>{t1}{t2}</Bar>;
+		$[4] = t1;
+		$[5] = t2;
+		$[6] = x;
+		$[7] = t3;
+	} else {
+		t3 = $[7];
+	}
+	return t3;
 }
 function Bar(t0) {
 	const $ = _c(3);

--- a/crates/oxc_react_compiler/tests/snapshots/jsx-outlining-duplicate-prop.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/jsx-outlining-duplicate-prop.snap
@@ -39,8 +39,35 @@ function Component(t0) {
 	return t2;
 }
 function _temp(t0) {
-	let { "i": i, "i1": i1, "x": x } = t0;
-	return <Bar x={x}><Baz i={i} /><Foo i={i1} /></Bar>;
+	const $ = _c(8);
+	const { "i": i, "i1": i1, "x": x } = t0;
+	let t1;
+	if ($[0] !== i) {
+		t1 = <Baz i={i} />;
+		$[0] = i;
+		$[1] = t1;
+	} else {
+		t1 = $[1];
+	}
+	let t2;
+	if ($[2] !== i1) {
+		t2 = <Foo i={i1} />;
+		$[2] = i1;
+		$[3] = t2;
+	} else {
+		t2 = $[3];
+	}
+	let t3;
+	if ($[4] !== t1 || $[5] !== t2 || $[6] !== x) {
+		t3 = <Bar x={x}>{t1}{t2}</Bar>;
+		$[4] = t1;
+		$[5] = t2;
+		$[6] = x;
+		$[7] = t3;
+	} else {
+		t3 = $[7];
+	}
+	return t3;
 }
 function Bar(t0) {
 	const $ = _c(3);

--- a/crates/oxc_react_compiler/tests/snapshots/jsx-outlining-jsx-stored-in-id.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/jsx-outlining-jsx-stored-in-id.snap
@@ -40,8 +40,26 @@ function Component(t0) {
 	return t2;
 }
 function _temp(t0) {
-	let { "i": i, "x": x } = t0;
-	return <Bar x={x}><Baz i={i} /></Bar>;
+	const $ = _c(5);
+	const { "i": i, "x": x } = t0;
+	let t1;
+	if ($[0] !== i) {
+		t1 = <Baz i={i} />;
+		$[0] = i;
+		$[1] = t1;
+	} else {
+		t1 = $[1];
+	}
+	let t2;
+	if ($[2] !== t1 || $[3] !== x) {
+		t2 = <Bar x={x}>{t1}</Bar>;
+		$[2] = t1;
+		$[3] = x;
+		$[4] = t2;
+	} else {
+		t2 = $[4];
+	}
+	return t2;
 }
 function Bar(t0) {
 	const $ = _c(3);

--- a/crates/oxc_react_compiler/tests/snapshots/jsx-outlining-separate-nested.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/jsx-outlining-separate-nested.snap
@@ -39,8 +39,44 @@ function Component(t0) {
 	return t2;
 }
 function _temp(t0) {
-	let { "i": i, "j": j, "k": k, "x": x } = t0;
-	return <Bar x={x}><Baz i={i} /><Joe j={j} /><Foo k={k} /></Bar>;
+	const $ = _c(11);
+	const { "i": i, "j": j, "k": k, "x": x } = t0;
+	let t1;
+	if ($[0] !== i) {
+		t1 = <Baz i={i} />;
+		$[0] = i;
+		$[1] = t1;
+	} else {
+		t1 = $[1];
+	}
+	let t2;
+	if ($[2] !== j) {
+		t2 = <Joe j={j} />;
+		$[2] = j;
+		$[3] = t2;
+	} else {
+		t2 = $[3];
+	}
+	let t3;
+	if ($[4] !== k) {
+		t3 = <Foo k={k} />;
+		$[4] = k;
+		$[5] = t3;
+	} else {
+		t3 = $[5];
+	}
+	let t4;
+	if ($[6] !== t1 || $[7] !== t2 || $[8] !== t3 || $[9] !== x) {
+		t4 = <Bar x={x}>{t1}{t2}{t3}</Bar>;
+		$[6] = t1;
+		$[7] = t2;
+		$[8] = t3;
+		$[9] = x;
+		$[10] = t4;
+	} else {
+		t4 = $[10];
+	}
+	return t4;
 }
 function Bar(t0) {
 	const $ = _c(3);

--- a/crates/oxc_react_compiler/tests/snapshots/jsx-outlining-simple.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/jsx-outlining-simple.snap
@@ -39,8 +39,26 @@ function Component(t0) {
 	return t2;
 }
 function _temp(t0) {
-	let { "i": i, "x": x } = t0;
-	return <Bar x={x}><Baz i={i} /></Bar>;
+	const $ = _c(5);
+	const { "i": i, "x": x } = t0;
+	let t1;
+	if ($[0] !== i) {
+		t1 = <Baz i={i} />;
+		$[0] = i;
+		$[1] = t1;
+	} else {
+		t1 = $[1];
+	}
+	let t2;
+	if ($[2] !== t1 || $[3] !== x) {
+		t2 = <Bar x={x}>{t1}</Bar>;
+		$[2] = t1;
+		$[3] = x;
+		$[4] = t2;
+	} else {
+		t2 = $[4];
+	}
+	return t2;
 }
 function Bar(t0) {
 	const $ = _c(3);

--- a/crates/oxc_react_compiler/tests/snapshots/jsx-outlining-with-non-jsx-children.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/jsx-outlining-with-non-jsx-children.snap
@@ -40,8 +40,36 @@ function Component(t0) {
 	return t2;
 }
 function _temp(t0) {
-	let { "i": i, "t": t, "k": k, "x": x } = t0;
-	return <Bar x={x}><Baz i={i}>{t}</Baz><Foo k={k} /></Bar>;
+	const $ = _c(9);
+	const { "i": i, "t": t, "k": k, "x": x } = t0;
+	let t1;
+	if ($[0] !== i || $[1] !== t) {
+		t1 = <Baz i={i}>{t}</Baz>;
+		$[0] = i;
+		$[1] = t;
+		$[2] = t1;
+	} else {
+		t1 = $[2];
+	}
+	let t2;
+	if ($[3] !== k) {
+		t2 = <Foo k={k} />;
+		$[3] = k;
+		$[4] = t2;
+	} else {
+		t2 = $[4];
+	}
+	let t3;
+	if ($[5] !== t1 || $[6] !== t2 || $[7] !== x) {
+		t3 = <Bar x={x}>{t1}{t2}</Bar>;
+		$[5] = t1;
+		$[6] = t2;
+		$[7] = x;
+		$[8] = t3;
+	} else {
+		t3 = $[8];
+	}
+	return t3;
 }
 function Bar(t0) {
 	const $ = _c(3);


### PR DESCRIPTION
## What

Implements `compile_outlined_fn`, previously a stub that returned an outlined function's un-memoized codegen unchanged. Functions extracted by `@enableJsxOutlining` are now memoized, matching Babel.

## Why

`@enableJsxOutlining` extracts repeated JSX into a `_temp` helper. oxc's outlined-codegen loop produced `_temp` **un-memoized** (no `_c(...)` cache), diverging from Babel which emits a memoized helper.

Root cause: Babel compiles the outlined function twice — a throwaway un-memoized pass from the outlined-codegen loop, then a second compile after re-inserting it as a top-level `FunctionDeclaration`, which runs it through the full pipeline (scope terminals → reactive scopes → memo blocks). oxc only did the first pass; `compile_outlined_fn` was the intended hook for the second but was left unimplemented.

## How

Mirror Babel's re-insert-and-recompile: print the synthesized outlined function to source, re-parse it in a fresh arena (giving real, unique spans — the compiler uses `span.start` as node identity, and the synthesized AST has none), rebuild semantics + scope info, and run it back through `compile_fn` as its own component.

`oxc_parser`/`oxc_codegen` move from dev-deps to deps since the library now re-parses.

## Result

All 9 `jsx-outlining-*` fixtures now match Babel's `_c(N)` cache layout exactly (cache sizes verified across `Component` + `_temp` + helpers). No other fixtures change.