### PR TITLE
fix(react_compiler): remove clippy allows

### DIFF
--- a/crates/oxc_react_compiler/Cargo.toml
+++ b/crates/oxc_react_compiler/Cargo.toml
@@ -46,6 +46,7 @@ oxc_syntax = { workspace = true }
 hmac-sha256 = { workspace = true }
 indexmap = { workspace = true }
 rustc-hash = { workspace = true }
+cow-utils = { workspace = true }
 
 [dev-dependencies]
 # The example and integration tests parse source and print the compiled program; the
@@ -56,7 +57,6 @@ oxc_parser = { workspace = true }
 # Snapshot testing of the compiler over the upstream fixture corpus (tests/snapshot.rs).
 insta = { workspace = true, features = ["glob"] }
 convert_case = { workspace = true }
-cow-utils = { workspace = true }
 
 # Catch usage of old `AstBuilder` APIs in tests, without affecting downstream consumers.
 # If we enabled `disable_old_builder` feature in main dependency, feature unification would

--- a/crates/oxc_react_compiler/src/lib.rs
+++ b/crates/oxc_react_compiler/src/lib.rs
@@ -6,32 +6,21 @@ pub mod scope;
 
 // Vendored React Compiler core crates (from oxc-project/forked-react-compiler),
 // each crate flattened to a module. Kept near byte-for-byte with upstream for easy
-// re-syncing, so `clippy::all` is relaxed here rather than editing the vendored code.
+// re-syncing.
 // They are `pub` so the public API may name types that originate inside them (e.g.
 // `TransformResult::events`); being `pub` also keeps `dead_code` quiet on the parts
 // the conversion layer doesn't reach, so only the few genuinely-dead private items
 // carry their own targeted `#[allow(dead_code)]`.
-#[allow(clippy::all)]
 pub mod react_compiler;
-#[allow(clippy::all)]
 pub mod react_compiler_diagnostics;
-#[allow(clippy::all)]
 pub mod react_compiler_hir;
-#[allow(clippy::all)]
 pub mod react_compiler_inference;
-#[allow(clippy::all)]
 pub mod react_compiler_lowering;
-#[allow(clippy::all)]
 pub mod react_compiler_optimization;
-#[allow(clippy::all)]
 pub mod react_compiler_reactive_scopes;
-#[allow(clippy::all)]
 pub mod react_compiler_ssa;
-#[allow(clippy::all)]
 pub mod react_compiler_typeinference;
-#[allow(clippy::all)]
 pub mod react_compiler_utils;
-#[allow(clippy::all)]
 pub mod react_compiler_validation;
 
 use crate::react_compiler::entrypoint::compile_result::CompileResult;

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/imports.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/imports.rs
@@ -255,7 +255,7 @@ fn is_hook_name(name: &str) -> bool {
         && bytes[0] == b'u'
         && bytes[1] == b's'
         && bytes[2] == b'e'
-        && bytes.get(3).map_or(false, |c| c.is_ascii_uppercase() || c.is_ascii_digit())
+        && bytes.get(3).is_some_and(|c| c.is_ascii_uppercase() || c.is_ascii_digit())
 }
 
 /// Get the runtime module name based on the compiler target.

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
@@ -96,6 +96,7 @@ use crate::react_compiler::debug_print;
 /// Currently: creates an Environment, runs BuildHIR (lowering), and produces
 /// debug output via the context. Returns a CodegenFunction with zeroed memo
 /// stats on success (codegen is not yet implemented).
+#[allow(clippy::too_many_arguments)]
 pub fn compile_fn<'a>(
     ast: &oxc_ast::builder::AstBuilder<'a>,
     func: &FunctionNode<'_>,
@@ -117,7 +118,7 @@ pub fn compile_fn<'a>(
     env.instrument_fn_name = context.instrument_fn_name.clone();
     env.instrument_gating_name = context.instrument_gating_name.clone();
     env.hook_guard_name = context.hook_guard_name.clone();
-    env.seed_uid_known_names(&context.known_referenced_names());
+    env.seed_uid_known_names(context.known_referenced_names());
 
     env.reference_node_ids = scope.all_reference_positions().clone();
 
@@ -694,7 +695,7 @@ pub fn compile_fn<'a>(
         context.log_debug(DebugLogEntry::new("RenameVariables", debug));
     }
 
