### PR TITLE
perf(linter/eslint/prefer-rest-params): run on functions instead of all identifiers

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -1375,7 +1375,7 @@ impl RuleRunner for crate::rules::eslint::prefer_regex_literals::PreferRegexLite
 
 impl RuleRunner for crate::rules::eslint::prefer_rest_params::PreferRestParams {
     const NODE_TYPES: Option<&AstTypesBitset> =
-        Some(&AstTypesBitset::from_types(&[AstType::IdentifierReference]));
+        Some(&AstTypesBitset::from_types(&[AstType::Function]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/rules/eslint/prefer_rest_params.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_rest_params.rs
@@ -3,7 +3,6 @@ use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
-use oxc_str::static_ident;
 
 fn prefer_rest_params_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Use the rest parameters instead of `arguments`.")
@@ -71,31 +70,37 @@ declare_oxc_lint!(
 
 impl Rule for PreferRestParams {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        if let AstKind::IdentifierReference(identifier) = node.kind() {
-            if identifier.name != "arguments"
-                || !is_inside_of_function(node, ctx)
-                || is_not_normal_member_access(node, ctx)
-            {
-                return;
+        let AstKind::Function(_) = node.kind() else {
+            return;
+        };
+
+        let Some(references) = ctx.scoping().root_unresolved_references().get("arguments") else {
+            return;
+        };
+
+        for &reference_id in references {
+            let reference = ctx.scoping().get_reference(reference_id);
+            let reference_node = ctx.nodes().get_node(reference.node_id());
+            if !is_owned_by_function(reference_node, node, ctx) {
+                continue;
             }
-            let binding = ctx.scoping().find_binding(node.scope_id(), static_ident!("arguments"));
-            if binding.is_none() {
-                ctx.diagnostic(prefer_rest_params_diagnostic(node.span()));
+
+            if !is_not_normal_member_access(reference_node, ctx) {
+                ctx.diagnostic(prefer_rest_params_diagnostic(reference_node.span()));
             }
         }
     }
 }
 
-fn is_inside_of_function(node: &AstNode, ctx: &LintContext) -> bool {
-    let mut current = node;
-    while !matches!(current.kind(), AstKind::Program(_)) {
-        let parent = ctx.nodes().parent_node(current.id());
-        if matches!(parent.kind(), AstKind::Function(_)) {
-            return true;
-        }
-        current = parent;
-    }
-    false
+fn is_owned_by_function(
+    reference_node: &AstNode,
+    function_node: &AstNode,
+    ctx: &LintContext,
+) -> bool {
+    ctx.nodes()
+        .ancestors(reference_node.id())
+        .find(|ancestor| matches!(ancestor.kind(), AstKind::Function(_)))
+        .is_some_and(|ancestor| ancestor.id() == function_node.id())
 }
 
 fn is_not_normal_member_access(identifier: &AstNode, ctx: &LintContext) -> bool {
@@ -124,6 +129,8 @@ fn test() {
         "function foo() { arguments[0]; }",
         "function foo() { arguments[1]; }",
         "function foo() { arguments[Symbol.iterator]; }",
+        "function foo() { function bar() { arguments; } }",
+        "function foo() { var bar = () => arguments; }",
     ];
 
     Tester::new(PreferRestParams::NAME, PreferRestParams::PLUGIN, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_rest_params.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_rest_params.snap
@@ -29,3 +29,17 @@ source: crates/oxc_linter/src/tester.rs
    ·                  ─────────
    ╰────
   help: Replace `arguments` with rest parameters (`...args`).
+
+  ⚠ eslint(prefer-rest-params): Use the rest parameters instead of `arguments`.
+   ╭─[prefer_rest_params.tsx:1:35]
+ 1 │ function foo() { function bar() { arguments; } }
+   ·                                   ─────────
+   ╰────
+  help: Replace `arguments` with rest parameters (`...args`).
+
+  ⚠ eslint(prefer-rest-params): Use the rest parameters instead of `arguments`.
+   ╭─[prefer_rest_params.tsx:1:34]
+ 1 │ function foo() { var bar = () => arguments; }
+   ·                                  ─────────
+   ╰────
+  help: Replace `arguments` with rest parameters (`...args`).

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -166,7 +166,7 @@ eslint/prefer-object-has-own                               |  62606
 eslint/prefer-object-spread                                |  62606
 eslint/prefer-promise-reject-errors                        |  64027
 eslint/prefer-regex-literals                               |  64027
-eslint/prefer-rest-params                                  | 209565
+eslint/prefer-rest-params                                  |  14283
 eslint/prefer-spread                                       |  62606
 eslint/prefer-template                                     |  20604
 eslint/preserve-caught-error                               |    151


### PR DESCRIPTION
Currently this rule runs on all identifier references and then checks if they are `arguments`, then checks if they are in a function scope.

Now, we run on all functions instead, then search for `arguments` inside of functions, which should result in a smaller amount of total rule calls and overall work.