### PR TITLE
perf(linter/eslint/no-new-func): only run on new and call expressions

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -891,13 +891,8 @@ impl RuleRunner for crate::rules::eslint::no_new::NoNew {
 }
 
 impl RuleRunner for crate::rules::eslint::no_new_func::NoNewFunc {
-    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
-        AstType::CallExpression,
-        AstType::ComputedMemberExpression,
-        AstType::NewExpression,
-        AstType::PrivateFieldExpression,
-        AstType::StaticMemberExpression,
-    ]));
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::NewExpression]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_new_func.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_func.rs
@@ -1,8 +1,8 @@
-use oxc_ast::{AstKind, ast::IdentifierReference};
+use oxc_ast::{AstKind, ast::IdentifierReference, ast::MemberExpression};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::IsGlobalReference;
-use oxc_span::{GetSpan, Span};
+use oxc_span::Span;
 use oxc_str::static_ident;
 
 use crate::{AstNode, context::LintContext, rule::Rule};
@@ -73,50 +73,35 @@ impl Rule for NoNewFunc {
                 check(id, new_expr.arguments_span(), ctx);
             }
             AstKind::CallExpression(call_expr) => {
-                let Some(obj_id) = call_expr.callee.get_identifier_reference() else {
+                let Some(obj_id) = get_function_constructor_reference(&call_expr.callee) else {
                     return;
                 };
 
                 check(obj_id, call_expr.arguments_span(), ctx);
             }
-            member_expr if member_expr.is_member_expression_kind() => {
-                let Some(member_expr) = member_expr.as_member_expression_kind() else {
-                    return;
-                };
-
-                let parent = ctx.nodes().ancestor_kinds(node.id()).find(|node| {
-                    !matches!(
-                        node,
-                        AstKind::ChainExpression(_) | AstKind::ParenthesizedExpression(_)
-                    )
-                });
-
-                let Some(AstKind::CallExpression(parent_call_expr)) = parent else {
-                    return;
-                };
-
-                if !parent_call_expr.callee.span().contains_inclusive(node.span()) {
-                    return;
-                }
-
-                let Some(static_property_name) =
-                    &member_expr.static_property_name().map(|s| s.as_str())
-                else {
-                    return;
-                };
-
-                if !["apply", "bind", "call"].contains(static_property_name) {
-                    return;
-                }
-
-                let Some(obj_id) = member_expr.object().get_identifier_reference() else {
-                    return;
-                };
-
-                check(obj_id, parent_call_expr.arguments_span(), ctx);
-            }
             _ => {}
         }
+    }
+}
+
+fn get_function_constructor_reference<'a>(
+    callee: &'a oxc_ast::ast::Expression<'a>,
+) -> Option<&'a IdentifierReference<'a>> {
+    callee.get_identifier_reference().or_else(|| {
+        let member_expr = member_expression_through_chain(callee)?;
+        let property_name = member_expr.static_property_name()?;
+        matches!(property_name, "apply" | "bind" | "call")
+            .then(|| member_expr.object().get_identifier_reference())?
+    })
+}
+
+fn member_expression_through_chain<'a>(
+    expr: &'a oxc_ast::ast::Expression<'a>,
+) -> Option<&'a MemberExpression<'a>> {
+    match expr.get_inner_expression() {
+        expr if expr.is_member_expression() => expr.as_member_expression(),
+        oxc_ast::ast::Expression::ChainExpression(chain) => chain.expression.member_expression(),
+        _ => None,
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_new_func.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_func.rs
@@ -1,4 +1,7 @@
-use oxc_ast::{AstKind, ast::IdentifierReference, ast::MemberExpression};
+use oxc_ast::{
+    AstKind,
+    ast::{Expression, IdentifierReference, MemberExpression},
+};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::IsGlobalReference;
@@ -85,7 +88,7 @@ impl Rule for NoNewFunc {
 }
 
 fn get_function_constructor_reference<'a>(
-    callee: &'a oxc_ast::ast::Expression<'a>,
+    callee: &'a Expression<'a>,
 ) -> Option<&'a IdentifierReference<'a>> {
     callee.get_identifier_reference().or_else(|| {
         let member_expr = member_expression_through_chain(callee)?;
@@ -96,11 +99,11 @@ fn get_function_constructor_reference<'a>(
 }
 
 fn member_expression_through_chain<'a>(
-    expr: &'a oxc_ast::ast::Expression<'a>,
+    expr: &'a Expression<'a>,
 ) -> Option<&'a MemberExpression<'a>> {
     match expr.get_inner_expression() {
         expr if expr.is_member_expression() => expr.as_member_expression(),
-        oxc_ast::ast::Expression::ChainExpression(chain) => chain.expression.member_expression(),
+        Expression::ChainExpression(chain) => chain.expression.member_expression(),
         _ => None,
     }
 }

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -94,7 +94,7 @@ eslint/no-multi-str                                        |  62460
 eslint/no-negated-condition                                |  17912
 eslint/no-nested-ternary                                   |   4722
 eslint/no-new                                              |   1421
-eslint/no-new-func                                         | 159324
+eslint/no-new-func                                         |  64027
 eslint/no-new-native-nonconstructor                        |   1421
 eslint/no-new-wrappers                                     |   1421
 eslint/no-nonoctal-decimal-escape                          |  62460


### PR DESCRIPTION
Currently this rule runs on all new expressions, call expressions, and member expressions. However, we really only care about new expressions and call expressions, so we don't need to check member expressions explicitly at the top-level. Now, we look at call expressions and then handle if it's part of a member expressions. This way, we can skip files that don't contain member expressions for this rule.