### PR TITLE
fix(react_compiler): align memoization cache-slot allocation with Babel

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -3684,6 +3684,11 @@ fn lower_expression<'a>(
             value: PrimitiveValue::String(lit.value.to_string().into()),
             loc: builder.source_location(lit.span),
         }),
+        oxc::Expression::RegExpLiteral(regexp) => Ok(InstructionValue::RegExpLiteral {
+            pattern: regexp.regex.pattern.text.as_str().to_string(),
+            flags: regexp.regex.flags.to_string(),
+            loc: builder.source_location(regexp.span),
+        }),
         oxc::Expression::BinaryExpression(bin) => {
             let loc = builder.source_location(bin.span);
             let left = lower_expression_to_temporary(builder, &bin.left)?;

--- a/crates/oxc_react_compiler/tests/snapshots/regexp-literal.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/regexp-literal.snap
@@ -8,8 +8,9 @@ function Component(props) {
 	let t0;
 	let value;
 	if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+		const pattern = /foo/g;
 		value = makeValue();
-		t0 = undefined.test(value);
+		t0 = pattern.test(value);
 		$[0] = t0;
 		$[1] = value;
 	} else {


### PR DESCRIPTION
## Root cause

On ~57 ecosystem files, oxc allocated **one fewer `_c()` cache slot** than `babel-plugin-react-compiler` in a function (e.g. oxc `_c(25)` where Babel emits `_c(26)`; oxc `[26,40]` where Babel `[27,40]`), shifting every subsequent `$[i]` index by −1.

The construct responsible is the **regex literal**. In `react_compiler_lowering/build_hir.rs`, `lower_expression` had no arm for `oxc::Expression::RegExpLiteral`, so every regex literal fell through the catch-all that "bails to undefined":

```rust
_ => {
    // not-yet-ported arms bail to undefined
    Ok(InstructionValue::Primitive { value: PrimitiveValue::Undefined, loc })
}
```

Two consequences:

1. **Correctness**: the regex was dropped from the output — e.g. `useId().replace(/:/g, "")` compiled to `t1.replace(undefined, "")`, and `pattern.test(value)` compiled to `undefined.test(value)`.
2. **Slot count**: an `undefined` primitive does not allocate, so `may_allocate` never gave it a reactive scope. Babel treats a regex literal as an allocation and memoizes it (a nested `Symbol.for("react.memo_cache_sentinel")` scope when it has no deps), reserving one extra slot. That missing slot was the −1.

All the downstream machinery for regex was **already implemented** — the HIR variant `InstructionValue::RegExpLiteral`, its codegen (`codegen_reactive_function.rs`), `may_allocate` (returns `true`), aliasing/type inference, and every visitor. Only the lowering arm was missing.

## The fix

Add the single missing arm in `lower_expression`, mirroring TS `BuildHIR`'s `case 'RegExpLiteral'`:

```rust
oxc::Expression::RegExpLiteral(regexp) => Ok(InstructionValue::RegExpLiteral {
    pattern: regexp.regex.pattern.text.as_str().to_string(),
    flags: regexp.regex.flags.to_string(),
    loc: builder.source_location(regexp.span),
}),
```

The regex now lowers to a real value and receives its own reactive scope, matching Babel's sentinel-memoized nested scope. Minimal repro output now equals Babel byte-for-byte:

```js
// before: t1 = t0.replace(undefined, "");   _c(4)
// after (matches Babel):                     _c(5)
if ($[0] !== t0) {
  let t2;
  if ($[2] === Symbol.for("react.memo_cache_sentinel")) {
    t2 = /:/g;
    $[2] = t2;
  } else { t2 = $[2]; }
  t1 = t0.replace(t2, "");
  ...
}
```

## Before/after `_c(N)` on ecosystem files

| file | before | after / Babel |
| --- | --- | --- |
| `create-better-t-stack/.../charts/dash-tail-stroke.tsx` | `_c(25)` | `_c(26)` |
| `create-better-t-stack/.../charts/area-chart.tsx` | `_c(26)`,`_c(40)` | `_c(27)`,`_c(40)` |
| `.../day-picker.tsx` | `_c(77)` | `_c(78)` |
| `.../DynamicLink.tsx` | `_c(15)` | `_c(16)` |
| `.../Image.jsx` | `_c(23)` | `_c(24)` |

Across the 420 regex-containing ecosystem source files: **48 went from mismatch → matching Babel's slot multiset, with 0 regressions** (files that matched Babel before still match). The handful still differing do so for unrelated pre-existing reasons (whole extra/missing scopes), not the regex slot.

## Snapshot note

Exactly one fixture snapshot changes: `regexp-literal.snap` — the dedicated regex fixture, whose old golden captured the `undefined.test(value)` bug. The new snapshot is **byte-identical to the upstream Babel `regexp-literal.expect.md` golden** (`const pattern = /foo/g; … pattern.test(value)`). `CI=1 cargo test -p oxc_react_compiler` is green; `cargo fmt` / `cargo clippy --all-targets -D warnings` clean.