### PR TITLE
fix(react_compiler): compile generic functions instead of over-bailing on type-param hoisting

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -254,7 +254,19 @@ fn lower_block_statement_inner<'a>(
         .bindings_with_child_blocks(scope_id)
         .into_iter()
         .filter(|&sid| {
-            !matches!(scope.binding_kind(sid), AstBindingKind::Param | AstBindingKind::Module)
+            // Type-only symbols (type parameters, interfaces, pure type aliases)
+            // are not part of Babel's `scope.bindings`, so its hoisting analysis
+            // never treats a pure-type-position reference to one as a
+            // referenced-before-declared use. OXC does give them a symbol, so
+            // without this guard a generic function that mentions its own type
+            // parameter `T` inside a nested function over-bails with
+            // "Unsupported declaration type for hoisting". See
+            // `ScopeResolver::is_type_only_binding`.
+            !scope.is_type_only_binding(sid)
+                && !matches!(
+                    scope.binding_kind(sid),
+                    AstBindingKind::Param | AstBindingKind::Module
+                )
                 && !matches!(
                     scope.decl_kind(sid),
                     DeclKind::FunctionExpression

--- a/crates/oxc_react_compiler/src/scope.rs
+++ b/crates/oxc_react_compiler/src/scope.rs
@@ -276,6 +276,28 @@ impl<'s, 'a> ScopeResolver<'s, 'a> {
         }
     }
 
+    /// Whether a symbol is a type-only binding — a type parameter, interface,
+    /// or a pure type alias / type-only import.
+    ///
+    /// Babel never registers these in `scope.bindings`, so its BuildHIR hoisting
+    /// analysis can never see them: `stmt.scope.getBinding(name)` returns `null`
+    /// for a type name, so the "referenced before declaration" check bails out
+    /// early and the identifier is never hoisted. OXC's semantic model *does*
+    /// give type parameters and interfaces a symbol, which lands them in the
+    /// hoistable set with an unclassifiable declaration kind and makes every
+    /// pure-type-position reference inside a nested function look like a
+    /// referenced-before-declared use — over-bailing whole generic functions
+    /// that Babel compiles. Excluding type-only symbols mirrors Babel's binding
+    /// table exactly.
+    ///
+    /// Symbols that are *also* values (a `class`, an `enum`, a value module, or
+    /// an `interface`/`class` merged declaration) are not type-only and remain
+    /// hoistable, matching Babel, which does register those.
+    pub fn is_type_only_binding(&self, symbol_id: SymbolId) -> bool {
+        let flags = self.scoping().symbol_flags(symbol_id);
+        flags.is_type() && !flags.is_value()
+    }
+
     /// The kind of the symbol's declaration AST node.
     pub fn decl_kind(&self, symbol_id: SymbolId) -> DeclKind {
         match self.nodes.get_node(self.scoping.symbol_declaration(symbol_id)).kind() {

--- a/crates/oxc_react_compiler/tests/snapshots/error.todo-round2_identifier_diff.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/error.todo-round2_identifier_diff.snap
@@ -4,7 +4,6 @@ input_file: crates/oxc_react_compiler/fixtures/error.todo-round2_identifier_diff
 ---
 Diagnostics:
 
-OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] Todo: Unsupported declaration type for hoisting", labels: One([LabeledSpan { label: None, span: SourceSpan { offset: SourceOffset(167), length: 596 }, primary: false }]), help: Some("variable \"OuterProps\" declared with Unknown"), note: None, severity: Warning, code: OxcCode { scope: None, number: None }, url: None } }
 OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] Todo: (BuildHIR::lowerExpression) Handle ClassExpression expressions", labels: One([LabeledSpan { label: None, span: SourceSpan { offset: SourceOffset(368), length: 387 }, primary: false }]), help: None, note: None, severity: Warning, code: OxcCode { scope: None, number: None }, url: None } }
 
 No changes.


### PR DESCRIPTION
## Problem

oxc over-bails on **generic functions** (`Component<T>`, `useThing<T>()`) that `babel-plugin-react-compiler` compiles. It emits `[ReactCompiler] Todo: Unsupported declaration type for hoisting` with help `variable "T" declared with Unknown`, then passes the whole function through unmemoized. This was the largest oxc capability gap vs upstream Babel across the ecosystem corpus.