-    prune_hoisted_contexts(&mut reactive_fn, &mut env)?;
+    prune_hoisted_contexts(&mut reactive_fn, &env)?;
 
     if context.debug_enabled {
         let debug =

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -14,6 +14,7 @@
 //! 5. Processing each function through the compilation pipeline
 //! 6. Applying compiled functions back to the AST
 
+use cow_utils::CowUtils;
 use oxc_ast::ast as oxc;
 use oxc_diagnostics::{Diagnostics, OxcDiagnostic};
 use oxc_span::Span;
@@ -287,12 +288,12 @@ fn is_hook_name(s: &str) -> bool {
         && bytes[0] == b'u'
         && bytes[1] == b's'
         && bytes[2] == b'e'
-        && bytes.get(3).map_or(false, |c| c.is_ascii_uppercase() || c.is_ascii_digit())
+        && bytes.get(3).is_some_and(|c| c.is_ascii_uppercase() || c.is_ascii_digit())
 }
 
 /// Check if a name looks like a React component (starts with uppercase letter).
 fn is_component_name(name: &str) -> bool {
-    name.chars().next().map_or(false, |c| c.is_ascii_uppercase())
+    name.chars().next().is_some_and(|c| c.is_ascii_uppercase())
 }
 
 /// Check if an expression is a hook call (identifier with hook name, or
@@ -307,7 +308,7 @@ fn expr_is_hook(expr: &oxc::Expression) -> bool {
             }
             // Object must be a PascalCase identifier
             if let oxc::Expression::Identifier(obj) = &member.object {
-                obj.name.chars().next().map_or(false, |c| c.is_ascii_uppercase())
+                obj.name.chars().next().is_some_and(|c| c.is_ascii_uppercase())
             } else {
                 false
             }
@@ -513,7 +514,7 @@ fn calls_hooks_or_creates_jsx_in_stmt(stmt: &oxc::Statement) -> bool {
                 || if_stmt
                     .alternate
                     .as_ref()
-                    .map_or(false, |alt| calls_hooks_or_creates_jsx_in_stmt(alt))
+                    .is_some_and(|alt| calls_hooks_or_creates_jsx_in_stmt(alt))
         }
         oxc::Statement::ForStatement(for_stmt) => {
             if let Some(ref init) = for_stmt.init {
@@ -690,7 +691,7 @@ fn calls_hooks_or_creates_jsx_in_expr(expr: &oxc::Expression) -> bool {
         oxc::Expression::UpdateExpression(update) => match &update.argument {
             oxc::SimpleAssignmentTarget::AssignmentTargetIdentifier(_) => false,
             target => {
-                target.as_member_expression().map_or(false, calls_hooks_or_creates_jsx_in_member)
+                target.as_member_expression().is_some_and(calls_hooks_or_creates_jsx_in_member)
             }
         },
         oxc::Expression::StaticMemberExpression(member) => {
@@ -706,10 +707,9 @@ fn calls_hooks_or_creates_jsx_in_expr(expr: &oxc::Expression) -> bool {
         oxc::Expression::AwaitExpression(await_expr) => {
             calls_hooks_or_creates_jsx_in_expr(&await_expr.argument)
         }
-        oxc::Expression::YieldExpression(yield_expr) => yield_expr
-            .argument
-            .as_ref()
-            .map_or(false, |arg| calls_hooks_or_creates_jsx_in_expr(arg)),
+        oxc::Expression::YieldExpression(yield_expr) => {
+            yield_expr.argument.as_ref().is_some_and(|arg| calls_hooks_or_creates_jsx_in_expr(arg))
+        }
         oxc::Expression::TaggedTemplateExpression(tagged) => {
             calls_hooks_or_creates_jsx_in_expr(&tagged.tag)
                 || tagged.quasi.expressions.iter().any(calls_hooks_or_creates_jsx_in_expr)
@@ -722,7 +722,7 @@ fn calls_hooks_or_creates_jsx_in_expr(expr: &oxc::Expression) -> bool {
                 calls_hooks_or_creates_jsx_in_expr(&s.argument)
             }
             oxc::ArrayExpressionElement::Elision(_) => false,
-            other => other.as_expression().map_or(false, calls_hooks_or_creates_jsx_in_expr),
+            other => other.as_expression().is_some_and(calls_hooks_or_creates_jsx_in_expr),
         }),
         oxc::Expression::ObjectExpression(obj) => obj.properties.iter().any(|prop| match prop {
             oxc::ObjectPropertyKind::SpreadProperty(s) => {
@@ -885,16 +885,16 @@ fn calls_hooks_or_creates_jsx_in_binding(pattern: &oxc::BindingPattern) -> bool 
                 || obj
                     .rest
                     .as_ref()
-                    .map_or(false, |r| calls_hooks_or_creates_jsx_in_binding(&r.argument))
+                    .is_some_and(|r| calls_hooks_or_creates_jsx_in_binding(&r.argument))
         }
         oxc::BindingPattern::ArrayPattern(arr) => {
             arr.elements
                 .iter()
-                .any(|e| e.as_ref().map_or(false, calls_hooks_or_creates_jsx_in_binding))
+                .any(|e| e.as_ref().is_some_and(calls_hooks_or_creates_jsx_in_binding))
                 || arr
                     .rest
                     .as_ref()
-                    .map_or(false, |r| calls_hooks_or_creates_jsx_in_binding(&r.argument))
+                    .is_some_and(|r| calls_hooks_or_creates_jsx_in_binding(&r.argument))
         }
         oxc::BindingPattern::AssignmentPattern(assign) => {
             calls_hooks_or_creates_jsx_in_expr(&assign.right)
@@ -984,6 +984,7 @@ enum FunctionBody<'a> {
 /// and the function's name and context.
 ///
 /// This is the Rust equivalent of `getReactFunctionType` in Program.ts.
+#[allow(clippy::too_many_arguments)]
 fn get_react_function_type(
     name: Option<&str>,
     params: &oxc::FormalParameters,
@@ -1227,6 +1228,7 @@ fn try_compile_function<'a>(
 /// Returns `Ok(Some(codegen_fn))` when the function was compiled and should be applied,
 /// `Ok(None)` when the function was skipped or lint-only,
 /// or `Err(CompileResult)` if a fatal error should short-circuit the program.
+#[allow(clippy::result_large_err)]
 fn process_fn<'a>(
     ast: &oxc_ast::builder::AstBuilder<'a>,
     source: &CompileSource,
@@ -2701,7 +2703,7 @@ fn ox_add_imports_to_program<'a>(
     }
 
     let mut sorted_modules: Vec<_> = imports.iter().collect();
-    sorted_modules.sort_by(|(a, _), (b, _)| a.to_lowercase().cmp(&b.to_lowercase()));
+    sorted_modules.sort_by_key(|(a, _)| a.cow_to_lowercase());
 
     let is_module = matches!(program.source_type.module_kind(), oxc_span::ModuleKind::Module);
 

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/suppression.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/suppression.rs
@@ -116,15 +116,14 @@ fn matches_flow_suppression(value: &str) -> bool {
     let after_dollar_flow = &value[idx + "$Flow".len()..];
 
     // Match FlowFixMe (with optional word chars), FlowExpectedError, or FlowIssue
-    let after_kind = if after_dollar_flow.starts_with("FixMe") {
+    let after_kind = if let Some(rest) = after_dollar_flow.strip_prefix("FixMe") {
         // Skip "FixMe" + any word characters
-        let rest = &after_dollar_flow["FixMe".len()..];
         let word_end = rest.find(|c: char| !c.is_alphanumeric() && c != '_').unwrap_or(rest.len());
         &rest[word_end..]
-    } else if after_dollar_flow.starts_with("ExpectedError") {
-        &after_dollar_flow["ExpectedError".len()..]
-    } else if after_dollar_flow.starts_with("Issue") {
-        &after_dollar_flow["Issue".len()..]
+    } else if let Some(rest) = after_dollar_flow.strip_prefix("ExpectedError") {
+        rest
+    } else if let Some(rest) = after_dollar_flow.strip_prefix("Issue") {
+        rest
     } else {
         return false;
     };
@@ -231,7 +230,7 @@ pub fn filter_suppressions_that_affect_function(
                     .enable_comment
                     .as_ref()
                     .and_then(|c| c.end)
-                    .map_or(false, |end| end < fn_end))
+                    .is_some_and(|end| end < fn_end))
         {
             suppressions_in_scope.push(suppression);
         }
@@ -243,7 +242,7 @@ pub fn filter_suppressions_that_affect_function(
                     .enable_comment
                     .as_ref()
                     .and_then(|c| c.end)
-                    .map_or(false, |end| end > fn_end))
+                    .is_some_and(|end| end > fn_end))
         {
             suppressions_in_scope.push(suppression);
         }

--- a/crates/oxc_react_compiler/src/react_compiler_diagnostics/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_diagnostics/mod.rs
@@ -30,6 +30,7 @@ pub enum ErrorCategory {
     Config,
     Gating,
     Suppression,
+    #[allow(clippy::upper_case_acronyms)]
     FBT,
 }
 

--- a/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
@@ -1,5 +1,6 @@
 use std::mem::take;
 
+use cow_utils::CowUtils;
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 
@@ -492,7 +493,7 @@ impl<'a> Environment<'a> {
                                 ErrorCategory::Config,
                                 "Invalid type configuration for module",
                             )
-                            .with_description(format!("{}", first_error))
+                            .with_description(first_error.to_string())
                             .with_loc(loc),
                         )?;
                     }
@@ -536,7 +537,7 @@ impl<'a> Environment<'a> {
                                 ErrorCategory::Config,
                                 "Invalid type configuration for module",
                             )
-                            .with_description(format!("{}", first_error))
+                            .with_description(first_error.to_string())
                             .with_loc(loc),
                         )?;
                     }
@@ -757,7 +758,7 @@ impl<'a> Environment<'a> {
     }
 
     fn is_known_react_module(&self, module_name: &str) -> bool {
-        let lower = module_name.to_lowercase();
+        let lower = module_name.cow_to_lowercase();
         lower == "react" || lower == "react-dom"
     }
 
@@ -957,7 +958,7 @@ impl<'a> Environment<'a> {
     /// Looks up the identifier's type and checks its function signature.
     pub fn has_no_alias_signature(&self, identifier_id: IdentifierId) -> bool {
         let ty = &self.types[self.identifiers[identifier_id.0 as usize].type_.0 as usize];
-        self.get_function_signature(ty).ok().flatten().map_or(false, |sig| sig.no_alias)
+        self.get_function_signature(ty).ok().flatten().is_some_and(|sig| sig.no_alias)
     }
 
     /// Get the hook kind for an identifier, if its type represents a hook.

--- a/crates/oxc_react_compiler/src/react_compiler_hir/environment_config.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/environment_config.rs
@@ -39,18 +39,13 @@ pub struct HookConfig {
     pub transitive_mixed_data: bool,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ExhaustiveEffectDepsMode {
+    #[default]
     Off,
     All,
     MissingOnly,
     ExtraOnly,
-}
-
-impl Default for ExhaustiveEffectDepsMode {
-    fn default() -> Self {
-        Self::Off
-    }
 }
 
 /// Compiler environment configuration. Contains feature flags and settings.

--- a/crates/oxc_react_compiler/src/react_compiler_hir/globals.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/globals.rs
@@ -62,7 +62,7 @@ impl GlobalRegistry {
     }
 
     pub fn contains_key(&self, key: &str) -> bool {
-        self.entries.contains_key(key) || self.base.map_or(false, |b| b.contains_key(key))
+        self.entries.contains_key(key) || self.base.is_some_and(|b| b.contains_key(key))
     }
 
     /// Iterate over all keys in the registry (base + extras).
@@ -81,6 +81,12 @@ impl GlobalRegistry {
     pub fn into_inner(self) -> FxHashMap<String, Global> {
         debug_assert!(self.base.is_none(), "into_inner() called on overlay-mode GlobalRegistry");
         self.entries
+    }
+}
+
+impl Default for GlobalRegistry {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
@@ -187,6 +187,7 @@ pub enum ParamPattern {
 
 /// The HIR control-flow graph
 #[derive(Debug, Clone)]
+#[allow(clippy::upper_case_acronyms)]
 pub struct HIR {
     pub entry: BlockId,
     pub blocks: FxIndexMap<BlockId, BasicBlock>,
@@ -1256,12 +1257,27 @@ impl NonLocalBinding {
 #[derive(Debug, Clone)]
 pub enum Type {
     Primitive,
-    Function { shape_id: Option<String>, return_type: Box<Type>, is_constructor: bool },
-    Object { shape_id: Option<String> },
-    TypeVar { id: TypeId },
+    Function {
+        shape_id: Option<String>,
+        return_type: Box<Type>,
+        is_constructor: bool,
+    },
+    Object {
+        shape_id: Option<String>,
+    },
+    #[allow(clippy::enum_variant_names)]
+    TypeVar {
+        id: TypeId,
+    },
     Poly,
-    Phi { operands: Vec<Type> },
-    Property { object_type: Box<Type>, object_name: String, property_name: PropertyNameKind },
+    Phi {
+        operands: Vec<Type>,
+    },
+    Property {
+        object_type: Box<Type>,
+        object_name: String,
+        property_name: PropertyNameKind,
+    },
     ObjectMethod,
 }
 
@@ -1340,6 +1356,7 @@ pub enum MutationReason {
 /// Describes the aliasing/mutation/data-flow effects of an instruction or terminal.
 /// Ported from TS `AliasingEffect` in `AliasingEffects.ts`.
 #[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
 pub enum AliasingEffect {
     /// Marks the given value and its direct aliases as frozen.
     Freeze { value: Place, reason: ValueReason },

--- a/crates/oxc_react_compiler/src/react_compiler_hir/object_shape.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/object_shape.rs
@@ -170,6 +170,12 @@ impl ShapeRegistry {
     }
 }
 
+impl Default for ShapeRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Clone for ShapeRegistry {
     fn clone(&self) -> Self {
         Self { base: self.base, entries: self.entries.clone() }

--- a/crates/oxc_react_compiler/src/react_compiler_hir/print.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/print.rs
@@ -703,6 +703,7 @@ impl<'a, 'h> PrintFormatter<'a, 'h> {
     /// Format an InstructionValue. The `inner_func_formatter` callback is invoked
     /// for FunctionExpression/ObjectMethod to format the inner HirFunction. If None,
     /// a placeholder is printed instead.
+    #[allow(clippy::type_complexity)]
     pub fn format_instruction_value(
         &mut self,
         value: &InstructionValue<'h>,

--- a/crates/oxc_react_compiler/src/react_compiler_hir/reactive.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/reactive.rs
@@ -50,6 +50,7 @@ pub type ReactiveBlock<'a> = Vec<ReactiveStatement<'a>>;
 
 /// TS: ReactiveStatement (discriminated union with 'kind' field)
 #[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
 pub enum ReactiveStatement<'a> {
     Instruction(ReactiveInstruction<'a>),
     Terminal(ReactiveTerminalStatement<'a>),

--- a/crates/oxc_react_compiler/src/react_compiler_hir/visitors.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/visitors.rs
@@ -752,7 +752,7 @@ pub fn map_instruction_value_operands(
 
 /// Maps call arguments in place.
 /// Equivalent to TS `mapCallArguments`.
-pub fn map_call_arguments(args: &mut Vec<PlaceOrSpread>, f: &mut impl FnMut(Place) -> Place) {
+pub fn map_call_arguments(args: &mut [PlaceOrSpread], f: &mut impl FnMut(Place) -> Place) {
     for arg in args.iter_mut() {
         match arg {
             PlaceOrSpread::Place(place) => {

--- a/crates/oxc_react_compiler/src/react_compiler_inference/align_reactive_scopes_to_block_scopes_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/align_reactive_scopes_to_block_scopes_hir.rs
@@ -131,7 +131,7 @@ pub fn align_reactive_scopes_to_block_scopes_hir(func: &mut HirFunction, env: &m
 
         // Visit instruction lvalues and operands
         let block = func.body.blocks.get(&block_id).unwrap();
-        let instr_ids: Vec<InstructionId> = block.instructions.iter().copied().collect();
+        let instr_ids: Vec<InstructionId> = block.instructions.to_vec();
         for &instr_id in &instr_ids {
             let instr = &func.instructions[instr_id.0 as usize];
             let eval_order = instr.id;

--- a/crates/oxc_react_compiler/src/react_compiler_inference/build_reactive_scope_terminals_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/build_reactive_scope_terminals_hir.rs
@@ -124,8 +124,7 @@ fn collect_scope_rewrites(func: &HirFunction, env: &mut Environment) -> Vec<Term
     let mut fallthroughs: FxHashMap<ScopeId, BlockId> = FxHashMap::default();
     let mut active_items: Vec<ScopeId> = Vec::new();
 
-    for i in 0..items.len() {
-        let curr = items[i];
+    for &curr in &items {
         let curr_start = env.scopes[curr.0 as usize].range.start;
         let curr_end = env.scopes[curr.0 as usize].range.end;
 

--- a/crates/oxc_react_compiler/src/react_compiler_inference/flatten_reactive_loops_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/flatten_reactive_loops_hir.rs
@@ -36,19 +36,17 @@ pub fn flatten_reactive_loops_hir(func: &mut HirFunction) {
             | Terminal::While { fallthrough, .. } => {
                 active_loops.push(*fallthrough);
             }
-            Terminal::Scope { block, fallthrough, scope, id, loc } => {
-                if !active_loops.is_empty() {
-                    let new_terminal = Terminal::PrunedScope {
-                        block: *block,
-                        fallthrough: *fallthrough,
-                        scope: *scope,
-                        id: *id,
-                        loc: *loc,
-                    };
-                    // We need to drop the borrow and reborrow mutably
-                    let block_mut = func.body.blocks.get_mut(&block_id).unwrap();
-                    block_mut.terminal = new_terminal;
-                }
+            Terminal::Scope { block, fallthrough, scope, id, loc } if !active_loops.is_empty() => {
+                let new_terminal = Terminal::PrunedScope {
+                    block: *block,
+                    fallthrough: *fallthrough,
+                    scope: *scope,
+                    id: *id,
+                    loc: *loc,
+                };
+                // We need to drop the borrow and reborrow mutably
+                let block_mut = func.body.blocks.get_mut(&block_id).unwrap();
+                block_mut.terminal = new_terminal;
             }
             // All other terminal kinds: no action needed
             _ => {}

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
@@ -202,7 +202,7 @@ pub fn infer_mutation_aliasing_effects(
                 let name = ident_info
                     .and_then(|ident| ident.name.as_ref())
                     .map(|n| n.value().to_string())
-                    .unwrap_or_else(|| "".to_string());
+                    .unwrap_or_default();
                 // Use usage_loc if available, otherwise fall back to identifier's own loc
                 let error_loc = usage_loc.or_else(|| ident_info.and_then(|i| i.loc));
                 // Match TS printPlace format: "<unknown> name$id:type"
@@ -356,15 +356,10 @@ impl InferenceState {
                 let vid = ValueId(from.0 | 0x80000000);
                 let mut set = FxHashSet::default();
                 set.insert(vid);
-                if !self.values.contains_key(&vid) {
-                    self.values.insert(
-                        vid,
-                        AbstractValue {
-                            kind: ValueKind::Mutable,
-                            reason: hashset_of(ValueReason::Other),
-                        },
-                    );
-                }
+                self.values.entry(vid).or_insert_with(|| AbstractValue {
+                    kind: ValueKind::Mutable,
+                    reason: hashset_of(ValueReason::Other),
+                });
                 set
             }
         };
@@ -801,10 +796,8 @@ fn find_non_mutated_destructure_spreads(
 ) -> FxHashSet<IdentifierId> {
     let mut known_frozen: FxHashSet<IdentifierId> = FxHashSet::default();
     if func.fn_type == ReactFunctionType::Component {
-        if let Some(param) = func.params.first() {
-            if let ParamPattern::Place(p) = param {
-                known_frozen.insert(p.identifier);
-            }
+        if let Some(ParamPattern::Place(p)) = func.params.first() {
+            known_frozen.insert(p.identifier);
         }
     } else {
         for param in &func.params {
@@ -1206,6 +1199,7 @@ fn freeze_function_captures_transitive(
 // applyEffect
 // =============================================================================
 
+#[allow(clippy::only_used_in_recursion)]
 fn apply_effect(
     context: &mut Context,
     state: &mut InferenceState,
@@ -1514,10 +1508,9 @@ fn apply_effect(
                         let inner_func = &env.functions[func_id.0 as usize];
                         if inner_func.aliasing_effects.is_some() {
                             // Build or retrieve the signature from the function expression
-                            if !context.function_signature_cache.contains_key(&func_id) {
-                                let sig = build_signature_from_function_expression(env, func_id);
-                                context.function_signature_cache.insert(func_id, sig);
-                            }
+                            context.function_signature_cache.entry(func_id).or_insert_with(|| {
+                                build_signature_from_function_expression(env, func_id)
+                            });
                             let sig =
                                 context.function_signature_cache.get(&func_id).unwrap().clone();
                             let inner_func = &env.functions[func_id.0 as usize];
@@ -2290,6 +2283,7 @@ fn compute_signature_for_instruction(
 // Legacy signature support
 // =============================================================================
 
+#[allow(clippy::too_many_arguments)]
 fn compute_effects_for_legacy_signature(
     state: &InferenceState,
     signature: &FunctionSignature,
@@ -2443,9 +2437,7 @@ fn get_argument_effect(
     is_spread: bool,
     spread_loc: Option<SourceLocation>,
 ) -> (Effect, Option<CompilerErrorDetail>) {
-    if !is_spread {
-        (sig_effect, None)
-    } else if sig_effect == Effect::Mutate || sig_effect == Effect::ConditionallyMutate {
+    if !is_spread || sig_effect == Effect::Mutate || sig_effect == Effect::ConditionallyMutate {
         (sig_effect, None)
     } else {
         // Spread with Freeze effect is unsupported for hook arguments
@@ -2493,7 +2485,7 @@ fn are_arguments_immutable_and_non_mutating(
                                 .iter()
                                 .any(|e| is_known_mutable_effect(*e));
                             let has_mutable_rest =
-                                fn_sig.rest_param.map_or(false, |e| is_known_mutable_effect(e));
+                                fn_sig.rest_param.is_some_and(is_known_mutable_effect);
                             return !has_mutable_param && !has_mutable_rest;
                         }
                     }
@@ -2548,6 +2540,7 @@ fn is_known_mutable_effect(effect: Effect) -> bool {
 // Aliasing signature config support (new-style signatures)
 // =============================================================================
 
+#[allow(clippy::too_many_arguments)]
 fn compute_effects_for_aliasing_signature_config(
     env: &mut Environment,
     config: &AliasingSignatureConfig,
@@ -3138,7 +3131,7 @@ fn format_type_for_print(ty: &Type) -> String {
 }
 
 fn is_phi_with_jsx(ty: &Type) -> bool {
-    if let Type::Phi { operands } = ty { operands.iter().any(|op| is_jsx_type(op)) } else { false }
+    if let Type::Phi { operands } = ty { operands.iter().any(is_jsx_type) } else { false }
 }
 
 fn place_or_spread_to_hole(pos: &PlaceOrSpread) -> PlaceOrSpreadOrHole {

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_ranges.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_ranges.rs
@@ -214,6 +214,7 @@ impl AliasingState {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn mutate(
         &mut self,
         index: usize,
@@ -490,7 +491,7 @@ pub fn infer_mutation_aliasing_ranges(
             state.create(&phi.place, NodeValue::Phi);
             for (&pred, operand) in &phi.operands {
                 if !seen_blocks.contains(&pred) {
-                    pending_phis.entry(pred).or_insert_with(Vec::new).push(PendingPhiOperand {
+                    pending_phis.entry(pred).or_default().push(PendingPhiOperand {
                         from: operand.clone(),
                         into: phi.place.clone(),
                         index,
@@ -1032,8 +1033,7 @@ pub fn infer_mutation_aliasing_ranges(
             false, // never record errors for simulated mutations
         );
 
-        for j in 0..tracked.len() {
-            let from = &tracked[j];
+        for from in &tracked {
             if from.identifier == into.identifier || from.identifier == returns_identifier_id {
                 continue;
             }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_places.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_places.rs
@@ -192,7 +192,7 @@ pub fn infer_reactive_places(
                             Effect::Unknown => {
                                 return Err(CompilerDiagnostic::new(
                                     ErrorCategory::Invariant,
-                                    &format!("Unexpected unknown effect at {:?}", op_place.loc),
+                                    format!("Unexpected unknown effect at {:?}", op_place.loc),
                                     None,
                                 ));
                             }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_scope_variables.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_scope_variables.rs
@@ -81,7 +81,7 @@ pub fn infer_reactive_scope_variables(
     });
 
     // Set loc on each scope
-    for (_group_id, state) in &scopes {
+    for state in scopes.values() {
         env.scopes[state.scope_id.0 as usize].loc = state.loc;
     }
 
@@ -108,7 +108,7 @@ pub fn infer_reactive_scope_variables(
             EvaluationOrder(max_instruction.0.max(block.terminal.evaluation_order().0));
     }
 
-    for (_group_id, state) in &scopes {
+    for state in scopes.values() {
         let scope = &env.scopes[state.scope_id.0 as usize];
         if scope.range.start == EvaluationOrder(0)
             || scope.range.end == EvaluationOrder(0)
@@ -117,7 +117,7 @@ pub fn infer_reactive_scope_variables(
         {
             return Err(CompilerDiagnostic::new(
                 ErrorCategory::Invariant,
-                &format!(
+                format!(
                     "Invalid mutable range for scope: Scope @{} has range [{}:{}] but the valid range is [1:{}]",
                     scope.id.0,
                     scope.range.start.0,

--- a/crates/oxc_react_compiler/src/react_compiler_inference/memoize_fbt_and_macro_operands_in_same_scope.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/memoize_fbt_and_macro_operands_in_same_scope.rs
@@ -99,9 +99,8 @@ pub fn memoize_fbt_and_macro_operands_in_same_scope(
     let mut macro_tags = populate_macro_tags(func, &macro_kinds);
 
     // Phase 3: Reverse data-flow to merge arguments of macro invocations
-    let macro_values = merge_macro_arguments(func, env, &mut macro_tags, &macro_kinds);
 
-    macro_values
+    merge_macro_arguments(func, env, &mut macro_tags, &macro_kinds)
 }
 
 /// Forward data-flow analysis to identify all macro tags, including
@@ -131,21 +130,22 @@ fn populate_macro_tags(
                         macro_tags.insert(lvalue_id, macro_def.clone());
                     }
                 }
-                InstructionValue::PropertyLoad { object, property, .. } => {
-                    if let PropertyLiteral::String(prop_name) = property {
-                        if let Some(macro_def) = macro_tags.get(&object.identifier).cloned() {
-                            let property_macro = if let Some(ref props) = macro_def.properties {
-                                let prop_def =
-                                    props.get(prop_name.as_str()).or_else(|| props.get("*"));
-                                match prop_def {
-                                    Some(def) => def.clone(),
-                                    None => macro_def.clone(),
-                                }
-                            } else {
-                                macro_def.clone()
-                            };
-                            macro_tags.insert(lvalue_id, property_macro);
-                        }
+                InstructionValue::PropertyLoad {
+                    object,
+                    property: PropertyLiteral::String(prop_name),
+                    ..
+                } => {
+                    if let Some(macro_def) = macro_tags.get(&object.identifier).cloned() {
+                        let property_macro = if let Some(ref props) = macro_def.properties {
+                            let prop_def = props.get(prop_name.as_str()).or_else(|| props.get("*"));
+                            match prop_def {
+                                Some(def) => def.clone(),
+                                None => macro_def.clone(),
+                            }
+                        } else {
+                            macro_def.clone()
+                        };
+                        macro_tags.insert(lvalue_id, property_macro);
                     }
                 }
                 _ => {}

--- a/crates/oxc_react_compiler/src/react_compiler_inference/merge_overlapping_reactive_scopes_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/merge_overlapping_reactive_scopes_hir.rs
@@ -153,11 +153,11 @@ fn collect_scope_info(func: &HirFunction, env: &Environment) -> ScopeInfo {
     // Convert to sorted vecs (descending by id for pop-from-end)
     let mut scope_starts: Vec<ScopeStartEntry> =
         scope_starts_map.into_iter().map(|(id, scopes)| ScopeStartEntry { id, scopes }).collect();
-    scope_starts.sort_by(|a, b| b.id.cmp(&a.id));
+    scope_starts.sort_by_key(|a| std::cmp::Reverse(a.id));
 
     let mut scope_ends: Vec<ScopeEndEntry> =
         scope_ends_map.into_iter().map(|(id, scopes)| ScopeEndEntry { id, scopes }).collect();
-    scope_ends.sort_by(|a, b| b.id.cmp(&a.id));
+    scope_ends.sort_by_key(|a| std::cmp::Reverse(a.id));
 
     ScopeInfo { scope_starts, scope_ends, place_scopes }
 }
@@ -173,55 +173,47 @@ fn visit_instruction_id(
     env: &Environment,
 ) {
     // Handle all scopes that end at this instruction
-    if let Some(top) = scope_info.scope_ends.last() {
-        if top.id <= id {
-            let scope_end_entry = scope_info.scope_ends.pop().unwrap();
+    if let Some(scope_end_entry) = scope_info.scope_ends.pop_if(|top| top.id <= id) {
+        // Sort scopes by start descending (matching active_scopes order)
+        let mut scopes_sorted = scope_end_entry.scopes;
+        scopes_sorted.sort_by(|a, b| {
+            let a_start = env.scopes[a.0 as usize].range.start;
+            let b_start = env.scopes[b.0 as usize].range.start;
+            b_start.cmp(&a_start)
+        });
 
-            // Sort scopes by start descending (matching active_scopes order)
-            let mut scopes_sorted = scope_end_entry.scopes;
-            scopes_sorted.sort_by(|a, b| {
-                let a_start = env.scopes[a.0 as usize].range.start;
-                let b_start = env.scopes[b.0 as usize].range.start;
-                b_start.cmp(&a_start)
-            });
-
-            for scope in &scopes_sorted {
-                let idx = state.active_scopes.iter().position(|s| s == scope);
-                if let Some(idx) = idx {
-                    // Detect and merge all overlapping scopes
-                    if idx != state.active_scopes.len() - 1 {
-                        let mut to_union: Vec<ScopeId> = vec![*scope];
-                        to_union.extend_from_slice(&state.active_scopes[idx + 1..]);
-                        state.joined.union(&to_union);
-                    }
-                    state.active_scopes.remove(idx);
+        for scope in &scopes_sorted {
+            let idx = state.active_scopes.iter().position(|s| s == scope);
+            if let Some(idx) = idx {
+                // Detect and merge all overlapping scopes
+                if idx != state.active_scopes.len() - 1 {
+                    let mut to_union: Vec<ScopeId> = vec![*scope];
+                    to_union.extend_from_slice(&state.active_scopes[idx + 1..]);
+                    state.joined.union(&to_union);
                 }
+                state.active_scopes.remove(idx);
             }
         }
     }
 
     // Handle all scopes that begin at this instruction
-    if let Some(top) = scope_info.scope_starts.last() {
-        if top.id <= id {
-            let scope_start_entry = scope_info.scope_starts.pop().unwrap();
+    if let Some(scope_start_entry) = scope_info.scope_starts.pop_if(|top| top.id <= id) {
+        // Sort by end descending
+        let mut scopes_sorted = scope_start_entry.scopes;
+        scopes_sorted.sort_by(|a, b| {
+            let a_end = env.scopes[a.0 as usize].range.end;
+            let b_end = env.scopes[b.0 as usize].range.end;
+            b_end.cmp(&a_end)
+        });
 
-            // Sort by end descending
-            let mut scopes_sorted = scope_start_entry.scopes;
-            scopes_sorted.sort_by(|a, b| {
-                let a_end = env.scopes[a.0 as usize].range.end;
-                let b_end = env.scopes[b.0 as usize].range.end;
-                b_end.cmp(&a_end)
-            });
+        state.active_scopes.extend_from_slice(&scopes_sorted);
 
-            state.active_scopes.extend_from_slice(&scopes_sorted);
-
-            // Merge all identical scopes (same start and end)
-            for i in 1..scopes_sorted.len() {
-                let prev = scopes_sorted[i - 1];
-                let curr = scopes_sorted[i];
-                if env.scopes[prev.0 as usize].range.end == env.scopes[curr.0 as usize].range.end {
-                    state.joined.union(&[prev, curr]);
-                }
+        // Merge all identical scopes (same start and end)
+        for i in 1..scopes_sorted.len() {
+            let prev = scopes_sorted[i - 1];
+            let curr = scopes_sorted[i];
+            if env.scopes[prev.0 as usize].range.end == env.scopes[curr.0 as usize].range.end {
+                state.joined.union(&[prev, curr]);
             }
         }
     }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
@@ -1740,9 +1740,7 @@ impl<'a> DependencyCollectionContext<'a> {
             return;
         }
         let decl_id = env.identifiers[identifier_id.0 as usize].declaration_id;
-        if !self.declarations.contains_key(&decl_id) {
-            self.declarations.insert(decl_id, decl.clone());
-        }
+        self.declarations.entry(decl_id).or_insert_with(|| decl.clone());
         self.reassignments.insert(identifier_id, decl);
     }
 
@@ -1902,22 +1900,20 @@ fn visit_inner_function_blocks(
     // Clone inner function's instructions and block structure to avoid
     // borrow conflicts when mutating env through handle_instruction.
     let inner_instrs: Vec<Instruction> = env.functions[func_id.0 as usize].instructions.clone();
-    let inner_blocks: Vec<(BlockId, Vec<InstructionId>, Vec<(BlockId, IdentifierId)>, Terminal)> =
-        env.functions[func_id.0 as usize]
-            .body
-            .blocks
-            .iter()
-            .map(|(bid, blk)| {
-                let phi_ops: Vec<(BlockId, IdentifierId)> = blk
-                    .phis
-                    .iter()
-                    .flat_map(|phi| {
-                        phi.operands.iter().map(|(pred, place)| (*pred, place.identifier))
-                    })
-                    .collect();
-                (*bid, blk.instructions.clone(), phi_ops, blk.terminal.clone())
-            })
-            .collect();
+    type InnerBlockSnapshot = (BlockId, Vec<InstructionId>, Vec<(BlockId, IdentifierId)>, Terminal);
+    let inner_blocks: Vec<InnerBlockSnapshot> = env.functions[func_id.0 as usize]
+        .body
+        .blocks
+        .iter()
+        .map(|(bid, blk)| {
+            let phi_ops: Vec<(BlockId, IdentifierId)> = blk
+                .phis
+                .iter()
+                .flat_map(|phi| phi.operands.iter().map(|(pred, place)| (*pred, place.identifier)))
+                .collect();
+            (*bid, blk.instructions.clone(), phi_ops, blk.terminal.clone())
+        })
+        .collect();
 
     for (inner_bid, inner_instr_ids, inner_phis, inner_terminal) in &inner_blocks {
         for &(_pred_id, op_id) in inner_phis {

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -1,3 +1,4 @@
+use cow_utils::CowUtils;
 use rustc_hash::FxHashSet;
 
 use crate::react_compiler_diagnostics::CompilerDiagnostic;
@@ -67,7 +68,7 @@ fn validate_ts_this_parameters_in_function_range(
 
 /// Get the Babel-style type name of an Expression node (e.g. "Identifier", "NumericLiteral").
 fn build_temporary_place(builder: &mut HirBuilder<'_, '_>, loc: Option<SourceLocation>) -> Place {
-    let id = builder.make_temporary(loc.clone());
+    let id = builder.make_temporary(loc);
     Place { identifier: id, reactive: false, effect: Effect::Unknown, loc }
 }
 
@@ -92,7 +93,7 @@ fn lower_value_to_temporary<'a>(
         }
     }
     let loc = value.loc().cloned();
-    let place = build_temporary_place(builder, loc.clone());
+    let place = build_temporary_place(builder, loc);
     builder.push(Instruction {
         id: EvaluationOrder(0),
         lvalue: place.clone(),
@@ -415,8 +416,8 @@ fn lower_block_statement_inner<'a>(
                 will_hoist.push(HoistInfo {
                     binding_id: *binding_id,
                     name: name.clone(),
-                    kind: kind.clone(),
-                    declaration_type: decl_type.clone(),
+                    kind: *kind,
+                    declaration_type: *decl_type,
                     first_ref_pos: hoist_ref_pos,
                     first_ref_nid: hoist_ref_nid,
                 });
@@ -470,14 +471,10 @@ fn lower_block_statement_inner<'a>(
             };
 
             // Look up the reference location for the DeclareContext instruction.
-            let ref_loc = builder.identifier_locs().get(&info.first_ref_nid).map(|e| e.loc.clone());
+            let ref_loc = builder.identifier_locs().get(&info.first_ref_nid).map(|e| e.loc);
             let identifier = builder.resolve_binding(&info.name, info.binding_id)?;
-            let place = Place {
-                effect: Effect::Unknown,
-                identifier,
-                reactive: false,
-                loc: ref_loc.clone(),
-            };
+            let place =
+                Place { effect: Effect::Unknown, identifier, reactive: false, loc: ref_loc };
             lower_value_to_temporary(
                 builder,
                 InstructionValue::DeclareContext {
@@ -532,6 +529,11 @@ enum FunctionBody<'a> {
     Block(&'a oxc::FunctionBody<'a>),
     Expression(&'a oxc::Expression<'a>),
 }
+
+type LowerInnerResult<'a> = Result<
+    (HirFunction<'a>, FxIndexMap<String, SymbolId>, FxIndexMap<SymbolId, IdentifierId>),
+    CompilerError,
+>;
 
 /// Main entry point: lower a function AST node into HIR.
 ///
@@ -629,6 +631,7 @@ pub fn lower<'a>(
 // =============================================================================
 
 /// Result of resolving an identifier for assignment.
+#[allow(clippy::too_many_arguments)]
 fn lower_inner<'a>(
     params: &'a oxc::FormalParameters<'a>,
     body: FunctionBody<'a>,
@@ -647,10 +650,7 @@ fn lower_inner<'a>(
     is_top_level: bool,
     identifier_locs: &IdentifierLocIndex,
     line_offsets: &LineOffsets,
-) -> Result<
-    (HirFunction<'a>, FxIndexMap<String, SymbolId>, FxIndexMap<SymbolId, IdentifierId>),
-    CompilerError,
-> {
+) -> LowerInnerResult<'a> {
     validate_ts_this_parameter(scope, function_scope)?;
 
     let mut builder = HirBuilder::new(
@@ -671,12 +671,7 @@ fn lower_inner<'a>(
     let mut context: Vec<Place> = Vec::new();
     for (&symbol_id, ctx_loc) in &context_map {
         let identifier = builder.resolve_binding(scope.symbol_name(symbol_id), symbol_id)?;
-        context.push(Place {
-            identifier,
-            effect: Effect::Unknown,
-            reactive: false,
-            loc: ctx_loc.clone(),
-        });
+        context.push(Place { identifier, effect: Effect::Unknown, reactive: false, loc: *ctx_loc });
     }
 
     // Process parameters.
@@ -693,7 +688,7 @@ fn lower_inner<'a>(
             let param_loc = builder.source_location(ident.span);
             let mut binding = builder.resolve_identifier(
                 ident.name.as_str(),
-                param_loc.clone(),
+                param_loc,
                 builder.scope().resolve_binding_identifier(ident),
             )?;
             if !matches!(binding, VariableBinding::Identifier { .. }) {
@@ -707,7 +702,7 @@ fn lower_inner<'a>(
                     let identifier = builder.resolve_binding_with_loc(
                         ident.name.as_str(),
                         symbol_id,
-                        param_loc.clone(),
+                        param_loc,
                     )?;
                     binding = VariableBinding::Identifier { identifier, binding_kind };
                 }
@@ -751,11 +746,11 @@ fn lower_inner<'a>(
         // param, then delegate the binding via `lower_binding_assignment` (running
         // the default ternary first when an initializer is present).
         let param_loc = builder.source_location(param.span);
-        let place = build_temporary_place(&mut builder, param_loc.clone());
+        let place = build_temporary_place(&mut builder, param_loc);
         promote_temporary(&mut builder, place.identifier);
         hir_params.push(ParamPattern::Place(place.clone()));
         let value = if let Some(initializer) = &param.initializer {
-            lower_default_to_temp(&mut builder, param_loc.clone(), initializer, place)?
+            lower_default_to_temp(&mut builder, param_loc, initializer, place)?
         } else {
             place
         };
@@ -774,7 +769,7 @@ fn lower_inner<'a>(
     // delegate the binding of the rest argument.
     if let Some(rest) = &params.rest {
         let rest_loc = builder.source_location(rest.span);
-        let place = build_temporary_place(&mut builder, rest_loc.clone());
+        let place = build_temporary_place(&mut builder, rest_loc);
         hir_params.push(ParamPattern::Spread(SpreadPattern { place: place.clone() }));
         lower_binding_assignment(
             &mut builder,
@@ -830,8 +825,7 @@ fn lower_inner<'a>(
     let (hir_body, instructions, used_names, child_bindings) = builder.build()?;
 
     // Create the returns place
-    let returns =
-        crate::react_compiler_lowering::hir_builder::create_temporary_place(env, loc.clone());
+    let returns = crate::react_compiler_lowering::hir_builder::create_temporary_place(env, loc);
 
     Ok((
         HirFunction {
@@ -875,7 +869,7 @@ fn lower_identifier(
     loc: Option<SourceLocation>,
     symbol: Option<SymbolId>,
 ) -> Result<Place, CompilerError> {
-    let binding = builder.resolve_identifier(name, loc.clone(), symbol)?;
+    let binding = builder.resolve_identifier(name, loc, symbol)?;
     match binding {
         VariableBinding::Identifier { identifier, .. } => {
             Ok(Place { identifier, effect: Effect::Unknown, reactive: false, loc })
@@ -889,7 +883,7 @@ fn lower_identifier(
                         description: Some(
                             "Eval is an anti-pattern in JavaScript, and the code executed cannot be evaluated by React Compiler".to_string(),
                         ),
-                        loc: loc.clone(),
+                        loc,
                         suggestions: None,
                     })?;
                 }
@@ -908,8 +902,7 @@ fn lower_identifier(
                 VariableBinding::ModuleLocal { name } => NonLocalBinding::ModuleLocal { name },
                 VariableBinding::Identifier { .. } => unreachable!(),
             };
-            let instr_value =
-                InstructionValue::LoadGlobal { binding: non_local_binding, loc: loc.clone() };
+            let instr_value = InstructionValue::LoadGlobal { binding: non_local_binding, loc };
             lower_value_to_temporary(builder, instr_value)
         }
     }
@@ -1045,7 +1038,7 @@ fn lower_member_expression_impl<'a>(
                 reason: "(BuildHIR::lowerMemberExpression) Handle private field property"
                     .to_string(),
                 description: None,
-                loc: loc.clone(),
+                loc,
                 suggestions: None,
             })?;
             Ok(LoweredMemberExpression {
@@ -1073,12 +1066,12 @@ fn lower_import_keyword_to_temporary(
         category: ErrorCategory::Todo,
         reason: "(BuildHIR::lowerExpression) Handle Import expressions".to_string(),
         description: None,
-        loc: loc.clone(),
+        loc: *loc,
         suggestions: None,
     })?;
     lower_value_to_temporary(
         builder,
-        InstructionValue::Primitive { value: PrimitiveValue::Undefined, loc: loc.clone() },
+        InstructionValue::Primitive { value: PrimitiveValue::Undefined, loc: *loc },
     )
 }
 
@@ -1094,7 +1087,7 @@ fn lower_private_name_to_temporary(
         category: ErrorCategory::Todo,
         reason: "(BuildHIR::lowerExpression) Handle PrivateName expressions".to_string(),
         description: None,
-        loc: loc.clone(),
+        loc,
         suggestions: None,
     })?;
     lower_value_to_temporary(
@@ -1267,7 +1260,7 @@ fn lower_member_expression_from_simple_target<'a>(
                 reason: "(BuildHIR::lowerMemberExpression) Handle private field property"
                     .to_string(),
                 description: None,
-                loc: loc.clone(),
+                loc,
                 suggestions: None,
             })?;
             Ok(LoweredMemberExpression {
@@ -1319,7 +1312,7 @@ fn lower_identifier_for_assignment(
     name: &str,
     symbol: Option<SymbolId>,
 ) -> Result<Option<IdentifierForAssignment>, CompilerError> {
-    let mut binding = builder.resolve_identifier(name, ident_loc.clone(), symbol)?;
+    let mut binding = builder.resolve_identifier(name, ident_loc, symbol)?;
     if !matches!(binding, VariableBinding::Identifier { .. }) && kind != InstructionKind::Reassign {
         if let Some(symbol_id) =
             builder.scope().find_binding_in_descendants(name, builder.function_scope())
@@ -1327,8 +1320,7 @@ fn lower_identifier_for_assignment(
             let bk = crate::react_compiler_lowering::convert_binding_kind(
                 &builder.scope().binding_kind(symbol_id),
             );
-            let identifier =
-                builder.resolve_binding_with_loc(name, symbol_id, ident_loc.clone())?;
+            let identifier = builder.resolve_binding_with_loc(name, symbol_id, ident_loc)?;
             binding = VariableBinding::Identifier { identifier, binding_kind: bk };
         }
     }
@@ -1341,7 +1333,7 @@ fn lower_identifier_for_assignment(
                 builder.record_error(CompilerErrorDetail {
                     reason: "Cannot reassign a `const` variable".to_string(),
                     category: ErrorCategory::Syntax,
-                    loc: loc.clone(),
+                    loc,
                     description: Some(format!("`{}` is declared as const", name)),
                     suggestions: None,
                 })?;
@@ -1414,7 +1406,7 @@ fn lower_binding_assignment<'a>(
             let id_loc = builder.source_location(id.span);
             let result = lower_identifier_for_assignment(
                 builder,
-                loc.clone(),
+                loc,
                 id_loc,
                 kind,
                 id.name.as_str(),
@@ -1442,7 +1434,7 @@ fn lower_binding_assignment<'a>(
                                 reason: "Expected `const` declaration not to be reassigned"
                                     .to_string(),
                                 category: ErrorCategory::Syntax,
-                                loc: loc.clone(),
+                                loc,
                                 suggestions: None,
                                 description: None,
                             })?;
@@ -1490,7 +1482,7 @@ fn lower_binding_assignment<'a>(
                             let id_loc = builder.source_location(id.span);
                             match lower_identifier_for_assignment(
                                 builder,
-                                id_loc.clone(),
+                                id_loc,
                                 id_loc,
                                 kind,
                                 id.name.as_str(),
@@ -1596,12 +1588,12 @@ fn lower_binding_assignment<'a>(
                         kind,
                     },
                     value: value.clone(),
-                    loc: loc.clone(),
+                    loc,
                 },
             )?;
 
             for (place, path) in followups {
-                let followup_loc = builder.source_location(path.span()).or(loc.clone());
+                let followup_loc = builder.source_location(path.span()).or(loc);
                 lower_binding_assignment(
                     builder,
                     followup_loc,
@@ -1644,7 +1636,7 @@ fn lower_binding_assignment<'a>(
                             let id_loc = builder.source_location(id.span);
                             match lower_identifier_for_assignment(
                                 builder,
-                                id_loc.clone(),
+                                id_loc,
                                 id_loc,
                                 kind,
                                 id.name.as_str(),
@@ -1771,12 +1763,12 @@ fn lower_binding_assignment<'a>(
                         kind,
                     },
                     value: value.clone(),
-                    loc: loc.clone(),
+                    loc,
                 },
             )?;
 
             for (place, path) in followups {
-                let followup_loc = builder.source_location(path.span()).or(loc.clone());
+                let followup_loc = builder.source_location(path.span()).or(loc);
                 lower_binding_assignment(
                     builder,
                     followup_loc,
@@ -1791,7 +1783,7 @@ fn lower_binding_assignment<'a>(
         oxc::BindingPattern::AssignmentPattern(pattern) => {
             // Default value: if value === undefined, use default, else use value.
             let pat_loc = builder.source_location(pattern.span);
-            let temp = lower_default_to_temp(builder, pat_loc.clone(), &pattern.right, value)?;
+            let temp = lower_default_to_temp(builder, pat_loc, &pattern.right, value)?;
             // Recursively assign the resolved value to the left pattern.
             lower_binding_assignment(builder, pat_loc, kind, &pattern.left, temp, assignment_style)
         }
@@ -1808,14 +1800,14 @@ fn lower_default_to_temp<'a>(
     default: &'a oxc::Expression<'a>,
     value: Place,
 ) -> Result<Place, CompilerError> {
-    let temp = build_temporary_place(builder, pat_loc.clone());
+    let temp = build_temporary_place(builder, pat_loc);
 
     let test_block = builder.reserve(BlockKind::Value);
     let continuation_block = builder.reserve(builder.current_block_kind());
     let continuation_id = continuation_block.id;
 
     let temp_consequent = temp.clone();
-    let pat_loc_consequent = pat_loc.clone();
+    let pat_loc_consequent = pat_loc;
     let consequent = builder.try_enter(BlockKind::Value, |builder, _| {
         let default_value = lower_reorderable_expression(builder, default)?;
         lower_value_to_temporary(
@@ -1824,19 +1816,19 @@ fn lower_default_to_temp<'a>(
                 lvalue: LValue { place: temp_consequent.clone(), kind: InstructionKind::Const },
                 value: default_value,
                 type_annotation: None,
-                loc: pat_loc_consequent.clone(),
+                loc: pat_loc_consequent,
             },
         )?;
         Ok(Terminal::Goto {
             block: continuation_id,
             variant: GotoVariant::Break,
             id: EvaluationOrder(0),
-            loc: pat_loc_consequent.clone(),
+            loc: pat_loc_consequent,
         })
     });
 
     let temp_alternate = temp.clone();
-    let pat_loc_alternate = pat_loc.clone();
+    let pat_loc_alternate = pat_loc;
     let value_alternate = value.clone();
     let alternate = builder.try_enter(BlockKind::Value, |builder, _| {
         lower_value_to_temporary(
@@ -1845,14 +1837,14 @@ fn lower_default_to_temp<'a>(
                 lvalue: LValue { place: temp_alternate.clone(), kind: InstructionKind::Const },
                 value: value_alternate.clone(),
                 type_annotation: None,
-                loc: pat_loc_alternate.clone(),
+                loc: pat_loc_alternate,
             },
         )?;
         Ok(Terminal::Goto {
             block: continuation_id,
             variant: GotoVariant::Break,
             id: EvaluationOrder(0),
-            loc: pat_loc_alternate.clone(),
+            loc: pat_loc_alternate,
         })
     });
 
@@ -1861,14 +1853,14 @@ fn lower_default_to_temp<'a>(
             test: test_block.id,
             fallthrough: continuation_id,
             id: EvaluationOrder(0),
-            loc: pat_loc.clone(),
+            loc: pat_loc,
         },
         test_block,
     );
 
     let undef = lower_value_to_temporary(
         builder,
-        InstructionValue::Primitive { value: PrimitiveValue::Undefined, loc: pat_loc.clone() },
+        InstructionValue::Primitive { value: PrimitiveValue::Undefined, loc: pat_loc },
     )?;
     let test = lower_value_to_temporary(
         builder,
@@ -1876,7 +1868,7 @@ fn lower_default_to_temp<'a>(
             left: value,
             operator: BinaryOperator::StrictEqual,
             right: undef,
-            loc: pat_loc.clone(),
+            loc: pat_loc,
         },
     )?;
     builder.terminate_with_continuation(
@@ -1911,7 +1903,7 @@ fn lower_member_assignment_target<'a>(
             category: ErrorCategory::Invariant,
             reason: "MemberExpression may only appear in an assignment expression".to_string(),
             description: None,
-            loc: loc.clone(),
+            loc,
             suggestions: None,
         })?;
         return Ok(None);
@@ -2017,7 +2009,7 @@ fn lower_assignment_target<'a>(
             let id_loc = builder.source_location(id.span);
             let result = lower_identifier_for_assignment(
                 builder,
-                loc.clone(),
+                loc,
                 id_loc,
                 kind,
                 id.name.as_str(),
@@ -2044,7 +2036,7 @@ fn lower_assignment_target<'a>(
                                 reason: "Expected `const` declaration not to be reassigned"
                                     .to_string(),
                                 category: ErrorCategory::Syntax,
-                                loc: loc.clone(),
+                                loc,
                                 suggestions: None,
                                 description: None,
                             })?;
@@ -2126,7 +2118,7 @@ fn lower_assignment_target<'a>(
                             let id_loc = builder.source_location(id.span);
                             match lower_identifier_for_assignment(
                                 builder,
-                                id_loc.clone(),
+                                id_loc,
                                 id_loc,
                                 kind,
                                 id.name.as_str(),
@@ -2239,12 +2231,12 @@ fn lower_assignment_target<'a>(
                         kind,
                     },
                     value: value.clone(),
-                    loc: loc.clone(),
+                    loc,
                 },
             )?;
 
             for (place, path) in followups {
-                lower_followup_target(builder, loc.clone(), kind, path, place, assignment_style)?;
+                lower_followup_target(builder, loc, kind, path, place, assignment_style)?;
             }
             Ok(Some(temporary))
         }
@@ -2333,7 +2325,7 @@ fn lower_assignment_target<'a>(
                             let id_loc = builder.source_location(id.span);
                             match lower_identifier_for_assignment(
                                 builder,
-                                id_loc.clone(),
+                                id_loc,
                                 id_loc,
                                 kind,
                                 id.name.as_str(),
@@ -2399,7 +2391,7 @@ fn lower_assignment_target<'a>(
                                     let id_loc = builder.source_location(id.span);
                                     match lower_identifier_for_assignment(
                                         builder,
-                                        id_loc.clone(),
+                                        id_loc,
                                         id_loc,
                                         kind,
                                         id.name.as_str(),
@@ -2540,12 +2532,12 @@ fn lower_assignment_target<'a>(
                         kind,
                     },
                     value: value.clone(),
-                    loc: loc.clone(),
+                    loc,
                 },
             )?;
 
             for (place, path) in followups {
-                lower_followup_target(builder, loc.clone(), kind, path, place, assignment_style)?;
+                lower_followup_target(builder, loc, kind, path, place, assignment_style)?;
             }
             Ok(Some(temporary))
         }
@@ -2593,7 +2585,7 @@ fn lower_identifier_followup_store(
     let id_loc = builder.source_location(id.span);
     let result = lower_identifier_for_assignment(
         builder,
-        loc.clone(),
+        loc,
         id_loc,
         kind,
         id.name.as_str(),
@@ -2710,14 +2702,14 @@ fn lower_assignment_target_default<'a>(
 ) -> Result<Option<Place>, CompilerError> {
     let pat_loc = builder.source_location(span);
 
-    let temp = build_temporary_place(builder, pat_loc.clone());
+    let temp = build_temporary_place(builder, pat_loc);
 
     let test_block = builder.reserve(BlockKind::Value);
     let continuation_block = builder.reserve(builder.current_block_kind());
     let continuation_id = continuation_block.id;
 
     let temp_consequent = temp.clone();
-    let pat_loc_consequent = pat_loc.clone();
+    let pat_loc_consequent = pat_loc;
     let consequent = builder.try_enter(BlockKind::Value, |builder, _| {
         let default_value = lower_reorderable_expression(builder, default)?;
         lower_value_to_temporary(
@@ -2726,19 +2718,19 @@ fn lower_assignment_target_default<'a>(
                 lvalue: LValue { place: temp_consequent.clone(), kind: InstructionKind::Const },
                 value: default_value,
                 type_annotation: None,
-                loc: pat_loc_consequent.clone(),
+                loc: pat_loc_consequent,
             },
         )?;
         Ok(Terminal::Goto {
             block: continuation_id,
             variant: GotoVariant::Break,
             id: EvaluationOrder(0),
-            loc: pat_loc_consequent.clone(),
+            loc: pat_loc_consequent,
         })
     });
 
     let temp_alternate = temp.clone();
-    let pat_loc_alternate = pat_loc.clone();
+    let pat_loc_alternate = pat_loc;
     let value_alternate = value.clone();
     let alternate = builder.try_enter(BlockKind::Value, |builder, _| {
         lower_value_to_temporary(
@@ -2747,14 +2739,14 @@ fn lower_assignment_target_default<'a>(
                 lvalue: LValue { place: temp_alternate.clone(), kind: InstructionKind::Const },
                 value: value_alternate.clone(),
                 type_annotation: None,
-                loc: pat_loc_alternate.clone(),
+                loc: pat_loc_alternate,
             },
         )?;
         Ok(Terminal::Goto {
             block: continuation_id,
             variant: GotoVariant::Break,
             id: EvaluationOrder(0),
-            loc: pat_loc_alternate.clone(),
+            loc: pat_loc_alternate,
         })
     });
 
@@ -2763,14 +2755,14 @@ fn lower_assignment_target_default<'a>(
             test: test_block.id,
             fallthrough: continuation_id,
             id: EvaluationOrder(0),
-            loc: pat_loc.clone(),
+            loc: pat_loc,
         },
         test_block,
     );
 
     let undef = lower_value_to_temporary(
         builder,
-        InstructionValue::Primitive { value: PrimitiveValue::Undefined, loc: pat_loc.clone() },
+        InstructionValue::Primitive { value: PrimitiveValue::Undefined, loc: pat_loc },
     )?;
     let test = lower_value_to_temporary(
         builder,
@@ -2778,7 +2770,7 @@ fn lower_assignment_target_default<'a>(
             left: value,
             operator: BinaryOperator::StrictEqual,
             right: undef,
-            loc: pat_loc.clone(),
+            loc: pat_loc,
         },
     )?;
     builder.terminate_with_continuation(
@@ -2788,7 +2780,7 @@ fn lower_assignment_target_default<'a>(
             alternate: alternate?,
             fallthrough: continuation_id,
             id: EvaluationOrder(0),
-            loc: pat_loc.clone(),
+            loc: pat_loc,
         },
         continuation_block,
     );
@@ -2855,7 +2847,7 @@ fn lower_chain_expression<'a>(
         | oxc::ChainElement::PrivateFieldExpression(_) => {
             let member = chain.expression.as_member_expression().unwrap();
             let place = lower_optional_member_expression_impl(builder, member, None)?.1;
-            Ok(InstructionValue::LoadLocal { loc: place.loc.clone(), place })
+            Ok(InstructionValue::LoadLocal { loc: place.loc, place })
         }
     }
 }
@@ -2880,7 +2872,7 @@ fn lower_chain_subexpr<'a>(
         {
             let member = expr.as_member_expression().unwrap();
             let place = lower_optional_member_expression_impl(builder, member, None)?.1;
-            Ok(InstructionValue::LoadLocal { loc: place.loc.clone(), place })
+            Ok(InstructionValue::LoadLocal { loc: place.loc, place })
         }
         oxc::Expression::CallExpression(call) if expr_contains_optional(expr) => {
             lower_optional_call_expression_impl(builder, call, None)
@@ -2901,7 +2893,7 @@ fn lower_optional_member_expression_impl<'a>(
 ) -> Result<(Place, Place), CompilerError> {
     let optional = member.optional();
     let loc = builder.source_location(member.span());
-    let place = build_temporary_place(builder, loc.clone());
+    let place = build_temporary_place(builder, loc);
     let continuation_block = builder.reserve(builder.current_block_kind());
     let continuation_id = continuation_block.id;
     let consequent = builder.reserve(BlockKind::Value);
@@ -2914,7 +2906,7 @@ fn lower_optional_member_expression_impl<'a>(
         builder.try_enter(BlockKind::Value, |builder, _block_id| {
             let temp = lower_value_to_temporary(
                 builder,
-                InstructionValue::Primitive { value: PrimitiveValue::Undefined, loc: loc.clone() },
+                InstructionValue::Primitive { value: PrimitiveValue::Undefined, loc },
             )?;
             lower_value_to_temporary(
                 builder,
@@ -2922,14 +2914,14 @@ fn lower_optional_member_expression_impl<'a>(
                     lvalue: LValue { kind: InstructionKind::Const, place: place.clone() },
                     value: temp,
                     type_annotation: None,
-                    loc: loc.clone(),
+                    loc,
                 },
             )?;
             Ok(Terminal::Goto {
                 block: continuation_id,
                 variant: GotoVariant::Break,
                 id: EvaluationOrder(0),
-                loc: loc.clone(),
+                loc,
             })
         })
     }?;
@@ -2965,7 +2957,7 @@ fn lower_optional_member_expression_impl<'a>(
             alternate,
             fallthrough: continuation_id,
             id: EvaluationOrder(0),
-            loc: loc.clone(),
+            loc,
         })
     });
 
@@ -2981,14 +2973,14 @@ fn lower_optional_member_expression_impl<'a>(
                 lvalue: LValue { kind: InstructionKind::Const, place: place.clone() },
                 value: temp,
                 type_annotation: None,
-                loc: loc.clone(),
+                loc,
             },
         )?;
         Ok(Terminal::Goto {
             block: continuation_id,
             variant: GotoVariant::Break,
             id: EvaluationOrder(0),
-            loc: loc.clone(),
+            loc,
         })
     })?;
 
@@ -2998,7 +2990,7 @@ fn lower_optional_member_expression_impl<'a>(
             test: test_block?,
             fallthrough: continuation_id,
             id: EvaluationOrder(0),
-            loc: loc.clone(),
+            loc,
         },
         continuation_block,
     );
@@ -3015,7 +3007,7 @@ fn lower_optional_call_expression_impl<'a>(
 ) -> Result<InstructionValue<'a>, CompilerError> {
     let optional = call.optional;
     let loc = builder.source_location(call.span);
-    let place = build_temporary_place(builder, loc.clone());
+    let place = build_temporary_place(builder, loc);
     let continuation_block = builder.reserve(builder.current_block_kind());
     let continuation_id = continuation_block.id;
     let consequent = builder.reserve(BlockKind::Value);
@@ -3026,7 +3018,7 @@ fn lower_optional_call_expression_impl<'a>(
         builder.try_enter(BlockKind::Value, |builder, _block_id| {
             let temp = lower_value_to_temporary(
                 builder,
-                InstructionValue::Primitive { value: PrimitiveValue::Undefined, loc: loc.clone() },
+                InstructionValue::Primitive { value: PrimitiveValue::Undefined, loc },
             )?;
             lower_value_to_temporary(
                 builder,
@@ -3034,14 +3026,14 @@ fn lower_optional_call_expression_impl<'a>(
                     lvalue: LValue { kind: InstructionKind::Const, place: place.clone() },
                     value: temp,
                     type_annotation: None,
-                    loc: loc.clone(),
+                    loc,
                 },
             )?;
             Ok(Terminal::Goto {
                 block: continuation_id,
                 variant: GotoVariant::Break,
                 id: EvaluationOrder(0),
-                loc: loc.clone(),
+                loc,
             })
         })
     }?;
@@ -3100,26 +3092,22 @@ fn lower_optional_call_expression_impl<'a>(
             alternate,
             fallthrough: continuation_id,
             id: EvaluationOrder(0),
-            loc: loc.clone(),
+            loc,
         })
     });
 
     // Block to evaluate if the callee is non-null/undefined.
     builder.try_enter_reserved(consequent, |builder| {
         let args = lower_arguments(builder, &call.arguments)?;
-        let temp = build_temporary_place(builder, loc.clone());
+        let temp = build_temporary_place(builder, loc);
 
         match callee_info.as_ref().unwrap() {
             CalleeInfo::CallExpression { callee } => {
                 builder.push(Instruction {
                     id: EvaluationOrder(0),
                     lvalue: temp.clone(),
-                    value: InstructionValue::CallExpression {
-                        callee: callee.clone(),
-                        args,
-                        loc: loc.clone(),
-                    },
-                    loc: loc.clone(),
+                    value: InstructionValue::CallExpression { callee: callee.clone(), args, loc },
+                    loc,
                     effects: None,
                 });
             }
@@ -3131,9 +3119,9 @@ fn lower_optional_call_expression_impl<'a>(
                         receiver: receiver.clone(),
                         property: property.clone(),
                         args,
-                        loc: loc.clone(),
+                        loc,
                     },
-                    loc: loc.clone(),
+                    loc,
                     effects: None,
                 });
             }
@@ -3145,14 +3133,14 @@ fn lower_optional_call_expression_impl<'a>(
                 lvalue: LValue { kind: InstructionKind::Const, place: place.clone() },
                 value: temp,
                 type_annotation: None,
-                loc: loc.clone(),
+                loc,
             },
         )?;
         Ok(Terminal::Goto {
             block: continuation_id,
             variant: GotoVariant::Break,
             id: EvaluationOrder(0),
-            loc: loc.clone(),
+            loc,
         })
     })?;
 
@@ -3162,7 +3150,7 @@ fn lower_optional_call_expression_impl<'a>(
             test: test_block?,
             fallthrough: continuation_id,
             id: EvaluationOrder(0),
-            loc: loc.clone(),
+            loc,
         },
         continuation_block,
     );
@@ -3345,7 +3333,7 @@ fn lower_function_declaration<'a>(
         func_decl.id.as_ref().map(|id| id.name.as_str()),
         func_decl.generator,
         func_decl.r#async,
-        loc.clone(),
+        loc,
         scope,
         env,
         Some(parent_bindings),
@@ -3371,7 +3359,7 @@ fn lower_function_declaration<'a>(
         name_hint: None,
         lowered_func,
         expr_type: FunctionExpressionType::FunctionDeclaration,
-        loc: loc.clone(),
+        loc,
     };
     let fn_place = lower_value_to_temporary(builder, fn_value)?;
 
@@ -3396,13 +3384,13 @@ fn lower_function_declaration<'a>(
                         &builder.scope().binding_kind(symbol_id),
                     );
                     let identifier =
-                        builder.resolve_binding_with_loc(name, symbol_id, ident_loc.clone())?;
+                        builder.resolve_binding_with_loc(name, symbol_id, ident_loc)?;
                     VariableBinding::Identifier { identifier, binding_kind }
                 }
                 None => {
                     let mut binding = builder.resolve_identifier(
                         name,
-                        ident_loc.clone(),
+                        ident_loc,
                         builder.scope().resolve_binding_identifier(id_node),
                     )?;
                     if matches!(&binding, VariableBinding::Global { .. }) {
@@ -3419,8 +3407,7 @@ fn lower_function_declaration<'a>(
                         if let Some(symbol_id) = fallback {
                             let symbol =
                                 builder.scope().declaration_start(symbol_id).map(|_| symbol_id);
-                            binding =
-                                builder.resolve_identifier(name, ident_loc.clone(), symbol)?;
+                            binding = builder.resolve_identifier(name, ident_loc, symbol)?;
                         }
                     }
                     if matches!(&binding, VariableBinding::Identifier { .. }) {
@@ -3439,12 +3426,7 @@ fn lower_function_declaration<'a>(
                     // which was already set during define_binding.
                     // Use the full function declaration loc for the Place,
                     // matching the TS behavior where lowerAssignment uses stmt.node.loc
-                    let place = Place {
-                        identifier,
-                        reactive: false,
-                        effect: Effect::Unknown,
-                        loc: loc.clone(),
-                    };
+                    let place = Place { identifier, reactive: false, effect: Effect::Unknown, loc };
                     if is_context {
                         lower_value_to_temporary(
                             builder,
@@ -3622,18 +3604,14 @@ fn gather_captured_context(
                 continue;
             }
             let loc = identifier_locs.get(&ref_nid).map(|entry| {
-                if let Some(oe_loc) = &entry.opening_element_loc {
-                    oe_loc.clone()
-                } else {
-                    entry.loc.clone()
-                }
+                if let Some(oe_loc) = &entry.opening_element_loc { *oe_loc } else { entry.loc }
             });
             captured
                 .entry(symbol_id)
                 .and_modify(|(min_pos, existing_loc)| {
                     if ref_start < *min_pos {
                         *min_pos = ref_start;
-                        *existing_loc = loc.clone();
+                        *existing_loc = loc;
                     }
                 })
                 .or_insert((ref_start, loc));
@@ -3673,7 +3651,7 @@ fn lower_expression<'a>(
         oxc::Expression::Identifier(ident) => {
             let loc = builder.source_location(ident.span);
             let symbol = builder.scope().resolve_reference(ident);
-            let place = lower_identifier(builder, ident.name.as_str(), loc.clone(), symbol)?;
+            let place = lower_identifier(builder, ident.name.as_str(), loc, symbol)?;
             if builder.is_context_identifier(symbol) {
                 Ok(InstructionValue::LoadContext { place, loc })
             } else {
@@ -3750,7 +3728,7 @@ fn lower_expression<'a>(
                             category: ErrorCategory::Syntax,
                             reason: "Only object properties can be deleted".to_string(),
                             description: None,
-                            loc: loc.clone(),
+                            loc,
                             suggestions: None,
                         })?;
                         Ok(InstructionValue::Primitive { value: PrimitiveValue::Undefined, loc })
@@ -3772,7 +3750,7 @@ fn lower_expression<'a>(
             let continuation_id = continuation_block.id;
             let test_block = builder.reserve(BlockKind::Value);
             let test_block_id = test_block.id;
-            let place = build_temporary_place(builder, loc.clone());
+            let place = build_temporary_place(builder, loc);
             let left_loc = builder.source_location(logical.left.span());
             let left_place = build_temporary_place(builder, left_loc);
 
@@ -3783,27 +3761,27 @@ fn lower_expression<'a>(
                         lvalue: LValue { kind: InstructionKind::Const, place: place.clone() },
                         value: left_place.clone(),
                         type_annotation: None,
-                        loc: left_place.loc.clone(),
+                        loc: left_place.loc,
                     },
                 )?;
                 Ok(Terminal::Goto {
                     block: continuation_id,
                     variant: GotoVariant::Break,
                     id: EvaluationOrder(0),
-                    loc: left_place.loc.clone(),
+                    loc: left_place.loc,
                 })
             });
 
             let alternate_block = builder.try_enter(BlockKind::Value, |builder, _block_id| {
                 let right = lower_expression_to_temporary(builder, &logical.right)?;
-                let right_loc = right.loc.clone();
+                let right_loc = right.loc;
                 lower_value_to_temporary(
                     builder,
                     InstructionValue::StoreLocal {
                         lvalue: LValue { kind: InstructionKind::Const, place: place.clone() },
                         value: right,
                         type_annotation: None,
-                        loc: right_loc.clone(),
+                        loc: right_loc,
                     },
                 )?;
                 Ok(Terminal::Goto {
@@ -3826,7 +3804,7 @@ fn lower_expression<'a>(
                     test: test_block_id,
                     fallthrough: continuation_id,
                     id: EvaluationOrder(0),
-                    loc: loc.clone(),
+                    loc,
                 },
                 test_block,
             );
@@ -3835,9 +3813,9 @@ fn lower_expression<'a>(
             builder.push(Instruction {
                 id: EvaluationOrder(0),
                 lvalue: left_place.clone(),
-                value: InstructionValue::LoadLocal { place: left_value, loc: loc.clone() },
+                value: InstructionValue::LoadLocal { place: left_value, loc },
                 effects: None,
-                loc: loc.clone(),
+                loc,
             });
 
             builder.terminate_with_continuation(
@@ -3847,12 +3825,12 @@ fn lower_expression<'a>(
                     alternate: alternate_block?,
                     fallthrough: continuation_id,
                     id: EvaluationOrder(0),
-                    loc: loc.clone(),
+                    loc,
                 },
                 continuation_block,
             );
 
-            Ok(InstructionValue::LoadLocal { place: place.clone(), loc: place.loc.clone() })
+            Ok(InstructionValue::LoadLocal { place: place.clone(), loc: place.loc })
         }
         oxc::Expression::StaticMemberExpression(_)
         | oxc::Expression::ComputedMemberExpression(_)
@@ -3879,7 +3857,7 @@ fn lower_expression<'a>(
             let continuation_id = continuation_block.id;
             let test_block = builder.reserve(BlockKind::Value);
             let test_block_id = test_block.id;
-            let place = build_temporary_place(builder, loc.clone());
+            let place = build_temporary_place(builder, loc);
 
             // Block for the consequent (test is truthy)
             let consequent_ast_loc = builder.source_location(cond.consequent.span());
@@ -3891,7 +3869,7 @@ fn lower_expression<'a>(
                         lvalue: LValue { kind: InstructionKind::Const, place: place.clone() },
                         value: consequent,
                         type_annotation: None,
-                        loc: loc.clone(),
+                        loc,
                     },
                 )?;
                 Ok(Terminal::Goto {
@@ -3912,7 +3890,7 @@ fn lower_expression<'a>(
                         lvalue: LValue { kind: InstructionKind::Const, place: place.clone() },
                         value: alternate,
                         type_annotation: None,
-                        loc: loc.clone(),
+                        loc,
                     },
                 )?;
                 Ok(Terminal::Goto {
@@ -3928,7 +3906,7 @@ fn lower_expression<'a>(
                     test: test_block_id,
                     fallthrough: continuation_id,
                     id: EvaluationOrder(0),
-                    loc: loc.clone(),
+                    loc,
                 },
                 test_block,
             );
@@ -3942,12 +3920,12 @@ fn lower_expression<'a>(
                     alternate: alternate_block?,
                     fallthrough: continuation_id,
                     id: EvaluationOrder(0),
-                    loc: loc.clone(),
+                    loc,
                 },
                 continuation_block,
             );
 
-            Ok(InstructionValue::LoadLocal { place: place.clone(), loc: place.loc.clone() })
+            Ok(InstructionValue::LoadLocal { place: place.clone(), loc: place.loc })
         }
         oxc::Expression::SequenceExpression(seq) => {
             let loc = builder.source_location(seq.span);
@@ -3958,7 +3936,7 @@ fn lower_expression<'a>(
                     reason: "Expected sequence expression to have at least one expression"
                         .to_string(),
                     description: None,
-                    loc: loc.clone(),
+                    loc,
                     suggestions: None,
                 })?;
                 return Ok(InstructionValue::Primitive { value: PrimitiveValue::Undefined, loc });
@@ -3966,7 +3944,7 @@ fn lower_expression<'a>(
 
             let continuation_block = builder.reserve(builder.current_block_kind());
             let continuation_id = continuation_block.id;
-            let place = build_temporary_place(builder, loc.clone());
+            let place = build_temporary_place(builder, loc);
 
             let sequence_block = builder.try_enter(BlockKind::Sequence, |builder, _block_id| {
                 let mut last: Option<Place> = None;
@@ -3980,7 +3958,7 @@ fn lower_expression<'a>(
                             lvalue: LValue { kind: InstructionKind::Const, place: place.clone() },
                             value: last,
                             type_annotation: None,
-                            loc: loc.clone(),
+                            loc,
                         },
                     )?;
                 }
@@ -3988,7 +3966,7 @@ fn lower_expression<'a>(
                     block: continuation_id,
                     variant: GotoVariant::Break,
                     id: EvaluationOrder(0),
-                    loc: loc.clone(),
+                    loc,
                 })
             });
 
@@ -3997,7 +3975,7 @@ fn lower_expression<'a>(
                     block: sequence_block?,
                     fallthrough: continuation_id,
                     id: EvaluationOrder(0),
-                    loc: loc.clone(),
+                    loc,
                 },
                 continuation_block,
             );
@@ -4037,7 +4015,7 @@ fn lower_expression<'a>(
                     category: ErrorCategory::Todo,
                     reason: "(BuildHIR::lowerExpression) Handle tagged template where cooked value is different from raw value".to_string(),
                     description: None,
-                    loc: loc.clone(),
+                    loc,
                     suggestions: None,
                 })?;
                 return Ok(InstructionValue::Primitive { value: PrimitiveValue::Undefined, loc });
@@ -4067,7 +4045,7 @@ fn lower_expression<'a>(
                 reason: "(BuildHIR::lowerExpression) Handle YieldExpression expressions"
                     .to_string(),
                 description: None,
-                loc: loc.clone(),
+                loc,
                 suggestions: None,
             })?;
             Ok(InstructionValue::Primitive { value: PrimitiveValue::Undefined, loc })
@@ -4085,7 +4063,7 @@ fn lower_expression<'a>(
                     category: ErrorCategory::Todo,
                     reason: "(BuildHIR::lowerExpression) Handle MetaProperty expressions other than import.meta".to_string(),
                     description: None,
-                    loc: loc.clone(),
+                    loc,
                     suggestions: None,
                 })?;
                 Ok(InstructionValue::Primitive { value: PrimitiveValue::Undefined, loc })
@@ -4098,7 +4076,7 @@ fn lower_expression<'a>(
                 reason: "(BuildHIR::lowerExpression) Handle ClassExpression expressions"
                     .to_string(),
                 description: None,
-                loc: loc.clone(),
+                loc,
                 suggestions: None,
             })?;
             Ok(InstructionValue::Primitive { value: PrimitiveValue::Undefined, loc })
@@ -4109,7 +4087,7 @@ fn lower_expression<'a>(
                 category: ErrorCategory::Todo,
                 reason: "(BuildHIR::lowerExpression) Handle Super expressions".to_string(),
                 description: None,
-                loc: loc.clone(),
+                loc,
                 suggestions: None,
             })?;
             Ok(InstructionValue::Primitive { value: PrimitiveValue::Undefined, loc })
@@ -4120,7 +4098,7 @@ fn lower_expression<'a>(
                 category: ErrorCategory::Todo,
                 reason: "(BuildHIR::lowerExpression) Handle ThisExpression expressions".to_string(),
                 description: None,
-                loc: loc.clone(),
+                loc,
                 suggestions: None,
             })?;
             Ok(InstructionValue::Primitive { value: PrimitiveValue::Undefined, loc })
@@ -4192,7 +4170,7 @@ fn lower_expression<'a>(
                             operator: binary_op,
                             left: prev_value.clone(),
                             right: one,
-                            loc: member_loc.clone(),
+                            loc: member_loc,
                         },
                     )?;
 
@@ -4224,7 +4202,7 @@ fn lower_expression<'a>(
                     let result_place = if update.prefix { new_value_place } else { prev_value };
                     Ok(InstructionValue::LoadLocal {
                         place: result_place.clone(),
-                        loc: result_place.loc.clone(),
+                        loc: result_place.loc,
                     })
                 }
                 oxc::SimpleAssignmentTarget::AssignmentTargetIdentifier(ident) => {
@@ -4234,7 +4212,7 @@ fn lower_expression<'a>(
                             category: ErrorCategory::Todo,
                             reason: "(BuildHIR::lowerExpression) Handle UpdateExpression to variables captured within lambdas.".to_string(),
                             description: None,
-                            loc: loc.clone(),
+                            loc,
                             suggestions: None,
                         })?;
                         return Ok(InstructionValue::Primitive {
@@ -4244,11 +4222,8 @@ fn lower_expression<'a>(
                     }
 
                     let ident_loc = builder.source_location(ident.span);
-                    let binding = builder.resolve_identifier(
-                        ident.name.as_str(),
-                        ident_loc.clone(),
-                        symbol,
-                    )?;
+                    let binding =
+                        builder.resolve_identifier(ident.name.as_str(), ident_loc, symbol)?;
                     if matches!(binding, VariableBinding::Global { .. }) {
                         builder.record_error(CompilerErrorDetail {
                             category: ErrorCategory::Todo,
@@ -4256,7 +4231,7 @@ fn lower_expression<'a>(
                                 "UpdateExpression where argument is a global is not yet supported"
                                     .to_string(),
                             description: None,
-                            loc: loc.clone(),
+                            loc,
                             suggestions: None,
                         })?;
                         return Ok(InstructionValue::Primitive {
@@ -4271,7 +4246,7 @@ fn lower_expression<'a>(
                                 category: ErrorCategory::Todo,
                                 reason: "(BuildHIR::lowerExpression) Support UpdateExpression where argument is a global".to_string(),
                                 description: None,
-                                loc: loc.clone(),
+                                loc,
                                 suggestions: None,
                             })?;
                             return Ok(InstructionValue::Primitive {
@@ -4284,7 +4259,7 @@ fn lower_expression<'a>(
                         identifier,
                         effect: Effect::Unknown,
                         reactive: false,
-                        loc: ident_loc.clone(),
+                        loc: ident_loc,
                     };
 
                     // Load the current value
@@ -4321,7 +4296,7 @@ fn lower_expression<'a>(
                         category: ErrorCategory::Todo,
                         reason: "UpdateExpression with unsupported argument type".to_string(),
                         description: None,
-                        loc: loc.clone(),
+                        loc,
                         suggestions: None,
                     })?;
                     Ok(InstructionValue::Primitive { value: PrimitiveValue::Undefined, loc })
@@ -4461,15 +4436,14 @@ fn lower_assignment_expression<'a>(
                 let symbol = builder.scope().resolve_reference(ident);
                 let right = lower_expression_to_temporary(builder, &assign.right)?;
                 let ident_loc = builder.source_location(ident.span);
-                let binding =
-                    builder.resolve_identifier(ident.name.as_str(), ident_loc.clone(), symbol)?;
+                let binding = builder.resolve_identifier(ident.name.as_str(), ident_loc, symbol)?;
                 match binding {
                     VariableBinding::Identifier { identifier, binding_kind } => {
                         if binding_kind == BindingKind::Const {
                             builder.record_error(CompilerErrorDetail {
                                 reason: "Cannot reassign a `const` variable".to_string(),
                                 category: ErrorCategory::Syntax,
-                                loc: ident_loc.clone(),
+                                loc: ident_loc,
                                 description: Some(format!(
                                     "`{}` is declared as const",
                                     ident.name.as_str()
@@ -4496,7 +4470,7 @@ fn lower_assignment_expression<'a>(
                                         place: place.clone(),
                                     },
                                     value: right,
-                                    loc: place.loc.clone(),
+                                    loc: place.loc,
                                 },
                             )?;
                             Ok(InstructionValue::LoadLocal { place: temp.clone(), loc: temp.loc })
@@ -4510,7 +4484,7 @@ fn lower_assignment_expression<'a>(
                                     },
                                     value: right,
                                     type_annotation: None,
-                                    loc: place.loc.clone(),
+                                    loc: place.loc,
                                 },
                             )?;
                             Ok(InstructionValue::LoadLocal { place: temp.clone(), loc: temp.loc })
@@ -4633,7 +4607,7 @@ fn lower_assignment_expression<'a>(
                     reason: "Logical assignment operators (||=, &&=, ??=) are not yet supported"
                         .to_string(),
                     category: ErrorCategory::Todo,
-                    loc: loc.clone(),
+                    loc,
                     description: None,
                     suggestions: None,
                 })?;
@@ -4652,8 +4626,7 @@ fn lower_assignment_expression<'a>(
             oxc::AssignmentTarget::AssignmentTargetIdentifier(ident) => {
                 let ident_loc = builder.source_location(ident.span);
                 let symbol = builder.scope().resolve_reference(ident);
-                let left_place =
-                    lower_identifier(builder, ident.name.as_str(), ident_loc.clone(), symbol)?;
+                let left_place = lower_identifier(builder, ident.name.as_str(), ident_loc, symbol)?;
                 let right = lower_expression_to_temporary(builder, &assign.right)?;
                 let binary_place = lower_value_to_temporary(
                     builder,
@@ -4661,11 +4634,10 @@ fn lower_assignment_expression<'a>(
                         operator: binary_op,
                         left: left_place,
                         right,
-                        loc: loc.clone(),
+                        loc,
                     },
                 )?;
-                let binding =
-                    builder.resolve_identifier(ident.name.as_str(), ident_loc.clone(), symbol)?;
+                let binding = builder.resolve_identifier(ident.name.as_str(), ident_loc, symbol)?;
                 match binding {
                     VariableBinding::Identifier { identifier, .. } => {
                         let place = Place {
@@ -4683,7 +4655,7 @@ fn lower_assignment_expression<'a>(
                                         place: place.clone(),
                                     },
                                     value: binary_place,
-                                    loc: loc.clone(),
+                                    loc,
                                 },
                             )?;
                             Ok(InstructionValue::LoadContext { place, loc })
@@ -4697,7 +4669,7 @@ fn lower_assignment_expression<'a>(
                                     },
                                     value: binary_place,
                                     type_annotation: None,
-                                    loc: loc.clone(),
+                                    loc,
                                 },
                             )?;
                             Ok(InstructionValue::LoadLocal { place, loc })
@@ -4707,11 +4679,7 @@ fn lower_assignment_expression<'a>(
                         let name = ident.name.to_string();
                         let temp = lower_value_to_temporary(
                             builder,
-                            InstructionValue::StoreGlobal {
-                                name,
-                                value: binary_place,
-                                loc: loc.clone(),
-                            },
+                            InstructionValue::StoreGlobal { name, value: binary_place, loc },
                         )?;
                         Ok(InstructionValue::LoadLocal { place: temp.clone(), loc: temp.loc })
                     }
@@ -4733,7 +4701,7 @@ fn lower_assignment_expression<'a>(
                         operator: binary_op,
                         left: current_value,
                         right,
-                        loc: member_loc.clone(),
+                        loc: member_loc,
                     },
                 )?;
                 match lowered_property {
@@ -4756,7 +4724,7 @@ fn lower_assignment_expression<'a>(
                     reason: "Compound assignment to complex pattern is not yet supported"
                         .to_string(),
                     category: ErrorCategory::Todo,
-                    loc: loc.clone(),
+                    loc,
                     description: None,
                     suggestions: None,
                 })?;
