### PR TITLE
refactor(react-compiler): borrow strings where possible

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -101,11 +101,11 @@ enum CompileSourceKind {
 fn try_find_directive_enabling_memoization<'a>(
     directives: &'a [String],
     opts: &PluginOptions,
-) -> Result<Option<&'a String>, CompilerError> {
+) -> Result<Option<&'a str>, CompilerError> {
     // Check standard opt-in directives
     let opt_in = directives.iter().find(|d| OPT_IN_DIRECTIVES.contains(&d.as_str()));
     if let Some(directive) = opt_in {
-        return Ok(Some(directive));
+        return Ok(Some(directive.as_str()));
     }
 
     // Check dynamic gating directives
@@ -120,18 +120,18 @@ fn try_find_directive_enabling_memoization<'a>(
 fn find_directive_disabling_memoization<'a>(
     directives: &'a [String],
     opts: &PluginOptions,
-) -> Option<&'a String> {
+) -> Option<&'a str> {
     if let Some(ref custom_directives) = opts.custom_opt_out_directives {
-        directives.iter().find(|d| custom_directives.contains(d))
+        directives.iter().find(|d| custom_directives.contains(d)).map(String::as_str)
     } else {
-        directives.iter().find(|d| OPT_OUT_DIRECTIVES.contains(&d.as_str()))
+        directives.iter().find(|d| OPT_OUT_DIRECTIVES.contains(&d.as_str())).map(String::as_str)
     }
 }
 
 /// Result of a dynamic gating directive parse.
 struct DynamicGatingResult<'a> {
     #[allow(dead_code)]
-    directive: &'a String,
+    directive: &'a str,
     gating: GatingConfig,
 }
 
@@ -147,12 +147,12 @@ fn find_directives_dynamic_gating<'a>(
     };
 
     let mut errors: Vec<CompilerErrorDetail> = Vec::new();