Example — `actual/.../autocomplete/Autocomplete.tsx`: oxc `_c` was `[5, 6, 11]`, Babel `[5, 6, 11, 26, 125]`. oxc missed the two generic components `SingleAutocomplete<T extends AutocompleteItem>` and `MultiAutocomplete<T extends AutocompleteItem>`. After this change oxc emits `[5, 6, 11, 26, 125]` — identical to Babel.

## Mechanism

The referenced-before-declared hoisting scan in `build_hir.rs` (`lower_block_statement_inner`) collects "hoistable" bindings of a block, then hoists any that are referenced inside a nested function before their declaration. A hoisted binding whose declaration kind is neither `FunctionDeclaration` nor `VariableDeclarator` records the `Unsupported declaration type for hoisting` error.

The scan mirrors Babel's `BuildHIR` `case 'BlockStatement'`. The key upstream line is:

```js
for (const [, binding] of Object.entries(stmt.scope.bindings)) { ... }   // hoistable set
const binding = id.scope.getBinding(id.node.name);                       // per-reference lookup
if (binding != null && hoistableIdentifiers.has(binding.identifier) && (fnDepth > 0 || ...))
```

**Babel never registers a type parameter (or interface, or pure type alias) in `scope.bindings`.** Verified directly against the fork's Babel:

```
function C<T>(props){ const f = () => props.v as T; ... }
=> scope.bindings = ["props", "f"]        // no T
   getBinding("T") === undefined
```

So for Babel a type name has no binding, the hoist check short-circuits, and generic functions compile.

oxc's semantic model *does* give type parameters/interfaces a symbol. With `binding_kind`/`decl_kind` both `Unknown`, they passed the hoistable filter, and every pure-type-position reference to `T` inside a nested function (`(y: T)`, `x as T`, `useMemo<T>()`, `new Set<T>()`, `<Table<T>/>`, `const s: Array<T>`, `(): T =>`) looked like a referenced-before-declared use — bailing the whole function.

## Fix (narrow, binding-side)

Exclude **type-only symbols** from the hoistable set, matching Babel's `scope.bindings` exactly:

```rust
// scope.rs
pub fn is_type_only_binding(&self, symbol_id: SymbolId) -> bool {
    let flags = self.scoping().symbol_flags(symbol_id);
    flags.is_type() && !flags.is_value()
}
```

`is_type() && !is_value()` selects exactly type parameters, interfaces, pure type aliases, and type-only imports. Classes, enums, value modules, and `interface`/`class` merged declarations keep `is_value()` and remain hoistable — matching Babel, which *does* register those.

This is deliberately a **binding-side** filter, not a reference-side one. It never touches how value bindings' references are counted, so it cannot change any value binding's hoist decision — which is what makes it safe. (Prior reference-side attempts that skipped type-position references or erased type params regressed because they also affected value bindings referenced in type positions.)

## Validation

**Fixture snapshot corpus** (`tests/snapshots/`, 1734 fixtures): green. Exactly **one** snapshot changed — `error.todo-round2_identifier_diff` — and the change *removes* the spurious `variable "OuterProps" declared with Unknown` diagnostic (`OuterProps` is the type parameter of `withRemountOnChange<OuterProps extends {}>`). The fixture still bails on its genuine `Handle ClassExpression expressions` Todo, so the bail decision and `No changes.` output are preserved; only the bogus type-param diagnostic — which Babel never emits — is gone.

**Ecosystem** (697 generic-declaration candidate files across 44 repos, oxc vs fork Babel):

- **122** files hit the type-param over-bail before this change; **all 122** no longer do.
- **467** candidates now produce an `_c` multiset **byte-identical to Babel**.
- Files where oxc memoizes but Babel bails were checked against `git`-old oxc. The handful of newly-diverging files bail in Babel for reasons **unrelated to type parameters** (`Handle tagged template with interpolations`, `Expected all references to a variable to be consistently local or context references`). A minimal non-generic probe confirms oxc already compiled tagged-template interpolations that Babel bails on *before* this change (old `_c(4)` == new `_c(4)`, Babel `CompileError`) — so these are pre-existing oxc/Babel capability differences merely unmasked by removing a coincidental double-bail, not new over-compiles from this change. In three of them oxc gained a function whose `_c` value exactly matches a Babel slot (moving oxc closer to Babel).

`cargo fmt` and `cargo clippy -p oxc_react_compiler --all-targets -- -D warnings` are clean.