@@ -4899,7 +4867,7 @@ fn lower_jsx_element_expr<'a>(
                 let reason = format!("<{}> tags should be module-level imports", tag_name);
                 return Err(CompilerDiagnostic::new(ErrorCategory::Invariant, &reason, None)
                     .with_detail(CompilerDiagnosticDetail::Error {
-                        loc: id_loc.clone(),
+                        loc: id_loc,
                         message: Some(reason.clone()),
                         identifier_name: None,
                     })
@@ -4934,7 +4902,7 @@ fn lower_jsx_element_expr<'a>(
                     .iter()
                     .map(|loc| CompilerDiagnosticDetail::Error {
                         message: Some(format!("Multiple `<{}:{}>` tags found", tag_name, name)),
-                        loc: loc.clone(),
+                        loc: *loc,
                         identifier_name: None,
                     })
                     .collect();
@@ -5021,7 +4989,7 @@ fn lower_jsx_element_name(
         let loc = builder.source_location(span);
         if tag.starts_with(|c: char| c.is_ascii_uppercase()) {
             // Component tag: resolve as identifier and load
-            let place = lower_identifier(builder, tag, loc.clone(), symbol)?;
+            let place = lower_identifier(builder, tag, loc, symbol)?;
             let load_value = if builder.is_context_identifier(symbol) {
                 InstructionValue::LoadContext { place, loc }
             } else {
@@ -5062,16 +5030,13 @@ fn lower_jsx_element_name(
                     reason: "Expected JSXNamespacedName to have no colons in the namespace or name"
                         .to_string(),
                     description: Some(format!("Got `{}` : `{}`", namespace, name)),
-                    loc: loc.clone(),
+                    loc,
                     suggestions: None,
                 })?;
             }
             let place = lower_value_to_temporary(
                 builder,
-                InstructionValue::Primitive {
-                    value: PrimitiveValue::String(tag.into()),
-                    loc: loc.clone(),
-                },
+                InstructionValue::Primitive { value: PrimitiveValue::String(tag.into()), loc },
             )?;
             Ok(JsxTag::Place(place))
         }
@@ -5128,9 +5093,9 @@ fn lower_jsx_member_object_identifier(
     let id_loc = builder.source_location(span);
     let place = lower_identifier(builder, name, id_loc, symbol)?;
     let load_value = if builder.is_context_identifier(symbol) {
-        InstructionValue::LoadContext { place, loc: expr_loc.clone() }
+        InstructionValue::LoadContext { place, loc: *expr_loc }
     } else {
-        InstructionValue::LoadLocal { place, loc: expr_loc.clone() }
+        InstructionValue::LoadLocal { place, loc: *expr_loc }
     };
     lower_value_to_temporary(builder, load_value)
 }
@@ -5491,7 +5456,7 @@ fn trim_jsx_text(original: &str) -> Option<String> {
         let is_last_non_empty_line = i == last_non_empty_line;
 
         // Replace rendered whitespace tabs with spaces
-        let mut trimmed_line = line.replace('\t', " ");
+        let mut trimmed_line = line.cow_replace('\t', " ").into_owned();
 
         // Trim whitespace touching a newline (leading whitespace on non-first lines)
         if !is_first_line {
@@ -5941,7 +5906,7 @@ fn lower_statement<'a>(
                     reason: "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
                         .to_string(),
                     description: None,
-                    loc: loc.clone(),
+                    loc,
                     suggestions: None,
                 })?;
             }
