### PR TITLE
refactor(react_compiler): remove redundant source text storage

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/imports.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/imports.rs
@@ -28,7 +28,6 @@ pub struct NonLocalImportSpecifier {
 /// Equivalent to ProgramContext class in Imports.ts.
 pub struct ProgramContext {
     pub opts: PluginOptions,
-    pub code: Option<String>,
     pub react_runtime_module: String,
     pub suppressions: Vec<SuppressionRange>,
     pub has_module_scope_opt_out: bool,
@@ -52,7 +51,6 @@ pub struct ProgramContext {
 impl ProgramContext {
     pub fn new(
         opts: PluginOptions,
-        code: Option<String>,
         suppressions: Vec<SuppressionRange>,
         has_module_scope_opt_out: bool,
     ) -> Self {
@@ -60,7 +58,6 @@ impl ProgramContext {
         let debug_enabled = opts.debug;
         Self {
             opts,
-            code,
             react_runtime_module,
             suppressions,
             has_module_scope_opt_out,

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
@@ -106,6 +106,7 @@ pub fn compile_fn<'a>(
     mode: CompilerOutputMode,
     env_config: &EnvironmentConfig,
     context: &mut ProgramContext,
+    source_text: &str,
 ) -> Result<CodegenFunction<'a>, CompilerError> {
     let mut env = Environment::with_config(env_config.clone());
     env.fn_type = fn_type;
@@ -114,7 +115,6 @@ pub fn compile_fn<'a>(
         CompilerOutputMode::Client => OutputMode::Client,
         CompilerOutputMode::Lint => OutputMode::Lint,
     };
-    env.code = context.code.clone();
     env.instrument_fn_name = context.instrument_fn_name.clone();
     env.instrument_gating_name = context.instrument_gating_name.clone();
     env.hook_guard_name = context.hook_guard_name.clone();
@@ -122,9 +122,7 @@ pub fn compile_fn<'a>(
 
     env.reference_node_ids = scope.all_reference_positions().clone();
 
-    let line_offsets = crate::react_compiler_lowering::source_loc::LineOffsets::new(
-        context.code.as_deref().unwrap_or(""),
-    );
+    let line_offsets = crate::react_compiler_lowering::source_loc::LineOffsets::new(source_text);
     let mut hir = lower(func, fn_name, scope, &mut env, &line_offsets)?;
 
     // Check for Invariant errors after lowering, before logging HIR.

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -1188,6 +1188,7 @@ fn try_compile_function<'a>(
     output_mode: CompilerOutputMode,
     env_config: &EnvironmentConfig,
     context: &mut ProgramContext,
+    source_text: &str,
 ) -> Result<CodegenFunction<'a>, CompilerError> {
     // Check for suppressions that affect this function
     if let (Some(start), Some(end)) = (source.fn_start, source.fn_end) {
@@ -1213,6 +1214,7 @@ fn try_compile_function<'a>(
         output_mode,
         env_config,
         context,
+        source_text,
     )
 }
 
@@ -1229,6 +1231,7 @@ fn process_fn<'a>(
     output_mode: CompilerOutputMode,
     env_config: &EnvironmentConfig,
     context: &mut ProgramContext,
+    source_text: &str,
 ) -> Result<Option<CodegenFunction<'a>>, CompileResult<'a>> {
     // Parse directives from the function body
     let opt_in_result =
@@ -1248,7 +1251,8 @@ fn process_fn<'a>(
     };
 
     // Attempt compilation
-    let compile_result = try_compile_function(ast, source, scope, output_mode, env_config, context);
+    let compile_result =
+        try_compile_function(ast, source, scope, output_mode, env_config, context, source_text);
 
     match compile_result {
         Err(err) => {
@@ -2848,14 +2852,7 @@ pub fn compile_program<'a, 'p>(
         find_directive_disabling_memoization(&module_directives, &options).is_some();
 
     // Create program context
-    let mut context = ProgramContext::new(
-        options.clone(),
-        // Source text feeds the line-offset table (diagnostic line/col) and the fast
-        // refresh hash. The oxc front-end derives locations from it on demand.
-        Some(program.source_text.to_string()),
-        suppressions,
-        has_module_scope_opt_out,
-    );
+    let mut context = ProgramContext::new(options.clone(), suppressions, has_module_scope_opt_out);
 
     // Initialize known referenced names from scope bindings for UID collision detection
     context.init_from_scope(scope);
@@ -2917,7 +2914,15 @@ pub fn compile_program<'a, 'p>(
     let mut compiled_fns: Vec<CompiledFunction<'_, '_, '_>> = Vec::new();
 
     for source in &queue {
-        match process_fn(ast, source, scope, output_mode, &env_config, &mut context) {
+        match process_fn(
+            ast,
+            source,
+            scope,
+            output_mode,
+            &env_config,
+            &mut context,
+            program.source_text,
+        ) {
             Ok(Some(codegen_fn)) => {
                 compiled_fns.push(CompiledFunction { kind: source.kind, source, codegen_fn });
             }

--- a/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
@@ -64,9 +64,6 @@ pub struct Environment<'a> {
     // Output mode (Client, Ssr, Lint)
     pub output_mode: OutputMode,
 
-    // Source file code (for fast refresh hash computation)
-    pub code: Option<String>,
-
     // Pre-resolved import local names for instrumentation/hook guards.
     // Set by the program-level code before compilation.
     pub instrument_fn_name: Option<String>,
@@ -181,7 +178,6 @@ impl<'a> Environment<'a> {
             errors: CompilerError::new(),
             fn_type: ReactFunctionType::Other,
             output_mode: OutputMode::Client,
-            code: None,
             instrument_fn_name: None,
             instrument_gating_name: None,
             hook_guard_name: None,


### PR DESCRIPTION
Removes the duplicated source text stored on `ProgramContext` and `Environment`.

The pipeline now passes `program.source_text` directly when building line offsets for lowering.

Validated with `just fmt`, `cargo test -p oxc_react_compiler --test transform`, `cargo test -p oxc_react_compiler --test snapshot`, and `cargo check -p oxc_react_compiler`.