### PR TITLE
perf(linter/oxc/bad-array-method-on-arguments): only run on member expressions instead of all identifiers

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4119,8 +4119,10 @@ impl RuleRunner for crate::rules::oxc::approx_constant::ApproxConstant {
 }
 
 impl RuleRunner for crate::rules::oxc::bad_array_method_on_arguments::BadArrayMethodOnArguments {
-    const NODE_TYPES: Option<&AstTypesBitset> =
-        Some(&AstTypesBitset::from_types(&[AstType::IdentifierReference]));
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::ComputedMemberExpression,
+        AstType::StaticMemberExpression,
+    ]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/rules/oxc/bad_array_method_on_arguments.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_array_method_on_arguments.rs
@@ -1,4 +1,4 @@
-use oxc_ast::AstKind;
+use oxc_ast::{AstKind, MemberExpressionKind};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
@@ -64,18 +64,20 @@ declare_oxc_lint!(
 
 impl Rule for BadArrayMethodOnArguments {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let AstKind::IdentifierReference(ident) = node.kind() else {
-            return;
+        let member_expr = match node.kind() {
+            AstKind::ComputedMemberExpression(member_expr) => {
+                MemberExpressionKind::Computed(member_expr)
+            }
+            AstKind::StaticMemberExpression(member_expr) => {
+                MemberExpressionKind::Static(member_expr)
+            }
+            _ => return,
         };
-        if ident.name != "arguments" {
+        if !member_expr.object().is_specific_id("arguments") {
             return;
         }
 
-        let parent = ctx.nodes().parent_node(node.id());
-        let Some(member_expr) = parent.kind().as_member_expression_kind() else {
-            return;
-        };
-        let AstKind::CallExpression(_) = ctx.nodes().parent_kind(parent.id()) else {
+        let AstKind::CallExpression(_) = ctx.nodes().parent_kind(node.id()) else {
             return;
         };
         let Some(name) = member_expr.static_property_name() else {

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -363,7 +363,7 @@ node/no-path-concat                                        |  21217
 node/no-process-env                                        |  94090
 node/no-sync                                               |  62606
 oxc/approx-constant                                        |  14295
-oxc/bad-array-method-on-arguments                          | 209565
+oxc/bad-array-method-on-arguments                          |  94090
 oxc/bad-bitwise-operator                                   |  33609
 oxc/bad-char-at-comparison                                 |  62606
 oxc/bad-comparison-sequence                                |  20604


### PR DESCRIPTION
Currently we check every identifier reference to see if it's `arguments` and then using an array method in its parent node.

Now, we look for member expressions that include `arguments`, and then check its array method call expression. This should reduce the total number of rule calls.