### PR TITLE
perf(linter/jest-vitest/no-test-return-statement): only run on return statements

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2355,7 +2355,7 @@ impl RuleRunner for crate::rules::jest::no_test_prefixes::NoTestPrefixes {
 
 impl RuleRunner for crate::rules::jest::no_test_return_statement::NoTestReturnStatement {
     const NODE_TYPES: Option<&AstTypesBitset> =
-        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::Function]));
+        Some(&AstTypesBitset::from_types(&[AstType::ReturnStatement]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
@@ -4789,7 +4789,7 @@ impl RuleRunner for crate::rules::vitest::no_test_prefixes::NoTestPrefixes {
 
 impl RuleRunner for crate::rules::vitest::no_test_return_statement::NoTestReturnStatement {
     const NODE_TYPES: Option<&AstTypesBitset> =
-        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::Function]));
+        Some(&AstTypesBitset::from_types(&[AstType::ReturnStatement]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/rules/jest/no_test_return_statement.rs
+++ b/crates/oxc_linter/src/rules/jest/no_test_return_statement.rs
@@ -16,7 +16,7 @@ declare_oxc_lint!(NoTestReturnStatement, jest, style, docs = DOCUMENTATION, vers
 impl Rule for NoTestReturnStatement {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
-            AstKind::CallExpression(_) | AstKind::Function(_) => {}
+            AstKind::ReturnStatement(_) => {}
             _ => return,
         }
         run(node, ctx);
@@ -63,6 +63,24 @@ fn test() {
             "
                 it('one', () => expect(1).toBe(1));
                 function myHelper() {}
+            ",
+            None,
+        ),
+        (
+            "
+                function myHelper() {
+                    return expect(1).toBe(1);
+                }
+            ",
+            None,
+        ),
+        (
+            "
+                it('one', () => {
+                    function myHelper() {
+                        return expect(1).toBe(1);
+                    }
+                });
             ",
             None,
         ),

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/no_test_return_statement.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/no_test_return_statement.rs
@@ -1,10 +1,9 @@
-use oxc_allocator::ArenaBox;
 use oxc_ast::{
     AstKind,
-    ast::{CallExpression, Expression, FunctionBody, Statement},
+    ast::{CallExpression, Expression, ReturnStatement},
 };
 use oxc_diagnostics::OxcDiagnostic;
-use oxc_semantic::AstNode;
+use oxc_semantic::{AstNode, NodeId};
 use oxc_span::{GetSpan, Span};
 
 use crate::{
@@ -47,85 +46,117 @@ test('one', () => {
 ";
 
 pub fn run<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) {
-    match node.kind() {
-        AstKind::CallExpression(call_expr) => {
-            check_call_expression(call_expr, node, ctx);
-        }
-        AstKind::Function(fn_decl) => {
-            let Some(func_body) = &fn_decl.body else {
-                return;
-            };
-            check_test_return_statement(func_body, ctx);
-        }
-        _ => (),
-    }
-}
+    let AstKind::ReturnStatement(return_stmt) = node.kind() else { return };
+    let Some(call_expr) = returned_expect_call(return_stmt) else { return };
 
-fn check_call_expression<'a>(
-    call_expr: &'a CallExpression<'a>,
-    node: &AstNode<'a>,
-    ctx: &LintContext<'a>,
-) {
-    if !is_type_of_jest_fn_call(
-        call_expr,
-        &PossibleJestNode { node, original: None },
-        ctx,
-        &[JestFnKind::General(JestGeneralFnKind::Test)],
-    ) {
-        return;
-    }
-
-    for argument in &call_expr.arguments {
-        let Some(arg_expr) = argument.as_expression() else {
-            continue;
-        };
-        match arg_expr {
-            Expression::ArrowFunctionExpression(arrow_expr) => {
-                check_test_return_statement(&arrow_expr.body, ctx);
-            }
-            Expression::FunctionExpression(func_expr) => {
-                let Some(func_body) = &func_expr.body else {
-                    continue;
-                };
-                check_test_return_statement(func_body, ctx);
-            }
-            _ => {}
-        }
-    }
-}
-
-fn check_test_return_statement<'a>(
-    func_body: &ArenaBox<'_, FunctionBody<'a>>,
-    ctx: &LintContext<'a>,
-) {
-    let Some(return_stmt) =
-        func_body.statements.iter().find(|stmt| matches!(stmt, Statement::ReturnStatement(_)))
-    else {
-        return;
-    };
-
-    let Statement::ReturnStatement(stmt) = return_stmt else {
-        return;
-    };
-    let Some(Expression::CallExpression(call_expr)) = &stmt.argument else {
-        return;
-    };
-    let Some(mem_expr) = call_expr.callee.as_member_expression() else {
-        return;
-    };
-    let Expression::CallExpression(mem_call_expr) = mem_expr.object() else {
-        return;
-    };
-    let Expression::Identifier(ident) = &mem_call_expr.callee else {
-        return;
-    };
-
-    if ident.name != "expect" {
+    if !is_in_test_context(node, ctx) {
         return;
     }
 
     ctx.diagnostic(no_test_return_statement_diagnostic(Span::new(
-        return_stmt.span().start,
+        return_stmt.span.start,
         call_expr.span.start - 1,
     )));
+}
+
+fn returned_expect_call<'a>(
+    return_stmt: &'a ReturnStatement<'a>,
+) -> Option<&'a CallExpression<'a>> {
+    let Expression::CallExpression(call_expr) = return_stmt.argument.as_ref()? else {
+        return None;
+    };
+    let mem_expr = call_expr.callee.as_member_expression()?;
+    let Expression::CallExpression(mem_call_expr) = mem_expr.object() else {
+        return None;
+    };
+    let Expression::Identifier(ident) = &mem_call_expr.callee else {
+        return None;
+    };
+
+    if ident.name != "expect" {
+        return None;
+    }
+
+    Some(call_expr)
+}
+
+fn is_in_test_context<'a>(return_node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {
+    let Some(function_node) = containing_function_node(return_node, ctx) else { return false };
+
+    is_direct_test_callback(function_node, ctx) || is_referenced_test_callback(function_node, ctx)
+}
+
+fn containing_function_node<'a, 'c>(
+    return_node: &AstNode<'a>,
+    ctx: &'c LintContext<'a>,
+) -> Option<&'c AstNode<'a>> {
+    ctx.nodes().ancestors(return_node.id()).find(|ancestor| {
+        matches!(ancestor.kind(), AstKind::Function(_) | AstKind::ArrowFunctionExpression(_))
+    })
+}
+
+fn is_direct_test_callback<'a>(function_node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {
+    let call_node = ctx.nodes().parent_node(function_node.id());
+    let AstKind::CallExpression(call_expr) = call_node.kind() else { return false };
+
+    is_function_callback_argument(call_expr, function_node)
+        && is_test_call(call_expr, call_node, ctx)
+}
+
+fn is_referenced_test_callback<'a>(function_node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {
+    let AstKind::Function(function) = function_node.kind() else { return false };
+    if !function.is_function_declaration() {
+        return false;
+    }
+
+    let Some(symbol_id) = function.id.as_ref().map(oxc_ast::ast::BindingIdentifier::symbol_id)
+    else {
+        return false;
+    };
+
+    ctx.semantic()
+        .symbol_references(symbol_id)
+        .any(|reference| is_reference_test_callback(reference.node_id(), ctx))
+}
+
+fn is_reference_test_callback(reference_id: NodeId, ctx: &LintContext) -> bool {
+    let call_node = ctx.nodes().parent_node(reference_id);
+    let AstKind::CallExpression(call_expr) = call_node.kind() else { return false };
+
+    is_reference_callback_argument(call_expr, ctx.nodes().kind(reference_id).span())
+        && is_test_call(call_expr, call_node, ctx)
+}
+
+fn is_function_callback_argument(call_expr: &CallExpression, function_node: &AstNode) -> bool {
+    call_expr.arguments.iter().filter_map(|arg| arg.as_expression()).any(|expr| {
+        match (expr.get_inner_expression(), function_node.kind()) {
+            (
+                Expression::ArrowFunctionExpression(arrow_expr),
+                AstKind::ArrowFunctionExpression(node),
+            ) => arrow_expr.span == node.span,
+            (Expression::FunctionExpression(func_expr), AstKind::Function(node)) => {
+                func_expr.span == node.span
+            }
+            _ => false,
+        }
+    })
+}
+
+fn is_reference_callback_argument(call_expr: &CallExpression, reference_span: Span) -> bool {
+    call_expr.arguments.iter().filter_map(|arg| arg.as_expression()).any(|expr| {
+        matches!(expr.get_inner_expression(), Expression::Identifier(ident) if ident.span == reference_span)
+    })
+}
+
+fn is_test_call<'a>(
+    call_expr: &'a CallExpression<'a>,
+    call_node: &AstNode<'a>,
+    ctx: &LintContext<'a>,
+) -> bool {
+    is_type_of_jest_fn_call(
+        call_expr,
+        &PossibleJestNode { node: call_node, original: None },
+        ctx,
+        &[JestFnKind::General(JestGeneralFnKind::Test)],
+    )
 }

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/no_test_return_statement.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/no_test_return_statement.rs
@@ -46,38 +46,30 @@ test('one', () => {
 ";
 
 pub fn run<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) {
-    let AstKind::ReturnStatement(return_stmt) = node.kind() else { return };
-    let Some(call_expr) = returned_expect_call(return_stmt) else { return };
-
-    if !is_in_test_context(node, ctx) {
-        return;
+    if let AstKind::ReturnStatement(return_stmt) = node.kind()
+        && let Some(call_expr) = returned_expect_call(return_stmt)
+        && is_in_test_context(node, ctx)
+    {
+        ctx.diagnostic(no_test_return_statement_diagnostic(Span::new(
+            return_stmt.span.start,
+            call_expr.span.start - 1,
+        )));
     }
-
-    ctx.diagnostic(no_test_return_statement_diagnostic(Span::new(
-        return_stmt.span.start,
-        call_expr.span.start - 1,
-    )));
 }
 
 fn returned_expect_call<'a>(
     return_stmt: &'a ReturnStatement<'a>,
 ) -> Option<&'a CallExpression<'a>> {
-    let Expression::CallExpression(call_expr) = return_stmt.argument.as_ref()? else {
-        return None;
-    };
-    let mem_expr = call_expr.callee.as_member_expression()?;
-    let Expression::CallExpression(mem_call_expr) = mem_expr.object() else {
-        return None;
-    };
-    let Expression::Identifier(ident) = &mem_call_expr.callee else {
-        return None;
-    };
-
-    if ident.name != "expect" {
-        return None;
+    if let Expression::CallExpression(call_expr) = return_stmt.argument.as_ref()?
+        && let Expression::CallExpression(mem_call_expr) =
+            call_expr.callee.as_member_expression()?.object()
+        && let Expression::Identifier(ident) = &mem_call_expr.callee
+        && ident.name == "expect"
+    {
+        return Some(call_expr);
     }
 
-    Some(call_expr)
+    None
 }
 
 fn is_in_test_context<'a>(return_node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {

--- a/crates/oxc_linter/src/rules/vitest/no_test_return_statement.rs
+++ b/crates/oxc_linter/src/rules/vitest/no_test_return_statement.rs
@@ -16,7 +16,7 @@ declare_oxc_lint!(NoTestReturnStatement, vitest, style, docs = DOCUMENTATION, ve
 impl Rule for NoTestReturnStatement {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
-            AstKind::CallExpression(_) | AstKind::Function(_) => {}
+            AstKind::ReturnStatement(_) => {}
             _ => return,
         }
         run(node, ctx);
@@ -63,6 +63,24 @@ fn test() {
             "
                 it('one', () => expect(1).toBe(1));
                 function myHelper() {}
+            ",
+            None,
+        ),
+        (
+            "
+                function myHelper() {
+                    return expect(1).toBe(1);
+                }
+            ",
+            None,
+        ),
+        (
+            "
+                it('one', () => {
+                    function myHelper() {
+                        return expect(1).toBe(1);
+                    }
+                });
             ",
             None,
         ),

--- a/crates/oxc_linter/src/snapshots/jest_no_test_return_statement.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_test_return_statement.snap
@@ -24,37 +24,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ jest(no-test-return-statement): Jest tests should not return a value
    ╭─[no_test_return_statement.tsx:3:21]
- 2 │                 it('one', function () {
- 3 │                     return expect(1).toBe(1);
-   ·                     ──────
- 4 │                 });
-   ╰────
-  help: Use `await` for async assertions or remove the return statement.
-  note: Jest ignores returned values from tests.
-
-  ⚠ jest(no-test-return-statement): Jest tests should not return a value
-   ╭─[no_test_return_statement.tsx:3:21]
  2 │                 it.skip('one', function () {
- 3 │                     return expect(1).toBe(1);
-   ·                     ──────
- 4 │                 });
-   ╰────
-  help: Use `await` for async assertions or remove the return statement.
-  note: Jest ignores returned values from tests.
-
-  ⚠ jest(no-test-return-statement): Jest tests should not return a value
-   ╭─[no_test_return_statement.tsx:3:21]
- 2 │                 it.skip('one', function () {
- 3 │                     return expect(1).toBe(1);
-   ·                     ──────
- 4 │                 });
-   ╰────
-  help: Use `await` for async assertions or remove the return statement.
-  note: Jest ignores returned values from tests.
-
-  ⚠ jest(no-test-return-statement): Jest tests should not return a value
-   ╭─[no_test_return_statement.tsx:3:21]
- 2 │                 it.each``('one', function () {
  3 │                     return expect(1).toBe(1);
    ·                     ──────
  4 │                 });
@@ -84,37 +54,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ jest(no-test-return-statement): Jest tests should not return a value
    ╭─[no_test_return_statement.tsx:3:21]
- 2 │                 it.each()('one', function () {
- 3 │                     return expect(1).toBe(1);
-   ·                     ──────
- 4 │                 });
-   ╰────
-  help: Use `await` for async assertions or remove the return statement.
-  note: Jest ignores returned values from tests.
-
-  ⚠ jest(no-test-return-statement): Jest tests should not return a value
-   ╭─[no_test_return_statement.tsx:3:21]
  2 │                 it.only.each``('one', function () {
- 3 │                     return expect(1).toBe(1);
-   ·                     ──────
- 4 │                 });
-   ╰────
-  help: Use `await` for async assertions or remove the return statement.
-  note: Jest ignores returned values from tests.
-
-  ⚠ jest(no-test-return-statement): Jest tests should not return a value
-   ╭─[no_test_return_statement.tsx:3:21]
- 2 │                 it.only.each``('one', function () {
- 3 │                     return expect(1).toBe(1);
-   ·                     ──────
- 4 │                 });
-   ╰────
-  help: Use `await` for async assertions or remove the return statement.
-  note: Jest ignores returned values from tests.
-
-  ⚠ jest(no-test-return-statement): Jest tests should not return a value
-   ╭─[no_test_return_statement.tsx:3:21]
- 2 │                 it.only.each()('one', function () {
  3 │                     return expect(1).toBe(1);
    ·                     ──────
  4 │                 });

--- a/crates/oxc_linter/src/snapshots/vitest_no_test_return_statement.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_no_test_return_statement.snap
@@ -24,37 +24,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ vitest(no-test-return-statement): Jest tests should not return a value
    ╭─[no_test_return_statement.tsx:3:21]
- 2 │                 it('one', function () {
- 3 │                     return expect(1).toBe(1);
-   ·                     ──────
- 4 │                 });
-   ╰────
-  help: Use `await` for async assertions or remove the return statement.
-  note: Jest ignores returned values from tests.
-
-  ⚠ vitest(no-test-return-statement): Jest tests should not return a value
-   ╭─[no_test_return_statement.tsx:3:21]
  2 │                 it.skip('one', function () {
- 3 │                     return expect(1).toBe(1);
-   ·                     ──────
- 4 │                 });
-   ╰────
-  help: Use `await` for async assertions or remove the return statement.
-  note: Jest ignores returned values from tests.
-
-  ⚠ vitest(no-test-return-statement): Jest tests should not return a value
-   ╭─[no_test_return_statement.tsx:3:21]
- 2 │                 it.skip('one', function () {
- 3 │                     return expect(1).toBe(1);
-   ·                     ──────
- 4 │                 });
-   ╰────
-  help: Use `await` for async assertions or remove the return statement.
-  note: Jest ignores returned values from tests.
-
-  ⚠ vitest(no-test-return-statement): Jest tests should not return a value
-   ╭─[no_test_return_statement.tsx:3:21]
- 2 │                 it.each``('one', function () {
  3 │                     return expect(1).toBe(1);
    ·                     ──────
  4 │                 });
@@ -84,37 +54,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ vitest(no-test-return-statement): Jest tests should not return a value
    ╭─[no_test_return_statement.tsx:3:21]
- 2 │                 it.each()('one', function () {
- 3 │                     return expect(1).toBe(1);
-   ·                     ──────
- 4 │                 });
-   ╰────
-  help: Use `await` for async assertions or remove the return statement.
-  note: Jest ignores returned values from tests.
-
-  ⚠ vitest(no-test-return-statement): Jest tests should not return a value
-   ╭─[no_test_return_statement.tsx:3:21]
  2 │                 it.only.each``('one', function () {
- 3 │                     return expect(1).toBe(1);
-   ·                     ──────
- 4 │                 });
-   ╰────
-  help: Use `await` for async assertions or remove the return statement.
-  note: Jest ignores returned values from tests.
-
-  ⚠ vitest(no-test-return-statement): Jest tests should not return a value
-   ╭─[no_test_return_statement.tsx:3:21]
- 2 │                 it.only.each``('one', function () {
- 3 │                     return expect(1).toBe(1);
-   ·                     ──────
- 4 │                 });
-   ╰────
-  help: Use `await` for async assertions or remove the return statement.
-  note: Jest ignores returned values from tests.
-
-  ⚠ vitest(no-test-return-statement): Jest tests should not return a value
-   ╭─[no_test_return_statement.tsx:3:21]
- 2 │                 it.only.each()('one', function () {
  3 │                     return expect(1).toBe(1);
    ·                     ──────
  4 │                 });

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -241,7 +241,7 @@ jest/no-restricted-jest-methods                            |      0
 jest/no-restricted-matchers                                |      0
 jest/no-standalone-expect                                  |      7
 jest/no-test-prefixes                                      |      0
-jest/no-test-return-statement                              |  76889
+jest/no-test-return-statement                              |  14199
 jest/no-unneeded-async-expect-function                     |      0
 jest/no-untyped-mock-factory                               |      0
 jest/padding-around-after-all-blocks                       |      0
@@ -688,7 +688,7 @@ vitest/no-restricted-matchers                              |      0
 vitest/no-restricted-vi-methods                            |      0
 vitest/no-standalone-expect                                |      7
 vitest/no-test-prefixes                                    |      0
-vitest/no-test-return-statement                            |  76889
+vitest/no-test-return-statement                            |  14199
 vitest/no-unneeded-async-expect-function                   |      0
 vitest/padding-around-after-all-blocks                     |      0
 vitest/padding-around-test-blocks                          |      0


### PR DESCRIPTION
This rule had a nice target AST node that appears infrequently: `ReturnStatement`. If a file doesn't contain that node type, we can completely skip this rule. This also resolved an issue where we reported duplicate diagnostics because we reported once for the `return` and once for the function call chain.