### PR TITLE
feat(type_checker): parse root files and load their imports in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,9 +420,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2758,7 +2758,11 @@ dependencies = [
  "oxc_resolver",
  "oxc_semantic",
  "oxc_span",
+ "oxc_str",
+ "oxc_syntax",
+ "rayon",
  "rustc-hash",
+ "self_cell",
 ]
 
 [[package]]

--- a/crates/oxc_type_checker/Cargo.toml
+++ b/crates/oxc_type_checker/Cargo.toml
@@ -35,19 +35,21 @@ path = "src/main.rs"
 test = false
 
 [dependencies]
+oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }
 oxc_diagnostics = { workspace = true }
 oxc_index = { workspace = true }
+oxc_parser = { workspace = true }
 oxc_resolver = { workspace = true }
 oxc_semantic = { workspace = true }
 oxc_span = { workspace = true }
+oxc_str = { workspace = true }
+oxc_syntax = { workspace = true }
 
 anyhow = { workspace = true }
 bpaf = { workspace = true, features = ["autocomplete", "bright-color", "derive"] }
 indexmap = { workspace = true }
+rayon = { workspace = true }
 rustc-hash = { workspace = true }
-
-[dev-dependencies]
-oxc_allocator = { workspace = true }
-oxc_parser = { workspace = true }
+self_cell = { workspace = true }

--- a/crates/oxc_type_checker/src/compiler/fileloader.rs
+++ b/crates/oxc_type_checker/src/compiler/fileloader.rs
@@ -1,69 +1,305 @@
 //! Port of typescript-go's `internal/compiler/fileloader.go`.
 //!
-//! [`FileLoader::process_all_program_files`] is the entry point (tsgo `processAllProgramFiles`):
-//! it normalizes and deduplicates the root file names into [`ProcessedFiles`].
+//! [`FileLoader::process_all_program_files`] (tsgo `processAllProgramFiles`) parses the root files,
+//! follows their references — triple-slash path references, type reference directives, imports,
+//! and module augmentations — to load the dependent files in parallel, and collects everything
+//! into [`ProcessedFiles`]. Import resolution mirrors `resolveImportsAndModuleAugmentations` —
+//! including its `shouldAddFile` gating — but reuses `oxc_resolver`'s TS-aware `resolve_dts`
+//! (mode-less: tsgo resolves each usage under its ESM/CJS resolution mode). Lib files and project
+//! references are not loaded yet.
 
 use std::path::{Path, PathBuf};
 
 use oxc_index::IndexVec;
+use oxc_resolver::{
+    ResolveOptions, Resolver, TsconfigDiscovery, TsconfigOptions, TsconfigReferences,
+};
+use oxc_span::VALID_EXTENSIONS;
+use oxc_str::CompactStr;
 use rustc_hash::FxHashMap;
 
-use crate::tspath;
+use crate::{
+    tsoptions::{
+        SUPPORTED_TS_EXTENSIONS_WITH_JSON_FLAT, get_allow_js, get_resolve_json_module,
+        get_supported_extensions, get_supported_extensions_with_json_flat,
+    },
+    tspath::{self, file_extension_is, file_extension_is_one_of},
+};
 
-use super::program::FileId;
+use super::{
+    filesparser::FilesParser,
+    host::CompilerHost,
+    program::{FileId, ProgramOptions},
+    source_file::SourceFile,
+};
 
-/// A program's collected root files — the subset of tsgo's `processedFiles` needed before
-/// parsing: the ordered file list plus a path -> id lookup.
-///
-/// tsgo stores `files []*ast.SourceFile` + `filesByPath map[tspath.Path]*ast.SourceFile`; here
-/// `files` holds the normalized root paths (parsed source files replace them once parsing lands)
-/// and `files_by_path` maps each path to its [`FileId`].
+/// A resolved reference from one file to another (tsgo `resolvedRef` + the resolution key):
+/// the import specifier (`None` for triple-slash references and type reference directives,
+/// which have no module name) and the normalized dependency path.
+pub(super) type SubTask = (Option<CompactStr>, PathBuf);
+
+/// A program's loaded files — the subset of tsgo's `processedFiles` this step fills.
 #[derive(Debug, Default)]
 pub(super) struct ProcessedFiles {
-    /// Root files, in include order (tsgo `files`).
-    pub(super) files: IndexVec<FileId, PathBuf>,
+    /// Parsed files in tsgo's program order (tsgo `files`): a post-order walk of the import
+    /// graph from the root files, so dependencies come before their importers.
+    pub(super) files: IndexVec<FileId, SourceFile>,
     /// Normalized path -> file id (tsgo `filesByPath`).
     pub(super) files_by_path: FxHashMap<PathBuf, FileId>,
+    /// Root/import paths that produced no source file (tsgo `missingFiles`): unreadable files
+    /// and files with unsupported extensions.
+    pub(super) missing_files: Vec<PathBuf>,
+    /// Each file's resolved module-graph edges: import specifier -> dependency [`FileId`]
+    /// (tsgo `resolvedModules`, which keys by path; ours is aligned with `files`).
+    pub(super) resolved_modules: IndexVec<FileId, FxHashMap<CompactStr, FileId>>,
 }
 