@@ -6024,10 +5989,10 @@ fn lower_statement<'a>(
                         // No init expression (e.g., `for (; ...)`), add a placeholder
                         let placeholder = InstructionValue::Primitive {
                             value: PrimitiveValue::Undefined,
-                            loc: loc.clone(),
+                            loc,
                         };
                         lower_value_to_temporary(builder, placeholder)?;
-                        loc.clone()
+                        loc
                     }
                     Some(oxc::ForStatementInit::VariableDeclaration(var_decl)) => {
                         let init_loc = builder.source_location(var_decl.span);
@@ -6041,7 +6006,7 @@ fn lower_statement<'a>(
                             category: ErrorCategory::Todo,
                             reason: "(BuildHIR::lowerStatement) Handle non-variable initialization in ForStatement".to_string(),
                             description: None,
-                            loc: loc.clone(),
+                            loc,
                             suggestions: None,
                         })?;
                         lower_expression_to_temporary(builder, expr)?;
@@ -6101,7 +6066,7 @@ fn lower_statement<'a>(
                     loop_block: body_block,
                     fallthrough: continuation_id,
                     id: EvaluationOrder(0),
-                    loc: loc.clone(),
+                    loc,
                 },
                 test_block,
             );
@@ -6116,7 +6081,7 @@ fn lower_statement<'a>(
                         alternate: continuation_id,
                         fallthrough: continuation_id,
                         id: EvaluationOrder(0),