-    let mut matches: Vec<(&'a String, String)> = Vec::new();
+    let mut matches: Vec<(&'a str, String)> = Vec::new();
 
     for directive in directives {
         if let Some(ident) = parse_dynamic_gating_directive(directive) {
             if is_valid_identifier(ident) {
-                matches.push((directive, ident.to_string()));
+                matches.push((directive.as_str(), ident.to_string()));
             } else {
                 let detail = CompilerErrorDetail::new(
                     ErrorCategory::Gating,
@@ -173,7 +173,7 @@ fn find_directives_dynamic_gating<'a>(
     }
 
     if matches.len() > 1 {
-        let names: Vec<String> = matches.iter().map(|(d, _)| (*d).clone()).collect();
+        let names: Vec<&str> = matches.iter().map(|(d, _)| *d).collect();
         let mut err = CompilerError::new();
         let detail = CompilerErrorDetail::new(
             ErrorCategory::Gating,
@@ -2295,9 +2295,9 @@ impl<'a, 'b> oxc_ast_visit::VisitMut<'a> for OxcReplaceWithGatedVisitor<'a, 'b> 
                 _ => None,
             };
             if let Some(name) = replace_name {
-                let name = name.unwrap_or_else(|| "anonymous".to_string());
+                let name = name.as_deref().unwrap_or("anonymous");
                 let is_export = matches!(stmts[i], Statement::ExportNamedDeclaration(_));
-                let const_decl = self.build_const_decl(&name);
+                let const_decl = self.build_const_decl(name);
                 if is_export {
                     use oxc_span::SPAN;
                     let decl = match const_decl {

--- a/crates/oxc_react_compiler/src/react_compiler_hir/globals.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/globals.rs
@@ -67,13 +67,14 @@ impl GlobalRegistry {
 
     /// Iterate over all keys in the registry (base + extras).
     /// Keys in extras that shadow base keys appear only once.
-    pub fn keys(&self) -> impl Iterator<Item = &String> {
+    pub fn keys(&self) -> impl Iterator<Item = &str> {
         let base_keys = self
             .base
             .into_iter()
             .flat_map(|b| b.keys())
-            .filter(|k| !self.entries.contains_key(k.as_str()));
-        self.entries.keys().chain(base_keys)
+            .filter(|k| !self.entries.contains_key(k.as_str()))
+            .map(String::as_str);
+        self.entries.keys().map(String::as_str).chain(base_keys)
     }
 
     /// Consume the registry and return the inner FxHashMap.

--- a/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
@@ -1142,6 +1142,12 @@ pub enum PropertyLiteral {
     Number(FloatValue),
 }
 
+impl PropertyLiteral {
+    pub fn is_string(&self, value: &str) -> bool {
+        matches!(self, Self::String(s) if s == value)
+    }
+}
+
 impl std::fmt::Display for PropertyLiteral {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/crates/oxc_react_compiler/src/react_compiler_hir/print.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/print.rs
@@ -8,6 +8,8 @@
 //! It also exports standalone formatting functions (format_loc, format_primitive, etc.)
 //! that require no state.
 
+use std::borrow::Cow;
+
 use rustc_hash::FxHashSet;
 
 use crate::react_compiler_diagnostics::CompilerError;
@@ -48,10 +50,10 @@ use crate::react_compiler_hir::type_config::ValueReason;
 // Standalone formatting functions (no state needed)
 // =============================================================================
 
-pub fn format_loc(loc: &Option<SourceLocation>) -> String {
+pub fn format_loc(loc: &Option<SourceLocation>) -> Cow<'_, str> {
     match loc {
-        Some(l) => format_loc_value(l),
-        None => "generated".to_string(),
+        Some(l) => Cow::Owned(format_loc_value(l)),
+        None => Cow::Borrowed("generated"),
     }
 }
 
@@ -85,14 +87,14 @@ pub fn format_js_string(s: &str) -> String {
     result
 }
 
-pub fn format_primitive(prim: &PrimitiveValue) -> String {
+pub fn format_primitive(prim: &PrimitiveValue) -> Cow<'_, str> {
     match prim {
-        PrimitiveValue::Null => "null".to_string(),
-        PrimitiveValue::Undefined => "undefined".to_string(),
-        PrimitiveValue::Boolean(b) => format!("{}", b),
-        PrimitiveValue::Number(n) => format_js_number(n.value()),
+        PrimitiveValue::Null => Cow::Borrowed("null"),
+        PrimitiveValue::Undefined => Cow::Borrowed("undefined"),
+        PrimitiveValue::Boolean(b) => Cow::Owned(format!("{}", b)),
+        PrimitiveValue::Number(n) => Cow::Owned(format_js_number(n.value())),
         PrimitiveValue::String(s) => match s.as_str() {
-            Some(utf8) => format_js_string(utf8),
+            Some(utf8) => Cow::Owned(format_js_string(utf8)),
             // Ill-formed strings: escape the well-formed segments exactly like
             // format_js_string and render each unpaired surrogate as \uXXXX,
             // matching what TS's JSON.stringify-based printer emits.
@@ -135,16 +137,16 @@ pub fn format_primitive(prim: &PrimitiveValue) -> String {
                     }
                 }
                 result.push('"');
-                result
+                Cow::Owned(result)
             }
         },
     }
 }
 
-pub fn format_property_literal(prop: &PropertyLiteral) -> String {
+pub fn format_property_literal(prop: &PropertyLiteral) -> Cow<'_, str> {
     match prop {
-        PropertyLiteral::String(s) => s.clone(),
-        PropertyLiteral::Number(n) => format_js_number(n.value()),
+        PropertyLiteral::String(s) => Cow::Borrowed(s.as_str()),
+        PropertyLiteral::Number(n) => Cow::Owned(format_js_number(n.value())),
     }
 }
 
@@ -472,10 +474,7 @@ impl<'a, 'h> PrintFormatter<'a, 'h> {
                         .path
                         .iter()
                         .map(|p| {
-                            let prop = match &p.property {
-                                PropertyLiteral::String(s) => s.clone(),
-                                PropertyLiteral::Number(n) => format_js_number(n.value()),
-                            };
+                            let prop = format_property_literal(&p.property);
                             format!("{}{}", if p.optional { "?." } else { "." }, prop)
                         })
                         .collect();
@@ -538,41 +537,37 @@ impl<'a, 'h> PrintFormatter<'a, 'h> {
 
     pub fn format_type(&self, type_id: TypeId) -> String {
         if let Some(ty) = self.env.types.get(type_id.0 as usize) {
-            self.format_type_value(ty)
+            self.format_type_value(ty).into_owned()
         } else {
             format!("Type({})", type_id.0)
         }
     }
 
-    pub fn format_type_value(&self, ty: &Type) -> String {
+    pub fn format_type_value(&self, ty: &Type) -> Cow<'_, str> {
         match ty {
-            Type::Primitive => "Primitive".to_string(),
-            Type::Function { shape_id, return_type, is_constructor } => {
-                format!(
-                    "Function {{ shapeId: {}, return: {}, isConstructor: {} }}",
-                    match shape_id {
-                        Some(s) => format!("\"{}\"", s),
-                        None => "null".to_string(),
-                    },
-                    self.format_type_value(return_type),
-                    is_constructor
-                )
-            }
-            Type::Object { shape_id } => {
-                format!(
-                    "Object {{ shapeId: {} }}",
-                    match shape_id {
-                        Some(s) => format!("\"{}\"", s),
-                        None => "null".to_string(),
-                    }
-                )
-            }
-            Type::TypeVar { id } => format!("Type({})", id.0),
-            Type::Poly => "Poly".to_string(),
+            Type::Primitive => Cow::Borrowed("Primitive"),
+            Type::Function { shape_id, return_type, is_constructor } => Cow::Owned(format!(
+                "Function {{ shapeId: {}, return: {}, isConstructor: {} }}",
+                match shape_id {
+                    Some(s) => Cow::Owned(format!("\"{}\"", s)),
+                    None => Cow::Borrowed("null"),
+                },
+                self.format_type_value(return_type),
+                is_constructor
+            )),
+            Type::Object { shape_id } => Cow::Owned(format!(
+                "Object {{ shapeId: {} }}",
+                match shape_id {
+                    Some(s) => Cow::Owned(format!("\"{}\"", s)),
+                    None => Cow::Borrowed("null"),
+                }
+            )),
+            Type::TypeVar { id } => Cow::Owned(format!("Type({})", id.0)),
+            Type::Poly => Cow::Borrowed("Poly"),
             Type::Phi { operands } => {
                 let ops: Vec<String> =
-                    operands.iter().map(|op| self.format_type_value(op)).collect();
-                format!("Phi {{ operands: [{}] }}", ops.join(", "))
+                    operands.iter().map(|op| self.format_type_value(op).into_owned()).collect();
+                Cow::Owned(format!("Phi {{ operands: [{}] }}", ops.join(", ")))
             }
             Type::Property { object_type, object_name, property_name } => {
                 let prop_str = match property_name {
@@ -583,14 +578,14 @@ impl<'a, 'h> PrintFormatter<'a, 'h> {
                         format!("computed({})", self.format_type_value(value))
                     }
                 };
-                format!(
+                Cow::Owned(format!(
                     "Property {{ objectType: {}, objectName: \"{}\", propertyName: {} }}",
                     self.format_type_value(object_type),
                     object_name,
                     prop_str
-                )
+                ))
             }
-            Type::ObjectMethod => "ObjectMethod".to_string(),
+            Type::ObjectMethod => Cow::Borrowed("ObjectMethod"),
         }
     }
 

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
@@ -11,6 +11,8 @@
 //! creation, aliasing, mutation, freezing, and error conditions for each
 //! instruction and terminal in the HIR.
 
+use std::borrow::Cow;
+
 use crate::react_compiler_utils::FxIndexMap;
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
@@ -624,12 +626,14 @@ struct InstructionSignature {
 fn hash_effect(effect: &AliasingEffect) -> String {
     match effect {
         AliasingEffect::Apply { receiver, function, mutates_function, args, into, .. } => {
-            let args_str: Vec<String> = args
+            let args_str: Vec<Cow<'_, str>> = args
                 .iter()
                 .map(|a| match a {
-                    PlaceOrSpreadOrHole::Hole => String::new(),
-                    PlaceOrSpreadOrHole::Place(p) => format!("{}", p.identifier.0),
-                    PlaceOrSpreadOrHole::Spread(s) => format!("...{}", s.place.identifier.0),
+                    PlaceOrSpreadOrHole::Hole => Cow::Borrowed(""),
+                    PlaceOrSpreadOrHole::Place(p) => Cow::Owned(format!("{}", p.identifier.0)),
+                    PlaceOrSpreadOrHole::Spread(s) => {
+                        Cow::Owned(format!("...{}", s.place.identifier.0))
+                    }
                 })
                 .collect();
             format!(
@@ -3070,33 +3074,33 @@ fn get_hook_kind_for_type<'a>(
 }
 
 /// Format a Type for printPlace-style output, matching TS's `printType()`.
-fn format_type_for_print(ty: &Type) -> String {
+fn format_type_for_print(ty: &Type) -> Cow<'_, str> {
     match ty {
-        Type::Primitive => String::new(),
+        Type::Primitive => Cow::Borrowed(""),
         Type::Function { shape_id, return_type, .. } => {
             if let Some(sid) = shape_id {
                 let ret = format_type_for_print(return_type);
                 if ret.is_empty() {
-                    format!(":TFunction<{}>()", sid)
+                    Cow::Owned(format!(":TFunction<{}>()", sid))
                 } else {
-                    format!(":TFunction<{}>():  {}", sid, ret)
+                    Cow::Owned(format!(":TFunction<{}>():  {}", sid, ret))
                 }
             } else {
-                ":TFunction".to_string()
+                Cow::Borrowed(":TFunction")
             }
         }
         Type::Object { shape_id } => {
             if let Some(sid) = shape_id {
-                format!(":TObject<{}>", sid)
+                Cow::Owned(format!(":TObject<{}>", sid))
             } else {
-                ":TObject".to_string()
+                Cow::Borrowed(":TObject")
             }
         }
-        Type::Poly => ":TPoly".to_string(),
-        Type::Phi { .. } => ":TPhi".to_string(),
-        Type::Property { .. } => ":TProperty".to_string(),
-        Type::TypeVar { .. } => String::new(),
-        Type::ObjectMethod => ":TObjectMethod".to_string(),
+        Type::Poly => Cow::Borrowed(":TPoly"),
+        Type::Phi { .. } => Cow::Borrowed(":TPhi"),
+        Type::Property { .. } => Cow::Borrowed(":TProperty"),
+        Type::TypeVar { .. } => Cow::Borrowed(""),
+        Type::ObjectMethod => Cow::Borrowed(":TObjectMethod"),
     }
 }
 

--- a/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
@@ -1832,11 +1832,7 @@ impl<'a> DependencyCollectionContext<'a> {
         // Handle ref.current access
         let dep = if is_use_ref_type(
             &env.types[env.identifiers[dep.identifier.0 as usize].type_.0 as usize],
-        ) && dep
-            .path
-            .first()
-            .map(|p| p.property == PropertyLiteral::String("current".to_string()))
-            .unwrap_or(false)
+        ) && dep.path.first().map(|p| p.property.is_string("current")).unwrap_or(false)
         {
             ReactiveScopeDependency {
                 identifier: dep.identifier,

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/name_anonymous_functions.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/name_anonymous_functions.rs
@@ -11,6 +11,7 @@
 //!
 //! Conditional on `env.config.enable_name_anonymous_functions`.
 
+use std::borrow::Cow;
 use std::mem::take;
 
 use rustc_hash::FxHashMap;
@@ -65,8 +66,8 @@ pub fn name_anonymous_functions(func: &mut HirFunction, env: &mut Environment) {
     if updates.is_empty() {
         return;
     }
-    let update_map: FxHashMap<FunctionId, &String> =
-        updates.iter().map(|(fid, name)| (*fid, name)).collect();
+    let update_map: FxHashMap<FunctionId, &str> =
+        updates.iter().map(|(fid, name)| (*fid, name.as_str())).collect();
 
     // Apply name updates to the inner HirFunction in the arena
     for (function_id, name) in &updates {
@@ -88,14 +89,14 @@ pub fn name_anonymous_functions(func: &mut HirFunction, env: &mut Environment) {
 /// Apply name hints to FunctionExpression instruction values.
 fn apply_name_hints_to_instructions(
     instructions: &mut [Instruction],
-    update_map: &FxHashMap<FunctionId, &String>,
+    update_map: &FxHashMap<FunctionId, &str>,
 ) {
     for instr in instructions.iter_mut() {
         if let InstructionValue::FunctionExpression { lowered_func, name_hint, .. } =
             &mut instr.value
         {
             if let Some(new_name) = update_map.get(&lowered_func.func) {
-                *name_hint = Some((*new_name).clone());
+                *name_hint = Some((*new_name).to_string());
             }
         }
     }
@@ -248,14 +249,18 @@ fn handle_call(
     let callee_ty = &env.types[callee_ident.type_.0 as usize];
     let hook_kind = env.get_hook_kind_for_type(callee_ty).ok().flatten();
 
-    let callee_name: String = if let Some(hk) = hook_kind {
+    let callee_name: Cow<'_, str> = if let Some(hk) = hook_kind {
         if *hk != HookKind::Custom {
-            hk.to_string()
+            Cow::Owned(hk.to_string())
         } else {
-            names.get(&callee_id).cloned().unwrap_or_else(|| "(anonymous)".to_string())
+            names
+                .get(&callee_id)
+                .map_or(Cow::Borrowed("(anonymous)"), |name| Cow::Borrowed(name.as_str()))
         }
     } else {
-        names.get(&callee_id).cloned().unwrap_or_else(|| "(anonymous)".to_string())
+        names
+            .get(&callee_id)
+            .map_or(Cow::Borrowed("(anonymous)"), |name| Cow::Borrowed(name.as_str()))
     };
 
     // Count how many args are tracked functions

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
@@ -940,8 +940,10 @@ fn ox_codegen_reactive_scope<'a, 'h>(
     if let Some(ref early_return) = early_return_value {
         let early_ident = &cx.env.identifiers[early_return.value.0 as usize];
         let name = match &early_ident.name {
-            Some(crate::react_compiler_hir::IdentifierName::Named(n)) => n.clone(),
-            Some(crate::react_compiler_hir::IdentifierName::Promoted(n)) => n.clone(),
+            Some(
+                crate::react_compiler_hir::IdentifierName::Named(n)
+                | crate::react_compiler_hir::IdentifierName::Promoted(n),
+            ) => n.as_str(),
             None => {
                 return Err(invariant_err(
                     "Expected early return value to be promoted to a named variable",
@@ -951,14 +953,14 @@ fn ox_codegen_reactive_scope<'a, 'h>(
         };
         let test = oxc_ast::ast::Expression::new_binary_expression(
             SPAN,
-            oxc_ast::ast::Expression::new_identifier(SPAN, ox_str(&cx.ast, &name), &cx.ast),
+            oxc_ast::ast::Expression::new_identifier(SPAN, ox_str(&cx.ast, name), &cx.ast),
             oxc::BinaryOperator::StrictInequality,
             ox_symbol_for(&cx.ast, EARLY_RETURN_SENTINEL),
             &cx.ast,
         );
         let return_stmt = oxc_ast::ast::Statement::new_return_statement(
             SPAN,
-            Some(oxc_ast::ast::Expression::new_identifier(SPAN, ox_str(&cx.ast, &name), &cx.ast)),
+            Some(oxc_ast::ast::Expression::new_identifier(SPAN, ox_str(&cx.ast, name), &cx.ast)),
             &cx.ast,
         );
         let consequent = oxc_ast::ast::Statement::new_block_statement(

--- a/crates/oxc_react_compiler/src/react_compiler_ssa/rewrite_instruction_kinds_based_on_reassignment.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_ssa/rewrite_instruction_kinds_based_on_reassignment.rs
@@ -15,6 +15,8 @@
 //! may be converted to a `const` if the reassignment is not used and was removed
 //! by dead code elimination.
 
+use std::borrow::Cow;
+
 use rustc_hash::FxHashMap;
 
 use crate::react_compiler_diagnostics::{
@@ -47,35 +49,30 @@ fn invariant_error_with_loc(
 }
 
 /// Format an InstructionKind variant name (matches TS `${kind}` interpolation).
-fn format_kind(kind: Option<InstructionKind>) -> String {
+fn format_kind(kind: Option<InstructionKind>) -> &'static str {
     match kind {
-        Some(InstructionKind::Const) => "Const".to_string(),
-        Some(InstructionKind::Let) => "Let".to_string(),
-        Some(InstructionKind::Reassign) => "Reassign".to_string(),
-        Some(InstructionKind::Catch) => "Catch".to_string(),
-        Some(InstructionKind::HoistedConst) => "HoistedConst".to_string(),
-        Some(InstructionKind::HoistedLet) => "HoistedLet".to_string(),
-        Some(InstructionKind::HoistedFunction) => "HoistedFunction".to_string(),
-        Some(InstructionKind::Function) => "Function".to_string(),
-        None => "null".to_string(),
+        Some(InstructionKind::Const) => "Const",
+        Some(InstructionKind::Let) => "Let",
+        Some(InstructionKind::Reassign) => "Reassign",
+        Some(InstructionKind::Catch) => "Catch",
+        Some(InstructionKind::HoistedConst) => "HoistedConst",
+        Some(InstructionKind::HoistedLet) => "HoistedLet",
+        Some(InstructionKind::HoistedFunction) => "HoistedFunction",
+        Some(InstructionKind::Function) => "Function",
+        None => "null",
     }
 }
 
 /// Format a Place like TS `printPlace()`: `<effect> <name>$<id>[<range>]{reactive}`
 fn format_place(place: &Place, env: &Environment) -> String {
     let ident = &env.identifiers[place.identifier.0 as usize];
-    let name = match &ident.name {
-        Some(n) => n.value().to_string(),
-        None => String::new(),
-    };
-    let scope = match ident.scope {
-        Some(scope_id) => format!("_@{}", scope_id.0),
-        None => String::new(),
-    };
+    let name = ident.name.as_ref().map_or("", |name| name.value());
+    let scope =
+        ident.scope.map_or(Cow::Borrowed(""), |scope_id| Cow::Owned(format!("_@{}", scope_id.0)));
     let mutable_range = if ident.mutable_range.end.0 > ident.mutable_range.start.0 + 1 {
-        format!("[{}:{}]", ident.mutable_range.start.0, ident.mutable_range.end.0)
+        Cow::Owned(format!("[{}:{}]", ident.mutable_range.start.0, ident.mutable_range.end.0))
     } else {
-        String::new()
+        Cow::Borrowed("")
     };
     let reactive = if place.reactive { "{reactive}" } else { "" };
     format!(

--- a/crates/oxc_react_compiler/src/react_compiler_typeinference/infer_types.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_typeinference/infer_types.rs
@@ -539,8 +539,7 @@ fn generate_instruction_types(
             let return_type = make_type(types);
             let mut shape_id = None;
             if unifier.enable_treat_set_identifiers_as_state_setters {
-                let name = get_name(names, callee.identifier);
-                if name.starts_with("set") {
+                if names.get(&callee.identifier).is_some_and(|name| name.starts_with("set")) {
                     shape_id = Some(BUILT_IN_SET_STATE_ID.to_string());
                 }
             }

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_context_variable_lvalues.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_context_variable_lvalues.rs
@@ -159,10 +159,7 @@ fn validate_context_variable_lvalues_impl(
 fn format_place(place: &Place, identifiers: &[Identifier]) -> String {
     let id = place.identifier;
     let ident = &identifiers[id.0 as usize];
-    let name = match &ident.name {
-        Some(n) => n.value().to_string(),
-        None => String::new(),
-    };
+    let name = ident.name.as_ref().map_or("", |name| name.value());
     format!("{} {}${}", place.effect, name, id.0)
 }
 

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_exhaustive_dependencies.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_exhaustive_dependencies.rs
@@ -14,8 +14,9 @@ use crate::react_compiler_hir::visitors::{
 };
 use crate::react_compiler_hir::{
     ArrayElement, BlockId, DependencyPathEntry, Effect, HirFunction, Identifier, IdentifierId,
-    InstructionKind, InstructionValue, ManualMemoDependency, ManualMemoDependencyRoot,
-    NonLocalBinding, ParamPattern, Place, PlaceOrSpread, PropertyLiteral, Terminal, Type,
+    IdentifierName, InstructionKind, InstructionValue, ManualMemoDependency,
+    ManualMemoDependencyRoot, NonLocalBinding, ParamPattern, Place, PlaceOrSpread, PropertyLiteral,
+    Terminal, Type,
 };
 
 /// Port of ValidateExhaustiveDependencies.ts
@@ -228,8 +229,8 @@ fn get_identifier_type<'a>(
     &types[ident.type_.0 as usize]
 }
 
-fn get_identifier_name(id: IdentifierId, identifiers: &[Identifier]) -> Option<String> {
-    identifiers[id.0 as usize].name.as_ref().map(|n| n.value().to_string())
+fn get_identifier_name(id: IdentifierId, identifiers: &[Identifier]) -> Option<&str> {
+    identifiers[id.0 as usize].name.as_ref().map(IdentifierName::value)
 }
 
 // =============================================================================
@@ -671,7 +672,7 @@ fn collect_dependencies(
                     let is_numeric = matches!(property, PropertyLiteral::Number(_));
                     let is_ref_current =
                         is_use_ref_type(get_identifier_type(object.identifier, identifiers, types))
-                            && *property == PropertyLiteral::String("current".to_string());
+                            && property.is_string("current");
 
                     if is_numeric || is_ref_current {
                         visit_candidate_dependency(
@@ -1128,7 +1129,7 @@ fn validate_dependencies(
             ) => {
                 let a_name = get_identifier_name(*a_id, identifiers);
                 let b_name = get_identifier_name(*b_id, identifiers);
-                match (a_name.as_deref(), b_name.as_deref()) {
+                match (a_name, b_name) {
                     (Some(an), Some(bn)) => {
                         if *a_id != *b_id {
                             an.cmp(bn)
@@ -1160,7 +1161,7 @@ fn validate_dependencies(
             ) => {
                 let a_name = ab.name();
                 let b_name = get_identifier_name(*b_id, identifiers);
-                match b_name.as_deref() {
+                match b_name {
                     Some(bn) => a_name.cmp(bn),
                     None => Ordering::Equal,
                 }
@@ -1171,7 +1172,7 @@ fn validate_dependencies(
             ) => {
                 let a_name = get_identifier_name(*a_id, identifiers);
                 let b_name = bb.name();
-                match a_name.as_deref() {
+                match a_name {
                     Some(an) => an.cmp(b_name),
                     None => Ordering::Equal,
                 }
@@ -1305,11 +1306,12 @@ fn validate_dependencies(
     // Add detail items for missing deps
     for dep in &filtered_missing {
         if let InferredDependency::Local { identifier, path: _, loc, .. } = dep {
-            let mut hint = String::new();
             let ty = get_identifier_type(*identifier, identifiers, types);
-            if is_stable_type(ty) {
-                hint = ". Refs, setState functions, and other \"stable\" values generally do not need to be added as dependencies, but this variable may change over time to point to different values".to_string();
-            }
+            let hint = if is_stable_type(ty) {
+                ". Refs, setState functions, and other \"stable\" values generally do not need to be added as dependencies, but this variable may change over time to point to different values"
+            } else {
+                ""
+            };
             let dep_str = print_inferred_dependency(dep, identifiers);
             diagnostic.details.push(CompilerDiagnosticDetail::Error {
                 loc: *loc,
@@ -1399,8 +1401,7 @@ fn print_inferred_dependency(dep: &InferredDependency, identifiers: &[Identifier
     match dep {
         InferredDependency::Global { binding } => binding.name().to_string(),
         InferredDependency::Local { identifier, path, .. } => {
-            let name = get_identifier_name(*identifier, identifiers)
-                .unwrap_or_else(|| "<unnamed>".to_string());
+            let name = get_identifier_name(*identifier, identifiers).unwrap_or("<unnamed>");
             let path_str: String = path
                 .iter()
                 .map(|p| format!("{}.{}", if p.optional { "?" } else { "" }, p.property))
@@ -1412,10 +1413,9 @@ fn print_inferred_dependency(dep: &InferredDependency, identifiers: &[Identifier
 
 fn print_manual_memo_dependency(dep: &ManualMemoDependency, identifiers: &[Identifier]) -> String {
     let name = match &dep.root {
-        ManualMemoDependencyRoot::Global { identifier_name } => identifier_name.clone(),
+        ManualMemoDependencyRoot::Global { identifier_name } => identifier_name.as_str(),
         ManualMemoDependencyRoot::NamedLocal { value, .. } => {
-            get_identifier_name(value.identifier, identifiers)
-                .unwrap_or_else(|| "<unnamed>".to_string())
+            get_identifier_name(value.identifier, identifiers).unwrap_or("<unnamed>")
         }
     };
     let path_str: String = dep

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_capitalized_calls.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_capitalized_calls.rs
@@ -13,7 +13,7 @@ pub fn validate_no_capitalized_calls(
     env: &mut Environment,
 ) -> Result<(), CompilerError> {
     // Build the allow list from global registry keys + config entries
-    let mut allow_list: FxHashSet<String> = env.globals().keys().cloned().collect();
+    let mut allow_list: FxHashSet<String> = env.globals().keys().map(str::to_owned).collect();
     if let Some(config_entries) = &env.config.validate_no_capitalized_calls {
         for entry in config_entries {
             allow_list.insert(entry.clone());

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_ref_access_in_render.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_ref_access_in_render.rs
@@ -13,7 +13,7 @@ use crate::react_compiler_hir::visitors::{
 };
 use crate::react_compiler_hir::{
     AliasingEffect, BlockId, HirFunction, Identifier, IdentifierId, InstructionValue, ParamPattern,
-    Place, PrimitiveValue, PropertyLiteral, Terminal, Type, UnaryOperator, is_use_ref_type,
+    Place, PrimitiveValue, Terminal, Type, UnaryOperator, is_use_ref_type,
 };
 
 const ERROR_DESCRIPTION: &str = "React refs are values that are not needed for rendering. \
@@ -493,7 +493,7 @@ fn collect_temporaries_sidemap(
                 }
                 InstructionValue::PropertyLoad { object, property, .. } => {
                     if is_ref_type(object.identifier, identifiers, types)
-                        && *property == PropertyLiteral::String("current".to_string())
+                        && property.is_string("current")
                     {
                         continue;
                     }

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_set_state_in_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_set_state_in_effects.rs
@@ -24,9 +24,9 @@ use crate::react_compiler_hir::dominator::{compute_post_dominator_tree, post_dom
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::{
     BlockId, HirFunction, Identifier, IdentifierId, InstructionValue, PlaceOrSpread,
-    PropertyLiteral, SourceLocation, Terminal, Type, is_ref_value_type, is_set_state_type,
-    is_use_effect_event_type, is_use_effect_hook_type, is_use_insertion_effect_hook_type,
-    is_use_layout_effect_hook_type, is_use_ref_type, visitors,
+    SourceLocation, Terminal, Type, is_ref_value_type, is_set_state_type, is_use_effect_event_type,
+    is_use_effect_hook_type, is_use_insertion_effect_hook_type, is_use_layout_effect_hook_type,
+    is_use_ref_type, visitors,
 };
 
 pub fn validate_no_set_state_in_effects(
@@ -360,7 +360,7 @@ fn get_set_state_call(
                 }
 
                 if let InstructionValue::PropertyLoad { object, property, .. } = &instr.value {
-                    if *property == PropertyLiteral::String("current".to_string()) {
+                    if property.is_string("current") {
                         let obj_ident = &identifiers[object.identifier.0 as usize];
                         let obj_ty = &types[obj_ident.type_.0 as usize];
                         if is_use_ref_type(obj_ty) || is_ref_value_type(obj_ty) {
@@ -450,7 +450,7 @@ fn get_set_state_call(
 
                 // Special case: PropertyLoad of .current on ref/refValue
                 if let InstructionValue::PropertyLoad { object, property, .. } = &instr.value {
-                    if *property == PropertyLiteral::String("current".to_string()) {
+                    if property.is_string("current") {
                         let obj_ident = &identifiers[object.identifier.0 as usize];
                         let obj_ty = &types[obj_ident.type_.0 as usize];
                         if is_use_ref_type(obj_ty) || is_ref_value_type(obj_ty) {

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_preserved_manual_memoization.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_preserved_manual_memoization.rs
@@ -548,18 +548,12 @@ fn compare_deps(
     if is_subpath
         && (source.path.len() == inferred.path.len()
             || (inferred.path.len() >= source.path.len()
-                && !inferred
-                    .path
-                    .iter()
-                    .any(|t| t.property == PropertyLiteral::String("current".to_string()))))
+                && !inferred.path.iter().any(|t| t.property.is_string("current"))))
     {
         CompareDependencyResult::Ok
     } else if is_subpath {
-        if source.path.iter().any(|t| t.property == PropertyLiteral::String("current".to_string()))
-            || inferred
-                .path
-                .iter()
-                .any(|t| t.property == PropertyLiteral::String("current".to_string()))
+        if source.path.iter().any(|t| t.property.is_string("current"))
+            || inferred.path.iter().any(|t| t.property.is_string("current"))
         {
             CompareDependencyResult::RefAccessDifference
         } else {
@@ -578,21 +572,20 @@ fn pretty_print_scope_dependency(
 ) -> String {
     let ident = &identifiers[dep_id.0 as usize];
     let root_str = match &ident.name {
-        Some(IdentifierName::Named(n)) => n.clone(),
-        Some(IdentifierName::Promoted(n)) => n.clone(),
-        None => "[unnamed]".to_string(),
+        Some(IdentifierName::Named(n) | IdentifierName::Promoted(n)) => n.as_str(),
+        None => "[unnamed]",
     };
     let path_str: String = dep_path
         .iter()
         .map(|entry| {
-            let prop = match &entry.property {
-                PropertyLiteral::String(s) => s.clone(),
-                PropertyLiteral::Number(n) => format!("{}", n),
-            };
-            if entry.optional { format!("?.{}", prop) } else { format!(".{}", prop) }
+            let prefix = if entry.optional { "?." } else { "." };
+            match &entry.property {
+                PropertyLiteral::String(s) => format!("{prefix}{s}"),
+                PropertyLiteral::Number(n) => format!("{prefix}{n}"),
+            }
         })
         .collect();
-    format!("{}{}", root_str, path_str)
+    format!("{root_str}{path_str}")
 }
 
 /// Pretty-print a manual memo dependency for error messages.
@@ -605,29 +598,24 @@ fn print_manual_memo_dependency(
         ManualMemoDependencyRoot::NamedLocal { value, .. } => {
             let ident = &identifiers[value.identifier.0 as usize];
             match &ident.name {
-                Some(IdentifierName::Named(n)) => n.clone(),
-                Some(IdentifierName::Promoted(n)) => n.clone(),
-                None => "[unnamed]".to_string(),
+                Some(IdentifierName::Named(n) | IdentifierName::Promoted(n)) => n.as_str(),
+                None => "[unnamed]",
             }
         }
-        ManualMemoDependencyRoot::Global { identifier_name } => identifier_name.clone(),
+        ManualMemoDependencyRoot::Global { identifier_name } => identifier_name.as_str(),
     };
     let path_str: String = dep
         .path
         .iter()
         .map(|entry| {
-            let prop = match &entry.property {
-                PropertyLiteral::String(s) => s.clone(),
-                PropertyLiteral::Number(n) => format!("{}", n),
-            };
-            if with_optional && entry.optional {
-                format!("?.{}", prop)
-            } else {
-                format!(".{}", prop)
+            let prefix = if with_optional && entry.optional { "?." } else { "." };
+            match &entry.property {
+                PropertyLiteral::String(s) => format!("{prefix}{s}"),
+                PropertyLiteral::Number(n) => format!("{prefix}{n}"),
             }
         })
         .collect();
-    format!("{}{}", root_str, path_str)
+    format!("{root_str}{path_str}")
 }
 
 fn get_compare_dependency_result_description(result: CompareDependencyResult) -> &'static str {
@@ -710,20 +698,20 @@ fn validate_inferred_dep(
             .collect::<Vec<_>>()
             .join(", ");
         let result_desc = error_diagnostic
-            .map(|d| get_compare_dependency_result_description(d).to_string())
-            .unwrap_or_else(|| "Inferred dependency not present in source".to_string());
-        format!(
+            .map(get_compare_dependency_result_description)
+            .unwrap_or("Inferred dependency not present in source");
+        Some(format!(
             "The inferred dependency was `{}`, but the source dependencies were [{}]. {}",
             dep_str, source_deps_str, result_desc
-        )
+        ))
     } else {
-        String::new()
+        None
     };
 
     let description = format!(
         "React Compiler has skipped optimizing this component because the existing manual memoization could not be preserved. \
          The inferred dependencies did not match the manually specified dependencies, which could cause the value to change more or less frequently than expected. {}",
-        extra
+        extra.as_deref().unwrap_or_default()
     );
 
     let diag = CompilerDiagnostic::new(


### PR DESCRIPTION
AI-assisted.

Borrow string slices in react compiler helper APIs and avoid temporary String allocation when checking `PropertyLiteral` values.

Validation:
- `cargo test -p oxc_react_compiler`
- `cargo clippy -p oxc_react_compiler --all-targets -- -W clippy::ptr_arg -W clippy::unnecessary_to_owned -W clippy::cmp_owned`
- `just ready` reached the full test suite; it failed on unrelated oxlint ANSI snapshot output differences in `output_formatter::test::test_output_formatter_diagnostic_formats*`.