### PR TITLE
perf(react_compiler): skip compiled files before prefilters

### DIFF
--- a/crates/oxc_react_compiler/fixtures/type-only-runtime-cache-import.tsx
+++ b/crates/oxc_react_compiler/fixtures/type-only-runtime-cache-import.tsx
@@ -1,0 +1,10 @@
+import type { c as useMemoCache } from 'react/compiler-runtime';
+
+function Component(props: { text: string }) {
+  return <div>{props.text}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ text: 'hello' }],
+};

--- a/crates/oxc_react_compiler/src/lib.rs
+++ b/crates/oxc_react_compiler/src/lib.rs
@@ -17,6 +17,7 @@ mod react_compiler_utils;
 mod react_compiler_validation;
 
 use crate::react_compiler::entrypoint::compile_result::CompileResult;
+use crate::react_compiler::entrypoint::imports::get_react_compiler_runtime_module;
 use crate::react_compiler::entrypoint::program::compile_program;
 use prefilter::{has_react_like_functions, has_resource_management_declarations};
 use scope::ScopeResolver;
@@ -113,6 +114,12 @@ fn compile<'a>(
     allocator: &'a Allocator,
     options: PluginOptions,
 ) -> (Option<Program<'a>>, Diagnostics) {
+    // Check for existing runtime imports (file already compiled).
+    if has_memo_cache_function_import(program, &get_react_compiler_runtime_module(&options.target))
+    {
+        return (None, Diagnostics::default());
+    }
+
     // Skip files with no React-like functions, unless the mode compiles everything.
     if !matches!(options.compilation_mode.as_str(), "all" | "annotation")
         && !has_react_like_functions(program)
@@ -144,6 +151,36 @@ fn compile<'a>(
     });
 
     (compiled, diagnostics)
+}
+
+fn has_memo_cache_function_import(program: &Program<'_>, module_name: &str) -> bool {
+    for stmt in &program.body {
+        if let oxc_ast::ast::Statement::ImportDeclaration(import) = stmt
+            && import.source.value == module_name
+            && import.import_kind.is_value()
+            && let Some(specifiers) = &import.specifiers
+        {
+            for specifier in specifiers {
+                if let oxc_ast::ast::ImportDeclarationSpecifier::ImportSpecifier(data) = specifier
+                    && data.import_kind.is_value()
+                {
+                    let imported_name = match &data.imported {
+                        oxc_ast::ast::ModuleExportName::IdentifierName(id) => {
+                            Some(id.name.as_str())
+                        }
+                        oxc_ast::ast::ModuleExportName::IdentifierReference(id) => {
+                            Some(id.name.as_str())
+                        }
+                        oxc_ast::ast::ModuleExportName::StringLiteral(s) => Some(s.value.as_str()),
+                    };
+                    if imported_name == Some("c") {
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+    false
 }
 
 /// Carry over the comments attached to top-level statements of the compiled

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -16,7 +16,7 @@
 
 use cow_utils::CowUtils;
 use oxc_ast::ast as oxc;
-use oxc_diagnostics::{Diagnostics, OxcDiagnostic};
+use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::Span;
 use rustc_hash::FxHashMap;
 
@@ -34,7 +34,6 @@ use oxc_syntax::scope::ScopeId;
 use super::compile_result::CodegenFunction;
 use super::compile_result::CompileResult;
 use super::imports::ProgramContext;
-use super::imports::get_react_compiler_runtime_module;
 use super::imports::validate_restricted_imports;
 use super::pipeline;
 use super::plugin_options::CompilerOutputMode;
@@ -1304,44 +1303,6 @@ fn process_fn<'a>(
             Ok(Some(codegen_fn))
         }
     }
-}
-
-// -----------------------------------------------------------------------
-// Import checking
-// -----------------------------------------------------------------------
-
-/// Check if the program already has a `c` import from the React Compiler runtime module.
-/// If so, the file was already compiled and should be skipped.
-fn has_memo_cache_function_import(program: &oxc::Program, module_name: &str) -> bool {
-    for stmt in &program.body {
-        if let oxc::Statement::ImportDeclaration(import) = stmt {
-            if import.source.value == module_name {
-                if let Some(specifiers) = &import.specifiers {
-                    for specifier in specifiers {
-                        if let oxc::ImportDeclarationSpecifier::ImportSpecifier(data) = specifier {
-                            let imported_name = match &data.imported {
-                                oxc::ModuleExportName::IdentifierName(id) => Some(id.name.as_str()),
-                                oxc::ModuleExportName::IdentifierReference(id) => {
-                                    Some(id.name.as_str())
-                                }
-                                oxc::ModuleExportName::StringLiteral(s) => Some(s.value.as_str()),
-                            };
-                            if imported_name == Some("c") {
-                                return true;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-    false
-}
-
-/// Check if compilation should be skipped for this program.
-fn should_skip_compilation(program: &oxc::Program, options: &PluginOptions) -> bool {
-    let runtime_module = get_react_compiler_runtime_module(&options.target);
-    has_memo_cache_function_import(program, &runtime_module)
 }
 
 // -----------------------------------------------------------------------
@@ -2839,7 +2800,6 @@ fn ox_is_non_namespaced_import(import: &oxc_ast::ast::ImportDeclaration) -> bool
 /// along with any logger events.
 ///
 /// This function implements the logic from the TS entrypoint (Program.ts):
-/// - shouldSkipCompilation: check for existing runtime imports
 /// - validateRestrictedImports: check for blocklisted imports
 /// - findProgramSuppressions: find eslint/flow suppression comments
 /// - findFunctionsToCompile: traverse program to find components and hooks
@@ -2855,11 +2815,6 @@ pub fn compile_program<'a, 'p>(
     let output_mode = CompilerOutputMode::from_opts(&options);
 
     let program = oxc_program;
-
-    // Check for existing runtime imports (file already compiled)
-    if should_skip_compilation(program, &options) {
-        return CompileResult::Success { ast: None, diagnostics: Diagnostics::new() };
-    }
 
     // Validate restricted imports from the environment config
     let restricted_imports = options.environment.validate_blocklisted_imports.clone();

--- a/crates/oxc_react_compiler/tests/snapshots/type-only-runtime-cache-import.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/type-only-runtime-cache-import.snap
@@ -1,0 +1,22 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/type-only-runtime-cache-import.tsx
+---
+import { c as _c } from "react/compiler-runtime";
+import type { c as useMemoCache } from "react/compiler-runtime";
+function Component(props) {
+	const $ = _c(2);
+	let t0;
+	if ($[0] !== props.text) {
+		t0 = <div>{props.text}</div>;
+		$[0] = props.text;
+		$[1] = t0;
+	} else {
+		t0 = $[1];
+	}
+	return t0;
+}
+export const FIXTURE_ENTRYPOINT = {
+	fn: Component,
+	params: [{ text: "hello" }]
+};


### PR DESCRIPTION
Moves the already-compiled runtime import check to the start of React Compiler compile.

Adds one fixture snapshot for a type-only runtime cache import, which must still compile and inject the value runtime import.

Validated with `just fmt`, `cargo test -p oxc_react_compiler --test snapshot`, `cargo test -p oxc_react_compiler --test transform`, and `cargo check -p oxc_react_compiler`.