-                        loc: loc.clone(),
+                        loc,
                     },
                     continuation_block,
                 );
@@ -6126,14 +6091,12 @@ fn lower_statement<'a>(
                     reason: "(BuildHIR::lowerStatement) Handle empty test in ForStatement"
                         .to_string(),
                     description: None,
-                    loc: loc.clone(),
+                    loc,
                     suggestions: None,
                 })?;
                 // Treat `for(;;)` as `while(true)` to keep the builder state consistent
-                let true_val = InstructionValue::Primitive {
-                    value: PrimitiveValue::Boolean(true),
-                    loc: loc.clone(),
-                };
+                let true_val =
+                    InstructionValue::Primitive { value: PrimitiveValue::Boolean(true), loc };
                 let test = lower_value_to_temporary(builder, true_val)?;
                 builder.terminate_with_continuation(
                     Terminal::Branch {
@@ -6183,7 +6146,7 @@ fn lower_statement<'a>(
                     loop_block,
                     fallthrough: continuation_id,
                     id: EvaluationOrder(0),
-                    loc: loc.clone(),
+                    loc,
                 },
                 conditional_block,
             );
@@ -6237,7 +6200,7 @@ fn lower_statement<'a>(
                     test: conditional_id,
                     fallthrough: continuation_id,
                     id: EvaluationOrder(0),
-                    loc: loc.clone(),
+                    loc,
                 },
                 conditional_block,
             );
@@ -6288,7 +6251,7 @@ fn lower_statement<'a>(
                     loop_block,
                     fallthrough: continuation_id,
                     id: EvaluationOrder(0),
-                    loc: loc.clone(),
+                    loc,
                 },
                 init_block,
             );
@@ -6297,20 +6260,16 @@ fn lower_statement<'a>(
             let left_loc = builder.source_location(for_in.left.span());
             let next_property = lower_value_to_temporary(
                 builder,
-                InstructionValue::NextPropertyOf { value, loc: left_loc.clone() },
+                InstructionValue::NextPropertyOf { value, loc: left_loc },
             )?;
 
-            let assign_result = lower_for_in_of_left(
-                builder,
-                &for_in.left,
-                left_loc.clone(),
-                next_property.clone(),
-            )?;
+            let assign_result =
+                lower_for_in_of_left(builder, &for_in.left, left_loc, next_property.clone())?;
             // Use the assign result (StoreLocal temp) as the test, matching TS behavior
             let test_value = assign_result.unwrap_or(next_property);
             let test = lower_value_to_temporary(
                 builder,
-                InstructionValue::LoadLocal { place: test_value, loc: left_loc.clone() },
+                InstructionValue::LoadLocal { place: test_value, loc: left_loc },
             )?;
             builder.terminate_with_continuation(
                 Terminal::Branch {
@@ -6319,7 +6278,7 @@ fn lower_statement<'a>(
                     alternate: continuation_id,
                     fallthrough: continuation_id,
                     id: EvaluationOrder(0),
-                    loc: loc.clone(),
+                    loc,
                 },
                 continuation_block,
             );
@@ -6338,7 +6297,7 @@ fn lower_statement<'a>(
                     category: ErrorCategory::Todo,
                     reason: "(BuildHIR::lowerStatement) Handle for-await loops".to_string(),
                     description: None,
-                    loc: loc.clone(),
+                    loc,
                     suggestions: None,
                 })?;
                 return Ok(());
@@ -6370,7 +6329,7 @@ fn lower_statement<'a>(
                     loop_block,
                     fallthrough: continuation_id,
                     id: EvaluationOrder(0),
-                    loc: loc.clone(),
+                    loc,
                 },
                 init_block,
             );
@@ -6378,14 +6337,14 @@ fn lower_statement<'a>(
             // Init block: GetIterator, goto test
             let iterator = lower_value_to_temporary(
                 builder,
-                InstructionValue::GetIterator { collection: value.clone(), loc: value.loc.clone() },
+                InstructionValue::GetIterator { collection: value.clone(), loc: value.loc },
             )?;
             builder.terminate_with_continuation(
                 Terminal::Goto {
                     block: test_block_id,
                     variant: GotoVariant::Break,
                     id: EvaluationOrder(0),
-                    loc: loc.clone(),
+                    loc,
                 },
                 test_block,
             );
@@ -6397,21 +6356,17 @@ fn lower_statement<'a>(
                 InstructionValue::IteratorNext {
                     iterator: iterator.clone(),
                     collection: value.clone(),
-                    loc: left_loc.clone(),
+                    loc: left_loc,
                 },
             )?;
 
-            let assign_result = lower_for_in_of_left(
-                builder,
-                &for_of.left,
-                left_loc.clone(),
-                advance_iterator.clone(),
-            )?;
+            let assign_result =
+                lower_for_in_of_left(builder, &for_of.left, left_loc, advance_iterator.clone())?;
             // Use the assign result (StoreLocal temp) as the test, matching TS behavior
             let test_value = assign_result.unwrap_or(advance_iterator);
             let test = lower_value_to_temporary(
                 builder,
-                InstructionValue::LoadLocal { place: test_value, loc: left_loc.clone() },
+                InstructionValue::LoadLocal { place: test_value, loc: left_loc },
             )?;
             builder.terminate_with_continuation(
                 Terminal::Branch {
@@ -6420,7 +6375,7 @@ fn lower_statement<'a>(
                     alternate: continuation_id,
                     fallthrough: continuation_id,
                     id: EvaluationOrder(0),
-                    loc: loc.clone(),
+                    loc,
                 },
                 continuation_block,
             );
@@ -6447,7 +6402,7 @@ fn lower_statement<'a>(
                             reason: "Expected at most one `default` branch in a switch statement"
                                 .to_string(),
                             description: None,
-                            loc: case_loc.clone(),
+                            loc: case_loc,
                             suggestions: None,
                         })?;
                         break;
@@ -6468,7 +6423,7 @@ fn lower_statement<'a>(
                                 block: fallthrough_target,
                                 variant: GotoVariant::Break,
                                 id: EvaluationOrder(0),
-                                loc: case_loc.clone(),
+                                loc: case_loc,
                             })
                         },
                     )
@@ -6518,7 +6473,7 @@ fn lower_statement<'a>(
                             "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
                                 .to_string(),
                         description: None,
-                        loc: loc.clone(),
+                        loc,
                         suggestions: None,
                     })?;
                     return Ok(());
@@ -6530,7 +6485,7 @@ fn lower_statement<'a>(
                     category: ErrorCategory::Todo,
                     reason: "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause".to_string(),
                     description: None,
-                    loc: loc.clone(),
+                    loc,
                     suggestions: None,
                 })?;
             }
@@ -6561,13 +6516,13 @@ fn lower_statement<'a>(
                     None
                 } else {
                     let param_loc = builder.source_location(param.pattern.span());
-                    let id = builder.make_temporary(param_loc.clone());
+                    let id = builder.make_temporary(param_loc);
                     promote_temporary(builder, id);
                     let place = Place {
                         identifier: id,
                         effect: Effect::Unknown,
                         reactive: false,
-                        loc: param_loc.clone(),
+                        loc: param_loc,
                     };
                     // Emit DeclareLocal for the catch binding
                     lower_value_to_temporary(
@@ -6594,7 +6549,7 @@ fn lower_statement<'a>(
                 if let Some((ref place, pattern)) = handler_binding_for_block {
                     lower_binding_assignment(
                         builder,
-                        handler_param_loc.clone().flatten().or_else(|| handler_loc.clone()),
+                        handler_param_loc.flatten().or(handler_loc),
                         InstructionKind::Catch,
                         pattern,
                         place.clone(),
@@ -6620,7 +6575,7 @@ fn lower_statement<'a>(
                     block: continuation_id,
                     variant: GotoVariant::Break,
                     id: EvaluationOrder(0),
-                    loc: handler_loc.clone(),
+                    loc: handler_loc,
                 })
             })?;
 
@@ -6640,7 +6595,7 @@ fn lower_statement<'a>(
                     block: continuation_id,
                     variant: GotoVariant::Try,
                     id: EvaluationOrder(0),
-                    loc: try_body_loc.clone(),
+                    loc: try_body_loc,
                 })
             })?;
 
@@ -6829,7 +6784,7 @@ fn lower_variable_declaration<'a>(
             let id_loc = builder.source_location(id.span);
             let mut binding = builder.resolve_identifier(
                 id.name.as_str(),
-                id_loc.clone(),
+                id_loc,
                 builder.scope().resolve_binding_identifier(id),
             )?;
             if !matches!(binding, VariableBinding::Identifier { .. }) {
@@ -6842,11 +6797,8 @@ fn lower_variable_declaration<'a>(
                     let binding_kind = crate::react_compiler_lowering::convert_binding_kind(
                         &builder.scope().binding_kind(symbol_id),
                     );
-                    let identifier = builder.resolve_binding_with_loc(
-                        id.name.as_str(),
-                        symbol_id,
-                        id_loc.clone(),
-                    )?;
+                    let identifier =
+                        builder.resolve_binding_with_loc(id.name.as_str(), symbol_id, id_loc)?;
                     binding = VariableBinding::Identifier { identifier, binding_kind };
                 }
             }
@@ -6855,12 +6807,8 @@ fn lower_variable_declaration<'a>(
                     // Update the identifier's loc to the declaration site
                     // (it may have been first created at a reference site during hoisting)
                     builder.set_identifier_declaration_loc(identifier, &id_loc);
-                    let place = Place {
-                        identifier,
-                        effect: Effect::Unknown,
-                        reactive: false,
-                        loc: id_loc.clone(),
-                    };
+                    let place =
+                        Place { identifier, effect: Effect::Unknown, reactive: false, loc: id_loc };
                     if builder.is_context_identifier(builder.scope().resolve_binding_identifier(id))
                     {
                         if kind == InstructionKind::Const {
@@ -6868,7 +6816,7 @@ fn lower_variable_declaration<'a>(
                                 reason: "Expect `const` declaration not to be reassigned"
                                     .to_string(),
                                 category: ErrorCategory::Syntax,
-                                loc: id_loc.clone(),
+                                loc: id_loc,
                                 description: None,
                                 suggestions: None,
                             })?;
@@ -6937,7 +6885,7 @@ fn lower_for_in_of_left<'a>(
                         var_decl.declarations.len()
                     ),
                     description: None,
-                    loc: left_loc.clone(),
+                    loc: left_loc,
                     suggestions: None,
                 })?;
             }

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/hir_builder.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/hir_builder.rs
@@ -20,6 +20,11 @@ use oxc_span::Span;
 use crate::react_compiler_lowering::identifier_loc_index::IdentifierLocIndex;
 use crate::react_compiler_lowering::source_loc::LineOffsets;
 
