### PR TITLE
feat(lexer): add oxc_lexer, a unfused SIMD lexer for JS/TS/TSX

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -62,6 +62,10 @@ writeable = "writeable"
 IIFEs = "IIFEs"
 allowIIFEs = "allowIIFEs"
 TAGS_PEV_FORMATE_DESCRIPTION = "TAGS_PEV_FORMATE_DESCRIPTION"
+# oxc_lexer
+tpos = "tpos"
+vor = "vor"
+PUNCT1_NKNOWN = "PUNCT1_NKNOWN"
 # Vendored react_compiler local-variable abbreviations (PrivateName, Optional{Call,Member}Expression, plural of `from`)
 pn = "pn"
 oce = "oce"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1945,6 +1945,7 @@ dependencies = [
  "oxc_estree_tokens",
  "oxc_formatter",
  "oxc_formatter_core",
+ "oxc_lexer",
  "oxc_tasks_common",
  "oxc_tasks_transform_checker",
  "phf",
@@ -2153,6 +2154,17 @@ dependencies = [
  "tokio",
  "tower-lsp-server",
  "tracing",
+]
+
+[[package]]
+name = "oxc_lexer"
+version = "0.137.0"
+dependencies = [
+ "memchr",
+ "oxc_ast",
+ "oxc_diagnostics",
+ "oxc_span",
+ "oxc_syntax",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_lexer"
-version = "0.137.0"
+version = "0.139.0"
 dependencies = [
  "memchr",
  "oxc_ast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,6 +159,7 @@ oxc_formatter_css = { path = "crates/oxc_formatter_css" } # CSS formatter
 oxc_formatter_graphql = { path = "crates/oxc_formatter_graphql" } # GraphQL formatter
 oxc_formatter_json = { path = "crates/oxc_formatter_json" } # JSON formatter
 oxc_language_server = { path = "crates/oxc_language_server", default-features = false } # Language server
+oxc_lexer = { path = "crates/oxc_lexer" } # JS/TS lexer (incubating; x86_64 SIMD, stub elsewhere)
 oxc_linter = { path = "crates/oxc_linter" } # Linting engine
 oxc_macros = { path = "crates/oxc_macros" } # Proc macros
 oxc_config = { path = "crates/oxc_config" } # Config discovery
@@ -271,7 +272,7 @@ unicode-width = "0.2"
 website_common = { path = "tasks/website_common" }
 
 [workspace.metadata.cargo-shear]
-ignored = ["oxc_transform_napi", "oxc_parser_napi", "oxc_minify_napi"]
+ignored = ["oxc_transform_napi", "oxc_parser_napi", "oxc_minify_napi", "oxc_lexer"]
 
 # `oxc_allocator` is both dogfooded here (workspace path) and published to crates.io.
 # External workspace-dependencies (e.g. `oxc-css-parser`) pull it from the registry,

--- a/crates/oxc_lexer/Cargo.toml
+++ b/crates/oxc_lexer/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "oxc_lexer"
+version = "0.137.0"
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+homepage.workspace = true
+include = ["/src"]
+keywords.workspace = true
+license.workspace = true
+publish = false
+repository.workspace = true
+rust-version.workspace = true
+description.workspace = true
+
+[lints]
+workspace = true
+
+[lib]
+doctest = false
+
+[dependencies]
+oxc_ast = { workspace = true }
+oxc_syntax = { workspace = true }
+memchr = { workspace = true }
+
+oxc_diagnostics = { workspace = true, optional = true }
+oxc_span = { workspace = true, optional = true }
+
+[features]
+oxc_diagnostics = ["dep:oxc_diagnostics", "dep:oxc_span"]

--- a/crates/oxc_lexer/Cargo.toml
+++ b/crates/oxc_lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_lexer"
-version = "0.137.0"
+version = "0.139.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_lexer/README.md
+++ b/crates/oxc_lexer/README.md
@@ -1,0 +1,18 @@
+# Oxc Lexer
+
+A spec compliant standalone lexer for JS/JSX/TS on x86_64; Other platforms coming soon.
+
+## Overview
+
+- Test262 compliant.
+- TS/JSX Working
+- UTF-8 validation costs 0.15CPB (Cycles per byte), optional parameter.
+
+## Building
+
+Requires static AVX2/BMI2 (x86_64). Without the flags the crate compiles to an
+empty stub so workspace-wide builds still pass on any platform:
+
+```sh
+RUSTFLAGS="-C target-feature=+avx2,+bmi2" cargo test -p oxc_lexer --all-features
+```

--- a/crates/oxc_lexer/src/arena.rs
+++ b/crates/oxc_lexer/src/arena.rs
@@ -1,0 +1,224 @@
+use core::ptr;
+
+use crate::error::Diagnostic;
+
+#[repr(C)]
+#[derive(Clone, Copy, Default, Debug)]
+pub struct LineEntry {
+    pub off: u32,
+    pub line: u32,
+}
+
+#[derive(Debug)]
+pub struct LexResult {
+    pub diagnostics: *mut Diagnostic,
+    pub diagnostic_count: u32,
+    pub lines: *mut LineEntry,
+    pub line_count: u32,
+    pub hit_resource_limit: bool,
+
+    pub token_count: u32,
+    pub numbers_count: u32,
+    pub atoms_count: u32,
+    pub strings_count: u32,
+    pub templates_count: u32,
+    pub regex_flags_count: u32,
+    pub comment_meta_count: u32,
+    pub comments_count: u32,
+    pub cooked_bytes_count: u32,
+}
+
+macro_rules! lane_accessor {
+    ($(#[$doc:meta])* $name:ident, $field:ident, $count:ident, $ty:ty) => {
+        $(#[$doc])*
+        #[must_use]
+        pub fn $name<'a>(&'a self, arena: &'a Arena) -> &'a [$ty] {
+            if arena.$field.is_null() || self.$count == 0 {
+                return &[];
+            }
+            // SAFETY: the lex that produced `self` initialized exactly `$count` elements (count <= capacity asserted at the copy site).
+            unsafe { core::slice::from_raw_parts(arena.$field, self.$count as usize) }
+        }
+    };
+}
+
+impl LexResult {
+    #[must_use]
+    pub fn diagnostics(&self) -> &[Diagnostic] {
+        if self.diagnostics.is_null() || self.diagnostic_count == 0 {
+            return &[];
+        }
+        // SAFETY: the lex that produced `self` copied `diagnostic_count` diagnostics into this buffer.
+        unsafe { core::slice::from_raw_parts(self.diagnostics, self.diagnostic_count as usize) }
+    }
+
+    lane_accessor!(tok_kinds, tok_kinds, token_count, u8);
+
+    #[must_use]
+    pub fn tok_starts<'a>(&'a self, arena: &'a Arena) -> &'a [u32] {
+        if arena.tok_starts.is_null() {
+            return &[];
+        }
+        let n = self.token_count as usize;
+        let len_with_sentinel = if n == 0 { 0 } else { n + 1 };
+        // SAFETY: the lexer wrote `token_count` starts plus the sentinel.
+        unsafe { core::slice::from_raw_parts(arena.tok_starts, len_with_sentinel) }
+    }
+
+    lane_accessor!(numbers, numbers, numbers_count, f64);
+    lane_accessor!(strings, strings, strings_count, crate::token::StringSpan);
+    lane_accessor!(cooked_bytes, cooked_bytes, cooked_bytes_count, u8);
+    lane_accessor!(templates, templates, templates_count, crate::token::StringSpan);
+    lane_accessor!(atoms, atoms, atoms_count, crate::token::StringSpan);
+    lane_accessor!(regex_flags, regex_flags, regex_flags_count, oxc_ast::ast::RegExpFlags);
+    lane_accessor!(comment_meta, comment_meta, comment_meta_count, u8);
+    lane_accessor!(comments, comments, comments_count, oxc_ast::ast::Comment);
+}
+
+#[derive(Debug)]
+pub struct Arena {
+    pub tokens_capacity: u32,
+    pub diags: *mut Diagnostic,
+    pub diags_capacity: u32,
+    pub lines: *mut LineEntry,
+    pub lines_capacity: u32,
+
+    pub tok_kinds: *mut u8,
+    pub tok_kinds_capacity: u32,
+    pub tok_starts: *mut u32,
+    pub tok_starts_capacity: u32,
+    pub numbers: *mut f64,
+    pub numbers_capacity: u32,
+    pub atoms: *mut crate::token::StringSpan,
+    pub atoms_capacity: u32,
+    pub strings: *mut crate::token::StringSpan,
+    pub strings_capacity: u32,
+    pub cooked_bytes: *mut u8,
+    pub cooked_bytes_capacity: u32,
+    pub templates: *mut crate::token::StringSpan,
+    pub templates_capacity: u32,
+    pub regex_flags: *mut oxc_ast::ast::RegExpFlags,
+    pub regex_flags_capacity: u32,
+    pub comment_meta: *mut u8,
+    pub comment_meta_capacity: u32,
+    pub comments: *mut oxc_ast::ast::Comment,
+    pub comments_capacity: u32,
+}
+
+impl Arena {
+    #[must_use]
+    pub fn new(tokens_capacity: u32, diags_capacity: u32, lines_capacity: u32) -> Self {
+        Self {
+            tokens_capacity,
+            diags: alloc_uninit::<Diagnostic>(diags_capacity),
+            diags_capacity,
+            lines: alloc_uninit::<LineEntry>(lines_capacity),
+            lines_capacity,
+            tok_kinds: ptr::null_mut(),
+            tok_kinds_capacity: 0,
+            tok_starts: ptr::null_mut(),
+            tok_starts_capacity: 0,
+            numbers: ptr::null_mut(),
+            numbers_capacity: 0,
+            atoms: ptr::null_mut(),
+            atoms_capacity: 0,
+            strings: ptr::null_mut(),
+            strings_capacity: 0,
+            cooked_bytes: ptr::null_mut(),
+            cooked_bytes_capacity: 0,
+            templates: ptr::null_mut(),
+            templates_capacity: 0,
+            regex_flags: ptr::null_mut(),
+            regex_flags_capacity: 0,
+            comment_meta: ptr::null_mut(),
+            comment_meta_capacity: 0,
+            comments: ptr::null_mut(),
+            comments_capacity: 0,
+        }
+    }
+
+    pub fn ensure_token_capacity(&mut self) {
+        if !self.tok_kinds.is_null() {
+            return;
+        }
+        let cap = self.tokens_capacity;
+        if cap == 0 {
+            return;
+        }
+        self.tok_kinds = alloc_uninit::<u8>(cap);
+        self.tok_kinds_capacity = cap;
+        self.tok_starts = alloc_uninit::<u32>(cap + 1);
+        self.tok_starts_capacity = cap + 1;
+
+        self.numbers = alloc_uninit::<f64>((cap / 2) + 64);
+        self.numbers_capacity = (cap / 2) + 64;
+        self.atoms = alloc_uninit::<crate::token::StringSpan>((cap / 4) + 64);
+        self.atoms_capacity = (cap / 4) + 64;
+        self.strings = alloc_uninit::<crate::token::StringSpan>((cap / 2) + 64);
+        self.strings_capacity = (cap / 2) + 64;
+        self.cooked_bytes = alloc_uninit::<u8>(cap);
+        self.cooked_bytes_capacity = cap;
+        self.templates = alloc_uninit::<crate::token::StringSpan>((cap / 2) + 64);
+        self.templates_capacity = (cap / 2) + 64;
+        self.regex_flags = alloc_uninit::<oxc_ast::ast::RegExpFlags>((cap / 2) + 64);
+        self.regex_flags_capacity = (cap / 2) + 64;
+        self.comment_meta = alloc_uninit::<u8>((cap / 2) + 64);
+        self.comment_meta_capacity = (cap / 2) + 64;
+        self.comments = alloc_uninit::<oxc_ast::ast::Comment>((cap / 3) + 64);
+        self.comments_capacity = (cap / 3) + 64;
+    }
+}
+
+#[inline]
+fn alloc_uninit<T>(cap: u32) -> *mut T {
+    if cap == 0 {
+        return ptr::null_mut();
+    }
+    let mut v = Vec::<T>::with_capacity(cap as usize);
+    let p = v.as_mut_ptr();
+    core::mem::forget(v);
+    p
+}
+
+#[inline]
+unsafe fn free_uninit<T>(ptr: *mut T, cap: u32) {
+    if ptr.is_null() {
+        return;
+    }
+    // SAFETY: `ptr`/`cap` came from `alloc_uninit`'s leaked Vec; len 0 means only the allocation is released.
+    unsafe {
+        drop(Vec::from_raw_parts(ptr, 0, cap as usize));
+    }
+}
+
+impl Drop for Arena {
+    fn drop(&mut self) {
+        // SAFETY: every pointer is null or a live `alloc_uninit` allocation with the recorded capacity, freed once.
+        unsafe {
+            free_uninit::<Diagnostic>(self.diags, self.diags_capacity);
+            free_uninit::<LineEntry>(self.lines, self.lines_capacity);
+            free_uninit::<u8>(self.tok_kinds, self.tok_kinds_capacity);
+            free_uninit::<u32>(self.tok_starts, self.tok_starts_capacity);
+            free_uninit::<f64>(self.numbers, self.numbers_capacity);
+            free_uninit::<crate::token::StringSpan>(self.atoms, self.atoms_capacity);
+            free_uninit::<crate::token::StringSpan>(self.strings, self.strings_capacity);
+            free_uninit::<u8>(self.cooked_bytes, self.cooked_bytes_capacity);
+            free_uninit::<crate::token::StringSpan>(self.templates, self.templates_capacity);
+            free_uninit::<oxc_ast::ast::RegExpFlags>(self.regex_flags, self.regex_flags_capacity);
+            free_uninit::<u8>(self.comment_meta, self.comment_meta_capacity);
+            free_uninit::<oxc_ast::ast::Comment>(self.comments, self.comments_capacity);
+        }
+        self.diags = ptr::null_mut();
+        self.lines = ptr::null_mut();
+        self.tok_kinds = ptr::null_mut();
+        self.tok_starts = ptr::null_mut();
+        self.numbers = ptr::null_mut();
+        self.atoms = ptr::null_mut();
+        self.strings = ptr::null_mut();
+        self.cooked_bytes = ptr::null_mut();
+        self.templates = ptr::null_mut();
+        self.regex_flags = ptr::null_mut();
+        self.comment_meta = ptr::null_mut();
+        self.comments = ptr::null_mut();
+    }
+}

--- a/crates/oxc_lexer/src/comment_meta.rs
+++ b/crates/oxc_lexer/src/comment_meta.rs
@@ -1,0 +1,156 @@
+pub const CONTENT_NONE: u8 = 0;
+pub const CONTENT_LEGAL: u8 = 1;
+pub const CONTENT_JSDOC: u8 = 2;
+pub const CONTENT_JSDOC_LEGAL: u8 = 3;
+pub const CONTENT_PURE: u8 = 4;
+pub const CONTENT_NO_SIDE_EFFECTS: u8 = 5;
+pub const CONTENT_WEBPACK: u8 = 6;
+pub const CONTENT_VITE: u8 = 7;
+pub const CONTENT_COVERAGE_IGNORE: u8 = 8;
+pub const META_MULTILINE: u8 = 0x10;
+
+#[inline]
+pub fn content_from_ordinal(o: u8) -> oxc_ast::ast::CommentContent {
+    use oxc_ast::ast::CommentContent;
+    match o & 0x0F {
+        CONTENT_LEGAL => CommentContent::Legal,
+        CONTENT_JSDOC => CommentContent::Jsdoc,
+        CONTENT_JSDOC_LEGAL => CommentContent::JsdocLegal,
+        CONTENT_PURE => CommentContent::Pure,
+        CONTENT_NO_SIDE_EFFECTS => CommentContent::NoSideEffects,
+        CONTENT_WEBPACK => CommentContent::Webpack,
+        CONTENT_VITE => CommentContent::Vite,
+        CONTENT_COVERAGE_IGNORE => CommentContent::CoverageIgnore,
+        _ => CommentContent::None,
+    }
+}
+
+#[inline]
+fn body(src: &[u8], start: u32, end: u32, is_block: bool) -> &[u8] {
+    let (lo, hi) = if is_block {
+        (start as usize + 2, (end as usize).saturating_sub(2))
+    } else {
+        (start as usize + 2, end as usize)
+    };
+    let lo = lo.min(src.len());
+    let hi = hi.clamp(lo, src.len());
+    &src[lo..hi]
+}
+
+fn contains_license_or_preserve(hay: &[u8]) -> bool {
+    if hay.len() < 9 {
+        return false;
+    }
+    let lim = hay.len() - 8;
+    let mut i = 0;
+    while i < lim {
+        if hay[i] == b'@' {
+            match hay[i + 1] {
+                b'l' if &hay[i + 2..i + 8] == b"icense" => return true,
+                b'p' if &hay[i + 2..i + 9] == b"reserve" => return true,
+                _ => {}
+            }
+        }
+        i += 1;
+    }
+    false
+}
+
+fn has_nl_cr(bytes: &[u8]) -> bool {
+    bytes.iter().any(|&b| b == b'\n' || b == b'\r')
+}
+
+#[inline]
+fn classify(bytes: &[u8], is_block: bool, lic: bool) -> u8 {
+    if bytes.is_empty() {
+        return CONTENT_NONE;
+    }
+    match bytes[0] {
+        b'!' => return CONTENT_LEGAL,
+        b'*' if is_block => {
+            if !bytes.iter().all(|&c| c == b'*') {
+                return if lic { CONTENT_JSDOC_LEGAL } else { CONTENT_JSDOC };
+            }
+            return CONTENT_NONE;
+        }
+        _ => {}
+    }
+
+    let mut start = 0;
+    while start < bytes.len() && bytes[start].is_ascii_whitespace() {
+        start += 1;
+    }
+    if start >= bytes.len() {
+        return CONTENT_NONE;
+    }
+
+    match bytes[start] {
+        b'@' => {
+            start += 1;
+            if start >= bytes.len() {
+                return CONTENT_NONE;
+            }
+            if bytes[start..].starts_with(b"vite") {
+                return CONTENT_VITE;
+            }
+            if bytes[start..].starts_with(b"license") || bytes[start..].starts_with(b"preserve") {
+                return CONTENT_LEGAL;
+            }
+        }
+        b'#' => start += 1,
+        b'w' => {
+            if bytes[start..].starts_with(b"webpack")
+                && start + 7 < bytes.len()
+                && bytes[start + 7].is_ascii_uppercase()
+            {
+                return CONTENT_WEBPACK;
+            }
+            return if lic { CONTENT_LEGAL } else { CONTENT_NONE };
+        }
+        b'v' | b'c' | b'n' | b'i' => {
+            let rest = &bytes[start..];
+            if rest.starts_with(b"v8 ignore")
+                || rest.starts_with(b"c8 ignore")
+                || rest.starts_with(b"node:coverage")
+                || rest.starts_with(b"istanbul ignore")
+            {
+                return CONTENT_COVERAGE_IGNORE;
+            }
+            return if lic { CONTENT_LEGAL } else { CONTENT_NONE };
+        }
+        _ => return if lic { CONTENT_LEGAL } else { CONTENT_NONE },
+    }
+
+    if start < bytes.len() && bytes[start..].starts_with(b"__") {
+        let rest = &bytes[start + 2..];
+        if rest.starts_with(b"PURE__") {
+            return CONTENT_PURE;
+        } else if rest.starts_with(b"NO_SIDE_EFFECTS__") {
+            return CONTENT_NO_SIDE_EFFECTS;
+        }
+    }
+
+    if lic { CONTENT_LEGAL } else { CONTENT_NONE }
+}
+
+#[inline]
+pub fn meta_byte_flags(
+    src: &[u8],
+    start: u32,
+    end: u32,
+    is_block: bool,
+    ml: bool,
+    lic: bool,
+) -> u8 {
+    let ord = classify(body(src, start, end, is_block), is_block, lic) & 0x0F;
+    ord | if ml && is_block { META_MULTILINE } else { 0 }
+}
+
+#[inline]
+pub fn meta_byte_exact(src: &[u8], start: u32, end: u32, is_block: bool) -> u8 {
+    let b = body(src, start, end, is_block);
+    let lic = contains_license_or_preserve(b);
+    let ord = classify(b, is_block, lic) & 0x0F;
+    let ml = is_block && has_nl_cr(b);
+    ord | if ml { META_MULTILINE } else { 0 }
+}

--- a/crates/oxc_lexer/src/comment_meta.rs
+++ b/crates/oxc_lexer/src/comment_meta.rs
@@ -46,6 +46,7 @@ fn contains_license_or_preserve(hay: &[u8]) -> bool {
     while i < lim {
         if hay[i] == b'@' {
             match hay[i + 1] {
+                // spellchecker:disable-next-line
                 b'l' if &hay[i + 2..i + 8] == b"icense" => return true,
                 b'p' if &hay[i + 2..i + 9] == b"reserve" => return true,
                 _ => {}

--- a/crates/oxc_lexer/src/diagnostics.rs
+++ b/crates/oxc_lexer/src/diagnostics.rs
@@ -1,0 +1,507 @@
+use std::borrow::Cow;
+
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_span::Span;
+use oxc_syntax::identifier::{is_identifier_part_ascii, is_identifier_start};
+
+use crate::error::{Diagnostic, diag_code as Code, diag_severity};
+
+/// The diagnostic's span: the lexer stores `(off, len)`, oxc `(start, end)`.
+#[inline]
+fn span_of(d: &Diagnostic) -> Span {
+    Span::new(d.off, d.off + d.len)
+}
+
+/// The source slice the diagnostic covers; empty if out of bounds.
+#[inline]
+fn lexeme<'a>(source: &'a str, d: &Diagnostic) -> &'a str {
+    let (start, end) = (d.off as usize, (d.off + d.len) as usize);
+    source.get(start..end).unwrap_or("")
+}
+
+/// First char of the span (the offending character), or U+FFFD.
+#[inline]
+fn offending_char(source: &str, d: &Diagnostic) -> char {
+    lexeme(source, d).chars().next().unwrap_or('\u{FFFD}')
+}
+
+/// Decode the identifier escape whose text ends at `end`: the offending
+/// char of an escaped-non-identifier-char diagnostic exists only decoded,
+/// so the lexer emits an empty span after the escape and the bridge
+/// recovers the char here.
+fn decode_escape_ending_at(source: &str, end: u32) -> Option<char> {
+    let text = source.get(..end as usize)?;
+    let bs = text.rfind('\\')?;
+    let esc = &text[bs..];
+    let hex = if let Some(h) = esc.strip_prefix("\\u{") {
+        h.strip_suffix('}')?
+    } else {
+        esc.strip_prefix("\\u")?
+    };
+    char::from_u32(u32::from_str_radix(hex, 16).ok()?)
+}
+
+/// Honor the POD severity (every current code is an error).
+#[inline]
+fn diag(severity: u16, message: impl Into<Cow<'static, str>>) -> OxcDiagnostic {
+    if severity == diag_severity::WARNING {
+        OxcDiagnostic::warn(message)
+    } else {
+        OxcDiagnostic::error(message)
+    }
+}
+
+/// Is `off` the start of a numeric literal rather than an adjacency anchor
+/// inside one? Adjacency diags (`1.5n`, `0b12`) anchor right after a number
+/// char, so a number/identifier byte before `off` declines; so does a
+/// non-ASCII one (conservative — the fallback rendering applies).
+fn at_numeric_literal_start(source: &str, off: u32) -> bool {
+    let b = source.as_bytes();
+    let i = off as usize;
+    let starts = match b.get(i) {
+        Some(c) if c.is_ascii_digit() => true,
+        Some(b'.') => b.get(i + 1).is_some_and(u8::is_ascii_digit),
+        _ => false,
+    };
+    starts
+        && match i.checked_sub(1).and_then(|p| b.get(p)) {
+            None => true,
+            Some(&p) => {
+                p.is_ascii() && !p.is_ascii_alphanumeric() && !matches!(p, b'_' | b'$' | b'.')
+            }
+        }
+}
+
+/// The parser's first numeric error: a required digit was missing (empty
+/// span at the char), or identifier chars right after a number.
+enum NumErr {
+    Unexpected(usize),
+    NumberEnd(usize, usize),
+}
+
+/// Port of oxc_parser's numeric scanner (`lexer/numeric.rs`), stopping at
+/// its first diagnostic. Mirrors the quirks exactly: no separators in
+/// legacy-octal-like decimals, a legacy-octal exponent only as lowercase `e`
+/// after an `8`/`9` flipped the run to NonOctalDecimal, and `.` after a
+/// pure-octal run simply ends the token. Each method notes the parser
+/// function it ports.
+struct NumericWalk<'a> {
+    src: &'a str,
+    i: usize,
+}
+
+impl NumericWalk<'_> {
+    fn peek(&self) -> Option<u8> {
+        self.src.as_bytes().get(self.i).copied()
+    }
+
+    fn peek_char(&self) -> Option<char> {
+        self.src[self.i..].chars().next()
+    }
+
+    fn bump(&mut self) {
+        self.i += 1; // ASCII call sites only
+    }
+
+    fn walk(&mut self) -> Result<(), NumErr> {
+        match self.peek() {
+            Some(b'0') => {
+                self.bump();
+                self.zero()
+            }
+            Some(c) if c.is_ascii_digit() => {
+                self.bump();
+                self.decimal_after_first_digit()
+            }
+            // `.5`-style literal: fraction digits are REQUIRED.
+            Some(b'.') => {
+                self.bump();
+                self.decimal_digits()?;
+                self.optional_exponent()?;
+                self.check_after()
+            }
+            _ => Ok(()),
+        }
+    }
+
+    /// `read_zero`
+    fn zero(&mut self) -> Result<(), NumErr> {
+        match self.peek() {
+            Some(b'b' | b'B') => self.non_decimal(|c| matches!(c, b'0' | b'1')),
+            Some(b'o' | b'O') => self.non_decimal(|c| matches!(c, b'0'..=b'7')),
+            Some(b'x' | b'X') => self.non_decimal(u8::is_ascii_hexdigit),
+            // `0e...`: the parser returns straight out of the exponent read —
+            // no trailing-char check on this path.
+            Some(b'e' | b'E') => {
+                self.bump();
+                self.exponent()
+            }
+            Some(b'.') => {
+                self.bump();
+                self.optional_fraction_then_exponent()
+            }
+            Some(b'n') => {
+                self.bump();
+                self.check_after()
+            }
+            Some(c) if c.is_ascii_digit() => self.legacy_octal(),
+            _ => self.check_after(),
+        }
+    }
+
+    /// `read_non_decimal`
+    fn non_decimal(&mut self, is_digit: impl Fn(&u8) -> bool) -> Result<(), NumErr> {
+        self.bump(); // the radix marker
+        if self.peek().as_ref().is_some_and(&is_digit) {
+            self.bump();
+        } else {
+            return Err(NumErr::Unexpected(self.i));
+        }
+        while let Some(c) = self.peek() {
+            if c == b'_' {
+                self.bump();
+                if self.peek().as_ref().is_some_and(&is_digit) {
+                    self.bump();
+                } else {
+                    return Err(NumErr::Unexpected(self.i));
+                }
+            } else if is_digit(&c) {
+                self.bump();
+            } else {
+                break;
+            }
+        }
+        if self.peek() == Some(b'n') {
+            self.bump();
+        }
+        self.check_after()
+    }
+
+    /// `read_legacy_octal`
+    fn legacy_octal(&mut self) -> Result<(), NumErr> {
+        let mut decimal = false;
+        while let Some(c) = self.peek() {
+            match c {
+                b'0'..=b'7' => self.bump(),
+                b'8' | b'9' => {
+                    decimal = true;
+                    self.bump();
+                }
+                _ => break,
+            }
+        }
+        match self.peek() {
+            Some(b'.') if decimal => {
+                self.bump();
+                self.optional_fraction_then_exponent()
+            }
+            // Lowercase only, faithfully: the parser rejects `08E1`.
+            Some(b'e') if decimal => {
+                self.bump();
+                self.exponent()
+            }
+            _ => self.check_after(),
+        }
+    }
+
+    /// `decimal_literal_after_first_digit`
+    fn decimal_after_first_digit(&mut self) -> Result<(), NumErr> {
+        self.decimal_digits_after_first()?;
+        if self.peek() == Some(b'.') {
+            self.bump();
+            return self.optional_fraction_then_exponent();
+        }
+        if self.peek() == Some(b'n') {
+            self.bump();
+            return self.check_after();
+        }
+        self.optional_exponent()?;
+        self.check_after()
+    }
+
+    /// `decimal_literal_after_decimal_point_after_digits`
+    fn optional_fraction_then_exponent(&mut self) -> Result<(), NumErr> {
+        if self.peek().is_some_and(|c| c.is_ascii_digit()) {
+            self.bump();
+            self.decimal_digits_after_first()?;
+        }
+        self.optional_exponent()?;
+        self.check_after()
+    }
+
+    /// `read_decimal_digits` (first digit required)
+    fn decimal_digits(&mut self) -> Result<(), NumErr> {
+        if self.peek().is_some_and(|c| c.is_ascii_digit()) {
+            self.bump();
+        } else {
+            return Err(NumErr::Unexpected(self.i));
+        }
+        self.decimal_digits_after_first()
+    }
+
+    /// `read_decimal_digits_after_first_digit`
+    fn decimal_digits_after_first(&mut self) -> Result<(), NumErr> {
+        while let Some(c) = self.peek() {
+            if c == b'_' {
+                self.bump();
+                if self.peek().is_some_and(|c| c.is_ascii_digit()) {
+                    self.bump();
+                } else {
+                    return Err(NumErr::Unexpected(self.i));
+                }
+            } else if c.is_ascii_digit() {
+                self.bump();
+            } else {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    /// `optional_exponent`
+    fn optional_exponent(&mut self) -> Result<(), NumErr> {
+        if matches!(self.peek(), Some(b'e' | b'E')) {
+            self.bump();
+            return self.exponent();
+        }
+        Ok(())
+    }
+
+    /// `read_decimal_exponent`
+    fn exponent(&mut self) -> Result<(), NumErr> {
+        if matches!(self.peek(), Some(b'+' | b'-')) {
+            self.bump();
+        }
+        self.decimal_digits()
+    }
+
+    /// `check_after_numeric_literal`: an IdentifierStart or digit directly
+    /// after the literal, spanning it plus the identifier-start run after.
+    fn check_after(&mut self) -> Result<(), NumErr> {
+        let bad = match self.peek_char() {
+            None => false,
+            Some(c) if c.is_ascii() => is_identifier_part_ascii(c),
+            Some(c) => is_identifier_start(c),
+        };
+        if !bad {
+            return Ok(());
+        }
+        let start = self.i;
+        if let Some(c) = self.peek_char() {
+            self.i += c.len_utf8();
+        }
+        while let Some(c) = self.peek_char() {
+            if is_identifier_start(c) {
+                self.i += c.len_utf8();
+            } else {
+                break;
+            }
+        }
+        Err(NumErr::NumberEnd(start, self.i))
+    }
+}
+
+/// Re-walk the numeric literal at `off` and reproduce oxc_parser's first
+/// diagnostic for it; `None` when the walk finds nothing wrong.
+#[expect(clippy::cast_possible_truncation, reason = "source offsets are bounded by MAX_SOURCE_LEN")]
+fn parser_numeric_first_error(source: &str, off: u32, sev: u16) -> Option<OxcDiagnostic> {
+    let mut walk = NumericWalk { src: source, i: off as usize };
+    match walk.walk() {
+        Ok(()) => None,
+        Err(NumErr::Unexpected(at)) => {
+            let span = Span::new(at as u32, at as u32);
+            Some(match source[at..].chars().next() {
+                Some(c) => diag(sev, format!("Invalid Character `{c}`")).with_label(span),
+                None => diag(sev, "Unexpected end of file").with_label(span),
+            })
+        }
+        Err(NumErr::NumberEnd(start, end)) => Some(
+            diag(sev, "Invalid characters after number")
+                .with_label(Span::new(start as u32, end as u32)),
+        ),
+    }
+}
+
+/// Convert one lexer [`Diagnostic`] into an [`OxcDiagnostic`] with
+/// oxc_parser's message and span for that error class. `source` is the
+/// original text, needed to recover offending characters.
+#[expect(
+    clippy::match_same_arms,
+    reason = "distinct codes deliberately collapse to the parser's message (see module docs)"
+)]
+pub fn to_oxc_diagnostic(d: &Diagnostic, source: &str) -> OxcDiagnostic {
+    let span = span_of(d);
+    let sev = d.severity;
+
+    // Numeric diags anchored at the literal re-walk it for the parser's
+    // exact first error; adjacency-anchored spans and clean walks fall
+    // through to the static arms.
+    if matches!(
+        d.code,
+        Code::INVALID_NUMERIC_SEPARATOR | Code::INVALID_BIGINT | Code::INVALID_NUMERIC_LITERAL
+    ) && at_numeric_literal_start(source, d.off)
+        && let Some(exact) = parser_numeric_first_error(source, d.off, sev)
+    {
+        return exact;
+    }
+
+    match d.code {
+        // Exact 1:1 with oxc_parser/src/diagnostics.rs.
+        Code::UNTERMINATED_STRING => diag(sev, "Unterminated string").with_label(span),
+        Code::UNTERMINATED_BLOCK_COMMENT => {
+            diag(sev, "Unterminated multiline comment").with_label(span)
+        }
+        Code::UNTERMINATED_REGEXP => diag(sev, "Unterminated regular expression").with_label(span),
+        // The parser's string-escape message; "Invalid Unicode escape
+        // sequence" belongs to identifier escapes below.
+        Code::INVALID_UNICODE_ESCAPE => diag(sev, "Invalid escape sequence").with_label(span),
+        Code::UNEXPECTED_CHARACTER => {
+            // The len-0 shape is an escaped non-identifier char: the message
+            // embeds the decoded char, recovered from the escape text ending
+            // at `off`.
+            let ch = if d.len == 0 {
+                decode_escape_ending_at(source, d.off).unwrap_or('\u{FFFD}')
+            } else {
+                offending_char(source, d)
+            };
+            diag(sev, format!("Invalid Character `{ch}`")).with_label(span)
+        }
+        Code::INVALID_REGEXP_FLAG => diag(
+            sev,
+            format!("Unexpected flag {} in regular expression literal", offending_char(source, d)),
+        )
+        .with_label(span)
+        .with_help(format!("The allowed flags are `{}`", oxc_ast::ast::REGEXP_FLAGS_LIST)),
+        Code::DUPLICATE_REGEXP_FLAG => diag(
+            sev,
+            format!(
+                "Flag {} is mentioned twice in regular expression literal",
+                offending_char(source, d)
+            ),
+        )
+        .with_label(span)
+        .with_help("Remove the duplicated flag here"),
+        // A misplaced bigint suffix (`1.5n`) also reaches oxc_parser's
+        // `invalid_number_end` (its float path never consumes the `n`), so
+        // BIGINT collapses to the same message and span.
+        Code::INVALID_NUMERIC_LITERAL | Code::INVALID_BIGINT => {
+            diag(sev, "Invalid characters after number").with_label(span)
+        }
+
+        // The parser does not distinguish unterminated template from string,
+        // and reports newline-in-literal as "unterminated".
+        Code::UNTERMINATED_TEMPLATE => diag(sev, "Unterminated string").with_label(span),
+        Code::LINE_TERMINATOR_IN_STRING => diag(sev, "Unterminated string").with_label(span),
+        Code::LINE_TERMINATOR_IN_REGEXP => {
+            diag(sev, "Unterminated regular expression").with_label(span)
+        }
+        // The parser-side `invalid_number` message.
+        Code::INVALID_NUMERIC_SEPARATOR => {
+            diag(sev, format!("Invalid Number {}", lexeme(source, d))).with_label(span)
+        }
+        // The parser's identifier-escape message, distinct from the
+        // string-escape one above.
+        Code::INVALID_IDENTIFIER_ESCAPE => {
+            diag(sev, "Invalid Unicode escape sequence").with_label(span)
+        }
+
+        // The parser consumes valid &str, so its closest analog to bad UTF-8
+        // is the binary-file error, which carries no label.
+        Code::INVALID_UTF8 => diag(sev, "File appears to be binary.").with_error_code("TS", "1490"),
+        Code::INVALID_HASHBANG_POSITION => {
+            diag(sev, format!("Invalid Character `{}`", offending_char(source, d))).with_label(span)
+        }
+        Code::INVALID_REGEXP_GRAMMAR => diag(sev, "Invalid regular expression").with_label(span),
+        Code::ORACLE_DEPTH_EXCEEDED => diag(sev, "Nesting depth limit exceeded").with_label(span),
+        Code::ALLOCATION_LIMIT_EXCEEDED => diag(sev, "Source length exceeds 4 GiB limit"),
+
+        // OK never appears in the buffer; unknown codes get a fallback.
+        _ => diag(sev, "Lexer error").with_label(span),
+    }
+}
+
+/// Convert a slice of lexer diagnostics into the `Vec<OxcDiagnostic>` shape
+/// oxc_parser collects.
+#[must_use]
+pub fn to_oxc_diagnostics(diags: &[Diagnostic], source: &str) -> Vec<OxcDiagnostic> {
+    diags.iter().map(|d| to_oxc_diagnostic(d, source)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::diag_code;
+
+    fn d(code: u16, off: u32, len: u32) -> Diagnostic {
+        Diagnostic { off, len, code, severity: diag_severity::ERROR }
+    }
+
+    #[test]
+    fn reproduces_parser_messages_and_spans() {
+        let src = "let x = 'abc";
+        let g = to_oxc_diagnostic(&d(diag_code::UNTERMINATED_STRING, 8, 4), src);
+        assert_eq!(g.message.as_ref(), "Unterminated string");
+
+        // message embeds the offending char from `source`
+        let src = "a @ b";
+        let g = to_oxc_diagnostic(&d(diag_code::UNEXPECTED_CHARACTER, 2, 1), src);
+        assert_eq!(g.message.as_ref(), "Invalid Character `@`");
+
+        let src = "/a/z";
+        let g = to_oxc_diagnostic(&d(diag_code::INVALID_REGEXP_FLAG, 3, 1), src);
+        assert_eq!(g.message.as_ref(), "Unexpected flag z in regular expression literal");
+        assert_eq!(g.help.as_deref(), Some("The allowed flags are `gimsuydv`"));
+    }
+
+    #[test]
+    fn finer_codes_collapse_to_parser_text() {
+        let src = "`abc";
+        let g = to_oxc_diagnostic(&d(diag_code::UNTERMINATED_TEMPLATE, 0, 4), src);
+        assert_eq!(g.message.as_ref(), "Unterminated string");
+
+        // separator errors re-walk the literal: `1_000_` at EOF is the
+        // parser's unexpected-end, not "Invalid Number ..."
+        let src = "1_000_";
+        let g = to_oxc_diagnostic(&d(diag_code::INVALID_NUMERIC_SEPARATOR, 0, 6), src);
+        assert_eq!(g.message.as_ref(), "Unexpected end of file");
+    }
+
+    fn label(g: &OxcDiagnostic) -> (u32, u32) {
+        let l = g.labels.as_ref().first().expect("expected a labeled span");
+        (l.offset(), l.len())
+    }
+
+    #[test]
+    fn numeric_diags_reproduce_parser_walk() {
+        use diag_code as C;
+        // (source, POD code, POD off, POD len, parser message, parser label)
+        type Case = (&'static str, u16, u32, u32, &'static str, (u32, u32));
+        let cases: &[Case] = &[
+            ("x = 0b2;", C::INVALID_NUMERIC_LITERAL, 4, 2, "Invalid Character `2`", (6, 0)),
+            ("0b0_n;", C::INVALID_NUMERIC_SEPARATOR, 0, 5, "Invalid Character `n`", (4, 0)),
+            ("1__03;", C::INVALID_NUMERIC_SEPARATOR, 0, 5, "Invalid Character `_`", (2, 0)),
+            ("1_000_", C::INVALID_NUMERIC_SEPARATOR, 0, 6, "Unexpected end of file", (6, 0)),
+            ("0_0;", C::INVALID_NUMERIC_SEPARATOR, 0, 3, "Invalid characters after number", (1, 1)),
+            ("00n;", C::INVALID_BIGINT, 0, 3, "Invalid characters after number", (2, 1)),
+            (
+                "10._e1;",
+                C::INVALID_NUMERIC_SEPARATOR,
+                0,
+                6,
+                "Invalid characters after number",
+                (3, 2),
+            ),
+            ("00e1;", C::INVALID_NUMERIC_LITERAL, 0, 4, "Invalid characters after number", (2, 1)),
+        ];
+        for &(src, code, off, len, msg, lab) in cases {
+            let g = to_oxc_diagnostic(&d(code, off, len), src);
+            assert_eq!(g.message.as_ref(), msg, "message for {src:?}");
+            assert_eq!(label(&g), lab, "label for {src:?}");
+        }
+
+        // adjacency-anchored spans bypass the walk and keep their POD span
+        let g = to_oxc_diagnostic(&d(diag_code::INVALID_NUMERIC_LITERAL, 1, 2), "3in");
+        assert_eq!(g.message.as_ref(), "Invalid characters after number");
+        assert_eq!(label(&g), (1, 2));
+    }
+}

--- a/crates/oxc_lexer/src/error.rs
+++ b/crates/oxc_lexer/src/error.rs
@@ -1,0 +1,36 @@
+pub mod diag_code {
+    pub const OK: u16 = 0;
+    pub const UNTERMINATED_STRING: u16 = 1;
+    pub const UNTERMINATED_TEMPLATE: u16 = 2;
+    pub const UNTERMINATED_BLOCK_COMMENT: u16 = 3;
+    pub const UNTERMINATED_REGEXP: u16 = 4;
+    pub const LINE_TERMINATOR_IN_REGEXP: u16 = 5;
+    pub const INVALID_UTF8: u16 = 6;
+    pub const INVALID_UNICODE_ESCAPE: u16 = 7;
+    pub const INVALID_IDENTIFIER_ESCAPE: u16 = 8;
+    pub const INVALID_NUMERIC_SEPARATOR: u16 = 9;
+    pub const INVALID_BIGINT: u16 = 10;
+    pub const INVALID_NUMERIC_LITERAL: u16 = 11;
+    pub const INVALID_HASHBANG_POSITION: u16 = 12;
+    pub const INVALID_REGEXP_FLAG: u16 = 13;
+    pub const DUPLICATE_REGEXP_FLAG: u16 = 14;
+    pub const INVALID_REGEXP_GRAMMAR: u16 = 15;
+    pub const ORACLE_DEPTH_EXCEEDED: u16 = 16;
+    pub const ALLOCATION_LIMIT_EXCEEDED: u16 = 17;
+    pub const UNEXPECTED_CHARACTER: u16 = 18;
+    pub const LINE_TERMINATOR_IN_STRING: u16 = 19;
+}
+
+pub mod diag_severity {
+    pub const ERROR: u16 = 0;
+    pub const WARNING: u16 = 1;
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Default, Debug)]
+pub struct Diagnostic {
+    pub off: u32,
+    pub len: u32,
+    pub code: u16,
+    pub severity: u16,
+}

--- a/crates/oxc_lexer/src/lanes.rs
+++ b/crates/oxc_lexer/src/lanes.rs
@@ -977,7 +977,9 @@ unsafe fn cook_decode<const EMIT: bool, const CRLF: bool>(
                 wi += 1;
             }
             b'0' => {
+                // spellchecker:disable-next-line
                 let nd = i < be && (*src.add(i as usize)).is_ascii_digit();
+                // spellchecker:disable-next-line
                 if !nd {
                     *out.add(wi as usize) = 0;
                     wi += 1;

--- a/crates/oxc_lexer/src/lanes.rs
+++ b/crates/oxc_lexer/src/lanes.rs
@@ -1,0 +1,1329 @@
+// Kernel lint policy — see the note in `pipeline/mod.rs`.
+#![allow(unsafe_op_in_unsafe_fn, clippy::missing_safety_doc, clippy::undocumented_unsafe_blocks)]
+#![allow(clippy::pedantic, clippy::nursery)]
+#![allow(
+    clippy::needless_range_loop,
+    clippy::manual_range_contains,
+    clippy::collapsible_if,
+    clippy::collapsible_match
+)]
+
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::*;
+
+use crate::error::{Diagnostic, diag_code, diag_severity};
+use crate::token::StringSpan;
+
+#[derive(Default)]
+pub struct Lanes {
+    pub numbers: Vec<f64>,
+    pub strings: Vec<StringSpan>,
+    pub templates: Vec<StringSpan>,
+    pub atoms: Vec<StringSpan>,
+    pub regex_flags: Vec<u8>,
+    pub cooked: Vec<u8>,
+    pub comment_meta: Vec<u8>,
+    pub comments: Vec<oxc_ast::ast::Comment>,
+    /// Lexer diagnostics, pushed only on cold error paths; empty for valid input.
+    pub diags: Vec<Diagnostic>,
+    /// Byte ranges lexed content-blind (the `.tsx` type-argument skip): diagnostics landing in one are dropped at drain time.
+    pub diag_suppress: Vec<(u32, u32)>,
+    /// Positions of non-whitespace non-ASCII lead bytes, recorded by
+    /// `misc_pre` before carve clears literal interiors. Resolved at drain:
+    /// leads inside literal tokens are legal content and drop cheaply; only
+    /// code-level survivors pay the identifier-char check. Empty for
+    /// pure-ASCII input.
+    pub unicode_leads: Vec<u32>,
+}
+
+impl Lanes {
+    pub fn clear(&mut self) {
+        self.numbers.clear();
+        self.strings.clear();
+        self.templates.clear();
+        self.atoms.clear();
+        self.regex_flags.clear();
+        self.cooked.clear();
+        self.comment_meta.clear();
+        self.comments.clear();
+        self.diags.clear();
+        self.diag_suppress.clear();
+        self.unicode_leads.clear();
+    }
+
+    #[inline]
+    pub fn push_regex_flags(&mut self, src: &[u8], fs: usize, fe: usize) {
+        let mut f: u8 = 0;
+        for (k, &c) in src[fs..fe].iter().enumerate() {
+            let bit: u8 = match c {
+                b'g' => 1,
+                b'i' => 2,
+                b'm' => 4,
+                b's' => 8,
+                b'u' => 16,
+                b'y' => 32,
+                b'd' => 64,
+                b'v' => 128,
+                _ => 0,
+            };
+            // Unknown or repeated flag: diagnostic. At most 8 flag chars.
+            if bit == 0 {
+                self.push_diag((fs + k) as u32, 1, crate::error::diag_code::INVALID_REGEXP_FLAG);
+            } else if f & bit != 0 {
+                self.push_diag((fs + k) as u32, 1, crate::error::diag_code::DUPLICATE_REGEXP_FLAG);
+            }
+            f |= bit;
+        }
+        self.regex_flags.push(f);
+    }
+
+    /// Record a diagnostic. Cold and non-inlined so the push stays out of
+    /// the hot carve body.
+    #[cold]
+    #[inline(never)]
+    pub fn push_diag(&mut self, off: u32, len: u32, code: u16) {
+        self.diags.push(Diagnostic { off, len, code, severity: diag_severity::ERROR });
+    }
+
+    /// Line terminator in a string, with oxc_parser's exact span: opener
+    /// through the first unescaped CR/LF (for CRLF only the CR). Escaped
+    /// terminators are legal LineContinuations and are skipped the way the
+    /// parser's escape reader skips them. LS/PS are legal string content.
+    #[cold]
+    #[inline(never)]
+    pub fn push_line_terminator_in_string(&mut self, src: &[u8], s: usize, end: usize) {
+        let mut i = s + 1; // past the opening quote
+        let mut term_end = end; // fallback (unreachable: the scanner saw a terminator)
+        while i < end {
+            match src[i] {
+                b'\\' => {
+                    i += 1;
+                    if i < end && src[i] == b'\r' {
+                        i += 1;
+                        if i < end && src[i] == b'\n' {
+                            i += 1;
+                        }
+                    } else {
+                        i += 1;
+                    }
+                }
+                b'\r' | b'\n' => {
+                    term_end = i + 1;
+                    break;
+                }
+                _ => i += 1,
+            }
+        }
+        self.push_diag(s as u32, (term_end - s) as u32, diag_code::LINE_TERMINATOR_IN_STRING);
+    }
+
+    /// IdentifierStart or digit right after a numeric literal (`1.5n`,
+    /// `3in`, `0b12`), with oxc_parser's `invalid_number_end` span: the char
+    /// at `e2` plus the run of identifier-start chars after it.
+    #[cold]
+    #[inline(never)]
+    pub fn push_num_end_diag(&mut self, src: &[u8], e2: usize, code: u16) {
+        let end = ident_start_run_end(src, e2 + 1);
+        self.push_diag(e2 as u32, (end - e2) as u32, code);
+    }
+
+    /// Non-ASCII byte right after a numeric literal: a Unicode
+    /// IdentifierStart (`1π`) is the same invalid adjacency as the ASCII
+    /// case; Unicode whitespace is legal and invalid UTF-8 emits nothing
+    /// here.
+    #[cold]
+    #[inline(never)]
+    pub fn push_num_end_diag_unicode(&mut self, src: &[u8], e2: usize) {
+        let Some(ch) = decode_char_at(src, e2) else { return };
+        if !oxc_syntax::identifier::is_identifier_start(ch) {
+            return;
+        }
+        let end = ident_start_run_end(src, e2 + ch.len_utf8());
+        self.push_diag(
+            e2 as u32,
+            (end - e2) as u32,
+            crate::error::diag_code::INVALID_NUMERIC_LITERAL,
+        );
+    }
+
+    #[inline]
+    /// `EMIT`: report malformed escapes while cooking — strings only, since
+    /// template escapes are legal when tagged (the parser owns that error).
+    /// `CRLF`: normalize raw CRLF/CR to LF per the template TV rule
+    /// (ECMA-262 12.9.6.1). Monomorphized out of copies that don't need them.
+    fn cook<const EMIT: bool, const CRLF: bool>(
+        &mut self,
+        src: &[u8],
+        bs: u32,
+        be: u32,
+    ) -> (StringSpan, bool) {
+        let ss = self.cooked.len() as u32;
+        if be <= bs {
+            return (StringSpan::new(ss, ss & StringSpan::END_MASK, false), false);
+        }
+        let body_len = (be - bs) as usize;
+
+        self.cooked.reserve(body_len.max(32) + 8);
+        let base = self.cooked.as_mut_ptr();
+
+        let needs_decode = if body_len < 32 {
+            return self.cook_short_dispatch::<EMIT, CRLF>(src, bs, be, base, ss, body_len);
+        } else if CRLF {
+            span_has_bs_or_cr(src, bs as usize, be as usize)
+        } else {
+            span_has_bs(src, bs as usize, be as usize)
+        };
+        let (wi, lone, nes) = if needs_decode {
+            unsafe { cook_decode::<EMIT, CRLF>(src.as_ptr(), bs, be, base, ss, &mut self.diags) }
+        } else {
+            unsafe {
+                core::ptr::copy_nonoverlapping(
+                    src.as_ptr().add(bs as usize),
+                    base.add(ss as usize),
+                    body_len,
+                );
+            }
+            (ss + (be - bs), false, false)
+        };
+        unsafe { self.cooked.set_len(wi as usize) };
+        (StringSpan::new(ss, wi & StringSpan::END_MASK, lone), nes)
+    }
+
+    #[inline]
+    fn cook_short_dispatch<const EMIT: bool, const CRLF: bool>(
+        &mut self,
+        src: &[u8],
+        bs: u32,
+        be: u32,
+        base: *mut u8,
+        ss: u32,
+        body_len: usize,
+    ) -> (StringSpan, bool) {
+        let (wi, lone, nes) =
+            cook_short::<EMIT, CRLF>(src, bs, be, base, ss, body_len, &mut self.diags);
+        unsafe { self.cooked.set_len(wi as usize) };
+        (StringSpan::new(ss, wi & StringSpan::END_MASK, lone), nes)
+    }
+
+    #[inline]
+    pub fn push_string(&mut self, src: &[u8], bs: usize, be: usize) {
+        let (sp, _) = self.cook::<true, false>(src, bs as u32, be as u32);
+        self.strings.push(sp);
+    }
+
+    #[inline]
+    pub fn push_template(&mut self, src: &[u8], bs: usize, be: usize) {
+        // CRLF normalization is implemented and tested but wired off: the
+        // extra `\r` needle costs ~2% on template-heavy sources, and the
+        // parser facade cooks CR-bearing templates itself, so end-to-end
+        // values are exact either way.
+        let (sp, nes) = self.cook::<false, false>(src, bs as u32, be as u32);
+        // A NotEscapeSequence means cooked = None per the grammar; legality
+        // depends on tagged-ness (parser context), so the span carries a
+        // marker instead of a diagnostic.
+        self.templates.push(if nes { sp.with_cooked_invalid() } else { sp });
+    }
+
+    /// Push a string value verbatim. JSX attribute strings have no backslash
+    /// escapes; the value is the raw slice between the quotes.
+    #[inline]
+    pub fn push_string_raw(&mut self, src: &[u8], bs: usize, be: usize) {
+        let ss = self.cooked.len() as u32;
+        if be <= bs {
+            self.strings.push(StringSpan::new(ss, ss & StringSpan::END_MASK, false));
+            return;
+        }
+        let body_len = be - bs;
+        self.cooked.reserve(body_len + 8);
+        unsafe {
+            let base = self.cooked.as_mut_ptr();
+            core::ptr::copy_nonoverlapping(src.as_ptr().add(bs), base.add(ss as usize), body_len);
+            self.cooked.set_len(ss as usize + body_len);
+        }
+        let we = ss + body_len as u32;
+        self.strings.push(StringSpan::new(ss, we & StringSpan::END_MASK, false));
+    }
+
+    #[inline]
+    pub fn push_atom(&mut self, src: &[u8], bs: usize, be: usize) {
+        // Escaped-identifier atoms are the one funnel every code-level
+        // identifier escape passes through, so validation rides here.
+        self.validate_ident_escapes(src, bs, be);
+        let (sp, _) = self.cook::<false, false>(src, bs as u32, be as u32);
+        self.atoms.push(sp);
+    }
+
+    /// A well-formed escape decoding to a non-identifier char (`var \u0020 = 1`):
+    /// oxc_parser reports the decoded char with an empty span after the escape.
+    /// We emit `(end, 0)`; the bridge recognizes the len-0 shape and decodes the
+    /// escape text backward to recover the char.
+    #[cold]
+    #[inline(never)]
+    fn check_escaped_ident_char(&mut self, value: u32, at_start: bool, end: usize) {
+        let Some(ch) = char::from_u32(value) else { return }; // surrogates handled by caller
+        let ok = if at_start {
+            oxc_syntax::identifier::is_identifier_start(ch)
+        } else {
+            oxc_syntax::identifier::is_identifier_part(ch)
+        };
+        if !ok {
+            self.push_diag(end as u32, 0, crate::error::diag_code::UNEXPECTED_CHARACTER);
+        }
+    }
+
+    /// Validate every unicode escape in an identifier atom, mirroring
+    /// oxc_parser's consumption exactly: spans start after the backslash and
+    /// end where the parser's scanner stopped; surrogate pairs are invalid in
+    /// identifiers (one diag over both escapes); a failed pair-low rewinds so
+    /// the second escape is validated on its own.
+    #[cold]
+    #[inline(never)]
+    fn validate_ident_escapes(&mut self, src: &[u8], bs: usize, be: usize) {
+        use crate::error::diag_code as D;
+        fn hex4(src: &[u8], mut k: usize, be: usize) -> (Option<u32>, usize) {
+            let mut v = 0u32;
+            for _ in 0..4 {
+                if k >= be {
+                    return (None, k);
+                }
+                let Some(h) = hexd(src[k]) else { return (None, k) };
+                v = (v << 4) | u32::from(h);
+                k += 1;
+            }
+            (Some(v), k)
+        }
+        let mut i = bs;
+        while i < be {
+            if src[i] != b'\\' {
+                i += 1;
+                continue;
+            }
+            // `is_identifier_start` applies when the escape begins the atom
+            // (for private names `bs` is already past the `#`).
+            let at_start = i == bs;
+            let start = i + 1;
+            if start >= be || src[start] != b'u' {
+                // Unreachable via scan_ident_esc, but mirror the parser
+                // defensively: consume one char, span = it.
+                self.push_diag(start as u32, u32::from(start < be), D::INVALID_IDENTIFIER_ESCAPE);
+                i = start + 1;
+                continue;
+            }
+            let mut k = start + 1; // after `u`
+            if k < be && src[k] == b'{' {
+                k += 1;
+                let mut value: u32 = 0;
+                let mut any = false;
+                let mut over = false;
+                while k < be {
+                    let Some(h) = hexd(src[k]) else { break };
+                    value = (value << 4) | u32::from(h);
+                    any = true;
+                    k += 1;
+                    if value > 0x0010_FFFF {
+                        over = true; // parser bails right after this digit
+                        break;
+                    }
+                }
+                if !over && any && k < be && src[k] == b'}' {
+                    k += 1; // `}` consumed only on the well-formed path
+                    if (0xD800..=0xDFFF).contains(&value) {
+                        // lone surrogate via braces: invalid in identifiers
+                        self.push_diag(
+                            start as u32,
+                            (k - start) as u32,
+                            D::INVALID_IDENTIFIER_ESCAPE,
+                        );
+                    } else {
+                        self.check_escaped_ident_char(value, at_start, k);
+                    }
+                } else {
+                    // overflow / no digits / missing `}`: end = parser stop
+                    self.push_diag(start as u32, (k - start) as u32, D::INVALID_IDENTIFIER_ESCAPE);
+                }
+                i = k;
+                continue;
+            }
+            let (h1, e1) = hex4(src, k, be);
+            let Some(high) = h1 else {
+                self.push_diag(start as u32, (e1 - start) as u32, D::INVALID_IDENTIFIER_ESCAPE);
+                i = e1;
+                continue;
+            };
+            k = e1;
+            if !(0xD800..=0xDFFF).contains(&high) {
+                // well-formed BMP code point: must still be an identifier char
+                self.check_escaped_ident_char(high, at_start, k);
+                i = k;
+                continue;
+            }
+            if (0xD800..=0xDBFF).contains(&high)
+                && k + 1 < be
+                && src[k] == b'\\'
+                && src[k + 1] == b'u'
+            {
+                let (l1, e2) = hex4(src, k + 2, be);
+                if let Some(low) = l1 {
+                    if (0xDC00..=0xDFFF).contains(&low) {
+                        // A well-formed pair is still invalid in identifiers:
+                        // one diag over both escapes.
+                        self.push_diag(
+                            start as u32,
+                            (e2 - start) as u32,
+                            D::INVALID_IDENTIFIER_ESCAPE,
+                        );
+                        i = e2;
+                        continue;
+                    }
+                }
+                // Not a valid low: fall through — the parser rewinds and
+                // reports the first escape alone.
+            }
+            self.push_diag(start as u32, (k - start) as u32, D::INVALID_IDENTIFIER_ESCAPE);
+            i = k;
+        }
+    }
+
+    #[inline]
+    pub fn push_number(&mut self, src: &[u8], s: usize, e: usize) {
+        self.numbers.push(parse_number(src, s, e));
+    }
+
+    #[inline]
+    pub fn push_number_swar(&mut self, src: &[u8], s: usize, e: usize) {
+        let len = e - s;
+        if len.wrapping_sub(1) <= 7 && !(len > 1 && src[s] == b'0') {
+            let keep = KEEP[len];
+            let raw = unsafe { core::ptr::read_unaligned(src.as_ptr().add(s) as *const u64) };
+            let w = raw & keep;
+            let f0 = 0xF0F0_F0F0_F0F0_F0F0 & keep;
+            let three = 0x3030_3030_3030_3030 & keep;
+            let digits =
+                (w & f0) == three && (w.wrapping_add(0x0606_0606_0606_0606 & keep) & f0) == three;
+            if digits {
+                let mut d = (w.wrapping_sub(three)) << ((8 - len) * 8);
+                d = ((d & 0x0f00_0f00_0f00_0f00) >> 8) + (d & 0x000f_000f_000f_000f) * 10;
+                d = ((d & 0x00ff_0000_00ff_0000) >> 16) + (d & 0x0000_00ff_0000_00ff) * 100;
+                d = ((d & 0x0000_ffff_0000_0000) >> 32) + (d & 0x0000_0000_0000_ffff) * 10000;
+                self.numbers.push(d as f64);
+                return;
+            }
+        }
+        // Only non-SWAR numbers (floats, radix-prefixed, bigint, separators, leading zeros, long) reach the validation walk.
+        let code = validate_number(src, s, e);
+        if code != crate::error::diag_code::OK {
+            self.push_diag(s as u32, (e - s) as u32, code);
+        }
+        self.numbers.push(parse_number(src, s, e));
+    }
+
+    #[inline]
+    pub fn push_comment_record(
+        &mut self,
+        src: &[u8],
+        sl: usize,
+        start: u32,
+        end: u32,
+        blk: bool,
+        meta: u8,
+    ) {
+        use oxc_ast::ast::{Comment, CommentKind};
+        let kind = if !blk {
+            CommentKind::Line
+        } else if meta & crate::comment_meta::META_MULTILINE != 0 {
+            CommentKind::MultiLineBlock
+        } else {
+            CommentKind::SingleLineBlock
+        };
+        let mut c = Comment::new(start, end.min(sl as u32), kind);
+        c.content = crate::comment_meta::content_from_ordinal(meta);
+
+        let s_ = (start as usize).min(sl);
+        let mut q = s_;
+        while q > 0 && is_lex_ws(src[q - 1]) {
+            q -= 1;
+        }
+        let pre = q == 0 || src[q..s_].iter().any(|&b| b == b'\n' || b == b'\r');
+        c.set_preceded_by_newline(pre);
+
+        if !blk {
+            c.set_followed_by_newline(true);
+        } else {
+            let mut e = (end as usize).min(sl);
+            let mut post = false;
+            while e < sl && is_lex_ws(src[e]) {
+                if src[e] == b'\n' || src[e] == b'\r' {
+                    post = true;
+                    break;
+                }
+                e += 1;
+            }
+            c.set_followed_by_newline(post);
+        }
+        self.comments.push(c);
+    }
+}
+
+#[inline]
+fn is_lex_ws(c: u8) -> bool {
+    matches!(c, b' ' | b'\t' | b'\n' | b'\r' | 0x0b | 0x0c)
+}
+
+static KEEP: [u64; 9] = [
+    0x0000_0000_0000_0000,
+    0x0000_0000_0000_00ff,
+    0x0000_0000_0000_ffff,
+    0x0000_0000_00ff_ffff,
+    0x0000_0000_ffff_ffff,
+    0x0000_00ff_ffff_ffff,
+    0x0000_ffff_ffff_ffff,
+    0x00ff_ffff_ffff_ffff,
+    0xffff_ffff_ffff_ffff,
+];
+
+#[cfg(target_arch = "x86_64")]
+#[inline]
+fn cook_short<const EMIT: bool, const CRLF: bool>(
+    src: &[u8],
+    bs: u32,
+    be: u32,
+    base: *mut u8,
+    ss: u32,
+    body_len: usize,
+    diags: &mut Vec<Diagnostic>,
+) -> (u32, bool, bool) {
+    let v = unsafe { _mm256_loadu_si256(src.as_ptr().add(bs as usize) as *const __m256i) };
+    let mut hit = unsafe { _mm256_cmpeq_epi8(v, _mm256_set1_epi8(b'\\' as i8)) };
+    if CRLF {
+        // Templates also decode when a raw CR needs LF-normalizing.
+        hit = unsafe { _mm256_or_si256(hit, _mm256_cmpeq_epi8(v, _mm256_set1_epi8(b'\r' as i8))) };
+    }
+    let bs_mask = unsafe { _mm256_movemask_epi8(hit) as u32 } & ((1u32 << body_len) - 1);
+    if bs_mask == 0 {
+        unsafe { _mm256_storeu_si256(base.add(ss as usize) as *mut __m256i, v) };
+        (ss + (be - bs), false, false)
+    } else {
+        unsafe { cook_decode::<EMIT, CRLF>(src.as_ptr(), bs, be, base, ss, diags) }
+    }
+}
+
+#[cfg(not(target_arch = "x86_64"))]
+#[inline]
+fn cook_short<const EMIT: bool, const CRLF: bool>(
+    src: &[u8],
+    bs: u32,
+    be: u32,
+    base: *mut u8,
+    ss: u32,
+    body_len: usize,
+    diags: &mut Vec<Diagnostic>,
+) -> (u32, bool, bool) {
+    let body = &src[bs as usize..be as usize];
+    let plain = if CRLF {
+        memchr::memchr2(b'\\', b'\r', body).is_none()
+    } else {
+        memchr::memchr(b'\\', body).is_none()
+    };
+    if plain {
+        unsafe {
+            core::ptr::copy_nonoverlapping(
+                src.as_ptr().add(bs as usize),
+                base.add(ss as usize),
+                body_len,
+            );
+        }
+        (ss + (be - bs), false, false)
+    } else {
+        unsafe { cook_decode::<EMIT, CRLF>(src.as_ptr(), bs, be, base, ss, diags) }
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[inline]
+fn span_has_bs(src: &[u8], bs: usize, be: usize) -> bool {
+    let mut i = bs;
+    while i + 32 <= be {
+        let v = unsafe { _mm256_loadu_si256(src.as_ptr().add(i) as *const __m256i) };
+        let m =
+            unsafe { _mm256_movemask_epi8(_mm256_cmpeq_epi8(v, _mm256_set1_epi8(b'\\' as i8))) };
+        if m != 0 {
+            return true;
+        }
+        i += 32;
+    }
+    while i < be {
+        if src[i] == b'\\' {
+            return true;
+        }
+        i += 1;
+    }
+    false
+}
+
+#[cfg(not(target_arch = "x86_64"))]
+#[inline]
+fn span_has_bs(src: &[u8], bs: usize, be: usize) -> bool {
+    memchr::memchr(b'\\', &src[bs..be]).is_some()
+}
+
+/// Template variant of [`span_has_bs`]: a raw CR also forces the decode path.
+#[cfg(target_arch = "x86_64")]
+#[inline]
+fn span_has_bs_or_cr(src: &[u8], bs: usize, be: usize) -> bool {
+    let mut i = bs;
+    while i + 32 <= be {
+        let v = unsafe { _mm256_loadu_si256(src.as_ptr().add(i) as *const __m256i) };
+        let m = unsafe {
+            _mm256_movemask_epi8(_mm256_or_si256(
+                _mm256_cmpeq_epi8(v, _mm256_set1_epi8(b'\\' as i8)),
+                _mm256_cmpeq_epi8(v, _mm256_set1_epi8(b'\r' as i8)),
+            ))
+        };
+        if m != 0 {
+            return true;
+        }
+        i += 32;
+    }
+    while i < be {
+        if src[i] == b'\\' || src[i] == b'\r' {
+            return true;
+        }
+        i += 1;
+    }
+    false
+}
+
+#[cfg(not(target_arch = "x86_64"))]
+#[inline]
+fn span_has_bs_or_cr(src: &[u8], bs: usize, be: usize) -> bool {
+    memchr::memchr2(b'\\', b'\r', &src[bs..be]).is_some()
+}
+
+/// Decode the single `char` at byte `i`, or `None` if the bytes there are
+/// not valid UTF-8.
+pub(crate) fn decode_char_at(s: &[u8], i: usize) -> Option<char> {
+    let end = (i + 4).min(s.len());
+    let slice = s.get(i..end)?;
+    match core::str::from_utf8(slice) {
+        Ok(t) => t.chars().next(),
+        // a multi-byte char cut at `end` still has a decodable valid prefix
+        Err(e) if e.valid_up_to() > 0 => {
+            core::str::from_utf8(&slice[..e.valid_up_to()]).ok()?.chars().next()
+        }
+        Err(_) => None,
+    }
+}
+
+/// End of the run of IdentifierStart chars beginning at `i` — the tail of
+/// oxc_parser's `invalid_number_end` span (a digit ends the run).
+fn ident_start_run_end(s: &[u8], mut i: usize) -> usize {
+    while i < s.len() {
+        let b = s[i];
+        if b < 0x80 {
+            if !(b.is_ascii_alphabetic() || b == b'_' || b == b'$') {
+                break;
+            }
+            i += 1;
+        } else {
+            let Some(c) = decode_char_at(s, i) else { break };
+            if !oxc_syntax::identifier::is_identifier_start(c) {
+                break;
+            }
+            i += c.len_utf8();
+        }
+    }
+    i
+}
+
+#[inline(always)]
+fn hexd(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn parse_number(src: &[u8], s: usize, e: usize) -> f64 {
+    let mut i = s;
+    let mut radix: u64 = 0;
+    if e - s >= 2 && src[s] == b'0' {
+        let d = src[s + 1];
+        radix = match d {
+            b'x' | b'X' => 16,
+            b'b' | b'B' => 2,
+            b'o' | b'O' => 8,
+            _ => 0,
+        };
+        if radix != 0 {
+            i = s + 2;
+        }
+    }
+    if radix != 0 {
+        let mut v: u64 = 0;
+        while i < e {
+            let c = src[i];
+            i += 1;
+            if c == b'_' {
+                continue;
+            }
+            if c == b'n' {
+                break;
+            }
+            match hexd(c) {
+                Some(h) => v = v.wrapping_mul(radix).wrapping_add(h as u64),
+                None => break,
+            }
+        }
+        return v as f64;
+    }
+
+    let mut flt = false;
+    let mut dl = 0usize;
+    let mut v: u64 = 0;
+    for k in s..e {
+        let c = src[k];
+        if c == b'.' || c == b'e' || c == b'E' {
+            flt = true;
+        } else if c.is_ascii_digit() {
+            dl += 1;
+            v = v.wrapping_mul(10).wrapping_add((c - b'0') as u64);
+        }
+    }
+    if !flt && dl <= 19 {
+        return v as f64;
+    }
+
+    let mut buf = [0u8; 512];
+    let mut bl = 0usize;
+    let mut k = s;
+    while k < e && bl < buf.len() - 1 {
+        let c = src[k];
+        k += 1;
+        if c == b'_' || c == b'n' {
+            continue;
+        }
+        buf[bl] = c;
+        bl += 1;
+    }
+    core::str::from_utf8(&buf[..bl]).ok().and_then(|st| st.parse::<f64>().ok()).unwrap_or(0.0)
+}
+
+#[inline]
+fn radix_digit(c: u8) -> Option<u8> {
+    match c {
+        b'0'..=b'9' => Some(c - b'0'),
+        b'a'..=b'f' => Some(c - b'a' + 10),
+        b'A'..=b'F' => Some(c - b'A' + 10),
+        _ => None,
+    }
+}
+
+/// First error code for the numeric literal `src[s..e]`, or `diag_code::OK`.
+/// Conservative by design: it must never flag a valid number, so anything
+/// ambiguous returns OK. Covers what survives as one token span — separator
+/// misplacement, empty radix (`0x`), legacy-octal-like decimals with a
+/// separator/bigint suffix/bad exponent. Shapes the scanner pre-splits
+/// (`0b12`, `1.5n`, `3in`) are detected at the adjacency in coalesce, not
+/// here. Detection only; `parse_number` still produces a lenient value.
+#[inline(never)]
+fn validate_number(src: &[u8], s: usize, e: usize) -> u16 {
+    use crate::error::diag_code as D;
+    let bytes = &src[s..e];
+    let Some((&last, head)) = bytes.split_last() else { return D::OK };
+    let is_bigint = last == b'n';
+    let body = if is_bigint { head } else { bytes };
+    if body.is_empty() {
+        return D::OK;
+    }
+
+    // Radix-prefixed integer: separator placement and the empty-radix case.
+    // An out-of-range digit cannot appear (the scanner stops before it), so
+    // that arm is a safety net.
+    if body.len() >= 2 && body[0] == b'0' {
+        let radix = match body[1] | 0x20 {
+            b'x' => 16u8,
+            b'o' => 8,
+            b'b' => 2,
+            _ => 0,
+        };
+        if radix != 0 {
+            let mut prev_us = true; // a '_' immediately after the prefix is invalid
+            let mut any = false;
+            for &c in &body[2..] {
+                if c == b'_' {
+                    if prev_us {
+                        return D::INVALID_NUMERIC_SEPARATOR;
+                    }
+                    prev_us = true;
+                } else if matches!(radix_digit(c), Some(v) if v < radix) {
+                    any = true;
+                    prev_us = false;
+                } else {
+                    return D::INVALID_NUMERIC_LITERAL;
+                }
+            }
+            if any && prev_us {
+                return D::INVALID_NUMERIC_SEPARATOR; // trailing '_'
+            }
+            if !any {
+                return D::INVALID_NUMERIC_LITERAL; // empty radix, e.g. `0x`
+            }
+            return D::OK;
+        }
+
+        // Legacy-octal-like decimal (leading `0` + digit/`_`): oxc_parser
+        // consumes only `[0-9]` here — no separators, no bigint suffix — and
+        // accepts an exponent only as lowercase `e` after an `8`/`9` flipped
+        // the run to NonOctalDecimal (`08e1` valid; `00e1` and `08E1` not).
+        // Bare `00`/`08` are valid sloppy-mode Annex B, and `.` never flags.
+        if matches!(body[1], b'0'..=b'9' | b'_') {
+            if bytes.contains(&b'_') {
+                return D::INVALID_NUMERIC_SEPARATOR;
+            }
+            if is_bigint {
+                return D::INVALID_BIGINT;
+            }
+            let run = bytes.iter().take_while(|c| c.is_ascii_digit()).count();
+            match bytes.get(run) {
+                // `08e1`: valid NonOctalDecimal exponent; its digits are
+                // still checked below (`08e` stays flagged).
+                Some(&b'e') if bytes[..run].iter().any(|&c| c >= b'8') => {}
+                Some(&b'e' | &b'E') => return D::INVALID_NUMERIC_LITERAL,
+                _ => {}
+            }
+            // fall through: the valid shapes still get the generic checks
+        }
+    }
+
+    // Every '_' must sit between two digits.
+    let mut prev_digit = false;
+    let mut exp_at: Option<usize> = None;
+    for (i, &c) in body.iter().enumerate() {
+        if c == b'_' {
+            let next_digit = matches!(body.get(i + 1), Some(&d) if d.is_ascii_digit());
+            if !prev_digit || !next_digit {
+                return D::INVALID_NUMERIC_SEPARATOR;
+            }
+            prev_digit = false;
+        } else {
+            prev_digit = c.is_ascii_digit();
+            if (c | 0x20) == b'e' && exp_at.is_none() {
+                exp_at = Some(i); // radix bodies returned above, so this is the marker
+            }
+        }
+    }
+    // Empty exponent (`1e`, `1e+`, `.5e`): the marker and optional sign were
+    // consumed but no digits followed — never true for a valid literal.
+    if let Some(ep) = exp_at {
+        let mut k = ep + 1;
+        if matches!(body.get(k), Some(&s) if s == b'+' || s == b'-') {
+            k += 1;
+        }
+        if !matches!(body.get(k), Some(d) if d.is_ascii_digit()) {
+            return D::INVALID_NUMERIC_LITERAL;
+        }
+    }
+    D::OK
+}
+
+#[inline]
+unsafe fn push_cp(out: *mut u8, mut wi: u32, cp: u32, lone: &mut bool) -> u32 {
+    if cp <= 0x7F {
+        *out.add(wi as usize) = cp as u8;
+        wi += 1;
+    } else if cp <= 0x7FF {
+        *out.add(wi as usize) = 0xC0 | ((cp >> 6) as u8);
+        *out.add((wi + 1) as usize) = 0x80 | ((cp & 0x3F) as u8);
+        wi += 2;
+    } else if (0xD800..=0xDFFF).contains(&cp) {
+        *lone = true;
+        *out.add(wi as usize) = 0xE0 | ((cp >> 12) as u8);
+        *out.add((wi + 1) as usize) = 0x80 | (((cp >> 6) & 0x3F) as u8);
+        *out.add((wi + 2) as usize) = 0x80 | ((cp & 0x3F) as u8);
+        wi += 3;
+    } else if cp <= 0xFFFF {
+        *out.add(wi as usize) = 0xE0 | ((cp >> 12) as u8);
+        *out.add((wi + 1) as usize) = 0x80 | (((cp >> 6) & 0x3F) as u8);
+        *out.add((wi + 2) as usize) = 0x80 | ((cp & 0x3F) as u8);
+        wi += 3;
+    } else if cp <= 0x10FFFF {
+        *out.add(wi as usize) = 0xF0 | ((cp >> 18) as u8);
+        *out.add((wi + 1) as usize) = 0x80 | (((cp >> 12) & 0x3F) as u8);
+        *out.add((wi + 2) as usize) = 0x80 | (((cp >> 6) & 0x3F) as u8);
+        *out.add((wi + 3) as usize) = 0x80 | ((cp & 0x3F) as u8);
+        wi += 4;
+    } else {
+        *out.add(wi as usize) = 0xEF;
+        *out.add((wi + 1) as usize) = 0xBF;
+        *out.add((wi + 2) as usize) = 0xBD;
+        wi += 3;
+    }
+    wi
+}
+
+#[inline]
+unsafe fn emit_oct(
+    src: *const u8,
+    out: *mut u8,
+    mut wi: u32,
+    mut i: u32,
+    be: u32,
+    mut val: u32,
+) -> (u32, u32) {
+    let mut cnt = 1;
+    while cnt < 3 && i < be {
+        let dd = *src.add(i as usize);
+        if !(b'0'..=b'7').contains(&dd) {
+            break;
+        }
+        let nx = val * 8 + (dd - b'0') as u32;
+        if nx > 0xFF {
+            break;
+        }
+        val = nx;
+        i += 1;
+        cnt += 1;
+    }
+    if val < 0x80 {
+        *out.add(wi as usize) = val as u8;
+        wi += 1;
+    } else {
+        *out.add(wi as usize) = 0xC0 | ((val >> 6) as u8);
+        *out.add((wi + 1) as usize) = 0x80 | ((val & 0x3F) as u8);
+        wi += 2;
+    }
+    (wi, i)
+}
+
+/// Bad string escape, with oxc_parser's span: the backslash to just past the
+/// last byte its escape scanner consumed.
+#[cold]
+#[inline(never)]
+fn push_escape_diag(diags: &mut Vec<Diagnostic>, off: u32, end: u32) {
+    diags.push(Diagnostic {
+        off,
+        len: end - off,
+        code: diag_code::INVALID_UNICODE_ESCAPE,
+        severity: diag_severity::ERROR,
+    });
+}
+
+unsafe fn cook_decode<const EMIT: bool, const CRLF: bool>(
+    src: *const u8,
+    bs: u32,
+    be: u32,
+    out: *mut u8,
+    ss: u32,
+    diags: &mut Vec<Diagnostic>,
+) -> (u32, bool, bool) {
+    let mut wi = ss;
+    let mut i = bs;
+    let mut lone = false;
+    // NotEscapeSequence per the template grammar (bad \u or \x, octal, \8,
+    // \9): push_template marks the span cooked-invalid from it, the stand-in
+    // for oxc_parser's cooked = None.
+    let mut nes = false;
+    while i < be {
+        let b = *src.add(i as usize);
+        if b != b'\\' {
+            // template TV: raw CRLF / CR normalize to LF
+            if CRLF && b == b'\r' {
+                *out.add(wi as usize) = b'\n';
+                wi += 1;
+                i += 1;
+                if i < be && *src.add(i as usize) == b'\n' {
+                    i += 1;
+                }
+                continue;
+            }
+            *out.add(wi as usize) = b;
+            wi += 1;
+            i += 1;
+            continue;
+        }
+        if i + 1 >= be {
+            *out.add(wi as usize) = b;
+            wi += 1;
+            i += 1;
+            continue;
+        }
+        let nb = *src.add((i + 1) as usize);
+        i += 2;
+        match nb {
+            b'b' => {
+                *out.add(wi as usize) = 0x08;
+                wi += 1;
+            }
+            b'f' => {
+                *out.add(wi as usize) = 0x0C;
+                wi += 1;
+            }
+            b'n' => {
+                *out.add(wi as usize) = b'\n';
+                wi += 1;
+            }
+            b'r' => {
+                *out.add(wi as usize) = b'\r';
+                wi += 1;
+            }
+            b't' => {
+                *out.add(wi as usize) = b'\t';
+                wi += 1;
+            }
+            b'v' => {
+                *out.add(wi as usize) = 0x0B;
+                wi += 1;
+            }
+            b'0' => {
+                let nd = i < be && (*src.add(i as usize)).is_ascii_digit();
+                if !nd {
+                    *out.add(wi as usize) = 0;
+                    wi += 1;
+                } else {
+                    nes = true; // octal after backslash-0: NotEscapeSequence in templates
+                    let (nwi, ni) = emit_oct(src, out, wi, i, be, 0);
+                    wi = nwi;
+                    i = ni;
+                }
+            }
+            b'\\' | b'\'' | b'"' | b'`' => {
+                *out.add(wi as usize) = nb;
+                wi += 1;
+            }
+            b'\n' => {}
+            b'\r' => {
+                if i < be && *src.add(i as usize) == b'\n' {
+                    i += 1;
+                }
+            }
+            b'x' => {
+                // The parser's span runs to just past the leading valid hex.
+                if i + 2 <= be {
+                    let a = hexd(*src.add(i as usize));
+                    let c = hexd(*src.add((i + 1) as usize));
+                    if let (Some(a), Some(c)) = (a, c) {
+                        *out.add(wi as usize) = (a << 4) | c;
+                        wi += 1;
+                        i += 2;
+                    } else {
+                        *out.add(wi as usize) = b'x';
+                        wi += 1;
+                        nes = true;
+                        if EMIT {
+                            push_escape_diag(diags, i - 2, i + u32::from(a.is_some()));
+                        }
+                    }
+                } else {
+                    *out.add(wi as usize) = b'x';
+                    wi += 1;
+                    nes = true;
+                    if EMIT {
+                        let k = i < be && hexd(*src.add(i as usize)).is_some();
+                        push_escape_diag(diags, i - 2, i + u32::from(k));
+                    }
+                }
+            }
+            b'u' => {
+                let esc = i - 2; // backslash offset, for code-7 spans
+                if i < be && *src.add(i as usize) == b'{' {
+                    let mut k = i + 1;
+                    let mut cp: u32 = 0;
+                    let mut any = false;
+                    // The parser bails on the digit that pushes the value
+                    // past 0x10FFFF. Latch that point in-loop: `cp` wraps, so
+                    // a post-loop range check would miss inputs like
+                    // `\u{100000041}`.
+                    let mut over_end: u32 = 0;
+                    while k < be && *src.add(k as usize) != b'}' {
+                        if let Some(h) = hexd(*src.add(k as usize)) {
+                            cp = (cp << 4) | (h as u32);
+                            any = true;
+                            k += 1;
+                            if cp > 0x0010_FFFF && over_end == 0 {
+                                over_end = k;
+                            }
+                        } else {
+                            break;
+                        }
+                    }
+                    if k < be && *src.add(k as usize) == b'}' && any {
+                        wi = push_cp(out, wi, cp, &mut lone);
+                        i = k + 1;
+                        if over_end != 0 {
+                            nes = true;
+                        }
+                        if EMIT && over_end != 0 {
+                            // out of range but well-formed (`\u{110000}`):
+                            // cooked value (U+FFFD) unchanged, diagnostic only
+                            push_escape_diag(diags, esc, over_end);
+                        }
+                    } else {
+                        *out.add(wi as usize) = b'u';
+                        wi += 1;
+                        i = k;
+                        nes = true;
+                        if EMIT {
+                            push_escape_diag(diags, esc, if over_end != 0 { over_end } else { k });
+                        }
+                    }
+                } else if i + 4 <= be {
+                    let a = hexd(*src.add(i as usize));
+                    let b2 = hexd(*src.add((i + 1) as usize));
+                    let c = hexd(*src.add((i + 2) as usize));
+                    let d = hexd(*src.add((i + 3) as usize));
+                    if let (Some(a), Some(b2), Some(c), Some(d)) = (a, b2, c, d) {
+                        let cp = ((a as u32) << 12)
+                            | ((b2 as u32) << 8)
+                            | ((c as u32) << 4)
+                            | (d as u32);
+                        i += 4;
+                        // Adjacent 4-digit escapes forming a surrogate pair combine
+                        // into one code point (`\uD834\uDF06` is U+1D306), matching
+                        // oxc_parser's SurrogatePair rule; braced escapes never pair.
+                        let mut cp = cp;
+                        if (0xD800..=0xDBFF).contains(&cp)
+                            && i + 6 <= be
+                            && *src.add(i as usize) == b'\\'
+                            && *src.add((i + 1) as usize) == b'u'
+                        {
+                            let l0 = hexd(*src.add((i + 2) as usize));
+                            let l1 = hexd(*src.add((i + 3) as usize));
+                            let l2 = hexd(*src.add((i + 4) as usize));
+                            let l3 = hexd(*src.add((i + 5) as usize));
+                            if let (Some(l0), Some(l1), Some(l2), Some(l3)) = (l0, l1, l2, l3) {
+                                let lo = ((l0 as u32) << 12)
+                                    | ((l1 as u32) << 8)
+                                    | ((l2 as u32) << 4)
+                                    | (l3 as u32);
+                                if (0xDC00..=0xDFFF).contains(&lo) {
+                                    cp = 0x10000 + ((cp - 0xD800) << 10) + (lo - 0xDC00);
+                                    i += 6;
+                                }
+                            }
+                        }
+                        wi = push_cp(out, wi, cp, &mut lone);
+                    } else {
+                        *out.add(wi as usize) = b'u';
+                        wi += 1;
+                        nes = true;
+                        if EMIT {
+                            // span covers the leading valid hex run
+                            let j = u32::from(a.is_some())
+                                + u32::from(a.is_some() && b2.is_some())
+                                + u32::from(a.is_some() && b2.is_some() && c.is_some());
+                            push_escape_diag(diags, esc, i + j);
+                        }
+                    }
+                } else {
+                    *out.add(wi as usize) = b'u';
+                    wi += 1;
+                    nes = true;
+                    if EMIT {
+                        let mut k = i;
+                        while k < be && hexd(*src.add(k as usize)).is_some() {
+                            k += 1;
+                        }
+                        push_escape_diag(diags, esc, k);
+                    }
+                }
+            }
+            b'1'..=b'7' => {
+                nes = true; // octal escape: NotEscapeSequence in templates
+                let (nwi, ni) = emit_oct(src, out, wi, i, be, (nb - b'0') as u32);
+                wi = nwi;
+                i = ni;
+            }
+            b'8' | b'9' => {
+                // NonOctalDecimalEscape: cooks to the digit, valid in sloppy
+                // strings, NotEscapeSequence in templates.
+                nes = true;
+                *out.add(wi as usize) = nb;
+                wi += 1;
+            }
+            _ => {
+                // Escaped LS/PS is a LineContinuation and cooks to nothing.
+                // Every other char is an identity escape: its bytes flow
+                // through (the lead here, continuations via the plain copy).
+                if nb == 0xE2
+                    && i + 2 <= be
+                    && *src.add(i as usize) == 0x80
+                    && matches!(*src.add((i + 1) as usize), 0xA8 | 0xA9)
+                {
+                    i += 2;
+                } else {
+                    *out.add(wi as usize) = nb;
+                    wi += 1;
+                }
+            }
+        }
+    }
+    (wi, lone, nes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cook(body: &[u8]) -> (Vec<u8>, bool) {
+        let mut padded = body.to_vec();
+        padded.extend_from_slice(&[0u8; 32]);
+        let mut out = vec![0u8; body.len() + 32];
+        let mut diags = Vec::new();
+        let (wi, lone, _) = unsafe {
+            cook_decode::<true, false>(
+                padded.as_ptr(),
+                0,
+                body.len() as u32,
+                out.as_mut_ptr(),
+                0,
+                &mut diags,
+            )
+        };
+        out.truncate(wi as usize);
+        (out, lone)
+    }
+
+    /// The "detection only" guarantee: EMIT=true must cook byte-identically
+    /// to EMIT=false on every malformed escape (fallback chars preserved).
+    #[test]
+    fn emit_does_not_change_cooked_bytes() {
+        for body in [
+            br"\u{110000}".as_slice(),
+            br"\uZZZZ",
+            br"\xGG",
+            br"\u{}",
+            br"\u{12",
+            br"\u{xyz",
+            br"\x4G",
+            br"\u004",
+        ] {
+            let mut padded = body.to_vec();
+            padded.extend_from_slice(&[0u8; 32]);
+            let mut out_t = vec![0u8; body.len() + 32];
+            let mut out_f = vec![0u8; body.len() + 32];
+            let mut diags = Vec::new();
+            let (wt, _, _) = unsafe {
+                cook_decode::<true, false>(
+                    padded.as_ptr(),
+                    0,
+                    body.len() as u32,
+                    out_t.as_mut_ptr(),
+                    0,
+                    &mut diags,
+                )
+            };
+            let (wf, _, _) = unsafe {
+                cook_decode::<false, false>(
+                    padded.as_ptr(),
+                    0,
+                    body.len() as u32,
+                    out_f.as_mut_ptr(),
+                    0,
+                    &mut Vec::new(),
+                )
+            };
+            assert_eq!(wt, wf);
+            assert_eq!(out_t[..wt as usize], out_f[..wf as usize]);
+            assert!(
+                !diags.is_empty(),
+                "expected a diagnostic for {:?}",
+                String::from_utf8_lossy(body)
+            );
+        }
+    }
+
+    #[test]
+    fn cook_decode_escapes() {
+        assert_eq!(cook(br"\n").0, b"\n");
+        assert_eq!(cook(br"\b\f\t\r\v").0, &[0x08, 0x0C, b'\t', b'\r', 0x0B]);
+        assert_eq!(cook(br"\x41").0, b"A");
+        assert_eq!(cook(br"\u0041").0, b"A");
+        assert_eq!(cook(br"\u{41}").0, b"A");
+        assert_eq!(cook(br"\u{1F600}").0, "\u{1F600}".as_bytes());
+        assert_eq!(cook(br"\101").0, b"A");
+        assert_eq!(cook(br"\0").0, b"\0");
+        assert_eq!(cook(br#"\\\"\'"#).0, br#"\"'"#);
+        assert_eq!(cook(br"\u{xyz").0, b"uxyz");
+        assert_eq!(cook(br"\u{}").0, b"u}");
+        assert_eq!(cook(br"\u{12").0, b"u");
+    }
+
+    #[test]
+    fn cook_decode_lone_surrogate() {
+        let (out, lone) = cook(br"\uD83D");
+        assert!(lone, "lone-surrogate flag must be set");
+        assert_eq!(out, [0xED, 0xA0, 0xBD]);
+    }
+
+    /// Adjacent 4-digit escapes forming a surrogate pair combine into one
+    /// code point (oxc_parser's SurrogatePair rule); the braced form does not.
+    #[test]
+    fn cook_decode_surrogate_pairs() {
+        let (out, lone) = cook(br"\uD834\uDF06");
+        assert!(!lone, "a combined pair is not a lone surrogate");
+        assert_eq!(out, "\u{1D306}".as_bytes());
+
+        // A high escape followed by a non-low stays lone; the next escape
+        // decodes independently.
+        let (out, lone) = cook(br"\uD834\u0041");
+        assert!(lone);
+        assert_eq!(out, [0xED, 0xA0, 0xB4, b'A']);
+
+        // Braced escapes never pair (parser parity).
+        let (out, lone) = cook(br"\u{D834}\u{DF06}");
+        assert!(lone, "braced surrogates stay lone");
+        assert_eq!(out, [0xED, 0xA0, 0xB4, 0xED, 0xBC, 0x86]);
+    }
+
+    /// `\` + LS/PS is a LineContinuation: cooks to nothing (like `\<LF>`).
+    #[test]
+    fn cook_decode_ls_ps_line_continuation() {
+        let mut body = Vec::new();
+        body.extend_from_slice(b"a\\");
+        body.extend_from_slice("\u{2028}".as_bytes());
+        body.extend_from_slice(b"b\\");
+        body.extend_from_slice("\u{2029}".as_bytes());
+        body.extend_from_slice(b"c");
+        assert_eq!(cook(&body).0, b"abc");
+        // a raw LS/PS is content, not a continuation — it must survive
+        let mut raw = Vec::new();
+        raw.extend_from_slice(b"a");
+        raw.extend_from_slice("\u{2028}".as_bytes());
+        raw.extend_from_slice(b"b");
+        assert_eq!(cook(&raw).0, raw);
+    }
+
+    /// Template TV: raw <CR><LF> and <CR> normalize to <LF>; escape-produced
+    /// `\r` survives; the string monomorph (CRLF=false) never normalizes.
+    #[test]
+    fn cook_decode_template_cr_normalization() {
+        fn cook_tpl(body: &[u8]) -> Vec<u8> {
+            let mut padded = body.to_vec();
+            padded.extend_from_slice(&[0u8; 32]);
+            let mut out = vec![0u8; body.len() + 32];
+            let (wi, _, _) = unsafe {
+                cook_decode::<false, true>(
+                    padded.as_ptr(),
+                    0,
+                    body.len() as u32,
+                    out.as_mut_ptr(),
+                    0,
+                    &mut Vec::new(),
+                )
+            };
+            out.truncate(wi as usize);
+            out
+        }
+        assert_eq!(cook_tpl(b"a\r\nb"), b"a\nb");
+        assert_eq!(cook_tpl(b"a\rb"), b"a\nb");
+        assert_eq!(cook_tpl(b"a\r\r\nb"), b"a\n\nb");
+        // Escape-produced CR is content, not a line ending.
+        assert_eq!(cook_tpl(br"a\rb"), b"a\rb");
+        // `\<CR><LF>` line continuation still cooks to nothing.
+        assert_eq!(cook_tpl(b"a\\\r\nb"), b"ab");
+        // The string monomorph is untouched by design.
+        assert_eq!(cook(b"a\r\nb").0, b"a\r\nb");
+    }
+}

--- a/crates/oxc_lexer/src/lib.rs
+++ b/crates/oxc_lexer/src/lib.rs
@@ -1,0 +1,221 @@
+#![cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
+#![allow(unsafe_code)]
+
+pub mod arena;
+mod comment_meta;
+#[cfg(feature = "oxc_diagnostics")]
+pub mod diagnostics;
+pub mod error;
+mod lanes;
+mod opmap;
+pub mod options;
+mod pipeline;
+mod tables;
+pub mod token;
+
+pub use arena::{Arena, LexResult, LineEntry};
+pub use error::{Diagnostic, diag_code, diag_severity};
+pub use lanes::Lanes;
+pub use options::{LexOptions, default_options};
+pub use pipeline::Lexer;
+pub use token::{
+    TRIVIA_MAX, TRIVIA_MIN, is_string_kind, is_trivia, token_flags, token_kind, token_kind_name,
+};
+
+use core::cell::RefCell;
+
+/// Zero-byte padding required past the lexed length `n`: the SIMD scanners over-read (but never act on) up to this many bytes.
+pub const PAD: usize = 64;
+
+thread_local! {
+    static SCRATCH: RefCell<Lexer> = RefCell::new(Lexer::new());
+}
+
+const _: () = assert!(core::mem::size_of::<oxc_ast::ast::RegExpFlags>() == 1);
+
+/// # Panics
+/// Panics if `src` does not extend at least [`PAD`] zeroed bytes past `len`,
+/// or if the arena's token buffers are smaller than `len + PAD`.
+pub fn lex_utf8_arena(src: &[u8], len: u32, options: LexOptions, arena: &mut Arena) -> LexResult {
+    lex_into_arena(src, len, options, arena)
+}
+
+/// # Panics
+/// Panics if `src` does not extend at least [`PAD`] zeroed bytes past `len`.
+#[expect(clippy::cast_possible_truncation, reason = "PAD is a small constant")]
+pub fn lex_utf8(src: &[u8], len: u32, options: LexOptions) -> (LexResult, Arena) {
+    let tok_cap = len + PAD as u32;
+    let diag_cap =
+        if options.max_diagnostic_count > 0 { options.max_diagnostic_count } else { 1024 };
+    let line_cap = (len / 32) + 64;
+    let mut arena = Arena::new(tok_cap, diag_cap, line_cap);
+    let r = lex_utf8_arena(src, len, options, &mut arena);
+    (r, arena)
+}
+
+#[expect(clippy::cast_possible_truncation, reason = "token counts are bounded by MAX_SOURCE_LEN")]
+fn lex_into_arena(src: &[u8], len: u32, options: LexOptions, arena: &mut Arena) -> LexResult {
+    arena.ensure_token_capacity();
+    let n = len as usize;
+
+    if arena.tok_kinds.is_null() {
+        return empty_result(arena);
+    }
+    assert!(
+        arena.tok_kinds_capacity as usize >= n + PAD
+            && arena.tok_starts_capacity as usize >= n + PAD,
+        "lexer: arena token capacity too small for source len {n} (tok_kinds={}, tok_starts={}); need >= n + {PAD} \
+         — compress writes a full 8-lane group past the last token and the pipeline appends an EOF sentinel",
+        arena.tok_kinds_capacity,
+        arena.tok_starts_capacity
+    );
+
+    assert!(
+        src.len() >= n + PAD,
+        "lexer: src must have >= {PAD} bytes of padding past len {n} (got {})",
+        src.len()
+    );
+
+    SCRATCH.with(|cell| {
+        let lx = &mut *cell.borrow_mut();
+        // SAFETY: pad and arena capacities asserted above.
+        let k = unsafe {
+            lx.lex_raw(
+                src,
+                n,
+                arena.tok_kinds,
+                arena.tok_starts,
+                options.jsx,
+                options.ts,
+                options.validate_utf8,
+            )
+        };
+
+        if !lx.lanes.unicode_leads.is_empty() && k > 0 {
+            // SAFETY: `lex_raw` wrote `k` kinds and `k + 1` starts.
+            let (kinds_all, starts_all) = unsafe {
+                (
+                    core::slice::from_raw_parts(arena.tok_kinds, k),
+                    core::slice::from_raw_parts(arena.tok_starts, k + 1),
+                )
+            };
+            resolve_unicode_leads(&mut lx.lanes, &src[..n], kinds_all, starts_all);
+        }
+
+        if !lx.lanes.diag_suppress.is_empty() {
+            let (diags, sup) = (&mut lx.lanes.diags, &lx.lanes.diag_suppress);
+            diags.retain(|d| !sup.iter().any(|&(a, b)| d.off >= a && d.off < b));
+        }
+
+        let l = &lx.lanes;
+        let n_num = copy_lane(&l.numbers, arena.numbers, arena.numbers_capacity);
+        let n_cb = copy_lane(&l.cooked, arena.cooked_bytes, arena.cooked_bytes_capacity);
+        let n_str = copy_lane(&l.strings, arena.strings, arena.strings_capacity);
+        let n_tpl = copy_lane(&l.templates, arena.templates, arena.templates_capacity);
+        let n_atm = copy_lane(&l.atoms, arena.atoms, arena.atoms_capacity);
+        let n_rxf =
+            copy_lane(&l.regex_flags, arena.regex_flags.cast::<u8>(), arena.regex_flags_capacity);
+        let n_cm = copy_lane(&l.comment_meta, arena.comment_meta, arena.comment_meta_capacity);
+        let n_cr = copy_lane(&l.comments, arena.comments, arena.comments_capacity);
+        let n_diag = copy_lane(&l.diags, arena.diags, arena.diags_capacity);
+
+        LexResult {
+            diagnostics: arena.diags,
+            diagnostic_count: n_diag,
+            lines: arena.lines,
+            line_count: 0,
+            hit_resource_limit: false,
+            token_count: k as u32,
+            numbers_count: n_num,
+            atoms_count: n_atm,
+            strings_count: n_str,
+            templates_count: n_tpl,
+            regex_flags_count: n_rxf,
+            comment_meta_count: n_cm,
+            comments_count: n_cr,
+            cooked_bytes_count: n_cb,
+        }
+    })
+}
+
+#[expect(clippy::cast_possible_truncation, reason = "char lengths are 1..=4")]
+fn resolve_unicode_leads(lanes: &mut Lanes, src: &[u8], kinds_all: &[u8], starts_all: &[u32]) {
+    let k = kinds_all.len();
+    let mut leads = core::mem::take(&mut lanes.unicode_leads);
+    let mut ti = 0usize;
+    for &off in &leads {
+        while ti + 1 < k && token::offset(starts_all[ti + 1]) <= off {
+            ti += 1;
+        }
+        if !candidate_is_code_level(kinds_all[ti]) {
+            continue;
+        }
+        let Some(ch) = lanes::decode_char_at(src, off as usize) else { continue };
+        if oxc_syntax::identifier::is_identifier_part(ch) {
+            continue;
+        }
+        let code = if ch == '\u{FFFD}' {
+            // oxc_parser treats a code-level replacement char as a binary file.
+            error::diag_code::INVALID_UTF8
+        } else {
+            error::diag_code::UNEXPECTED_CHARACTER
+        };
+        lanes.diags.push(error::Diagnostic {
+            off,
+            len: ch.len_utf8() as u32,
+            code,
+            severity: error::diag_severity::ERROR,
+        });
+    }
+    leads.clear();
+    lanes.unicode_leads = leads;
+}
+
+/// Literal interiors, trivia, and JSX text may legally contain any char; only candidates landing in code-level tokens are worth checking.
+fn candidate_is_code_level(kind: u8) -> bool {
+    use token::token_kind as T;
+    !(is_trivia(kind)
+        || is_string_kind(kind)
+        || kind == T::REGEXP
+        || (T::TEMPLATE_NO_SUB..=T::TEMPLATE_TAIL).contains(&kind)
+        || (T::TEMPLATE_NO_SUB_COOKED..=T::TEMPLATE_TAIL_COOKED).contains(&kind)
+        || kind == T::JSX_TEXT)
+}
+
+fn empty_result(arena: &Arena) -> LexResult {
+    LexResult {
+        diagnostics: arena.diags,
+        diagnostic_count: 0,
+        lines: arena.lines,
+        line_count: 0,
+        hit_resource_limit: true,
+        token_count: 0,
+        numbers_count: 0,
+        atoms_count: 0,
+        strings_count: 0,
+        templates_count: 0,
+        regex_flags_count: 0,
+        comment_meta_count: 0,
+        comments_count: 0,
+        cooked_bytes_count: 0,
+    }
+}
+
+#[inline]
+#[expect(clippy::cast_possible_truncation, reason = "lane lengths are bounded by u32 capacities")]
+fn copy_lane<T: Copy>(srcv: &[T], dst: *mut T, cap: u32) -> u32 {
+    if dst.is_null() {
+        return 0;
+    }
+
+    assert!(
+        srcv.len() <= cap as usize,
+        "lexer: lane overflow ({} entries, capacity {cap}) — arena lane sizing out of date",
+        srcv.len()
+    );
+    // SAFETY: `dst` is non-null with capacity >= srcv.len(), asserted above.
+    unsafe {
+        core::ptr::copy_nonoverlapping(srcv.as_ptr(), dst, srcv.len());
+    }
+    srcv.len() as u32
+}

--- a/crates/oxc_lexer/src/opmap.rs
+++ b/crates/oxc_lexer/src/opmap.rs
@@ -1,0 +1,615 @@
+// Kernel lint policy — see the note in `pipeline/mod.rs`.
+#![allow(unsafe_op_in_unsafe_fn, clippy::missing_safety_doc, clippy::undocumented_unsafe_blocks)]
+#![allow(clippy::pedantic, clippy::nursery)]
+#![allow(
+    clippy::needless_range_loop,
+    clippy::manual_range_contains,
+    clippy::collapsible_if,
+    clippy::collapsible_match
+)]
+
+use crate::token::token_kind;
+
+pub const KW_COUNT_JS: usize = 46;
+pub const KW_COUNT_TS: usize = 81;
+pub const KW_KIND_BASE: u8 = token_kind::KW_BASE;
+
+/// Keyword spellings and the token kind each rewrites to (the JS set).
+/// `get`/`set` map to IDENT (contextual, never keywords at lex time) but
+/// stay in the table so the perfect hash keeps its shape.
+pub const KEYWORDS: [(&str, u8); KW_COUNT_JS] = [
+    ("await", token_kind::KW_AWAIT),
+    ("break", token_kind::KW_BREAK),
+    ("case", token_kind::KW_CASE),
+    ("catch", token_kind::KW_CATCH),
+    ("class", token_kind::KW_CLASS),
+    ("const", token_kind::KW_CONST),
+    ("continue", token_kind::KW_CONTINUE),
+    ("debugger", token_kind::KW_DEBUGGER),
+    ("default", token_kind::KW_DEFAULT),
+    ("delete", token_kind::KW_DELETE),
+    ("do", token_kind::KW_DO),
+    ("else", token_kind::KW_ELSE),
+    ("enum", token_kind::KW_ENUM),
+    ("export", token_kind::KW_EXPORT),
+    ("extends", token_kind::KW_EXTENDS),
+    ("finally", token_kind::KW_FINALLY),
+    ("for", token_kind::KW_FOR),
+    ("function", token_kind::KW_FUNCTION),
+    ("if", token_kind::KW_IF),
+    ("import", token_kind::KW_IMPORT),
+    ("in", token_kind::KW_IN),
+    ("instanceof", token_kind::KW_INSTANCEOF),
+    ("new", token_kind::KW_NEW),
+    ("of", token_kind::KW_OF),
+    ("return", token_kind::KW_RETURN),
+    ("super", token_kind::KW_SUPER),
+    ("switch", token_kind::KW_SWITCH),
+    ("this", token_kind::KW_THIS),
+    ("throw", token_kind::KW_THROW),
+    ("try", token_kind::KW_TRY),
+    ("typeof", token_kind::KW_TYPEOF),
+    ("var", token_kind::KW_VAR),
+    ("void", token_kind::KW_VOID),
+    ("while", token_kind::KW_WHILE),
+    ("with", token_kind::KW_WITH),
+    ("yield", token_kind::KW_YIELD),
+    ("let", token_kind::KW_LET),
+    ("static", token_kind::KW_STATIC),
+    ("async", token_kind::KW_ASYNC),
+    ("get", token_kind::IDENT),
+    ("set", token_kind::IDENT),
+    ("as", token_kind::KW_AS),
+    ("from", token_kind::KW_FROM),
+    ("true", token_kind::KW_TRUE),
+    ("false", token_kind::KW_FALSE),
+    ("null", token_kind::KW_NULL),
+];
+
+/// TS-mode additions: TypeScript's contextual keywords plus the strict-mode
+/// reserved words. JS mode lexes every one of these spellings as IDENT.
+pub const KEYWORDS_TS_EXTRA: [(&str, u8); KW_COUNT_TS - KW_COUNT_JS] = [
+    ("abstract", token_kind::KW_ABSTRACT),
+    ("accessor", token_kind::KW_ACCESSOR),
+    ("any", token_kind::KW_ANY),
+    ("asserts", token_kind::KW_ASSERTS),
+    ("bigint", token_kind::KW_BIGINT),
+    ("boolean", token_kind::KW_BOOLEAN),
+    ("declare", token_kind::KW_DECLARE),
+    ("global", token_kind::KW_GLOBAL),
+    ("implements", token_kind::KW_IMPLEMENTS),
+    ("infer", token_kind::KW_INFER),
+    ("interface", token_kind::KW_INTERFACE),
+    ("intrinsic", token_kind::KW_INTRINSIC),
+    ("is", token_kind::KW_IS),
+    ("keyof", token_kind::KW_KEYOF),
+    ("module", token_kind::KW_MODULE),
+    ("namespace", token_kind::KW_NAMESPACE),
+    ("never", token_kind::KW_NEVER),
+    ("number", token_kind::KW_NUMBER),
+    ("object", token_kind::KW_OBJECT),
+    ("out", token_kind::KW_OUT),
+    ("override", token_kind::KW_OVERRIDE),
+    ("package", token_kind::KW_PACKAGE),
+    ("private", token_kind::KW_PRIVATE),
+    ("protected", token_kind::KW_PROTECTED),
+    ("public", token_kind::KW_PUBLIC),
+    ("readonly", token_kind::KW_READONLY),
+    ("require", token_kind::KW_REQUIRE),
+    ("satisfies", token_kind::KW_SATISFIES),
+    ("string", token_kind::KW_STRING),
+    ("symbol", token_kind::KW_SYMBOL),
+    ("type", token_kind::KW_TYPE),
+    ("undefined", token_kind::KW_UNDEFINED),
+    ("unique", token_kind::KW_UNIQUE),
+    ("unknown", token_kind::KW_UNKNOWN),
+    ("using", token_kind::KW_USING),
+];
+
+const fn keywords_ts() -> [(&'static str, u8); KW_COUNT_TS] {
+    let mut out = [("", 0u8); KW_COUNT_TS];
+    let mut i = 0;
+    while i < KW_COUNT_JS {
+        out[i] = KEYWORDS[i];
+        i += 1;
+    }
+    while i < KW_COUNT_TS {
+        out[i] = KEYWORDS_TS_EXTRA[i - KW_COUNT_JS];
+        i += 1;
+    }
+    out
+}
+
+/// The TS-mode keyword set: [`KEYWORDS`] followed by [`KEYWORDS_TS_EXTRA`].
+pub static KEYWORDS_TS: [(&str, u8); KW_COUNT_TS] = keywords_ts();
+
+/// First punctuator kind — the token-kind space reserves [32, 128) for them.
+pub const OP_KIND_BASE: u8 = token_kind::LBRACE;
+pub const OPMAP_NOPS: usize = 33;
+
+pub struct OpDef {
+    pub txt: &'static [u8],
+    pub len: u8,
+    pub kind: u8,
+}
+
+macro_rules! op {
+    ($t:literal, $k:expr) => {
+        OpDef { txt: $t, len: $t.len() as u8, kind: $k }
+    };
+}
+
+pub static OPMAP_OPS: [OpDef; OPMAP_NOPS] = [
+    op!(b"<=", token_kind::LE),
+    op!(b">=", token_kind::GE),
+    op!(b"==", token_kind::EQ_EQ),
+    op!(b"!=", token_kind::BANG_EQ),
+    op!(b"===", token_kind::EQ_EQ_EQ),
+    op!(b"!==", token_kind::BANG_EQ_EQ),
+    op!(b"**", token_kind::STAR_STAR),
+    op!(b"++", token_kind::PLUS_PLUS),
+    op!(b"--", token_kind::MINUS_MINUS),
+    op!(b"<<", token_kind::LSHIFT),
+    op!(b">>", token_kind::RSHIFT),
+    op!(b">>>", token_kind::URSHIFT),
+    op!(b"&&", token_kind::AMP_AMP),
+    op!(b"||", token_kind::PIPE_PIPE),
+    op!(b"??", token_kind::NULLISH),
+    op!(b"?.", token_kind::OPTIONAL_CHAIN),
+    op!(b"=>", token_kind::ARROW),
+    op!(b"+=", token_kind::PLUS_EQ),
+    op!(b"-=", token_kind::MINUS_EQ),
+    op!(b"*=", token_kind::STAR_EQ),
+    op!(b"%=", token_kind::PERCENT_EQ),
+    op!(b"<<=", token_kind::LSHIFT_EQ),
+    op!(b">>=", token_kind::RSHIFT_EQ),
+    op!(b">>>=", token_kind::URSHIFT_EQ),
+    op!(b"&=", token_kind::AMP_EQ),
+    op!(b"|=", token_kind::PIPE_EQ),
+    op!(b"^=", token_kind::CARET_EQ),
+    op!(b"&&=", token_kind::AMP_AMP_EQ),
+    op!(b"||=", token_kind::PIPE_PIPE_EQ),
+    op!(b"??=", token_kind::NULLISH_EQ),
+    op!(b"**=", token_kind::STAR_STAR_EQ),
+    op!(b"...", token_kind::ELLIPSIS),
+    op!(b"/=", token_kind::SLASH_EQ),
+];
+
+pub const OP_QDOT: u8 = token_kind::OPTIONAL_CHAIN;
+pub const OP_SLASH_EQ: u8 = token_kind::SLASH_EQ;
+
+pub const PUNCT1_KIND_UNKNOWN: u8 = 255;
+pub const PUNCT1_NKNOWN: usize = 26;
+
+/// Single-char punctuators and their kinds. `#` maps to UNKNOWN: a bare `#`
+/// is invalid on its own (private names and hashbangs are resolved earlier).
+pub const PUNCT1: [(u8, u8); PUNCT1_NKNOWN] = [
+    (b'(', token_kind::LPAREN),
+    (b')', token_kind::RPAREN),
+    (b'[', token_kind::LBRACKET),
+    (b']', token_kind::RBRACKET),
+    (b'{', token_kind::LBRACE),
+    (b'}', token_kind::RBRACE),
+    (b';', token_kind::SEMI),
+    (b',', token_kind::COMMA),
+    (b'.', token_kind::DOT),
+    (b'<', token_kind::LT),
+    (b'>', token_kind::GT),
+    (b'+', token_kind::PLUS),
+    (b'-', token_kind::MINUS),
+    (b'*', token_kind::STAR),
+    (b'/', token_kind::SLASH),
+    (b'%', token_kind::PERCENT),
+    (b'&', token_kind::AMP),
+    (b'|', token_kind::PIPE),
+    (b'^', token_kind::CARET),
+    (b'!', token_kind::BANG),
+    (b'~', token_kind::TILDE),
+    (b'?', token_kind::QUESTION),
+    (b':', token_kind::COLON),
+    (b'=', token_kind::EQ),
+    (b'@', token_kind::AT),
+    (b'#', PUNCT1_KIND_UNKNOWN),
+];
+
+const fn punct1_list() -> [u8; PUNCT1_NKNOWN] {
+    let mut out = [0u8; PUNCT1_NKNOWN];
+    let mut i = 0;
+    while i < PUNCT1_NKNOWN {
+        out[i] = PUNCT1[i].0;
+        i += 1;
+    }
+    out
+}
+
+const fn punct1_tok() -> [u8; PUNCT1_NKNOWN] {
+    let mut out = [0u8; PUNCT1_NKNOWN];
+    let mut i = 0;
+    while i < PUNCT1_NKNOWN {
+        out[i] = PUNCT1[i].1;
+        i += 1;
+    }
+    out
+}
+
+/// Column views of [`PUNCT1`].
+pub static PUNCT1_LIST: [u8; PUNCT1_NKNOWN] = punct1_list();
+pub static PUNCT1_TOK: [u8; PUNCT1_NKNOWN] = punct1_tok();
+
+pub struct OpMap {
+    pub opmap_mul: u32,
+    pub opmap_slot: [u8; 256],
+
+    pub punct1_ord: [u8; 256],
+}
+
+pub const KW_MAX: usize = KW_COUNT_TS;
+/// Slot count of the keyword hash tables — must cover the smallest shift a
+/// set may search (JS shift 25 → 128 slots, TS shift 23 → 512).
+pub const KW_SLOTS: usize = 512;
+
+/// Verified first-try hints for the deterministic perfect-hash searches
+/// below (checked for injectivity before use, so a word-list edit can never
+/// ship a stale constant — it just falls back to the search).
+pub const KW_HASH_HINT_JS: (u32, u32) = (0x0058_DC65, 25);
+pub const KW_HASH_HINT_TS: (u32, u32) = (0x000B_385B, 23);
+
+/// One keyword-recognition table set: spellings, perfect hash, and the
+/// verify patterns `kw_verify_batch` compares against. `Tables` holds two —
+/// the JS set and the TS set — and `lex_raw` selects by `LexOptions::ts`.
+///
+/// The hash key differs per set. JS keys on `(c0, c1, len)`; the TS set
+/// keys on `(c0, c1, last, len)` because the wider list has pairs the
+/// narrow key cannot separate (static/string, declare/default,
+/// interface/intrinsic).
+pub struct KwSet {
+    pub ts_key: bool,
+    pub kw_len: [u8; KW_MAX],
+    pub kw_first8: [u64; KW_MAX],
+    pub kw_ext: [u16; KW_MAX],
+    pub kw_tok: [u8; KW_MAX],
+    pub mask_tab: [u64; 9],
+    pub kw_hash_mul: u32,
+    pub kw_hash_shift: u32,
+    pub kw_slot: [u8; KW_SLOTS],
+    pub kwh_pat: [u64; KW_SLOTS],
+    pub kwh_kind: [u8; KW_SLOTS],
+}
+
+#[inline(always)]
+pub fn kw_key(c0: u8, c1: u8, len: u32) -> u32 {
+    (c0 as u32) | ((c1 as u32) << 8) | (len << 16)
+}
+
+#[inline(always)]
+pub fn kw_key_ts(c0: u8, c1: u8, clast: u8, len: u32) -> u32 {
+    (c0 as u32) | ((c1 as u32) << 8) | ((clast as u32) << 16) | (len << 24)
+}
+
+#[inline(always)]
+pub fn op_key(c0: u8, c1: u8, c2: u8, len: u32) -> u32 {
+    (c0 as u32) | ((c1 as u32) << 8) | ((c2 as u32) << 16) | (len << 24)
+}
+
+impl KwSet {
+    pub fn build(
+        list: &[(&'static str, u8)],
+        ts_key: bool,
+        shifts: &[u32],
+        hint: (u32, u32),
+    ) -> KwSet {
+        let n = list.len();
+        assert!(n >= 2 && n <= KW_MAX && n < 0xFF, "opmap.rs: bad KwSet word count");
+        let mut s = KwSet {
+            ts_key,
+            kw_len: [0; KW_MAX],
+            kw_first8: [0; KW_MAX],
+            kw_ext: [0; KW_MAX],
+            kw_tok: [0; KW_MAX],
+            mask_tab: [0; 9],
+            kw_hash_mul: 0,
+            kw_hash_shift: 0,
+            kw_slot: [0xFF; KW_SLOTS],
+            kwh_pat: [!0u64; KW_SLOTS],
+            kwh_kind: [0; KW_SLOTS],
+        };
+        for i in 0..n {
+            let bytes = list[i].0.as_bytes();
+            let len = bytes.len();
+            assert!(len >= 2 && len <= 10, "opmap.rs: keyword length out of range");
+            s.kw_len[i] = len as u8;
+            s.kw_tok[i] = list[i].1;
+            let mut w: u64 = 0;
+            let m = if len < 8 { len } else { 8 };
+            for k in 0..m {
+                w |= (bytes[k] as u64) << (8 * k);
+            }
+            s.kw_first8[i] = w;
+            let mut e: u16 = 0;
+            if len > 8 {
+                for k in 8..len {
+                    e |= (bytes[k] as u16) << (8 * (k - 8));
+                }
+            }
+            s.kw_ext[i] = e;
+        }
+        for l in 0..=8usize {
+            s.mask_tab[l] = if l >= 8 { !0u64 } else { (1u64 << (8 * l)) - 1 };
+        }
+        let keyof = |i: usize| -> u32 {
+            let b = list[i].0.as_bytes();
+            if ts_key {
+                kw_key_ts(b[0], b[1], b[b.len() - 1], b.len() as u32)
+            } else {
+                kw_key(b[0], b[1], b.len() as u32)
+            }
+        };
+        let injective = |mul: u32, shift: u32| -> bool {
+            if (1usize << (32 - shift)) > KW_SLOTS {
+                return false;
+            }
+            let mut used = [false; KW_SLOTS];
+            for i in 0..n {
+                let slot = (keyof(i).wrapping_mul(mul) >> shift) as usize;
+                if used[slot] {
+                    return false;
+                }
+                used[slot] = true;
+            }
+            true
+        };
+        if hint.0 != 0 && injective(hint.0, hint.1) {
+            s.kw_hash_mul = hint.0;
+            s.kw_hash_shift = hint.1;
+        } else {
+            'search: {
+                for &shift in shifts {
+                    let mut m: u64 = 1;
+                    while m < (1u64 << 23) {
+                        if injective(m as u32, shift) {
+                            s.kw_hash_mul = m as u32;
+                            s.kw_hash_shift = shift;
+                            break 'search;
+                        }
+                        m += 2;
+                    }
+                }
+                panic!("opmap.rs: kw perfect-hash search FAILED");
+            }
+        }
+        for i in 0..n {
+            let slot = (keyof(i).wrapping_mul(s.kw_hash_mul) >> s.kw_hash_shift) as usize;
+            s.kw_slot[slot] = i as u8;
+            if s.kw_len[i] <= 8 {
+                s.kwh_pat[slot] = s.kw_first8[i];
+                s.kwh_kind[slot] = s.kw_tok[i];
+            }
+        }
+        s
+    }
+
+    /// Exact keyword match of the `len` bytes at `p`: the token kind on a
+    /// hit (IDENT for the get/set placeholders), 0 otherwise.
+    #[inline(always)]
+    pub unsafe fn lookup(&self, p: *const u8, len: usize) -> u32 {
+        if len < 2 || len > 10 {
+            return 0;
+        }
+        let key = if self.ts_key {
+            kw_key_ts(*p, *p.add(1), *p.add(len - 1), len as u32)
+        } else {
+            kw_key(*p, *p.add(1), len as u32)
+        };
+        let idx = self.kw_slot[(key.wrapping_mul(self.kw_hash_mul) >> self.kw_hash_shift) as usize];
+        if idx == 0xFF {
+            return 0;
+        }
+        let idx = idx as usize;
+        if self.kw_len[idx] as usize != len {
+            return 0;
+        }
+        let w = core::ptr::read_unaligned(p as *const u64);
+        if (w & self.mask_tab[if len < 8 { len } else { 8 }]) != self.kw_first8[idx] {
+            return 0;
+        }
+        if len > 8 {
+            let e = core::ptr::read_unaligned(p.add(8) as *const u16);
+            let emask: u16 = if len == 9 { 0x00FF } else { 0xFFFF };
+            if (e & emask) != self.kw_ext[idx] {
+                return 0;
+            }
+        }
+        self.kw_tok[idx] as u32
+    }
+
+    pub fn self_check(&self, list: &[(&'static str, u8)]) {
+        for i in 0..list.len() {
+            let mut buf = [0u8; 16];
+            let bytes = list[i].0.as_bytes();
+            buf[..bytes.len()].copy_from_slice(bytes);
+            unsafe {
+                assert!(
+                    self.lookup(buf.as_ptr(), bytes.len()) == list[i].1 as u32,
+                    "opmap self-check: kw lookup({}) wrong",
+                    list[i].0
+                );
+                assert!(
+                    self.lookup(buf.as_ptr(), bytes.len() + 1) == 0,
+                    "opmap self-check: kw lookup({}+1) matched",
+                    list[i].0
+                );
+            }
+        }
+        for neg in [
+            "lets",
+            "iff",
+            "i",
+            "instanceofx",
+            "Class",
+            "nul",
+            "nulll",
+            "truee",
+            "types",
+            "strin",
+            "interfac",
+            "interfacee",
+            "intrinsics",
+            "undefine",
+            "satisfiess",
+        ] {
+            let mut buf = [0u8; 16];
+            buf[..neg.len()].copy_from_slice(neg.as_bytes());
+            unsafe {
+                assert!(
+                    self.lookup(buf.as_ptr(), neg.len()) == 0,
+                    "opmap self-check: kw negative {neg} matched"
+                );
+            }
+        }
+    }
+}
+
+impl OpMap {
+    pub fn new() -> OpMap {
+        let mut m =
+            OpMap { opmap_mul: 0, opmap_slot: [0xFF; 256], punct1_ord: [PUNCT1_KIND_UNKNOWN; 256] };
+        m.opmap_init();
+        m.punct1_init();
+        m.self_check();
+        m
+    }
+
+    fn opmap_init(&mut self) {
+        for i in 0..OPMAP_NOPS {
+            let a = &OPMAP_OPS[i];
+            assert!(
+                a.len as usize == a.txt.len() && a.kind >= OP_KIND_BASE && a.kind <= 89,
+                "opmap.rs: bad OpDef {i}"
+            );
+            for j in (i + 1)..OPMAP_NOPS {
+                let b = &OPMAP_OPS[j];
+                let a2 = if a.len >= 3 { a.txt[2] } else { 0 };
+                let b2 = if b.len >= 3 { b.txt[2] } else { 0 };
+                assert!(
+                    !(a.len == b.len && a.txt[0] == b.txt[0] && a.txt[1] == b.txt[1] && a2 == b2),
+                    "opmap.rs: (c0,c1,c2,len) collision"
+                );
+            }
+        }
+        let mut m: u64 = (1u64 << 24) | 1;
+        while m < (1u64 << 28) {
+            let mut used = [0u8; 256];
+            let mut ok = true;
+            for i in 0..OPMAP_NOPS {
+                let o = &OPMAP_OPS[i];
+                let c2 = if o.len >= 3 { o.txt[2] } else { 0 };
+                let key = op_key(o.txt[0], o.txt[1], c2, o.len as u32);
+                let slot = (key.wrapping_mul(m as u32) >> 24) as usize;
+                if used[slot] != 0 {
+                    ok = false;
+                    break;
+                }
+                used[slot] = 1;
+            }
+            if ok {
+                self.opmap_mul = m as u32;
+                self.opmap_slot = [0xFF; 256];
+                for i in 0..OPMAP_NOPS {
+                    let o = &OPMAP_OPS[i];
+                    let c2 = if o.len >= 3 { o.txt[2] } else { 0 };
+                    let key = op_key(o.txt[0], o.txt[1], c2, o.len as u32);
+                    let slot = (key.wrapping_mul(self.opmap_mul) >> 24) as usize;
+                    self.opmap_slot[slot] = i as u8;
+                }
+                return;
+            }
+            m += 2;
+        }
+        panic!("opmap.rs: opmap perfect-hash search FAILED");
+    }
+
+    fn punct1_init(&mut self) {
+        self.punct1_ord = [PUNCT1_KIND_UNKNOWN; 256];
+        for i in 0..PUNCT1_NKNOWN {
+            self.punct1_ord[PUNCT1_LIST[i] as usize] = PUNCT1_TOK[i];
+        }
+    }
+
+    #[inline(always)]
+    pub fn opmap_lookup(&self, b0: u8, b1: u8, b2: u8, b3: u8, len: u32) -> u32 {
+        let c2 = if len >= 3 { b2 } else { 0 };
+        let key = op_key(b0, b1, c2, len);
+        let idx = self.opmap_slot[(key.wrapping_mul(self.opmap_mul) >> 24) as usize];
+        if idx == 0xFF {
+            return 0;
+        }
+        let o = &OPMAP_OPS[idx as usize];
+        if o.len as u32 != len {
+            return 0;
+        }
+        if o.txt[0] != b0 || o.txt[1] != b1 {
+            return 0;
+        }
+        if len >= 3 && o.txt[2] != b2 {
+            return 0;
+        }
+        if len >= 4 && o.txt[3] != b3 {
+            return 0;
+        }
+        o.kind as u32
+    }
+
+    fn self_check(&self) {
+        let mut seen_kind = [0u8; 256];
+        for i in 0..OPMAP_NOPS {
+            let o = &OPMAP_OPS[i];
+            let mut b = [0u8; 4];
+            b[..o.len as usize].copy_from_slice(&o.txt[..o.len as usize]);
+            assert!(
+                self.opmap_lookup(b[0], b[1], b[2], b[3], o.len as u32) == o.kind as u32,
+                "opmap self-check: opmap_lookup wrong"
+            );
+            assert!(seen_kind[o.kind as usize] == 0, "opmap self-check: duplicate ordinal");
+            seen_kind[o.kind as usize] = 1;
+        }
+        assert!(
+            self.opmap_lookup(b'.', b'.', 0, 0, 2) == 0
+                && self.opmap_lookup(b'<', b'<', 0, 0, 2) == 83
+                && self.opmap_lookup(b'<', b'=', 0, 0, 2) == 49
+                && self.opmap_lookup(b'>', b'>', b'>', 0, 3) == 87
+                && self.opmap_lookup(b'>', b'>', b'=', 0, 3) == 86
+                && self.opmap_lookup(b'=', b'=', 0, 0, 2) == 53
+                && self.opmap_lookup(b'=', b'/', 0, 0, 2) == 0,
+            "opmap self-check: op spot-checks failed"
+        );
+        let mut seen = [0u8; 256];
+        for i in 0..PUNCT1_NKNOWN {
+            let ord = self.punct1_ord[PUNCT1_LIST[i] as usize];
+            assert!(
+                ord == PUNCT1_TOK[i] && seen[ord as usize] == 0,
+                "opmap self-check: PUNCT1 ordinal wrong/dup"
+            );
+            seen[ord as usize] = 1;
+        }
+        for b in 0..256usize {
+            let ord = self.punct1_ord[b];
+            let is_known = PUNCT1_LIST.contains(&(b as u8));
+            assert!(
+                is_known || ord == PUNCT1_KIND_UNKNOWN,
+                "opmap self-check: PUNCT1_ORD should be unknown"
+            );
+        }
+        assert!(
+            self.punct1_ord[b'(' as usize] == 34
+                && self.punct1_ord[b'#' as usize] == 255
+                && self.punct1_ord[b'a' as usize] == 255
+                && self.punct1_ord[b'"' as usize] == 255
+                && self.punct1_ord[b'`' as usize] == 255
+                && self.punct1_ord[b'\\' as usize] == 255
+                && self.punct1_ord[b'$' as usize] == 255
+                && self.punct1_ord[b' ' as usize] == 255
+                && self.punct1_ord[0] == 255,
+            "opmap self-check: PUNCT1 spot-checks failed"
+        );
+    }
+}

--- a/crates/oxc_lexer/src/opmap.rs
+++ b/crates/oxc_lexer/src/opmap.rs
@@ -441,6 +441,7 @@ impl KwSet {
             }
         }
         for neg in [
+            // spellchecker:off
             "lets",
             "iff",
             "i",
@@ -456,6 +457,7 @@ impl KwSet {
             "intrinsics",
             "undefine",
             "satisfiess",
+            // spellchecker:on
         ] {
             let mut buf = [0u8; 16];
             buf[..neg.len()].copy_from_slice(neg.as_bytes());

--- a/crates/oxc_lexer/src/options.rs
+++ b/crates/oxc_lexer/src/options.rs
@@ -1,0 +1,40 @@
+#[derive(Clone, Copy, Debug)]
+pub struct LexOptions {
+    pub source_type_module: bool,
+    pub jsx: bool,
+    pub ts: bool,
+    pub validate_regexp_literals: bool,
+    pub emit_comments: bool,
+    pub emit_whitespace: bool,
+    pub collect_line_table: bool,
+    pub tolerate_hashbang: bool,
+    pub strip_utf8_bom: bool,
+    pub validate_utf8: bool,
+    pub max_oracle_depth: u32,
+    pub max_token_count: u32,
+    pub max_diagnostic_count: u32,
+}
+
+impl Default for LexOptions {
+    fn default() -> Self {
+        Self {
+            source_type_module: false,
+            jsx: false,
+            ts: false,
+            validate_regexp_literals: false,
+            emit_comments: false,
+            emit_whitespace: false,
+            collect_line_table: false,
+            tolerate_hashbang: true,
+            strip_utf8_bom: true,
+            validate_utf8: false,
+            max_oracle_depth: 65536,
+            max_token_count: 0,
+            max_diagnostic_count: 1024,
+        }
+    }
+}
+
+pub fn default_options() -> LexOptions {
+    LexOptions::default()
+}

--- a/crates/oxc_lexer/src/pipeline/bitmap.rs
+++ b/crates/oxc_lexer/src/pipeline/bitmap.rs
@@ -1,0 +1,101 @@
+use core::arch::x86_64::*;
+
+#[inline(always)]
+pub(super) unsafe fn bm_next1(bm: *const u64, i: usize, n: usize) -> usize {
+    let mut w = i >> 6;
+    let x = *bm.add(w) & !((1u64 << (i & 63)).wrapping_sub(1));
+    if x != 0 {
+        let r = (w << 6) + x.trailing_zeros() as usize;
+        return if r < n { r } else { n };
+    }
+    w += 1;
+    while (w << 6) < n {
+        let x = *bm.add(w);
+        if x != 0 {
+            let r = (w << 6) + x.trailing_zeros() as usize;
+            return if r < n { r } else { n };
+        }
+        w += 1;
+    }
+    n
+}
+#[inline(always)]
+pub(super) unsafe fn bm_prev1(bm: *const u64, p: usize) -> i64 {
+    if p == 0 {
+        return -1;
+    }
+    let i = p - 1;
+    let mut w = (i >> 6) as i64;
+    let lim = i & 63;
+    let mask = if lim == 63 { !0u64 } else { (1u64 << (lim + 1)) - 1 };
+    let x = *bm.add(w as usize) & mask;
+    if x != 0 {
+        return (w << 6) + (63 - x.leading_zeros() as i64);
+    }
+    w -= 1;
+    while w >= 0 {
+        let x = *bm.add(w as usize);
+        if x != 0 {
+            return (w << 6) + (63 - x.leading_zeros() as i64);
+        }
+        w -= 1;
+    }
+    -1
+}
+#[inline(always)]
+pub(super) unsafe fn bm_set1(bm: *mut u64, i: usize) {
+    *bm.add(i >> 6) |= 1u64 << (i & 63);
+}
+#[inline(always)]
+pub(super) unsafe fn bm_next0(bm: *const u64, i: usize, n: usize) -> usize {
+    let mut w = i >> 6;
+    let mut inv = !*bm.add(w) & !((1u64 << (i & 63)).wrapping_sub(1));
+    while inv == 0 {
+        w += 1;
+        if (w << 6) >= n {
+            return n;
+        }
+        inv = !*bm.add(w);
+    }
+    let r = (w << 6) + inv.trailing_zeros() as usize;
+    if r < n { r } else { n }
+}
+#[inline(always)]
+pub(super) unsafe fn bm_clear_range(bm: *mut u64, a: usize, b: usize) {
+    if a > b {
+        return;
+    }
+    let wa = a >> 6;
+    let wb = b >> 6;
+    let lo = (!0u64) << (a & 63);
+    let hi = if (b & 63) == 63 { !0u64 } else { (1u64 << ((b & 63) + 1)) - 1 };
+    if wa == wb {
+        *bm.add(wa) &= !(lo & hi);
+        return;
+    }
+    *bm.add(wa) &= !lo;
+    let mut w = wa + 1;
+    while w < wb {
+        *bm.add(w) = 0;
+        w += 1;
+    }
+    *bm.add(wb) &= !hi;
+}
+#[inline]
+pub(super) unsafe fn bm_any(bm: *const u64, nw: usize) -> bool {
+    let mut w = 0usize;
+    while w + 4 <= nw {
+        let v = _mm256_loadu_si256(bm.add(w) as *const __m256i);
+        if _mm256_testz_si256(v, v) == 0 {
+            return true;
+        }
+        w += 4;
+    }
+    while w < nw {
+        if *bm.add(w) != 0 {
+            return true;
+        }
+        w += 1;
+    }
+    false
+}

--- a/crates/oxc_lexer/src/pipeline/carve.rs
+++ b/crates/oxc_lexer/src/pipeline/carve.rs
@@ -1,0 +1,860 @@
+use crate::comment_meta;
+use crate::error::diag_code;
+use crate::lanes::Lanes;
+use crate::opmap::OP_SLASH_EQ;
+use crate::tables::{Tables, hex_val, is_digit, is_id_start, is_word, is_ws};
+
+use super::bitmap::{bm_clear_range, bm_next0, bm_set1};
+use super::find::{
+    find_jsx_tag, find_jsx_tag_ts, find_jsx_text, find_line_terminator, find_opener,
+    find_opener_jsx5, find_opener_jsx7, find_opener6, find1, find2, scan_block_comment,
+    scan_line_comment, scan_quoted, scan_regex, scan_tmpl_text,
+};
+use super::regex_div::prev_is_regex;
+use super::{
+    BCOM, HASHBANG, JEND, JSX_LT, JTEXT, LCOM, REGEX, STR, TMPL_HEAD, TMPL_MIDDLE, TMPL_NOSUB,
+    TMPL_TAIL,
+};
+
+/// Annex B B.1.3: a `-->` close-comment counts only at line start — scanning
+/// back must reach a LineTerminator (or start of input) crossing nothing but
+/// whitespace and block comments; a newline inside a crossed block comment
+/// also qualifies. Cold: called only on a literal `-->`.
+fn html_close_at_line_start(src: &[u8], mut q: usize) -> bool {
+    loop {
+        if q == 0 {
+            return true; // start of input
+        }
+        let c = src[q - 1];
+        match c {
+            b' ' | b'\t' | 0x0b | 0x0c => q -= 1,
+            b'\n' | b'\r' => return true,
+            // LS/PS ending at q-1.
+            0xA8 | 0xA9 => {
+                return q >= 3 && src[q - 2] == 0x80 && src[q - 3] == 0xE2;
+            }
+            // `*/` at (q-2, q-1): skip back to its `/*`; a newline inside the
+            // comment body satisfies the rule.
+            b'/' if q >= 2 && src[q - 2] == b'*' => {
+                let mut m = q - 2;
+                let mut saw_nl = false;
+                loop {
+                    if m < 2 {
+                        return saw_nl; // unbalanced `*/`
+                    }
+                    if src[m - 2] == b'/' && src[m - 1] == b'*' {
+                        q = m - 2;
+                        break;
+                    }
+                    let b = src[m - 1];
+                    if b == b'\n' || b == b'\r' {
+                        saw_nl = true;
+                    }
+                    m -= 1;
+                }
+                if saw_nl {
+                    return true;
+                }
+                // single-line block comment skipped; keep scanning
+            }
+            _ => return false,
+        }
+    }
+}
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum JMode {
+    Js,
+    Tag,
+    Text,
+}
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum JFrameKind {
+    /// `${...}` of a split template literal (mode JS; `depth` counts nested `{}`).
+    TemplateSub,
+    /// `{...}` JSX expression container (mode JS; `depth` counts nested `{}`).
+    JsxCont,
+    /// A `<...>` opening tag being lexed (mode TAG).
+    JsxTag,
+    /// An opened element whose children are being lexed (mode TEXT).
+    JsxElem,
+}
+#[derive(Clone, Copy)]
+struct JFrame {
+    kind: JFrameKind,
+    /// Mode to restore when this frame pops.
+    parent: JMode,
+    /// Nested-brace counter (TemplateSub / JsxCont only).
+    depth: u32,
+}
+/// Stamp a single-byte JSX-structural punct: set its final `kind` and clear
+/// its `opch` bit so `coalesce` cannot re-fuse it (`<div>=` into `>=`).
+#[inline(always)]
+unsafe fn jsx_punct(kind: *mut u8, opch: *mut u64, off: usize, k: u8) {
+    *kind.add(off) = k;
+    *opch.add(off >> 6) &= !(1u64 << (off & 63));
+}
+/// `.tsx` disambiguation: at an operand-position `<IDENT...`, is this a TS
+/// type-parameter list rather than a JSX element? In `.tsx` a bare `<T>` is
+/// JSX (a generic arrow must be written `<T,>`), so the signals are a
+/// trailing `,`, a default `=`, or an `extends` constraint. Bounded forward
+/// peek; the source pad makes the look-aheads safe past `n`.
+#[inline]
+fn ts_is_type_params(src: &[u8], n: usize, t: usize) -> bool {
+    let mut p = t;
+    // optional `const` type-parameter modifier: `<const T,>`
+    if n - p >= 6 && &src[p..p + 5] == b"const" && !is_word(src[p + 5]) {
+        let mut qq = p + 5;
+        while qq < n && is_ws(src[qq]) {
+            qq += 1;
+        }
+        if qq < n && is_id_start(src[qq]) {
+            p = qq; // `const` was a modifier; advance to the real param
+        }
+    }
+    while p < n && is_word(src[p]) {
+        p += 1; // first type-parameter identifier
+    }
+    while p < n && is_ws(src[p]) {
+        p += 1;
+    }
+    if p >= n {
+        return false;
+    }
+    let c = src[p];
+    if c == b',' || c == b'=' {
+        return true; // `<T,>`  `<T,U>`  `<T = D>`
+    }
+    // `extends` is also a legal JSX attribute name; it signals a generic only
+    // as a full word not followed by `=` (attr value) or `>` (boolean attr).
+    if n - p >= 7 && &src[p..p + 7] == b"extends" && !is_word(src[p + 7]) {
+        let mut qq = p + 7;
+        while qq < n && is_ws(src[qq]) {
+            qq += 1;
+        }
+        let d = if qq < n { src[qq] } else { 0 };
+        return !(d == b'=' || d == b'>');
+    }
+    false
+}
+
+/// Lex the string literal opening at `s`. Returns the resume index. Shared
+/// by `carve` and `carve_jsx` JS mode.
+#[inline(always)]
+unsafe fn lex_string(
+    src: *const u8,
+    srcs: &[u8],
+    n: usize,
+    st: *mut u64,
+    kind: *mut u8,
+    s: usize,
+    c: u8,
+    lanes: &mut Lanes,
+) -> usize {
+    let mut saw_nl = false;
+    let e = scan_quoted(src, n, s + 1, c, &mut saw_nl);
+    let end = if e < n { e + 1 } else { n };
+    if saw_nl {
+        // The terminator wins over unterminated-at-EOF, same as oxc_parser.
+        lanes.push_line_terminator_in_string(srcs, s, end);
+    } else if e >= n {
+        lanes.push_diag(s as u32, (n - s) as u32, diag_code::UNTERMINATED_STRING);
+    }
+    *kind.add(s) = STR;
+    if end > s + 1 {
+        bm_clear_range(st, s + 1, end - 1);
+    }
+    let be = if e < n {
+        e
+    } else if n > s + 1 && *src.add(n - 1) == c {
+        n - 1
+    } else {
+        n
+    };
+    lanes.push_string(srcs, s + 1, be);
+    end
+}
+
+/// Lex the template text segment starting at `s` (a backtick or a
+/// substitution-closing `}`): `head_kind` if it ends in `${`, `flat_kind` if
+/// it closes or runs to EOF. Returns `(resume index, substitution opened)`;
+/// the caller pushes its own nesting frame.
+#[inline(always)]
+unsafe fn lex_template_segment(
+    src: *const u8,
+    srcs: &[u8],
+    n: usize,
+    st: *mut u64,
+    kind: *mut u8,
+    s: usize,
+    head_kind: u8,
+    flat_kind: u8,
+    lanes: &mut Lanes,
+) -> (usize, bool) {
+    let mut term = 0i32;
+    let end = scan_tmpl_text(src, n, s + 1, &mut term);
+    if term == 0 {
+        lanes.push_diag(s as u32, (end - s) as u32, diag_code::UNTERMINATED_TEMPLATE);
+    }
+    *kind.add(s) = if term == 2 { head_kind } else { flat_kind };
+    if end > s + 1 {
+        bm_clear_range(st, s + 1, end - 1);
+    }
+    lanes.push_template(srcs, s + 1, end - [0usize, 1, 2][term as usize]);
+    (end, term == 2)
+}
+
+/// Lex the `//` line comment at `s`. Returns the resume index.
+#[inline(always)]
+unsafe fn lex_line_comment(
+    src: *const u8,
+    srcs: &[u8],
+    n: usize,
+    st: *mut u64,
+    kind: *mut u8,
+    s: usize,
+    lanes: &mut Lanes,
+) -> usize {
+    let (end, lic_q) = scan_line_comment(src, n, s + 2);
+    *kind.add(s) = LCOM;
+    if end > s + 1 {
+        bm_clear_range(st, s + 1, end - 1);
+    }
+    if end < n {
+        bm_set1(st, end);
+    }
+    let lic = lic_q >= 0 && (lic_q as usize) + 8 < end;
+    let m = comment_meta::meta_byte_flags(&srcs[..n], s as u32, end as u32, false, false, lic);
+    debug_assert_eq!(
+        m,
+        comment_meta::meta_byte_exact(&srcs[..n], s as u32, end as u32, false),
+        "LCOM meta fused != exact at {s}"
+    );
+    lanes.comment_meta.push(m);
+    lanes.push_comment_record(srcs, n, s as u32, end as u32, false, m);
+    end
+}
+
+/// Lex the `/*` block comment at `s` (unterminated at EOF is diagnosed).
+/// Returns the resume index.
+#[inline(always)]
+unsafe fn lex_block_comment(
+    src: *const u8,
+    srcs: &[u8],
+    n: usize,
+    st: *mut u64,
+    kind: *mut u8,
+    s: usize,
+    lanes: &mut Lanes,
+) -> usize {
+    let (e, saw_nl, lic_q) = scan_block_comment(src, n, s + 2);
+    let end = if e < n { e + 1 } else { n };
+    if e >= n {
+        lanes.push_diag(s as u32, (n - s) as u32, diag_code::UNTERMINATED_BLOCK_COMMENT);
+    }
+    *kind.add(s) = BCOM;
+    if end > s + 1 {
+        bm_clear_range(st, s + 1, end - 1);
+    }
+    let m = if e < n {
+        let lic = lic_q >= 0 && (lic_q as usize) + 8 < e - 1;
+        comment_meta::meta_byte_flags(&srcs[..n], s as u32, end as u32, true, saw_nl, lic)
+    } else {
+        comment_meta::meta_byte_exact(&srcs[..n], s as u32, end as u32, true)
+    };
+    debug_assert_eq!(
+        m,
+        comment_meta::meta_byte_exact(&srcs[..n], s as u32, end as u32, true),
+        "BCOM meta fused != exact at {s}"
+    );
+    lanes.comment_meta.push(m);
+    lanes.push_comment_record(srcs, n, s as u32, end as u32, true, m);
+    end
+}
+
+/// Lex the regex literal at `s` (the regex-vs-division decision is already
+/// made): body, flag run, diagnostics. Returns the resume index.
+#[inline(always)]
+unsafe fn lex_regex(
+    src: *const u8,
+    srcs: &[u8],
+    n: usize,
+    st: *mut u64,
+    kind: *mut u8,
+    word: *const u64,
+    s: usize,
+    lanes: &mut Lanes,
+) -> usize {
+    let mut nl_at = usize::MAX;
+    let e = scan_regex(src, n, s + 1, &mut nl_at);
+    let fs = if e < n { e + 1 } else { n };
+    if nl_at != usize::MAX {
+        // oxc_parser reports a line terminator in the body as "unterminated"
+        // with a span ending just past the first one, even when a later `/`
+        // closes our token.
+        lanes.push_diag(s as u32, (nl_at + 1 - s) as u32, diag_code::LINE_TERMINATOR_IN_REGEXP);
+    } else if e >= n {
+        lanes.push_diag(s as u32, (n - s) as u32, diag_code::UNTERMINATED_REGEXP);
+    }
+    let mut end = fs;
+    if end < n && (*word.add(end >> 6) >> (end & 63)) & 1 != 0 {
+        end = bm_next0(word, end, n);
+    }
+    *kind.add(s) = REGEX;
+    if end > s + 1 {
+        bm_clear_range(st, s + 1, end - 1);
+    }
+    lanes.push_regex_flags(srcs, fs, end);
+    end
+}
+
+/// The `/` dispatch shared by `carve` and `carve_jsx` JS mode: line comment,
+/// block comment, regex, `/=`, or a bare slash left for `coalesce`.
+#[inline(always)]
+unsafe fn lex_slash(
+    t: &Tables,
+    src: *const u8,
+    srcs: &[u8],
+    n: usize,
+    st: *mut u64,
+    kind: *mut u8,
+    opch: *mut u64,
+    word: *const u64,
+    digit: *const u64,
+    ts: bool,
+    s: usize,
+    lanes: &mut Lanes,
+) -> usize {
+    let d = if s + 1 < n { *src.add(s + 1) } else { 0 };
+    if d == b'/' {
+        lex_line_comment(src, srcs, n, st, kind, s, lanes)
+    } else if d == b'*' {
+        lex_block_comment(src, srcs, n, st, kind, s, lanes)
+    } else if prev_is_regex(t, src, st, kind, word, digit, n, s, ts) {
+        lex_regex(src, srcs, n, st, kind, word, s, lanes)
+    } else if s + 1 < n && *src.add(s + 1) == b'=' {
+        // `/=`: absorb the `=`.
+        *kind.add(s) = OP_SLASH_EQ;
+        *st.add((s + 1) >> 6) &= !(1u64 << ((s + 1) & 63));
+        *opch.add((s + 1) >> 6) &= !(1u64 << ((s + 1) & 63));
+        s + 2
+    } else {
+        s + 1
+    }
+}
+
+/// Skip the payload of a brace-form unicode escape whose `{` is at `s`: the
+/// escape was already joined into its identifier by `misc_pre`, and its
+/// braces must not count toward substitution nesting.
+#[inline(always)]
+unsafe fn skip_unicode_brace_escape(src: *const u8, n: usize, s: usize) -> usize {
+    let mut j = s + 1;
+    while j < n && hex_val(*src.add(j)) != 255 {
+        j += 1;
+    }
+    if j < n && *src.add(j) == b'}' {
+        j += 1;
+    }
+    j
+}
+
+/// JSX-aware carve: a 3-mode (JS / TAG / TEXT) pushdown over a single frame
+/// stack, emitting JSX_LT / JEND / JTEXT and raw (no-escape) attribute
+/// strings. All JSX logic lives here; `classify` is untouched.
+///
+/// Unlike `carve`, takes `digit`/`dot`/`kwinit` as `*mut`: a JTEXT run's
+/// start byte keeps its `st` bit yet may be a digit/keyword/operator char,
+/// so those bits are cleared there to keep `coalesce` and `keywords` from
+/// re-interpreting it.
+pub(super) unsafe fn carve_jsx(
+    t: &Tables,
+    srcs: &[u8],
+    n: usize,
+    st: *mut u64,
+    kind: *mut u8,
+    opch: *mut u64,
+    word: *const u64,
+    digit: *mut u64,
+    dot: *mut u64,
+    kwinit: *mut u64,
+    ts: bool,
+    lanes: &mut Lanes,
+) {
+    let src = srcs.as_ptr();
+    let mut stack: Vec<JFrame> = Vec::with_capacity(64);
+    let mut mode = JMode::Js;
+    let mut text_start = 0usize;
+    let mut i = 0usize;
+    if n >= 2 && *src == b'#' && *src.add(1) == b'!' {
+        let end = find_line_terminator(src, n, 2);
+        *kind = HASHBANG;
+        bm_clear_range(st, 1, end - 1);
+        if end < n {
+            bm_set1(st, end);
+        }
+        i = end;
+    }
+    loop {
+        match mode {
+            JMode::Js => {
+                let in_brace = stack.last().is_some_and(|f| {
+                    matches!(f.kind, JFrameKind::TemplateSub | JFrameKind::JsxCont)
+                });
+                let s = if in_brace {
+                    find_opener_jsx7(src, n, i)
+                } else {
+                    find_opener_jsx5(src, n, i)
+                };
+                if s >= n {
+                    break;
+                }
+                let c = *src.add(s);
+                match c {
+                    b'"' | b'\'' => {
+                        i = lex_string(src, srcs, n, st, kind, s, c, lanes);
+                    }
+                    b'`' => {
+                        let (end, opened_sub) = lex_template_segment(
+                            src, srcs, n, st, kind, s, TMPL_HEAD, TMPL_NOSUB, lanes,
+                        );
+                        if opened_sub {
+                            stack.push(JFrame {
+                                kind: JFrameKind::TemplateSub,
+                                parent: JMode::Js,
+                                depth: 0,
+                            });
+                        }
+                        i = end;
+                    }
+                    b'{' => {
+                        if s >= 2 && *src.add(s - 1) == b'u' && *src.add(s - 2) == b'\\' {
+                            i = skip_unicode_brace_escape(src, n, s);
+                        } else {
+                            if let Some(f) = stack.last_mut() {
+                                f.depth += 1;
+                            }
+                            i = s + 1;
+                        }
+                    }
+                    b'}' => {
+                        let top_kind = stack.last().map(|f| f.kind);
+                        let top_depth = stack.last().map_or(0, |f| f.depth);
+                        if top_depth > 0 {
+                            if let Some(f) = stack.last_mut() {
+                                f.depth -= 1;
+                            }
+                            i = s + 1;
+                        } else if top_kind == Some(JFrameKind::TemplateSub) {
+                            stack.pop();
+                            let (end, opened_sub) = lex_template_segment(
+                                src,
+                                srcs,
+                                n,
+                                st,
+                                kind,
+                                s,
+                                TMPL_MIDDLE,
+                                TMPL_TAIL,
+                                lanes,
+                            );
+                            if opened_sub {
+                                stack.push(JFrame {
+                                    kind: JFrameKind::TemplateSub,
+                                    parent: JMode::Js,
+                                    depth: 0,
+                                });
+                            }
+                            i = end;
+                        } else if top_kind == Some(JFrameKind::JsxCont) {
+                            let parent = stack.last().map_or(JMode::Js, |f| f.parent);
+                            stack.pop();
+                            mode = parent;
+                            if mode == JMode::Text {
+                                text_start = s + 1;
+                            }
+                            i = s + 1;
+                        } else {
+                            i = s + 1;
+                        }
+                    }
+                    b'/' => {
+                        i = lex_slash(t, src, srcs, n, st, kind, opch, word, digit, ts, s, lanes);
+                    }
+                    b'<' => {
+                        let c1 = if s + 1 < n { *src.add(s + 1) } else { 0 };
+                        if c1 == b'<' {
+                            // `<<` shift: skip both, or the second `<` would
+                            // read the first as an operand preceder.
+                            i = s + 2;
+                        } else if c1 == b'=' || is_digit(c1) {
+                            // `<=` / `a<5`: leave for coalesce.
+                            i = s + 1;
+                        } else if prev_is_regex(t, src, st, kind, word, digit, n, s, ts) {
+                            // Operand position: candidate JSX.
+                            let mut tpos = s + 1;
+                            while tpos < n && is_ws(*src.add(tpos)) {
+                                tpos += 1;
+                            }
+                            let tc = if tpos < n { *src.add(tpos) } else { 0 };
+                            if tc == b'>' {
+                                // fragment `<>`
+                                jsx_punct(kind, opch, s, JSX_LT);
+                                stack.push(JFrame {
+                                    kind: JFrameKind::JsxTag,
+                                    parent: JMode::Js,
+                                    depth: 0,
+                                });
+                                mode = JMode::Tag;
+                            } else if is_id_start(tc) && !(ts && ts_is_type_params(srcs, n, tpos)) {
+                                // Element — unless `.tsx` says this is a
+                                // type-parameter list, which stays a less-than.
+                                jsx_punct(kind, opch, s, JSX_LT);
+                                stack.push(JFrame {
+                                    kind: JFrameKind::JsxTag,
+                                    parent: JMode::Js,
+                                    depth: 0,
+                                });
+                                mode = JMode::Tag;
+                            }
+                            i = s + 1;
+                        } else {
+                            // Operator position: less-than.
+                            i = s + 1;
+                        }
+                    }
+                    _ => {
+                        i = s + 1;
+                    }
+                }
+            }
+            JMode::Tag => {
+                let s = if ts { find_jsx_tag_ts(src, n, i) } else { find_jsx_tag(src, n, i) };
+                if s >= n {
+                    break;
+                }
+                // Tag/attr names that spell reserved words must stay IDENT:
+                // clear their `kwinit` so the `keywords` pass skips them.
+                if s > i {
+                    bm_clear_range(kwinit, i, s - 1);
+                }
+                let c = *src.add(s);
+                // `.tsx`: a type-argument list on the element
+                // (`<Box<number> ...>`) puts a balanced `<...>` run inside
+                // the opening tag; skip it so its inner `>` cannot close the
+                // tag. The skip is content-blind — a string type-arg is not
+                // carved (wrong kinds, still monotonic), and a literal
+                // `<`/`>` inside one desyncs the depth count. Content-aware
+                // skipping belongs to a TS type-aware round.
+                if ts && c == b'<' {
+                    let mut depth = 1i32;
+                    let mut p = s + 1;
+                    while p < n && depth != 0 {
+                        let q = find2(src, n, p, b'<', b'>');
+                        if q >= n {
+                            p = n;
+                            break;
+                        }
+                        depth += if *src.add(q) == b'<' { 1 } else { -1 };
+                        p = q + 1;
+                    }
+                    // Later passes can emit spurious diagnostics from the
+                    // uncarved interior; record the span so drain-time
+                    // filtering drops them.
+                    lanes.diag_suppress.push((s as u32, p as u32));
+                    i = p;
+                    continue;
+                }
+                match c {
+                    b'"' | b'\'' => {
+                        // JSX attribute string: no escapes, ends at next quote.
+                        let e = find1(src, n, s + 1, c);
+                        let end = if e < n { e + 1 } else { n };
+                        *kind.add(s) = STR;
+                        if end > s + 1 {
+                            bm_clear_range(st, s + 1, end - 1);
+                        }
+                        let be = if e < n {
+                            e
+                        } else if n > s + 1 && *src.add(n - 1) == c {
+                            n - 1
+                        } else {
+                            n
+                        };
+                        lanes.push_string_raw(srcs, s + 1, be);
+                        i = end;
+                    }
+                    b'{' => {
+                        stack.push(JFrame {
+                            kind: JFrameKind::JsxCont,
+                            parent: JMode::Tag,
+                            depth: 0,
+                        });
+                        mode = JMode::Js;
+                        i = s + 1;
+                    }
+                    b'/' => {
+                        let d = if s + 1 < n { *src.add(s + 1) } else { 0 };
+                        if d == b'*' {
+                            // comment inside a tag = whitespace
+                            i = lex_block_comment(src, srcs, n, st, kind, s, lanes);
+                        } else if d == b'/' {
+                            i = lex_line_comment(src, srcs, n, st, kind, s, lanes);
+                        } else if d == b'>' {
+                            // self-close `/>`
+                            let gp = s + 1;
+                            jsx_punct(kind, opch, gp, JEND);
+                            let parent = stack.last().map_or(JMode::Js, |f| f.parent);
+                            stack.pop();
+                            mode = parent;
+                            if mode == JMode::Text {
+                                text_start = gp + 1;
+                            }
+                            i = gp + 1;
+                        } else {
+                            // lone `/` (malformed) — stays a slash.
+                            i = s + 1;
+                        }
+                    }
+                    b'>' => {
+                        // opening tag ends; children begin
+                        if let Some(f @ JFrame { kind: JFrameKind::JsxTag, .. }) = stack.last_mut()
+                        {
+                            f.kind = JFrameKind::JsxElem;
+                        }
+                        jsx_punct(kind, opch, s, crate::token::token_kind::GT);
+                        mode = JMode::Text;
+                        text_start = s + 1;
+                        i = s + 1;
+                    }
+                    _ => {
+                        i = s + 1;
+                    }
+                }
+            }
+            JMode::Text => {
+                let s = find_jsx_text(src, n, i);
+                let runend = if s < n { s } else { n };
+                if runend > text_start {
+                    // One JTEXT token for the run; neutralize its start byte
+                    // against coalesce/keywords and clear the interior.
+                    bm_set1(st, text_start);
+                    *kind.add(text_start) = JTEXT;
+                    let w = text_start >> 6;
+                    let bit = 1u64 << (text_start & 63);
+                    *opch.add(w) &= !bit;
+                    *digit.add(w) &= !bit;
+                    *dot.add(w) &= !bit;
+                    *kwinit.add(w) &= !bit;
+                    if runend > text_start + 1 {
+                        bm_clear_range(st, text_start + 1, runend - 1);
+                    }
+                }
+                if s >= n {
+                    break;
+                }
+                let c = *src.add(s);
+                if c == b'{' {
+                    stack.push(JFrame { kind: JFrameKind::JsxCont, parent: JMode::Text, depth: 0 });
+                    mode = JMode::Js;
+                    i = s + 1;
+                } else if c == b'>' || c == b'}' {
+                    // A stray `>`/`}` ends the run; clear its opch so
+                    // coalesce can't fuse adjacent strays into `>>`.
+                    *opch.add(s >> 6) &= !(1u64 << (s & 63));
+                    text_start = s + 1;
+                    i = s + 1;
+                } else {
+                    // c == '<'
+                    let c1 = if s + 1 < n { *src.add(s + 1) } else { 0 };
+                    if c1 == b'/' {
+                        // closing tag `</name>` or `</>`; the name stays IDENT
+                        let gp = find1(src, n, s + 2, b'>');
+                        if gp > s + 2 {
+                            bm_clear_range(kwinit, s + 2, gp - 1);
+                        }
+                        jsx_punct(kind, opch, s, JSX_LT);
+                        if gp < n {
+                            jsx_punct(kind, opch, gp, JEND);
+                        }
+                        let parent = stack.last().map_or(JMode::Js, |f| f.parent);
+                        stack.pop();
+                        mode = parent;
+                        let after = if gp < n { gp + 1 } else { n };
+                        if mode == JMode::Text {
+                            text_start = after;
+                        }
+                        i = after;
+                    } else if c1 == b'>' || is_id_start(c1) {
+                        // child element / fragment
+                        jsx_punct(kind, opch, s, JSX_LT);
+                        stack.push(JFrame {
+                            kind: JFrameKind::JsxTag,
+                            parent: JMode::Text,
+                            depth: 0,
+                        });
+                        mode = JMode::Tag;
+                        i = s + 1;
+                    } else {
+                        // malformed lone `<` in text — clear opch, no `<<` fusion
+                        *opch.add(s >> 6) &= !(1u64 << (s & 63));
+                        text_start = s + 1;
+                        i = s + 1;
+                    }
+                }
+            }
+        }
+    }
+}
+pub(super) unsafe fn carve(
+    t: &Tables,
+    srcs: &[u8],
+    n: usize,
+    st: *mut u64,
+    kind: *mut u8,
+    opch: *mut u64,
+    word: *const u64,
+    digit: *const u64,
+    ts: bool,
+    lanes: &mut Lanes,
+) {
+    let src = srcs.as_ptr();
+    let mut depth: Vec<u32> = Vec::with_capacity(64);
+    let mut i = 0usize;
+    if n >= 2 && *src == b'#' && *src.add(1) == b'!' {
+        let end = find_line_terminator(src, n, 2);
+        *kind = HASHBANG;
+        bm_clear_range(st, 1, end - 1);
+        if end < n {
+            bm_set1(st, end);
+        }
+        i = end;
+    }
+    loop {
+        let nsub = depth.len();
+        let s = if nsub != 0 { find_opener6(src, n, i) } else { find_opener(src, n, i) };
+        if s >= n {
+            break;
+        }
+        let c = *src.add(s);
+        match c {
+            b'"' | b'\'' => {
+                i = lex_string(src, srcs, n, st, kind, s, c, lanes);
+            }
+            b'`' => {
+                let (end, opened_sub) =
+                    lex_template_segment(src, srcs, n, st, kind, s, TMPL_HEAD, TMPL_NOSUB, lanes);
+                if opened_sub {
+                    depth.push(0);
+                }
+                i = end;
+            }
+            b'{' => {
+                if s >= 2 && *src.add(s - 1) == b'u' && *src.add(s - 2) == b'\\' {
+                    i = skip_unicode_brace_escape(src, n, s);
+                } else {
+                    let top = depth.len() - 1;
+                    depth[top] += 1;
+                    i = s + 1;
+                }
+            }
+            b'}' => {
+                let top = depth.len() - 1;
+                if depth[top] > 0 {
+                    depth[top] -= 1;
+                    i = s + 1;
+                } else {
+                    depth.pop();
+                    let (end, opened_sub) = lex_template_segment(
+                        src,
+                        srcs,
+                        n,
+                        st,
+                        kind,
+                        s,
+                        TMPL_MIDDLE,
+                        TMPL_TAIL,
+                        lanes,
+                    );
+                    if opened_sub {
+                        depth.push(0);
+                    }
+                    i = end;
+                }
+            }
+            b'/' => {
+                i = lex_slash(t, src, srcs, n, st, kind, opch, word, digit, ts, s, lanes);
+            }
+            b'<' => {
+                // Annex B B.1.3: `<!--` begins a line comment, valid anywhere.
+                // A bare `<` falls through as an operator.
+                if s + 3 < n
+                    && *src.add(s + 1) == b'!'
+                    && *src.add(s + 2) == b'-'
+                    && *src.add(s + 3) == b'-'
+                {
+                    let end = find_line_terminator(src, n, s + 4);
+                    *kind.add(s) = LCOM;
+                    if end > s + 1 {
+                        bm_clear_range(st, s + 1, end - 1);
+                    }
+                    if end < n {
+                        bm_set1(st, end);
+                    }
+                    // `<`, `!`, `-` are opchars: clear the span from `opch`
+                    // or `coalesce` would re-tokenize `<!--` as operators.
+                    bm_clear_range(opch, s, end - 1);
+                    // meta_byte_exact skips a 2-byte delimiter; pass s + 2 so
+                    // the 4-byte `<!--` is skipped. The record keeps (s, end).
+                    let m = comment_meta::meta_byte_exact(
+                        &srcs[..n],
+                        (s + 2) as u32,
+                        end as u32,
+                        false,
+                    );
+                    lanes.comment_meta.push(m);
+                    lanes.push_comment_record(srcs, n, s as u32, end as u32, false, m);
+                    i = end;
+                } else {
+                    i = s + 1;
+                }
+            }
+            b'>' => {
+                // Annex B B.1.3: `-->` begins a line comment, but only at
+                // line start. `s` is the `>`; the `-->` starts at s - 2.
+                if s >= 2
+                    && *src.add(s - 1) == b'-'
+                    && *src.add(s - 2) == b'-'
+                    && html_close_at_line_start(srcs, s - 2)
+                {
+                    let start = s - 2;
+                    let end = find_line_terminator(src, n, s + 1);
+                    *kind.add(start) = LCOM;
+                    bm_set1(st, start);
+                    if end > start + 1 {
+                        bm_clear_range(st, start + 1, end - 1);
+                    }
+                    if end < n {
+                        bm_set1(st, end);
+                    }
+                    // Clear the span from `opch` (see `<!--` above).
+                    bm_clear_range(opch, start, end - 1);
+                    // `-->` is a 3-byte delimiter; pass start + 1 so the
+                    // 2-byte-delimiter body resolves to [s + 1, end).
+                    let m = comment_meta::meta_byte_exact(
+                        &srcs[..n],
+                        (start + 1) as u32,
+                        end as u32,
+                        false,
+                    );
+                    lanes.comment_meta.push(m);
+                    lanes.push_comment_record(srcs, n, start as u32, end as u32, false, m);
+                    i = end;
+                } else {
+                    i = s + 1;
+                }
+            }
+            _ => {
+                i = s + 1;
+            }
+        }
+    }
+}

--- a/crates/oxc_lexer/src/pipeline/classify.rs
+++ b/crates/oxc_lexer/src/pipeline/classify.rs
@@ -1,0 +1,371 @@
+use core::arch::x86_64::*;
+
+use crate::error::diag_code;
+use crate::lanes::Lanes;
+use crate::opmap::{KW_KIND_BASE, PUNCT1_KIND_UNKNOWN};
+use crate::tables::{PH_A, PH_B, PH_T0, PH_T1, Tables, is_digit, is_id_start, is_op_char, is_word};
+
+use super::bitmap::{bm_clear_range, bm_next0, bm_prev1, bm_set1};
+use super::find::{load256, mm, scan_ident_esc, veq};
+use super::{IDENT, IDENT_ESC, NUM, PRIV_IDENT, PRIV_IDENT_ESC, WS};
+
+#[inline(always)]
+unsafe fn vpunct1(
+    v: __m256i,
+    hn: __m256i,
+    pa: __m256i,
+    pb: __m256i,
+    pt0: __m256i,
+    pt1: __m256i,
+    v96: __m256i,
+) -> __m256i {
+    let h = _mm256_xor_si256(_mm256_shuffle_epi8(pa, v), _mm256_shuffle_epi8(pb, hn));
+    let o0 = _mm256_shuffle_epi8(pt0, h);
+    let o1 = _mm256_shuffle_epi8(pt1, h);
+    let ord = _mm256_blendv_epi8(o0, o1, _mm256_slli_epi16::<3>(h));
+    let ctl = _mm256_cmpgt_epi8(_mm256_set1_epi8(0x20), v);
+    _mm256_blendv_epi8(ord, v96, ctl)
+}
+pub(super) unsafe fn classify(
+    t: &Tables,
+    ts: bool,
+    src: *const u8,
+    n: usize,
+    word: *mut u64,
+    st: *mut u64,
+    kwinit: *mut u64,
+    opch: *mut u64,
+    digit: *mut u64,
+    dot: *mut u64,
+    misc: *mut u64,
+    kind: *mut u8,
+) {
+    // The merged LUT variants differ only in the keyword-initial bits; the
+    // selection happens once, outside the loop.
+    let mrg_lo = if ts { &t.mrg_lo_ts } else { &t.mrg_lo };
+    let mut cw: u64 = 0;
+    let mut cs: u64 = 0;
+    let mut i = 0usize;
+    let mut b = 0usize;
+    let v_pha = _mm256_broadcastsi128_si256(_mm_loadu_si128(PH_A.as_ptr() as *const __m128i));
+    let v_phb = _mm256_broadcastsi128_si256(_mm_loadu_si128(PH_B.as_ptr() as *const __m128i));
+    let v_pht0 = _mm256_broadcastsi128_si256(_mm_loadu_si128(PH_T0.as_ptr() as *const __m128i));
+    let v_pht1 = _mm256_broadcastsi128_si256(_mm_loadu_si128(PH_T1.as_ptr() as *const __m128i));
+    let v_96 = _mm256_set1_epi8(PUNCT1_KIND_UNKNOWN as i8);
+    let v_ws = _mm256_set1_epi8(WS as i8);
+    let v_ident = _mm256_set1_epi8(IDENT as i8);
+    let v_num = _mm256_set1_epi8(NUM as i8);
+    let v_mlo = _mm256_broadcastsi128_si256(_mm_loadu_si128(mrg_lo.as_ptr() as *const __m128i));
+    let v_mhi = _mm256_broadcastsi128_si256(_mm_loadu_si128(t.mrg_hi.as_ptr() as *const __m128i));
+    let v_wblo = _mm256_broadcastsi128_si256(_mm_loadu_si128(t.wb_lo.as_ptr() as *const __m128i));
+    let v_wbhi = _mm256_broadcastsi128_si256(_mm_loadu_si128(t.wb_hi.as_ptr() as *const __m128i));
+    let v_kwpl = _mm256_set1_epi8(0x03);
+    let v_oppl = _mm256_set1_epi8(0x3c);
+    let v_wdpl = _mm256_set1_epi8(0x3f);
+    let v_wspl = _mm256_set1_epi8(0xc0u8 as i8);
+    let v_dgpl = _mm256_set1_epi8(0x02);
+    let v_ones = _mm256_set1_epi8(0xffu8 as i8);
+    let v_zero = _mm256_setzero_si256();
+    let v_x0f = _mm256_set1_epi8(0x0f);
+    while i + 64 <= n {
+        let v0 = load256(src, i);
+        let v1 = load256(src, i + 32);
+        let hn0 = _mm256_and_si256(_mm256_srli_epi16::<4>(v0), v_x0f);
+        let hn1 = _mm256_and_si256(_mm256_srli_epi16::<4>(v1), v_x0f);
+        let tb0 =
+            _mm256_and_si256(_mm256_shuffle_epi8(v_wblo, v0), _mm256_shuffle_epi8(v_wbhi, hn0));
+        let tb1 =
+            _mm256_and_si256(_mm256_shuffle_epi8(v_wblo, v1), _mm256_shuffle_epi8(v_wbhi, hn1));
+        let nw0 = _mm256_cmpeq_epi8(_mm256_and_si256(tb0, v_wdpl), v_zero);
+        let nw1 = _mm256_cmpeq_epi8(_mm256_and_si256(tb1, v_wdpl), v_zero);
+        // Non-ASCII bytes count as identifier chars in `word` and are folded
+        // into `misc` so `misc_pre` can re-classify Unicode whitespace.
+        let na0 = _mm256_cmpgt_epi8(v_zero, v0);
+        let na1 = _mm256_cmpgt_epi8(v_zero, v1);
+        let w0 = _mm256_or_si256(_mm256_xor_si256(nw0, v_ones), na0);
+        let w1 = _mm256_or_si256(_mm256_xor_si256(nw1, v_ones), na1);
+        let nws0 = _mm256_cmpeq_epi8(_mm256_and_si256(tb0, v_wspl), v_zero);
+        let nws1 = _mm256_cmpeq_epi8(_mm256_and_si256(tb1, v_wspl), v_zero);
+        let d0 = _mm256_cmpgt_epi8(_mm256_and_si256(tb0, v_dgpl), v_zero);
+        let d1 = _mm256_cmpgt_epi8(_mm256_and_si256(tb1, v_dgpl), v_zero);
+        let wordm = (mm(w0) as u64) | ((mm(w1) as u64) << 32);
+        let wsm = ((!mm(nws0)) as u64) | (((!mm(nws1)) as u64) << 32);
+        *word.add(b) = wordm;
+        *digit.add(b) = (mm(d0) as u64) | ((mm(d1) as u64) << 32);
+        *misc.add(b) = (mm(_mm256_or_si256(_mm256_or_si256(veq(v0, b'#'), veq(v0, b'\\')), na0))
+            as u64)
+            | ((mm(_mm256_or_si256(_mm256_or_si256(veq(v1, b'#'), veq(v1, b'\\')), na1)) as u64)
+                << 32);
+        let t0 = _mm256_and_si256(_mm256_shuffle_epi8(v_mlo, v0), _mm256_shuffle_epi8(v_mhi, hn0));
+        let t1 = _mm256_and_si256(_mm256_shuffle_epi8(v_mlo, v1), _mm256_shuffle_epi8(v_mhi, hn1));
+        *dot.add(b) = (mm(t0) as u64) | ((mm(t1) as u64) << 32);
+        *kwinit.add(b) = (mm(_mm256_cmpgt_epi8(_mm256_and_si256(t0, v_kwpl), v_zero)) as u64)
+            | ((mm(_mm256_cmpgt_epi8(_mm256_and_si256(t1, v_kwpl), v_zero)) as u64) << 32);
+        *opch.add(b) = (mm(_mm256_cmpgt_epi8(_mm256_and_si256(t0, v_oppl), v_zero)) as u64)
+            | ((mm(_mm256_cmpgt_epi8(_mm256_and_si256(t1, v_oppl), v_zero)) as u64) << 32);
+        let wprev = (wordm << 1) | cw;
+        let sprev = (wsm << 1) | cs;
+        cw = wordm >> 63;
+        cs = wsm >> 63;
+        *st.add(b) = (wsm & !sprev) | (wordm & !wprev) | (!wsm & !wordm);
+        let mut k0 = vpunct1(v0, hn0, v_pha, v_phb, v_pht0, v_pht1, v_96);
+        k0 = _mm256_blendv_epi8(v_ws, k0, nws0);
+        k0 = _mm256_blendv_epi8(k0, v_ident, w0);
+        k0 = _mm256_blendv_epi8(k0, v_num, d0);
+        let mut k1 = vpunct1(v1, hn1, v_pha, v_phb, v_pht0, v_pht1, v_96);
+        k1 = _mm256_blendv_epi8(v_ws, k1, nws1);
+        k1 = _mm256_blendv_epi8(k1, v_ident, w1);
+        k1 = _mm256_blendv_epi8(k1, v_num, d1);
+        _mm256_storeu_si256(kind.add(b * 64) as *mut __m256i, k0);
+        _mm256_storeu_si256(kind.add(b * 64 + 32) as *mut __m256i, k1);
+        i += 64;
+        b += 1;
+    }
+    if i < n {
+        let mut w: u64 = 0;
+        let mut stw: u64 = 0;
+        let mut kwi: u64 = 0;
+        let mut opw: u64 = 0;
+        let mut dgw: u64 = 0;
+        let mut dtw: u64 = 0;
+        let mut msw: u64 = 0;
+        let mut prev_word = cw & 1;
+        let mut prev_ws = cs & 1;
+        let tail = n - i;
+        for kk in 0..tail {
+            let c = *src.add(i + kk);
+            let isw = is_word(c);
+            let isws = crate::tables::is_ws(c);
+            if isw {
+                w |= 1u64 << kk;
+            }
+            if if ts { crate::tables::is_kw_init_ts(c) } else { crate::tables::is_kw_init(c) } {
+                kwi |= 1u64 << kk;
+            }
+            if is_op_char(c) {
+                opw |= 1u64 << kk;
+            }
+            if is_digit(c) {
+                dgw |= 1u64 << kk;
+            }
+            if c == b'.' {
+                dtw |= 1u64 << kk;
+            }
+            if c == b'#' || c == b'\\' || c >= 0x80 {
+                msw |= 1u64 << kk;
+            }
+            let start = (isws && prev_ws == 0) || (isw && prev_word == 0) || (!isws && !isw);
+            if start {
+                stw |= 1u64 << kk;
+            }
+            let kd = if isws {
+                WS
+            } else if isw {
+                if is_digit(c) { NUM } else { IDENT }
+            } else {
+                t.op.punct1_ord[c as usize]
+            };
+            *kind.add(i + kk) = kd;
+            prev_word = isw as u64;
+            prev_ws = isws as u64;
+        }
+        *word.add(b) = w;
+        *st.add(b) = stw;
+        *kwinit.add(b) = kwi;
+        *opch.add(b) = opw;
+        *digit.add(b) = dgw;
+        *dot.add(b) = dtw;
+        *misc.add(b) = msw;
+    }
+}
+/// Byte length (2 or 3) of the multi-byte ECMAScript WhiteSpace /
+/// LineTerminator at `p`, or 0. The non-ASCII set: U+00A0, U+1680,
+/// U+2000..=U+200A, U+2028, U+2029, U+202F, U+205F, U+3000, U+FEFF.
+#[inline]
+unsafe fn unicode_ws_len(src: *const u8, p: usize) -> usize {
+    let c1 = *src.add(p + 1);
+    match *src.add(p) {
+        0xC2 => usize::from(c1 == 0xA0) * 2,
+        0xE1 => usize::from(c1 == 0x9A && *src.add(p + 2) == 0x80) * 3,
+        0xE2 => {
+            let c2 = *src.add(p + 2);
+            let is_ws = (c1 == 0x80
+                && ((0x80..=0x8A).contains(&c2) || c2 == 0xA8 || c2 == 0xA9 || c2 == 0xAF))
+                || (c1 == 0x81 && c2 == 0x9F);
+            usize::from(is_ws) * 3
+        }
+        0xE3 => usize::from(c1 == 0x80 && *src.add(p + 2) == 0x80) * 3,
+        0xEF => usize::from(c1 == 0xBB && *src.add(p + 2) == 0xBF) * 3,
+        _ => 0,
+    }
+}
+/// Validate the UTF-8 sequence led by the byte at `p` (>= 0x80). Returns
+/// `(valid, cont)` where `cont` is the count of range-valid continuation
+/// bytes after the lead. Second-byte ranges are per-lead, so overlongs,
+/// surrogates, and out-of-range sequences report the same maximal subpart
+/// as `std::str::from_utf8`'s `error_len`.
+#[inline]
+unsafe fn utf8_seq_check(src: *const u8, p: usize, n: usize) -> (bool, usize) {
+    let (need, lo, hi): (usize, u8, u8) = match *src.add(p) {
+        0xC2..=0xDF => (1, 0x80, 0xBF),
+        0xE0 => (2, 0xA0, 0xBF),
+        0xE1..=0xEC | 0xEE..=0xEF => (2, 0x80, 0xBF),
+        0xED => (2, 0x80, 0x9F),
+        0xF0 => (3, 0x90, 0xBF),
+        0xF1..=0xF3 => (3, 0x80, 0xBF),
+        0xF4 => (3, 0x80, 0x8F),
+        // 0x80..=0xBF stray continuation, 0xC0/0xC1 overlong leads, 0xF5..=0xFF
+        _ => return (false, 0),
+    };
+    let mut cont = 0usize;
+    if p + 1 < n && *src.add(p + 1) >= lo && *src.add(p + 1) <= hi {
+        cont = 1;
+        while cont < need && p + 1 + cont < n {
+            let b = *src.add(p + 1 + cont);
+            if !(0x80..=0xBF).contains(&b) {
+                break;
+            }
+            cont += 1;
+        }
+    }
+    (cont == need, cont)
+}
+/// `VUTF8` (`LexOptions::validate_utf8`) adds UTF-8 well-formedness
+/// validation to the non-ASCII walk. Monomorphized so the default `false`
+/// copy pays nothing for it.
+pub(super) unsafe fn misc_pre<const VUTF8: bool>(
+    src: *const u8,
+    n: usize,
+    st: *mut u64,
+    word: *mut u64,
+    misc: *const u64,
+    kind: *mut u8,
+    lanes: &mut Lanes,
+) -> usize {
+    let mut nesc = 0usize;
+    let nw = (n + 63) >> 6;
+    // VUTF8 only: continuation bits spilling into the next word, and the
+    // once-per-file latch for the UTF-8 diagnostic (parser parity; also
+    // bounds the diag Vec on binary input).
+    let mut skip_lo: u64 = 0;
+    let mut utf8_bad = false;
+    for w in 0..nw {
+        let mut m = if VUTF8 { *misc.add(w) & !skip_lo } else { *misc.add(w) };
+        if VUTF8 {
+            skip_lo = 0;
+        }
+        while m != 0 {
+            let bit = m.trailing_zeros() as usize;
+            m &= m - 1;
+            let p = (w << 6) + bit;
+            let c = *src.add(p);
+            // Multi-byte Unicode whitespace was bulk-classified as an
+            // identifier char; re-mark it as a whitespace token boundary.
+            // Continuation bytes and non-ws leads fall through cheaply.
+            if c >= 0x80 {
+                if VUTF8 {
+                    let (ok, cont) = utf8_seq_check(src, p, n);
+                    if ok {
+                        // Consume the verified continuation bits so they are
+                        // not re-visited; a continuation still visible to the
+                        // walk had no valid lead — that is the stray-
+                        // continuation check.
+                        let cm: u128 = (((1u128 << cont) - 1) << 1) << (p & 63);
+                        m &= !(cm as u64);
+                        skip_lo |= (cm >> 64) as u64;
+                    } else if !utf8_bad {
+                        utf8_bad = true;
+                        // Span = the maximal invalid subpart; one diag per
+                        // file, context-free (fires inside strings too).
+                        lanes.push_diag(p as u32, (1 + cont) as u32, diag_code::INVALID_UTF8);
+                        continue;
+                    } else {
+                        continue;
+                    }
+                }
+                let len = unicode_ws_len(src, p);
+                if len != 0 {
+                    *kind.add(p) = WS;
+                    bm_clear_range(word, p, p + len - 1);
+                    bm_set1(st, p);
+                    bm_clear_range(st, p + 1, p + len - 1);
+                    if p + len < n {
+                        bm_set1(st, p + len);
+                    }
+                } else if (0xC2..=0xF4).contains(&c) {
+                    // Non-whitespace lead: record the position only. The
+                    // identifier-char check is deferred to drain, where leads
+                    // inside literal tokens drop before ever paying for it.
+                    lanes.unicode_leads.push(p as u32);
+                }
+                continue;
+            }
+            if (*st.add(p >> 6) >> (p & 63)) & 1 == 0 {
+                continue;
+            }
+            if c == b'#' {
+                if p == 0 && n > 1 && *src.add(1) == b'!' {
+                    continue;
+                }
+                // Accept an id-start or a leading unicode escape, so a
+                // private name whose first char is itself an escape forms
+                // one token instead of `#` + escape.
+                let c1 = *src.add(p + 1);
+                if !(is_id_start(c1) || (c1 == b'\\' && *src.add(p + 2) == b'u')) {
+                    continue;
+                }
+                let e0 = bm_next0(word, p + 1, n);
+                let e = if *src.add(e0) == b'\\' && *src.add(e0 + 1) == b'u' {
+                    *kind.add(p) = PRIV_IDENT_ESC;
+                    scan_ident_esc(src, n, e0)
+                } else {
+                    *kind.add(p) = PRIV_IDENT;
+                    e0
+                };
+                bm_clear_range(st, p + 1, e - 1);
+            } else {
+                if *src.add(p + 1) != b'u' {
+                    continue;
+                }
+                *kind.add(p) = IDENT_ESC;
+                nesc += 1;
+                let e = scan_ident_esc(src, n, p);
+                bm_clear_range(st, p + 1, e - 1);
+            }
+        }
+    }
+    nesc
+}
+pub(super) unsafe fn misc_post(
+    src: *const u8,
+    n: usize,
+    st: *mut u64,
+    word: *const u64,
+    misc: *const u64,
+    kind: *mut u8,
+) {
+    let nw = (n + 63) >> 6;
+    for w in 0..nw {
+        let mut m = *misc.add(w);
+        while m != 0 {
+            let bit = m.trailing_zeros() as usize;
+            m &= m - 1;
+            let p = (w << 6) + bit;
+            if *src.add(p) != b'\\' || *src.add(p + 1) != b'u' {
+                continue;
+            }
+            if (*st.add(p >> 6) >> (p & 63)) & 1 == 0 {
+                continue;
+            }
+            if p == 0 || (*word.add((p - 1) >> 6) >> ((p - 1) & 63)) & 1 == 0 {
+                continue;
+            }
+            let tt = bm_prev1(st, p);
+            let k = *kind.add(tt as usize);
+            if k == IDENT || (k >= KW_KIND_BASE && k != PUNCT1_KIND_UNKNOWN) {
+                *kind.add(tt as usize) = IDENT_ESC;
+                *st.add(p >> 6) &= !(1u64 << (p & 63));
+            }
+        }
+    }
+}

--- a/crates/oxc_lexer/src/pipeline/coalesce.rs
+++ b/crates/oxc_lexer/src/pipeline/coalesce.rs
@@ -1,0 +1,325 @@
+use core::arch::x86_64::{_MM_HINT_T0, _mm_prefetch};
+
+use crate::error::diag_code;
+use crate::lanes::Lanes;
+use crate::opmap::{KwSet, OP_QDOT};
+use crate::tables::{Tables, is_digit, is_op_char, is_word};
+
+use super::NUM;
+use super::bitmap::{bm_clear_range, bm_next0, bm_set1};
+use super::find::scan_number;
+use super::keywords::{KWB, kw_verify_batch};
+
+unsafe fn munch_walk(
+    t: &Tables,
+    src: *const u8,
+    n: usize,
+    st: *mut u64,
+    opch: *const u64,
+    kind: *mut u8,
+    mut pos: usize,
+) -> usize {
+    let end = bm_next0(opch, pos, n);
+    while end - pos >= 2 {
+        bm_set1(st, pos);
+        let rem = end - pos;
+        let lmax: u32 = if rem < 4 { rem as u32 } else { 4 };
+        let b0 = *src.add(pos);
+        let b1 = *src.add(pos + 1);
+        let b2 = *src.add(pos + 2);
+        let b3 = *src.add(pos + 3);
+        let mut opk: u32 = 0;
+        let mut opl: u32 = 0;
+        let mut l = lmax;
+        while l >= 2 {
+            let k = t.op.opmap_lookup(b0, b1, b2, b3, l);
+            if k != 0 && !(k == OP_QDOT as u32 && pos + 2 < n && is_digit(*src.add(pos + 2))) {
+                opk = k;
+                opl = l;
+                break;
+            }
+            l -= 1;
+        }
+        if opk != 0 {
+            *kind.add(pos) = opk as u8;
+            let mut j = 1usize;
+            while j < opl as usize {
+                *st.add((pos + j) >> 6) &= !(1u64 << ((pos + j) & 63));
+                j += 1;
+            }
+            pos += opl as usize;
+        } else {
+            pos += 1;
+        }
+    }
+    if end - pos == 1 {
+        bm_set1(st, pos);
+    }
+    pos
+}
+unsafe fn glue_number(
+    t: &Tables,
+    kw: &KwSet,
+    src: *const u8,
+    n: usize,
+    st: *mut u64,
+    opch: *mut u64,
+    word: *const u64,
+    kind: *mut u8,
+    mut p: usize,
+    lanes: &mut Lanes,
+) -> usize {
+    loop {
+        let e2 = scan_number(src, n, p);
+        *kind.add(p) = NUM + (*src.add(e2 - 1) == b'n') as u8;
+        if e2 > p + 1 {
+            bm_clear_range(st, p + 1, e2 - 1);
+            bm_clear_range(opch, p, e2 - 1);
+        }
+        if e2 >= n {
+            return n;
+        }
+        bm_set1(st, e2);
+        let c = *src.add(e2);
+        // A word char abutting the number end (`1.5n`, `3in`, `0b12`, `1π`)
+        // is a spec-invalid adjacency. Never true on valid input, so the
+        // whole arm is cold.
+        if is_word(c) {
+            let srcs = core::slice::from_raw_parts(src, n);
+            if c < 0x80 {
+                // A surviving `n` is a misplaced bigint suffix; scan_number
+                // consumes legal ones. Token spans are unchanged either way.
+                let code = if c == b'n' {
+                    diag_code::INVALID_BIGINT
+                } else {
+                    diag_code::INVALID_NUMERIC_LITERAL
+                };
+                lanes.push_num_end_diag(srcs, e2, code);
+                if is_digit(c) {
+                    // Digit invalid for the radix (`0b12`) or after a bigint
+                    // suffix (`1n2`): keep gluing from it.
+                    p = e2;
+                    continue;
+                }
+                // This token start postdates the kwc mask built in the word
+                // prelude, so resolve any keyword kind inline (`3in` is `3`
+                // + KW_IN). Same inputs as kw_verify_batch: length from the
+                // word bitmap, no match right after a member `.` (a number
+                // ending in `.` is that dot-run's first dot).
+                if *src.add(e2 - 1) != b'.' {
+                    let wb = word as *const u8;
+                    let x = core::ptr::read_unaligned(wb.add(e2 >> 3) as *const u64) >> (e2 & 7);
+                    let kk = kw.lookup(src.add(e2), (!x).trailing_zeros() as usize);
+                    if kk != 0 {
+                        *kind.add(e2) = kk as u8;
+                    }
+                }
+            } else {
+                // Cold decode; flags only a real Unicode IdentifierStart.
+                lanes.push_num_end_diag_unicode(srcs, e2);
+            }
+            return e2; // token start already set at e2
+        }
+        if e2 + 1 < n && is_op_char(c) && (*opch.add((e2 + 1) >> 6) >> ((e2 + 1) & 63)) & 1 != 0 {
+            let q = munch_walk(t, src, n, st, opch, kind, e2);
+            if q < n
+                && *src.add(q) == b'.'
+                && is_digit(*src.add(q + 1))
+                && (*st.add(q >> 6) >> (q & 63)) & 1 != 0
+            {
+                p = q;
+                continue;
+            }
+            return q;
+        }
+        return e2;
+    }
+}
+/// Dispatch to the key-monomorphized verify without duplicating `coalesce`
+/// itself: one predictable branch per flush, not per candidate, keyed off
+/// the set itself so the walk carries no extra mode scalar.
+#[inline(always)]
+unsafe fn kw_flush(
+    kw: &KwSet,
+    src: *const u8,
+    word: *const u64,
+    kind: *mut u8,
+    kwpos: *const u32,
+    k: usize,
+) {
+    if kw.ts_key {
+        kw_verify_batch::<true>(kw, src, word, kind, kwpos, k);
+    } else {
+        kw_verify_batch::<false>(kw, src, word, kind, kwpos, k);
+    }
+}
+pub(super) unsafe fn coalesce(
+    t: &Tables,
+    kw: &KwSet,
+    src: *const u8,
+    n: usize,
+    st: *mut u64,
+    opch: *mut u64,
+    word: *const u64,
+    digit: *const u64,
+    dot: *const u64,
+    kwinit: *const u64,
+    kind: *mut u8,
+    kwpos: *mut u32,
+    lanes: &mut Lanes,
+) {
+    let nw = (n + 63) >> 6;
+    let mut opprev: u64 = 0;
+    let mut dtprev: u64 = 0;
+    let mut cursor: usize = 0;
+    let mut k = 0usize;
+    for w in 0..nw {
+        let op = *opch.add(w);
+        let opnext = if w + 1 < nw { *opch.add(w + 1) } else { 0 };
+        let dg = *digit.add(w);
+        let dgnext = if w + 1 < nw { *digit.add(w + 1) } else { 0 };
+        let dt = *dot.add(w);
+        let stw = *st.add(w);
+        let wd = *word.add(w);
+        let wnext = if w + 1 < nw { *word.add(w + 1) } else { 0 };
+        // The whole keywords stage lives inside this walk: the candidate
+        // filter (token-start keyword-initial word char, next char also
+        // word, not right after a member `.`, length <= 10 by the word-local
+        // run filter) computes from values already in registers, candidates
+        // extract into `kwpos`, and the batch verifies every KWB words while
+        // this window's src/kind lines are still warm. The only token start
+        // minted behind the filter is glue_number's invalid adjacency, which
+        // resolves its keyword kind inline with the same inputs, so the two
+        // writes agree even when both fire.
+        let dm = dt & !((dt << 1) | (dtprev >> 63));
+        let dcarry = ((dtprev >> 63) & !(dtprev >> 62)) & 1;
+        let mut kwc =
+            stw & wd & *kwinit.add(w) & ((wd >> 1) | (wnext << 63)) & !((dm << 1) | dcarry);
+        let r2 = wd & (wd >> 1);
+        let r4 = r2 & (r2 >> 2);
+        let r8 = r4 & (r4 >> 4);
+        kwc &= !(r8 & (r2 >> 8) & (wd >> 10));
+        dtprev = dt;
+        if kwc != 0 {
+            let base = (w << 6) as u32;
+            let cnt = kwc.count_ones() as usize;
+            _mm_prefetch(src.add(base as usize) as *const i8, _MM_HINT_T0);
+            _mm_prefetch(kind.add(base as usize) as *const i8, _MM_HINT_T0);
+            *kwpos.add(k) = base + kwc.trailing_zeros();
+            kwc &= kwc.wrapping_sub(1);
+            *kwpos.add(k + 1) = base + kwc.trailing_zeros();
+            kwc &= kwc.wrapping_sub(1);
+            *kwpos.add(k + 2) = base + kwc.trailing_zeros();
+            kwc &= kwc.wrapping_sub(1);
+            *kwpos.add(k + 3) = base + kwc.trailing_zeros();
+            kwc &= kwc.wrapping_sub(1);
+            if cnt > 4 {
+                let mut kk = k + 4;
+                while kwc != 0 {
+                    *kwpos.add(kk) = base + kwc.trailing_zeros();
+                    kk += 1;
+                    kwc &= kwc - 1;
+                }
+            }
+            k += cnt;
+        }
+        let multi = op & !((op << 1) | (opprev >> 63)) & ((op >> 1) | (opnext << 63)) & stw;
+        let dige0 = stw & dg;
+        let dote = stw & dt & ((dg >> 1) | (dgnext << 63));
+        let mut dige = dige0;
+        if dige != 0 {
+            let dend = !dg & (dg << 1);
+            let bad = dend & (wd | dt);
+            let mut keep: u64 = if bad != 0 { !0u64 } else { 0 };
+            if dg >> 63 != 0 {
+                keep |= 1u64 << (64 - (!dg).leading_zeros());
+            }
+            dige &= keep;
+        }
+        let mut ev = multi | dige | dote;
+        let rare = dige | dote;
+        opprev = op;
+        while ev != 0 {
+            let bit = ev.trailing_zeros() as usize;
+            ev &= ev - 1;
+            let p = (w << 6) + bit;
+            if p < cursor {
+                continue;
+            }
+            if (rare >> bit) & 1 != 0 {
+                if (dige >> bit) & 1 != 0 {
+                    let x = (wd >> bit) | ((wnext << (63 - bit)) << 1);
+                    let y = (dg >> bit) | ((dgnext << (63 - bit)) << 1);
+                    let wl = (!x).trailing_zeros() as usize;
+                    let dl = (!y).trailing_zeros() as usize;
+                    if wl == dl && wl < 64 && *src.add(p + wl) != b'.' {
+                        continue;
+                    }
+                }
+                cursor = glue_number(t, kw, src, n, st, opch, word, kind, p, lanes);
+            } else {
+                let y2 = (op >> bit) | ((opnext << (63 - bit)) << 1);
+                let run = (!y2).trailing_zeros() as usize;
+                let q = core::ptr::read_unaligned(src.add(p) as *const u32);
+                let b0 = q as u8;
+                let b1 = (q >> 8) as u8;
+                if run == 2 {
+                    let key = (q & 0xFFFF) | (2u32 << 24);
+                    let pack = t.op2_pack[(key.wrapping_mul(t.op.opmap_mul) >> 24) as usize];
+                    let want = 2u32 | ((b0 as u32) << 8) | ((b1 as u32) << 16);
+                    let mut ok = ((pack ^ want) & 0x00FF_FFFF) == 0;
+                    let kk = (pack >> 24) as u8;
+                    ok &= !((kk == OP_QDOT) && is_digit((q >> 16) as u8));
+                    let hm: u8 = 0u8.wrapping_sub(ok as u8);
+                    *kind.add(p) = (*kind.add(p) & !hm) | (kk & hm);
+                    let clr = (ok as u64) << ((p + 1) & 63);
+                    *st.add((p + 1) >> 6) &= !clr;
+                    cursor = p + 1 + ok as usize;
+                    continue;
+                }
+                if run > 3 {
+                    cursor = munch_walk(t, src, n, st, opch, kind, p);
+                    continue;
+                }
+                let b2 = (q >> 16) as u8;
+                let key3 = (q & 0xFF_FFFF) | (3u32 << 24);
+                let p3 = t.op3_pack[(key3.wrapping_mul(t.op.opmap_mul) >> 24) as usize];
+                let want3 = 3u64 | ((b0 as u64) << 8) | ((b1 as u64) << 16) | ((b2 as u64) << 24);
+                let ok3 = ((p3 ^ want3) & 0xFFFF_FFFF) == 0;
+                let key2a = (q & 0xFFFF) | (2u32 << 24);
+                let pa = t.op2_pack[(key2a.wrapping_mul(t.op.opmap_mul) >> 24) as usize];
+                let wanta = 2u32 | ((b0 as u32) << 8) | ((b1 as u32) << 16);
+                let ka = (pa >> 24) as u8;
+                let mut ok2a = ((pa ^ wanta) & 0x00FF_FFFF) == 0;
+                ok2a &= !((ka == OP_QDOT) && is_digit(b2));
+                let key2b = ((q >> 8) & 0xFFFF) | (2u32 << 24);
+                let pb = t.op2_pack[(key2b.wrapping_mul(t.op.opmap_mul) >> 24) as usize];
+                let wantb = 2u32 | ((b1 as u32) << 8) | ((b2 as u32) << 16);
+                let kb = (pb >> 24) as u8;
+                let mut ok2b = ((pb ^ wantb) & 0x00FF_FFFF) == 0;
+                ok2b &= !((kb == OP_QDOT) && is_digit((q >> 24) as u8));
+                let sel3 = ok3;
+                let sel2a = !ok3 && ok2a;
+                let sel2b = !ok3 && !ok2a && ok2b;
+                let m0: u8 = 0u8.wrapping_sub((sel3 || sel2a) as u8);
+                let k0v: u8 = if sel3 { (p3 >> 32) as u8 } else { ka };
+                *kind.add(p) = (*kind.add(p) & !m0) | (k0v & m0);
+                let m1: u8 = 0u8.wrapping_sub(sel2b as u8);
+                *kind.add(p + 1) = (*kind.add(p + 1) & !m1) | (kb & m1);
+                let clr1 = ((sel3 || sel2a) as u64) << ((p + 1) & 63);
+                *st.add((p + 1) >> 6) &= !clr1;
+                let clr2 = ((sel3 || sel2b) as u64) << ((p + 2) & 63);
+                *st.add((p + 2) >> 6) &= !clr2;
+                let mut adv = if sel3 { 3 } else { run - 1 };
+                adv = if sel2a { 2 } else { adv };
+                adv = if sel2b { 3 } else { adv };
+                cursor = p + adv;
+            }
+        }
+        if w & (KWB - 1) == KWB - 1 {
+            kw_flush(kw, src, word, kind, kwpos, k);
+            k = 0;
+        }
+    }
+    kw_flush(kw, src, word, kind, kwpos, k);
+}

--- a/crates/oxc_lexer/src/pipeline/compress.rs
+++ b/crates/oxc_lexer/src/pipeline/compress.rs
@@ -1,0 +1,177 @@
+use core::arch::x86_64::*;
+
+use crate::error::diag_code;
+use crate::lanes::Lanes;
+use crate::tables::Tables;
+
+use super::{BIGINT, IDENT_ESC, NUM, PRIV_IDENT_ESC};
+
+pub(super) unsafe fn compress(
+    t: &Tables,
+    st: *const u64,
+    kind: *const u8,
+    nb: usize,
+    starts: *mut u32,
+    kinds: *mut u8,
+) -> usize {
+    let mut m = 0usize;
+    for b in 0..nb {
+        let mword = *st.add(b);
+        if mword == 0 {
+            continue;
+        }
+        let base = b * 64;
+        let o0: u32 = 0;
+        let o1 = o0 + (mword & 0xff).count_ones();
+        let o2 = o1 + (mword & 0xff00).count_ones();
+        let o3 = o2 + (mword & 0xff_0000).count_ones();
+        let o4 = o3 + (mword & 0xff00_0000).count_ones();
+        let o5 = o4 + (mword & 0xff_0000_0000).count_ones();
+        let o6 = o5 + (mword & 0xff00_0000_0000).count_ones();
+        let o7 = o6 + (mword & 0xff_0000_0000_0000).count_ones();
+        let o8 = o7 + (mword >> 56).count_ones();
+        macro_rules! chunk {
+            ($ch:expr, $off:expr) => {{
+                let sub = ((mword >> (8 * $ch)) & 0xff) as usize;
+                let row = &t.comp_lut[sub];
+                let lut = _mm256_load_si256(row.lanes.as_ptr() as *const __m256i);
+                let cs = _mm256_add_epi32(_mm256_set1_epi32((base + 8 * $ch) as i32), lut);
+                _mm256_storeu_si256(starts.add(m + $off as usize) as *mut __m256i, cs);
+                let kb = _mm_loadl_epi64(kind.add(base + 8 * $ch) as *const __m128i);
+                let ck = _mm_shuffle_epi8(kb, _mm_load_si128(row.bytes.as_ptr() as *const __m128i));
+                _mm_storel_epi64(kinds.add(m + $off as usize) as *mut __m128i, ck);
+            }};
+        }
+        chunk!(0, o0);
+        chunk!(1, o1);
+        chunk!(2, o2);
+        chunk!(3, o3);
+        chunk!(4, o4);
+        chunk!(5, o5);
+        chunk!(6, o6);
+        chunk!(7, o7);
+        m += o8 as usize;
+    }
+    m
+}
+pub(super) unsafe fn lanes_post(
+    src: &[u8],
+    out_kinds: *const u8,
+    out_starts: *const u32,
+    m: usize,
+    lanes: &mut Lanes,
+) {
+    let v_num = _mm256_set1_epi8(NUM as i8);
+    let v_big = _mm256_set1_epi8(BIGINT as i8);
+    let v_esc = _mm256_set1_epi8(IDENT_ESC as i8);
+    let v_pesc = _mm256_set1_epi8(PRIV_IDENT_ESC as i8);
+    macro_rules! hits {
+        ($v:expr) => {{
+            let v = $v;
+            _mm256_or_si256(
+                _mm256_or_si256(_mm256_cmpeq_epi8(v, v_num), _mm256_cmpeq_epi8(v, v_big)),
+                _mm256_or_si256(_mm256_cmpeq_epi8(v, v_esc), _mm256_cmpeq_epi8(v, v_pesc)),
+            )
+        }};
+    }
+    macro_rules! emit {
+        ($j:expr) => {{
+            let j = $j;
+            let s = *out_starts.add(j) as usize;
+            let e = *out_starts.add(j + 1) as usize;
+            let k = *out_kinds.add(j);
+            if k < IDENT_ESC {
+                lanes.push_number_swar(src, s, e);
+            } else if k == IDENT_ESC {
+                lanes.push_atom(src, s, e);
+            } else {
+                lanes.push_atom(src, s + 1, e);
+            }
+        }};
+    }
+    // 255 (INVALID) is the byte-class default for stray/control bytes and
+    // reaches the output as a 1-byte token. Track "any seen" alongside the
+    // value sweep; localize cold.
+    let v_inv = _mm256_set1_epi8(-1i8); // 0xFF == token_kind::INVALID
+    let mut inv = _mm256_setzero_si256();
+    let mut i = 0usize;
+    while i + 64 <= m {
+        let v0 = _mm256_loadu_si256(out_kinds.add(i) as *const __m256i);
+        let v1 = _mm256_loadu_si256(out_kinds.add(i + 32) as *const __m256i);
+        let h0 = hits!(v0);
+        let h1 = hits!(v1);
+        inv = _mm256_or_si256(
+            inv,
+            _mm256_or_si256(_mm256_cmpeq_epi8(v0, v_inv), _mm256_cmpeq_epi8(v1, v_inv)),
+        );
+        let mut mask = (_mm256_movemask_epi8(h0) as u32 as u64)
+            | ((_mm256_movemask_epi8(h1) as u32 as u64) << 32);
+        while mask != 0 {
+            emit!(i + mask.trailing_zeros() as usize);
+            mask &= mask - 1;
+        }
+        i += 64;
+    }
+    let mut inv_dirty = _mm256_movemask_epi8(inv) != 0;
+    while i < m {
+        let v = _mm256_loadu_si256(out_kinds.add(i) as *const __m256i);
+        let hit = hits!(v);
+        let mut mask = _mm256_movemask_epi8(hit) as u32;
+        let mut invm = _mm256_movemask_epi8(_mm256_cmpeq_epi8(v, v_inv)) as u32;
+        let rem = m - i;
+        if rem < 32 {
+            mask &= (1u32 << rem) - 1;
+            invm &= (1u32 << rem) - 1;
+        }
+        inv_dirty |= invm != 0;
+        while mask != 0 {
+            emit!(i + mask.trailing_zeros() as usize);
+            mask &= mask - 1;
+        }
+        i += 32;
+    }
+    // Cold, invalid input only: each 255 token is itself the bad byte.
+    if inv_dirty {
+        let nn = *out_starts.add(m); // EOF sentinel == n
+        // Span of the one char at `cs` (utf8 length, clamped, empty at EOF):
+        // `\` and `#` errors blame the char after them, like oxc_parser.
+        let char_after = |cs: u32| -> u32 {
+            if cs >= nn {
+                return 0;
+            }
+            let b = src[cs as usize];
+            let l: u32 = if b < 0x80 {
+                1
+            } else if b >= 0xF0 {
+                4
+            } else if b >= 0xE0 {
+                3
+            } else if b >= 0xC0 {
+                2
+            } else {
+                1 // continuation/invalid byte: code 6 fires alongside
+            };
+            l.min(nn - cs)
+        };
+        for j in 0..m {
+            if *out_kinds.add(j) == 255 {
+                let s = *out_starts.add(j);
+                let e = *out_starts.add(j + 1);
+                let b0 = src[s as usize];
+                if b0 == b'\\' {
+                    // Bare code-level `\` (`x = \A`): literal-interior
+                    // backslashes never survive carve, so this is a real
+                    // identifier-escape error. The parser spans the one char
+                    // after the `\`.
+                    lanes.push_diag(s + 1, char_after(s + 1), diag_code::INVALID_IDENTIFIER_ESCAPE);
+                } else if b0 == b'#' {
+                    // Misplaced `#` (including `#!` past offset 0): the
+                    // parser consumes the char after `#` and reports on it.
+                    lanes.push_diag(s + 1, char_after(s + 1), diag_code::UNEXPECTED_CHARACTER);
+                } else {
+                    lanes.push_diag(s, e - s, diag_code::UNEXPECTED_CHARACTER);
+                }
+            }
+        }
+    }
+}

--- a/crates/oxc_lexer/src/pipeline/find.rs
+++ b/crates/oxc_lexer/src/pipeline/find.rs
@@ -224,6 +224,7 @@ pub(super) unsafe fn scan_quoted(
 #[inline(always)]
 unsafe fn lic_verify_at(src: *const u8, q: usize) -> bool {
     let c1 = *src.add(q + 1);
+    // spellchecker:disable-next-line
     (c1 == b'l' && core::slice::from_raw_parts(src.add(q + 2), 6) == b"icense")
         || (c1 == b'p' && core::slice::from_raw_parts(src.add(q + 2), 7) == b"reserve")
 }

--- a/crates/oxc_lexer/src/pipeline/find.rs
+++ b/crates/oxc_lexer/src/pipeline/find.rs
@@ -1,0 +1,534 @@
+use core::arch::x86_64::*;
+
+use crate::tables::{hex_val, is_digit, is_word};
+
+#[inline(always)]
+pub(super) unsafe fn veq(v: __m256i, c: u8) -> __m256i {
+    _mm256_cmpeq_epi8(v, _mm256_set1_epi8(c as i8))
+}
+#[inline(always)]
+pub(super) unsafe fn mm(v: __m256i) -> u32 {
+    _mm256_movemask_epi8(v) as u32
+}
+#[inline(always)]
+pub(super) unsafe fn load256(src: *const u8, i: usize) -> __m256i {
+    _mm256_loadu_si256(src.add(i) as *const __m256i)
+}
+#[inline]
+pub(super) unsafe fn find1(src: *const u8, n: usize, mut i: usize, a: u8) -> usize {
+    while i + 32 <= n {
+        let m = mm(veq(load256(src, i), a));
+        if m != 0 {
+            return i + m.trailing_zeros() as usize;
+        }
+        i += 32;
+    }
+    while i < n {
+        if *src.add(i) == a {
+            return i;
+        }
+        i += 1;
+    }
+    n
+}
+#[inline]
+pub(super) unsafe fn find2(src: *const u8, n: usize, mut i: usize, a: u8, b: u8) -> usize {
+    while i + 32 <= n {
+        let v = load256(src, i);
+        let m = mm(_mm256_or_si256(veq(v, a), veq(v, b)));
+        if m != 0 {
+            return i + m.trailing_zeros() as usize;
+        }
+        i += 32;
+    }
+    while i < n {
+        let c = *src.add(i);
+        if c == a || c == b {
+            return i;
+        }
+        i += 1;
+    }
+    n
+}
+#[inline]
+unsafe fn find3(src: *const u8, n: usize, mut i: usize, a: u8, b: u8, c: u8) -> usize {
+    while i + 32 <= n {
+        let v = load256(src, i);
+        let m = mm(_mm256_or_si256(_mm256_or_si256(veq(v, a), veq(v, b)), veq(v, c)));
+        if m != 0 {
+            return i + m.trailing_zeros() as usize;
+        }
+        i += 32;
+    }
+    while i < n {
+        let ch = *src.add(i);
+        if ch == a || ch == b || ch == c {
+            return i;
+        }
+        i += 1;
+    }
+    n
+}
+#[inline]
+unsafe fn find4(src: *const u8, n: usize, mut i: usize, a: u8, b: u8, c: u8, d: u8) -> usize {
+    while i + 32 <= n {
+        let v = load256(src, i);
+        let m = mm(_mm256_or_si256(
+            _mm256_or_si256(veq(v, a), veq(v, b)),
+            _mm256_or_si256(veq(v, c), veq(v, d)),
+        ));
+        if m != 0 {
+            return i + m.trailing_zeros() as usize;
+        }
+        i += 32;
+    }
+    while i < n {
+        let x = *src.add(i);
+        if x == a || x == b || x == c || x == d {
+            return i;
+        }
+        i += 1;
+    }
+    n
+}
+/// First ECMAScript LineTerminator at/after `i`: LF, CR, or the 3-byte LS/PS
+/// (U+2028/U+2029). Stops at LS/PS too, so the hashbang scan cannot run
+/// through one. A 0xE2 that isn't LS/PS keeps scanning; the 2-byte confirm
+/// past a trailing 0xE2 reads the pad, which can never match 0x80.
+#[inline]
+pub(super) unsafe fn find_line_terminator(src: *const u8, n: usize, mut i: usize) -> usize {
+    loop {
+        let p = find3(src, n, i, b'\n', b'\r', 0xE2);
+        if p >= n {
+            return n;
+        }
+        if *src.add(p) != 0xE2 {
+            return p;
+        }
+        if *src.add(p + 1) == 0x80 && (*src.add(p + 2) == 0xA8 || *src.add(p + 2) == 0xA9) {
+            return p;
+        }
+        i = p + 1;
+    }
+}
+/// OR-fold of `vpcmpeqb` results, associated as a tree.
+macro_rules! vor {
+    ($a:expr) => { $a };
+    ($a:expr, $b:expr) => { _mm256_or_si256($a, $b) };
+    ($a:expr, $b:expr, $($rest:expr),+) => {
+        _mm256_or_si256(vor!($a, $b), vor!($($rest),+))
+    };
+}
+
+/// Define a fixed-needle SIMD finder: `$name(src, n, i)` returns the index
+/// of the first byte in `src[i..n]` matching any needle, or `n`.
+macro_rules! simd_finder {
+    ($(#[$attr:meta])* $name:ident: $($needle:expr),+ $(,)?) => {
+        $(#[$attr])*
+        #[inline]
+        pub(super) unsafe fn $name(src: *const u8, n: usize, mut i: usize) -> usize {
+            while i + 32 <= n {
+                let v = load256(src, i);
+                let m = mm(vor!($(veq(v, $needle)),+));
+                if m != 0 {
+                    return i + m.trailing_zeros() as usize;
+                }
+                i += 32;
+            }
+            while i < n {
+                let c = *src.add(i);
+                if $(c == $needle)||+ {
+                    return i;
+                }
+                i += 1;
+            }
+            n
+        }
+    };
+}
+
+simd_finder!(
+    /// JS-mode top-level scan: string/template/regex-or-comment openers plus
+    /// the Annex B `<!--` / `-->` trigger bytes.
+    find_opener: b'"', b'\'', b'`', b'/', b'<', b'>'
+);
+simd_finder!(
+    /// [`find_opener`] widened with `{` / `}` — used inside template
+    /// substitutions, where braces drive the nesting depth.
+    find_opener6: b'"', b'\'', b'`', b'/', b'{', b'}', b'<', b'>'
+);
+simd_finder!(
+    /// [`find_opener`] shape for `carve_jsx` JS mode at top level: `<` (the
+    /// JSX-start byte) instead of the Annex B `<` / `>` pair.
+    find_opener_jsx5: b'"', b'\'', b'`', b'/', b'<'
+);
+simd_finder!(
+    /// [`find_opener_jsx5`] widened with `{` / `}`. Used by `carve_jsx` JS
+    /// mode inside a template substitution or JSX expression container.
+    find_opener_jsx7: b'"', b'\'', b'`', b'/', b'{', b'}', b'<'
+);
+simd_finder!(
+    /// TAG-mode scan: the bytes that matter inside an opening `<...>` tag.
+    find_jsx_tag: b'"', b'\'', b'{', b'/', b'>'
+);
+simd_finder!(
+    /// [`find_jsx_tag`] widened with `<` (`.tsx` only), so `carve_jsx` can
+    /// spot and skip a type-argument list inside the opening tag.
+    find_jsx_tag_ts: b'"', b'\'', b'{', b'/', b'>', b'<'
+);
+simd_finder!(
+    /// TEXT-mode scan (strict): JSX child text ends at any of `< { > }`.
+    find_jsx_text: b'<', b'{', b'>', b'}'
+);
+simd_finder!(
+    /// Template-body scan: terminator, escape lead, or `$` (`${` starts a
+    /// substitution).
+    find_tmpl: b'`', b'\\', b'$'
+);
+simd_finder!(
+    /// Regex-body scan. LF/CR and the 0xE2 lead (LS/PS) are watched so
+    /// line terminators in the body can be diagnosed.
+    find_regex: b'/', b'\\', b'[', b']', b'\n', b'\r', 0xE2
+);
+#[inline]
+pub(super) unsafe fn scan_quoted(
+    src: *const u8,
+    n: usize,
+    mut i: usize,
+    q: u8,
+    saw_nl: &mut bool,
+) -> usize {
+    loop {
+        // LF/CR are watched too: raw line terminators in strings are diagnosed.
+        let p = find4(src, n, i, q, b'\\', b'\n', b'\r');
+        if p >= n {
+            return n;
+        }
+        let ch = *src.add(p);
+        if ch == b'\\' {
+            // Escape, including line continuations. `\<CR><LF>` is one
+            // LineTerminatorSequence: skip all three bytes, or the next find
+            // lands on the LF and flags a legal continuation.
+            let crlf = *src.add(p + 1) == b'\r' && *src.add(p + 2) == b'\n';
+            i = p + 2 + usize::from(crlf);
+            continue;
+        }
+        if ch == b'\n' || ch == b'\r' {
+            *saw_nl = true;
+            i = p + 1; // keep scanning so the token end is unchanged
+            continue;
+        }
+        return p;
+    }
+}
+#[inline(always)]
+unsafe fn lic_verify_at(src: *const u8, q: usize) -> bool {
+    let c1 = *src.add(q + 1);
+    (c1 == b'l' && core::slice::from_raw_parts(src.add(q + 2), 6) == b"icense")
+        || (c1 == b'p' && core::slice::from_raw_parts(src.add(q + 2), 7) == b"reserve")
+}
+#[inline(always)]
+unsafe fn lic_first(src: *const u8, base: usize, mut am: u32) -> i64 {
+    while am != 0 {
+        let q = base + am.trailing_zeros() as usize;
+        am &= am - 1;
+        if lic_verify_at(src, q) {
+            return q as i64;
+        }
+    }
+    -1
+}
+pub(super) unsafe fn scan_block_comment(
+    src: *const u8,
+    n: usize,
+    mut i: usize,
+) -> (usize, bool, i64) {
+    let mut saw_nl = false;
+    let mut lic_q: i64 = -1;
+    while i + 32 <= n {
+        let v = load256(src, i);
+        let vn = load256(src, i + 1);
+        let term = mm(_mm256_and_si256(veq(v, b'*'), veq(vn, b'/')));
+        let nl = mm(_mm256_or_si256(veq(v, b'\n'), veq(v, b'\r')));
+        let at = mm(veq(v, b'@'));
+        if term != 0 {
+            let j = term.trailing_zeros() as usize;
+            let bodymask: u32 = if j > 0 { (1u32 << j) - 1 } else { 0 };
+            saw_nl |= (nl & bodymask) != 0;
+            if lic_q < 0 {
+                let am = at & bodymask;
+                if am != 0 {
+                    lic_q = lic_first(src, i, am);
+                }
+            }
+            return (i + j + 1, saw_nl, lic_q);
+        }
+        saw_nl |= nl != 0;
+        if lic_q < 0 && at != 0 {
+            lic_q = lic_first(src, i, at);
+        }
+        i += 32;
+    }
+    while i + 1 < n {
+        let c = *src.add(i);
+        if c == b'*' && *src.add(i + 1) == b'/' {
+            return (i + 1, saw_nl, lic_q);
+        }
+        if c == b'\n' || c == b'\r' {
+            saw_nl = true;
+        }
+        if c == b'@' && lic_q < 0 && lic_verify_at(src, i) {
+            lic_q = i as i64;
+        }
+        i += 1;
+    }
+    (n, saw_nl, lic_q)
+}
+/// Scan a `//` line comment to its LineTerminator (LF, CR, or LS/PS),
+/// tracking the first `@license` / `@preserve` position for comment
+/// metadata. A 0xE2 that isn't LS/PS (typographic punctuation in prose) is
+/// cleared from the mask and the scan continues; the LS/PS confirm can read
+/// the pad, which never matches 0x80.
+pub(super) unsafe fn scan_line_comment(src: *const u8, n: usize, mut i: usize) -> (usize, i64) {
+    let mut lic_q: i64 = -1;
+    while i + 32 <= n {
+        let v = load256(src, i);
+        let term_v = _mm256_or_si256(_mm256_or_si256(veq(v, b'\n'), veq(v, b'\r')), veq(v, 0xE2));
+        let mut term = mm(term_v);
+        let at = mm(veq(v, b'@'));
+        while term != 0 {
+            let t = term.trailing_zeros() as usize;
+            let c = *src.add(i + t);
+            if c == 0xE2
+                && !(*src.add(i + t + 1) == 0x80
+                    && (*src.add(i + t + 2) == 0xA8 || *src.add(i + t + 2) == 0xA9))
+            {
+                term &= term - 1; // not LS/PS: clear and keep scanning
+                continue;
+            }
+            if lic_q < 0 {
+                let am = at & if t > 0 { (1u32 << t) - 1 } else { 0 };
+                if am != 0 {
+                    lic_q = lic_first(src, i, am);
+                }
+            }
+            return (i + t, lic_q);
+        }
+        if lic_q < 0 && at != 0 {
+            lic_q = lic_first(src, i, at);
+        }
+        i += 32;
+    }
+    while i < n {
+        let c = *src.add(i);
+        if c == b'\n' || c == b'\r' {
+            return (i, lic_q);
+        }
+        if c == 0xE2
+            && *src.add(i + 1) == 0x80
+            && (*src.add(i + 2) == 0xA8 || *src.add(i + 2) == 0xA9)
+        {
+            return (i, lic_q);
+        }
+        if c == b'@' && lic_q < 0 && lic_verify_at(src, i) {
+            lic_q = i as i64;
+        }
+        i += 1;
+    }
+    (n, lic_q)
+}
+#[inline]
+pub(super) unsafe fn scan_regex(
+    src: *const u8,
+    n: usize,
+    mut i: usize,
+    nl_at: &mut usize,
+) -> usize {
+    let mut incl = false;
+    loop {
+        let p = find_regex(src, n, i);
+        if p >= n {
+            return n;
+        }
+        let c = *src.add(p);
+        if c == b'\\' {
+            // An escaped line terminator is still invalid in a regex (the
+            // grammar requires a NonTerminator); record it here or the p+2
+            // skip would sail past it. The p+1<n guard keeps garbage pad
+            // bytes after a `\` at EOF out of the diagnostics.
+            if p + 1 < n {
+                let c1 = *src.add(p + 1);
+                if (c1 == b'\n' || c1 == b'\r') && *nl_at == usize::MAX {
+                    *nl_at = p + 1;
+                } else if c1 == 0xE2
+                    && *nl_at == usize::MAX
+                    && p + 3 < n
+                    && *src.add(p + 2) == 0x80
+                    && (*src.add(p + 3) == 0xA8 || *src.add(p + 3) == 0xA9)
+                {
+                    // Escaped LS/PS: span ends past the whole char; the p+2
+                    // skip lands mid-sequence (unwatched 0x80) and sails on.
+                    *nl_at = p + 3;
+                }
+            }
+            i = p + 2;
+            continue;
+        }
+        if c == b'\n' || c == b'\r' {
+            // Raw line terminator: invalid anywhere in the body, `[...]`
+            // included. Record the first; keep scanning so the token end
+            // (and every downstream span) is unchanged.
+            if *nl_at == usize::MAX {
+                *nl_at = p;
+            }
+            i = p + 1;
+            continue;
+        }
+        if c == 0xE2 {
+            // LS/PS are line terminators too; other E2-led chars (em dash,
+            // arrows) fall through untouched.
+            if *nl_at == usize::MAX
+                && p + 2 < n
+                && *src.add(p + 1) == 0x80
+                && (*src.add(p + 2) == 0xA8 || *src.add(p + 2) == 0xA9)
+            {
+                *nl_at = p + 2; // span ends past the whole char
+            }
+            i = p + 1;
+            continue;
+        }
+        if incl {
+            if c == b']' {
+                incl = false;
+            }
+            i = p + 1;
+            continue;
+        }
+        if c == b'[' {
+            incl = true;
+            i = p + 1;
+            continue;
+        }
+        if c == b'/' {
+            return p;
+        }
+        i = p + 1;
+    }
+}
+#[inline]
+pub(super) unsafe fn scan_tmpl_text(
+    src: *const u8,
+    n: usize,
+    mut i: usize,
+    term: &mut i32,
+) -> usize {
+    loop {
+        let p = find_tmpl(src, n, i);
+        if p >= n {
+            *term = 0;
+            return n;
+        }
+        let c = *src.add(p);
+        if c == b'\\' {
+            i = p + 2;
+            continue;
+        }
+        if c == b'`' {
+            *term = 1;
+            return p + 1;
+        }
+        if *src.add(p + 1) == b'{' {
+            *term = 2;
+            return p + 2;
+        }
+        i = p + 1;
+    }
+}
+#[inline]
+pub(super) unsafe fn scan_number(src: *const u8, n: usize, pos: usize) -> usize {
+    if *src.add(pos) == b'0' && pos + 1 < n {
+        let c = *src.add(pos + 1) | 0x20;
+        if c == b'x' || c == b'o' || c == b'b' {
+            let radix = if c == b'x' {
+                16
+            } else if c == b'o' {
+                8
+            } else {
+                2
+            };
+            let mut i = pos + 2;
+            while i < n {
+                let d = *src.add(i);
+                if d == b'_' {
+                    i += 1;
+                    continue;
+                }
+                if hex_val(d) < radix {
+                    i += 1;
+                } else {
+                    break;
+                }
+            }
+            if i < n && *src.add(i) == b'n' {
+                return i + 1;
+            }
+            return i;
+        }
+    }
+    let mut i = pos;
+    let mut is_float = false;
+    while i < n && (is_digit(*src.add(i)) || *src.add(i) == b'_') {
+        i += 1;
+    }
+    if i < n && *src.add(i) == b'.' {
+        is_float = true;
+        i += 1;
+        while i < n && (is_digit(*src.add(i)) || *src.add(i) == b'_') {
+            i += 1;
+        }
+    }
+    if i < n && (*src.add(i) | 0x20) == b'e' {
+        is_float = true;
+        i += 1;
+        if i < n && (*src.add(i) == b'+' || *src.add(i) == b'-') {
+            i += 1;
+        }
+        while i < n && (is_digit(*src.add(i)) || *src.add(i) == b'_') {
+            i += 1;
+        }
+    }
+    if !is_float && i < n && *src.add(i) == b'n' {
+        return i + 1;
+    }
+    i
+}
+#[inline]
+pub(super) unsafe fn scan_ident_esc(src: *const u8, n: usize, p: usize) -> usize {
+    let mut i = p;
+    while i < n {
+        if *src.add(i) == b'\\' && i + 1 < n && *src.add(i + 1) == b'u' {
+            i += 2;
+            if i < n && *src.add(i) == b'{' {
+                i += 1;
+                while i < n && hex_val(*src.add(i)) != 255 {
+                    i += 1;
+                }
+                if i < n && *src.add(i) == b'}' {
+                    i += 1;
+                }
+            } else {
+                let mut k = 0;
+                while k < 4 && i < n && hex_val(*src.add(i)) != 255 {
+                    i += 1;
+                    k += 1;
+                }
+            }
+            while i < n && is_word(*src.add(i)) {
+                i += 1;
+            }
+            continue;
+        }
+        break;
+    }
+    i
+}

--- a/crates/oxc_lexer/src/pipeline/keywords.rs
+++ b/crates/oxc_lexer/src/pipeline/keywords.rs
@@ -1,0 +1,52 @@
+use core::arch::x86_64::*;
+
+use crate::opmap::KwSet;
+
+use super::IDENT;
+
+pub(super) const KWB: usize = 64;
+/// Resolve a batch of keyword candidates (positions collected by
+/// `coalesce`): exact match against the perfect-hash tables, patching
+/// `kind` from IDENT to the keyword kind on hit. `TS_KEY` selects the
+/// active set's hash key — `(c0, c1, len)` for JS, `(c0, c1, last, len)`
+/// for TS — monomorphized so the JS copy carries none of the wider key.
+/// Kept out of line: inlining would double both variants into each of
+/// coalesce's flush sites, and one call per KWB words is free.
+#[inline(never)]
+pub(super) unsafe fn kw_verify_batch<const TS_KEY: bool>(
+    kw: &KwSet,
+    src: *const u8,
+    word: *const u64,
+    kind: *mut u8,
+    pos: *const u32,
+    k: usize,
+) {
+    let wb = word as *const u8;
+    for ix in 0..k {
+        let p = *pos.add(ix) as usize;
+        let x = core::ptr::read_unaligned(wb.add(p >> 3) as *const u64) >> (p & 7);
+        let len = (!x).trailing_zeros() as usize;
+        if len > 8 {
+            let kk = kw.lookup(src.add(p), len);
+            if kk != 0 {
+                *kind.add(p) = kk as u8;
+            }
+            continue;
+        }
+        let w8 = core::ptr::read_unaligned(src.add(p) as *const u64);
+        let z = _bzhi_u64(w8, (len << 3) as u32);
+        let key = if TS_KEY {
+            // Last char comes off the bzhi'd word: bits above len*8 are
+            // already zero, so the shift leaves exactly that byte.
+            (w8 as u32 & 0xFFFF) | (((z >> ((len << 3) - 8)) as u32) << 16) | ((len as u32) << 24)
+        } else {
+            (w8 as u32 & 0xFFFF) | ((len as u32) << 16)
+        };
+        let h = (key.wrapping_mul(kw.kw_hash_mul) >> kw.kw_hash_shift) as usize;
+        let hm: u8 = 0u8.wrapping_sub((z == kw.kwh_pat[h]) as u8);
+        // Candidates are code-level identifier starts (carve cleared every
+        // literal interior and JSX start from the masks), so the incumbent
+        // kind is IDENT: select over it instead of a read-modify-write.
+        *kind.add(p) = (IDENT & !hm) | (kw.kwh_kind[h] & hm);
+    }
+}

--- a/crates/oxc_lexer/src/pipeline/mod.rs
+++ b/crates/oxc_lexer/src/pipeline/mod.rs
@@ -1,0 +1,233 @@
+// Kernel lint policy (this module tree, `lanes`, `opmap`, `tables`): the
+// `unsafe fn` boundary is the reviewed surface, and the pedantic/nursery
+// style lints fight the SIMD idiom. API modules keep the full workspace bar.
+#![allow(unsafe_op_in_unsafe_fn, clippy::missing_safety_doc, clippy::undocumented_unsafe_blocks)]
+#![allow(clippy::pedantic, clippy::nursery)]
+#![allow(
+    clippy::needless_range_loop,
+    clippy::manual_range_contains,
+    clippy::collapsible_if,
+    clippy::collapsible_match
+)]
+
+mod bitmap;
+mod carve;
+mod classify;
+mod coalesce;
+mod compress;
+mod find;
+mod keywords;
+mod regex_div;
+
+use crate::PAD;
+use crate::lanes::Lanes;
+use crate::options::LexOptions;
+use crate::tables::Tables;
+
+use bitmap::bm_any;
+use carve::{carve, carve_jsx};
+use classify::{classify, misc_post, misc_pre};
+use coalesce::coalesce;
+use compress::{compress, lanes_post};
+use keywords::KWB;
+
+use crate::token::token_kind;
+
+// Short kind aliases for the pipeline, tied to `token_kind` so they can't drift.
+pub(crate) const WS: u8 = token_kind::WHITESPACE;
+pub(crate) const IDENT: u8 = token_kind::IDENT;
+pub(crate) const NUM: u8 = token_kind::NUMBER;
+pub(crate) const BIGINT: u8 = token_kind::BIGINT;
+pub(crate) const STR: u8 = token_kind::STRING;
+pub(crate) const LCOM: u8 = token_kind::LINE_COMMENT;
+pub(crate) const BCOM: u8 = token_kind::BLOCK_COMMENT;
+pub(crate) const REGEX: u8 = token_kind::REGEXP;
+pub(crate) const TMPL_NOSUB: u8 = token_kind::TEMPLATE_NO_SUB;
+pub(crate) const TMPL_HEAD: u8 = token_kind::TEMPLATE_HEAD;
+pub(crate) const TMPL_MIDDLE: u8 = token_kind::TEMPLATE_MIDDLE;
+pub(crate) const TMPL_TAIL: u8 = token_kind::TEMPLATE_TAIL;
+pub(crate) const HASHBANG: u8 = token_kind::HASHBANG;
+pub(crate) const IDENT_ESC: u8 = token_kind::IDENT_ESCAPED;
+pub(crate) const PRIV_IDENT: u8 = token_kind::PRIVATE_IDENT;
+pub(crate) const PRIV_IDENT_ESC: u8 = token_kind::PRIVATE_IDENT_ESCAPED;
+pub(crate) const EOF: u8 = token_kind::EOF;
+
+// JSX coarse kinds, written only by `carve_jsx`. `JEND`/`JSX_LT` read as
+// values in `prev_is_regex` (after a completed element, `/` is division).
+pub(crate) const JTEXT: u8 = token_kind::JSX_TEXT;
+pub(crate) const JEND: u8 = token_kind::JSX_TAG_END;
+pub(crate) const JSX_LT: u8 = token_kind::JSX_LT;
+
+// `glue_number` computes the kind as `NUM + is_bigint` — keep them adjacent.
+const _: () = assert!(BIGINT == NUM + 1);
+
+pub struct Lexer {
+    word: Vec<u64>,
+    st: Vec<u64>,
+    kwinit: Vec<u64>,
+    opch: Vec<u64>,
+    digit: Vec<u64>,
+    dot: Vec<u64>,
+    misc: Vec<u64>,
+    kind: Vec<u8>,
+    kwpos: Vec<u32>,
+    nb_cap: usize,
+    pub starts: Vec<u32>,
+    pub kinds: Vec<u8>,
+    out_cap: usize,
+    pub lanes: Lanes,
+    tables: Box<Tables>,
+}
+
+impl Default for Lexer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Lexer {
+    pub fn new() -> Lexer {
+        Lexer {
+            word: Vec::new(),
+            st: Vec::new(),
+            kwinit: Vec::new(),
+            opch: Vec::new(),
+            digit: Vec::new(),
+            dot: Vec::new(),
+            misc: Vec::new(),
+            kind: Vec::new(),
+            kwpos: Vec::new(),
+            nb_cap: 0,
+            starts: Vec::new(),
+            kinds: Vec::new(),
+            out_cap: 0,
+            lanes: Lanes::default(),
+            tables: Box::new(Tables::new()),
+        }
+    }
+
+    fn ensure(&mut self, n: usize) {
+        let nb = n.div_ceil(64) + 1;
+        if self.nb_cap < nb {
+            self.word.resize(nb, 0);
+            self.st.resize(nb, 0);
+            self.kwinit.resize(nb, 0);
+            self.opch.resize(nb, 0);
+            self.digit.resize(nb, 0);
+            self.dot.resize(nb, 0);
+            self.misc.resize(nb, 0);
+            self.kind.resize(nb * 64, 0);
+            self.nb_cap = nb;
+        }
+        if self.kwpos.is_empty() {
+            self.kwpos.resize(KWB * 64 + 8, 0);
+        }
+        let need = n + PAD;
+        if self.out_cap < need {
+            self.starts.resize(need, 0);
+            self.kinds.resize(need, 0);
+            self.out_cap = need;
+        }
+    }
+
+    /// Run the full pipeline over `src[..n]`, writing the token stream into
+    /// `out_kinds`/`out_starts` (EOF sentinel last) and the value lanes and
+    /// diagnostics into `self.lanes`. Returns the token count including EOF.
+    ///
+    /// # Safety
+    ///
+    /// - `src` must extend at least [`PAD`] zeroed bytes past `n`.
+    /// - `out_kinds` must be valid for `n + PAD` byte writes and `out_starts`
+    ///   for `n + PAD` u32 writes: `compress` stores full 8-lane groups past
+    ///   the last token, and the EOF sentinel follows it.
+    pub unsafe fn lex_raw(
+        &mut self,
+        src: &[u8],
+        n: usize,
+        out_kinds: *mut u8,
+        out_starts: *mut u32,
+        jsx: bool,
+        ts: bool,
+        vutf8: bool,
+    ) -> usize {
+        debug_assert!(src.len() >= n + PAD, "source must extend PAD zeroed bytes past n");
+        self.ensure(n);
+        self.lanes.clear();
+        if n == 0 {
+            *out_kinds = EOF;
+            *out_starts = 0;
+            *out_starts.add(1) = 0;
+            return 1;
+        }
+        let nb = n.div_ceil(64);
+        let sp = src.as_ptr();
+        let word = self.word.as_mut_ptr();
+        let st = self.st.as_mut_ptr();
+        let kwinit = self.kwinit.as_mut_ptr();
+        let opch = self.opch.as_mut_ptr();
+        let digit = self.digit.as_mut_ptr();
+        let dot = self.dot.as_mut_ptr();
+        let misc = self.misc.as_mut_ptr();
+        let kind = self.kind.as_mut_ptr();
+        let kwpos = self.kwpos.as_mut_ptr();
+        let t: &Tables = &self.tables;
+
+        // Keyword recognition is mode-scoped: the TS set (and its wider
+        // kwinit letter class) only ever sees TS input, so JS lexing is
+        // byte-identical to a build without it.
+        let kws = if ts { &t.kwts } else { &t.kwjs };
+        classify(t, ts, sp, n, word, st, kwinit, opch, digit, dot, misc, kind);
+        *word.add(nb) = 0;
+        *st.add(nb) = 0;
+        *kwinit.add(nb) = 0;
+        *opch.add(nb) = 0;
+        *digit.add(nb) = 0;
+        *dot.add(nb) = 0;
+        *misc.add(nb) = 0;
+
+        let mut nesc = 0usize;
+        if bm_any(misc, nb) {
+            nesc = if vutf8 {
+                misc_pre::<true>(sp, n, st, word, misc, kind, &mut self.lanes)
+            } else {
+                misc_pre::<false>(sp, n, st, word, misc, kind, &mut self.lanes)
+            };
+        }
+        if jsx {
+            carve_jsx(t, src, n, st, kind, opch, word, digit, dot, kwinit, ts, &mut self.lanes);
+        } else {
+            carve(t, src, n, st, kind, opch, word, digit, ts, &mut self.lanes);
+        }
+        coalesce(t, kws, sp, n, st, opch, word, digit, dot, kwinit, kind, kwpos, &mut self.lanes);
+        if nesc != 0 {
+            misc_post(sp, n, st, word, misc, kind);
+        }
+        let m = compress(t, st, kind, nb, out_starts, out_kinds);
+        *out_kinds.add(m) = EOF;
+        *out_starts.add(m) = n as u32;
+        *out_starts.add(m + 1) = n as u32;
+        lanes_post(src, out_kinds, out_starts, m, &mut self.lanes);
+        m + 1
+    }
+
+    /// Lex `src[..n]` into the internal `starts`/`kinds` buffers (mode from
+    /// `options`), returning the token count including EOF. Test/bench
+    /// entry; the arena API is [`crate::lex_utf8`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `src` does not extend at least [`PAD`] zeroed bytes past `n`.
+    pub fn lex(&mut self, src: &[u8], n: usize, options: LexOptions) -> usize {
+        assert!(
+            src.len() >= n + PAD,
+            "lexer: src must have >= {PAD} bytes of padding past len {n} (got {})",
+            src.len()
+        );
+        self.ensure(n);
+        let kinds = self.kinds.as_mut_ptr();
+        let starts = self.starts.as_mut_ptr();
+        unsafe {
+            self.lex_raw(src, n, kinds, starts, options.jsx, options.ts, options.validate_utf8)
+        }
+    }
+}

--- a/crates/oxc_lexer/src/pipeline/regex_div.rs
+++ b/crates/oxc_lexer/src/pipeline/regex_div.rs
@@ -1,0 +1,338 @@
+use crate::opmap::{OP_KIND_BASE, OP_QDOT};
+use crate::tables::{Tables, is_digit, is_glue_join, is_word, is_ws};
+
+use super::bitmap::{bm_next0, bm_next1, bm_prev1};
+use super::find::scan_number;
+use super::{
+    BCOM, HASHBANG, IDENT, IDENT_ESC, JEND, JSX_LT, LCOM, NUM, PRIV_IDENT, PRIV_IDENT_ESC, REGEX,
+    STR, TMPL_HEAD, TMPL_MIDDLE, TMPL_NOSUB, TMPL_TAIL, WS,
+};
+
+#[inline]
+unsafe fn glue_anchor(src: *const u8, st: *const u64, qi: usize) -> usize {
+    let mut a = qi;
+    loop {
+        let q = bm_prev1(st, a);
+        if q < 0 {
+            break;
+        }
+        if !is_glue_join(*src.add(q as usize)) {
+            break;
+        }
+        a = q as usize;
+    }
+    a
+}
+unsafe fn prev_regex_sim(t: &Tables, src: *const u8, n: usize, a: usize, p: usize) -> bool {
+    let mut lastk: i32 = -1;
+    let mut ls = 0usize;
+    let mut le = 0usize;
+    let mut pos = a;
+    while pos < p {
+        let c = *src.add(pos);
+        if c == b'.' && pos + 1 < n && is_digit(*src.add(pos + 1)) {
+            ls = pos;
+            pos = scan_number(src, n, pos);
+            le = pos;
+            lastk = NUM as i32;
+            continue;
+        }
+        if is_digit(c) {
+            ls = pos;
+            pos = scan_number(src, n, pos);
+            le = pos;
+            lastk = NUM as i32;
+            continue;
+        }
+        if is_word(c) {
+            ls = pos;
+            while pos < n && is_word(*src.add(pos)) {
+                pos += 1;
+            }
+            le = pos;
+            lastk = IDENT as i32;
+            continue;
+        }
+        if c == b'.' || c == b'+' || c == b'-' || c == b'?' {
+            let b1 = *src.add(pos + 1);
+            let b2 = *src.add(pos + 2);
+            let b3 = *src.add(pos + 3);
+            let mut opl: usize = 1;
+            for l in (2..=4u32).rev() {
+                if pos + l as usize > n {
+                    continue;
+                }
+                let kk = t.op.opmap_lookup(c, b1, b2, b3, l);
+                if kk == 0 {
+                    continue;
+                }
+                if kk == OP_QDOT as u32 && pos + 2 < n && is_digit(*src.add(pos + 2)) {
+                    continue;
+                }
+                opl = l as usize;
+                break;
+            }
+            ls = pos;
+            le = pos + opl;
+            lastk = 1000;
+            pos += opl;
+            continue;
+        }
+        break;
+    }
+    if lastk == -1 {
+        return true;
+    }
+    if lastk == NUM as i32 {
+        return false;
+    }
+    if lastk == IDENT as i32 {
+        if ls > 0 && *src.add(ls - 1) == b'.' && (ls < 2 || *src.add(ls - 2) != b'.') {
+            return false;
+        }
+        return t.is_regex_keyword(src.add(ls), le - ls);
+    }
+    !(*src.add(le - 1) == b')' || *src.add(le - 1) == b']')
+}
+/// Distance cap (in token starts) for the backward delimiter matches below;
+/// past it we fall back to the safe legacy "`}` means regex" answer. Only
+/// pathological input gets near it.
+const BRACE_MATCH_CAP: u32 = 1024;
+/// Previous significant token start before `pos` (skipping trivia), or -1 at
+/// start of input.
+#[inline]
+unsafe fn bm_prev_sig(st: *const u64, kind: *const u8, pos: usize) -> i64 {
+    let mut q = bm_prev1(st, pos);
+    while q >= 0 {
+        let k = *kind.add(q as usize);
+        if k == WS || k == LCOM || k == BCOM || k == HASHBANG {
+            q = bm_prev1(st, q as usize);
+            continue;
+        }
+        break;
+    }
+    q
+}
+/// Punctuators after which only an expression can begin: a `{` here is an
+/// object literal, a `function` a function expression. `>` is excluded
+/// because `=>` ends in it (an arrow's `{}` is a block body); `=` is safe
+/// because every operator ending in `=` lands on the `=`.
+#[inline(always)]
+fn is_operand_punct(ch: u8) -> bool {
+    matches!(
+        ch,
+        b'(' | b'['
+            | b','
+            | b'='
+            | b'?'
+            | b'+'
+            | b'-'
+            | b'*'
+            | b'/'
+            | b'%'
+            | b'&'
+            | b'|'
+            | b'^'
+            | b'!'
+            | b'~'
+            | b'<'
+    )
+}
+/// Is the token at `pos` in operand (expression-only) position? Strict
+/// whitelist; anything else returns false. Deliberately not `prev_is_regex`:
+/// a regex may follow `;`/`:`/`else`, but a `{` there is a block, so reusing
+/// it would be unsound. Complement of acorn's `braceIsBlock`.
+#[inline]
+unsafe fn operand_position(src: *const u8, st: *const u64, kind: *const u8, pos: usize) -> bool {
+    let q = bm_prev_sig(st, kind, pos);
+    if q < 0 {
+        return false; // start of input => statement position
+    }
+    let p = q as usize;
+    if *kind.add(p) < OP_KIND_BASE {
+        // Of the value kinds, only a template substitution (`${ {..} }`)
+        // puts what follows in operand position.
+        let k = *kind.add(p);
+        return k == TMPL_HEAD || k == TMPL_MIDDLE;
+    }
+    is_operand_punct(*src.add(p))
+}
+/// Does the identifier at `pos` equal exactly `kw`? The following-byte check
+/// rejects longer identifiers (the source pad makes it safe at EOF).
+#[inline]
+unsafe fn ident_is(src: *const u8, pos: usize, kw: &[u8]) -> bool {
+    let mut i = 0;
+    while i < kw.len() {
+        if *src.add(pos + i) != kw[i] {
+            return false;
+        }
+        i += 1;
+    }
+    !is_word(*src.add(pos + kw.len()))
+}
+/// Match the close punctuator at `from` back to its opener, counting only
+/// punctuator delimiters — template-closing `}`s and cleared literal
+/// interiors are invisible. None if unbalanced or past the cap.
+#[inline]
+unsafe fn match_delim_back(
+    src: *const u8,
+    st: *const u64,
+    kind: *const u8,
+    from: usize,
+    open: u8,
+    close: u8,
+) -> Option<usize> {
+    let mut depth: i32 = 1;
+    let mut steps: u32 = 0;
+    let mut q = bm_prev1(st, from);
+    while q >= 0 {
+        steps += 1;
+        if steps > BRACE_MATCH_CAP {
+            return None;
+        }
+        let pos = q as usize;
+        if *kind.add(pos) >= OP_KIND_BASE {
+            let c = *src.add(pos);
+            if c == close {
+                depth += 1;
+            } else if c == open {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(pos);
+                }
+            }
+        }
+        q = bm_prev1(st, pos);
+    }
+    None
+}
+/// Does the `{` at `brace` open a value (object literal or function-
+/// expression body) rather than a block? Class expressions and TS `as {..}`
+/// are not handled; they fall back to regex, same as legacy.
+#[inline]
+unsafe fn brace_opens_value(src: *const u8, st: *const u64, kind: *const u8, brace: usize) -> bool {
+    let q = bm_prev_sig(st, kind, brace);
+    if q < 0 {
+        return false; // start of input => block
+    }
+    let p = q as usize;
+    if *kind.add(p) < OP_KIND_BASE {
+        let k = *kind.add(p);
+        return k == TMPL_HEAD || k == TMPL_MIDDLE; // `${ {..} }`
+    }
+    let ch = *src.add(p);
+    if is_operand_punct(ch) {
+        return true; // object literal in operand position
+    }
+    // `{` preceded by `)` may be a function-expression body:
+    // `function (..) { } /`. Match the `)` to its `(`; if an anonymous
+    // `function` sits before the `(` in operand position, the `{}` is a
+    // value and the `/` is division.
+    if ch == b')' {
+        if let Some(lp) = match_delim_back(src, st, kind, p, b'(', b')') {
+            let w = bm_prev_sig(st, kind, lp);
+            if w >= 0 {
+                let wp = w as usize;
+                if *kind.add(wp) < OP_KIND_BASE
+                    && ident_is(src, wp, b"function")
+                    && operand_position(src, st, kind, wp)
+                {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+/// A `/` right after `}`: regex if the `}` closed a block, division if it
+/// closed a value. Cold; any uncertainty falls back to regex (the legacy
+/// answer), which can never introduce a stream-swallowing regex.
+#[inline]
+unsafe fn brace_close_is_regex(src: *const u8, st: *const u64, kind: *const u8, qi: usize) -> bool {
+    match match_delim_back(src, st, kind, qi, b'{', b'}') {
+        Some(brace) => !brace_opens_value(src, st, kind, brace),
+        None => true, // unbalanced / cap => fallback regex
+    }
+}
+pub(super) unsafe fn prev_is_regex(
+    t: &Tables,
+    src: *const u8,
+    st: *const u64,
+    kind: *const u8,
+    word: *const u64,
+    digit: *const u64,
+    n: usize,
+    p: usize,
+    ts: bool,
+) -> bool {
+    let mut q = bm_prev1(st, p);
+    while q >= 0 {
+        let qi = q as usize;
+        let k = *kind.add(qi);
+        if k == WS || k == LCOM || k == BCOM || k == HASHBANG {
+            q = bm_prev1(st, qi);
+            continue;
+        }
+        if k == STR
+            || k == REGEX
+            || k == TMPL_NOSUB
+            || k == TMPL_TAIL
+            || k == PRIV_IDENT
+            || k == IDENT_ESC
+            || k == PRIV_IDENT_ESC
+            || k == JEND
+            || k == JSX_LT
+        {
+            return false;
+        }
+        if k == TMPL_HEAD || k == TMPL_MIDDLE {
+            return true;
+        }
+        if k == NUM {
+            let we = bm_next0(word, qi, n);
+            let de = bm_next0(digit, qi, n);
+            if de >= we {
+                return false;
+            }
+            return prev_regex_sim(t, src, n, glue_anchor(src, st, qi), p);
+        }
+        if k == IDENT {
+            if qi > 0 && *src.add(qi - 1) == b'.' && (qi < 2 || *src.add(qi - 2) != b'.') {
+                return false;
+            }
+            let e = bm_next1(st, qi + 1, n);
+            return t.is_regex_keyword(src.add(qi), e - qi);
+        }
+        if k >= OP_KIND_BASE {
+            let ch = *src.add(qi);
+            // TS postfix non-null `!`: `x! / 2` is division, not a regex —
+            // look through the `!`, unless a newline sits before it (ASI
+            // makes it a prefix `!/re/`).
+            if ts && ch == b'!' {
+                let mut j = qi;
+                while j > 0
+                    && is_ws(*src.add(j - 1))
+                    && *src.add(j - 1) != b'\n'
+                    && *src.add(j - 1) != b'\r'
+                {
+                    j -= 1;
+                }
+                if j > 0 && (*src.add(j - 1) == b'\n' || *src.add(j - 1) == b'\r') {
+                    return true; // prefix `!`
+                }
+                q = bm_prev1(st, qi); // postfix: keep walking
+                continue;
+            }
+            if ch == b'.' || ch == b'+' || ch == b'-' {
+                return prev_regex_sim(t, src, n, glue_anchor(src, st, qi), p);
+            }
+            // `}` closed either a block (regex follows) or a value (division).
+            if ch == b'}' {
+                return brace_close_is_regex(src, st, kind, qi);
+            }
+            return !(ch == b')' || ch == b']');
+        }
+        return true;
+    }
+    true
+}

--- a/crates/oxc_lexer/src/tables.rs
+++ b/crates/oxc_lexer/src/tables.rs
@@ -1,0 +1,368 @@
+// Kernel lint policy — see the note in `pipeline/mod.rs`.
+#![allow(unsafe_op_in_unsafe_fn, clippy::missing_safety_doc, clippy::undocumented_unsafe_blocks)]
+#![allow(clippy::pedantic, clippy::nursery)]
+#![allow(
+    clippy::needless_range_loop,
+    clippy::manual_range_contains,
+    clippy::collapsible_if,
+    clippy::collapsible_match
+)]
+
+use crate::opmap::{
+    KEYWORDS, KEYWORDS_TS, KW_HASH_HINT_JS, KW_HASH_HINT_TS, KW_KIND_BASE, KwSet, OPMAP_NOPS,
+    OPMAP_OPS, OpMap, PUNCT1_KIND_UNKNOWN, PUNCT1_LIST, PUNCT1_NKNOWN, PUNCT1_TOK, op_key,
+};
+
+#[inline(always)]
+pub fn is_ws(c: u8) -> bool {
+    c == b' ' || c == b'\t' || c == b'\n' || c == b'\r' || c == 0x0c || c == 0x0b
+}
+#[inline(always)]
+pub fn is_digit(c: u8) -> bool {
+    c >= b'0' && c <= b'9'
+}
+#[inline(always)]
+pub fn is_id_start(c: u8) -> bool {
+    (c >= b'a' && c <= b'z') || (c >= b'A' && c <= b'Z') || c == b'_' || c == b'$' || c >= 0x80
+}
+#[inline(always)]
+pub fn is_word(c: u8) -> bool {
+    is_id_start(c) || is_digit(c)
+}
+#[inline(always)]
+pub fn hex_val(c: u8) -> u32 {
+    if c >= b'0' && c <= b'9' {
+        return (c - b'0') as u32;
+    }
+    let l = c | 0x20;
+    if l >= b'a' && l <= b'f' {
+        return (l - b'a' + 10) as u32;
+    }
+    255
+}
+#[inline(always)]
+pub fn is_glue_join(c: u8) -> bool {
+    is_word(c) || c == b'.' || c == b'+' || c == b'-' || c == b'?'
+}
+
+pub const KWINIT_LO: [u8; 16] = [0, 1, 3, 3, 3, 1, 3, 3, 0, 3, 0, 0, 1, 0, 1, 1];
+pub const KWINIT_HI: [u8; 16] = [0, 0, 0, 0, 0, 0, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0];
+#[inline(always)]
+pub fn is_kw_init(c: u8) -> bool {
+    (KWINIT_LO[(c & 15) as usize] & KWINIT_HI[(c >> 4) as usize]) != 0
+}
+/// TS-mode variant: the JS set plus `k`/`m`/`p`/`u` (keyof, module, the
+/// p-words, unique/unknown/undefined/using). Same hi-nibble rows.
+pub const KWINIT_TS_LO: [u8; 16] = [2, 1, 3, 3, 3, 3, 3, 3, 0, 3, 0, 1, 1, 1, 1, 1];
+#[inline(always)]
+pub fn is_kw_init_ts(c: u8) -> bool {
+    (KWINIT_TS_LO[(c & 15) as usize] & KWINIT_HI[(c >> 4) as usize]) != 0
+}
+pub const OPCH_LO: [u8; 16] = [0, 1, 0, 0, 0, 1, 1, 0, 0, 0, 1, 1, 10, 3, 7, 2];
+pub const OPCH_HI: [u8; 16] = [0, 0, 1, 2, 0, 4, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0];
+#[inline(always)]
+pub fn is_op_char(c: u8) -> bool {
+    (OPCH_LO[(c & 15) as usize] & OPCH_HI[(c >> 4) as usize]) != 0
+}
+pub const PH_A: [u8; 16] = [4, 13, 19, 20, 0, 14, 7, 8, 10, 26, 22, 0, 29, 23, 3, 2];
+pub const PH_B: [u8; 16] = [24, 26, 2, 16, 31, 25, 19, 30, 0, 0, 0, 0, 0, 0, 0, 0];
+pub const PH_T0: [u8; 16] = [68, 38, 58, 76, 255, 72, 42, 52, 34, 33, 255, 255, 70, 48, 37, 55];
+pub const PH_T1: [u8; 16] = [40, 255, 43, 50, 64, 61, 255, 255, 35, 36, 80, 89, 255, 82, 32, 41];
+#[inline(always)]
+pub fn punct1_hash(c: u8) -> u8 {
+    if c < 0x20 {
+        return PUNCT1_KIND_UNKNOWN;
+    }
+    let h = (PH_A[(c & 15) as usize] ^ PH_B[((c >> 4) & 15) as usize]) & 31;
+    if h < 16 { PH_T0[h as usize] } else { PH_T1[(h & 15) as usize] }
+}
+
+/// One 64-byte cache line per `st`-mask byte for `compress`: the 8
+/// left-packed set-bit positions as u32 lanes, then the same as a 16-byte
+/// pshufb control. Fused so each mask byte touches one line, not two tables.
+#[repr(C, align(64))]
+pub struct CompressRow {
+    pub lanes: [u32; 8],
+    pub bytes: [u8; 16],
+    pad: [u8; 16],
+}
+
+const _: () = assert!(core::mem::size_of::<CompressRow>() == 64);
+
+pub struct Tables {
+    pub op: OpMap,
+    pub kwjs: KwSet,
+    pub kwts: KwSet,
+    pub regex_kw_mask: u64,
+    pub mrg_lo: [u8; 16],
+    pub mrg_hi: [u8; 16],
+    pub mrg_lo_ts: [u8; 16],
+    pub wb_lo: [u8; 16],
+    pub wb_hi: [u8; 16],
+    pub op2_pack: [u32; 256],
+    pub op3_pack: [u64; 256],
+    pub comp_lut: [CompressRow; 256],
+}
+
+impl Tables {
+    pub fn new() -> Tables {
+        let op = OpMap::new();
+        let kwjs = KwSet::build(&KEYWORDS, false, &[25, 24], KW_HASH_HINT_JS);
+        let kwts = KwSet::build(&KEYWORDS_TS, true, &[23], KW_HASH_HINT_TS);
+        kwjs.self_check(&KEYWORDS);
+        kwts.self_check(&KEYWORDS_TS);
+        let mut t = Tables {
+            op,
+            kwjs,
+            kwts,
+            regex_kw_mask: 0,
+            mrg_lo: [0; 16],
+            mrg_hi: [0; 16],
+            mrg_lo_ts: [0; 16],
+            wb_lo: [0; 16],
+            wb_hi: [0; 16],
+            op2_pack: [0; 256],
+            op3_pack: [0; 256],
+            comp_lut: [const { CompressRow { lanes: [0; 8], bytes: [0; 16], pad: [0; 16] } }; 256],
+        };
+        t.build_regex_kw_mask();
+        t.build_op_pack();
+        t.build_merged_luts();
+        t.build_lane_lut();
+        kwinit_selfcheck();
+        opch_selfcheck();
+        t.merged_selfcheck();
+        punct1_hash_selfcheck();
+        t.kwset_selfcheck();
+        t
+    }
+
+    fn build_regex_kw_mask(&mut self) {
+        // `of` is deliberately absent: it precedes a regex only in a for-of
+        // head (never written — a RegExp isn't iterable), while `instance/of/g`
+        // style division is real code. Matches es-module-lexer/SWC/RESS.
+        const RX: [&str; 13] = [
+            "in",
+            "do",
+            "new",
+            "case",
+            "void",
+            "else",
+            "yield",
+            "await",
+            "throw",
+            "return",
+            "typeof",
+            "delete",
+            "instanceof",
+        ];
+        // Indexed by kind offset from KW_BASE (all 13 sit in the JS kind
+        // block, offsets < 64), so the mask is set-independent.
+        let mut mask = 0u64;
+        for r in RX.iter() {
+            let mut found: i32 = -1;
+            for kw in KEYWORDS.iter() {
+                if kw.0 == *r {
+                    found = (kw.1 - KW_KIND_BASE) as i32;
+                    break;
+                }
+            }
+            assert!(found >= 0 && found < 64, "tables.rs: regex-kw {r} missing from KEYWORDS");
+            mask |= 1u64 << found;
+        }
+        self.regex_kw_mask = mask;
+    }
+
+    /// Is the word at `p` one of the keywords a regex may directly follow?
+    /// Text-based and called only before any keyword-kind rewrite, so the JS
+    /// set answers for both modes (every RX word is in both sets, and no
+    /// other spelling has its mask bit).
+    #[inline(always)]
+    pub unsafe fn is_regex_keyword(&self, p: *const u8, len: usize) -> bool {
+        let k = self.kwjs.lookup(p, len);
+        k >= KW_KIND_BASE as u32 && ((self.regex_kw_mask >> (k - KW_KIND_BASE as u32)) & 1) != 0
+    }
+
+    fn build_op_pack(&mut self) {
+        self.op2_pack = [0; 256];
+        self.op3_pack = [0; 256];
+        for i in 0..OPMAP_NOPS {
+            let o = &OPMAP_OPS[i];
+            let c2 = if o.len >= 3 { o.txt[2] } else { 0 };
+            let key = op_key(o.txt[0], o.txt[1], c2, o.len as u32);
+            let h = (key.wrapping_mul(self.op.opmap_mul) >> 24) as usize;
+            if o.len == 2 {
+                self.op2_pack[h] = 2u32
+                    | ((o.txt[0] as u32) << 8)
+                    | ((o.txt[1] as u32) << 16)
+                    | ((o.kind as u32) << 24);
+            } else if o.len == 3 {
+                self.op3_pack[h] = 3u64
+                    | ((o.txt[0] as u64) << 8)
+                    | ((o.txt[1] as u64) << 16)
+                    | ((o.txt[2] as u64) << 24)
+                    | ((o.kind as u64) << 32);
+            }
+        }
+    }
+
+    fn build_merged_luts(&mut self) {
+        self.mrg_lo = [0; 16];
+        self.mrg_hi = [0; 16];
+        self.mrg_lo_ts = [0; 16];
+        const ROWS: [(u8, u8, u8); 7] =
+            [(6, 0, 0), (7, 1, 0), (2, 2, 1), (3, 3, 1), (5, 4, 1), (7, 5, 1), (2, 7, 2)];
+        for &(hi, bit, set) in ROWS.iter() {
+            for lo in 0..16u8 {
+                let c = (hi << 4) | lo;
+                let inset = match set {
+                    0 => is_kw_init(c),
+                    1 => is_op_char(c),
+                    _ => c == b'.',
+                };
+                if inset {
+                    self.mrg_lo[lo as usize] |= 1u8 << bit;
+                }
+                // TS variant: only the keyword-initial rows differ.
+                let inset_ts = if set == 0 { is_kw_init_ts(c) } else { inset };
+                if inset_ts {
+                    self.mrg_lo_ts[lo as usize] |= 1u8 << bit;
+                }
+            }
+            self.mrg_hi[hi as usize] |= 1u8 << bit;
+        }
+        self.wb_lo = [0; 16];
+        self.wb_hi = [0; 16];
+        const BROWS: [(u8, u8); 8] =
+            [(2, 0), (3, 1), (4, 2), (5, 3), (6, 4), (7, 5), (0, 6), (2, 7)];
+        for &(hi, bit) in BROWS.iter() {
+            for lo in 0..16u8 {
+                let c = (hi << 4) | lo;
+                let inset = match bit {
+                    0 => c == b'$',
+                    1 => is_digit(c),
+                    2 => c >= b'A' && c <= b'O',
+                    3 => (c >= b'P' && c <= b'Z') || c == b'_',
+                    4 => c >= b'a' && c <= b'o',
+                    5 => c >= b'p' && c <= b'z',
+                    6 => is_ws(c) && c != b' ',
+                    _ => c == b' ',
+                };
+                if inset {
+                    self.wb_lo[lo as usize] |= 1u8 << bit;
+                }
+            }
+            self.wb_hi[hi as usize] |= 1u8 << bit;
+        }
+    }
+
+    fn build_lane_lut(&mut self) {
+        for m in 0..256usize {
+            let row = &mut self.comp_lut[m];
+            let mut k = 0usize;
+            for bit in 0..8usize {
+                if (m >> bit) & 1 != 0 {
+                    row.lanes[k] = bit as u32;
+                    row.bytes[k] = bit as u8;
+                    k += 1;
+                }
+            }
+            for j in k..8 {
+                row.lanes[j] = 0;
+            }
+            for j in k..16 {
+                row.bytes[j] = 0x80;
+            }
+        }
+    }
+
+    fn merged_selfcheck(&self) {
+        for c in 0..256usize {
+            let cb = c as u8;
+            let t = if c < 0x80 { self.mrg_lo[c & 15] & self.mrg_hi[c >> 4] } else { 0 };
+            let kw = (t & 0x03) != 0;
+            let opp = (t & 0x3C) != 0;
+            let dt = (t & 0x80) != 0;
+            assert!(
+                kw == is_kw_init(cb) && opp == is_op_char(cb) && dt == (cb == b'.'),
+                "tables.rs: MRG_LO/HI wrong at byte {c:#04x}"
+            );
+            let tt = if c < 0x80 { self.mrg_lo_ts[c & 15] & self.mrg_hi[c >> 4] } else { 0 };
+            assert!(
+                ((tt & 0x03) != 0) == is_kw_init_ts(cb)
+                    && ((tt & 0x3C) != 0) == opp
+                    && ((tt & 0x80) != 0) == dt,
+                "tables.rs: MRG_LO_TS wrong at byte {c:#04x}"
+            );
+            let tb = if c < 0x80 { self.wb_lo[c & 15] & self.wb_hi[c >> 4] } else { 0 };
+            let wd = (c >= 0x80) || (tb & 0x3F) != 0;
+            let ws = (tb & 0xC0) != 0;
+            let dg = (tb & 0x02) != 0;
+            assert!(
+                wd == is_word(cb) && ws == is_ws(cb) && dg == is_digit(cb),
+                "tables.rs: WB_LO/HI wrong at byte {c:#04x}"
+            );
+        }
+    }
+
+    /// Cross-set behavior the unit tests rely on: TS spellings resolve only
+    /// through the TS set, and JS words agree byte-for-byte across sets.
+    fn kwset_selfcheck(&self) {
+        let mut buf = [0u8; 16];
+        for (w, tok) in KEYWORDS_TS.iter() {
+            let bytes = w.as_bytes();
+            buf.fill(0);
+            buf[..bytes.len()].copy_from_slice(bytes);
+            let js = unsafe { self.kwjs.lookup(buf.as_ptr(), bytes.len()) };
+            let ts = unsafe { self.kwts.lookup(buf.as_ptr(), bytes.len()) };
+            assert!(ts == *tok as u32, "tables.rs: kwts lookup({w}) wrong");
+            let in_js = KEYWORDS.iter().any(|k| k.0 == *w);
+            assert!(js == if in_js { *tok as u32 } else { 0 }, "tables.rs: kwjs lookup({w}) wrong");
+        }
+    }
+}
+
+fn kwinit_selfcheck() {
+    let mut in_set = [false; 256];
+    for kw in KEYWORDS.iter() {
+        in_set[kw.0.as_bytes()[0] as usize] = true;
+    }
+    for c in 0..256usize {
+        assert!(is_kw_init(c as u8) == in_set[c], "tables.rs: KWINIT_LO/HI wrong at byte {c:#04x}");
+    }
+    let mut in_set_ts = [false; 256];
+    for kw in KEYWORDS_TS.iter() {
+        in_set_ts[kw.0.as_bytes()[0] as usize] = true;
+    }
+    for c in 0..256usize {
+        assert!(
+            is_kw_init_ts(c as u8) == in_set_ts[c],
+            "tables.rs: KWINIT_TS_LO wrong at byte {c:#04x}"
+        );
+    }
+}
+
+fn opch_selfcheck() {
+    const OPCHARS: &[u8] = b"=!<>+-*&|^%?.";
+    let mut in_set = [false; 256];
+    for &q in OPCHARS {
+        in_set[q as usize] = true;
+    }
+    for c in 0..256usize {
+        assert!(is_op_char(c as u8) == in_set[c], "tables.rs: OPCH_LO/HI wrong at byte {c:#04x}");
+    }
+}
+
+fn punct1_hash_selfcheck() {
+    let mut punct1_ord = [PUNCT1_KIND_UNKNOWN; 256];
+    for i in 0..PUNCT1_NKNOWN {
+        punct1_ord[PUNCT1_LIST[i] as usize] = PUNCT1_TOK[i];
+    }
+    for c in 0..256usize {
+        let cb = c as u8;
+        if is_word(cb) || is_ws(cb) {
+            continue;
+        }
+        assert!(punct1_hash(cb) == punct1_ord[c], "tables.rs: PH_A/B/T wrong at byte {c:#04x}");
+    }
+}

--- a/crates/oxc_lexer/src/token.rs
+++ b/crates/oxc_lexer/src/token.rs
@@ -1,0 +1,517 @@
+/// Token kinds are plain `u8`s the pipeline computes them arithmetically and blends them in SIMD registers.
+pub mod token_kind {
+    pub const EOF: u8 = 0;
+
+    pub const IDENT: u8 = 1;
+    pub const PRIVATE_IDENT: u8 = 2;
+    pub const NUMBER: u8 = 3;
+    pub const BIGINT: u8 = 4;
+    pub const STRING: u8 = 5;
+    pub const REGEXP: u8 = 6;
+    pub const TEMPLATE_NO_SUB: u8 = 7;
+    pub const TEMPLATE_HEAD: u8 = 8;
+    pub const TEMPLATE_MIDDLE: u8 = 9;
+    pub const TEMPLATE_TAIL: u8 = 10;
+
+    pub const LINE_COMMENT: u8 = 11;
+    pub const BLOCK_COMMENT: u8 = 12;
+    pub const HASHBANG: u8 = 13;
+    pub const WHITESPACE: u8 = 14;
+    pub const LINE_TERMINATOR: u8 = 15;
+
+    pub const STRING_COOKED: u8 = 16;
+    pub const IDENT_ESCAPED: u8 = 17;
+    pub const PRIVATE_IDENT_ESCAPED: u8 = 18;
+    pub const TEMPLATE_NO_SUB_COOKED: u8 = 19;
+    pub const TEMPLATE_HEAD_COOKED: u8 = 20;
+    pub const TEMPLATE_MIDDLE_COOKED: u8 = 21;
+    pub const TEMPLATE_TAIL_COOKED: u8 = 22;
+    pub const DECIMAL: u8 = 23;
+    pub const FLOAT: u8 = 24;
+    pub const BINARY: u8 = 25;
+    pub const OCTAL: u8 = 26;
+    pub const HEX: u8 = 27;
+    pub const JSX_TEXT: u8 = 28;
+    pub const JSX_TAG_END: u8 = 29;
+    pub const JSX_LT: u8 = 30;
+    pub const LBRACE: u8 = 32;
+    pub const RBRACE: u8 = 33;
+    pub const LPAREN: u8 = 34;
+    pub const RPAREN: u8 = 35;
+    pub const LBRACKET: u8 = 36;
+    pub const RBRACKET: u8 = 37;
+    pub const DOT: u8 = 38;
+    pub const ELLIPSIS: u8 = 39;
+    pub const SEMI: u8 = 40;
+    pub const COMMA: u8 = 41;
+    pub const COLON: u8 = 42;
+    pub const QUESTION: u8 = 43;
+    pub const OPTIONAL_CHAIN: u8 = 44;
+    pub const NULLISH: u8 = 45;
+    pub const NULLISH_EQ: u8 = 46;
+    pub const ARROW: u8 = 47;
+    pub const LT: u8 = 48;
+    pub const LE: u8 = 49;
+    pub const GT: u8 = 50;
+    pub const GE: u8 = 51;
+    pub const EQ: u8 = 52;
+    pub const EQ_EQ: u8 = 53;
+    pub const EQ_EQ_EQ: u8 = 54;
+    pub const BANG: u8 = 55;
+    pub const BANG_EQ: u8 = 56;
+    pub const BANG_EQ_EQ: u8 = 57;
+    pub const PLUS: u8 = 58;
+    pub const PLUS_PLUS: u8 = 59;
+    pub const PLUS_EQ: u8 = 60;
+    pub const MINUS: u8 = 61;
+    pub const MINUS_MINUS: u8 = 62;
+    pub const MINUS_EQ: u8 = 63;
+    pub const STAR: u8 = 64;
+    pub const STAR_STAR: u8 = 65;
+    pub const STAR_EQ: u8 = 66;
+    pub const STAR_STAR_EQ: u8 = 67;
+    pub const SLASH: u8 = 68;
+    pub const SLASH_EQ: u8 = 69;
+    pub const PERCENT: u8 = 70;
+    pub const PERCENT_EQ: u8 = 71;
+    pub const AMP: u8 = 72;
+    pub const AMP_AMP: u8 = 73;
+    pub const AMP_EQ: u8 = 74;
+    pub const AMP_AMP_EQ: u8 = 75;
+    pub const PIPE: u8 = 76;
+    pub const PIPE_PIPE: u8 = 77;
+    pub const PIPE_EQ: u8 = 78;
+    pub const PIPE_PIPE_EQ: u8 = 79;
+    pub const CARET: u8 = 80;
+    pub const CARET_EQ: u8 = 81;
+    pub const TILDE: u8 = 82;
+    pub const LSHIFT: u8 = 83;
+    pub const LSHIFT_EQ: u8 = 84;
+    pub const RSHIFT: u8 = 85;
+    pub const RSHIFT_EQ: u8 = 86;
+    pub const URSHIFT: u8 = 87;
+    pub const URSHIFT_EQ: u8 = 88;
+    pub const AT: u8 = 89;
+    pub const KW_BASE: u8 = 128;
+    pub const KW_BREAK: u8 = 128;
+    pub const KW_CASE: u8 = 129;
+    pub const KW_CATCH: u8 = 130;
+    pub const KW_CLASS: u8 = 131;
+    pub const KW_CONST: u8 = 132;
+    pub const KW_CONTINUE: u8 = 133;
+    pub const KW_DEBUGGER: u8 = 134;
+    pub const KW_DEFAULT: u8 = 135;
+    pub const KW_DELETE: u8 = 136;
+    pub const KW_DO: u8 = 137;
+    pub const KW_ELSE: u8 = 138;
+    pub const KW_ENUM: u8 = 139;
+    pub const KW_EXPORT: u8 = 140;
+    pub const KW_EXTENDS: u8 = 141;
+    pub const KW_FALSE: u8 = 142;
+    pub const KW_FINALLY: u8 = 143;
+    pub const KW_FOR: u8 = 144;
+    pub const KW_FUNCTION: u8 = 145;
+    pub const KW_IF: u8 = 146;
+    pub const KW_IMPORT: u8 = 147;
+    pub const KW_IN: u8 = 148;
+    pub const KW_INSTANCEOF: u8 = 149;
+    pub const KW_NEW: u8 = 150;
+    pub const KW_NULL: u8 = 151;
+    pub const KW_RETURN: u8 = 152;
+    pub const KW_SUPER: u8 = 153;
+    pub const KW_SWITCH: u8 = 154;
+    pub const KW_THIS: u8 = 155;
+    pub const KW_THROW: u8 = 156;
+    pub const KW_TRUE: u8 = 157;
+    pub const KW_TRY: u8 = 158;
+    pub const KW_TYPEOF: u8 = 159;
+    pub const KW_VAR: u8 = 160;
+    pub const KW_VOID: u8 = 161;
+    pub const KW_WHILE: u8 = 162;
+    pub const KW_WITH: u8 = 163;
+    pub const KW_YIELD: u8 = 164;
+    pub const KW_LET: u8 = 165;
+    pub const KW_STATIC: u8 = 166;
+    pub const KW_ASYNC: u8 = 167;
+    pub const KW_AWAIT: u8 = 168;
+    pub const KW_OF: u8 = 169;
+    pub const KW_FROM: u8 = 170;
+    pub const KW_AS: u8 = 171;
+    // TS-mode contextual keywords (`LexOptions::ts`) plus the strict-mode
+    // reserved words; JS mode lexes all of these spellings as IDENT.
+    // Contiguous after the JS block so `>= KW_BASE` range checks cover both.
+    pub const KW_ABSTRACT: u8 = 172;
+    pub const KW_ACCESSOR: u8 = 173;
+    pub const KW_ANY: u8 = 174;
+    pub const KW_ASSERTS: u8 = 175;
+    pub const KW_BIGINT: u8 = 176;
+    pub const KW_BOOLEAN: u8 = 177;
+    pub const KW_DECLARE: u8 = 178;
+    pub const KW_GLOBAL: u8 = 179;
+    pub const KW_IMPLEMENTS: u8 = 180;
+    pub const KW_INFER: u8 = 181;
+    pub const KW_INTERFACE: u8 = 182;
+    pub const KW_INTRINSIC: u8 = 183;
+    pub const KW_IS: u8 = 184;
+    pub const KW_KEYOF: u8 = 185;
+    pub const KW_MODULE: u8 = 186;
+    pub const KW_NAMESPACE: u8 = 187;
+    pub const KW_NEVER: u8 = 188;
+    pub const KW_NUMBER: u8 = 189;
+    pub const KW_OBJECT: u8 = 190;
+    pub const KW_OUT: u8 = 191;
+    pub const KW_OVERRIDE: u8 = 192;
+    pub const KW_PACKAGE: u8 = 193;
+    pub const KW_PRIVATE: u8 = 194;
+    pub const KW_PROTECTED: u8 = 195;
+    pub const KW_PUBLIC: u8 = 196;
+    pub const KW_READONLY: u8 = 197;
+    pub const KW_REQUIRE: u8 = 198;
+    pub const KW_SATISFIES: u8 = 199;
+    pub const KW_STRING: u8 = 200;
+    pub const KW_SYMBOL: u8 = 201;
+    pub const KW_TYPE: u8 = 202;
+    pub const KW_UNDEFINED: u8 = 203;
+    pub const KW_UNIQUE: u8 = 204;
+    pub const KW_UNKNOWN: u8 = 205;
+    pub const KW_USING: u8 = 206;
+    pub const INVALID: u8 = 255;
+}
+
+pub const TRIVIA_MIN: u8 = token_kind::LINE_COMMENT;
+pub const TRIVIA_MAX: u8 = token_kind::LINE_TERMINATOR;
+
+#[inline]
+#[must_use]
+pub const fn is_trivia(kind: u8) -> bool {
+    kind.wrapping_sub(TRIVIA_MIN) <= TRIVIA_MAX - TRIVIA_MIN
+}
+
+#[inline]
+#[must_use]
+pub const fn is_string_kind(kind: u8) -> bool {
+    kind == token_kind::STRING || kind == token_kind::STRING_COOKED
+}
+
+#[inline]
+#[must_use]
+pub const fn is_template_no_sub_kind(kind: u8) -> bool {
+    kind == token_kind::TEMPLATE_NO_SUB || kind == token_kind::TEMPLATE_NO_SUB_COOKED
+}
+
+#[inline]
+#[must_use]
+pub const fn is_template_head_kind(kind: u8) -> bool {
+    kind == token_kind::TEMPLATE_HEAD || kind == token_kind::TEMPLATE_HEAD_COOKED
+}
+
+#[inline]
+#[must_use]
+pub const fn is_template_middle_kind(kind: u8) -> bool {
+    kind == token_kind::TEMPLATE_MIDDLE || kind == token_kind::TEMPLATE_MIDDLE_COOKED
+}
+
+#[inline]
+#[must_use]
+pub const fn is_template_tail_kind(kind: u8) -> bool {
+    kind == token_kind::TEMPLATE_TAIL || kind == token_kind::TEMPLATE_TAIL_COOKED
+}
+
+#[inline]
+#[must_use]
+pub const fn is_ident_kind(kind: u8) -> bool {
+    kind == token_kind::IDENT || kind == token_kind::IDENT_ESCAPED
+}
+
+#[inline]
+#[must_use]
+pub const fn is_private_ident_kind(kind: u8) -> bool {
+    kind == token_kind::PRIVATE_IDENT || kind == token_kind::PRIVATE_IDENT_ESCAPED
+}
+
+#[inline]
+#[must_use]
+pub const fn is_numeric_kind(kind: u8) -> bool {
+    kind == token_kind::NUMBER
+        || kind == token_kind::DECIMAL
+        || kind == token_kind::FLOAT
+        || kind == token_kind::BINARY
+        || kind == token_kind::OCTAL
+        || kind == token_kind::HEX
+}
+
+pub mod token_flags {
+    pub const LINE_BEFORE: u16 = 1 << 0;
+    pub const COMMENT_BEFORE: u16 = 1 << 1;
+    pub const HAS_ESCAPE: u16 = 1 << 2;
+    pub const HAS_NON_ASCII: u16 = 1 << 3;
+    pub const CONTAINS_NEWLINE: u16 = 1 << 4;
+    pub const UNTERMINATED: u16 = 1 << 5;
+    pub const INVALID: u16 = 1 << 6;
+    pub const LEGACY_OCTAL: u16 = 1 << 7;
+    pub const ESCAPED_KEYWORD: u16 = 1 << 8;
+    pub const REGEXP_VALIDATED: u16 = 1 << 9;
+    pub const ASI_RESTRICTED: u16 = 1 << 10;
+}
+
+const _: () = assert!(token_kind::HASHBANG > token_kind::LINE_COMMENT);
+const _: () = assert!(token_kind::HASHBANG < token_kind::LINE_TERMINATOR);
+
+pub fn token_kind_name(kind: u8) -> &'static str {
+    use token_kind::*;
+    match kind {
+        EOF => "EOF",
+        IDENT => "IDENT",
+        PRIVATE_IDENT => "PRIVATE_IDENT",
+        NUMBER => "NUMBER",
+        BIGINT => "BIGINT",
+        STRING => "STRING",
+        STRING_COOKED => "STRING_COOKED",
+        IDENT_ESCAPED => "IDENT_ESCAPED",
+        PRIVATE_IDENT_ESCAPED => "PRIVATE_IDENT_ESCAPED",
+        TEMPLATE_NO_SUB_COOKED => "TEMPLATE_NO_SUB_COOKED",
+        TEMPLATE_HEAD_COOKED => "TEMPLATE_HEAD_COOKED",
+        TEMPLATE_MIDDLE_COOKED => "TEMPLATE_MIDDLE_COOKED",
+        TEMPLATE_TAIL_COOKED => "TEMPLATE_TAIL_COOKED",
+        DECIMAL => "DECIMAL",
+        FLOAT => "FLOAT",
+        BINARY => "BINARY",
+        OCTAL => "OCTAL",
+        HEX => "HEX",
+        JSX_TEXT => "JSX_TEXT",
+        JSX_TAG_END => "JSX_TAG_END",
+        JSX_LT => "JSX_LT",
+        REGEXP => "REGEXP",
+        TEMPLATE_NO_SUB => "TEMPLATE_NO_SUB",
+        TEMPLATE_HEAD => "TEMPLATE_HEAD",
+        TEMPLATE_MIDDLE => "TEMPLATE_MIDDLE",
+        TEMPLATE_TAIL => "TEMPLATE_TAIL",
+        LINE_COMMENT => "LINE_COMMENT",
+        BLOCK_COMMENT => "BLOCK_COMMENT",
+        HASHBANG => "HASHBANG",
+        WHITESPACE => "WHITESPACE",
+        LINE_TERMINATOR => "LINE_TERMINATOR",
+        LBRACE => "{",
+        RBRACE => "}",
+        LPAREN => "(",
+        RPAREN => ")",
+        LBRACKET => "[",
+        RBRACKET => "]",
+        DOT => ".",
+        ELLIPSIS => "...",
+        SEMI => ";",
+        COMMA => ",",
+        COLON => ":",
+        QUESTION => "?",
+        OPTIONAL_CHAIN => "?.",
+        NULLISH => "??",
+        NULLISH_EQ => "??=",
+        ARROW => "=>",
+        LT => "<",
+        LE => "<=",
+        GT => ">",
+        GE => ">=",
+        EQ => "=",
+        EQ_EQ => "==",
+        EQ_EQ_EQ => "===",
+        BANG => "!",
+        BANG_EQ => "!=",
+        BANG_EQ_EQ => "!==",
+        PLUS => "+",
+        PLUS_PLUS => "++",
+        PLUS_EQ => "+=",
+        MINUS => "-",
+        MINUS_MINUS => "--",
+        MINUS_EQ => "-=",
+        STAR => "*",
+        STAR_STAR => "**",
+        STAR_EQ => "*=",
+        STAR_STAR_EQ => "**=",
+        SLASH => "/",
+        SLASH_EQ => "/=",
+        PERCENT => "%",
+        PERCENT_EQ => "%=",
+        AMP => "&",
+        AMP_AMP => "&&",
+        AMP_EQ => "&=",
+        AMP_AMP_EQ => "&&=",
+        PIPE => "|",
+        PIPE_PIPE => "||",
+        PIPE_EQ => "|=",
+        PIPE_PIPE_EQ => "||=",
+        CARET => "^",
+        CARET_EQ => "^=",
+        TILDE => "~",
+        LSHIFT => "<<",
+        LSHIFT_EQ => "<<=",
+        RSHIFT => ">>",
+        RSHIFT_EQ => ">>=",
+        URSHIFT => ">>>",
+        URSHIFT_EQ => ">>>=",
+        AT => "@",
+        KW_BREAK => "break",
+        KW_CASE => "case",
+        KW_CATCH => "catch",
+        KW_CLASS => "class",
+        KW_CONST => "const",
+        KW_CONTINUE => "continue",
+        KW_DEBUGGER => "debugger",
+        KW_DEFAULT => "default",
+        KW_DELETE => "delete",
+        KW_DO => "do",
+        KW_ELSE => "else",
+        KW_ENUM => "enum",
+        KW_EXPORT => "export",
+        KW_EXTENDS => "extends",
+        KW_FALSE => "false",
+        KW_FINALLY => "finally",
+        KW_FOR => "for",
+        KW_FUNCTION => "function",
+        KW_IF => "if",
+        KW_IMPORT => "import",
+        KW_IN => "in",
+        KW_INSTANCEOF => "instanceof",
+        KW_NEW => "new",
+        KW_NULL => "null",
+        KW_RETURN => "return",
+        KW_SUPER => "super",
+        KW_SWITCH => "switch",
+        KW_THIS => "this",
+        KW_THROW => "throw",
+        KW_TRUE => "true",
+        KW_TRY => "try",
+        KW_TYPEOF => "typeof",
+        KW_VAR => "var",
+        KW_VOID => "void",
+        KW_WHILE => "while",
+        KW_WITH => "with",
+        KW_YIELD => "yield",
+        KW_LET => "let",
+        KW_STATIC => "static",
+        KW_ASYNC => "async",
+        KW_AWAIT => "await",
+        KW_OF => "of",
+        KW_FROM => "from",
+        KW_AS => "as",
+        KW_ABSTRACT => "abstract",
+        KW_ACCESSOR => "accessor",
+        KW_ANY => "any",
+        KW_ASSERTS => "asserts",
+        KW_BIGINT => "bigint",
+        KW_BOOLEAN => "boolean",
+        KW_DECLARE => "declare",
+        KW_GLOBAL => "global",
+        KW_IMPLEMENTS => "implements",
+        KW_INFER => "infer",
+        KW_INTERFACE => "interface",
+        KW_INTRINSIC => "intrinsic",
+        KW_IS => "is",
+        KW_KEYOF => "keyof",
+        KW_MODULE => "module",
+        KW_NAMESPACE => "namespace",
+        KW_NEVER => "never",
+        KW_NUMBER => "number",
+        KW_OBJECT => "object",
+        KW_OUT => "out",
+        KW_OVERRIDE => "override",
+        KW_PACKAGE => "package",
+        KW_PRIVATE => "private",
+        KW_PROTECTED => "protected",
+        KW_PUBLIC => "public",
+        KW_READONLY => "readonly",
+        KW_REQUIRE => "require",
+        KW_SATISFIES => "satisfies",
+        KW_STRING => "string",
+        KW_SYMBOL => "symbol",
+        KW_TYPE => "type",
+        KW_UNDEFINED => "undefined",
+        KW_UNIQUE => "unique",
+        KW_UNKNOWN => "unknown",
+        KW_USING => "using",
+        INVALID => "INVALID",
+        _ => "<unknown>",
+    }
+}
+
+/// Bit 31 of a `starts` entry: reserved "newline before this token" flag.
+/// The lexer does not set it yet, but consumers must still read offsets
+/// through [`offset`].
+pub const NEWLINE_BEFORE_MASK: u32 = 0x8000_0000;
+
+pub const OFFSET_MASK: u32 = 0x7FFF_FFFF;
+
+/// Maximum lexable source length in bytes, imposed by the 31-bit offset field.
+pub const MAX_SOURCE_LEN: u32 = OFFSET_MASK;
+
+#[inline]
+pub const fn offset(s: u32) -> u32 {
+    s & OFFSET_MASK
+}
+
+#[inline]
+pub const fn newline(s: u32) -> bool {
+    (s & NEWLINE_BEFORE_MASK) != 0
+}
+
+#[inline]
+pub const fn pack_start(offset: u32, newline_before: bool) -> u32 {
+    debug_assert!(offset <= OFFSET_MASK);
+    if newline_before { offset | NEWLINE_BEFORE_MASK } else { offset }
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Clone, Copy)]
+pub struct StringSpan {
+    pub start: u32,
+    pub end_and_flags: u32,
+}
+
+#[expect(clippy::inline_always, reason = "cook-path hot: spans are packed per string/template")]
+impl StringSpan {
+    pub const LONE_SURROGATES_MASK: u32 = 0x8000_0000;
+    pub const END_MASK: u32 = 0x7FFF_FFFF;
+    /// On `start`, template spans only: the body contained a
+    /// `NotEscapeSequence` (bad `\u`/`\x`, octal, `\8`/`\9`). The equivalent
+    /// of oxc_parser's `cooked: None`, from which a parser raises the
+    /// untagged-template error. Raw `start` reads must mask.
+    pub const COOKED_INVALID_MASK: u32 = 0x8000_0000;
+    pub const START_MASK: u32 = 0x7FFF_FFFF;
+
+    #[inline(always)]
+    #[must_use]
+    pub const fn new(start: u32, end: u32, lone_surrogates: bool) -> Self {
+        debug_assert!(end <= Self::END_MASK);
+        let end_and_flags = if lone_surrogates { end | Self::LONE_SURROGATES_MASK } else { end };
+        Self { start, end_and_flags }
+    }
+
+    #[inline(always)]
+    #[must_use]
+    pub const fn with_cooked_invalid(self) -> Self {
+        Self { start: self.start | Self::COOKED_INVALID_MASK, end_and_flags: self.end_and_flags }
+    }
+
+    #[inline(always)]
+    #[must_use]
+    pub const fn start(self) -> u32 {
+        self.start & Self::START_MASK
+    }
+
+    #[inline(always)]
+    #[must_use]
+    pub const fn cooked_invalid(self) -> bool {
+        (self.start & Self::COOKED_INVALID_MASK) != 0
+    }
+
+    #[inline(always)]
+    #[must_use]
+    pub const fn end(self) -> u32 {
+        self.end_and_flags & Self::END_MASK
+    }
+
+    #[inline(always)]
+    #[must_use]
+    pub const fn lone_surrogates(self) -> bool {
+        (self.end_and_flags & Self::LONE_SURROGATES_MASK) != 0
+    }
+}

--- a/crates/oxc_lexer/tests/diagnostics.rs
+++ b/crates/oxc_lexer/tests/diagnostics.rs
@@ -380,6 +380,7 @@ fn invalid_unicode_character() {
 fn valid_unicode_never_flagged() {
     // identifier chars, whitespace, and anything inside literal content
     for src in [
+        // spellchecker:disable-next-line
         "var caf\u{E9} = 1;",                   // é: ID_Continue
         "var \u{4F60}\u{597D} = 1;",            // CJK idents
         "let \u{3C0} = 3.14;",                  // π
@@ -436,6 +437,7 @@ fn valid_utf8_never_flagged() {
     let codes_v =
         |s: &str| -> Vec<u16> { diags_bytes(s.as_bytes()).iter().map(|d| d.code).collect() };
     for src in [
+        // spellchecker:disable-next-line
         "let caf\u{e9} = 1;",        // 2-byte
         "x = '\u{1F600}';",          // 4-byte emoji in string
         "a\u{a0}b",                  // NBSP (ws-reclass path preserved)

--- a/crates/oxc_lexer/tests/diagnostics.rs
+++ b/crates/oxc_lexer/tests/diagnostics.rs
@@ -1,0 +1,678 @@
+//! Diagnostic coverage for every code class. Each positive test has a
+//! `*_never_flagged` counterpart: valid input must emit nothing.
+#![cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
+#![expect(
+    clippy::cast_possible_truncation,
+    clippy::unreadable_literal,
+    reason = "test helpers: lengths fit u32; the fuzz PRNG uses raw constants"
+)]
+
+use oxc_lexer::{Diagnostic, PAD, default_options, diag_code, lex_utf8};
+
+fn diags(code: &str) -> Vec<Diagnostic> {
+    let mut buf = code.as_bytes().to_vec();
+    let len = buf.len() as u32;
+    buf.resize(buf.len() + PAD, 0); // lexer over-reads up to PAD bytes past `len`
+    let (res, _arena) = lex_utf8(&buf, len, default_options());
+    res.diagnostics().to_vec()
+}
+
+fn codes(code: &str) -> Vec<u16> {
+    diags(code).iter().map(|d| d.code).collect()
+}
+
+fn codes_jsx(code: &str) -> Vec<u16> {
+    let mut buf = code.as_bytes().to_vec();
+    let len = buf.len() as u32;
+    buf.resize(buf.len() + PAD, 0);
+    let mut opts = default_options();
+    opts.jsx = true;
+    let (res, _arena) = lex_utf8(&buf, len, opts);
+    res.diagnostics().iter().map(|d| d.code).collect()
+}
+
+fn codes_tsx(code: &str) -> Vec<u16> {
+    let mut buf = code.as_bytes().to_vec();
+    let len = buf.len() as u32;
+    buf.resize(buf.len() + PAD, 0);
+    let mut opts = default_options();
+    opts.jsx = true;
+    opts.ts = true;
+    let (res, _arena) = lex_utf8(&buf, len, opts);
+    res.diagnostics().iter().map(|d| d.code).collect()
+}
+
+#[test]
+fn unterminated_string() {
+    // opener at 4 to EOF: span (4, 4)
+    let d = diags("x = 'abc");
+    assert_eq!(d.len(), 1);
+    assert_eq!(d[0].code, diag_code::UNTERMINATED_STRING);
+    assert_eq!((d[0].off, d[0].len), (4, 4));
+}
+
+#[test]
+fn unterminated_template() {
+    assert_eq!(codes("x = `abc"), vec![diag_code::UNTERMINATED_TEMPLATE]);
+    assert_eq!(codes("x = `a${b}c"), vec![diag_code::UNTERMINATED_TEMPLATE]);
+    // An open substitution at EOF is a parser-level error; oxc_parser's
+    // lexer is also silent here.
+    assert!(codes("x = `a${b").is_empty());
+}
+
+#[test]
+fn unterminated_block_comment() {
+    assert_eq!(codes("x /* abc"), vec![diag_code::UNTERMINATED_BLOCK_COMMENT]);
+}
+
+#[test]
+fn unterminated_regex() {
+    assert_eq!(codes("x = /abc"), vec![diag_code::UNTERMINATED_REGEXP]);
+}
+
+#[test]
+fn unterminated_in_jsx_path() {
+    // carve_jsx must detect the same unterminated literals as carve
+    assert_eq!(codes_jsx("const x = 'abc"), vec![diag_code::UNTERMINATED_STRING]);
+    assert_eq!(codes_jsx("const x = `abc"), vec![diag_code::UNTERMINATED_TEMPLATE]);
+    assert_eq!(codes_jsx("const x = 1 /* abc"), vec![diag_code::UNTERMINATED_BLOCK_COMMENT]);
+    assert_eq!(codes_jsx("const x = /abc"), vec![diag_code::UNTERMINATED_REGEXP]);
+    assert!(codes_jsx("const el = <div className='x'>hi</div>;").is_empty());
+}
+
+#[test]
+fn numeric_separator_and_empty_radix() {
+    use diag_code as D;
+    assert_eq!(codes("x = 1_000_"), vec![D::INVALID_NUMERIC_SEPARATOR]); // trailing
+    assert_eq!(codes("x = 1__2"), vec![D::INVALID_NUMERIC_SEPARATOR]); // double
+    assert_eq!(codes("x = 0x_1"), vec![D::INVALID_NUMERIC_SEPARATOR]); // after prefix
+    assert_eq!(codes("x = 0xAB_"), vec![D::INVALID_NUMERIC_SEPARATOR]); // trailing in hex
+    assert_eq!(codes("x = 0x;"), vec![D::INVALID_NUMERIC_LITERAL]); // empty radix
+}
+
+#[test]
+fn legacy_octal_like_decimal() {
+    use diag_code as D;
+    // Leading `0` + digit: no separators, no bigint suffix, and an exponent
+    // only as lowercase `e` after an 8/9 (oxc_parser's read_legacy_octal
+    // quirk).
+    assert_eq!(codes("x = 0_0;"), vec![D::INVALID_NUMERIC_SEPARATOR]);
+    assert_eq!(codes("x = 00_0;"), vec![D::INVALID_NUMERIC_SEPARATOR]);
+    assert_eq!(codes("x = 08_0;"), vec![D::INVALID_NUMERIC_SEPARATOR]);
+    assert_eq!(codes("x = 00n;"), vec![D::INVALID_BIGINT]);
+    assert_eq!(codes("x = 08n;"), vec![D::INVALID_BIGINT]);
+    assert_eq!(codes("x = 0008n;"), vec![D::INVALID_BIGINT]);
+    assert_eq!(codes("x = 00e1;"), vec![D::INVALID_NUMERIC_LITERAL]);
+    assert_eq!(codes("x = 08E1;"), vec![D::INVALID_NUMERIC_LITERAL]);
+}
+
+#[test]
+fn valid_numbers_never_flagged() {
+    for n in [
+        "123",
+        "1_000",
+        "1_000_000",
+        "3.14",
+        "1e10",
+        "1E3",
+        "1e1_0",
+        "1.0e-1_0",
+        "0xFF",
+        "0xDEAD_BEEF",
+        "0o17",
+        "0b1010",
+        "123n",
+        "1_000n",
+        "0xFFn",
+        ".5",
+        "5.",
+        "0.0",
+        "0",
+        // legacy-octal-like decimals that are valid in sloppy mode
+        "00",
+        "0123",
+        "08",
+        "09",
+        "0008",
+        "08.5",
+        "09e1",
+        "08e-1",
+    ] {
+        assert!(codes(&format!("x = {n};")).is_empty(), "false positive on valid `{n}`");
+    }
+}
+
+#[test]
+fn numeric_adjacency() {
+    use diag_code as D;
+    // misplaced bigint suffix: span = the trailing `n`
+    let d = diags("x = 1.5n;");
+    assert_eq!(d.len(), 1);
+    assert_eq!(d[0].code, D::INVALID_BIGINT);
+    assert_eq!((d[0].off, d[0].len), (7, 1));
+    assert_eq!(codes("x = 1e3n;"), vec![D::INVALID_BIGINT]);
+    // digit invalid for the radix: span = that digit only (a digit is not an
+    // identifier start, so the parser's run stops after one char)
+    let d = diags("x = 0b12;");
+    assert_eq!(d.len(), 1);
+    assert_eq!(d[0].code, D::INVALID_NUMERIC_LITERAL);
+    assert_eq!((d[0].off, d[0].len), (7, 1));
+    assert_eq!(codes("x = 0o18;"), vec![D::INVALID_NUMERIC_LITERAL]);
+    // number followed by an identifier: span covers the ident run
+    let d = diags("x = 3in y;");
+    assert_eq!(d.len(), 1);
+    assert_eq!(d[0].code, D::INVALID_NUMERIC_LITERAL);
+    assert_eq!((d[0].off, d[0].len), (5, 2)); // `in`
+    let d = diags("x = 123abc;");
+    assert_eq!((d[0].off, d[0].len), (7, 3)); // `abc`
+    assert_eq!(codes("x = 0xFFg;"), vec![D::INVALID_NUMERIC_LITERAL]);
+    // coalesce is shared by all four modes, so the jsx path fires too
+    assert_eq!(codes_jsx("x = 1.5n;"), vec![D::INVALID_BIGINT]);
+}
+
+#[test]
+fn valid_numeric_adjacency_never_flagged() {
+    for src in [
+        "x = 0x1Fn;",          // hex bigint: `n` consumed by the scanner
+        "x = 123n;",           // decimal bigint
+        "x = 1_000n;",         // bigint with separators
+        "x = 0b101;",          // valid binary
+        "x = 1..toString();",  // number `1.` then `.` property access — dot is legal
+        "x = 1.e3;",           // exponent directly after the dot
+        "x = 1.5.toString();", // float then member access
+        "let abc123def = 1;",  // digits inside an identifier never glue as numbers
+        "x = x1;",             // trailing digit in identifier
+        "x = .5;",             // dot-led float
+        "x = 5.;",             // trailing-dot float
+        "for (var i in x) {}", // spaced `in` operator
+        "x = 1 in y;",         // spaced `in` after number
+        "x = a instanceof b;",
+        "t = `${1}n`;",        // template text after a substitution
+        "s = '1.5n';",         // string interior
+        "c = /* 1.5n */ 1;",   // comment interior
+        "r = /1.5n/;",         // regex interior
+        "x = 1\u{a0}+ 2;",     // NBSP after number: Unicode WHITESPACE, not ident
+        "x = 1\u{2028}y = 2;", // LS after number: a line terminator, valid
+        "x = 1\u{3000}+ 2;",   // ideographic space after number
+    ] {
+        assert!(codes(src).is_empty(), "false positive on `{src}`");
+    }
+    // JSX text and expression containers must not glue text as numbers.
+    assert!(codes_jsx("const el = <div>1.5n</div>;").is_empty());
+    assert!(codes_jsx("const el = <div a=\"3in\">{1.5}</div>;").is_empty());
+    // The content-blind TSX type-arg skip must not leak numeric diagnostics
+    // from digit-letter adjacency inside a string type-arg.
+    assert!(codes_tsx("const el = <Foo<\"3px\"> x={1}/>;").is_empty());
+    assert!(codes_tsx("const el = <Foo<1.5, \"2xl\"> y/>;").is_empty());
+}
+
+#[test]
+fn regex_flags() {
+    use diag_code as D;
+    assert_eq!(codes("r = /x/q;"), vec![D::INVALID_REGEXP_FLAG]); // unknown flag
+    assert_eq!(codes("r = /x/gg;"), vec![D::DUPLICATE_REGEXP_FLAG]); // duplicate
+    assert!(codes("r = /x/gimsuydv;").is_empty()); // all valid flags, once each
+    assert!(codes("r = /x/;").is_empty()); // no flags
+}
+
+#[test]
+fn unexpected_character() {
+    use diag_code as D;
+    assert_eq!(codes("a\u{1}b"), vec![D::UNEXPECTED_CHARACTER]);
+    assert_eq!(codes("x = 1\u{7} 2"), vec![D::UNEXPECTED_CHARACTER]);
+    assert_eq!(codes("\u{1}\u{2}"), vec![D::UNEXPECTED_CHARACTER, D::UNEXPECTED_CHARACTER]);
+}
+
+#[test]
+fn line_terminator_in_string() {
+    use diag_code as D;
+    assert_eq!(codes("x = 'a\nb';"), vec![D::LINE_TERMINATOR_IN_STRING]);
+    assert_eq!(codes("x = 'a\r\nb';"), vec![D::LINE_TERMINATOR_IN_STRING]);
+    // escaped line terminators are legal continuations, CRLF as one sequence
+    assert!(codes("x = 'a\\\nb';").is_empty());
+    assert!(codes("x = 'a\\\rb';").is_empty());
+    assert!(codes("x = 'a\\\r\nb';").is_empty());
+    // escaped backslash followed by a raw terminator is invalid
+    assert_eq!(codes("x = 'a\\\\\r\nb';"), vec![D::LINE_TERMINATOR_IN_STRING]);
+
+    // Span parity: opener through the first unescaped terminator; for CRLF
+    // only the CR (the parser consumes one char, then reports).
+    let d = diags("x = 'a\nb';");
+    assert_eq!((d[0].off, d[0].len), (4, 3));
+    let d = diags("x = 'a\r\nb';");
+    assert_eq!((d[0].off, d[0].len), (4, 3));
+    let d = diags("x = 'a\\\\\r\nb';");
+    assert_eq!((d[0].off, d[0].len), (4, 5));
+}
+
+#[test]
+fn line_terminator_in_regexp() {
+    use diag_code as D;
+    // Our token still runs to the closing `/`; the diagnostic reproduces the
+    // parser's span, opener to just past the first terminator.
+    let d = diags("x = /a\nb/;");
+    assert_eq!(d.len(), 1);
+    assert_eq!(d[0].code, D::LINE_TERMINATOR_IN_REGEXP);
+    assert_eq!((d[0].off, d[0].len), (4, 3)); // `/a<LF>`
+    let d = diags("x = /a\r\nb/;");
+    assert_eq!(d.len(), 1);
+    assert_eq!(d[0].code, D::LINE_TERMINATOR_IN_REGEXP);
+    assert_eq!((d[0].off, d[0].len), (4, 3)); // `/a<CR>`: one diag, span past the CR
+    // escaped terminators and terminators inside `[...]` are also invalid
+    assert_eq!(codes("x = /a\\\nb/;"), vec![D::LINE_TERMINATOR_IN_REGEXP]);
+    assert_eq!(codes("x = /a\\\r\nb/;"), vec![D::LINE_TERMINATOR_IN_REGEXP]);
+    // backslash at EOF: the escape peek must not read pad bytes and
+    // fabricate a terminator
+    assert_eq!(codes("x = /a\\"), vec![D::UNTERMINATED_REGEXP]);
+    assert_eq!(codes("x = /a[\n]b/;"), vec![D::LINE_TERMINATOR_IN_REGEXP]);
+    // newline then EOF: the parser stops at the terminator first
+    assert_eq!(codes("x = /abc\n"), vec![D::LINE_TERMINATOR_IN_REGEXP]);
+    assert_eq!(codes_jsx("x = /a\nb/;"), vec![D::LINE_TERMINATOR_IN_REGEXP]);
+    assert!(codes("x = /a\\nb/g;").is_empty()); // `\n` as two chars
+    assert!(codes("x = a / b\nc / d;").is_empty()); // division across lines
+    assert!(codes("x = /a[b-z]+/;").is_empty());
+}
+
+#[test]
+fn invalid_unicode_escape_in_string() {
+    use diag_code as D;
+    // Spans run from the backslash to just past the last byte the parser's
+    // escape scanner consumed. (`x = ` puts the `\` at offset 5.)
+    let d = diags(r#"x = "\u{110000}";"#); // out of range: span `\u{110000` (excl `}`)
+    assert_eq!(d.len(), 1);
+    assert_eq!((d[0].off, d[0].len, d[0].code), (5, 9, D::INVALID_UNICODE_ESCAPE));
+    let d = diags(r#"x = "\uZZZZ";"#); // bad hex: span `\u`
+    assert_eq!((d[0].off, d[0].len, d[0].code), (5, 2, D::INVALID_UNICODE_ESCAPE));
+    let d = diags(r#"x = "\u1ZZZ";"#); // one leading valid digit: span `\u1`
+    assert_eq!((d[0].off, d[0].len), (5, 3));
+    let d = diags(r#"x = "\xGG";"#); // bad hex \x: span `\x`
+    assert_eq!((d[0].off, d[0].len, d[0].code), (5, 2, D::INVALID_UNICODE_ESCAPE));
+    let d = diags(r#"x = "\x4G";"#); // partial hex: span `\x4`
+    assert_eq!((d[0].off, d[0].len), (5, 3));
+    let d = diags(r#"x = "\u{}";"#); // empty braces: span `\u{`
+    assert_eq!((d[0].off, d[0].len), (5, 3));
+    let d = diags(r#"x = "\u{12";"#); // unterminated braces: `\u{12`
+    assert_eq!(d.len(), 1);
+    assert_eq!((d[0].off, d[0].len), (5, 5));
+    // the parser stops at the digit that crosses 0x10FFFF
+    let d = diags(r#"x = "\u{1100000}";"#);
+    assert_eq!((d[0].off, d[0].len), (5, 9)); // `\u{110000`
+    // u32 wrap-around: `\u{100000041}` wraps back into range
+    assert_eq!(codes(r#"x = "\u{100000041}";"#), vec![D::INVALID_UNICODE_ESCAPE]);
+    let d = diags(r#"x = "\u{0041ZZZ}";"#); // non-hex break, in-range value
+    assert_eq!((d[0].off, d[0].len), (5, 7)); // `\u{0041`
+    let d = diags(r#"x = "\u004";"#); // truncated at the closing quote
+    assert_eq!((d[0].off, d[0].len), (5, 5)); // `\u004`
+    // one error per bad escape, anchored at each backslash
+    assert_eq!(codes(r#"x = "\xG \xG";"#).len(), 2);
+    let d = diags(r#"x = "\uD800\uZZZZ";"#); // 2nd escape bad
+    assert_eq!(d.len(), 1);
+    assert_eq!((d[0].off, d[0].len), (11, 2));
+}
+
+#[test]
+fn valid_escapes_never_flagged() {
+    for s in [
+        r#""\u0041""#,
+        r#""\u{1F600}""#,
+        r#""\u{0}""#,
+        r#""\u{10FFFF}""#,     // boundary: strictly-greater check
+        r#""\u{0000000041}""#, // leading zeros never cross the limit
+        r#""\z""#,             // NonEscapeCharacter — valid, cooks to `z`
+        r#""\\n""#,            // escaped backslash + literal n
+        r#""\0""#,
+        r#""\01""#, // legacy octal: parser/strict-mode territory
+        r#""\7""#,
+        r#""\8""#,           // NonOctalDecimalEscape: parser territory
+        r#""\uD800""#,       // lone surrogate: valid in strings
+        r#""\uD83D\uDE00""#, // surrogate-pair escapes (two valid escapes)
+        r#""😀""#,           // raw multi-byte content, no escapes
+        r#""\x41""#,
+    ] {
+        assert!(codes(&format!("x = {s};")).is_empty(), "false positive on `{s}`");
+    }
+    assert!(codes("x = 'a\\\nb';").is_empty()); // LF line continuation
+    assert!(codes("x = 'a\\\r\nb';").is_empty()); // CRLF line continuation
+}
+
+#[test]
+fn template_invalid_escapes_stay_silent() {
+    // An invalid escape in a tagged template is legal, and tagged-ness is
+    // parser context; oxc_parser's lexer is also silent here.
+    assert!(codes(r"t = `\uZZZZ`;").is_empty());
+    assert!(codes(r"t = `\u{110000}`;").is_empty());
+    assert!(codes(r"t = `\xGG`;").is_empty());
+    assert!(codes(r"t = tag`\uZZ`;").is_empty());
+    assert!(codes(r"t = `a${b}\uZZ`;").is_empty()); // middle/tail segments
+}
+
+#[test]
+fn invalid_unicode_escape_jsx_path() {
+    use diag_code as D;
+    assert_eq!(codes_jsx(r#"const x = "\uZZZZ";"#), vec![D::INVALID_UNICODE_ESCAPE]);
+    // JSX attribute strings have no escapes — the value is verbatim source.
+    assert!(codes_jsx(r#"const el = <div a="\uZZ">x</div>;"#).is_empty());
+}
+
+#[test]
+fn valid_input_emits_nothing() {
+    assert!(codes("let x = 'abc';").is_empty());
+    assert!(codes("const t = `a${b}c`; /* ok */ // ok\nlet r = /x/g;").is_empty());
+    assert!(codes("function f(){ return 1 / 2; }").is_empty());
+}
+
+#[test]
+fn invalid_unicode_character() {
+    use diag_code as D;
+    // Chars that are neither whitespace nor ID_Start/ID_Continue at code
+    // level: U+2E2F vertical tilde, U+180E Mongolian vowel separator, emoji.
+    let d = diags("var x\u{2E2F} = 1;");
+    assert_eq!(d.len(), 1);
+    assert_eq!((d[0].off, d[0].len, d[0].code), (5, 3, D::UNEXPECTED_CHARACTER));
+    assert_eq!(codes("var \u{180E}x = 1;"), vec![D::UNEXPECTED_CHARACTER]);
+    assert_eq!(codes("let a = \u{1F600};"), vec![D::UNEXPECTED_CHARACTER]);
+    // A raw U+FFFD at code level is oxc_parser's binary-file error, distinct
+    // from opt-in UTF-8 validation.
+    assert_eq!(codes("var \u{FFFD} = 1;"), vec![D::INVALID_UTF8]);
+}
+
+#[test]
+fn valid_unicode_never_flagged() {
+    // identifier chars, whitespace, and anything inside literal content
+    for src in [
+        "var caf\u{E9} = 1;",                   // é: ID_Continue
+        "var \u{4F60}\u{597D} = 1;",            // CJK idents
+        "let \u{3C0} = 3.14;",                  // π
+        "x\u{00A0}= 1;",                        // NBSP whitespace
+        "let s = '\u{1F600}\u{2E2F}\u{180E}';", // anything in a string
+        "let t = `\u{1F600} ${x} \u{2E2F}`;",   // anything in a template
+        "// \u{2E2F}\u{1F600}\nlet u = 1;",     // anything in a comment
+        "/* \u{180E} */ let v = 1;",            // block comment
+        "x = /\u{1F600}/u;",                    // anything in a regex body
+    ] {
+        assert!(codes(src).is_empty(), "false positive on valid {src:?}");
+    }
+}
+
+fn diags_bytes(code: &[u8]) -> Vec<Diagnostic> {
+    let mut buf = code.to_vec();
+    let len = buf.len() as u32;
+    buf.resize(buf.len() + PAD, 0);
+    let mut opts = default_options();
+    opts.validate_utf8 = true;
+    let (res, _arena) = lex_utf8(&buf, len, opts);
+    res.diagnostics().to_vec()
+}
+
+#[test]
+fn invalid_utf8() {
+    use diag_code as D;
+    // span = the maximal invalid subpart; one diagnostic per file
+    let d = diags_bytes(b"x = \xFF;"); // lone invalid byte
+    assert_eq!(d.len(), 1);
+    assert_eq!((d[0].off, d[0].len, d[0].code), (4, 1, D::INVALID_UTF8));
+    assert_eq!(diags_bytes(b"x = \xC3;")[0].code, D::INVALID_UTF8); // truncated 2-byte
+    assert_eq!(diags_bytes(b"x = \xC3").len(), 1); // truncated at EOF
+    assert_eq!(diags_bytes(b"x = \x80;")[0].code, D::INVALID_UTF8); // stray continuation
+    // Overlong / surrogate / beyond-U+10FFFF: byte 2 is range-checked per
+    // lead, so the invalid subpart is the lead alone.
+    let d = diags_bytes(b"x = '\xE0\x80\x80';");
+    assert_eq!((d[0].off, d[0].len, d[0].code), (5, 1, D::INVALID_UTF8));
+    let d = diags_bytes(b"x = '\xED\xA0\x80';");
+    assert_eq!((d[0].off, d[0].len), (5, 1));
+    let d = diags_bytes(b"x = '\xF4\x90\x80\x80';");
+    assert_eq!((d[0].off, d[0].len), (5, 1));
+    // truncated 4-byte at EOF: lead + two range-valid continuations
+    let d = diags_bytes(b"x = \xF0\x9F\x98");
+    assert_eq!((d[0].off, d[0].len), (4, 3));
+    assert_eq!(diags_bytes(b"x = \xFF + \xFF;").len(), 1); // first subpart only
+    // context-free: fires inside a string body too
+    let d = diags_bytes(b"x = 'a\xFFb';");
+    assert_eq!((d[0].off, d[0].code), (6, D::INVALID_UTF8));
+}
+
+#[test]
+fn valid_utf8_never_flagged() {
+    let codes_v =
+        |s: &str| -> Vec<u16> { diags_bytes(s.as_bytes()).iter().map(|d| d.code).collect() };
+    for src in [
+        "let caf\u{e9} = 1;",        // 2-byte
+        "x = '\u{1F600}';",          // 4-byte emoji in string
+        "a\u{a0}b",                  // NBSP (ws-reclass path preserved)
+        "let \u{4e2d}\u{6587} = 1;", // CJK identifier (3-byte)
+        "x\u{2028}y = 1;",           // LS
+        "s = '\u{FEFF}';",           // ZWNBSP mid-file
+    ] {
+        assert!(
+            !codes_v(src).contains(&diag_code::INVALID_UTF8),
+            "false positive on valid UTF-8 `{src}`"
+        );
+    }
+}
+
+#[test]
+fn utf8_fuzz_against_std() {
+    use diag_code as D;
+    // Deterministic LCG fuzz against std::str::from_utf8: a diag iff std
+    // errors, offset == valid_up_to(), len == error_len() when std has one.
+    let mut s: u64 = 0x243F_6A88_85A3_08D3;
+    for _ in 0..4000 {
+        let mut buf = vec![b' ']; // keep offset 0 clear of hashbang/BOM handling
+        s = s.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        let len = 3 + (s >> 59) as usize;
+        for _ in 0..len {
+            s = s.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            let r = (s >> 33) as u8;
+            buf.push(if r & 1 == 0 { 0x40 + (r >> 3) } else { r });
+        }
+        let d = diags_bytes(&buf);
+        let first6 = d.iter().find(|d| d.code == D::INVALID_UTF8);
+        match core::str::from_utf8(&buf) {
+            Ok(_) => assert!(first6.is_none(), "false positive on valid UTF-8 {buf:?}"),
+            Err(e) => {
+                let d6 = first6.unwrap_or_else(|| panic!("missed invalid UTF-8 in {buf:?}"));
+                assert_eq!(d6.off as usize, e.valid_up_to(), "offset mismatch on {buf:?}");
+                if let Some(l) = e.error_len() {
+                    assert_eq!(d6.len as usize, l, "subpart len mismatch on {buf:?}");
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn invalid_identifier_escape_bare() {
+    use diag_code as D;
+    // bare `\`: span = the one char after it, backslash excluded
+    let d = diags(r"x = \A");
+    assert_eq!(d.len(), 1);
+    assert_eq!((d[0].off, d[0].len, d[0].code), (5, 1, D::INVALID_IDENTIFIER_ESCAPE));
+    // backslash at EOF: empty span at n
+    let d = diags(r"x = \");
+    assert_eq!((d[0].off, d[0].len, d[0].code), (5, 0, D::INVALID_IDENTIFIER_ESCAPE));
+    // control bytes keep their own code
+    assert_eq!(codes("a\u{1}b"), vec![D::UNEXPECTED_CHARACTER]);
+}
+
+#[test]
+fn invalid_identifier_escape_payload() {
+    use diag_code as D;
+    // spans start after the backslash, end where the parser scanner stopped
+    let d = diags(r"var \uZZ = 1");
+    assert_eq!(d.len(), 1);
+    assert_eq!((d[0].off, d[0].len, d[0].code), (5, 1, D::INVALID_IDENTIFIER_ESCAPE));
+    let d = diags(r"var \u004 = 1"); // 3 leading valid hex
+    assert_eq!((d[0].off, d[0].len), (5, 4));
+    let d = diags(r"var \u{} = 1"); // no digits; closing brace NOT consumed
+    assert_eq!((d[0].off, d[0].len), (5, 2));
+    let d = diags(r"var \u{110000} = 1"); // stops right after the crossing digit
+    assert_eq!(d.len(), 1);
+    assert_eq!((d[0].off, d[0].len), (5, 8));
+    let d = diags(r"var \u{FFFFFFFFFF} = 1"); // ditto, incremental check
+    assert_eq!((d[0].off, d[0].len), (5, 8));
+    let d = diags(r"var \u{12 = 1"); // missing closing brace
+    assert_eq!((d[0].off, d[0].len), (5, 4));
+    // surrogates: lone (both forms) and pairs are invalid in identifiers
+    let d = diags(r"var \uD800 = 1");
+    assert_eq!((d[0].off, d[0].len), (5, 5));
+    let d = diags(r"var \u{D800} = 1");
+    assert_eq!((d[0].off, d[0].len), (5, 7));
+    // a well-formed pair: one diagnostic spanning both escapes
+    let src = ["var ", r"\uD800", r"\uDC00", " = 1"].concat();
+    let d = diags(&src);
+    assert_eq!(d.len(), 1);
+    assert_eq!((d[0].off, d[0].len), (5, 11));
+    // high + invalid low: the parser rewinds — two independent diagnostics
+    let src = ["var ", r"\uD800", r"\uD800", " = 1"].concat();
+    let d = diags(&src);
+    assert_eq!(d.len(), 2);
+    assert_eq!((d[0].off, d[0].len), (5, 5));
+    assert_eq!((d[1].off, d[1].len), (11, 5));
+}
+
+#[test]
+fn invalid_identifier_escape_jsx_path() {
+    use diag_code as D;
+    assert!(codes_jsx(r"const \u{110000} = 1").contains(&D::INVALID_IDENTIFIER_ESCAPE));
+    assert!(codes_jsx(r"const el = <div>a\b</div>;").is_empty()); // JSX text
+}
+
+#[test]
+fn valid_identifier_escapes_never_flagged() {
+    use diag_code as D;
+    for src in [
+        r"let \u0041 = 1;",        // 4-digit form
+        r"let \u{41} = 1;",        // brace form
+        r"let \u{10FFFF} = 1;",    // boundary code point (ident-char check deferred)
+        r"a\u0041b",               // mid-identifier escape (misc_post merge)
+        r"n\u0065w",               // keyword lookalike via escape
+        r"class A{ #\u0061 = 1 }", // private name with escape
+        r"x = '\n';",              // string escapes: not this class
+        r"r = /\d+/g;",            // regex escapes: interiors carved
+        r"// \A",                  // comment interior
+        "t = `a\nb`;",             // template interior
+    ] {
+        assert!(!codes(src).contains(&D::INVALID_IDENTIFIER_ESCAPE), "false positive on `{src}`");
+    }
+    // Out-of-range escape in a STRING is code 7's business, never code 8.
+    assert!(!codes(r"s = '\u{110000}';").contains(&D::INVALID_IDENTIFIER_ESCAPE));
+}
+
+#[test]
+fn empty_exponent() {
+    use diag_code as D;
+    // `1e` / `1e+`: the marker and sign were consumed but no digits followed
+    let d = diags("x = 1e;");
+    assert_eq!(d.len(), 1);
+    assert_eq!((d[0].off, d[0].len, d[0].code), (4, 2, D::INVALID_NUMERIC_LITERAL));
+    let d = diags("x = 1e+;");
+    assert_eq!((d[0].off, d[0].len, d[0].code), (4, 3, D::INVALID_NUMERIC_LITERAL));
+    assert_eq!(codes("x = .5e;"), vec![D::INVALID_NUMERIC_LITERAL]);
+    assert_eq!(codes("x = 0e;"), vec![D::INVALID_NUMERIC_LITERAL]);
+    assert_eq!(codes("x = 08e;"), vec![D::INVALID_NUMERIC_LITERAL]);
+    // `1en`: empty exponent and misplaced bigint suffix both fire — unlike
+    // the parser, we don't abort at the first error
+    let cs = codes("x = 1en;");
+    assert!(cs.contains(&D::INVALID_NUMERIC_LITERAL));
+    assert!(cs.contains(&D::INVALID_BIGINT));
+    for n in ["1e3", "1E+5", "1e-1", "1.e3", "1e1_0", ".5e2", "0e0", "0xe", "0xEn"] {
+        assert!(codes(&format!("x = {n};")).is_empty(), "false positive on `{n}`");
+    }
+}
+
+#[test]
+fn unicode_ident_after_number() {
+    use diag_code as D;
+    // same adjacency error as ASCII; span = the identifier-start run
+    let d = diags("x = 1π;");
+    assert_eq!(d.len(), 1);
+    assert_eq!((d[0].off, d[0].len, d[0].code), (5, 2, D::INVALID_NUMERIC_LITERAL));
+    let d = diags("x = 123abcπ;");
+    assert_eq!((d[0].off, d[0].len), (7, 5)); // `abc` + 2-byte pi
+    assert_eq!(codes("x = 1.5π;"), vec![D::INVALID_NUMERIC_LITERAL]);
+    // unicode whitespace after a number stays clean
+    assert!(codes("x = 1\u{a0}+ 2;").is_empty());
+    assert!(codes("x = 1\u{2028}y = 2;").is_empty());
+}
+
+#[test]
+fn escaped_char_not_identifier() {
+    use diag_code as D;
+    // A well-formed escape decoding to a non-identifier char: empty span
+    // right after the escape (the bridge decodes backward for the message).
+    let d = diags(r"var \u0020 = 1");
+    assert_eq!(d.len(), 1);
+    assert_eq!((d[0].off, d[0].len, d[0].code), (10, 0, D::UNEXPECTED_CHARACTER));
+    let d = diags(r"var \u{30}x = 1");
+    assert_eq!((d[0].off, d[0].len, d[0].code), (10, 0, D::UNEXPECTED_CHARACTER));
+    // mid-identifier escapes use is_identifier_part: digits fine there,
+    assert!(codes(r"let a\u{30}b = 1;").is_empty());
+    // whitespace not
+    assert_eq!(codes(r"let a\u0020b = 1;"), vec![D::UNEXPECTED_CHARACTER]);
+    for src in [r"let \u0041 = 1;", r"let \u{24} = 1;", r"let a\u{5F}b = 1;"] {
+        assert!(codes(src).is_empty(), "false positive on `{src}`");
+    }
+}
+
+#[test]
+fn line_separator_in_regexp() {
+    use diag_code as D;
+    // LS/PS are LineTerminators: invalid in regex bodies, raw or escaped;
+    // span ends past the whole 3-byte char
+    let d = diags("x = /a\u{2028}b/;");
+    assert_eq!(d.len(), 1);
+    assert_eq!((d[0].off, d[0].len, d[0].code), (4, 5, D::LINE_TERMINATOR_IN_REGEXP));
+    assert_eq!(codes("x = /a\u{2029}b/;"), vec![D::LINE_TERMINATOR_IN_REGEXP]);
+    let d = diags("x = /a\\\u{2028}b/;"); // escaped LS: still invalid
+    assert_eq!(d.len(), 1);
+    assert_eq!((d[0].off, d[0].len), (4, 6));
+    assert!(codes("x = /a\u{2014}b/;").is_empty()); // other E2-led chars are fine
+    assert!(codes("x = /a\u{2713}b/u;").is_empty());
+    assert!(codes(r"x = /a\u2028b/;").is_empty()); // escape text, no raw LS
+    assert!(codes("s = '\u{2028}';").is_empty()); // legal in strings/templates
+    assert!(codes("t = `\u{2028}`;").is_empty());
+}
+
+#[test]
+fn misplaced_hash() {
+    use diag_code as D;
+    // A `#` that opens neither a hashbang nor a private name: the parser
+    // consumes the char after `#` and reports on it.
+    let d = diags("\n#!/bin/sh");
+    let h = d.iter().find(|x| x.code == D::UNEXPECTED_CHARACTER).unwrap();
+    assert_eq!((h.off, h.len), (2, 1)); // later garbage tokens may add diags
+    let d = diags("x = #;");
+    assert_eq!(d.len(), 1);
+    assert_eq!((d[0].off, d[0].len, d[0].code), (5, 1, D::UNEXPECTED_CHARACTER));
+    let d = diags("x = #"); // `#` at EOF: empty span at n
+    assert_eq!((d[0].off, d[0].len), (5, 0));
+    assert!(codes("#!/usr/bin/env node\nlet x = 1;").is_empty());
+    assert!(codes("class A { #x = 1; m() { return this.#x; } }").is_empty());
+}
+
+#[test]
+fn template_cooked_invalid_marker() {
+    // A NotEscapeSequence makes the cooked value None; legality depends on
+    // tagged-ness, so the span carries a marker bit, not a diagnostic.
+    let get = |code: &str| -> Vec<bool> {
+        let mut buf = code.as_bytes().to_vec();
+        let len = buf.len() as u32;
+        buf.resize(buf.len() + PAD, 0);
+        let (res, arena) = lex_utf8(&buf, len, default_options());
+        res.templates(&arena).iter().map(|t| t.cooked_invalid()).collect()
+    };
+    assert_eq!(get(r"t = `\uZZ`;"), vec![true]); // bad unicode escape
+    assert_eq!(get(r"t = `\xG`;"), vec![true]); // bad hex escape
+    assert_eq!(get(r"t = `\u{110000}`;"), vec![true]); // out of range
+    assert_eq!(get(r"t = `\101`;"), vec![true]); // octal
+    assert_eq!(get(r"t = `\8`;"), vec![true]); // NonOctalDecimalEscape
+    assert_eq!(get(r"t = `\n`;"), vec![false]); // ordinary escape
+    assert_eq!(get(r"t = `\0`;"), vec![false]); // NUL, no digit after
+    assert_eq!(get("t = `abc`;"), vec![false]); // no escapes
+    assert_eq!(get(r"t = `a${b}c`;"), vec![false, false]); // head + tail
+    // still zero diagnostics, matching oxc_parser's silent lexer
+    assert!(codes(r"t = `\101`;").is_empty());
+    assert!(codes(r"t = `\uZZ`;").is_empty());
+    // strings are untouched by the marker path
+    assert!(codes(r#"s = "\8";"#).is_empty());
+}

--- a/crates/oxc_lexer/tests/ts_keywords.rs
+++ b/crates/oxc_lexer/tests/ts_keywords.rs
@@ -112,6 +112,7 @@ fn ts_key_separates_narrow_key_collisions() {
 #[test]
 fn near_misses_stay_ident() {
     for w in [
+        // spellchecker:off
         "types",
         "strin",
         "stringg",
@@ -128,6 +129,7 @@ fn near_misses_stay_ident() {
         "prototype",
         "Number",
         "String",
+        // spellchecker:on
     ] {
         assert_eq!(first_kind(w, true), k::IDENT, "ts near-miss: {w}");
         assert_eq!(first_kind(w, false), k::IDENT, "js near-miss: {w}");

--- a/crates/oxc_lexer/tests/ts_keywords.rs
+++ b/crates/oxc_lexer/tests/ts_keywords.rs
@@ -1,0 +1,225 @@
+//! TS-mode keyword recognition: the TS set is active only under
+//! `LexOptions::ts`, JS mode must be unaffected, and the wider TS hash key
+//! must separate the pairs the JS key cannot.
+#![cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
+
+use oxc_lexer::{Lexer, PAD, default_options, token_kind as k};
+
+/// All 35 TS-mode additions, mirroring `KEYWORDS_TS_EXTRA` (kept literal so
+/// a table typo cannot hide behind shared constants).
+const TS_WORDS: [(&str, u8); 35] = [
+    ("abstract", k::KW_ABSTRACT),
+    ("accessor", k::KW_ACCESSOR),
+    ("any", k::KW_ANY),
+    ("asserts", k::KW_ASSERTS),
+    ("bigint", k::KW_BIGINT),
+    ("boolean", k::KW_BOOLEAN),
+    ("declare", k::KW_DECLARE),
+    ("global", k::KW_GLOBAL),
+    ("implements", k::KW_IMPLEMENTS),
+    ("infer", k::KW_INFER),
+    ("interface", k::KW_INTERFACE),
+    ("intrinsic", k::KW_INTRINSIC),
+    ("is", k::KW_IS),
+    ("keyof", k::KW_KEYOF),
+    ("module", k::KW_MODULE),
+    ("namespace", k::KW_NAMESPACE),
+    ("never", k::KW_NEVER),
+    ("number", k::KW_NUMBER),
+    ("object", k::KW_OBJECT),
+    ("out", k::KW_OUT),
+    ("override", k::KW_OVERRIDE),
+    ("package", k::KW_PACKAGE),
+    ("private", k::KW_PRIVATE),
+    ("protected", k::KW_PROTECTED),
+    ("public", k::KW_PUBLIC),
+    ("readonly", k::KW_READONLY),
+    ("require", k::KW_REQUIRE),
+    ("satisfies", k::KW_SATISFIES),
+    ("string", k::KW_STRING),
+    ("symbol", k::KW_SYMBOL),
+    ("type", k::KW_TYPE),
+    ("undefined", k::KW_UNDEFINED),
+    ("unique", k::KW_UNIQUE),
+    ("unknown", k::KW_UNKNOWN),
+    ("using", k::KW_USING),
+];
+
+/// Lex and return the non-trivia kinds (EOF dropped).
+fn kinds(code: &str, ts: bool, jsx: bool) -> Vec<u8> {
+    let mut buf = code.as_bytes().to_vec();
+    let n = buf.len();
+    buf.resize(n + PAD, 0);
+    let mut opts = default_options();
+    opts.ts = ts;
+    opts.jsx = jsx;
+    let mut lx = Lexer::new();
+    let count = lx.lex(&buf, n, opts);
+    lx.kinds[..count - 1].iter().copied().filter(|&kk| !oxc_lexer::is_trivia(kk)).collect()
+}
+
+fn first_kind(code: &str, ts: bool) -> u8 {
+    kinds(code, ts, false)[0]
+}
+
+#[test]
+fn ts_words_resolve_in_ts_mode_only() {
+    for (w, tok) in TS_WORDS {
+        assert_eq!(first_kind(w, true), tok, "ts mode: {w}");
+        assert_eq!(first_kind(w, false), k::IDENT, "js mode: {w}");
+    }
+}
+
+#[test]
+fn js_keywords_identical_in_both_modes() {
+    for (w, tok) in [
+        ("return", k::KW_RETURN),
+        ("instanceof", k::KW_INSTANCEOF),
+        ("await", k::KW_AWAIT),
+        ("let", k::KW_LET),
+        ("static", k::KW_STATIC),
+        ("as", k::KW_AS),
+        ("of", k::KW_OF),
+        ("null", k::KW_NULL),
+    ] {
+        assert_eq!(first_kind(w, false), tok, "js mode: {w}");
+        assert_eq!(first_kind(w, true), tok, "ts mode: {w}");
+    }
+    // get/set are in-table placeholders and stay IDENT everywhere.
+    for w in ["get", "set"] {
+        assert_eq!(first_kind(w, false), k::IDENT);
+        assert_eq!(first_kind(w, true), k::IDENT);
+    }
+}
+
+#[test]
+fn ts_key_separates_narrow_key_collisions() {
+    // These pairs share (c0, c1, len) — the JS key cannot tell them apart,
+    // the TS (c0, c1, last, len) key must.
+    assert_eq!(first_kind("static", true), k::KW_STATIC);
+    assert_eq!(first_kind("string", true), k::KW_STRING);
+    assert_eq!(first_kind("declare", true), k::KW_DECLARE);
+    assert_eq!(first_kind("default", true), k::KW_DEFAULT);
+    assert_eq!(first_kind("interface", true), k::KW_INTERFACE);
+    assert_eq!(first_kind("intrinsic", true), k::KW_INTRINSIC);
+    // (c0, last, len) and (c1, last, len) degenerate pairs, for key hygiene.
+    assert_eq!(first_kind("true", true), k::KW_TRUE);
+    assert_eq!(first_kind("type", true), k::KW_TYPE);
+    assert_eq!(first_kind("if", true), k::KW_IF);
+    assert_eq!(first_kind("of", true), k::KW_OF);
+}
+
+#[test]
+fn near_misses_stay_ident() {
+    for w in [
+        "types",
+        "strin",
+        "stringg",
+        "interfac",
+        "interfacee",
+        "intrinsics",
+        "implementss",
+        "undefine",
+        "undefinedd",
+        "usin",
+        "usingg",
+        "keyo",
+        "arguments",
+        "prototype",
+        "Number",
+        "String",
+    ] {
+        assert_eq!(first_kind(w, true), k::IDENT, "ts near-miss: {w}");
+        assert_eq!(first_kind(w, false), k::IDENT, "js near-miss: {w}");
+    }
+}
+
+#[test]
+fn member_access_words_stay_ident() {
+    // The candidate filter drops words right after a member dot.
+    assert_eq!(kinds("a.type", true, false), vec![k::IDENT, k::DOT, k::IDENT]);
+    assert_eq!(kinds("a?.string", true, false), vec![k::IDENT, k::OPTIONAL_CHAIN, k::IDENT]);
+    assert_eq!(kinds("module.exports", true, false), vec![k::KW_MODULE, k::DOT, k::IDENT]);
+}
+
+#[test]
+fn ts_statement_shapes() {
+    assert_eq!(
+        kinds("type X = string;", true, false),
+        vec![k::KW_TYPE, k::IDENT, k::EQ, k::KW_STRING, k::SEMI]
+    );
+    assert_eq!(
+        kinds("interface I { readonly x: number }", true, false),
+        vec![
+            k::KW_INTERFACE,
+            k::IDENT,
+            k::LBRACE,
+            k::KW_READONLY,
+            k::IDENT,
+            k::COLON,
+            k::KW_NUMBER,
+            k::RBRACE
+        ]
+    );
+    assert_eq!(
+        kinds("declare module 'x';", true, false),
+        vec![k::KW_DECLARE, k::KW_MODULE, k::STRING, k::SEMI]
+    );
+    // Same input in JS mode: every TS spelling is a plain identifier.
+    assert_eq!(
+        kinds("type X = string;", false, false),
+        vec![k::IDENT, k::IDENT, k::EQ, k::IDENT, k::SEMI]
+    );
+}
+
+#[test]
+fn tsx_mode_uses_ts_set() {
+    assert_eq!(
+        kinds("type P = { x: number };", true, true),
+        vec![
+            k::KW_TYPE,
+            k::IDENT,
+            k::EQ,
+            k::LBRACE,
+            k::IDENT,
+            k::COLON,
+            k::KW_NUMBER,
+            k::RBRACE,
+            k::SEMI
+        ]
+    );
+}
+
+#[test]
+fn number_adjacency_resolves_with_active_set() {
+    // glue_number's cold arm resolves the abutting word inline; it must use
+    // the mode's set. (`3in` is invalid input; spans still tokenize.)
+    let js = kinds("3in x", false, false);
+    assert_eq!(js[0], k::NUMBER);
+    assert_eq!(js[1], k::KW_IN);
+    let ts = kinds("3is x", true, false);
+    assert_eq!(ts[0], k::NUMBER);
+    assert_eq!(ts[1], k::KW_IS);
+    let js2 = kinds("3is x", false, false);
+    assert_eq!(js2[1], k::IDENT);
+}
+
+#[test]
+fn escape_continuation_demotes_ts_keyword() {
+    // `types` is one escaped identifier, not KW_TYPE + escape.
+    let got = kinds("type\\u0073 x", true, false);
+    assert_eq!(got[0], k::IDENT_ESCAPED);
+}
+
+#[test]
+fn regex_vs_division_untouched_by_ts_kinds() {
+    // Keyword-kind rewriting happens after the regex decision; `type` is
+    // not a regex-preceding keyword in either mode.
+    let ts = kinds("type/x/g", true, false);
+    assert_eq!(ts[0], k::KW_TYPE);
+    assert_eq!(ts[1], k::SLASH, "ts: `/` after `type` must be division");
+    let js = kinds("type/x/g", false, false);
+    assert_eq!(js[1], k::SLASH, "js: `/` after `type` must be division");
+    // Control: after a real RX keyword it is a regex in both modes.
+    assert_eq!(kinds("return /x/g", true, false)[1], k::REGEXP);
+}

--- a/tasks/coverage/Cargo.toml
+++ b/tasks/coverage/Cargo.toml
@@ -26,6 +26,7 @@ cow-utils = { workspace = true }
 oxc = { workspace = true, features = ["full", "isolated_declarations", "serialize", "conformance"] }
 oxc_ast = { workspace = true, features = ["disable_old_builder"] }
 oxc_estree_tokens = { workspace = true }
+oxc_lexer = { workspace = true, optional = true }
 oxc_formatter = { workspace = true }
 oxc_formatter_core = { workspace = true }
 oxc_tasks_common = { workspace = true }
@@ -43,6 +44,13 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 similar = { workspace = true }
 walkdir = { workspace = true }
+
+[features]
+# Differential lexer conformance. `oxc_lexer`'s SIMD core only exists on x86_64
+# with static AVX2/BMI2 (it compiles to an empty stub otherwise), so the harness
+# is opt-in and its cfg sites mirror the lexer's crate gate:
+#   RUSTFLAGS="-C target-feature=+avx2,+bmi2" cargo coverage --features lexer -- lexer
+lexer = ["dep:oxc_lexer", "oxc_lexer/oxc_diagnostics"]
 
 # `oxc_ast` is a feature-only dependency, to enable its `disable_old_builder` feature
 [package.metadata.cargo-shear]

--- a/tasks/coverage/src/lexer_diff.rs
+++ b/tasks/coverage/src/lexer_diff.rs
@@ -1,0 +1,208 @@
+use std::{
+    fmt::Write,
+    panic::{AssertUnwindSafe, catch_unwind},
+};
+
+use oxc::{
+    allocator::Allocator,
+    diagnostics::OxcDiagnostic,
+    parser::{Parser, config::TokensParserConfig},
+    span::SourceType,
+};
+use rayon::prelude::*;
+
+use crate::{
+    BabelFile, CoverageResult, MiscFile, Test262File, TestResult, TypeScriptFile, test262::TestFlag,
+};
+
+fn lexer_stream(
+    code: &str,
+    source_type: SourceType,
+) -> (Vec<(u32, u32)>, Vec<oxc_lexer::Diagnostic>) {
+    let n = code.len();
+    // `lex_utf8` requires >= n + 64 bytes of trailing padding.
+    let mut buf = Vec::with_capacity(n + 64);
+    buf.extend_from_slice(code.as_bytes());
+    buf.resize(n + 64, 0);
+
+    let mut options = oxc_lexer::default_options();
+    options.source_type_module = source_type.is_module();
+    options.jsx = source_type.is_jsx();
+    options.ts = source_type.is_typescript();
+    // Keep the stream fully contiguous so `starts[i + 1]` is token `i`'s true end.
+    options.emit_whitespace = true;
+    options.emit_comments = true;
+
+    let (result, arena) = oxc_lexer::lex_utf8(&buf, n as u32, options);
+    let kinds = result.tok_kinds(&arena);
+    let starts = result.tok_starts(&arena);
+
+    let mut spans = Vec::with_capacity(kinds.len());
+    for (i, &kind) in kinds.iter().enumerate() {
+        if kind == oxc_lexer::token_kind::EOF || oxc_lexer::is_trivia(kind) {
+            continue;
+        }
+        let start = oxc_lexer::token::offset(starts[i]);
+        let end = oxc_lexer::token::offset(starts[i + 1]);
+        spans.push((start, end));
+    }
+    let mut diags = result.diagnostics().to_vec();
+    diags.sort_by_key(|d| d.off);
+    (spans, diags)
+}
+
+fn oracle_stream(
+    code: &str,
+    source_type: SourceType,
+) -> Option<(Vec<(u32, u32)>, Vec<OxcDiagnostic>)> {
+    let allocator = Allocator::default();
+    let ret = Parser::new(&allocator, code, source_type).with_config(TokensParserConfig).parse();
+    if ret.panicked {
+        return None;
+    }
+    let spans = ret.tokens.iter().map(|t| (t.start(), t.end())).collect();
+    let errors = ret.diagnostics.errors().cloned().collect();
+    Some((spans, errors))
+}
+
+fn diag_key(d: &OxcDiagnostic) -> (String, Vec<(u32, u32)>) {
+    let labels = d
+        .labels
+        .as_ref()
+        .iter()
+        .map(|l| (l.offset(), l.offset().saturating_add(l.len())))
+        .collect();
+    (d.message.to_string(), labels)
+}
+
+fn label_start(d: &OxcDiagnostic) -> u32 {
+    d.labels.as_ref().first().map_or(0, |l| l.offset())
+}
+
+fn prefix_matches(ours: &[(u32, u32)], oracle: &[(u32, u32)], err_start: u32) -> bool {
+    for (a, b) in ours.iter().zip(oracle.iter()) {
+        if a.1 > err_start || b.1 > err_start {
+            break;
+        }
+        if a != b {
+            return false;
+        }
+    }
+    true
+}
+
+fn fmt_spans(spans: &[(u32, u32)], code: &str) -> String {
+    let mut out = String::new();
+    for &(start, end) in spans {
+        let slice = code.get(start as usize..end as usize).unwrap_or("<out-of-bounds>");
+        let _ = writeln!(out, "{start}..{end} {slice:?}");
+    }
+    out
+}
+
+/// One-line rendering of a diagnostic for mismatch output.
+fn fmt_diag(d: &OxcDiagnostic) -> String {
+    let (message, labels) = diag_key(d);
+    let spans = labels.iter().map(|(s, e)| format!("{s}..{e}")).collect::<Vec<_>>().join(", ");
+    format!("{message:?} @ [{spans}]")
+}
+
+/// Token-stream mismatch, with each side's first diagnostic appended so a
+/// failed error-case fallback shows *why* diagnostic parity did not hold.
+fn token_mismatch(
+    code: &str,
+    ours: &[(u32, u32)],
+    oracle: &[(u32, u32)],
+    ours_first: Option<&OxcDiagnostic>,
+    parser_first: Option<&OxcDiagnostic>,
+) -> TestResult {
+    let mut actual = fmt_spans(ours, code);
+    let mut expected = fmt_spans(oracle, code);
+    let none = || "(none)".to_string();
+    let _ = writeln!(actual, "first diagnostic: {}", ours_first.map_or_else(none, fmt_diag));
+    let _ = writeln!(expected, "first diagnostic: {}", parser_first.map_or_else(none, fmt_diag));
+    TestResult::Mismatch("Tokens", actual, expected)
+}
+
+fn lex_diff(code: &str, source_type: SourceType) -> TestResult {
+    let (oracle, parser_errors) =
+        match catch_unwind(AssertUnwindSafe(|| oracle_stream(code, source_type))) {
+            Ok(Some(stream)) => stream,
+            Ok(None) | Err(_) => return TestResult::Passed,
+        };
+
+    let (ours, our_diags) = match catch_unwind(AssertUnwindSafe(|| lexer_stream(code, source_type)))
+    {
+        Ok(stream) => stream,
+        Err(_) => return TestResult::ParseError("oxc_lexer panicked".to_string(), true),
+    };
+
+    let ours_first = our_diags.first().map(|d| oxc_lexer::diagnostics::to_oxc_diagnostic(d, code));
+    let parser_first =
+        parser_errors.iter().enumerate().min_by_key(|(i, e)| (label_start(e), *i)).map(|(_, e)| e);
+
+    if ours == oracle {
+        return match (&parser_first, &ours_first) {
+            (None, Some(diag)) => TestResult::Mismatch(
+                "Diagnostics",
+                format!("first diagnostic: {}\n", fmt_diag(diag)),
+                "(parser reported no errors)\n".to_string(),
+            ),
+            _ => TestResult::Passed,
+        };
+    }
+    if let (Some(parser_diag), Some(our_diag)) = (parser_first, &ours_first) {
+        if diag_key(our_diag) == diag_key(parser_diag)
+            && prefix_matches(&ours, &oracle, label_start(parser_diag))
+        {
+            return TestResult::Passed;
+        }
+    }
+
+    token_mismatch(code, &ours, &oracle, ours_first.as_ref(), parser_first)
+}
+
+pub fn run_lexer_test262(files: &[Test262File]) -> Vec<CoverageResult> {
+    files
+        .par_iter()
+        .map(|f| {
+            let mut source_type = SourceType::cjs().with_script(true);
+            if f.meta.flags.contains(&TestFlag::Module) {
+                source_type = source_type.with_module(true);
+            }
+            let result = lex_diff(&f.code, source_type);
+            CoverageResult { path: f.path.clone(), should_fail: false, result }
+        })
+        .collect()
+}
+
+pub fn run_lexer_babel(files: &[BabelFile]) -> Vec<CoverageResult> {
+    files
+        .par_iter()
+        .map(|f| {
+            let result = lex_diff(&f.code, f.source_type);
+            CoverageResult { path: f.path.clone(), should_fail: false, result }
+        })
+        .collect()
+}
+
+pub fn run_lexer_typescript(files: &[TypeScriptFile]) -> Vec<CoverageResult> {
+    files
+        .par_iter()
+        .map(|f| {
+            let source_type = SourceType::from_path(&f.path).unwrap_or_default();
+            let result = lex_diff(&f.code, source_type);
+            CoverageResult { path: f.path.clone(), should_fail: false, result }
+        })
+        .collect()
+}
+
+pub fn run_lexer_misc(files: &[MiscFile]) -> Vec<CoverageResult> {
+    files
+        .par_iter()
+        .map(|f| {
+            let result = lex_diff(&f.code, f.source_type);
+            CoverageResult { path: f.path.clone(), should_fail: false, result }
+        })
+        .collect()
+}

--- a/tasks/coverage/src/lib.rs
+++ b/tasks/coverage/src/lib.rs
@@ -10,6 +10,17 @@ mod typescript;
 
 mod tools;
 
+// Mirrors `oxc_lexer`'s crate gate: the lexer compiles to an empty stub without
+// static AVX2/BMI2 x86_64, so the differential harness only exists where the
+// lexer does (`--all-features` builds must pass on every target).
+#[cfg(all(
+    feature = "lexer",
+    target_arch = "x86_64",
+    target_feature = "avx2",
+    target_feature = "bmi2",
+))]
+mod lexer_diff;
+
 use std::{
     fmt::Write,
     path::{Path, PathBuf},
@@ -360,6 +371,28 @@ impl AppArgs {
         if self.filter.is_none() {
             typescript::save_reviewed_tsc_diagnostics_codes();
         }
+    }
+
+    /// Differential lexer conformance: compare `oxc_lexer`'s significant-token
+    /// spans against the parser's token stream over the corpora. Opt-in (kept out
+    /// of `run_all`) — requires the `lexer` feature and a static AVX2/BMI2 x86_64
+    /// build of `oxc_lexer`.
+    #[cfg(all(
+        feature = "lexer",
+        target_arch = "x86_64",
+        target_feature = "avx2",
+        target_feature = "bmi2",
+    ))]
+    pub fn run_lexer(&self, data: &TestData) {
+        self.run_tool("lexer_test262", TEST262_PATH, &data.test262, lexer_diff::run_lexer_test262);
+        self.run_tool("lexer_babel", BABEL_PATH, &data.babel, lexer_diff::run_lexer_babel);
+        self.run_tool(
+            "lexer_typescript",
+            TYPESCRIPT_PATH,
+            &data.typescript,
+            lexer_diff::run_lexer_typescript,
+        );
+        self.run_tool("lexer_misc", MISC_PATH, &data.misc, lexer_diff::run_lexer_misc);
     }
 
     pub fn run_semantic(&self, data: &TestData) {

--- a/tasks/coverage/src/main.rs
+++ b/tasks/coverage/src/main.rs
@@ -39,6 +39,13 @@ fn main() {
     let task = command.as_deref().unwrap_or("default");
     match task {
         "parser" => app_args.run_parser(&load()),
+        #[cfg(all(
+            feature = "lexer",
+            target_arch = "x86_64",
+            target_feature = "avx2",
+            target_feature = "bmi2",
+        ))]
+        "lexer" => app_args.run_lexer(&load()),
         "semantic" => app_args.run_semantic(&load()),
         "codegen" => app_args.run_codegen(&load()),
         "formatter" => app_args.run_formatter(&load()),


### PR DESCRIPTION
Adds the x86_64 version of my Research `SIMD For Context Sensitive Languages`.
(CPB = Cycles per byte)
- Adds new create crates/oxc_lexer; Which eventually lead into an unfused parser design inside oxc_parser
- Fully test262 compliant JS standalone Lexer; SIMD used has counterparts on every platform.
- Performs at 2.5CPB on checker.js on my ZEN 3 CPU; or around 1.5-1.75 gbs (3.8GHz).
- Across aarch64, + other platforms performance will hold which I've seen in my POCs but those targets will come later.
- Supports JSX/TS options, Which don't have much impact on overall perf results.

------

The expected results for seeing this work through [including on parser side on oxc_parser]
1. P95 improvements of 80-100% over current `oxc_parser`; 12-18% of this will come from the unfused contract where JS grammar specifically loves being able to see 'ahead' into `kinds` in various places. The rest comes from the perf improvements to the lexer itself and some wins that will come inside the parser from work now done in the lexer.