-/// Collects a program's root files, mirroring tsgo's `fileLoader`.
-///
-/// tsgo's `fileLoader` also parses each file and owns the resolver, supported-extension lists, and
-/// lib/project-reference bookkeeping; those arrive with later steps.
-pub(super) struct FileLoader<'a> {
-    current_directory: &'a Path,
-    processed: ProcessedFiles,
+/// Loads a program's files, mirroring tsgo's `fileLoader`. Holds the host (reads + parses), the
+/// module resolver, and the supported-extension tables computed from the compiler options.
+/// `Send + Sync`, so rayon workers share one by `&`.
+pub(super) struct FileLoader {
+    host: CompilerHost,
+    resolver: Resolver,
+    /// tsgo `supportedExtensions`, grouped by resolution priority (for extensionless
+    /// triple-slash references).
+    supported_extensions: &'static [&'static [&'static str]],
+    /// tsgo `supportedExtensionsWithJsonIfResolveJsonModule`, flattened (the load-time gate).
+    supported_extensions_with_json: Vec<&'static str>,
+    /// tsgo `CompilerOptions.GetAllowJS()`.
+    allow_js: bool,
+    /// tsgo `CompilerOptions.GetResolveJsonModule()`.
+    resolve_json_module: bool,
+    /// tsgo `CompilerOptions.Jsx` is set (gates `.tsx`/`.jsx` resolutions).
+    jsx: bool,
 }
 
-impl<'a> FileLoader<'a> {
-    /// Port of tsgo's `processAllProgramFiles`: collect the root files into the program's file
-    /// list, normalizing and deduplicating each path.
-    ///
-    /// tsgo also parses each file here (and discovers imports, lib files, and project references);
-    /// those are later steps.
-    pub(super) fn process_all_program_files(
-        current_directory: &'a Path,
-        root_files: &[PathBuf],
-    ) -> ProcessedFiles {
-        let mut loader = Self::new(current_directory);
-        for root_file in root_files {
-            loader.add_root_file(root_file);
+impl FileLoader {
+    fn new(opts: &ProgramOptions) -> Self {
+        let default_options = oxc_resolver::CompilerOptions::default();
+        let options =
+            opts.config.as_ref().map_or(&default_options, |config| &config.compiler_options);
+        Self {
+            host: CompilerHost::new(opts.current_directory.clone()),
+            resolver: build_resolver(opts.config.as_ref().map(|config| config.path.as_path())),
+            supported_extensions: get_supported_extensions(options),
+            supported_extensions_with_json: get_supported_extensions_with_json_flat(options),
+            allow_js: get_allow_js(options),
+            resolve_json_module: get_resolve_json_module(options),
+            jsx: options.jsx.is_some(),
         }
-        loader.processed
     }
 
-    fn new(current_directory: &'a Path) -> Self {
-        Self { current_directory, processed: ProcessedFiles::default() }
+    pub(super) fn host(&self) -> &CompilerHost {
+        &self.host
     }
 
-    /// tsgo `fileLoader.addRootFileTask`: add a root file, keyed by its normalized absolute path,
-    /// skipping a path that was already added.
-    fn add_root_file(&mut self, file_name: &Path) {
-        let path = tspath::to_path(self.current_directory, file_name);
-        if self.processed.files_by_path.contains_key(&path) {
-            return;
-        }
-        let id = self.processed.files.push(path.clone());
-        self.processed.files_by_path.insert(path, id);
+    pub(super) fn current_directory(&self) -> &Path {
+        self.host.current_directory()
     }
+
+    /// tsgo `fileLoader.toPath`: normalize a file name into its identity key.
+    pub(super) fn to_path(&self, file_name: &Path) -> PathBuf {
+        tspath::to_path(self.current_directory(), file_name)
+    }
+
+    /// tsgo `fileLoader.isSupportedExtension` (against
+    /// `supportedExtensionsWithJsonIfResolveJsonModule`).
+    pub(super) fn is_supported_extension(&self, file_name: &str) -> bool {
+        file_extension_is_one_of(file_name, &self.supported_extensions_with_json)
+    }
+
+    /// Resolve everything a file references into sub-tasks, in tsgo `parseTask.load` order:
+    /// triple-slash path references, type reference directives, (lib references — not loaded
+    /// yet), then imports and module augmentations.
+    pub(super) fn resolve_references(&self, source_file: &SourceFile) -> Vec<SubTask> {
+        let importing_file = source_file.file_name();
+        let mut resolutions = Vec::new();
+
+        for reference in source_file.referenced_files() {
+            if let Some(path) = self.resolve_tripleslash_path_reference(reference, importing_file) {
+                resolutions.push((None, path));
+            }
+        }
+        // tsgo `resolveTypeReferenceDirectives` (`resolver.ResolveTypeReferenceDirective`,
+        // approximated with `resolve_dts`: relative directives resolve as declaration files,
+        // bare names through `@types`).
+        for directive in source_file.type_reference_directives() {
+            if directive.is_empty() {
+                continue;
+            }
+            if let Ok(resolution) = self.resolver.resolve_dts(importing_file, directive) {
+                resolutions.push((None, self.to_path(resolution.path())));
+            }
+        }
+
+        self.resolve_imports_and_module_augmentations(source_file, &mut resolutions);
+        resolutions
+    }
+
+    /// tsgo `resolveTripleslashPathReference` + `getSourceFileFromReference`: resolve the
+    /// reference against the containing file's directory; a name with an extension must be
+    /// supported and exist, an extensionless name tries the primary supported extensions.
+    fn resolve_tripleslash_path_reference(
+        &self,
+        module_name: &str,
+        containing_file: &Path,
+    ) -> Option<PathBuf> {
+        let base_path = containing_file.parent()?;
+        let referenced = if Path::new(module_name).is_absolute() {
+            PathBuf::from(module_name)
+        } else {
+            base_path.join(module_name)
+        };
+        let normalized = self.to_path(&referenced);
+        let file_name = normalized.to_string_lossy();
+        if tspath::has_extension(&file_name) {
+            if self.is_supported_extension(&file_name) && self.host.file_exists(&normalized) {
+                return Some(normalized);
+            }
+            return None;
+        }
+        for extension in self.supported_extensions[0] {
+            let mut candidate = normalized.clone().into_os_string();
+            candidate.push(extension);
+            let candidate = PathBuf::from(candidate);
+            if self.host.file_exists(&candidate) {
+                return Some(candidate);
+            }
+        }
+        None
+    }
+
+    /// tsgo `resolveImportsAndModuleAugmentations`: resolve the file's imports and module
+    /// augmentations to normalized dependency paths, applying `shouldAddFile`'s gates —
+    /// resolutions a `GetResolutionDiagnostic` would reject (`.json` without `resolveJsonModule`,
+    /// `.tsx`/`.jsx` without `jsx`, arbitrary extensions outside declaration files), JavaScript
+    /// files without `allowJs`, and JavaScript files under `node_modules` (tsgo elides those
+    /// beyond `maxNodeModuleJsDepth`, which defaults to 0; the option itself is not exposed by
+    /// `oxc_resolver`, so depths above 0 are not supported). Specifiers that don't resolve
+    /// (e.g. uninstalled packages) are skipped.
+    fn resolve_imports_and_module_augmentations(
+        &self,
+        source_file: &SourceFile,
+        resolutions: &mut Vec<SubTask>,
+    ) {
+        let importing_file = source_file.file_name();
+        let is_declaration_file = source_file.source_type().is_typescript_definition();
+        let module_names = source_file.imports().iter().chain(source_file.module_augmentations());
+
+        for module_name in module_names {
+            if module_name.is_empty() {
+                continue;
+            }
+            let Some(resolution) = self.resolve_module_name(importing_file, module_name) else {
+                continue;
+            };
+            let resolved_file_name = resolution.path().to_string_lossy();
+
+            // tsgo `shouldAddFile`: `!(isJsFile && !GetAllowJS())`, and JS files found under
+            // node_modules are elided (`elideOnDepth` with the default depth limit of 0).
+            // Checked by path component so Windows separators match too.
+            let is_js_file = !file_extension_is_one_of(
+                &resolved_file_name,
+                SUPPORTED_TS_EXTENSIONS_WITH_JSON_FLAT,
+            );
+            if is_js_file
+                && (!self.allow_js
+                    || resolution
+                        .path()
+                        .components()
+                        .any(|component| component.as_os_str() == "node_modules"))
+            {
+                continue;
+            }
+            // tsgo `module.GetResolutionDiagnostic`: resolutions that would error are not added.
+            if !self.resolution_allowed(&resolved_file_name, is_declaration_file) {
+                continue;
+            }
+            resolutions.push((Some(module_name.clone()), self.to_path(resolution.path())));
+        }
+    }
+
+    /// tsgo `resolver.ResolveModuleName`, via `oxc_resolver`. `resolve_dts` mirrors TS's
+    /// code-module resolution, which never loads a literal `.json` file (only its `.d.json.ts`
+    /// substitution) — JSON modules resolve through tsgo's separate `tryResolveJsonModule`
+    /// branch, stood in for here by the general-purpose resolver.
+    fn resolve_module_name(
+        &self,
+        importing_file: &Path,
+        module_name: &str,
+    ) -> Option<oxc_resolver::Resolution> {
+        // tsc resolves specifiers literally — a bundler-style query or fragment suffix
+        // (`./worker.ts?worker`) never matches a file. `oxc_resolver` would strip and resolve
+        // it, so guard here (a leading `#` is a package import, not a fragment).
+        if module_name.char_indices().any(|(i, c)| i > 0 && (c == '?' || c == '#')) {
+            return None;
+        }
+        match self.resolver.resolve_dts(importing_file, module_name) {
+            Ok(resolution) => Some(resolution),
+            Err(_) => {
+                if self.resolve_json_module && file_extension_is(module_name, ".json") {
+                    let importing_dir = importing_file.parent()?;
+                    self.resolver.resolve(importing_dir, module_name).ok()
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
+    /// tsgo `module.GetResolutionDiagnostic` returning no diagnostic. TS extensions are always
+    /// allowed; `.tsx`/`.jsx` need the `jsx` option; `.js`-family extensions are handled by the
+    /// caller's `allowJs` gate; `.json` needs `resolveJsonModule`; anything else is only allowed
+    /// from declaration files (`allowArbitraryExtensions` is not exposed by `oxc_resolver`).
+    fn resolution_allowed(&self, resolved_file_name: &str, is_declaration_file: bool) -> bool {
+        if file_extension_is_one_of(
+            resolved_file_name,
+            &[".d.ts", ".d.cts", ".d.mts", ".ts", ".cts", ".mts"],
+        ) || file_extension_is_one_of(resolved_file_name, &[".js", ".mjs", ".cjs"])
+        {
+            true
+        } else if file_extension_is_one_of(resolved_file_name, &[".tsx", ".jsx"]) {
+            self.jsx
+        } else if file_extension_is(resolved_file_name, ".json") {
+            self.resolve_json_module
+        } else {
+            is_declaration_file
+        }
+    }
+
+    /// tsgo `processAllProgramFiles`: parse the roots, load their transitive imports in parallel,
+    /// and collect the result.
+    pub(super) fn process_all_program_files(opts: &ProgramOptions) -> ProcessedFiles {
+        let loader = FileLoader::new(opts);
+        let mut files_parser = FilesParser::default();
+        files_parser.parse(&loader, &opts.root_files);
+        files_parser.get_processed_files()
+    }
+}
+
+/// Build the module resolver for TS declaration resolution (`resolve_dts`): TS extensions,
+/// TS-style `.js`->`.ts`/`.tsx`/`.d.ts` extension substitution (mirroring the order of tsgo's
+/// `tryAddingExtensions`, used by the resolver paths that fall back to the general algorithm,
+/// e.g. package `imports`), and the project's tsconfig (for `paths`/`baseUrl`).
+fn build_resolver(tsconfig: Option<&Path>) -> Resolver {
+    let tsconfig = tsconfig.map(|path| {
+        TsconfigDiscovery::Manual(TsconfigOptions {
+            config_file: path.to_path_buf(),
+            references: TsconfigReferences::Auto,
+        })
+    });
+    let alias = |extensions: &[&str]| extensions.iter().map(ToString::to_string).collect();
+    Resolver::new(ResolveOptions {
+        extensions: VALID_EXTENSIONS.iter().map(|ext| format!(".{ext}")).collect(),
+        main_fields: vec!["module".to_string(), "main".to_string()],
+        condition_names: vec!["module".to_string(), "import".to_string()],
+        extension_alias: vec![
+            (".js".to_string(), alias(&[".ts", ".tsx", ".d.ts", ".js", ".jsx"])),
+            (".jsx".to_string(), alias(&[".tsx", ".ts", ".d.ts", ".jsx", ".js"])),
+            (".mjs".to_string(), alias(&[".mts", ".d.mts", ".mjs"])),
+            (".cjs".to_string(), alias(&[".cts", ".d.cts", ".cjs"])),
+        ],
+        tsconfig,
+        ..ResolveOptions::default()
+    })
 }

--- a/crates/oxc_type_checker/src/compiler/filesparser.rs
+++ b/crates/oxc_type_checker/src/compiler/filesparser.rs
@@ -1,0 +1,212 @@
+//! Port of typescript-go's `internal/compiler/filesparser.go`.
+//!
+//! [`FilesParser::parse`] loads all root files and their transitive imports, mirroring tsgo's
+//! `filesParser` walk — but driven by rayon instead of a work group (per the request). A single
+//! graph thread owns the dedup set and drains results; rayon workers do the parse + import
+//! resolution. Dedup is therefore lock-free (single-threaded), following `oxc_linter`'s runtime.
+//!
+//! [`FilesParser::get_processed_files`] then assigns [`FileId`](super::FileId)s in tsgo's
+//! `collectFiles` order — a post-order walk of the task graph from the roots, so a file's
+//! dependencies come before it — which also keeps the output deterministic despite rayon's
+//! nondeterministic arrival order.
+
+use std::{
+    any::Any,
+    panic::{self, AssertUnwindSafe},
+    path::PathBuf,
+    sync::mpsc,
+};
+
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use crate::tspath::has_extension;
+
+use super::{
+    fileloader::{FileLoader, ProcessedFiles, SubTask},
+    source_file::{SourceFile, SourceFileParseOptions},
+};
+
+/// A unit of work: load one file. Mirrors tsgo's `parseTask` (pre-load state).
+struct ParseTask {
+    path: PathBuf,
+}
+
+impl ParseTask {
+    /// tsgo `parseTask.load`: gate unsupported extensions, read + parse the file, then resolve
+    /// its imports and module augmentations into sub-tasks.
+    fn load(self, loader: &FileLoader) -> LoadedTask {
+        // tsgo drops files with unsupported extensions before parsing (they still count as
+        // missing); extensionless files are loaded as-is.
+        let file_name = self.path.to_string_lossy();
+        if has_extension(&file_name) && !loader.is_supported_extension(&file_name) {
+            return LoadedTask { path: self.path, source_file: None, sub_tasks: Vec::new() };
+        }
+
+        let opts = SourceFileParseOptions { file_name: self.path.clone(), path: self.path.clone() };
+        match loader.host().get_source_file(opts) {
+            Some(source_file) => {
+                let sub_tasks = loader.resolve_references(&source_file);
+                LoadedTask { path: self.path, source_file: Some(source_file), sub_tasks }
+            }
+            None => LoadedTask { path: self.path, source_file: None, sub_tasks: Vec::new() },
+        }
+    }
+}
+
+/// A loaded [`ParseTask`]: the parsed [`SourceFile`] (`None` if unreadable or unsupported) and
+/// the file's resolved references in resolution order — tsgo's `subTasks` and `resolutionsInFile`
+/// combined into one [`SubTask`] list.
+struct LoadedTask {
+    path: PathBuf,
+    source_file: Option<SourceFile>,
+    sub_tasks: Vec<SubTask>,
+}
+
+/// What a worker reports back: a loaded task, or the payload of a panic that occurred while
+/// loading it — so the graph thread can re-raise the panic rather than hang.
+enum WorkerResult {
+    Loaded(Box<LoadedTask>),
+    Panicked(Box<dyn Any + Send>),
+}
+
+/// Drives parallel loading and collects the result, mirroring tsgo's `filesParser`.
+#[derive(Default)]
+pub(super) struct FilesParser {
+    /// Every loaded task, keyed by normalized path (tsgo `taskDataByPath`).
+    tasks_by_path: FxHashMap<PathBuf, LoadedTask>,
+    /// The normalized root paths, in root order (tsgo walks `rootTasks`).
+    root_paths: Vec<PathBuf>,
+}
+
+impl FilesParser {
+    /// Load `root_files` and every file reachable through their imports, in parallel
+    /// (tsgo `filesParser.parse`).
+    pub(super) fn parse(&mut self, loader: &FileLoader, root_files: &[PathBuf]) {
+        rayon::scope(|scope| {
+            let (tx, rx) = mpsc::channel::<WorkerResult>();
+            // `encountered` dedups by normalized path; owned solely by this (graph) thread, so no
+            // locking. `pending` counts spawned-but-not-yet-collected tasks; every worker reports
+            // back exactly once (even on panic), so it always reaches 0.
+            let mut encountered = FxHashSet::<PathBuf>::default();
+            let mut pending = 0usize;
+
+            // Seed the roots.
+            for root in root_files {
+                let path = loader.to_path(root);
+                self.root_paths.push(path.clone());
+                if encountered.insert(path.clone()) {
+                    pending += 1;
+                    spawn_load(scope, loader, path, tx.clone());
+                }
+            }
+
+            // Drain results, enqueuing newly-discovered dependencies. While the channel is empty
+            // the graph thread donates itself to the pool via `yield_now` instead of idling.
+            while pending > 0 {
+                let result = match rx.try_recv() {
+                    Ok(result) => result,
+                    Err(mpsc::TryRecvError::Empty) => {
+                        rayon::yield_now();
+                        continue;
+                    }
+                    Err(mpsc::TryRecvError::Disconnected) => break,
+                };
+                pending -= 1;
+                let task = match result {
+                    WorkerResult::Loaded(task) => *task,
+                    // A worker panicked (e.g. a parser bug on some file). Re-raise it here rather
+                    // than spinning the drain loop forever or silently dropping the file.
+                    WorkerResult::Panicked(payload) => panic::resume_unwind(payload),
+                };
+                for (_specifier, dep_path) in &task.sub_tasks {
+                    if encountered.insert(dep_path.clone()) {
+                        pending += 1;
+                        spawn_load(scope, loader, dep_path.clone(), tx.clone());
+                    }
+                }
+                self.tasks_by_path.insert(task.path.clone(), task);
+            }
+        });
+    }
+
+    /// tsgo `filesParser.getProcessedFiles`: assign [`FileId`](super::FileId)s by walking the
+    /// task graph from the roots in post-order (`collectFiles` collects a task's sub-tasks
+    /// before the task itself), then link each file's resolutions to the ids.
+    pub(super) fn get_processed_files(&mut self) -> ProcessedFiles {
+        /// A task whose sub-tasks are being walked; the task itself is collected once the
+        /// cursor passes the last one.
+        struct Frame {
+            task: LoadedTask,
+            next_sub_task: usize,
+        }
+
+        let mut processed = ProcessedFiles::default();
+        let mut sub_tasks_by_id: Vec<Vec<SubTask>> = Vec::new();
+        let mut stack: Vec<Frame> = Vec::new();
+        // The walk visits every encountered path exactly once: `tasks_by_path.remove` marks a
+        // task visited, and paths without a task (already taken) are skipped. Iterative rather
+        // than recursive (as in tsgo) so a deep import chain cannot overflow the stack.
+        for root in std::mem::take(&mut self.root_paths) {
+            if let Some(task) = self.tasks_by_path.remove(&root) {
+                stack.push(Frame { task, next_sub_task: 0 });
+            }
+            while let Some(frame) = stack.last_mut() {
+                if let Some((_, dep_path)) = frame.task.sub_tasks.get(frame.next_sub_task) {
+                    let dep_path = dep_path.clone();
+                    frame.next_sub_task += 1;
+                    if let Some(task) = self.tasks_by_path.remove(&dep_path) {
+                        stack.push(Frame { task, next_sub_task: 0 });
+                    }
+                } else {
+                    let task = stack.pop().unwrap().task;
+                    match task.source_file {
+                        Some(source_file) => {
+                            let id = processed.files.push(source_file);
+                            processed.files_by_path.insert(task.path, id);
+                            sub_tasks_by_id.push(task.sub_tasks);
+                        }
+                        None => processed.missing_files.push(task.path),
+                    }
+                }
+            }
+        }
+
+        // Link the module-graph edges: import specifier -> dependency FileId (dropping
+        // dependencies that failed to load; triple-slash references have no specifier).
+        processed.resolved_modules = sub_tasks_by_id
+            .into_iter()
+            .map(|sub_tasks| {
+                sub_tasks
+                    .into_iter()
+                    .filter_map(|(specifier, dep_path)| {
+                        let specifier = specifier?;
+                        processed.files_by_path.get(&dep_path).map(|&id| (specifier, id))
+                    })
+                    .collect()
+            })
+            .collect();
+        processed
+    }
+}
+
+/// Spawn a rayon worker that loads `path` and reports back to the graph thread exactly once — the
+/// loaded task, or the panic payload if loading panicked. Reporting on panic (instead of just
+/// unwinding the worker) keeps `pending` accurate and lets the graph thread re-raise the panic,
+/// rather than the drain loop hanging on a task that never reports.
+fn spawn_load<'scope>(
+    scope: &rayon::Scope<'scope>,
+    loader: &'scope FileLoader,
+    path: PathBuf,
+    tx: mpsc::Sender<WorkerResult>,
+) {
+    scope.spawn(move |_| {
+        let result = match panic::catch_unwind(AssertUnwindSafe(|| ParseTask { path }.load(loader)))
+        {
+            Ok(task) => WorkerResult::Loaded(Box::new(task)),
+            Err(payload) => WorkerResult::Panicked(payload),
+        };
+        // The receiver is only gone once the graph thread has stopped draining (it is finishing, or
+        // itself unwinding a re-raised panic), so a failed send here can be dropped.
+        let _ = tx.send(result);
+    });
+}

--- a/crates/oxc_type_checker/src/compiler/host.rs
+++ b/crates/oxc_type_checker/src/compiler/host.rs
@@ -1,0 +1,63 @@
+//! Port of typescript-go's `internal/compiler/host.go`.
+//!
+//! The [`CompilerHost`] abstracts the current directory and the file system.
+//! [`CompilerHost::get_source_file`] reads a file's text and parses it (tsgo
+//! `compilerHost.GetSourceFile`). It is `Send + Sync` so rayon workers can share one by `&`.
+
+use std::{
+    fmt,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use oxc_resolver::{FileSystem, FileSystemOs};
+use oxc_span::SourceType;
+
+use super::source_file::{SourceFile, SourceFileParseOptions};
+
+/// The host a [`Program`](super::program::Program) is loaded from.
+///
+/// Mirrors tsgo's `CompilerHost`. The file system is an [`oxc_resolver::FileSystem`] (tsgo's
+/// `vfs.FS`) behind `Arc<dyn ..>`.
+pub struct CompilerHost {
+    current_directory: PathBuf,
+    fs: Arc<dyn FileSystem>,
+}
+
+impl CompilerHost {
+    /// Create a host rooted at `current_directory`, backed by the OS file system.
+    pub fn new(current_directory: PathBuf) -> Self {
+        Self { current_directory, fs: Arc::new(FileSystemOs) }
+    }
+
+    /// The directory relative paths are resolved against (tsgo `GetCurrentDirectory`).
+    pub fn current_directory(&self) -> &Path {
+        &self.current_directory
+    }
+
+    /// Whether `path` is an existing regular file (tsgo `host.FS().FileExists`).
+    pub fn file_exists(&self, path: &Path) -> bool {
+        self.fs.metadata(path).is_ok_and(oxc_resolver::FileMetadata::is_file)
+    }
+
+    /// Read and parse the file described by `opts`, mirroring tsgo's `compilerHost.GetSourceFile`:
+    /// read the text through the file system, then parse it.
+    ///
+    /// Returns `None` if the file cannot be read (tsgo returns `nil`).
+    pub fn get_source_file(&self, opts: SourceFileParseOptions) -> Option<SourceFile> {
+        let source_text = self.fs.read_to_string(&opts.file_name).ok()?;
+        // Derive the JS/TS dialect from the extension. Extensions oxc's `SourceType` cannot model
+        // (notably `.json`) fall back to the default so the file still enters the program; faithful
+        // JSON handling is deferred.
+        let source_type = SourceType::from_path(&opts.file_name).unwrap_or_default();
+        Some(SourceFile::parse(opts, source_text, source_type))
+    }
+}
+
+impl fmt::Debug for CompilerHost {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CompilerHost")
+            .field("current_directory", &self.current_directory)
+            .finish_non_exhaustive()
+    }
+}

--- a/crates/oxc_type_checker/src/compiler/mod.rs
+++ b/crates/oxc_type_checker/src/compiler/mod.rs
@@ -1,11 +1,17 @@
 //! Port of typescript-go's `internal/compiler` package.
 //!
-//! Collects a program's root files — expanded from the tsconfig or given on the command line —
-//! into an index-vec keyed by [`FileId`], normalizing and deduplicating them. Path normalization
-//! reuses `oxc_resolver` (tsgo's `internal/tspath`). Parsing and binding those files is a later
-//! step.
+//! Builds a [`Program`] from a project's root files: parse each file, follow its imports and
+//! module augmentations to load the dependent files (in parallel via rayon), and collect them —
+//! in tsgo's dependency-first program order — into an index-vec keyed by [`FileId`]. File
+//! reading, path normalization, and module resolution reuse `oxc_resolver`. Binding and type
+//! checking are later steps, as are lib files, type reference directives, and project references.
 
 mod fileloader;
+mod filesparser;
+mod host;
 mod program;
+mod references;
+mod source_file;
 
-pub use program::{FileId, Program};
+pub use program::{FileId, Program, ProgramOptions};
+pub use source_file::SourceFile;

--- a/crates/oxc_type_checker/src/compiler/program.rs
+++ b/crates/oxc_type_checker/src/compiler/program.rs
@@ -1,13 +1,20 @@
 //! Port of typescript-go's `internal/compiler/program.go`.
 
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use oxc_index::{IndexSlice, define_nonmax_u32_index_type};
+use oxc_resolver::TsConfig;
 
-use super::fileloader::{FileLoader, ProcessedFiles};
+use super::{
+    fileloader::{FileLoader, ProcessedFiles},
+    source_file::SourceFile,
+};
 
 define_nonmax_u32_index_type! {
-    /// Index of a root file within a [`Program`].
+    /// Index of a [`SourceFile`] within a [`Program`].
     ///
     /// typescript-go has no integer file id — it keys files by their normalized `tspath.Path`.
     /// This typed index is an oxc-side addition so files can be referenced by a cheap `u32` (and,
@@ -15,30 +22,54 @@ define_nonmax_u32_index_type! {
     pub struct FileId;
 }
 
-/// A program's collected root files. Mirrors tsgo's `Program` (which embeds `processedFiles`).
+/// The inputs a [`Program`] is created from, mirroring tsgo's `ProgramOptions`.
 ///
-/// This is the in-memory model the type checker will run over. Today it holds only the root file
-/// list; parsing and binding the files, import resolution, and checking are later steps.
+/// tsgo's `Host` is created internally from `current_directory`; `config` stands in for tsgo's
+/// `Config` when a tsconfig drives the compilation.
+#[derive(Debug)]
+pub struct ProgramOptions {
+    /// The directory relative paths resolve against (tsgo `Host.GetCurrentDirectory`).
+    pub current_directory: PathBuf,
+    /// The root files to load (tsgo `Config.FileNames()`).
+    pub root_files: Vec<PathBuf>,
+    /// The parsed project tsconfig (tsgo `Config`), driving module resolution
+    /// (`paths`/`baseUrl`) and the compiler-option gates. `None` when files are compiled
+    /// directly without a config file.
+    pub config: Option<Arc<TsConfig>>,
+}
+
+/// A program: the source files loaded from a set of root files (roots + their transitive imports).
+/// Mirrors tsgo's `Program` (which embeds `processedFiles`).
+///
+/// This is the in-memory model the type checker will run over. Files are parsed (AST + module
+/// record) but not yet bound; type checking is a later step.
 #[derive(Debug)]
 pub struct Program {
+    opts: ProgramOptions,
     processed: ProcessedFiles,
 }
 
 impl Program {
-    /// Port of tsgo's `NewProgram`: collect `root_files` into the program's file list,
-    /// normalizing each path and deduplicating (relative paths resolve against
-    /// `current_directory`).
-    pub fn new(current_directory: &Path, root_files: &[PathBuf]) -> Self {
-        Self { processed: FileLoader::process_all_program_files(current_directory, root_files) }
+    /// Port of tsgo's `NewProgram`: parse the root files, follow their imports to load every
+    /// dependent file (in parallel), and collect them.
+    pub fn new(opts: ProgramOptions) -> Self {
+        let processed = FileLoader::process_all_program_files(&opts);
+        Self { opts, processed }
     }
 
-    /// All root files, in include order (tsgo `Program.SourceFiles`).
-    pub fn files(&self) -> &IndexSlice<FileId, [PathBuf]> {
+    /// The options the program was created from (tsgo `Program.Options`).
+    pub fn options(&self) -> &ProgramOptions {
+        &self.opts
+    }
+
+    /// All source files in program order — a post-order walk of the import graph from the root
+    /// files, so dependencies come before their importers (tsgo `Program.SourceFiles`).
+    pub fn files(&self) -> &IndexSlice<FileId, [SourceFile]> {
         &self.processed.files
     }
 
-    /// The file with the given [`FileId`].
-    pub fn file(&self, id: FileId) -> &Path {
+    /// The source file with the given [`FileId`].
+    pub fn file(&self, id: FileId) -> &SourceFile {
         &self.processed.files[id]
     }
 
@@ -48,12 +79,24 @@ impl Program {
         self.processed.files_by_path.get(path).copied()
     }
 
-    /// The number of root files.
+    /// The file `specifier` resolves to from within `id`, if it was loaded (tsgo
+    /// `Program.GetResolvedModule`).
+    pub fn resolved_module(&self, id: FileId, specifier: &str) -> Option<FileId> {
+        self.processed.resolved_modules[id].get(specifier).copied()
+    }
+
+    /// Paths that could not be loaded — unreadable files and files with unsupported extensions
+    /// (tsgo `missingFiles`).
+    pub fn missing_files(&self) -> &[PathBuf] {
+        &self.processed.missing_files
+    }
+
+    /// The number of source files.
     pub fn len(&self) -> usize {
         self.processed.files.len()
     }
 
-    /// Whether the program has no root files.
+    /// Whether the program has no source files.
     pub fn is_empty(&self) -> bool {
         self.processed.files.is_empty()
     }

--- a/crates/oxc_type_checker/src/compiler/references.rs
+++ b/crates/oxc_type_checker/src/compiler/references.rs
@@ -1,0 +1,297 @@
+//! Port of typescript-go's `internal/parser/references.go`.
+//!
+//! [`collect_external_module_references`] gathers the module specifiers a file references, in
+//! tsgo's order: statically imported specifiers in source order (`collectModuleReferences`),
+//! then dynamic `import()` calls and `import("...")` type queries in source order
+//! (`ForEachDynamicImportOrRequireCall`), plus the file's `declare module "..."` augmentations.
+//!
+//! oxc's parser already collects top-level static imports/re-exports into the module record; the
+//! AST walks here add the rest: `import x = require("...")`, statements nested inside ambient
+//! module bodies, dynamic `import()`s, `import("...")` type queries, CommonJS `require("...")`
+//! calls in JavaScript files, and the ambient module declarations themselves.
+
+use oxc_ast::ast::{
+    CallExpression, Declaration, Expression, ImportExpression, Program as AstProgram, Statement,
+    TSImportType, TSModuleDeclarationBody, TSModuleDeclarationName, TSModuleReference,
+};
+use oxc_ast_visit::{Visit, walk};
+use oxc_span::GetSpan;
+use oxc_str::CompactStr;
+use oxc_syntax::module_record::ModuleRecord;
+
+use crate::tspath::is_external_module_name_relative;
+
+/// A file's external module references (tsgo `SourceFile.Imports` + `ModuleAugmentations` +
+/// `ReferencedFiles` + `TypeReferenceDirectives`).
+#[derive(Debug, Default)]
+pub(super) struct ExternalModuleReferences {
+    /// Module specifiers referenced by imports: static imports/re-exports in source order,
+    /// followed by dynamic `import()`s and `import("...")` type queries in source order.
+    pub imports: Vec<CompactStr>,
+    /// String-literal `declare module "..."` names that augment an existing external module.
+    pub module_augmentations: Vec<CompactStr>,
+    /// `/// <reference path="..." />` pragmas (tsgo `SourceFile.ReferencedFiles`).
+    pub referenced_files: Vec<CompactStr>,
+    /// `/// <reference types="..." />` pragmas (tsgo `SourceFile.TypeReferenceDirectives`).
+    pub type_reference_directives: Vec<CompactStr>,
+}
+
+/// tsgo `collectExternalModuleReferences`: collect every module specifier the resolver should
+/// see for this file.
+pub(super) fn collect_external_module_references(
+    program: &AstProgram<'_>,
+    module_record: &ModuleRecord<'_>,
+    is_declaration_file: bool,
+) -> ExternalModuleReferences {
+    let mut collector = Collector {
+        // tsgo `ast.IsExternalModule`: the file has an external module indicator.
+        is_external_module: module_record.has_module_syntax,
+        is_declaration_file,
+        statics: Vec::new(),
+        module_augmentations: Vec::new(),
+    };
+
+    // Top-level static imports/re-exports, already collected by the parser (source position of
+    // each request comes from the module record, so ordering below can interleave them with the
+    // statements the walk finds).
+    for (specifier, requests) in &module_record.requested_modules {
+        let specifier = specifier.as_str();
+        if specifier.is_empty() {
+            continue;
+        }
+        for request in requests {
+            collector.statics.push((request.span.start, CompactStr::from(specifier)));
+        }
+    }
+
+    // tsgo `collectModuleReferences` over the top-level statements: adds `import x = require()`,
+    // statements nested in ambient module bodies, and module augmentations.
+    for statement in &program.body {
+        collector.collect_module_references(statement, false);
+    }
+    collector.statics.sort_by_key(|(start, _)| *start);
+
+    // tsgo `ForEachDynamicImportOrRequireCall` (string-literal-like arguments, including
+    // type-space imports): one AST walk collects dynamic `import()`s, `import("...")` type
+    // queries, and — in JavaScript files only — `require("...")` calls.
+    let mut dynamics: Vec<(u32, CompactStr)> = Vec::new();
+    let mut calls = CallCollector {
+        dynamics: &mut dynamics,
+        collect_require_calls: program.source_type.is_javascript(),
+    };
+    calls.visit_program(program);
+    dynamics.sort_by_key(|(start, _)| *start);
+
+    let imports =
+        collector.statics.into_iter().chain(dynamics).map(|(_, specifier)| specifier).collect();
+
+    let mut references = ExternalModuleReferences {
+        imports,
+        module_augmentations: collector.module_augmentations,
+        ..ExternalModuleReferences::default()
+    };
+    collect_reference_pragmas(program, &mut references);
+    references
+}
+
+/// tsgo's scanner collects `/// <reference ... />` pragmas from the file's leading trivia —
+/// the comments before the first token (directive prologue or statement).
+fn collect_reference_pragmas(program: &AstProgram<'_>, references: &mut ExternalModuleReferences) {
+    let first_token_start = program
+        .directives
+        .first()
+        .map(|directive| directive.span.start)
+        .or_else(|| program.body.first().map(|statement| statement.span().start))
+        .unwrap_or(u32::MAX);
+    for comment in &program.comments {
+        if comment.span.start >= first_token_start {
+            break;
+        }
+        if !comment.is_line() {
+            continue;
+        }
+        let content = comment.content_span().source_text(program.source_text);
+        let Some((name, value)) = parse_reference_pragma(content) else { continue };
+        if value.is_empty() {
+            continue;
+        }
+        match name {
+            "path" => references.referenced_files.push(CompactStr::from(value)),
+            "types" => references.type_reference_directives.push(CompactStr::from(value)),
+            // `lib="..."` references default lib files, which are not loaded yet;
+            // `no-default-lib` carries no file reference.
+            _ => {}
+        }
+    }
+}
+
+/// Parse a `/ <reference path|types = "..." />` line-comment body (the leading `//` is already
+/// stripped), mirroring tsc's `fullTripleSlashReference(Path|TypeReference)RegEx`: the attribute
+/// must directly follow `<reference`.
+fn parse_reference_pragma(content: &str) -> Option<(&'static str, &str)> {
+    let rest = content.strip_prefix('/')?.trim_start();
+    let rest = rest.strip_prefix("<reference")?;
+    let rest = rest.trim_start();
+    let (name, rest) = if let Some(rest) = rest.strip_prefix("path") {
+        ("path", rest)
+    } else if let Some(rest) = rest.strip_prefix("types") {
+        ("types", rest)
+    } else if let Some(rest) = rest.strip_prefix("lib") {
+        ("lib", rest)
+    } else {
+        return None;
+    };
+    let rest = rest.trim_start().strip_prefix('=')?.trim_start();
+    let quote = rest.chars().next().filter(|&c| c == '"' || c == '\'')?;
+    let rest = &rest[1..];
+    let end = rest.find(quote)?;
+    Some((name, &rest[..end]))
+}
+
+struct Collector {
+    is_external_module: bool,
+    is_declaration_file: bool,
+    /// (source position, specifier) of statically referenced modules, for source-order sorting.
+    statics: Vec<(u32, CompactStr)>,
+    module_augmentations: Vec<CompactStr>,
+}
+
+impl Collector {
+    /// tsgo `collectModuleReferences`. `in_ambient_module` is `true` inside the body of a
+    /// top-level ambient module declaration, where only non-relative names may reference other
+    /// external modules.
+    fn collect_module_references(&mut self, statement: &Statement<'_>, in_ambient_module: bool) {
+        match statement {
+            // `import x = require("...")` — not in oxc's module record.
+            Statement::TSImportEqualsDeclaration(decl) => {
+                if let TSModuleReference::ExternalModuleReference(reference) =
+                    &decl.module_reference
+                {
+                    let name = &reference.expression;
+                    self.add_static(name.span.start, &name.value, in_ambient_module);
+                }
+            }
+            // Top-level imports/re-exports are already in the module record; only the ones
+            // nested inside ambient module bodies need collecting here.
+            Statement::ImportDeclaration(decl) => {
+                if in_ambient_module {
+                    self.add_static(decl.source.span.start, &decl.source.value, true);
+                }
+            }
+            Statement::ExportNamedDeclaration(decl) => {
+                if in_ambient_module && let Some(source) = &decl.source {
+                    self.add_static(source.span.start, &source.value, true);
+                }
+                // `export import A = require("...")` wraps the import-equals declaration.
+                if let Some(Declaration::TSImportEqualsDeclaration(decl)) = &decl.declaration
+                    && let TSModuleReference::ExternalModuleReference(reference) =
+                        &decl.module_reference
+                {
+                    let name = &reference.expression;
+                    self.add_static(name.span.start, &name.value, in_ambient_module);
+                }
+            }
+            Statement::ExportAllDeclaration(decl) => {
+                if in_ambient_module {
+                    self.add_static(decl.source.span.start, &decl.source.value, true);
+                }
+            }
+            Statement::TSModuleDeclaration(decl) => {
+                // Only string-named ambient modules matter here (`declare global` has no module
+                // name to resolve; tsgo drops it at resolution time).
+                let TSModuleDeclarationName::StringLiteral(name) = &decl.id else { return };
+                if !(in_ambient_module || decl.declare || self.is_declaration_file) {
+                    return;
+                }
+                // Ambient module declarations can be interpreted as augmentations of existing
+                // external modules: in an external module file, any of them; in a script file,
+                // the non-relative ones immediately nested in a top-level ambient module.
+                if self.is_external_module
+                    || (in_ambient_module && !is_external_module_name_relative(&name.value))
+                {
+                    self.module_augmentations.push(CompactStr::from(name.value.as_str()));
+                } else if !in_ambient_module {
+                    // A top-level ambient module declaration in a script file *declares* the
+                    // module — nothing to resolve, but its body may reference other modules.
+                    if let Some(TSModuleDeclarationBody::TSModuleBlock(block)) = &decl.body {
+                        for statement in &block.body {
+                            self.collect_module_references(statement, true);
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Record a statically referenced module name. Inside an ambient module, relative names
+    /// cannot reference other external modules (TypeScript 1.0 spec §12.1.6).
+    fn add_static(&mut self, start: u32, name: &str, in_ambient_module: bool) {
+        if !name.is_empty() && (!in_ambient_module || !is_external_module_name_relative(name)) {
+            self.statics.push((start, CompactStr::from(name)));
+        }
+    }
+}
+
+/// Collects dynamic `import()`s, `import("...")` type queries (tsgo's "type space imports",
+/// which live in type positions anywhere in the AST), and — in JavaScript files —
+/// `require("...")` calls.
+struct CallCollector<'v> {
+    dynamics: &'v mut Vec<(u32, CompactStr)>,
+    collect_require_calls: bool,
+}
+
+impl CallCollector<'_> {
+    /// Record a string-literal-like specifier (tsgo `requireStringLiteralLikeArgument`: a plain
+    /// string literal or a no-substitution template), using the parsed (cooked) value so escape
+    /// sequences resolve the same file TypeScript would.
+    fn add_string_literal_like(&mut self, expression: &Expression<'_>) {
+        match expression {
+            Expression::StringLiteral(literal) => {
+                if !literal.value.is_empty() {
+                    self.dynamics
+                        .push((literal.span.start, CompactStr::from(literal.value.as_str())));
+                }
+            }
+            Expression::TemplateLiteral(template) if template.is_no_substitution_template() => {
+                let value = template.quasis[0].value.cooked.as_ref().map_or_else(
+                    || template.quasis[0].value.raw.as_str(),
+                    |cooked| cooked.as_str(),
+                );
+                if !value.is_empty() {
+                    self.dynamics.push((template.span.start, CompactStr::from(value)));
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+impl<'a> Visit<'a> for CallCollector<'_> {
+    fn visit_import_expression(&mut self, it: &ImportExpression<'a>) {
+        self.add_string_literal_like(&it.source);
+        walk::walk_import_expression(self, it);
+    }
+
+    fn visit_ts_import_type(&mut self, it: &TSImportType<'a>) {
+        if !it.source.value.is_empty() {
+            self.dynamics.push((it.source.span.start, CompactStr::from(it.source.value.as_str())));
+        }
+        // Type arguments may nest further import types.
+        walk::walk_ts_import_type(self, it);
+    }
+
+    fn visit_call_expression(&mut self, it: &CallExpression<'a>) {
+        // tsgo `IsRequireCall` (shape only, no shadowing check): a call to the identifier
+        // `require` with exactly one string-literal-like argument.
+        if self.collect_require_calls
+            && let Expression::Identifier(callee) = &it.callee
+            && callee.name == "require"
+            && it.arguments.len() == 1
+            && let Some(argument) = it.arguments[0].as_expression()
+        {
+            self.add_string_literal_like(argument);
+        }
+        walk::walk_call_expression(self, it);
+    }
+}

--- a/crates/oxc_type_checker/src/compiler/source_file.rs
+++ b/crates/oxc_type_checker/src/compiler/source_file.rs
@@ -1,0 +1,168 @@
+//! A parsed source file — its arena, AST, and module record — referenced by [`FileId`](super::FileId).
+//!
+//! Corresponds to typescript-go's `ast.SourceFile` (`internal/ast/ast.go`) + `SourceFileParseOptions`
+//! (`internal/ast/parseoptions.go`). A loaded file keeps its parsed AST so the checker can run over
+//! it without re-parsing, plus the collected external module references (tsgo `Imports` /
+//! `ModuleAugmentations`, see [`references`](super::references)). No `Semantic` is built yet — only
+//! the parse output (`Program` + `ModuleRecord`), which is what import discovery needs.
+
+use std::{
+    fmt,
+    path::{Path, PathBuf},
+};
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::Program as AstProgram;
+use oxc_diagnostics::Diagnostics;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use oxc_str::CompactStr;
+use oxc_syntax::module_record::ModuleRecord;
+use self_cell::self_cell;
+
+use super::references::{ExternalModuleReferences, collect_external_module_references};
+
+/// Inputs to parse a source file, mirroring tsgo's `ast.SourceFileParseOptions`.
+#[derive(Debug, Clone)]
+pub struct SourceFileParseOptions {
+    /// The file's resolved name (absolute, normalized).
+    pub file_name: PathBuf,
+    /// The normalized path used as the file's identity key (tsgo `tspath.Path`).
+    pub path: PathBuf,
+}
+
+/// Backing storage the AST + module record borrow from: the arena and the owned source text.
+struct SourceFileOwner {
+    allocator: Allocator,
+    source_text: String,
+}
+
+// A `SourceFile` is self-referential: the parsed `Program`/`ModuleRecord` borrow from the arena and
+// source text. `self_cell` stores the owner (arena + text) alongside the parse output that borrows
+// from it. Mirrors `oxc_linter`'s `ModuleContent`.
+self_cell! {
+    struct SourceFileCell {
+        owner: SourceFileOwner,
+        #[covariant]
+        dependent: SourceFileData,
+    }
+}
+
+struct SourceFileData<'a> {
+    program: AstProgram<'a>,
+    module_record: ModuleRecord<'a>,
+}
+
+// SAFETY: `SourceFileCell` owns the arena (inside `SourceFileOwner`) together with the `Program` and
+// `ModuleRecord` that borrow from it, with no outside borrows. Moving the cell moves the arena with
+// its dependents, so the arena references stay valid across threads. This lets a parsed file be sent
+// between rayon workers and the graph thread (mirrors `oxc_linter`'s `ModuleContent`).
+unsafe impl Send for SourceFileCell {}
+
+/// A single parsed source file.
+///
+/// Corresponds to tsgo's `*ast.SourceFile`. It keeps its arena-backed AST (`program`), import data
+/// (`module_record`), and the module specifiers collected for resolution (tsgo `Imports` /
+/// `ModuleAugmentations`). The resolved module-graph edges live on the program's
+/// `ProcessedFiles`, not the file (as in tsgo).
+pub struct SourceFile {
+    parse_options: SourceFileParseOptions,
+    source_type: SourceType,
+    cell: SourceFileCell,
+    /// Parse diagnostics. Owned (they do not borrow the arena). Not yet rendered.
+    diagnostics: Diagnostics,
+    /// The file's external module references (tsgo `SourceFile.Imports` + `ModuleAugmentations`).
+    references: ExternalModuleReferences,
+}
+
+impl SourceFile {
+    /// Parse `source_text`, mirroring tsgo's `parser.ParseSourceFile`: parse, then collect the
+    /// file's external module references. `source_type` selects the JS/TS dialect (derived from
+    /// the file extension).
+    pub(crate) fn parse(
+        parse_options: SourceFileParseOptions,
+        source_text: String,
+        source_type: SourceType,
+    ) -> Self {
+        let mut diagnostics = Diagnostics::new();
+        let owner = SourceFileOwner { allocator: Allocator::default(), source_text };
+        let cell = SourceFileCell::new(owner, |owner| {
+            let ret = Parser::new(&owner.allocator, &owner.source_text, source_type).parse();
+            diagnostics.extend(ret.diagnostics.into_vec());
+            SourceFileData { program: ret.program, module_record: ret.module_record }
+        });
+        let references = {
+            let data = cell.borrow_dependent();
+            collect_external_module_references(
+                &data.program,
+                &data.module_record,
+                source_type.is_typescript_definition(),
+            )
+        };
+        Self { parse_options, source_type, cell, diagnostics, references }
+    }
+
+    /// The file's resolved name (absolute, normalized).
+    pub fn file_name(&self) -> &Path {
+        &self.parse_options.file_name
+    }
+
+    /// The file's normalized identity key (tsgo `tspath.Path`).
+    pub fn path(&self) -> &Path {
+        &self.parse_options.path
+    }
+
+    /// The JS/TS dialect the file was parsed as.
+    pub fn source_type(&self) -> SourceType {
+        self.source_type
+    }
+
+    /// Parse diagnostics collected for this file.
+    pub fn diagnostics(&self) -> &Diagnostics {
+        &self.diagnostics
+    }
+
+    /// The parsed AST.
+    pub fn program(&self) -> &AstProgram<'_> {
+        &self.cell.borrow_dependent().program
+    }
+
+    /// The file's module record (imports/exports).
+    pub fn module_record(&self) -> &ModuleRecord<'_> {
+        &self.cell.borrow_dependent().module_record
+    }
+
+    /// The module specifiers this file imports, in tsgo's `SourceFile.Imports` order: static
+    /// imports/re-exports in source order, then dynamic `import()`s and `import("...")` type
+    /// queries in source order.
+    pub fn imports(&self) -> &[CompactStr] {
+        &self.references.imports
+    }
+
+    /// String-literal `declare module "..."` names that augment an existing external module
+    /// (tsgo `SourceFile.ModuleAugmentations`).
+    pub fn module_augmentations(&self) -> &[CompactStr] {
+        &self.references.module_augmentations
+    }
+
+    /// `/// <reference path="..." />` pragmas (tsgo `SourceFile.ReferencedFiles`).
+    pub fn referenced_files(&self) -> &[CompactStr] {
+        &self.references.referenced_files
+    }
+
+    /// `/// <reference types="..." />` pragmas (tsgo `SourceFile.TypeReferenceDirectives`).
+    pub fn type_reference_directives(&self) -> &[CompactStr] {
+        &self.references.type_reference_directives
+    }
+}
+
+impl fmt::Debug for SourceFile {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SourceFile")
+            .field("file_name", &self.parse_options.file_name)
+            .field("source_type", &self.source_type)
+            .field("diagnostics", &self.diagnostics.len())
+            .field("imports", &self.references.imports.len())
+            .finish_non_exhaustive()
+    }
+}

--- a/crates/oxc_type_checker/src/execute/tsc.rs
+++ b/crates/oxc_type_checker/src/execute/tsc.rs
@@ -9,7 +9,7 @@ use std::{
 use anyhow::{Context, Result, bail};
 
 use crate::{
-    compiler::Program,
+    compiler::{Program, ProgramOptions},
     tsoptions::{TypeCheckCommand, get_file_names, parse_command_line, parse_config_file},
     tspath::to_path,
 };
@@ -39,22 +39,23 @@ fn tsc_compilation(command: &TypeCheckCommand) -> Result<()> {
     let cwd =
         std::env::current_dir().context("Unable to determine the current working directory")?;
 
-    let root_files = match resolve_config_file(command, &cwd)? {
-        // A resolved config file: parse it (resolving `extends`) via `oxc_resolver`, then expand
-        // its file globs into the root file list.
+    let (root_files, config) = match resolve_config_file(command, &cwd)? {
+        // A resolved config file: parse it (resolving `extends`) via `oxc_resolver`, expand its
+        // file globs into the root file list, and keep the parsed config to drive module
+        // resolution and the compiler-option gates.
         Some(config_file) => {
             let tsconfig = parse_config_file(&config_file)?;
             println!("project: {}", config_file.display());
-            get_file_names(&tsconfig)
+            (get_file_names(&tsconfig), Some(tsconfig))
         }
         // Source files given without a config file: use them directly as roots.
-        None => command.files.clone(),
+        None => (command.files.clone(), None),
     };
 
-    // Collect the root files (normalized + deduplicated) into the program's file list.
-    let program = Program::new(&cwd, &root_files);
+    // Parse the roots, follow their imports to load every dependent file, and collect them.
+    let program = Program::new(ProgramOptions { current_directory: cwd, root_files, config });
     for file in program.files() {
-        println!("  {}", file.display());
+        println!("  {}", file.file_name().display());
     }
     println!("({} files)", program.len());
     Ok(())

--- a/crates/oxc_type_checker/src/tsoptions/mod.rs
+++ b/crates/oxc_type_checker/src/tsoptions/mod.rs
@@ -6,4 +6,8 @@ mod commandlineparser;
 mod tsconfigparsing;
 
 pub use commandlineparser::{TypeCheckCommand, parse_command_line};
+pub(crate) use tsconfigparsing::{
+    SUPPORTED_TS_EXTENSIONS_WITH_JSON_FLAT, get_allow_js, get_resolve_json_module,
+    get_supported_extensions, get_supported_extensions_with_json_flat,
+};
 pub use tsconfigparsing::{get_file_names, parse_config_file};

--- a/crates/oxc_type_checker/src/tsoptions/tsconfigparsing.rs
+++ b/crates/oxc_type_checker/src/tsoptions/tsconfigparsing.rs
@@ -29,6 +29,48 @@ const ALL_SUPPORTED_EXTENSIONS: &[&[&str]] = &[
     &[".mts", ".d.mts", ".mjs"],
 ];
 
+/// tsgo `tspath.SupportedTSExtensionsWithJsonFlat`: the extensions of resolved imports that are
+/// *not* considered JavaScript files by `resolveImportsAndModuleAugmentations`'s gating.
+pub const SUPPORTED_TS_EXTENSIONS_WITH_JSON_FLAT: &[&str] =
+    &[".ts", ".tsx", ".d.ts", ".cts", ".d.cts", ".mts", ".d.mts", ".json"];
+
+/// tsgo `CompilerOptions.GetAllowJS`: `allowJs` if set, otherwise fall back to `checkJs`.
+pub fn get_allow_js(options: &CompilerOptions) -> bool {
+    options.allow_js.unwrap_or(options.check_js == Some(true))
+}
+
+/// tsgo `CompilerOptions.GetResolveJsonModule`: the explicit value when set; otherwise `true`
+/// unless the module-resolution kind is `node16` (tsgo's `GetModuleResolutionKind` resolves
+/// every other default to `Bundler` or `nodenext`, both of which resolve JSON modules).
+///
+/// `oxc_resolver` does not expose `moduleResolution`, but tsc rejects
+/// `moduleResolution: node16/nodenext` unless `module` is set to a matching value
+/// (TS5109/TS5110), so deriving the kind from `module` alone is equivalent.
+pub fn get_resolve_json_module(options: &CompilerOptions) -> bool {
+    if let Some(explicit) = options.resolve_json_module {
+        return explicit;
+    }
+    !options.module.as_deref().is_some_and(|module| {
+        module.eq_ignore_ascii_case("node16") || module.eq_ignore_ascii_case("node18")
+    })
+}
+
+/// tsgo `GetSupportedExtensions`: JS extensions are added when `allowJs` (or `checkJs`) is on.
+pub fn get_supported_extensions(options: &CompilerOptions) -> &'static [&'static [&'static str]] {
+    if get_allow_js(options) { ALL_SUPPORTED_EXTENSIONS } else { SUPPORTED_TS_EXTENSIONS }
+}
+
+/// tsgo `GetSupportedExtensionsWithJsonIfResolveJsonModule`, flattened: every supported
+/// extension, plus `.json` when JSON modules resolve.
+pub fn get_supported_extensions_with_json_flat(options: &CompilerOptions) -> Vec<&'static str> {
+    let mut extensions: Vec<&'static str> =
+        get_supported_extensions(options).iter().flat_map(|group| group.iter().copied()).collect();
+    if get_resolve_json_module(options) {
+        extensions.push(".json");
+    }
+    extensions
+}
+
 /// Parse the `tsconfig.json` at `config_file`, resolving its `extends` chain.
 ///
 /// Mirrors tsgo's `GetParsedCommandLineOfConfigFile`, but delegates the JSONC parse and the
@@ -55,14 +97,11 @@ pub fn parse_config_file(config_file: &Path) -> anyhow::Result<Arc<TsConfig>> {
 pub fn get_file_names(tsconfig: &TsConfig) -> Vec<PathBuf> {
     let base = tsconfig.directory();
     let options = &tsconfig.compiler_options;
-    let extension_groups = supported_extension_groups(options);
+    let extension_groups = get_supported_extensions(options);
 
-    // Flat suffix list for the directory walk, plus `.json` when `resolveJsonModule` is on.
-    let mut walk_extensions: Vec<&str> =
-        extension_groups.iter().flat_map(|group| group.iter().copied()).collect();
-    if options.resolve_json_module == Some(true) {
-        walk_extensions.push(".json");
-    }
+    // Flat suffix list for the directory walk, plus `.json` when JSON modules resolve
+    // (tsgo walks with `GetSupportedExtensionsWithJsonIfResolveJsonModule`).
+    let walk_extensions = get_supported_extensions_with_json_flat(options);
 
     // Literal `files` are always included and cannot be removed by `include`/`exclude`.
     let mut literal_files = Vec::new();
@@ -134,13 +173,6 @@ pub fn get_file_names(tsconfig: &TsConfig) -> Vec<PathBuf> {
     result.extend(wildcard_files.into_values());
     result.extend(json_files.into_values());
     result
-}
-
-/// tsgo `GetSupportedExtensions`: JS extensions are added when `allowJs` (or `checkJs`) is on.
-fn supported_extension_groups(options: &CompilerOptions) -> &'static [&'static [&'static str]] {
-    // tsgo `GetAllowJS`: use `allowJs` if set, otherwise fall back to `checkJs`.
-    let allow_js = options.allow_js.unwrap_or(options.check_js == Some(true));
-    if allow_js { ALL_SUPPORTED_EXTENSIONS } else { SUPPORTED_TS_EXTENSIONS }
 }
 
 /// tsgo `hasFileWithHigherPriorityExtension`.

--- a/crates/oxc_type_checker/src/tspath.rs
+++ b/crates/oxc_type_checker/src/tspath.rs
@@ -57,6 +57,19 @@ pub fn change_extension(path: &str, new_extension: &str) -> String {
     format!("{path}{new_extension}")
 }
 
+/// tsgo `IsExternalModuleNameRelative`: the module name starts with `./`, `../`, or is `.`/`..`
+/// (`tspath.PathIsRelative`, including the Windows `.\` forms).
+pub fn is_external_module_name_relative(module_name: &str) -> bool {
+    let rest = if let Some(rest) = module_name.strip_prefix("..") {
+        rest
+    } else if let Some(rest) = module_name.strip_prefix('.') {
+        rest
+    } else {
+        return false;
+    };
+    rest.is_empty() || rest.starts_with('/') || rest.starts_with('\\')
+}
+
 /// tsgo `ToPath` / `GetNormalizedAbsolutePath`: resolve `file_name` against
 /// `current_directory` into an absolute, lexically-normalized path (collapsing `.`/`..`).
 ///

--- a/crates/oxc_type_checker/src/vfs/vfsmatch.rs
+++ b/crates/oxc_type_checker/src/vfs/vfsmatch.rs
@@ -262,15 +262,16 @@ impl GlobMatcher {
         }
     }
 
-    /// tsgo `matchesFileParts` (reduced to a boolean; include bucketing isn't needed).
-    fn file_matches(&self, segments: &[&str]) -> bool {
+    /// tsgo `matchesFileParts`: the index of the first include pattern the file matches (the
+    /// result bucket it lands in), or `None` when excluded or unmatched.
+    fn file_matches(&self, segments: &[&str]) -> Option<usize> {
         if self.excludes.iter().any(|pattern| pattern.matches(segments, false)) {
-            return false;
+            return None;
         }
         if self.includes.is_empty() {
-            return !self.had_includes;
+            return if self.had_includes { None } else { Some(0) };
         }
-        self.includes.iter().any(|pattern| pattern.matches(segments, false))
+        self.includes.iter().position(|pattern| pattern.matches(segments, false))
     }
 
     /// tsgo `matchesDirectoryParts`: could any file under this directory match?
@@ -326,6 +327,10 @@ fn get_base_paths(base: &Path, includes: &[String]) -> Vec<PathBuf> {
 /// tsgo `ReadDirectory`/`matchFiles`: collect files under `base` matching the specs, filtered
 /// by `extensions` (a flat suffix list). Directories are walked only when they could contain a
 /// match, so `node_modules` and excluded subtrees are pruned.
+///
+/// Files are kept in one result bucket per include pattern and the buckets are concatenated in
+/// include order (tsgo's `results [][]string`) — so a file's position follows the first include
+/// spec it matches, not the raw walk order.
 pub fn read_directory(
     base: &Path,
     extensions: &[&str],
@@ -334,11 +339,11 @@ pub fn read_directory(
 ) -> Vec<PathBuf> {
     let matcher = GlobMatcher::new(includes, excludes);
     let mut visited_symlinks = FxHashSet::default();
-    let mut results = Vec::new();
+    let mut results: Vec<Vec<PathBuf>> = vec![Vec::new(); matcher.includes.len().max(1)];
     for base_path in get_base_paths(base, includes) {
         visit(&base_path, &matcher, extensions, &mut visited_symlinks, &mut results);
     }
-    results
+    results.into_iter().flatten().collect()
 }
 
 fn visit(
@@ -346,7 +351,7 @@ fn visit(
     matcher: &GlobMatcher,
     extensions: &[&str],
     visited_symlinks: &mut FxHashSet<PathBuf>,
-    results: &mut Vec<PathBuf>,
+    results: &mut [Vec<PathBuf>],
 ) {
     let Ok(entries) = std::fs::read_dir(dir) else {
         return;
@@ -388,9 +393,9 @@ fn visit(
         }
         let full = dir.join(name);
         let full_string = full.to_string_lossy();
-        if matcher.file_matches(&path_segments(&full_string)) {
+        if let Some(bucket) = matcher.file_matches(&path_segments(&full_string)) {
             drop(full_string);
-            results.push(full);
+            results[bucket].push(full);
         }
     }
 


### PR DESCRIPTION
## Summary

Extends the type-checker's program loader to the full transitive load, mirroring typescript-go's `parseTask.load` → `resolveImportsAndModuleAugmentations` → `filesParser` work-group: **parse every root file, resolve everything it references, and recursively load the dependent files — parallelized with rayon.** `Program` now contains the whole transitive file set in tsgo's program order, each file with its parsed AST.

Verified file-for-file — **set and order** — against `tsgo --listFiles` across the ecosystem-ci repos (23 exact matches, including openclaw 16,230 files; remaining diffs are documented resolver-mode/JSDoc gaps, see Verification).

## Details

- **Keep the parsed ASTs.** Each loaded file is a `SourceFile` bundling its arena + `Program` (AST) + `ModuleRecord` behind a `self_cell` with `unsafe impl Send` (mirrors oxc_linter's `ModuleContent`). Resolved module-graph edges live on the program (`Program::resolved_module`, tsgo `resolvedModules`), not the file — as in tsgo, where `ast.SourceFile` is parse-only.
- **Parallel loading** (`filesparser.rs`): one `rayon::scope` where a single graph thread owns the dedup `FxHashSet` and drains results over an mpsc channel (dedup is lock-free — single-threaded), while workers `scope.spawn` the parse + resolve. `FileId`s are then assigned by tsgo's `collectFiles` order: a post-order walk of the task graph from the roots, so dependencies come before their importers — deterministic despite rayon's arrival order.
- **Reference collection** (`references.rs`, port of `internal/parser/references.go`): everything tsgo feeds the resolver — static imports/re-exports in source order, `import x = require("...")`, statements nested in ambient module bodies, `declare module "..."` augmentations, dynamic `import()`s, `import("...")` type queries, `require()` calls in JavaScript files, and `/// <reference path|types>` pragmas.
- **Resolution + `shouldAddFile` gating** (`fileloader.rs`): `oxc_resolver`'s TS-aware `resolve_dts` (`@types`, TS-faithful `.js`→`.ts`/`.tsx`/`.d.ts` substitution), driven by the project's tsconfig. Files with unsupported extensions are dropped at load time (tsgo `missingFiles`); JS resolutions require `allowJs` and are elided under node_modules (`maxNodeModuleJsDepth` default); `.json` follows the `GetResolveJsonModule` defaulting chain; `.tsx`/`.jsx` require `jsx`; arbitrary extensions only resolve from declaration files; bundler-style `?query` suffixes never resolve (tsc resolves specifiers literally).
- **Program root order**: `read_directory` now keeps one result bucket per include spec and flattens in spec order (tsgo `matchFiles`' `results [][]string`), so root order follows the include list, not raw walk order.
- `Program::new(ProgramOptions)` mirrors tsgo `NewProgram(opts)`. Deps: promote `oxc_parser` + `oxc_allocator`; add `self_cell`, `rayon`, `oxc_syntax`, `oxc_str`, `oxc_ast_visit`.

## Deferred

Lib files (`compilerOptions.lib`, `/// <reference lib>`, default lib), automatic type directives (`@types/*` auto-loading), per-usage ESM/CJS resolution modes (node16 extension strictness — `resolve_dts` is bundler-only), JSDoc type references in JS files, real JSON parsing (`.json` files enter the program but are not parsed as JSON yet), project references, processing diagnostics / file-include reasons, and case-insensitive dedup.

## Verification

- `cargo build` / `clippy` clean; doctests pass; nightly `--all-features` build + doc clean (the self_cell/CI condition). Deterministic: two runs over sentry-javascript (5,998 files) byte-identical.
- Targeted fixtures match tsgo exactly (order included): post-order DFS, dynamic imports, import-type queries, augmentations, `resolveJsonModule` defaulting (bundler vs `node16`), `allowJs` on/off, node_modules JS elision, unsupported-extension imports.
- **Ecosystem sweep** (33 repos, comparing set *and order* against `tsgo -p . --listFiles`, excluding lib files and node_modules): **23 exact, 0 panics** (openclaw 16,230 / posthog 8,164 / sentry 5,998 / outline 2,032 all order-exact). Remaining 3 diffs are documented gaps, all order-only or marginal: formatjs (tsc does not extension-append extensionless `#imports`-field targets), turborepo (`nodenext` forbids extensionless relative imports; our resolution is mode-less), kibana (2 files reachable only via JSDoc `@type {import(...)}` in JS). 7 errors: 4 are tsgo itself failing on the repo's config, 3 are the pre-existing unresolved-`extends`-package hard error.