### PR TITLE
refactor(react_compiler): remove redundant locals and parameters

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/imports.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/imports.rs
@@ -55,8 +55,8 @@ impl ProgramContext {
         has_module_scope_opt_out: bool,
     ) -> Self {
         let react_runtime_module = get_react_compiler_runtime_module(&opts.target);
-        let debug_enabled = opts.debug;
         Self {
+            debug_enabled: opts.debug,
             opts,
             react_runtime_module,
             suppressions,
@@ -65,7 +65,6 @@ impl ProgramContext {
             instrument_fn_name: None,
             instrument_gating_name: None,
             hook_guard_name: None,
-            debug_enabled,
             already_compiled: FxHashSet::default(),
             known_referenced_names: FxHashSet::default(),
             imports: FxHashMap::default(),

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
@@ -100,7 +100,6 @@ use crate::react_compiler::debug_print;
 pub fn compile_fn<'a>(
     ast: &oxc_ast::builder::AstBuilder<'a>,
     func: &FunctionNode<'_>,
-    fn_name: Option<&str>,
     scope: &ScopeResolver<'_, '_>,
     fn_type: ReactFunctionType,
     mode: CompilerOutputMode,
@@ -123,7 +122,7 @@ pub fn compile_fn<'a>(
     env.reference_node_ids = scope.all_reference_positions().clone();
 
     let line_offsets = crate::react_compiler_lowering::source_loc::LineOffsets::new(source_text);
-    let mut hir = lower(func, fn_name, scope, &mut env, &line_offsets)?;
+    let mut hir = lower(func, scope, &mut env, &line_offsets)?;
 
     // Check for Invariant errors after lowering, before logging HIR.
     // In TS, Invariant errors throw from recordError(), aborting lower() before
@@ -257,9 +256,8 @@ pub fn compile_fn<'a>(
     }
 
     let mut inner_logs: Vec<String> = Vec::new();
-    let debug_inner = context.debug_enabled;
     let analyse_result = analyse_functions(&mut hir, &mut env, &mut |inner_func, inner_env| {
-        if debug_inner {
+        if context.debug_enabled {
             inner_logs.push(debug_print::debug_hir(inner_func, inner_env));
         }
     });
@@ -768,15 +766,7 @@ pub fn compile_fn<'a>(
             outlined: Vec::new(),
         };
         if let Some(fn_type) = o.fn_type {
-            let fn_name = outlined_codegen.id.as_ref().map(|id| id.name.to_string());
-            match compile_outlined_fn(
-                outlined_codegen,
-                fn_name.as_deref(),
-                fn_type,
-                mode,
-                env_config,
-                context,
-            ) {
+            match compile_outlined_fn(outlined_codegen) {
                 Ok(compiled) => {
                     compiled_outlined
                         .push(OutlinedFunction { func: compiled, fn_type: Some(fn_type) });
@@ -819,13 +809,7 @@ pub fn compile_fn<'a>(
 /// functions are inserted into the program AST and re-compiled from scratch.
 pub fn compile_outlined_fn<'a>(
     codegen_fn: CodegenFunction<'a>,
-    fn_name: Option<&str>,
-    fn_type: ReactFunctionType,
-    mode: CompilerOutputMode,
-    env_config: &EnvironmentConfig,
-    context: &mut ProgramContext,
 ) -> Result<CodegenFunction<'a>, CompilerError> {
-    let _ = (fn_name, fn_type, mode, env_config, context);
     Ok(codegen_fn)
 }
 

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -460,8 +460,7 @@ fn returns_non_node_in_stmt(stmt: &oxc::Statement, result: &mut bool) {
 /// Check if a function returns non-node values.
 /// For arrow functions with expression body, checks the expression directly.
 /// For block bodies, walks the statements.
-fn returns_non_node_fn(params: &oxc::FormalParameters, body: &FunctionBody) -> bool {
-    let _ = params;
+fn returns_non_node_fn(body: &FunctionBody) -> bool {
     match body {
         FunctionBody::Block(block) => returns_non_node_in_stmts(&block.statements),
         FunctionBody::Expression(expr) => is_non_node(expr),
@@ -1057,7 +1056,7 @@ fn get_component_or_hook_like(
             // Check if it actually looks like a component
             let is_component = calls_hooks_or_creates_jsx(params, body)
                 && is_valid_component_params(params)
-                && !returns_non_node_fn(params, body);
+                && !returns_non_node_fn(body);
             return if is_component { Some(ReactFunctionType::Component) } else { None };
         } else if is_hook_name(fn_name) {
             // Hooks have hook invocations or JSX, but can take any # of arguments
@@ -1208,7 +1207,6 @@ fn try_compile_function<'a>(
     pipeline::compile_fn(
         ast,
         &source.fn_node,
-        source.fn_name.as_deref(),
         scope,
         source.fn_type,
         output_mode,
@@ -2421,7 +2419,6 @@ fn ox_apply_gated_conditional<'a>(
         &gating_config.import_specifier_name,
         None,
     );
-    let gating_callee_name = gating_import.name;
 
     // Clone the original function (matched by node_id) as the fallback expression
     // BEFORE replacing it.
@@ -2438,7 +2435,7 @@ fn ox_apply_gated_conditional<'a>(
     use oxc_span::SPAN;
     let gating_expression = oxc_ast::ast::Expression::new_conditional_expression(
         SPAN,
-        ox_gating_call(ast, &gating_callee_name),
+        ox_gating_call(ast, &gating_import.name),
         compiled_expr,
         original_expr,
         ast,
@@ -2462,7 +2459,6 @@ fn ox_clone_original_fn_as_expression<'a>(
     node_id: u32,
 ) -> Option<oxc_ast::ast::Expression<'a>> {
     use oxc_allocator::CloneIn;
-    use oxc_span::SPAN;
 
     struct Finder<'a, 'b> {
         ast: &'b oxc_ast::builder::AstBuilder<'a>,
@@ -2516,7 +2512,6 @@ fn ox_clone_original_fn_as_expression<'a>(
             oxc_ast_visit::walk::walk_arrow_function_expression(self, arrow);
         }
     }
-    let _ = (SPAN, ast.allocator());
     let mut finder = Finder { ast, node_id, found: None };
     oxc_ast_visit::Visit::visit_program(&mut finder, program);
     finder.found.map(|e| e.clone_in(ast.allocator()))
@@ -2584,9 +2579,11 @@ fn ox_splice_program<'a>(
     let needs_memo_import = replacements.iter().any(|r| r.codegen_fn.memo_slots_used > 0);
     if needs_memo_import {
         let import_spec = context.add_memo_cache_import();
-        let local_name = import_spec.name;
-        let mut visitor =
-            OxcRenameIdentifierVisitor { ast, old_name: "useMemoCache", new_name: &local_name };
+        let mut visitor = OxcRenameIdentifierVisitor {
+            ast,
+            old_name: "useMemoCache",
+            new_name: &import_spec.name,
+        };
         oxc_ast_visit::VisitMut::visit_program(&mut visitor, &mut program);
     }
 
@@ -2818,17 +2815,10 @@ pub fn compile_program<'a, 'p>(
     // Compute output mode once, up front
     let output_mode = CompilerOutputMode::from_opts(&options);
 
-    let program = oxc_program;
-
-    // Validate restricted imports from the environment config
-    let restricted_imports = options.environment.validate_blocklisted_imports.clone();
-
-    // Determine if we should check for eslint suppressions
-    let validate_exhaustive = options.environment.validate_exhaustive_memoization_dependencies;
-    let validate_hooks = options.environment.validate_hooks_usage;
-
     let eslint_rules: Option<Vec<String>> =
-        if validate_exhaustive && validate_hooks {
+        if options.environment.validate_exhaustive_memoization_dependencies
+            && options.environment.validate_hooks_usage
+        {
             // Don't check for ESLint suppressions if both validations are enabled
             None
         } else {
@@ -2839,15 +2829,15 @@ pub fn compile_program<'a, 'p>(
 
     // Find program-level suppressions from comments
     let suppressions = find_program_suppressions(
-        &program.comments,
-        program.source_text,
+        &oxc_program.comments,
+        oxc_program.source_text,
         eslint_rules.as_deref(),
         options.flow_suppressions,
     );
 
     // Check for module-scope opt-out directive
     let module_directives: Vec<String> =
-        program.directives.iter().map(|d| d.expression.value.to_string()).collect();
+        oxc_program.directives.iter().map(|d| d.expression.value.to_string()).collect();
     let has_module_scope_opt_out =
         find_directive_disabling_memoization(&module_directives, &options).is_some();
 
@@ -2858,7 +2848,9 @@ pub fn compile_program<'a, 'p>(
     context.init_from_scope(scope);
 
     // Validate restricted imports (needs context for handle_error)
-    if let Some(err) = validate_restricted_imports(program, &restricted_imports) {
+    if let Some(err) =
+        validate_restricted_imports(oxc_program, &options.environment.validate_blocklisted_imports)
+    {
         if let Some(result) = handle_error(&err, None, &mut context) {
             return result;
         }
@@ -2867,36 +2859,31 @@ pub fn compile_program<'a, 'p>(
 
     // Pre-register instrumentation imports to get stable local names.
     // These are needed before compilation so codegen can use the correct names.
-    let instrument_fn_name: Option<String>;
-    let instrument_gating_name: Option<String>;
-    let hook_guard_name: Option<String>;
+    let (instrument_fn_name, instrument_gating_name) =
+        if let Some(ref instrument_config) = options.environment.enable_emit_instrument_forget {
+            let fn_spec = context.add_import_specifier(
+                &instrument_config.fn_.source,
+                &instrument_config.fn_.import_specifier_name,
+                None,
+            );
+            let gating_name = instrument_config.gating.as_ref().map(|g| {
+                let spec = context.add_import_specifier(&g.source, &g.import_specifier_name, None);
+                spec.name.clone()
+            });
+            (Some(fn_spec.name.clone()), gating_name)
+        } else {
+            (None, None)
+        };
 
-    if let Some(ref instrument_config) = options.environment.enable_emit_instrument_forget {
-        let fn_spec = context.add_import_specifier(
-            &instrument_config.fn_.source,
-            &instrument_config.fn_.import_specifier_name,
-            None,
-        );
-        instrument_fn_name = Some(fn_spec.name.clone());
-        instrument_gating_name = instrument_config.gating.as_ref().map(|g| {
-            let spec = context.add_import_specifier(&g.source, &g.import_specifier_name, None);
+    let hook_guard_name =
+        options.environment.enable_emit_hook_guards.as_ref().map(|hook_guard_config| {
+            let spec = context.add_import_specifier(
+                &hook_guard_config.source,
+                &hook_guard_config.import_specifier_name,
+                None,
+            );
             spec.name.clone()
         });
-    } else {
-        instrument_fn_name = None;
-        instrument_gating_name = None;
-    }
-
-    if let Some(ref hook_guard_config) = options.environment.enable_emit_hook_guards {
-        let spec = context.add_import_specifier(
-            &hook_guard_config.source,
-            &hook_guard_config.import_specifier_name,
-            None,
-        );
-        hook_guard_name = Some(spec.name.clone());
-    } else {
-        hook_guard_name = None;
-    }
 
     // Store pre-resolved names on context for pipeline access
     context.instrument_fn_name = instrument_fn_name;
@@ -2904,7 +2891,7 @@ pub fn compile_program<'a, 'p>(
     context.hook_guard_name = hook_guard_name;
 
     // Find all functions to compile
-    let queue = find_functions_to_compile(program, &options, &mut context);
+    let queue = find_functions_to_compile(oxc_program, &options, &mut context);
 
     // Clone env_config once for all function compilations (avoids per-function clone
     // while satisfying the borrow checker — compile_fn needs &mut context + &env_config)
@@ -2921,7 +2908,7 @@ pub fn compile_program<'a, 'p>(
             output_mode,
             &env_config,
             &mut context,
-            program.source_text,
+            oxc_program.source_text,
         ) {
             Ok(Some(codegen_fn)) => {
                 compiled_fns.push(CompiledFunction { kind: source.kind, source, codegen_fn });

--- a/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
@@ -553,11 +553,9 @@ impl<'a> Environment<'a> {
         let module_type = module_config.map(|config| {
             let mut type_errors: Vec<String> = Vec::new();
             let ty = globals::install_type_config_with_errors(
-                &mut self.globals,
                 &mut self.shapes,
                 &config,
                 module_name,
-                (),
                 &mut type_errors,
             );
             // Store errors for later reporting when the import is actually used
@@ -700,6 +698,7 @@ impl<'a> Environment<'a> {
         self.outlined_functions.push(OutlinedFunctionEntry { func, fn_type });
     }
 
+    #[cfg(feature = "debug")]
     pub(crate) fn outlined_functions(&self) -> &[OutlinedFunctionEntry<'a>] {
         &self.outlined_functions
     }

--- a/crates/oxc_react_compiler/src/react_compiler_hir/globals.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/globals.rs
@@ -128,22 +128,18 @@ pub fn base_globals() -> &'static FxHashMap<String, Global> {
 
 /// Like `install_type_config` but collects validation errors.
 pub fn install_type_config_with_errors(
-    _globals: &mut GlobalRegistry,
     shapes: &mut ShapeRegistry,
     type_config: &TypeConfig,
     module_name: &str,
-    _loc: (),
     errors: &mut Vec<String>,
 ) -> Global {
-    install_type_config_inner(_globals, shapes, type_config, module_name, _loc, &mut Some(errors))
+    install_type_config_inner(shapes, type_config, module_name, &mut Some(errors))
 }
 
 fn install_type_config_inner(
-    _globals: &mut GlobalRegistry,
     shapes: &mut ShapeRegistry,
     type_config: &TypeConfig,
     module_name: &str,
-    _loc: (),
     errors: &mut Option<&mut Vec<String>>,
 ) -> Global {
     match type_config {
@@ -158,14 +154,8 @@ fn install_type_config_inner(
         },
         TypeConfig::Function(func_config) => {
             // Compute return type first to avoid double-borrow of shapes
-            let return_type = install_type_config_inner(
-                _globals,
-                shapes,
-                &func_config.return_type,
-                module_name,
-                (),
-                errors,
-            );
+            let return_type =
+                install_type_config_inner(shapes, &func_config.return_type, module_name, errors);
             add_function(
                 shapes,
                 Vec::new(),
@@ -191,14 +181,8 @@ fn install_type_config_inner(
         }
         TypeConfig::Hook(hook_config) => {
             // Compute return type first to avoid double-borrow of shapes
-            let return_type = install_type_config_inner(
-                _globals,
-                shapes,
-                &hook_config.return_type,
-                module_name,
-                (),
-                errors,
-            );
+            let return_type =
+                install_type_config_inner(shapes, &hook_config.return_type, module_name, errors);
             add_hook(
                 shapes,
                 HookSignatureBuilder {
@@ -225,11 +209,9 @@ fn install_type_config_inner(
                         .iter()
                         .map(|(key, value)| {
                             let ty = install_type_config_inner(
-                                _globals,
                                 shapes,
                                 value,
                                 module_name,
-                                (),
                                 errors,
                             );
                             // Validate hook-name vs hook-type consistency (matching TS installTypeConfig)

--- a/crates/oxc_react_compiler/src/react_compiler_inference/build_reactive_scope_terminals_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/build_reactive_scope_terminals_hir.rs
@@ -328,7 +328,7 @@ pub fn build_reactive_scope_terminals_hir(func: &mut HirFunction, env: &mut Envi
     }
 
     // Step 4: Fixup HIR to restore RPO, correct predecessors, renumber instructions
-    func.body.blocks = get_reverse_postordered_blocks(&func.body, &func.instructions);
+    func.body.blocks = get_reverse_postordered_blocks(&func.body);
     mark_predecessors(&mut func.body);
     mark_instruction_ids(&mut func.body, &mut func.instructions);
 

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
@@ -79,7 +79,7 @@ pub fn infer_mutation_aliasing_effects(
     env: &mut Environment,
     is_function_expression: bool,
 ) -> Result<(), CompilerDiagnostic> {
-    let mut initial_state = InferenceState::empty(env, is_function_expression);
+    let mut initial_state = InferenceState::empty(is_function_expression);
 
     // Map of blocks to the last (merged) incoming state that was processed
     let mut states_by_block: FxHashMap<BlockId, InferenceState> = FxHashMap::default();
@@ -294,7 +294,7 @@ struct InferenceState {
 }
 
 impl InferenceState {
-    fn empty(_env: &Environment, is_function_expression: bool) -> Self {
+    fn empty(is_function_expression: bool) -> Self {
         InferenceState {
             is_function_expression,
             values: FxHashMap::default(),
@@ -953,12 +953,8 @@ fn infer_block(
 
         // Compute signature if not cached
         if !context.instruction_signature_cache.contains_key(instr_idx) {
-            let sig = compute_signature_for_instruction(
-                context,
-                env,
-                &func.instructions[instr_index],
-                func,
-            );
+            let sig =
+                compute_signature_for_instruction(context, env, &func.instructions[instr_index]);
             context.instruction_signature_cache.insert(*instr_idx, sig);
         }
 
@@ -1814,7 +1810,6 @@ fn compute_signature_for_instruction(
     context: &mut Context,
     env: &Environment,
     instr: &Instruction,
-    _func: &HirFunction,
 ) -> InstructionSignature {
     let lvalue = &instr.lvalue;
     let value = &instr.value;
@@ -2266,7 +2261,7 @@ fn compute_effects_for_legacy_signature(
     lvalue: &Place,
     receiver: &Place,
     args: &[PlaceOrSpreadOrHole],
-    _loc: Option<&SourceLocation>,
+    loc: Option<&SourceLocation>,
     env: &Environment,
     function_values: &FxHashMap<ValueId, FunctionId>,
     todo_errors: &mut Vec<CompilerErrorDetail>,
@@ -2294,7 +2289,7 @@ fn compute_effects_for_legacy_signature(
             )),
         );
         diagnostic.details.push(CompilerDiagnosticDetail::Error {
-            loc: _loc.copied(),
+            loc: loc.copied(),
             message: Some("Cannot call impure function".to_string()),
         });
         effects.push(AliasingEffect::Impure { place: receiver.clone(), error: diagnostic });
@@ -2522,7 +2517,7 @@ fn compute_effects_for_aliasing_signature_config(
     receiver: &Place,
     args: &[PlaceOrSpreadOrHole],
     context: &[Place],
-    _loc: Option<&SourceLocation>,
+    loc: Option<&SourceLocation>,
     temp_cache: &mut FxHashMap<(IdentifierId, String), Place>,
 ) -> Result<Option<Vec<AliasingEffect>>, CompilerDiagnostic> {
     // Build substitutions from config strings to places
@@ -2716,7 +2711,7 @@ fn compute_effects_for_aliasing_signature_config(
                         args: apply_args,
                         into,
                         signature: None,
-                        loc: _loc.copied(),
+                        loc: loc.copied(),
                     });
                 } else {
                     return Ok(None);
@@ -2775,7 +2770,7 @@ fn compute_effects_for_aliasing_signature(
     receiver: &Place,
     args: &[PlaceOrSpreadOrHole],
     context: &[Place],
-    _loc: Option<&SourceLocation>,
+    loc: Option<&SourceLocation>,
 ) -> Result<Option<Vec<AliasingEffect>>, CompilerDiagnostic> {
     if signature.params.len() > args.len()
         || (args.len() > signature.params.len() && signature.rest.is_none())
@@ -2978,7 +2973,7 @@ fn compute_effects_for_aliasing_signature(
                         args: apply_args,
                         into: apply_into,
                         signature: s.clone(),
-                        loc: _loc.copied(),
+                        loc: loc.copied(),
                     });
                 } else {
                     return Ok(None);

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_scope_variables.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_scope_variables.rs
@@ -258,8 +258,6 @@ pub(crate) fn find_disjoint_mutable_values(
     let mut scope_identifiers = DisjointSet::<IdentifierId>::new();
     let mut declarations: FxHashMap<DeclarationId, IdentifierId> = FxHashMap::default();
 
-    let enable_forest = env.config.enable_forest;
-
     for (_block_id, block) in &func.body.blocks {
         // Handle phi nodes
         for phi in &block.phis {
@@ -299,7 +297,7 @@ pub(crate) fn find_disjoint_mutable_values(
                     operands.push(phi_operand.identifier);
                 }
                 scope_identifiers.union(&operands);
-            } else if enable_forest {
+            } else if env.config.enable_forest {
                 for (_pred_id, phi_operand) in &phi.operands {
                     scope_identifiers.union(&[phi_id, phi_operand.identifier]);
                 }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
@@ -88,13 +88,13 @@ pub fn propagate_scope_dependencies_hir(func: &mut HirFunction, env: &mut Enviro
             hoistables.expect("[PropagateScopeDependencies] Scope not found in tracked blocks");
 
         // Step 2: Calculate hoistable dependencies using the tree.
-        let mut tree = ReactiveScopeDependencyTreeHIR::new(hoistables.iter(), env);
+        let mut tree = ReactiveScopeDependencyTreeHIR::new(hoistables.iter());
         for dep in deps {
-            tree.add_dependency(dep.clone(), env);
+            tree.add_dependency(dep.clone());
         }
 
         // Step 3: Reduce dependencies to a minimal set.
-        let candidates = tree.derive_minimal_dependencies(env);
+        let candidates = tree.derive_minimal_dependencies();
         let scope = &mut env.scopes[scope_id.0 as usize];
         for candidate_dep in candidates {
             let already_exists = scope.dependencies.iter().any(|existing_dep| {
@@ -278,7 +278,7 @@ fn collect_temporaries_sidemap_impl(
             match &instr.value {
                 InstructionValue::PropertyLoad { object, property, loc, .. } if !used_outside => {
                     if inner_fn_context.is_none() || temporaries.contains_key(&object.identifier) {
-                        let prop = get_property(object, property, false, *loc, temporaries, env);
+                        let prop = get_property(object, property, false, *loc, temporaries);
                         temporaries.insert(instr.lvalue.identifier, prop);
                     }
                 }
@@ -346,7 +346,6 @@ fn get_property(
     optional: bool,
     loc: Option<SourceLocation>,
     temporaries: &FxHashMap<IdentifierId, ReactiveScopeDependency>,
-    _env: &Environment,
 ) -> ReactiveScopeDependency {
     let resolved = temporaries.get(&object.identifier);
     if let Some(resolved) = resolved {
@@ -432,7 +431,7 @@ fn traverse_function_optional(
         }
         if let Terminal::Optional { .. } = &block.terminal {
             if !ctx.seen_optionals.contains(&block.id) {
-                traverse_optional_block(block, func, env, ctx, None);
+                traverse_optional_block(block, func, ctx, None);
             }
         }
     }
@@ -447,11 +446,7 @@ struct MatchConsequentResult {
     property_load_loc: Option<SourceLocation>,
 }
 
-fn match_optional_test_block(
-    test: &Terminal,
-    func: &HirFunction,
-    _env: &Environment,
-) -> Option<MatchConsequentResult> {
+fn match_optional_test_block(test: &Terminal, func: &HirFunction) -> Option<MatchConsequentResult> {
     let (test_place, consequent_block_id, alternate_block_id) = match test {
         Terminal::Branch { test, consequent, alternate, .. } => (test, *consequent, *alternate),
         _ => return None,
@@ -517,7 +512,6 @@ fn match_optional_test_block(
 fn traverse_optional_block(
     optional_block: &BasicBlock,
     func: &HirFunction,
-    env: &Environment,
     ctx: &mut OptionalTraversalContext,
     outer_alternate: Option<BlockId>,
 ) -> Option<IdentifierId> {
@@ -602,7 +596,7 @@ fn traverse_optional_block(
                 _ => None,
             };
             let inner_optional_result =
-                traverse_optional_block(maybe_test_block, func, env, ctx, inner_alternate);
+                traverse_optional_block(maybe_test_block, func, ctx, inner_alternate);
             let inner_optional_id = inner_optional_result?;
 
             // Check that inner optional is part of the same chain
@@ -641,7 +635,7 @@ fn traverse_optional_block(
         }
     }
 
-    let match_result = match_optional_test_block(test_terminal, func, env)?;
+    let match_result = match_optional_test_block(test_terminal, func)?;
 
     // Verify consequent goto matches optional fallthrough
     if match_result.consequent_goto != fallthrough_block_id {
@@ -1509,10 +1503,7 @@ struct ReactiveScopeDependencyTreeHIR {
 }
 
 impl ReactiveScopeDependencyTreeHIR {
-    fn new<'a>(
-        hoistable_objects: impl Iterator<Item = &'a ReactiveScopeDependency>,
-        _env: &Environment,
-    ) -> Self {
+    fn new<'a>(hoistable_objects: impl Iterator<Item = &'a ReactiveScopeDependency>) -> Self {
         let mut hoistable_roots: FxHashMap<IdentifierId, (HoistableNode, bool)> =
             FxHashMap::default();
 
@@ -1558,7 +1549,7 @@ impl ReactiveScopeDependencyTreeHIR {
         Self { hoistable_roots, dep_roots: FxIndexMap::default() }
     }
 
-    fn add_dependency(&mut self, dep: ReactiveScopeDependency, _env: &Environment) {
+    fn add_dependency(&mut self, dep: ReactiveScopeDependency) {
         let root = self.dep_roots.entry(dep.identifier).or_insert_with(|| {
             (
                 DependencyNode {
@@ -1575,30 +1566,16 @@ impl ReactiveScopeDependencyTreeHIR {
         let mut hoistable_ptr: Option<&HoistableNode> = hoistable_cursor_root.map(|(n, _)| n);
 
         for entry in &dep.path {
-            let next_hoistable: Option<&HoistableNode>;
-            let access_type: PropertyAccessType;
-
-            if entry.optional {
-                next_hoistable =
-                    hoistable_ptr.and_then(|h| h.properties.get(&entry.property).map(|e| &e.node));
-
-                if hoistable_ptr.is_some()
-                    && hoistable_ptr.unwrap().access_type == HoistableAccessType::NonNull
-                {
-                    access_type = PropertyAccessType::UnconditionalAccess;
-                } else {
-                    access_type = PropertyAccessType::OptionalAccess;
+            let next_hoistable =
+                hoistable_ptr.and_then(|h| h.properties.get(&entry.property).map(|e| &e.node));
+            let access_type = match hoistable_ptr.map(|h| h.access_type) {
+                Some(HoistableAccessType::NonNull) => PropertyAccessType::UnconditionalAccess,
+                _ if entry.optional => PropertyAccessType::OptionalAccess,
+                _ => {
+                    // Break: truncate dependency
+                    break;
                 }
-            } else if hoistable_ptr.is_some()
-                && hoistable_ptr.unwrap().access_type == HoistableAccessType::NonNull
-            {
-                next_hoistable =
-                    hoistable_ptr.and_then(|h| h.properties.get(&entry.property).map(|e| &e.node));
-                access_type = PropertyAccessType::UnconditionalAccess;
-            } else {
-                // Break: truncate dependency
-                break;
-            }
+            };
 
             // make_or_merge_property
             let child = dep_cursor.properties.entry(entry.property.clone()).or_insert_with(|| {
@@ -1621,7 +1598,7 @@ impl ReactiveScopeDependencyTreeHIR {
             merge_access(dep_cursor.access_type, PropertyAccessType::OptionalDependency);
     }
 
-    fn derive_minimal_dependencies(&self, _env: &Environment) -> Vec<ReactiveScopeDependency> {
+    fn derive_minimal_dependencies(&self) -> Vec<ReactiveScopeDependency> {
         let mut results = Vec::new();
         for (&root_id, (root_node, reactive)) in &self.dep_roots {
             collect_minimal_deps_in_subtree(root_node, *reactive, root_id, &[], &mut results);
@@ -1795,7 +1772,7 @@ impl<'a> DependencyCollectionContext<'a> {
         loc: Option<SourceLocation>,
         env: &mut Environment,
     ) {
-        let dep = get_property(object, property, optional, loc, self.temporaries, env);
+        let dep = get_property(object, property, optional, loc, self.temporaries);
         self.visit_dependency(dep, env);
     }
 

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -536,11 +536,8 @@ type LowerInnerResult<'a> = Result<
 /// Main entry point: lower a function AST node into HIR.
 ///
 /// Receives a `FunctionNode` (discovered by the entrypoint) and lowers it to HIR.
-/// The `id` parameter provides the function name (which may come from the variable
-/// declarator rather than the function node itself, e.g. `const Foo = () => {}`).
 pub fn lower<'a>(
     func: &'a FunctionNode<'a>,
-    _id: Option<&str>,
     scope: &ScopeResolver<'_, 'a>,
     env: &mut Environment<'a>,
     line_offsets: &LineOffsets,
@@ -596,7 +593,7 @@ pub fn lower<'a>(
 
     // Pre-compute context identifiers: variables captured across function boundaries
     let context_identifiers =
-        find_context_identifiers(func, scope, env, &identifier_locs, line_offsets)?;
+        find_context_identifiers(func, scope, &identifier_locs, line_offsets)?;
 
     // For top-level functions, context is empty (no captured refs)
     let context_map: FxIndexMap<SymbolId, Option<SourceLocation>> = FxIndexMap::default();
@@ -1931,8 +1928,7 @@ fn lower_member_assignment_target<'a>(
             // Babel modeled `a.#b = v` as a non-computed MemberExpression with a
             // PrivateName property; the original `lower_assignment` member arm hit
             // the generic property `_` branch and bailed with this Todo.
-            let object = lower_expression_to_temporary(builder, &member.object)?;
-            let _ = object;
+            lower_expression_to_temporary(builder, &member.object)?;
             builder.record_error(CompilerErrorDetail {
                 reason:
                     "(BuildHIR::lowerAssignment) Handle PrivateName properties in MemberExpression"
@@ -2980,7 +2976,6 @@ fn lower_optional_call_expression_impl<'a>(
     call: &'a oxc::CallExpression<'a>,
     parent_alternate: Option<BlockId>,
 ) -> Result<InstructionValue<'a>, CompilerError> {
-    let optional = call.optional;
     let loc = builder.source_location(call.span);
     let place = build_temporary_place(builder, loc);
     let continuation_block = builder.reserve(builder.current_block_kind());
@@ -3121,7 +3116,7 @@ fn lower_optional_call_expression_impl<'a>(
 
     builder.terminate_with_continuation(
         Terminal::Optional {
-            optional,
+            optional: call.optional,
             test: test_block?,
             fallthrough: continuation_id,
             id: EvaluationOrder(0),
@@ -5815,7 +5810,7 @@ fn is_reorderable_expression(
 fn lower_statement<'a>(
     builder: &mut HirBuilder<'a, '_>,
     stmt: &'a oxc::Statement<'a>,
-    _label: Option<&str>,
+    label: Option<&str>,
     parent_scope: Option<crate::scope::ScopeId>,
 ) -> Result<(), CompilerDiagnostic> {
     match stmt {
@@ -5992,7 +5987,7 @@ fn lower_statement<'a>(
             let body_loc = builder.source_location(for_stmt.body.span());
             let body_block = builder.try_enter(BlockKind::Block, |builder, _block_id| {
                 builder.loop_scope(
-                    _label.map(|s| s.to_string()),
+                    label.map(|s| s.to_string()),
                     continue_target,
                     continuation_id,
                     |builder| {
@@ -6073,7 +6068,7 @@ fn lower_statement<'a>(
             let body_loc = builder.source_location(while_stmt.body.span());
             let loop_block = builder.try_enter(BlockKind::Block, |builder, _block_id| {
                 builder.loop_scope(
-                    _label.map(|s| s.to_string()),
+                    label.map(|s| s.to_string()),
                     conditional_id,
                     continuation_id,
                     |builder| {
@@ -6127,7 +6122,7 @@ fn lower_statement<'a>(
             let body_loc = builder.source_location(do_while_stmt.body.span());
             let loop_block = builder.try_enter(BlockKind::Block, |builder, _block_id| {
                 builder.loop_scope(
-                    _label.map(|s| s.to_string()),
+                    label.map(|s| s.to_string()),
                     conditional_id,
                     continuation_id,
                     |builder| {
@@ -6178,7 +6173,7 @@ fn lower_statement<'a>(
             let body_loc = builder.source_location(for_in.body.span());
             let loop_block = builder.try_enter(BlockKind::Block, |builder, _block_id| {
                 builder.loop_scope(
-                    _label.map(|s| s.to_string()),
+                    label.map(|s| s.to_string()),
                     init_block_id,
                     continuation_id,
                     |builder| {
@@ -6254,7 +6249,7 @@ fn lower_statement<'a>(
             let body_loc = builder.source_location(for_of.body.span());
             let loop_block = builder.try_enter(BlockKind::Block, |builder, _block_id| {
                 builder.loop_scope(
-                    _label.map(|s| s.to_string()),
+                    label.map(|s| s.to_string()),
                     init_block_id,
                     continuation_id,
                     |builder| {
@@ -6359,21 +6354,17 @@ fn lower_statement<'a>(
 
                 let fallthrough_target = fallthrough;
                 let block = builder.try_enter(BlockKind::Block, |builder, _block_id| {
-                    builder.switch_scope(
-                        _label.map(|s| s.to_string()),
-                        continuation_id,
-                        |builder| {
-                            for consequent in &case.consequent {
-                                lower_statement(builder, consequent, None, parent_scope)?;
-                            }
-                            Ok(Terminal::Goto {
-                                block: fallthrough_target,
-                                variant: GotoVariant::Break,
-                                id: EvaluationOrder(0),
-                                loc: case_loc,
-                            })
-                        },
-                    )
+                    builder.switch_scope(label.map(|s| s.to_string()), continuation_id, |builder| {
+                        for consequent in &case.consequent {
+                            lower_statement(builder, consequent, None, parent_scope)?;
+                        }
+                        Ok(Terminal::Goto {
+                            block: fallthrough_target,
+                            variant: GotoVariant::Break,
+                            id: EvaluationOrder(0),
+                            loc: case_loc,
+                        })
+                    })
                 })?;
 
                 let test = if let Some(test_expr) = &case.test {

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/find_context_identifiers.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/find_context_identifiers.rs
@@ -39,7 +39,6 @@ use crate::react_compiler_diagnostics::CompilerError;
 use crate::react_compiler_diagnostics::CompilerErrorDetail;
 use crate::react_compiler_diagnostics::ErrorCategory;
 use crate::react_compiler_diagnostics::SourceLocation;
-use crate::react_compiler_hir::environment::Environment;
 use crate::scope::ScopeId;
 use crate::scope::ScopeResolver;
 use crate::scope::SymbolId;
@@ -54,10 +53,9 @@ struct BindingInfo {
     referenced_by_inner_fn: bool,
 }
 
-struct ContextIdentifierVisitor<'a, 'b> {
+struct ContextIdentifierVisitor<'a> {
     scope: &'a ScopeResolver<'a, 'a>,
     line_offsets: &'a LineOffsets,
-    env: &'a mut Environment<'b>,
     /// The active scope stack. Initialized with the function-being-compiled's
     /// scope and pushed/popped for every scope-creating node, mirroring the
     /// original `AstWalker`.
@@ -69,7 +67,7 @@ struct ContextIdentifierVisitor<'a, 'b> {
     error: Option<CompilerError>,
 }
 
-impl<'a, 'b> ContextIdentifierVisitor<'a, 'b> {
+impl<'a> ContextIdentifierVisitor<'a> {
     fn current_scope(&self) -> ScopeId {
         self.scope_stack.last().copied().unwrap_or_else(|| self.scope.program_scope())
     }
@@ -141,11 +139,11 @@ impl<'a, 'b> ContextIdentifierVisitor<'a, 'b> {
             return;
         }
         let loc = self.line_offsets.source_location(span);
-        self.error = Some(make_unsupported_lval_error(self.env, type_name, Some(loc)));
+        self.error = Some(make_unsupported_lval_error(type_name, Some(loc)));
     }
 }
 
-impl<'a, 'b> Visit<'a> for ContextIdentifierVisitor<'a, 'b> {
+impl<'a> Visit<'a> for ContextIdentifierVisitor<'a> {
     // ---- function scopes (push BOTH the generic scope and the function stack) ----
 
     fn visit_function(&mut self, it: &oxc::Function<'a>, _flags: ScopeFlags) {
@@ -289,12 +287,11 @@ impl<'a, 'b> Visit<'a> for ContextIdentifierVisitor<'a, 'b> {
         self.visit_expression(&it.value);
     }
 
-    fn visit_class(&mut self, it: &oxc::Class<'a>) {
+    fn visit_class(&mut self, _it: &oxc::Class<'a>) {
         // The original walker did not recurse into a class's `super_class`
         // (extends) clause nor its body members; only the type-bearing parts
         // were walked, and those carried no `enter_identifier` calls. So the
         // class contributes nothing to the walker-based capture analysis.
-        let _ = it;
     }
 
     // ---- skip TS type subtrees (the original walked them as opaque RawNodes) ----
@@ -320,7 +317,7 @@ impl<'a, 'b> Visit<'a> for ContextIdentifierVisitor<'a, 'b> {
     fn visit_ts_module_declaration(&mut self, _it: &oxc::TSModuleDeclaration<'a>) {}
 }
 
-impl<'a, 'b> ContextIdentifierVisitor<'a, 'b> {
+impl<'a> ContextIdentifierVisitor<'a> {
     /// Recursively walk an assignment target to find all reassignment target
     /// identifiers, mirroring the original `walk_lval_for_reassignment`.
     fn walk_assignment_target_for_reassignment(
@@ -401,12 +398,7 @@ impl<'a, 'b> ContextIdentifierVisitor<'a, 'b> {
 /// aborting before BuildHIR ever runs or logs, so this must return Err rather
 /// than record-and-continue: otherwise Rust emits HIR debug entries for a
 /// function TS never lowered.
-fn make_unsupported_lval_error(
-    env: &mut Environment,
-    type_name: &str,
-    loc: Option<SourceLocation>,
-) -> CompilerError {
-    let _ = env;
+fn make_unsupported_lval_error(type_name: &str, loc: Option<SourceLocation>) -> CompilerError {
     let mut err = CompilerError::new();
     err.push_error_detail(CompilerErrorDetail {
         category: ErrorCategory::Todo,
@@ -443,7 +435,6 @@ fn is_captured_by_function(
 pub fn find_context_identifiers(
     func: &FunctionNode<'_>,
     scope: &ScopeResolver<'_, '_>,
-    env: &mut Environment,
     identifier_locs: &crate::react_compiler_lowering::identifier_loc_index::IdentifierLocIndex,
     line_offsets: &LineOffsets,
 ) -> Result<FxHashSet<SymbolId>, CompilerError> {
@@ -452,7 +443,6 @@ pub fn find_context_identifiers(
     let mut visitor = ContextIdentifierVisitor {
         scope,
         line_offsets,
-        env,
         scope_stack: vec![func_scope],
         function_stack: Vec::new(),
         binding_info: FxHashMap::default(),

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/hir_builder.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/hir_builder.rs
@@ -646,7 +646,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
 
         let mut instructions = std::mem::take(&mut self.instruction_table);
 
-        let rpo_blocks = get_reverse_postordered_blocks(&hir, &instructions);
+        let rpo_blocks = get_reverse_postordered_blocks(&hir);
 
         // Check for unreachable blocks that contain FunctionExpression instructions.
         // These could contain hoisted declarations that we can't safely remove.
@@ -682,9 +682,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
         mark_instruction_ids(&mut hir, &mut instructions);
         mark_predecessors(&mut hir);
 
-        let used_names = self.used_names;
-        let bindings = self.bindings;
-        Ok((hir, instructions, used_names, bindings))
+        Ok((hir, instructions, self.used_names, self.bindings))
     }
 
     // -----------------------------------------------------------------------
@@ -968,10 +966,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
 /// Blocks not reachable through successors are removed. Blocks that are
 /// only reachable as fallthroughs (not through real successor edges) are
 /// replaced with empty blocks that have an Unreachable terminal.
-pub fn get_reverse_postordered_blocks(
-    hir: &HIR,
-    _instructions: &[Instruction],
-) -> FxIndexMap<BlockId, BasicBlock> {
+pub fn get_reverse_postordered_blocks(hir: &HIR) -> FxIndexMap<BlockId, BasicBlock> {
     let mut visited: FxIndexSet<BlockId> = FxIndexSet::default();
     let mut used: FxIndexSet<BlockId> = FxIndexSet::default();
     let mut used_fallthroughs: FxIndexSet<BlockId> = FxIndexSet::default();

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
@@ -93,7 +93,7 @@ fn constant_propagation_impl<'a>(
          * If terminals have changed then blocks may have become newly unreachable.
          * Re-run minification of the graph (incl reordering instruction ids)
          */
-        func.body.blocks = get_reverse_postordered_blocks(&func.body, &func.instructions);
+        func.body.blocks = get_reverse_postordered_blocks(&func.body);
         remove_unreachable_for_updates(&mut func.body);
         remove_dead_do_while_statements(&mut func.body);
         remove_unnecessary_try_catch(&mut func.body);

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/inline_iifes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/inline_iifes.rs
@@ -290,7 +290,7 @@ pub fn inline_immediately_invoked_function_expressions<'a>(
 
         // If terminals have changed then blocks may have become newly unreachable.
         // Re-run minification of the graph (incl reordering instruction ids).
-        func.body.blocks = get_reverse_postordered_blocks(&func.body, &func.instructions);
+        func.body.blocks = get_reverse_postordered_blocks(&func.body);
         mark_instruction_ids(&mut func.body, &mut func.instructions);
         mark_predecessors(&mut func.body);
         merge_consecutive_blocks(func, &mut env.functions);

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/name_anonymous_functions.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/name_anonymous_functions.rs
@@ -42,15 +42,8 @@ pub fn name_anonymous_functions(func: &mut HirFunction, env: &mut Environment) {
         }
         // Whether or not we generated a name for the function at this node,
         // traverse into its nested functions to assign them names
-        let fallback;
-        let label = if let Some(ref gen_name) = node.generated_name {
-            gen_name.as_str()
-        } else if let Some(ref existing) = node.fn_name {
-            existing.as_str()
-        } else {
-            fallback = "<anonymous>";
-            fallback
-        };
+        let label =
+            node.generated_name.as_deref().or(node.fn_name.as_deref()).unwrap_or("<anonymous>");
         let next_prefix = format!("{}{} > ", prefix, label);
         for inner in &node.inner {
             visit(inner, &next_prefix, updates);
@@ -178,26 +171,10 @@ fn name_anonymous_functions_impl(func: &HirFunction, env: &Environment) -> Vec<N
                     }
                 }
                 InstructionValue::CallExpression { callee, args, .. } => {
-                    handle_call(
-                        env,
-                        func,
-                        callee.identifier,
-                        args,
-                        &mut functions,
-                        &names,
-                        &mut nodes,
-                    );
+                    handle_call(env, callee.identifier, args, &mut functions, &names, &mut nodes);
                 }
                 InstructionValue::MethodCall { property, args, .. } => {
-                    handle_call(
-                        env,
-                        func,
-                        property.identifier,
-                        args,
-                        &mut functions,
-                        &names,
-                        &mut nodes,
-                    );
+                    handle_call(env, property.identifier, args, &mut functions, &names, &mut nodes);
                 }
                 InstructionValue::JsxExpression { tag, props, .. } => {
                     for attr in props {
@@ -238,7 +215,6 @@ fn name_anonymous_functions_impl(func: &HirFunction, env: &Environment) -> Vec<N
 /// Handle CallExpression / MethodCall to generate names for function arguments.
 fn handle_call(
     env: &Environment,
-    _func: &HirFunction,
     callee_id: IdentifierId,
     args: &[PlaceOrSpread],
     functions: &mut FxHashMap<IdentifierId, usize>,

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/optimize_for_ssr.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/optimize_for_ssr.rs
@@ -172,13 +172,12 @@ pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
                 InstructionValue::JsxExpression { tag: JsxTag::Builtin(builtin), .. } => {
                     // Only optimize non-custom-element builtin tags
                     if !builtin.name.contains('-') {
-                        let tag_name = builtin.name.clone();
                         // Retain only props that are not known event handlers and not "ref"
                         if let InstructionValue::JsxExpression { props, .. } = &mut instr.value {
                             props.retain(|prop| match prop {
                                 JsxAttribute::SpreadAttribute { .. } => true,
                                 JsxAttribute::Attribute { name, .. } => {
-                                    !is_known_event_handler(&tag_name, name) && name != "ref"
+                                    !is_known_event_handler(name) && name != "ref"
                                 }
                             });
                         }
@@ -292,7 +291,7 @@ fn has_known_non_render_call(func: &HirFunction, env: &Environment) -> bool {
 }
 
 /// Returns true if the prop name matches the known event handler pattern `on[A-Z]`.
-fn is_known_event_handler(_tag: &str, prop: &str) -> bool {
+fn is_known_event_handler(prop: &str) -> bool {
     if prop.len() < 3 {
         return false;
     }

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/outline_jsx.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/outline_jsx.rs
@@ -257,7 +257,7 @@ fn collect_props<'a>(
     let mut attributes = Vec::new();
     let jsx_ids: FxHashSet<IdentifierId> = jsx_group.iter().map(|j| j.lvalue_id).collect();
 
-    let mut generate_name = |old_name: &str, _env: &mut Environment| -> String {
+    let mut generate_name = |old_name: &str| -> String {
         let mut new_name = old_name.to_string();
         while seen.contains(&new_name) {
             new_name = format!("{}{}", old_name, id_counter);
@@ -276,7 +276,7 @@ fn collect_props<'a>(
                 match attr {
                     JsxAttribute::SpreadAttribute { .. } => return None,
                     JsxAttribute::Attribute { name, place } => {
-                        let new_name = generate_name(name, env);
+                        let new_name = generate_name(name);
                         attributes.push(OutlinedJsxAttribute {
                             original_name: name.clone(),
                             new_name,
@@ -304,7 +304,7 @@ fn collect_props<'a>(
                         Some(IdentifierName::Promoted(n)) => n.clone(),
                         None => format!("#t{}", decl_id.0),
                     };
-                    let new_name = generate_name("t", env);
+                    let new_name = generate_name("t");
                     attributes.push(OutlinedJsxAttribute {
                         original_name: child_name,
                         new_name,

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/prune_maybe_throws.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/prune_maybe_throws.rs
@@ -32,7 +32,7 @@ pub fn prune_maybe_throws(
     if let Some(terminal_mapping) = terminal_mapping {
         // If terminals have changed then blocks may have become newly unreachable.
         // Re-run minification of the graph (incl reordering instruction ids).
-        func.body.blocks = get_reverse_postordered_blocks(&func.body, &func.instructions);
+        func.body.blocks = get_reverse_postordered_blocks(&func.body);
         remove_unreachable_for_updates(&mut func.body);
         remove_dead_do_while_statements(&mut func.body);
         remove_unnecessary_try_catch(&mut func.body);

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
@@ -1954,7 +1954,7 @@ fn ox_codegen_base_instruction_value<'a>(
                 false,
                 &cx.ast,
             );
-            let result = ox_maybe_wrap_hook_call(cx, call_expr, callee.identifier)?;
+            let result = ox_maybe_wrap_hook_call(cx, call_expr)?;
             Ok(OxValue::Expression(result))
         }
         InstructionValue::MethodCall { property, args, .. } => {
@@ -1984,7 +1984,7 @@ fn ox_codegen_base_instruction_value<'a>(
                 false,
                 &cx.ast,
             );
-            let result = ox_maybe_wrap_hook_call(cx, call_expr, property.identifier)?;
+            let result = ox_maybe_wrap_hook_call(cx, call_expr)?;
             Ok(OxValue::Expression(result))
         }
         InstructionValue::NewExpression { callee, args, .. } => {
@@ -3273,7 +3273,6 @@ fn ox_convert_member_expression_to_jsx<'a>(
 fn ox_maybe_wrap_hook_call<'a>(
     cx: &OxcContext<'a, '_, '_>,
     call_expr: oxc::Expression<'a>,
-    _callee_id: IdentifierId,
 ) -> Result<oxc::Expression<'a>, CompilerError> {
     // enableEmitHookGuards wrapping is deferred to a later batch; the guard is
     // off by default, so unwrapped calls match the differential floor.

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_escaping_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_escaping_scopes.rs
@@ -186,7 +186,7 @@ impl CollectState {
         identifier: DeclarationId,
     ) {
         if let Some(scope_id) = get_place_scope(env, id, place.identifier) {
-            let node = self.scopes.entry(scope_id).or_insert_with(|| {
+            self.scopes.entry(scope_id).or_insert_with(|| {
                 let scope_data = &env.scopes[scope_id.0 as usize];
                 let dependencies = scope_data
                     .dependencies
@@ -195,8 +195,6 @@ impl CollectState {
                     .collect();
                 ScopeNode { dependencies, seen: false }
             });
-            // Avoid unused variable warning — we needed the entry to exist
-            let _ = node;
             let identifier_node = self
                 .identifiers
                 .get_mut(&identifier)

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_exhaustive_dependencies.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_exhaustive_dependencies.rs
@@ -33,8 +33,6 @@ pub fn validate_exhaustive_dependencies(
     env: &mut Environment,
 ) -> Result<(), CompilerDiagnostic> {
     let reactive = collect_reactive_identifiers(func, &env.functions);
-    let validate_memo = env.config.validate_exhaustive_memoization_dependencies;
-    let validate_effect = env.config.validate_exhaustive_effect_dependencies;
 
     let mut temporaries: FxHashMap<IdentifierId, Temporary> = FxHashMap::default();
     for param in &func.params {
@@ -60,8 +58,8 @@ pub fn validate_exhaustive_dependencies(
     let mut callbacks = Callbacks {
         start_memo: &mut start_memo,
         memo_locals: &mut memo_locals,
-        validate_memo,
-        validate_effect,
+        validate_memo: env.config.validate_exhaustive_memoization_dependencies,
+        validate_effect: env.config.validate_exhaustive_effect_dependencies,
         reactive: &reactive,
         diagnostics: Vec::new(),
         invalid_memo_ids: FxHashSet::default(),
@@ -1300,8 +1298,7 @@ fn validate_dependencies(
         return Ok(None);
     }
 
-    let mut diagnostic =
-        create_diagnostic(category, &filtered_missing, &filtered_extra, identifiers)?;
+    let mut diagnostic = create_diagnostic(category, &filtered_missing, &filtered_extra)?;
 
     // Add detail items for missing deps
     for dep in &filtered_missing {
@@ -1483,7 +1480,6 @@ fn create_diagnostic(
     category: ErrorCategory,
     missing: &[&InferredDependency],
     extra: &[&ManualMemoDependency],
-    _identifiers: &[Identifier],
 ) -> Result<CompilerDiagnostic, CompilerDiagnostic> {
     let missing_str = if !missing.is_empty() { Some("missing") } else { None };
     let extra_str = if !extra.is_empty() { Some("extra") } else { None };

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_derived_computations_in_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_derived_computations_in_effects.rs
@@ -157,9 +157,7 @@ impl DerivationCache {
     }
 
     fn snapshot(&mut self) -> bool {
-        let has_changes = self.has_changes;
-        self.has_changes = false;
-        has_changes
+        std::mem::replace(&mut self.has_changes, false)
     }
 
     fn add_derivation_entry(
@@ -351,7 +349,7 @@ pub fn validate_no_derived_computations_in_effects_exp(
             record_phi_derivations(block, &mut context, env);
             for &instr_id in &block.instructions {
                 let instr = &func.instructions[instr_id.0 as usize];
-                record_instruction_derivations(instr, &mut context, is_first_pass, func, env)?;
+                record_instruction_derivations(instr, &mut context, is_first_pass, env)?;
             }
         }
 
@@ -377,7 +375,7 @@ pub fn validate_no_derived_computations_in_effects_exp(
         .collect();
 
     for (_key, effect_func_id, dep_elements) in &effects_cache {
-        validate_effect(*effect_func_id, dep_elements, &mut context, func, env, &mut errors);
+        validate_effect(*effect_func_id, dep_elements, &mut context, env, &mut errors);
     }
 
     Ok(errors)
@@ -415,7 +413,6 @@ fn record_instruction_derivations(
     instr: &Instruction,
     context: &mut ValidationContext,
     is_first_pass: bool,
-    _outer_func: &HirFunction,
     env: &Environment,
 ) -> Result<(), CompilerDiagnostic> {
     let identifiers = &env.identifiers;
@@ -444,13 +441,7 @@ fn record_instruction_derivations(
                 record_phi_derivations(block, context, env);
                 for &inner_instr_id in &block.instructions {
                     let inner_instr = &inner_func.instructions[inner_instr_id.0 as usize];
-                    record_instruction_derivations(
-                        inner_instr,
-                        context,
-                        is_first_pass,
-                        inner_func,
-                        env,
-                    )?;
+                    record_instruction_derivations(inner_instr, context, is_first_pass, env)?;
                 }
             }
         }
@@ -771,7 +762,6 @@ fn validate_effect(
     effect_func_id: FunctionId,
     dependencies: &[DepElement],
     context: &mut ValidationContext,
-    _outer_func: &HirFunction,
     env: &Environment,
     errors: &mut CompilerError,
 ) {

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_set_state_in_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_set_state_in_effects.rs
@@ -36,8 +36,6 @@ pub fn validate_no_set_state_in_effects(
     let identifiers = &env.identifiers;
     let types = &env.types;
     let functions = &env.functions;
-    let enable_verbose = env.config.enable_verbose_no_set_state_in_effect;
-    let enable_allow_set_state_from_refs = env.config.enable_allow_set_state_from_refs_in_effects;
 
     // Map from IdentifierId to the Place where the setState originated
     let mut set_state_functions: FxHashMap<IdentifierId, SetStateInfo> = FxHashMap::default();
@@ -75,7 +73,7 @@ pub fn validate_no_set_state_in_effects(
                             identifiers,
                             types,
                             functions,
-                            enable_allow_set_state_from_refs,
+                            env.config.enable_allow_set_state_from_refs_in_effects,
                             env.next_block_id_counter,
                         )?;
                         if let Some(info) = callee {
@@ -98,7 +96,11 @@ pub fn validate_no_set_state_in_effects(
                     {
                         if let Some(PlaceOrSpread::Place(arg_place)) = args.first() {
                             if let Some(info) = set_state_functions.get(&arg_place.identifier) {
-                                push_error(&mut errors, info, enable_verbose);
+                                push_error(
+                                    &mut errors,
+                                    info,
+                                    env.config.enable_verbose_no_set_state_in_effect,
+                                );
                             }
                         }
                     }
@@ -118,7 +120,11 @@ pub fn validate_no_set_state_in_effects(
                     {
                         if let Some(PlaceOrSpread::Place(arg_place)) = args.first() {
                             if let Some(info) = set_state_functions.get(&arg_place.identifier) {
-                                push_error(&mut errors, info, enable_verbose);
+                                push_error(
+                                    &mut errors,
+                                    info,
+                                    env.config.enable_verbose_no_set_state_in_effect,
+                                );
                             }
                         }
                     }

--- a/crates/oxc_react_compiler/src/scope.rs
+++ b/crates/oxc_react_compiler/src/scope.rs
@@ -381,16 +381,15 @@ impl<'s, 'a> ScopeResolver<'s, 'a> {
         &self,
         specifier_node_id: NodeId,
     ) -> Option<&'s ImportDeclaration<'a>> {
-        let nodes = self.nodes;
         let mut current_id = specifier_node_id;
         // Walk up the parent chain (max 10 levels to avoid infinite loop)
         for _ in 0..10 {
-            let parent_id = nodes.parent_id(current_id);
+            let parent_id = self.nodes.parent_id(current_id);
             if parent_id == current_id {
                 // Root node, no more parents
                 return None;
             }
-            if let AstKind::ImportDeclaration(decl) = nodes.get_node(parent_id).kind() {
+            if let AstKind::ImportDeclaration(decl) = self.nodes.get_node(parent_id).kind() {
                 return Some(decl);
             }
             current_id = parent_id;


### PR DESCRIPTION
AI-assisted.

Remove redundant local aliases and late-initialization patterns in `oxc_react_compiler`.

Validated with `just fmt`, `cargo check -p oxc_react_compiler`, `cargo test -p oxc_react_compiler --test transform`, `cargo test -p oxc_react_compiler --test snapshot`, and `cargo clippy -p oxc_react_compiler -- -W clippy::redundant_locals -W clippy::let_and_return -W clippy::needless_late_init`.