### PR TITLE
perf(minifier,mangler): skip building the AST node table for default mangling

### DIFF
--- a/crates/oxc_mangler/src/lib.rs
+++ b/crates/oxc_mangler/src/lib.rs
@@ -311,7 +311,11 @@ impl<'t> Mangler<'t> {
     /// Pass the symbol table to oxc_codegen to generate the mangled code.
     #[must_use]
     pub fn build(self, program: &Program<'_>) -> ManglerReturn {
-        let mut builder = SemanticBuilder::new().with_build_nodes(true).with_class_table(true);
+        // The AST node table is only read for `keep_names`; skip building it
+        // otherwise.
+        let build_nodes = self.options.keep_names.function || self.options.keep_names.class;
+        let mut builder =
+            SemanticBuilder::new().with_build_nodes(build_nodes).with_class_table(true);
         if let Some(stats) = self.stats {
             builder = builder.with_stats(stats);
         }

--- a/crates/oxc_mangler/src/lib.rs
+++ b/crates/oxc_mangler/src/lib.rs
@@ -573,11 +573,7 @@ impl<'a, 's> SlotAssignment<'a, 's> {
     /// when none are free. `slot_liveness[slot]` records the scopes a slot passes through live so
     /// descendant scopes can tell what's free. Invariant on the result: two symbols sharing a slot
     /// never have overlapping live ranges, so giving them one name is always safe.
-    fn compute(
-        allocator: &'a Allocator,
-        scoping: &'s Scoping,
-        constraints: &Constraints,
-    ) -> Self {
+    fn compute(allocator: &'a Allocator, scoping: &'s Scoping, constraints: &Constraints) -> Self {
         let keep_name_symbols = constraints.keep_name_symbols.as_ref();
         // Names of bindings in direct-`eval` scopes — collected here, reserved in Phase 4.
         // TODO: eval reservation is conservative — ideally we'd reserve names per-slot.

--- a/crates/oxc_minifier/src/lib.rs
+++ b/crates/oxc_minifier/src/lib.rs
@@ -142,8 +142,13 @@ impl<'a> Minifier {
             .options
             .mangle
             .map(|options| {
-                let mut builder =
-                    SemanticBuilder::new().with_build_nodes(true).with_class_table(true);
+                // The mangler only reads the AST node table for `keep_names`, so
+                // skip building it otherwise (it is the biggest part of this
+                // pre-mangle semantic pass).
+                let build_nodes = options.keep_names.function || options.keep_names.class;
+                let mut builder = SemanticBuilder::new()
+                    .with_build_nodes(build_nodes)
+                    .with_class_table(true);
                 if let Some(stats) = stats {
                     builder = builder.with_stats(stats);
                 }

--- a/crates/oxc_minifier/src/lib.rs
+++ b/crates/oxc_minifier/src/lib.rs
@@ -146,9 +146,8 @@ impl<'a> Minifier {
                 // skip building it otherwise (it is the biggest part of this
                 // pre-mangle semantic pass).
                 let build_nodes = options.keep_names.function || options.keep_names.class;
-                let mut builder = SemanticBuilder::new()
-                    .with_build_nodes(build_nodes)
-                    .with_class_table(true);
+                let mut builder =
+                    SemanticBuilder::new().with_build_nodes(build_nodes).with_class_table(true);
                 if let Some(stats) = stats {
                     builder = builder.with_stats(stats);
                 }

--- a/tasks/track_memory_allocations/allocs_minifier.snap
+++ b/tasks/track_memory_allocations/allocs_minifier.snap
@@ -1,16 +1,16 @@
 File                       | File size      || Sys allocs     | Sys reallocs   || Arena allocs   | Arena reallocs 
 ---------------------------------------------------------------------------------------------------------------------------
-checker.ts                 | 2.92 MB        ||            163 |              5 ||         152751 |          28253
+checker.ts                 | 2.92 MB        ||            161 |              5 ||         152751 |          28253
 
-App.tsx                    | 415.34 kB      ||             86 |              8 ||          17010 |           2702
+App.tsx                    | 415.34 kB      ||             84 |              8 ||          17010 |           2702
 
-RadixUIAdoptionSection.jsx | 2.52 kB        ||             24 |              0 ||             32 |              6
+RadixUIAdoptionSection.jsx | 2.52 kB        ||             22 |              0 ||             32 |              6
 
-pdf.mjs                    | 567.30 kB      ||           2579 |            205 ||          47484 |           7742
+pdf.mjs                    | 567.30 kB      ||           2577 |            205 ||          47484 |           7742
 
-antd.js                    | 6.69 MB        ||           1064 |             56 ||         337232 |          69333
+antd.js                    | 6.69 MB        ||           1062 |             56 ||         337232 |          69333
 
-binder.ts                  | 193.08 kB      ||             41 |              1 ||           7083 |            824
+binder.ts                  | 193.08 kB      ||             39 |              1 ||           7083 |            824
 
-kitchen-sink.tsx           | 732.90 kB      ||           2586 |            174 ||          90546 |          15840
+kitchen-sink.tsx           | 732.90 kB      ||           2584 |            174 ||          90546 |          15840
 


### PR DESCRIPTION
## What

Capstone of the "make the mangler node-table-free" series. The `oxc-minify` pipeline builds the semantic model **twice** — once before compress, once before mangle — and the second build's AST node table (`with_build_nodes(true)`) was pure overhead for the default (no-`keep_names`) path.

With the mangler's slot assignment no longer reading `ast_nodes` (the two sibling refactors below), the only remaining reader is the opt-in `keep_names` pass. This PR gates `with_build_nodes` on `keep_names` and drops the now-unused `ast_nodes` argument from `SlotAssignment::compute`.

Includes the two prerequisites:
- #24152 — resolve named-fn-expr names via `SymbolFlags`
- #24153 — expose `Scoping::symbol_declaration_scope`

## Measured impact

Full `oxc-minify` pipeline (parse → `Minifier::minify` → codegen minify), min of 7 runs over the 12 minification-benchmark files:

| | total | typescript.js | antd.js |
|---|---|---|---|
| main | 405.2 ms | 171.2 ms | 74.3 ms |
| this | 397.4 ms | 167.8 ms | 72.2 ms |
| **Δ** | **−1.9%** | −2.0% | −2.8% |

(Local wall-clock; CodSpeed CI is the authoritative signal. In the published package mimalloc makes the node-`Vec` allocation cheaper, so the real-world delta may be a touch smaller.)

## Correctness

Byte-identical mangled output:
- `tasks/minsize/minsize.snap` unchanged (12 libraries).
- All mangler + minifier-mangler tests pass; `keep_names` still builds the node table on demand (its snapshots are unchanged).