+type BuildResult<'a> = Result<
+    (HIR, Vec<Instruction<'a>>, FxIndexMap<String, SymbolId>, FxIndexMap<SymbolId, IdentifierId>),
+    CompilerError,
+>;
+
 // ---------------------------------------------------------------------------
 // Reserved word check (matches TS isReservedWord)
 // ---------------------------------------------------------------------------
@@ -178,6 +183,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
     /// - `bindings`: optional pre-existing bindings (e.g., from a parent function)
     /// - `context`: optional pre-existing captured context map
     /// - `entry_block_kind`: the kind of the entry block (defaults to `Block`)
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         env: &'b mut Environment<'a>,
         scope: &'b ScopeResolver<'b, 'a>,
@@ -257,7 +263,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
 
     /// Look up the source location of an identifier by its node_id.
     pub fn get_identifier_loc(&self, node_id: u32) -> Option<SourceLocation> {
-        self.identifier_locs.get(&node_id).map(|entry| entry.loc.clone())
+        self.identifier_locs.get(&node_id).map(|entry| entry.loc)
     }
 
     /// Check whether a reference at the given byte offset corresponds to a
@@ -340,7 +346,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
     /// after the instruction to model potential control flow to the handler,
     /// then continues in a new block.
     pub fn push(&mut self, instruction: Instruction<'a>) {
-        let loc = instruction.loc.clone();
+        let loc = instruction.loc;
         let instr_id = InstructionId(self.instruction_table.len() as u32);
         self.instruction_table.push(instruction);
         self.current.instructions.push(instr_id);
@@ -705,17 +711,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
     /// 5. Remove unnecessary try-catch
     /// 6. Number all instructions and terminals
     /// 7. Mark predecessor blocks
-    pub fn build(
-        mut self,
-    ) -> Result<
-        (
-            HIR,
-            Vec<Instruction<'a>>,
-            FxIndexMap<String, SymbolId>,
-            FxIndexMap<SymbolId, IdentifierId>,
-        ),
-        CompilerError,
-    > {
+    pub fn build(mut self) -> BuildResult<'a> {
         let mut hir = HIR { blocks: std::mem::take(&mut self.completed), entry: self.entry };
 
         let mut instructions = std::mem::take(&mut self.instruction_table);
@@ -736,7 +732,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
                     let loc = block
                         .instructions
                         .first()
-                        .and_then(|&i| instructions[i.0 as usize].loc.clone())
+                        .and_then(|&i| instructions[i.0 as usize].loc)
                         .or_else(|| block.terminal.loc().copied());
                     self.env.record_error(CompilerErrorDetail {
                         category: ErrorCategory::Todo,
@@ -811,7 +807,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
                     .scope
                     .declaration_start(symbol_id)
                     .and_then(|nid| self.get_identifier_loc(nid))
-                    .or_else(|| loc.clone());
+                    .or(loc);
                 self.env.record_error(CompilerErrorDetail {
                     category: ErrorCategory::Todo,
                     reason: "Support local variables named `fbt`".to_string(),
@@ -837,19 +833,14 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
         // Find a unique name: start with the original name, then try name_0, name_1, ...
         let mut candidate = name.to_string();
         let mut index = 0u32;
-        loop {
-            if let Some(&existing_symbol_id) = self.used_names.get(&candidate) {
-                if existing_symbol_id == symbol_id {
-                    // Same binding, use this name
-                    break;
-                }
-                // Name collision with a different binding, try the next suffix
-                candidate = format!("{}_{}", name, index);
-                index += 1;
-            } else {
-                // Name is available
+        while let Some(&existing_symbol_id) = self.used_names.get(&candidate) {
+            if existing_symbol_id == symbol_id {
+                // Same binding, use this name
                 break;
             }
+            // Name collision with a different binding, try the next suffix
+            candidate = format!("{}_{}", name, index);
+            index += 1;
         }
 
         // Record rename if the candidate differs from the original name
@@ -873,9 +864,9 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
         let decl_loc =
             self.scope.declaration_start(symbol_id).and_then(|nid| self.get_identifier_loc(nid));
         if let Some(ref dl) = decl_loc {
-            self.env.identifiers[id.0 as usize].loc = Some(dl.clone());
+            self.env.identifiers[id.0 as usize].loc = Some(*dl);
         } else if let Some(ref loc) = loc {
-            self.env.identifiers[id.0 as usize].loc = Some(loc.clone());
+            self.env.identifiers[id.0 as usize].loc = Some(*loc);
         }
 
         self.used_names.insert(candidate, symbol_id);
@@ -891,7 +882,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
         loc: &Option<SourceLocation>,
     ) {
         if let Some(loc_val) = loc {
-            self.env.identifiers[id.0 as usize].loc = Some(loc_val.clone());
+            self.env.identifiers[id.0 as usize].loc = Some(*loc_val);
         }
     }
 
@@ -1189,7 +1180,7 @@ pub fn remove_unnecessary_try_catch(hir: &mut HIR) {
                 &block.terminal
             {
                 if !block_ids.contains(handler) {
-                    return Some((block_id, *try_block, *handler, *fallthrough, loc.clone()));
+                    return Some((block_id, *try_block, *handler, *fallthrough, *loc));
                 }
             }
             None

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/identifier_loc_index.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/identifier_loc_index.rs
@@ -81,8 +81,7 @@ struct IdentifierLocVisitor<'a> {
 
 impl<'a> IdentifierLocVisitor<'a> {
     fn record(&mut self, span: oxc_span::Span, is_jsx: bool, is_declaration_name: bool) {
-        let opening_element_loc =
-            if is_jsx { self.current_opening_element_loc.clone() } else { None };
+        let opening_element_loc = if is_jsx { self.current_opening_element_loc } else { None };
         // `or_insert` keeps the richer entry already recorded for a node_id.
         // Function/class names are recorded as declaration names *before* the
         // generic binding-identifier walk re-visits them, so the declaration

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
@@ -406,7 +406,7 @@ fn evaluate_instruction<'a>(
                 let operand = read(constants, value);
                 if let Some(Constant::Primitive { value: PrimitiveValue::Number(n), .. }) = operand
                 {
-                    let negated = n.value() * -1.0;
+                    let negated = -n.value();
                     let loc = *loc;
                     let result = Constant::Primitive {
                         value: PrimitiveValue::Number(FloatValue::new(negated)),

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/dead_code_elimination.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/dead_code_elimination.rs
@@ -244,22 +244,21 @@ fn rewrite_instruction(
                 }
             }
         }
-        InstructionValue::StoreLocal { lvalue, type_annotation, loc, .. } => {
+        InstructionValue::StoreLocal { lvalue, type_annotation, loc, .. }
             if lvalue.kind != InstructionKind::Reassign
-                && !is_id_used(state, lvalue.place.identifier)
-            {
-                // This is a const/let declaration where the variable is accessed later,
-                // but where the value is always overwritten before being read.
-                // Rewrite to DeclareLocal so the initializer value can be DCE'd.
-                let new_lvalue = lvalue.clone();
-                let new_type_annotation = type_annotation.clone();
-                let new_loc = *loc;
-                instr.value = InstructionValue::DeclareLocal {
-                    lvalue: new_lvalue,
-                    type_annotation: new_type_annotation,
-                    loc: new_loc,
-                };
-            }
+                && !is_id_used(state, lvalue.place.identifier) =>
+        {
+            // This is a const/let declaration where the variable is accessed later,
+            // but where the value is always overwritten before being read.
+            // Rewrite to DeclareLocal so the initializer value can be DCE'd.
+            let new_lvalue = lvalue.clone();
+            let new_type_annotation = type_annotation.clone();
+            let new_loc = *loc;
+            instr.value = InstructionValue::DeclareLocal {
+                lvalue: new_lvalue,
+                type_annotation: new_type_annotation,
+                loc: new_loc,
+            };
         }
         _ => {}
     }
@@ -311,13 +310,10 @@ fn pruneable_value(value: &InstructionValue, state: &State, env: &Environment) -
             if env.output_mode == OutputMode::Ssr {
                 let callee_ty =
                     &env.types[env.identifiers[callee.identifier.0 as usize].type_.0 as usize];
-                if let Some(hook_kind) = env.get_hook_kind_for_type(callee_ty).ok().flatten() {
-                    match hook_kind {
-                        HookKind::UseState | HookKind::UseReducer | HookKind::UseRef => {
-                            return true;
-                        }
-                        _ => {}
-                    }
+                if let Some(HookKind::UseState | HookKind::UseReducer | HookKind::UseRef) =
+                    env.get_hook_kind_for_type(callee_ty).ok().flatten()
+                {
+                    return true;
                 }
             }
             false
@@ -326,13 +322,10 @@ fn pruneable_value(value: &InstructionValue, state: &State, env: &Environment) -
             if env.output_mode == OutputMode::Ssr {
                 let callee_ty =
                     &env.types[env.identifiers[property.identifier.0 as usize].type_.0 as usize];
-                if let Some(hook_kind) = env.get_hook_kind_for_type(callee_ty).ok().flatten() {
-                    match hook_kind {
-                        HookKind::UseState | HookKind::UseReducer | HookKind::UseRef => {
-                            return true;
-                        }
-                        _ => {}
-                    }
+                if let Some(HookKind::UseState | HookKind::UseReducer | HookKind::UseRef) =
+                    env.get_hook_kind_for_type(callee_ty).ok().flatten()
+                {
+                    return true;
                 }
             }
             false

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/drop_manual_memoization.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/drop_manual_memoization.rs
@@ -14,6 +14,7 @@
 
 use std::mem::discriminant;
 
+use cow_utils::CowUtils;
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 
@@ -216,7 +217,7 @@ fn process_manual_memo_call<'a>(
     let loc = func.instructions[instr_id.0 as usize].value.loc().cloned();
 
     // Replace the instruction value with the memoization replacement
-    let replacement = get_manual_memoization_replacement(&fn_place, loc.clone(), manual_memo.kind);
+    let replacement = get_manual_memoization_replacement(&fn_place, loc, manual_memo.kind);
     func.instructions[instr_id.0 as usize].value = replacement;
 
     if is_validation_enabled {
@@ -228,7 +229,7 @@ fn process_manual_memo_call<'a>(
                 Some("Expected the first argument to be an inline function expression".to_string()),
             )
             .with_detail(CompilerDiagnosticDetail::Error {
-                loc: fn_place.loc.clone(),
+                loc: fn_place.loc,
                 message: Some(
                     "Expected the first argument to be an inline function expression".to_string(),
                 ),
@@ -247,7 +248,7 @@ fn process_manual_memo_call<'a>(
                 identifier: fn_place.identifier,
                 effect: Effect::Unknown,
                 reactive: false,
-                loc: fn_place.loc.clone(),
+                loc: fn_place.loc,
             }
         };
 
@@ -378,26 +379,22 @@ pub fn collect_maybe_memo_dependencies(
         InstructionValue::LoadGlobal { binding, loc, .. } => Some(ManualMemoDependency {
             root: ManualMemoDependencyRoot::Global { identifier_name: binding.name().to_string() },
             path: vec![],
-            loc: loc.clone(),
+            loc: *loc,
         }),
         InstructionValue::PropertyLoad { object, property, loc, .. } => {
-            if let Some(object_dep) = maybe_deps.get(&object.identifier) {
-                Some(ManualMemoDependency {
-                    root: object_dep.root.clone(),
-                    path: {
-                        let mut path = object_dep.path.clone();
-                        path.push(DependencyPathEntry {
-                            property: property.clone(),
-                            optional,
-                            loc: loc.clone(),
-                        });
-                        path
-                    },
-                    loc: loc.clone(),
-                })
-            } else {
-                None
-            }
+            maybe_deps.get(&object.identifier).map(|object_dep| ManualMemoDependency {
+                root: object_dep.root.clone(),
+                path: {
+                    let mut path = object_dep.path.clone();
+                    path.push(DependencyPathEntry {
+                        property: property.clone(),
+                        optional,
+                        loc: *loc,
+                    });
+                    path
+                },
+                loc: *loc,
+            })
         }
         InstructionValue::LoadLocal { place, .. } | InstructionValue::LoadContext { place, .. } => {
             if let Some(source) = maybe_deps.get(&place.identifier) {
@@ -412,7 +409,7 @@ pub fn collect_maybe_memo_dependencies(
                         constant: false,
                     },
                     path: vec![],
-                    loc: place.loc.clone(),
+                    loc: place.loc,
                 })
             } else {
                 None
@@ -457,7 +454,7 @@ fn get_manual_memoization_replacement<'a>(
                 identifier: fn_place.identifier,
                 effect: Effect::Unknown,
                 reactive: false,
-                loc: loc.clone(),
+                loc,
             },
             loc,
         }
@@ -474,27 +471,27 @@ fn make_manual_memoization_markers<'a>(
 ) -> (Instruction<'a>, Instruction<'a>) {
     let start = Instruction {
         id: EvaluationOrder(0),
-        lvalue: create_temporary_place(env, fn_expr.loc.clone()),
+        lvalue: create_temporary_place(env, fn_expr.loc),
         value: InstructionValue::StartMemoize {
             manual_memo_id,
             deps: deps_list,
             deps_loc: Some(deps_loc),
             has_invalid_deps: false,
-            loc: fn_expr.loc.clone(),
+            loc: fn_expr.loc,
         },
-        loc: fn_expr.loc.clone(),
+        loc: fn_expr.loc,
         effects: None,
     };
     let finish = Instruction {
         id: EvaluationOrder(0),
-        lvalue: create_temporary_place(env, fn_expr.loc.clone()),
+        lvalue: create_temporary_place(env, fn_expr.loc),
         value: InstructionValue::FinishMemoize {
             manual_memo_id,
             decl: memo_decl.clone(),
             pruned: false,
-            loc: fn_expr.loc.clone(),
+            loc: fn_expr.loc,
         },
-        loc: fn_expr.loc.clone(),
+        loc: fn_expr.loc,
         effects: None,
     };
     (start, finish)
@@ -561,8 +558,8 @@ fn extract_manual_memoization_args(
 
     if maybe_deps_list.is_none() {
         let loc = match deps_list_place {
-            Some(PlaceOrSpread::Place(p)) => p.loc.clone(),
-            _ => instr.loc.clone(),
+            Some(PlaceOrSpread::Place(p)) => p.loc,
+            _ => instr.loc,
         };
         env.record_diagnostic(
             CompilerDiagnostic::new(
@@ -597,7 +594,7 @@ fn extract_manual_memoization_args(
                     Some("Expected the dependency list to be an array of simple expressions (e.g. `x`, `x.y.z`, `x?.y?.z`)".to_string()),
                 )
                 .with_detail(CompilerDiagnosticDetail::Error {
-                    loc: dep.loc.clone(),
+                    loc: dep.loc,
                     message: Some("Expected the dependency list to be an array of simple expressions (e.g. `x`, `x.y.z`, `x?.y?.z`)".to_string()),
                     identifier_name: None,
                 }),
@@ -605,11 +602,7 @@ fn extract_manual_memoization_args(
         }
     }
 
-    Some(ExtractedMemoArgs {
-        fn_place,
-        deps_list: Some(deps_list),
-        deps_loc: deps_info.loc.clone(),
-    })
+    Some(ExtractedMemoArgs { fn_place, deps_list: Some(deps_list), deps_loc: deps_info.loc })
 }
 
 // =============================================================================
@@ -671,7 +664,7 @@ fn find_optional_places(func: &HirFunction) -> Result<FxHashSet<IdentifierId>, C
 }
 
 fn is_known_react_module(module: &str) -> bool {
-    let lower = module.to_lowercase();
+    let lower = module.cow_to_lowercase();
     lower == "react" || lower == "react-dom"
 }
 

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/inline_iifes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/inline_iifes.rs
@@ -187,11 +187,11 @@ pub fn inline_immediately_invoked_function_expressions<'a>(
                                 // Replace return with LoadLocal + goto
                                 let load_instr = Instruction {
                                     id: EvaluationOrder(0),
-                                    loc: ret_loc.clone(),
+                                    loc: *ret_loc,
                                     lvalue: call_lvalue.clone(),
                                     value: InstructionValue::LoadLocal {
                                         place: value.clone(),
-                                        loc: ret_loc.clone(),
+                                        loc: *ret_loc,
                                     },
                                     effects: None,
                                 };
@@ -200,7 +200,7 @@ pub fn inline_immediately_invoked_function_expressions<'a>(
                                 inner_block.instructions.push(load_instr_id);
 
                                 let ret_id = *ret_id;
-                                let ret_loc = ret_loc.clone();
+                                let ret_loc = *ret_loc;
                                 inner_block.terminal = Terminal::Goto {
                                     block: continuation_block_id,
                                     id: ret_id,
@@ -333,16 +333,16 @@ fn rewrite_block<'a>(
     return_value: &Place,
 ) {
     if let Terminal::Return { value, loc: ret_loc, .. } = &block.terminal {
-        let store_lvalue = create_temporary_place(env, ret_loc.clone());
+        let store_lvalue = create_temporary_place(env, *ret_loc);
         let store_instr = Instruction {
             id: EvaluationOrder(0),
-            loc: ret_loc.clone(),
+            loc: *ret_loc,
             lvalue: store_lvalue,
             value: InstructionValue::StoreLocal {
                 lvalue: LValue { kind: InstructionKind::Reassign, place: return_value.clone() },
                 value: value.clone(),
                 type_annotation: None,
-                loc: ret_loc.clone(),
+                loc: *ret_loc,
             },
             effects: None,
         };
@@ -350,7 +350,7 @@ fn rewrite_block<'a>(
         instructions.push(store_instr);
         block.instructions.push(store_instr_id);
 
-        let ret_loc = ret_loc.clone();
+        let ret_loc = *ret_loc;
         block.terminal = Terminal::Goto {
             block: return_target,
             id: EvaluationOrder(0),
@@ -367,7 +367,7 @@ fn declare_temporary<'a>(
     block_id: BlockId,
     result: &Place,
 ) {
-    let declare_lvalue = create_temporary_place(env, result.loc.clone());
+    let declare_lvalue = create_temporary_place(env, result.loc);
     let declare_instr = Instruction {
         id: EvaluationOrder(0),
         loc: GENERATED_SOURCE,
@@ -375,7 +375,7 @@ fn declare_temporary<'a>(
         value: InstructionValue::DeclareLocal {
             lvalue: LValue { place: result.clone(), kind: InstructionKind::Let },
             type_annotation: None,
-            loc: result.loc.clone(),
+            loc: result.loc,
         },
         effects: None,
     };

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/name_anonymous_functions.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/name_anonymous_functions.rs
@@ -242,7 +242,7 @@ fn handle_call(
     args: &[PlaceOrSpread],
     functions: &mut FxHashMap<IdentifierId, usize>,
     names: &FxHashMap<IdentifierId, String>,
-    nodes: &mut Vec<Node>,
+    nodes: &mut [Node],
 ) {
     let callee_ident = &env.identifiers[callee_id.0 as usize];
     let callee_ty = &env.types[callee_ident.type_.0 as usize];

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/optimize_for_ssr.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/optimize_for_ssr.rs
@@ -105,28 +105,23 @@ pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
                                 }
                             }
                         }
-                        Some(HookKind::UseState) => {
-                            if args.len() == 1 {
-                                if let PlaceOrSpread::Place(arg) = &args[0] {
-                                    let arg_type = &env.types[env.identifiers
-                                        [arg.identifier.0 as usize]
-                                        .type_
-                                        .0
-                                        as usize];
-                                    if is_primitive_type(arg_type)
-                                        || is_plain_object_type(arg_type)
-                                        || is_array_type(arg_type)
-                                    {
-                                        let lvalue_id =
-                                            env.identifiers[instr.lvalue.identifier.0 as usize].id;
-                                        inlined_state.insert(
-                                            lvalue_id,
-                                            InlinedStateReplacement::LoadLocal {
-                                                place: arg.clone(),
-                                                loc: arg.loc,
-                                            },
-                                        );
-                                    }
+                        Some(HookKind::UseState) if args.len() == 1 => {
+                            if let PlaceOrSpread::Place(arg) = &args[0] {
+                                let arg_type = &env.types
+                                    [env.identifiers[arg.identifier.0 as usize].type_.0 as usize];
+                                if is_primitive_type(arg_type)
+                                    || is_plain_object_type(arg_type)
+                                    || is_array_type(arg_type)
+                                {
+                                    let lvalue_id =
+                                        env.identifiers[instr.lvalue.identifier.0 as usize].id;
+                                    inlined_state.insert(
+                                        lvalue_id,
+                                        InlinedStateReplacement::LoadLocal {
+                                            place: arg.clone(),
+                                            loc: arg.loc,
+                                        },
+                                    );
                                 }
                             }
                         }
@@ -174,21 +169,18 @@ pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
                             InstructionValue::Primitive { value: PrimitiveValue::Undefined, loc };
                     }
                 }
-                InstructionValue::JsxExpression { tag, .. } => {
-                    if let JsxTag::Builtin(builtin) = tag {
-                        // Only optimize non-custom-element builtin tags
-                        if !builtin.name.contains('-') {
-                            let tag_name = builtin.name.clone();
-                            // Retain only props that are not known event handlers and not "ref"
-                            if let InstructionValue::JsxExpression { props, .. } = &mut instr.value
-                            {
-                                props.retain(|prop| match prop {
-                                    JsxAttribute::SpreadAttribute { .. } => true,
-                                    JsxAttribute::Attribute { name, .. } => {
-                                        !is_known_event_handler(&tag_name, name) && name != "ref"
-                                    }
-                                });
-                            }
+                InstructionValue::JsxExpression { tag: JsxTag::Builtin(builtin), .. } => {
+                    // Only optimize non-custom-element builtin tags
+                    if !builtin.name.contains('-') {
+                        let tag_name = builtin.name.clone();
+                        // Retain only props that are not known event handlers and not "ref"
+                        if let InstructionValue::JsxExpression { props, .. } = &mut instr.value {
+                            props.retain(|prop| match prop {
+                                JsxAttribute::SpreadAttribute { .. } => true,
+                                JsxAttribute::Attribute { name, .. } => {
+                                    !is_known_event_handler(&tag_name, name) && name != "ref"
+                                }
+                            });
                         }
                     }
                 }

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/outline_jsx.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/outline_jsx.rs
@@ -200,7 +200,7 @@ fn outline_jsx_impl<'a>(
 fn process_and_outline_jsx<'a>(
     func: &mut HirFunction<'a>,
     env: &mut Environment<'a>,
-    jsx_group: &mut Vec<JsxInstrInfo>,
+    jsx_group: &mut [JsxInstrInfo],
     globals: &FxHashMap<IdentifierId, usize>,
     rewrite_instr: &mut FxHashMap<EvaluationOrder, Vec<Instruction<'a>>>,
     outlined_fns: &mut Vec<HirFunction<'a>>,
@@ -467,11 +467,10 @@ fn emit_load_globals<'a>(
     let mut instructions = Vec::new();
     for info in jsx_group {
         let instr = &func.instructions[info.instr_idx];
-        if let InstructionValue::JsxExpression { tag, .. } = &instr.value {
-            if let JsxTag::Place(tag_place) = tag {
-                let global_instr_idx = globals.get(&tag_place.identifier)?;
-                instructions.push(func.instructions[*global_instr_idx].clone());
-            }
+        if let InstructionValue::JsxExpression { tag: JsxTag::Place(tag_place), .. } = &instr.value
+        {
+            let global_instr_idx = globals.get(&tag_place.identifier)?;
+            instructions.push(func.instructions[*global_instr_idx].clone());
         }
     }
     Some(instructions)

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/prune_maybe_throws.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/prune_maybe_throws.rs
@@ -115,10 +115,10 @@ fn prune_maybe_throws_impl(func: &mut HirFunction) -> Option<FxHashMap<BlockId, 
 }
 
 fn instruction_may_throw(instr: &Instruction) -> bool {
-    match &instr.value {
+    !matches!(
+        &instr.value,
         InstructionValue::Primitive { .. }
-        | InstructionValue::ArrayExpression { .. }
-        | InstructionValue::ObjectExpression { .. } => false,
-        _ => true,
-    }
+            | InstructionValue::ArrayExpression { .. }
+            | InstructionValue::ObjectExpression { .. }
+    )
 }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/build_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/build_reactive_function.rs
@@ -1334,14 +1334,11 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
         let mut inner_value = result.value;
 
         // Flatten nested SequenceExpressions
-        loop {
-            match inner_value {
-                ReactiveValue::SequenceExpression { instructions: seq_instrs, value, .. } => {
-                    instructions.extend(seq_instrs);
-                    inner_value = *value;
-                }
-                _ => break,
-            }
+        while let ReactiveValue::SequenceExpression { instructions: seq_instrs, value, .. } =
+            inner_value
+        {
+            instructions.extend(seq_instrs);
+            inner_value = *value;
         }
 
         // Only add the final instruction if the innermost value is not just a LoadLocal

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/extract_scope_declarations_from_destructuring.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/extract_scope_declarations_from_destructuring.rs
@@ -115,8 +115,8 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
             } else if !reassigned.is_empty() {
                 // Mixed: replace reassigned items with temporaries and emit separate assignments
                 let mut renamed: Vec<(Place, Place)> = Vec::new();
-                let instr_loc = instruction.loc.clone();
-                let destr_loc = loc.clone();
+                let instr_loc = instruction.loc;
+                let destr_loc = *loc;
 
                 let env = &mut *self.env; // reborrow
                 visitors::map_pattern_operands(&mut lvalue.pattern, &mut |place: Place| {
@@ -131,7 +131,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
                     env.identifiers[temp_id.0 as usize].type_ = original_type;
                     // Set identifier loc to the place's source location
                     // (matches TS makeTemporaryIdentifier which receives place.loc)
-                    env.identifiers[temp_id.0 as usize].loc = place.loc.clone();
+                    env.identifiers[temp_id.0 as usize].loc = place.loc;
                     // Promote the temporary
                     env.identifiers[temp_id.0 as usize].name =
                         Some(IdentifierName::Promoted(format!("#t{}", decl_id.0)));
@@ -156,10 +156,10 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
                             lvalue: LValue { kind: InstructionKind::Reassign, place: original },
                             value: temporary,
                             type_annotation: None,
-                            loc: destr_loc.clone(),
+                            loc: destr_loc,
                         }),
                         effects: None,
-                        loc: instr_loc.clone(),
+                        loc: instr_loc,
                     });
                 }
                 extra_instructions = Some(extra);
@@ -169,13 +169,13 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
         // Update state.declared with declarations from the instruction(s)
         if let Some(ref extras) = extra_instructions {
             // Process the original instruction
-            update_declared_from_instruction(instruction, &self.env, state);
+            update_declared_from_instruction(instruction, self.env, state);
             // Process extra instructions
             for extra_instr in extras {
-                update_declared_from_instruction(extra_instr, &self.env, state);
+                update_declared_from_instruction(extra_instr, self.env, state);
             }
         } else {
-            update_declared_from_instruction(instruction, &self.env, state);
+            update_declared_from_instruction(instruction, self.env, state);
         }
 
         if let Some(extras) = extra_instructions {
@@ -208,12 +208,12 @@ fn update_declared_from_instruction<'a>(
                     state.declared.insert(identifier.declaration_id);
                 }
             }
-            InstructionValue::Destructure { lvalue, .. } => {
-                if lvalue.kind != InstructionKind::Reassign {
-                    for place in visitors::each_pattern_operand(&lvalue.pattern) {
-                        let identifier = &env.identifiers[place.identifier.0 as usize];
-                        state.declared.insert(identifier.declaration_id);
-                    }
+            InstructionValue::Destructure { lvalue, .. }
+                if lvalue.kind != InstructionKind::Reassign =>
+            {
+                for place in visitors::each_pattern_operand(&lvalue.pattern) {
+                    let identifier = &env.identifiers[place.identifier.0 as usize];
+                    state.declared.insert(identifier.declaration_id);
                 }
             }
             _ => {}

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/merge_reactive_scopes_that_invalidate_together.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/merge_reactive_scopes_that_invalidate_together.rs
@@ -145,9 +145,8 @@ impl<'a, 'e> MergeTransform<'a, 'e> {
         let mut current: Option<MergedScope> = None;
         let mut merged: Vec<MergedScope> = Vec::new();
 
-        let block_len = block.len();
-        for i in 0..block_len {
-            match &block[i] {
+        for (i, statement) in block.iter().enumerate() {
+            match statement {
                 ReactiveStatement::Terminal(_) => {
                     // Don't merge across terminals
                     if let Some(c) = current.take() {
@@ -493,19 +492,14 @@ fn can_merge_scopes<'a>(
 /// Check if a type is always invalidating (guaranteed to change when inputs change).
 pub fn is_always_invalidating_type(ty: &Type) -> bool {
     match ty {
-        Type::Object { shape_id } => {
-            if let Some(id) = shape_id {
-                matches!(
-                    id.as_str(),
-                    s if s == BUILT_IN_ARRAY_ID
-                        || s == BUILT_IN_OBJECT_ID
-                        || s == BUILT_IN_FUNCTION_ID
-                        || s == BUILT_IN_JSX_ID
-                )
-            } else {
-                false
-            }
-        }
+        Type::Object { shape_id: Some(id) } => matches!(
+            id.as_str(),
+            s if s == BUILT_IN_ARRAY_ID
+                || s == BUILT_IN_OBJECT_ID
+                || s == BUILT_IN_FUNCTION_ID
+                || s == BUILT_IN_JSX_ID
+        ),
+        Type::Object { shape_id: None } => false,
         Type::Function { .. } => true,
         _ => false,
     }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/print_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/print_reactive_function.rs
@@ -181,6 +181,7 @@ impl<'a, 'h> DebugPrinter<'a, 'h> {
             ReactiveValue::Instruction(iv) => {
                 // Build the inner function formatter callback if we have an hir_formatter
                 let hir_formatter = self.hir_formatter;
+                #[allow(clippy::type_complexity)]
                 let inner_func_cb: Option<
                     Box<dyn Fn(&mut PrintFormatter<'_, 'h>, &HirFunction<'h>) + '_>,
                 > = hir_formatter.map(|hf| {

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/promote_used_temporaries.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/promote_used_temporaries.rs
@@ -568,13 +568,12 @@ fn promote_interposed_instruction(
 
                     match iv {
                         InstructionValue::StoreContext { lvalue, .. }
-                        | InstructionValue::StoreLocal { lvalue, .. } => {
-                            if lvalue.kind == InstructionKind::Const
-                                || lvalue.kind == InstructionKind::HoistedConst
-                            {
-                                consts.insert(lvalue.place.identifier);
-                                const_store = true;
-                            }
+                        | InstructionValue::StoreLocal { lvalue, .. }
+                            if (lvalue.kind == InstructionKind::Const
+                                || lvalue.kind == InstructionKind::HoistedConst) =>
+                        {
+                            consts.insert(lvalue.place.identifier);
+                            const_store = true;
                         }
                         _ => {}
                     }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_hoisted_contexts.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_hoisted_contexts.rs
@@ -106,20 +106,19 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
         place: &Place,
         state: &mut VisitorState,
     ) -> Result<(), CompilerError> {
-        if let Some(kind) = state.uninitialized.get(&place.identifier) {
-            if let UninitializedKind::Func { definition } = kind {
-                if *definition != Some(place.identifier) {
-                    let mut err = CompilerError::new();
-                    err.push_error_detail(
-                        CompilerErrorDetail::new(
-                            ErrorCategory::Todo,
-                            "[PruneHoistedContexts] Rewrite hoisted function references"
-                                .to_string(),
-                        )
-                        .with_loc(place.loc),
-                    );
-                    return Err(err);
-                }
+        if let Some(UninitializedKind::Func { definition }) =
+            state.uninitialized.get(&place.identifier)
+        {
+            if *definition != Some(place.identifier) {
+                let mut err = CompilerError::new();
+                err.push_error_detail(
+                    CompilerErrorDetail::new(
+                        ErrorCategory::Todo,
+                        "[PruneHoistedContexts] Rewrite hoisted function references".to_string(),
+                    )
+                    .with_loc(place.loc),
+                );
+                return Err(err);
             }
         }
         Ok(())

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_escaping_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_escaping_scopes.rs
@@ -46,6 +46,11 @@ use crate::react_compiler_reactive_scopes::visitors::Transformed;
 use crate::react_compiler_reactive_scopes::visitors::transform_reactive_function;
 use crate::react_compiler_reactive_scopes::visitors::visit_reactive_function;
 
+type IdentifierMemoNode =
+    (MemoizationLevel, bool, FxIndexSet<DeclarationId>, FxIndexSet<ScopeId>, bool);
+type IdentifierMemoNodes = FxHashMap<DeclarationId, IdentifierMemoNode>;
+type ScopeMemoNodes = FxHashMap<ScopeId, (Vec<DeclarationId>, bool)>;
+
 // =============================================================================
 // Public entry point
 // =============================================================================
@@ -961,10 +966,7 @@ fn compute_memoized_identifiers(state: &CollectState) -> FxHashSet<DeclarationId
     let mut memoized = FxHashSet::default();
 
     // We need mutable access to the nodes, so we clone the state into mutable structures
-    let mut identifier_nodes: FxHashMap<
-        DeclarationId,
-        (MemoizationLevel, bool, FxIndexSet<DeclarationId>, FxIndexSet<ScopeId>, bool),
-    > = state
+    let mut identifier_nodes: IdentifierMemoNodes = state
         .identifiers
         .iter()
         .map(|(id, node)| {
@@ -981,7 +983,7 @@ fn compute_memoized_identifiers(state: &CollectState) -> FxHashSet<DeclarationId
         })
         .collect();
 
-    let mut scope_nodes: FxHashMap<ScopeId, (Vec<DeclarationId>, bool)> = state
+    let mut scope_nodes: ScopeMemoNodes = state
         .scopes
         .iter()
         .map(|(id, node)| (*id, (node.dependencies.clone(), node.seen)))
@@ -990,11 +992,8 @@ fn compute_memoized_identifiers(state: &CollectState) -> FxHashSet<DeclarationId
     fn visit(
         id: DeclarationId,
         force_memoize: bool,
-        identifier_nodes: &mut FxHashMap<
-            DeclarationId,
-            (MemoizationLevel, bool, FxIndexSet<DeclarationId>, FxIndexSet<ScopeId>, bool),
-        >,
-        scope_nodes: &mut FxHashMap<ScopeId, (Vec<DeclarationId>, bool)>,
+        identifier_nodes: &mut IdentifierMemoNodes,
+        scope_nodes: &mut ScopeMemoNodes,
         memoized: &mut FxHashSet<DeclarationId>,
     ) -> bool {
         let Some(&(level, _, _, _, seen)) = identifier_nodes.get(&id) else {
@@ -1035,11 +1034,8 @@ fn compute_memoized_identifiers(state: &CollectState) -> FxHashSet<DeclarationId
 
     fn force_memoize_scope_dependencies(
         id: ScopeId,
-        identifier_nodes: &mut FxHashMap<
-            DeclarationId,
-            (MemoizationLevel, bool, FxIndexSet<DeclarationId>, FxIndexSet<ScopeId>, bool),
-        >,
-        scope_nodes: &mut FxHashMap<ScopeId, (Vec<DeclarationId>, bool)>,
+        identifier_nodes: &mut IdentifierMemoNodes,
+        scope_nodes: &mut ScopeMemoNodes,
         memoized: &mut FxHashSet<DeclarationId>,
     ) {
         let seen = scope_nodes.get(&id).expect("Expected a node for all scopes").1;
@@ -1129,7 +1125,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for PruneScopesTransform<'a, 'e> {
             }) if store_lvalue.kind == InstructionKind::Reassign => {
                 let decl_id =
                     self.env.identifiers[store_lvalue.place.identifier.0 as usize].declaration_id;
-                let ids = self.reassignments.entry(decl_id).or_insert_with(FxHashSet::default);
+                let ids = self.reassignments.entry(decl_id).or_default();
                 ids.insert(store_value.identifier);
             }
             ReactiveValue::Instruction(InstructionValue::LoadLocal { place, .. }) => {
@@ -1142,8 +1138,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for PruneScopesTransform<'a, 'e> {
                 if has_scope && lvalue_no_scope {
                     if let Some(lv) = &instruction.lvalue {
                         let decl_id = self.env.identifiers[lv.identifier.0 as usize].declaration_id;
-                        let ids =
-                            self.reassignments.entry(decl_id).or_insert_with(FxHashSet::default);
+                        let ids = self.reassignments.entry(decl_id).or_default();
                         ids.insert(place.identifier);
                     }
                 }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_unused_labels.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_unused_labels.rs
@@ -69,8 +69,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
         }
 
         // Is this terminal reachable via a break/continue to its label?
-        let is_reachable_label =
-            stmt.label.as_ref().map_or(false, |label| state.contains(&label.id));
+        let is_reachable_label = stmt.label.as_ref().is_some_and(|label| state.contains(&label.id));
 
         if let ReactiveTerminal::Label { block, .. } = &mut stmt.terminal {
             if !is_reachable_label {

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/rename_variables.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/rename_variables.rs
@@ -177,14 +177,12 @@ impl<'a, 'e> ReactiveFunctionVisitor<'a> for Visitor<'a, 'e> {
     /// TS: `visitValue(id, value, state) { this.traverseValue(id, value, state); if (value.kind === 'FunctionExpression' || value.kind === 'ObjectMethod') this.visitHirFunction(value.loweredFunc.func, state) }`
     fn visit_value(&self, id: EvaluationOrder, value: &ReactiveValue<'a>, state: &mut Scopes) {
         self.traverse_value(id, value, state);
-        if let ReactiveValue::Instruction(iv) = value {
-            match iv {
-                InstructionValue::FunctionExpression { lowered_func, .. }
-                | InstructionValue::ObjectMethod { lowered_func, .. } => {
-                    self.visit_hir_function(lowered_func.func, state);
-                }
-                _ => {}
-            }
+        if let ReactiveValue::Instruction(
+            InstructionValue::FunctionExpression { lowered_func, .. }
+            | InstructionValue::ObjectMethod { lowered_func, .. },
+        ) = value
+        {
+            self.visit_hir_function(lowered_func.func, state);
         }
     }
 }

--- a/crates/oxc_react_compiler/src/react_compiler_ssa/rewrite_instruction_kinds_based_on_reassignment.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_ssa/rewrite_instruction_kinds_based_on_reassignment.rs
@@ -319,11 +319,8 @@ pub fn rewrite_instruction_kinds_based_on_reassignment(
         let block_id = &block_keys[bi];
         let instr_id = func.body.blocks[block_id].instructions[ili];
         let instr = &mut func.instructions[instr_id.0 as usize];
-        match &mut instr.value {
-            InstructionValue::StoreLocal { lvalue, .. } => {
-                lvalue.kind = InstructionKind::Const;
-            }
-            _ => {}
+        if let InstructionValue::StoreLocal { lvalue, .. } = &mut instr.value {
+            lvalue.kind = InstructionKind::Const;
         }
     }
 
@@ -331,11 +328,8 @@ pub fn rewrite_instruction_kinds_based_on_reassignment(
         let block_id = &block_keys[bi];
         let instr_id = func.body.blocks[block_id].instructions[ili];
         let instr = &mut func.instructions[instr_id.0 as usize];
-        match &mut instr.value {
-            InstructionValue::StoreLocal { lvalue, .. } => {
-                lvalue.kind = InstructionKind::Reassign;
-            }
-            _ => {}
+        if let InstructionValue::StoreLocal { lvalue, .. } = &mut instr.value {
+            lvalue.kind = InstructionKind::Reassign;
         }
     }
 
@@ -349,11 +343,8 @@ pub fn rewrite_instruction_kinds_based_on_reassignment(
         let block_id = &block_keys[bi];
         let instr_id = func.body.blocks[block_id].instructions[ili];
         let instr = &mut func.instructions[instr_id.0 as usize];
-        match &mut instr.value {
-            InstructionValue::Destructure { lvalue, .. } => {
-                lvalue.kind = kind;
-            }
-            _ => {}
+        if let InstructionValue::Destructure { lvalue, .. } = &mut instr.value {
+            lvalue.kind = kind;
         }
     }
 

--- a/crates/oxc_react_compiler/src/react_compiler_typeinference/infer_types.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_typeinference/infer_types.rs
@@ -49,7 +49,7 @@ pub fn infer_types(
     );
     generate(func, env, &mut unifier)?;
 
-    apply_function(func, &env.functions, &mut env.identifiers, &mut env.types, &mut unifier);
+    apply_function(func, &env.functions, &mut env.identifiers, &mut env.types, &unifier);
     Ok(())
 }
 
@@ -283,25 +283,21 @@ fn generate(
 ) -> Result<(), CompilerDiagnostic> {
     // Component params
     if func.fn_type == ReactFunctionType::Component {
-        if let Some(first) = func.params.first() {
-            if let ParamPattern::Place(place) = first {
-                let ty = get_type(place.identifier, &env.identifiers);
-                unifier.unify(
-                    ty,
-                    Type::Object { shape_id: Some(BUILT_IN_PROPS_ID.to_string()) },
-                    &env.shapes,
-                )?;
-            }
+        if let Some(ParamPattern::Place(place)) = func.params.first() {
+            let ty = get_type(place.identifier, &env.identifiers);
+            unifier.unify(
+                ty,
+                Type::Object { shape_id: Some(BUILT_IN_PROPS_ID.to_string()) },
+                &env.shapes,
+            )?;
         }
-        if let Some(second) = func.params.get(1) {
-            if let ParamPattern::Place(place) = second {
-                let ty = get_type(place.identifier, &env.identifiers);
-                unifier.unify(
-                    ty,
-                    Type::Object { shape_id: Some(BUILT_IN_USE_REF_ID.to_string()) },
-                    &env.shapes,
-                )?;
-            }
+        if let Some(ParamPattern::Place(place)) = func.params.get(1) {
+            let ty = get_type(place.identifier, &env.identifiers);
+            unifier.unify(
+                ty,
+                Type::Object { shape_id: Some(BUILT_IN_USE_REF_ID.to_string()) },
+                &env.shapes,
+            )?;
         }
     }
 
@@ -391,25 +387,21 @@ fn generate_for_function_id(
 
     // Process params for component inner functions
     if inner.fn_type == ReactFunctionType::Component {
-        if let Some(first) = inner.params.first() {
-            if let ParamPattern::Place(place) = first {
-                let ty = get_type(place.identifier, identifiers);
-                unifier.unify(
-                    ty,
-                    Type::Object { shape_id: Some(BUILT_IN_PROPS_ID.to_string()) },
-                    shapes,
-                )?;
-            }
+        if let Some(ParamPattern::Place(place)) = inner.params.first() {
+            let ty = get_type(place.identifier, identifiers);
+            unifier.unify(
+                ty,
+                Type::Object { shape_id: Some(BUILT_IN_PROPS_ID.to_string()) },
+                shapes,
+            )?;
         }
-        if let Some(second) = inner.params.get(1) {
-            if let ParamPattern::Place(place) = second {
-                let ty = get_type(place.identifier, identifiers);
-                unifier.unify(
-                    ty,
-                    Type::Object { shape_id: Some(BUILT_IN_USE_REF_ID.to_string()) },
-                    shapes,
-                )?;
-            }
+        if let Some(ParamPattern::Place(place)) = inner.params.get(1) {
+            let ty = get_type(place.identifier, identifiers);
+            unifier.unify(
+                ty,
+                Type::Object { shape_id: Some(BUILT_IN_USE_REF_ID.to_string()) },
+                shapes,
+            )?;
         }
     }
 
@@ -459,6 +451,7 @@ fn generate_for_function_id(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn generate_instruction_types(
     instr: &Instruction,
     instr_id: InstructionId,
@@ -854,7 +847,7 @@ fn apply_function(
     func: &HirFunction,
     functions: &[HirFunction],
     identifiers: &mut [Identifier],
-    types: &mut Vec<Type>,
+    types: &mut [Type],
     unifier: &Unifier,
 ) {
     for (_block_id, block) in &func.body.blocks {
@@ -905,7 +898,7 @@ fn apply_function(
 fn resolve_identifier(
     id: IdentifierId,
     identifiers: &mut [Identifier],
-    types: &mut Vec<Type>,
+    types: &mut [Type],
     unifier: &Unifier,
 ) {
     let type_id = identifiers[id.0 as usize].type_;
@@ -918,7 +911,7 @@ fn resolve_identifier(
 fn apply_instruction_lvalues(
     value: &InstructionValue,
     identifiers: &mut [Identifier],
-    types: &mut Vec<Type>,
+    types: &mut [Type],
     unifier: &Unifier,
 ) {
     match value {
@@ -980,7 +973,7 @@ fn apply_instruction_lvalues(
 fn apply_instruction_operands(
     value: &InstructionValue,
     identifiers: &mut [Identifier],
-    types: &mut Vec<Type>,
+    types: &mut [Type],
     unifier: &Unifier,
 ) {
     match value {

--- a/crates/oxc_react_compiler/src/react_compiler_utils/disjoint_set.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_utils/disjoint_set.rs
@@ -20,6 +20,12 @@ pub struct DisjointSet<K: Copy + Eq + Hash> {
     entries: FxIndexMap<K, K>,
 }
 
+impl<K: Copy + Eq + Hash> Default for DisjointSet<K> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<K: Copy + Eq + Hash> DisjointSet<K> {
     pub fn new() -> Self {
         DisjointSet { entries: FxIndexMap::default() }

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_exhaustive_dependencies.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_exhaustive_dependencies.rs
@@ -34,7 +34,7 @@ pub fn validate_exhaustive_dependencies(
 ) -> Result<(), CompilerDiagnostic> {
     let reactive = collect_reactive_identifiers(func, &env.functions);
     let validate_memo = env.config.validate_exhaustive_memoization_dependencies;
-    let validate_effect = env.config.validate_exhaustive_effect_dependencies.clone();
+    let validate_effect = env.config.validate_exhaustive_effect_dependencies;
 
     let mut temporaries: FxHashMap<IdentifierId, Temporary> = FxHashMap::default();
     for param in &func.params {
@@ -61,7 +61,7 @@ pub fn validate_exhaustive_dependencies(
         start_memo: &mut start_memo,
         memo_locals: &mut memo_locals,
         validate_memo,
-        validate_effect: validate_effect.clone(),
+        validate_effect,
         reactive: &reactive,
         diagnostics: Vec::new(),
         invalid_memo_ids: FxHashSet::default(),
@@ -1105,6 +1105,7 @@ fn collect_dependencies(
 // validateDependencies
 // =============================================================================
 
+#[allow(clippy::too_many_arguments)]
 fn validate_dependencies(
     mut inferred: Vec<InferredDependency>,
     manual_dependencies: &[ManualMemoDependency],

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_hooks_usage.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_hooks_usage.rs
@@ -349,7 +349,7 @@ pub fn validate_hooks_usage(
                     let object_kind = get_kind_for_place(value, &value_kinds, &env.identifiers);
                     // Process instr.lvalue and all pattern operands (matching TS eachInstructionLValue)
                     let pattern_places = each_pattern_operand(&lvalue.pattern);
-                    let all_lvalues = once(instr.lvalue.clone()).chain(pattern_places.into_iter());
+                    let all_lvalues = once(instr.lvalue.clone()).chain(pattern_places);
                     for place in all_lvalues {
                         let is_hook_property =
                             ident_is_hook_name(place.identifier, &env.identifiers);

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_locals_not_reassigned_after_render.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_locals_not_reassigned_after_render.rs
@@ -78,6 +78,7 @@ fn format_variable_name(place: &Place, identifiers: &[Identifier]) -> String {
 /// context variable. Returns the reassigned place if found, or None.
 ///
 /// Side effects: accumulates async-function reassignment diagnostics into `diagnostics`.
+#[allow(clippy::only_used_in_recursion, clippy::too_many_arguments)]
 fn get_context_reassignment(
     func: &HirFunction,
     identifiers: &[Identifier],

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_capitalized_calls.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_capitalized_calls.rs
@@ -1,3 +1,4 @@
+use cow_utils::CowUtils;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::react_compiler_diagnostics::{CompilerError, CompilerErrorDetail, ErrorCategory};
@@ -36,7 +37,7 @@ pub fn validate_no_capitalized_calls(
                     if !name.is_empty()
                         && name.starts_with(|c: char| c.is_ascii_uppercase())
                         // We don't want to flag CONSTANTS()
-                        && name != name.to_uppercase()
+                        && name != name.cow_to_uppercase()
                         && !allow_list.contains(name)
                     {
                         capital_load_globals.insert(lvalue_id, name.to_string());
@@ -55,11 +56,12 @@ pub fn validate_no_capitalized_calls(
                         continue;
                     }
                 }
-                InstructionValue::PropertyLoad { property, .. } => {
-                    if let PropertyLiteral::String(prop_name) = property {
-                        if prop_name.starts_with(|c: char| c.is_ascii_uppercase()) {
-                            capitalized_properties.insert(lvalue_id, prop_name.clone());
-                        }
+                InstructionValue::PropertyLoad {
+                    property: PropertyLiteral::String(prop_name),
+                    ..
+                } => {
+                    if prop_name.starts_with(|c: char| c.is_ascii_uppercase()) {
+                        capitalized_properties.insert(lvalue_id, prop_name.clone());
                     }
                 }
                 InstructionValue::MethodCall { property, loc, .. } => {

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_derived_computations_in_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_derived_computations_in_effects.rs
@@ -394,20 +394,18 @@ pub fn validate_no_derived_computations_in_effects_exp(
             }
         }
     } else if func.fn_type == ReactFunctionType::Component {
-        if let Some(param) = func.params.first() {
-            if let ParamPattern::Place(place) = param {
-                let name = identifiers[place.identifier.0 as usize].name.clone();
-                context.derivation_cache.cache.insert(
-                    place.identifier,
-                    DerivationMetadata {
-                        place_identifier: place.identifier,
-                        place_name: name,
-                        source_ids: FxIndexSet::default(),
-                        type_of_value: TypeOfValue::FromProps,
-                        is_state_source: true,
-                    },
-                );
-            }
+        if let Some(ParamPattern::Place(place)) = func.params.first() {
+            let name = identifiers[place.identifier.0 as usize].name.clone();
+            context.derivation_cache.cache.insert(
+                place.identifier,
+                DerivationMetadata {
+                    place_identifier: place.identifier,
+                    place_name: name,
+                    source_ids: FxIndexSet::default(),
+                    type_of_value: TypeOfValue::FromProps,
+                    is_state_source: true,
+                },
+            );
         }
     }
 
@@ -480,6 +478,7 @@ fn record_phi_derivations(block: &BasicBlock, context: &mut ValidationContext, e
     }
 }
 
+#[allow(clippy::only_used_in_recursion)]
 fn record_instruction_derivations(
     instr: &Instruction,
     context: &mut ValidationContext,
@@ -1204,9 +1203,7 @@ fn validate_effect_non_exp(
     // Check that the effect function only captures effect deps and setState
     for ctx in &effect_func.context {
         let ctx_ty = &tys[ids[ctx.identifier.0 as usize].type_.0 as usize];
-        if is_set_state_type(ctx_ty) {
-            continue;
-        } else if effect_deps.iter().any(|d| *d == ctx.identifier) {
+        if is_set_state_type(ctx_ty) || effect_deps.contains(&ctx.identifier) {
             continue;
         } else {
             return Vec::new();
@@ -1315,10 +1312,8 @@ fn validate_effect_non_exp(
                     return Vec::new();
                 }
             }
-            Terminal::Switch { test, .. } => {
-                if dep_values.contains_key(&test.identifier) {
-                    return Vec::new();
-                }
+            Terminal::Switch { test, .. } if dep_values.contains_key(&test.identifier) => {
+                return Vec::new();
             }
             _ => {}
         }

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_ref_access_in_render.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_ref_access_in_render.rs
@@ -245,7 +245,7 @@ impl Env {
         let widened_value = join_ref_access_types(&value, current.unwrap_or(&RefAccessType::None));
         if current.is_none() && widened_value == RefAccessType::None {
             // No change needed
-        } else if current.map_or(true, |c| c != &widened_value) {
+        } else if current != Some(&widened_value) {
             self.changed = true;
         }
         self.data.insert(operand_id, widened_value);
@@ -1025,9 +1025,9 @@ fn validate_no_ref_access_in_render_impl(
                             found_ref_id = Some(*id);
                         }
 
-                        if matches!(&left_type, Some(RefAccessType::Nullable)) {
-                            nullish = true;
-                        } else if matches!(&right_type, Some(RefAccessType::Nullable)) {
+                        if matches!(&left_type, Some(RefAccessType::Nullable))
+                            || matches!(&right_type, Some(RefAccessType::Nullable))
+                        {
                             nullish = true;
                         }
 

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_set_state_in_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_set_state_in_effects.rs
@@ -88,23 +88,18 @@ pub fn validate_no_set_state_in_effects(
                     let prop_type =
                         &types[identifiers[property.identifier.0 as usize].type_.0 as usize];
                     if is_use_effect_event_type(prop_type) {
-                        if let Some(first_arg) = args.first() {
-                            if let PlaceOrSpread::Place(arg_place) = first_arg {
-                                if let Some(info) = set_state_functions.get(&arg_place.identifier) {
-                                    set_state_functions
-                                        .insert(instr.lvalue.identifier, info.clone());
-                                }
+                        if let Some(PlaceOrSpread::Place(arg_place)) = args.first() {
+                            if let Some(info) = set_state_functions.get(&arg_place.identifier) {
+                                set_state_functions.insert(instr.lvalue.identifier, info.clone());
                             }
                         }
                     } else if is_use_effect_hook_type(prop_type)
                         || is_use_layout_effect_hook_type(prop_type)
                         || is_use_insertion_effect_hook_type(prop_type)
                     {
-                        if let Some(first_arg) = args.first() {
-                            if let PlaceOrSpread::Place(arg_place) = first_arg {
-                                if let Some(info) = set_state_functions.get(&arg_place.identifier) {
-                                    push_error(&mut errors, info, enable_verbose);
-                                }
+                        if let Some(PlaceOrSpread::Place(arg_place)) = args.first() {
+                            if let Some(info) = set_state_functions.get(&arg_place.identifier) {
+                                push_error(&mut errors, info, enable_verbose);
                             }
                         }
                     }
@@ -113,23 +108,18 @@ pub fn validate_no_set_state_in_effects(
                     let callee_type =
                         &types[identifiers[callee.identifier.0 as usize].type_.0 as usize];
                     if is_use_effect_event_type(callee_type) {
-                        if let Some(first_arg) = args.first() {
-                            if let PlaceOrSpread::Place(arg_place) = first_arg {
-                                if let Some(info) = set_state_functions.get(&arg_place.identifier) {
-                                    set_state_functions
-                                        .insert(instr.lvalue.identifier, info.clone());
-                                }
+                        if let Some(PlaceOrSpread::Place(arg_place)) = args.first() {
+                            if let Some(info) = set_state_functions.get(&arg_place.identifier) {
+                                set_state_functions.insert(instr.lvalue.identifier, info.clone());
                             }
                         }
                     } else if is_use_effect_hook_type(callee_type)
                         || is_use_layout_effect_hook_type(callee_type)
                         || is_use_insertion_effect_hook_type(callee_type)
                     {
-                        if let Some(first_arg) = args.first() {
-                            if let PlaceOrSpread::Place(arg_place) = first_arg {
-                                if let Some(info) = set_state_functions.get(&arg_place.identifier) {
-                                    push_error(&mut errors, info, enable_verbose);
-                                }
+                        if let Some(PlaceOrSpread::Place(arg_place)) = args.first() {
+                            if let Some(info) = set_state_functions.get(&arg_place.identifier) {
+                                push_error(&mut errors, info, enable_verbose);
                             }
                         }
                     }
@@ -361,6 +351,7 @@ fn create_ref_controlled_block_checker(
 /// Checks inner function body for direct setState calls. Returns the callee Place info
 /// if a setState call is found in the function body.
 /// Tracks ref-derived values to allow setState when the value being set comes from a ref.
+#[allow(clippy::too_many_arguments)]
 fn get_set_state_call(
     func: &HirFunction,
     set_state_functions: &mut FxHashMap<IdentifierId, SetStateInfo>,
@@ -519,44 +510,41 @@ fn get_set_state_call(
                         set_state_functions.insert(instr.lvalue.identifier, info);
                     }
                 }
-                InstructionValue::CallExpression { callee, args, .. } => {
-                    if is_set_state_type_by_id(callee.identifier, identifiers, types)
-                        || set_state_functions.contains_key(&callee.identifier)
-                    {
-                        if enable_allow_set_state_from_refs {
-                            // Check if the first argument is ref-derived
-                            if let Some(first_arg) = args.first() {
-                                if let PlaceOrSpread::Place(arg_place) = first_arg {
-                                    if is_derived_from_ref(
-                                        arg_place.identifier,
-                                        &ref_derived_values,
-                                        identifiers,
-                                        types,
-                                    ) {
-                                        // Allow setState when value is derived from ref
-                                        return Ok(None);
-                                    }
-                                }
-                            }
-                            // Check if the current block is controlled by a ref-derived condition
-                            if is_ref_controlled_block(block.id) {
-                                continue;
+                InstructionValue::CallExpression { callee, args, .. }
+                    if (is_set_state_type_by_id(callee.identifier, identifiers, types)
+                        || set_state_functions.contains_key(&callee.identifier)) =>
+                {
+                    if enable_allow_set_state_from_refs {
+                        // Check if the first argument is ref-derived
+                        if let Some(PlaceOrSpread::Place(arg_place)) = args.first() {
+                            if is_derived_from_ref(
+                                arg_place.identifier,
+                                &ref_derived_values,
+                                identifiers,
+                                types,
+                            ) {
+                                // Allow setState when value is derived from ref
+                                return Ok(None);
                             }
                         }
-                        // Get the user-visible identifier name, matching Babel's
-                        // loc.identifierName behavior. Uses declaration_id to find
-                        // the original named identifier when SSA creates unnamed copies.
-                        let callee_name = get_identifier_name_with_loc(
-                            callee.identifier,
-                            identifiers,
-                            &callee.loc,
-                            source_code,
-                        );
-                        return Ok(Some(SetStateInfo {
-                            loc: callee.loc,
-                            identifier_name: callee_name,
-                        }));
+                        // Check if the current block is controlled by a ref-derived condition
+                        if is_ref_controlled_block(block.id) {
+                            continue;
+                        }
                     }
+                    // Get the user-visible identifier name, matching Babel's
+                    // loc.identifierName behavior. Uses declaration_id to find
+                    // the original named identifier when SSA creates unnamed copies.
+                    let callee_name = get_identifier_name_with_loc(
+                        callee.identifier,
+                        identifiers,
+                        &callee.loc,
+                        source_code,
+                    );
+                    return Ok(Some(SetStateInfo {
+                        loc: callee.loc,
+                        identifier_name: callee_name,
+                    }));
                 }
                 _ => {}
             }

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_set_state_in_render.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_set_state_in_render.rs
@@ -119,12 +119,12 @@ fn validate_impl(
                     );
                     active_manual_memo_id = None;
                 }
-                InstructionValue::CallExpression { callee, .. } => {
-                    if is_set_state_id(callee.identifier, identifiers, types)
-                        || unconditional_set_state_functions.contains(&callee.identifier)
-                    {
-                        if active_manual_memo_id.is_some() {
-                            errors.push(
+                InstructionValue::CallExpression { callee, .. }
+                    if (is_set_state_id(callee.identifier, identifiers, types)
+                        || unconditional_set_state_functions.contains(&callee.identifier)) =>
+                {
+                    if active_manual_memo_id.is_some() {
+                        errors.push(
                                 CompilerDiagnostic::new(
                                     ErrorCategory::RenderSetState,
                                     "Calling setState from useMemo may trigger an infinite loop",
@@ -138,9 +138,9 @@ fn validate_impl(
                                     identifier_name: None,
                                 }),
                             );
-                        } else if unconditional_blocks.contains(&block.id) {
-                            if enable_use_keyed_state {
-                                errors.push(
+                    } else if unconditional_blocks.contains(&block.id) {
+                        if enable_use_keyed_state {
+                            errors.push(
                                     CompilerDiagnostic::new(
                                         ErrorCategory::RenderSetState,
                                         "Cannot call setState during render",
@@ -156,8 +156,8 @@ fn validate_impl(
                                         identifier_name: None,
                                     }),
                                 );
-                            } else {
-                                errors.push(
+                        } else {
+                            errors.push(
                                     CompilerDiagnostic::new(
                                         ErrorCategory::RenderSetState,
                                         "Cannot call setState during render",
@@ -173,7 +173,6 @@ fn validate_impl(
                                         identifier_name: None,
                                     }),
                                 );
-                            }
                         }
                     }
                 }

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_preserved_manual_memoization.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_preserved_manual_memoization.rs
@@ -245,10 +245,7 @@ fn visit_instruction(instr: &ReactiveInstruction, state: &mut VisitorState<'_, '
             }
 
             // TS: CompilerError.invariant(state.manualMemoState.manualMemoId === value.manualMemoId, ...)
-            if state
-                .manual_memo_state
-                .as_ref()
-                .map_or(true, |s| s.manual_memo_id != *manual_memo_id)
+            if state.manual_memo_state.as_ref().is_none_or(|s| s.manual_memo_id != *manual_memo_id)
             {
                 state.manual_memo_state = None;
                 return;
@@ -296,21 +293,21 @@ fn visit_instruction(instr: &ReactiveInstruction, state: &mut VisitorState<'_, '
                     .insert(value.identifier);
             }
         }
-        ReactiveValue::Instruction(InstructionValue::LoadLocal { place, .. }) => {
-            if state.manual_memo_state.is_some() {
-                let place_ident = &state.env.identifiers[place.identifier.0 as usize];
-                if let Some(ref lvalue) = instr.lvalue {
-                    let lvalue_ident = &state.env.identifiers[lvalue.identifier.0 as usize];
-                    if place_ident.scope.is_some() && lvalue_ident.scope.is_none() {
-                        state
-                            .manual_memo_state
-                            .as_mut()
-                            .unwrap()
-                            .reassignments
-                            .entry(lvalue_ident.declaration_id)
-                            .or_default()
-                            .insert(place.identifier);
-                    }
+        ReactiveValue::Instruction(InstructionValue::LoadLocal { place, .. })
+            if state.manual_memo_state.is_some() =>
+        {
+            let place_ident = &state.env.identifiers[place.identifier.0 as usize];
+            if let Some(ref lvalue) = instr.lvalue {
+                let lvalue_ident = &state.env.identifiers[lvalue.identifier.0 as usize];
+                if place_ident.scope.is_some() && lvalue_ident.scope.is_none() {
+                    state
+                        .manual_memo_state
+                        .as_mut()
+                        .unwrap()
+                        .reassignments
+                        .entry(lvalue_ident.declaration_id)
+                        .or_default()
+                        .insert(place.identifier);
                 }
             }
         }

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_static_components.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_static_components.rs
@@ -61,32 +61,27 @@ pub fn validate_static_components(func: &HirFunction) -> CompilerError {
                         known_dynamic_components.insert(lvalue.place.identifier, loc);
                     }
                 }
-                InstructionValue::JsxExpression { tag, .. } => {
-                    if let JsxTag::Place(tag_place) = tag {
-                        if let Some(location) = known_dynamic_components.get(&tag_place.identifier)
-                        {
-                            let location = *location;
-                            let diagnostic = CompilerDiagnostic::new(
-                                ErrorCategory::StaticComponents,
-                                "Cannot create components during render",
-                                Some("Components created during render will reset their state each time they are created. Declare components outside of render".to_string()),
-                            )
-                            .with_detail(CompilerDiagnosticDetail::Error {
-                                loc: tag_place.loc,
-                                message: Some(
-                                    "This component is created during render".to_string(),
-                                ),
-                                identifier_name: None,
-                            })
-                            .with_detail(CompilerDiagnosticDetail::Error {
-                                loc: location,
-                                message: Some(
-                                    "The component is created during render here".to_string(),
-                                ),
-                                identifier_name: None,
-                            });
-                            error.push_diagnostic(diagnostic);
-                        }
+                InstructionValue::JsxExpression { tag: JsxTag::Place(tag_place), .. } => {
+                    if let Some(location) = known_dynamic_components.get(&tag_place.identifier) {
+                        let location = *location;
+                        let diagnostic = CompilerDiagnostic::new(
+                            ErrorCategory::StaticComponents,
+                            "Cannot create components during render",
+                            Some("Components created during render will reset their state each time they are created. Declare components outside of render".to_string()),
+                        )
+                        .with_detail(CompilerDiagnosticDetail::Error {
+                            loc: tag_place.loc,
+                            message: Some("This component is created during render".to_string()),
+                            identifier_name: None,
+                        })
+                        .with_detail(CompilerDiagnosticDetail::Error {
+                            loc: location,
+                            message: Some(
+                                "The component is created during render here".to_string(),
+                            ),
+                            identifier_name: None,
+                        });
+                        error.push_diagnostic(diagnostic);
                     }
                 }
                 _ => {}


### PR DESCRIPTION
Removes the blanket `clippy::all` module allowances from `oxc_react_compiler` and fixes the resulting diagnostics with mechanical cleanups, targeted item-level allowances, and normal dependency access to `cow-utils`.

Validated with `just fmt`, `cargo clippy -p oxc_react_compiler --lib --all-targets -- -D warnings`, and `cargo test -p oxc_react_compiler`.

AI-assisted.