### PR TITLE
fix(transformer): clean up semantics for stripped TypeScript syntax

### DIFF
--- a/crates/oxc_semantic/src/scoping.rs
+++ b/crates/oxc_semantic/src/scoping.rs
@@ -512,6 +512,31 @@ impl Scoping {
         });
     }
 
+    /// Remove one declaration from a merged symbol and promote the first surviving declaration.
+    pub fn remove_symbol_declaration(&mut self, symbol_id: SymbolId, span: Span) {
+        let replacement = self.cell.with_dependent_mut(|_allocator, cell| {
+            let redeclarations = cell.symbol_redeclarations.get_mut(&symbol_id)?;
+            redeclarations.retain(|redeclaration| redeclaration.span != span);
+
+            let first = redeclarations.first()?.clone();
+            let flags = redeclarations
+                .iter()
+                .fold(SymbolFlags::None, |flags, redeclaration| flags | redeclaration.flags);
+            let has_redeclarations = redeclarations.len() > 1;
+            if !has_redeclarations {
+                cell.symbol_redeclarations.remove(&symbol_id);
+            }
+
+            Some((first, flags))
+        });
+
+        if let Some((replacement, flags)) = replacement {
+            *self.symbol_table.symbol_spans_mut(symbol_id) = replacement.span;
+            *self.symbol_table.symbol_declarations_mut(symbol_id) = replacement.declaration;
+            *self.symbol_table.symbol_flags_mut(symbol_id) = flags;
+        }
+    }
+
     #[inline]
     /// Create and store a reference entry.
     pub fn create_reference(&mut self, reference: Reference) -> ReferenceId {
@@ -997,7 +1022,30 @@ impl Scoping {
 
     /// Remove bindings that exist only in TypeScript type space.
     pub fn delete_typescript_bindings(&mut self) {
+        #[expect(
+            clippy::inline_always,
+            reason = "Hot predicate called for every semantic reference"
+        )]
+        #[inline(always)]
+        fn is_typescript_reference(reference: &Reference) -> bool {
+            let flags = reference.flags();
+            (flags.is_type() && !flags.is_value()) || flags.is_value_as_type()
+        }
+
+        let references = &self.references;
+
         self.cell.with_dependent_mut(|_allocator, cell| {
+            for reference_ids in &mut cell.resolved_references {
+                reference_ids
+                    .retain(|reference_id| !is_typescript_reference(&references[*reference_id]));
+            }
+
+            cell.root_unresolved_references.retain(|_name, reference_ids| {
+                reference_ids
+                    .retain(|reference_id| !is_typescript_reference(&references[*reference_id]));
+                !reference_ids.is_empty()
+            });
+
             for bindings in &mut cell.bindings {
                 bindings.retain(|_name, symbol_id| {
                     let flags = *self.symbol_table.symbol_flags(*symbol_id);

--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -88,6 +88,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for TypeScriptAnnotations<'a> {
                 }
                 Statement::ImportDeclaration(decl) => {
                     if decl.import_kind.is_type() {
+                        Self::remove_import_declaration_bindings(decl, ctx);
                         false
                     } else if let Some(specifiers) = &mut decl.specifiers {
                         if specifiers.is_empty() {
@@ -99,6 +100,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for TypeScriptAnnotations<'a> {
                                 let id = match specifier {
                                     ImportDeclarationSpecifier::ImportSpecifier(s) => {
                                         if s.import_kind.is_type() {
+                                            Self::remove_binding(&s.local, ctx);
                                             return false;
                                         }
                                         &s.local
@@ -112,10 +114,11 @@ impl<'a> Traverse<'a, TransformState<'a>> for TypeScriptAnnotations<'a> {
                                 };
                                 // If `only_remove_type_imports` is true, then we can return `true` to keep it because
                                 // it is not a type import, otherwise we need to check if the identifier is referenced
-                                if self.only_remove_type_imports {
+                                if self.only_remove_type_imports || self.has_value_reference(id, ctx) {
                                     true
                                 } else {
-                                    self.has_value_reference(id, ctx)
+                                    Self::remove_binding(id, ctx);
+                                    false
                                 }
                             });
 
@@ -541,6 +544,36 @@ impl<'a> TypeScriptAnnotations<'a> {
                 keep
             }
         }
+    }
+
+    fn remove_import_declaration_bindings(decl: &ImportDeclaration<'a>, ctx: &mut TraverseCtx<'a>) {
+        if let Some(specifiers) = &decl.specifiers {
+            for specifier in specifiers {
+                match specifier {
+                    ImportDeclarationSpecifier::ImportSpecifier(specifier) => {
+                        Self::remove_binding(&specifier.local, ctx);
+                    }
+                    ImportDeclarationSpecifier::ImportDefaultSpecifier(specifier) => {
+                        Self::remove_binding(&specifier.local, ctx);
+                    }
+                    ImportDeclarationSpecifier::ImportNamespaceSpecifier(specifier) => {
+                        Self::remove_binding(&specifier.local, ctx);
+                    }
+                }
+            }
+        }
+    }
+
+    fn remove_binding(ident: &BindingIdentifier<'a>, ctx: &mut TraverseCtx<'a>) {
+        let symbol_id = ident.symbol_id();
+        let flags = ctx.scoping().symbol_flags(symbol_id);
+        if (flags - SymbolFlags::Import - SymbolFlags::TypeImport).is_value() {
+            ctx.scoping_mut().remove_symbol_declaration(symbol_id, ident.span);
+            return;
+        }
+
+        let scope_id = ctx.scoping().symbol_scope_id(symbol_id);
+        ctx.scoping_mut().remove_binding(scope_id, ident.name);
     }
 
     /// Check if the given name is a JSX pragma or fragment pragma import

--- a/tasks/coverage/misc/pass/type-import-value-redeclaration.ts
+++ b/tasks/coverage/misc/pass/type-import-value-redeclaration.ts
@@ -1,0 +1,5 @@
+import type { Foo, TypeOnly } from "foo";
+import { type Foo2, type SpecifierOnly } from "foo";
+
+function Foo() {}
+function Foo2() {}

--- a/tasks/coverage/snapshots/codegen_misc.snap
+++ b/tasks/coverage/snapshots/codegen_misc.snap
@@ -1,3 +1,3 @@
 codegen_misc Summary:
-AST Parsed     : 69/69 (100.00%)
-Positive Passed: 69/69 (100.00%)
+AST Parsed     : 70/70 (100.00%)
+Positive Passed: 70/70 (100.00%)

--- a/tasks/coverage/snapshots/formatter_misc.snap
+++ b/tasks/coverage/snapshots/formatter_misc.snap
@@ -1,3 +1,3 @@
 formatter_misc Summary:
-AST Parsed     : 69/69 (100.00%)
-Positive Passed: 69/69 (100.00%)
+AST Parsed     : 70/70 (100.00%)
+Positive Passed: 70/70 (100.00%)

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,6 +1,6 @@
 parser_misc Summary:
-AST Parsed     : 69/69 (100.00%)
-Positive Passed: 69/69 (100.00%)
+AST Parsed     : 70/70 (100.00%)
+Positive Passed: 70/70 (100.00%)
 Negative Passed: 149/149 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -2,7 +2,7 @@ commit: 1fb0b771
 
 semantic_babel Summary:
 AST Parsed     : 2236/2236 (100.00%)
-Positive Passed: 2036/2236 (91.06%)
+Positive Passed: 2127/2236 (95.13%)
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/decorators/decorators-after-export/input.js
 Symbol span mismatch for "C":
 after transform: SymbolId(0): Span { start: 65, end: 66 }
@@ -35,16 +35,6 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "E":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/sourcetype-unambiguous/typescript-type-only/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["Foo"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/sourcetype-unambiguous/typescript-value-import/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["Foo"]
-rebuilt        : ScopeId(0): []
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/class-private-properties/await-in-private-property-in-params-of-async-arrow/input.js
 Bindings mismatch:
@@ -88,11 +78,6 @@ rebuilt        : ["arguments", "of", "require"]
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/class-private-method/typescript-invalid-abstract/input.ts
 'abstract' modifier cannot be used with a private identifier.
 
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/class-private-property/typescript/input.js
-Unresolved references mismatch:
-after transform: ["Array", "WeakMap", "foo", "require"]
-rebuilt        : ["WeakMap", "foo", "require"]
-
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/typescript/enum/input.js
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "a", "r"]
@@ -104,68 +89,15 @@ Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/typescript/instantiation-expression-optional-chain/input.ts
-Unresolved references mismatch:
-after transform: ["a", "c"]
-rebuilt        : ["a"]
-
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/typescript/loc-index-property/input.js
 Bindings mismatch:
 after transform: ScopeId(0): ["AssertsFoo", "Foo", "_defineProperty"]
 rebuilt        : ScopeId(0): ["AssertsFoo", "_defineProperty"]
 
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/typescript/optional-chaining/input.js
-Unresolved references mismatch:
-after transform: ["T", "foo"]
-rebuilt        : ["foo"]
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/arrow-function/arrow-function-with-newline/input.ts
-Unresolved references mismatch:
-after transform: ["arguments", "t"]
-rebuilt        : ["arguments"]
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/arrow-function/arrow-like-in-conditional-3/input.ts
-Unresolved references mismatch:
-after transform: ["v"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/arrow-function/arrow-like-in-conditional-4/input.ts
-Unresolved references mismatch:
-after transform: ["v"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/arrow-function/async-call-in-conditional/input.ts
-Unresolved references mismatch:
-after transform: ["a", "arguments", "async", "b"]
-rebuilt        : ["a", "arguments", "async"]
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/arrow-function/async-generic-false-positive/input.ts
-Unresolved references mismatch:
-after transform: ["T", "async"]
-rebuilt        : ["async"]
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/arrow-function/destructuring-with-annotation-newline/input.ts
-Unresolved references mismatch:
-after transform: ["T"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/assert-predicate/arrow-function/input.ts
-Unresolved references mismatch:
-after transform: ["asserts"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/assert-predicate/asserts-as-identifier/input.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["assertIsString"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["asserts"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/assert-predicate/asserts-this-with-predicate/input.ts
-Symbol reference IDs mismatch for "Foo":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(1): []
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/assert-predicate/asserts-var/input.ts
 Bindings mismatch:
@@ -177,58 +109,15 @@ Bindings mismatch:
 after transform: ScopeId(0): ["assertIsString"]
 rebuilt        : ScopeId(0): []
 
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/assert-predicate/function-declaration/input.ts
-Unresolved references mismatch:
-after transform: ["asserts"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/cast/as/input.ts
-Unresolved references mismatch:
-after transform: ["T", "x", "y"]
-rebuilt        : ["x", "y"]
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/cast/as-const/input.ts
-Unresolved references mismatch:
-after transform: ["a7", "const", "d", "o4"]
-rebuilt        : ["a7", "d", "o4"]
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/cast/destructuring-assignment-in-parens/input.ts
-Unresolved references mismatch:
-after transform: ["T", "a", "b", "c", "x", "y"]
-rebuilt        : ["a", "b", "c", "x", "y"]
-
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/cast/for-of-lhs/input.ts
 Reference flags mismatch for "a":
 after transform: ReferenceId(3): ReferenceFlags(Read)
 rebuilt        : ReferenceId(1): ReferenceFlags(Write)
-Unresolved references mismatch:
-after transform: ["T", "a"]
-rebuilt        : ["a"]
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/cast/need-parentheses/input.ts
-Unresolved references mismatch:
-after transform: ["T", "x"]
-rebuilt        : ["x"]
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/cast/satisfies/input.ts
-Unresolved references mismatch:
-after transform: ["T", "a", "b", "x", "y"]
-rebuilt        : ["a", "b", "x", "y"]
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/catch-clause/unknown/input.ts
-Unresolved references mismatch:
-after transform: ["A", "Error"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/abstract/input.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["C1", "C2", "C3", "C4", "C5"]
 rebuilt        : ScopeId(0): ["C1", "C3", "C4", "C5"]
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/async-optional-method/input.js
-Unresolved references mismatch:
-after transform: ["B", "Promise"]
-rebuilt        : ["B"]
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/constructor-with-modifier-names/input.ts
 Multiple constructor implementations are not allowed.
@@ -241,45 +130,10 @@ Unresolved references mismatch:
 after transform: ["a"]
 rebuilt        : []
 
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/expression-extends/input.ts
-Unresolved references mismatch:
-after transform: ["T", "f"]
-rebuilt        : ["f"]
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/expression-extends-implements/input.ts
-Unresolved references mismatch:
-after transform: ["T", "X", "f"]
-rebuilt        : ["f"]
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/expression-implements/input.ts
-Unresolved references mismatch:
-after transform: ["T", "X"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/extends/input.ts
-Unresolved references mismatch:
-after transform: ["T", "f"]
-rebuilt        : ["f"]
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/extends-expression-assertion/input.ts
-Unresolved references mismatch:
-after transform: ["Array", "B", "D", "T"]
-rebuilt        : ["B"]
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/extends-implements/input.ts
-Unresolved references mismatch:
-after transform: ["T", "X", "f"]
-rebuilt        : ["f"]
-
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/get-generic/input.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["C"]
 rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/implements/input.ts
-Unresolved references mismatch:
-after transform: ["T", "X"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/members-with-modifier-names/input.ts
 Function implementation is missing or not immediately following the declaration.
@@ -484,11 +338,6 @@ Symbol flags mismatch for "E":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/explicit-resource-management/valid-for-using-declaration-binding-of/input.js
-Unresolved references mismatch:
-after transform: ["Reader", "reader"]
-rebuilt        : ["reader"]
-
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/export/declare/input.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "N", "_bar", "bar", "f", "foo", "x"]
@@ -528,11 +377,6 @@ Symbol span mismatch for "N":
 after transform: SymbolId(1): Span { start: 37, end: 38 }
 rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/function/anonymous-generator/input.ts
-Unresolved references mismatch:
-after transform: ["Generator"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/function/declare/input.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["f"]
@@ -546,44 +390,9 @@ Bindings mismatch:
 after transform: ScopeId(0): ["f"]
 rebuilt        : ScopeId(0): []
 
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/import/equals/input.ts
-Unresolved references mismatch:
-after transform: ["B"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/import/equals-in-unambiguous/input.ts
-Unresolved references mismatch:
-after transform: ["B"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/import/export-import-type-require/input.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["a"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/import/import-default-and-named-id-type/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["bar", "type"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/import/import-default-id-type/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["type"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/import/import-named/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["foo"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/import/import-star-as/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["a"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/import/internal-comments/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A", "C", "D", "foo"]
 rebuilt        : ScopeId(0): []
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/import/type-asi/input.ts
@@ -591,22 +400,7 @@ Bindings mismatch:
 after transform: ScopeId(0): ["B", "b"]
 rebuilt        : ScopeId(0): []
 
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/extends/input.ts
-Unresolved references mismatch:
-after transform: ["X", "Z"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/extends-identifier-type-arguments/input.ts
-Unresolved references mismatch:
-after transform: ["X", "Y", "Z"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/method-computed/input.ts
-Unresolved references mismatch:
-after transform: ["Symbol"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/property-computed/input.ts
 Unresolved references mismatch:
 after transform: ["Symbol"]
 rebuilt        : []
@@ -692,11 +486,6 @@ Bindings mismatch:
 after transform: ScopeId(0): ["as", "satisfies"]
 rebuilt        : ScopeId(0): []
 
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/elision-arrow-destructuring-13636/input.ts
-Unresolved references mismatch:
-after transform: ["b", "c"]
-rebuilt        : ["c"]
-
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/is-default-export/input.ts
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode)
@@ -704,16 +493,6 @@ rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "E":
 after transform: SymbolId(1): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/nested-extends-in-arrow-type-param/input.ts
-Unresolved references mismatch:
-after transform: ["A", "B", "C", "D", "E", "F", "G"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/nested-extends-in-arrow-type-return/input.ts
-Unresolved references mismatch:
-after transform: ["A", "B", "C", "D", "E", "F", "G"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/callable-class/input.ts
 Symbol flags mismatch for "C":
@@ -764,11 +543,6 @@ rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "Test":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/export-func-in-declare-module/input.ts
-Unresolved references mismatch:
-after transform: ["X"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/export-namespace/input.ts
 Bindings mismatch:
@@ -898,166 +672,8 @@ rebuilt        : SymbolId(0): Span { start: 34, end: 35 }
 Symbol redeclarations mismatch for "a":
 after transform: SymbolId(1): [Span { start: 23, end: 24 }, Span { start: 34, end: 35 }]
 rebuilt        : SymbolId(0): []
-Unresolved references mismatch:
-after transform: ["M"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-import-let/input.ts
-Symbol flags mismatch for "Context":
-after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | Import)
-rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Context":
-after transform: SymbolId(1): Span { start: 16, end: 23 }
-rebuilt        : SymbolId(1): Span { start: 104, end: 111 }
-Symbol reference IDs mismatch for "Context":
-after transform: SymbolId(1): [ReferenceId(0)]
-rebuilt        : SymbolId(1): []
-Symbol redeclarations mismatch for "Context":
-after transform: SymbolId(1): [Span { start: 16, end: 23 }, Span { start: 104, end: 111 }]
-rebuilt        : SymbolId(1): []
-Symbol flags mismatch for "a":
-after transform: SymbolId(2): SymbolFlags(BlockScopedVariable | Import)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "a":
-after transform: SymbolId(2): Span { start: 49, end: 50 }
-rebuilt        : SymbolId(2): Span { start: 156, end: 157 }
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(2): [ReferenceId(2)]
-rebuilt        : SymbolId(2): []
-Symbol redeclarations mismatch for "a":
-after transform: SymbolId(2): [Span { start: 49, end: 50 }, Span { start: 156, end: 157 }]
-rebuilt        : SymbolId(2): []
-Symbol flags mismatch for "b":
-after transform: SymbolId(3): SymbolFlags(BlockScopedVariable | Import)
-rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "b":
-after transform: SymbolId(3): Span { start: 81, end: 82 }
-rebuilt        : SymbolId(3): Span { start: 170, end: 171 }
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(3): [ReferenceId(3)]
-rebuilt        : SymbolId(3): []
-Symbol redeclarations mismatch for "b":
-after transform: SymbolId(3): [Span { start: 81, end: 82 }, Span { start: 170, end: 171 }]
-rebuilt        : SymbolId(3): []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-import-type-let/input.ts
-Symbol flags mismatch for "Context":
-after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | TypeImport)
-rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Context":
-after transform: SymbolId(1): Span { start: 21, end: 28 }
-rebuilt        : SymbolId(1): Span { start: 119, end: 126 }
-Symbol reference IDs mismatch for "Context":
-after transform: SymbolId(1): [ReferenceId(0)]
-rebuilt        : SymbolId(1): []
-Symbol redeclarations mismatch for "Context":
-after transform: SymbolId(1): [Span { start: 21, end: 28 }, Span { start: 119, end: 126 }]
-rebuilt        : SymbolId(1): []
-Symbol flags mismatch for "a":
-after transform: SymbolId(2): SymbolFlags(BlockScopedVariable | TypeImport)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "a":
-after transform: SymbolId(2): Span { start: 59, end: 60 }
-rebuilt        : SymbolId(2): Span { start: 171, end: 172 }
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(2): [ReferenceId(2)]
-rebuilt        : SymbolId(2): []
-Symbol redeclarations mismatch for "a":
-after transform: SymbolId(2): [Span { start: 59, end: 60 }, Span { start: 171, end: 172 }]
-rebuilt        : SymbolId(2): []
-Symbol flags mismatch for "b":
-after transform: SymbolId(3): SymbolFlags(BlockScopedVariable | TypeImport)
-rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "b":
-after transform: SymbolId(3): Span { start: 96, end: 97 }
-rebuilt        : SymbolId(3): Span { start: 185, end: 186 }
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(3): [ReferenceId(3)]
-rebuilt        : SymbolId(3): []
-Symbol redeclarations mismatch for "b":
-after transform: SymbolId(3): [Span { start: 96, end: 97 }, Span { start: 185, end: 186 }]
-rebuilt        : SymbolId(3): []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-import-type-var/input.ts
-Symbol flags mismatch for "Context":
-after transform: SymbolId(1): SymbolFlags(FunctionScopedVariable | TypeImport)
-rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
-Symbol span mismatch for "Context":
-after transform: SymbolId(1): Span { start: 21, end: 28 }
-rebuilt        : SymbolId(1): Span { start: 119, end: 126 }
-Symbol reference IDs mismatch for "Context":
-after transform: SymbolId(1): [ReferenceId(0)]
-rebuilt        : SymbolId(1): []
-Symbol redeclarations mismatch for "Context":
-after transform: SymbolId(1): [Span { start: 21, end: 28 }, Span { start: 119, end: 126 }]
-rebuilt        : SymbolId(1): []
-Symbol flags mismatch for "a":
-after transform: SymbolId(2): SymbolFlags(FunctionScopedVariable | TypeImport)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol span mismatch for "a":
-after transform: SymbolId(2): Span { start: 59, end: 60 }
-rebuilt        : SymbolId(2): Span { start: 171, end: 172 }
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(2): [ReferenceId(2)]
-rebuilt        : SymbolId(2): []
-Symbol redeclarations mismatch for "a":
-after transform: SymbolId(2): [Span { start: 59, end: 60 }, Span { start: 171, end: 172 }]
-rebuilt        : SymbolId(2): []
-Symbol flags mismatch for "b":
-after transform: SymbolId(3): SymbolFlags(FunctionScopedVariable | TypeImport)
-rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
-Symbol span mismatch for "b":
-after transform: SymbolId(3): Span { start: 96, end: 97 }
-rebuilt        : SymbolId(3): Span { start: 185, end: 186 }
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(3): [ReferenceId(3)]
-rebuilt        : SymbolId(3): []
-Symbol redeclarations mismatch for "b":
-after transform: SymbolId(3): [Span { start: 96, end: 97 }, Span { start: 185, end: 186 }]
-rebuilt        : SymbolId(3): []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-import-var/input.ts
-Symbol flags mismatch for "Context":
-after transform: SymbolId(1): SymbolFlags(FunctionScopedVariable | Import)
-rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
-Symbol span mismatch for "Context":
-after transform: SymbolId(1): Span { start: 16, end: 23 }
-rebuilt        : SymbolId(1): Span { start: 104, end: 111 }
-Symbol reference IDs mismatch for "Context":
-after transform: SymbolId(1): [ReferenceId(0)]
-rebuilt        : SymbolId(1): []
-Symbol redeclarations mismatch for "Context":
-after transform: SymbolId(1): [Span { start: 16, end: 23 }, Span { start: 104, end: 111 }]
-rebuilt        : SymbolId(1): []
-Symbol flags mismatch for "a":
-after transform: SymbolId(2): SymbolFlags(FunctionScopedVariable | Import)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol span mismatch for "a":
-after transform: SymbolId(2): Span { start: 49, end: 50 }
-rebuilt        : SymbolId(2): Span { start: 156, end: 157 }
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(2): [ReferenceId(2)]
-rebuilt        : SymbolId(2): []
-Symbol redeclarations mismatch for "a":
-after transform: SymbolId(2): [Span { start: 49, end: 50 }, Span { start: 156, end: 157 }]
-rebuilt        : SymbolId(2): []
-Symbol flags mismatch for "b":
-after transform: SymbolId(3): SymbolFlags(FunctionScopedVariable | Import)
-rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
-Symbol span mismatch for "b":
-after transform: SymbolId(3): Span { start: 81, end: 82 }
-rebuilt        : SymbolId(3): Span { start: 170, end: 171 }
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(3): [ReferenceId(3)]
-rebuilt        : SymbolId(3): []
-Symbol redeclarations mismatch for "b":
-after transform: SymbolId(3): [Span { start: 81, end: 82 }, Span { start: 170, end: 171 }]
-rebuilt        : SymbolId(3): []
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-in-different-module-and-top-level/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["JSONSchema7", "foo", "fooBar"]
-rebuilt        : ScopeId(0): ["foo", "fooBar"]
 Symbol reference IDs mismatch for "fooBar":
 after transform: SymbolId(1): [ReferenceId(1), ReferenceId(4)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
@@ -1204,136 +820,6 @@ Symbol redeclarations mismatch for "X":
 after transform: SymbolId(0): [Span { start: 4, end: 5 }, Span { start: 17, end: 18 }]
 rebuilt        : SymbolId(0): []
 
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/tsx/anonymous-function-generator/input.ts
-Unresolved references mismatch:
-after transform: ["Generator"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/tsx/brace-is-block/input.tsx
-Unresolved references mismatch:
-after transform: ["D", "T"]
-rebuilt        : ["D"]
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/tsx/type-arguments/input.ts
-Unresolved references mismatch:
-after transform: ["C", "T", "f"]
-rebuilt        : ["C", "f"]
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-alias/generic-complex-tokens-true/input.ts
-Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/call/input.ts
-Unresolved references mismatch:
-after transform: ["T", "U", "f"]
-rebuilt        : ["f"]
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/call-optional-chain/input.ts
-Unresolved references mismatch:
-after transform: ["Q", "W", "f"]
-rebuilt        : ["f"]
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/instantiation-expression-binary-operator/input.ts
-Unresolved references mismatch:
-after transform: ["a", "b", "c"]
-rebuilt        : ["a", "c"]
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/instantiation-expression-optional-chain/input.ts
-Unresolved references mismatch:
-after transform: ["a", "c"]
-rebuilt        : ["a"]
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/new/input.ts
-Unresolved references mismatch:
-after transform: ["C", "T", "U"]
-rebuilt        : ["C"]
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/new-false-positive-3/input.ts
-Unresolved references mismatch:
-after transform: ["A", "B", "C"]
-rebuilt        : ["A", "C"]
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/new-without-arguments/input.ts
-Unresolved references mismatch:
-after transform: ["A", "T"]
-rebuilt        : ["A"]
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/new-without-arguments-asi/input.ts
-Unresolved references mismatch:
-after transform: ["A", "T"]
-rebuilt        : ["A"]
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/super-type-arguments/input.ts
-Unresolved references mismatch:
-after transform: ["B", "T"]
-rebuilt        : ["B"]
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/super-type-arguments-comments/input.ts
-Unresolved references mismatch:
-after transform: ["B", "T"]
-rebuilt        : ["B"]
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/tagged-template/input.ts
-Unresolved references mismatch:
-after transform: ["T", "f"]
-rebuilt        : ["f"]
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/tagged-template-no-asi/input.ts
-Unresolved references mismatch:
-after transform: ["C", "T"]
-rebuilt        : ["C"]
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments-bit-shift-left-like/after-bit-shift/input.ts
-Unresolved references mismatch:
-after transform: ["T", "f", "x"]
-rebuilt        : ["f", "x"]
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments-bit-shift-left-like/interface-heritage/input.ts
-Unresolved references mismatch:
-after transform: ["f"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-only-import-export-specifiers/export-type-only-as-as-keyword/input.ts
-Unresolved references mismatch:
-after transform: ["as"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-only-import-export-specifiers/import-basic/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A", "B", "C"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-only-import-export-specifiers/import-named-and-named-type/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["Component", "ComponentProps"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-only-import-export-specifiers/import-named-type/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["type"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-only-import-export-specifiers/import-named-type-as-as/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["as"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-only-import-export-specifiers/import-type-only-and-export/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["Foo1"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-only-import-export-specifiers/import-type-only-named-as/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["as"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-only-import-export-specifiers/import-type-only-named-keywords-as/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["a", "b"]
-rebuilt        : ScopeId(0): []
-
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/const-type-parameters/input.ts
 'const' modifier can only appear on a type parameter of a function, method or class
 'const' modifier can only appear on a type parameter of a function, method or class
@@ -1343,91 +829,6 @@ semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescr
 Identifier `method` has already been declared
 Identifier `method` has already been declared
 
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/function-in-generic/input.ts
-Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/import-type-declaration/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A", "B", "T", "Types"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/indexed/input.ts
-Unresolved references mismatch:
-after transform: ["K", "T"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/infer-with-constraints/input.ts
-Unresolved references mismatch:
-after transform: ["MustBeNumber"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/intrinsic-identifier/input.ts
-Unresolved references mismatch:
-after transform: ["intrinsic"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/literal-string-2/input.ts
-Unresolved references mismatch:
-after transform: ["bar"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/literal-string-4/input.ts
 'infer' declarations are only permitted in the 'extends' clause of a conditional type.
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/mapped-as/input.ts
-Unresolved references mismatch:
-after transform: ["Exclude", "NewKeyType"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/reference/input.ts
-Unresolved references mismatch:
-after transform: ["T"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/reference-generic/input.ts
-Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/reference-generic-nested/input.ts
-Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/tuple-labeled-after-unlabeled/input.ts
-Unresolved references mismatch:
-after transform: ["A", "B"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/tuple-labeled-before-unlabeled/input.ts
-Unresolved references mismatch:
-after transform: ["A", "B"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/tuple-unlabeled-spread-after-labeled/input.ts
-Unresolved references mismatch:
-after transform: ["A", "B"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/tuple-unlabeled-spread-before-labeled/input.ts
-Unresolved references mismatch:
-after transform: ["A", "B"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/type-operator/input.ts
-Unresolved references mismatch:
-after transform: ["T"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/typeof/input.ts
-Unresolved references mismatch:
-after transform: ["y"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/typeof-type-parameters/input.ts
-Unresolved references mismatch:
-after transform: ["w", "y"]
-rebuilt        : []
 

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -1,11 +1,6 @@
 semantic_misc Summary:
-AST Parsed     : 69/69 (100.00%)
-Positive Passed: 55/69 (79.71%)
-semantic Error: tasks/coverage/misc/pass/conditional-arrow-alternate-return-type.ts
-Unresolved references mismatch:
-after transform: ["Pick", "Record"]
-rebuilt        : []
-
+AST Parsed     : 70/70 (100.00%)
+Positive Passed: 62/70 (88.57%)
 semantic Error: tasks/coverage/misc/pass/declare-let-private.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["private"]
@@ -21,16 +16,6 @@ rebuilt        : ScopeId(7): Some(ScopeId(0))
 Unresolved reference IDs mismatch for "String":
 after transform: [ReferenceId(11), ReferenceId(12)]
 rebuilt        : [ReferenceId(18)]
-
-semantic Error: tasks/coverage/misc/pass/oxc-1288.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["from"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/misc/pass/oxc-1289.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["infer", "target", "type"]
-rebuilt        : ScopeId(0): []
 
 semantic Error: tasks/coverage/misc/pass/oxc-13284.js
 Bindings mismatch:
@@ -116,9 +101,6 @@ semantic Error: tasks/coverage/misc/pass/oxc-13284.ts
 Symbol reference IDs mismatch for "_super":
 after transform: SymbolId(18): [ReferenceId(14)]
 rebuilt        : SymbolId(9): []
-Unresolved references mismatch:
-after transform: ["Super", "WeakMap", "require", "super"]
-rebuilt        : ["Super", "WeakMap", "require"]
 
 semantic Error: tasks/coverage/misc/pass/oxc-2562.ts
 Symbol span mismatch for "HooksController":
@@ -128,71 +110,13 @@ Symbol span mismatch for "HooksController":
 after transform: SymbolId(1): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(2): Span { start: 67, end: 82 }
 
-semantic Error: tasks/coverage/misc/pass/oxc-3443.tsx
-Unresolved references mismatch:
-after transform: ["F"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/misc/pass/oxc-3910.ts
-Unresolved references mismatch:
-after transform: ["ServicesAccessor"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/misc/pass/oxc-3948-1.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["BrowserWorkingCopyBackupTracker", "CancellationToken", "DisposableStore", "EditorPart", "EditorService", "IEditorGroupsService", "IEditorService", "IFilesConfigurationService", "IInstantiationService", "ILifecycleService", "ILogService", "IUntitledTextResourceEditorInput", "IWorkingCopyBackup", "IWorkingCopyBackupService", "IWorkingCopyEditorHandler", "IWorkingCopyEditorService", "IWorkingCopyService", "InMemoryTestWorkingCopyBackupService", "LifecyclePhase", "Schemas", "TestServiceAccessor", "TestWorkingCopy", "URI", "UntitledTextEditorInput", "VSBuffer", "_asyncToGenerator", "_decorate", "_decorateMetadata", "_decorateParam", "_defineProperty", "assert", "bufferToReadable", "createEditorPart", "ensureNoDisposablesAreLeakedInTestSuite", "isWindows", "registerTestResourceEditor", "timeout", "toResource", "toTypedWorkingCopyId", "toUntypedWorkingCopyId", "workbenchInstantiationService", "workbenchTeardown"]
-rebuilt        : ScopeId(0): ["BrowserWorkingCopyBackupTracker", "DisposableStore", "EditorService", "IEditorGroupsService", "IEditorService", "IFilesConfigurationService", "ILifecycleService", "ILogService", "IWorkingCopyBackupService", "IWorkingCopyEditorService", "IWorkingCopyService", "InMemoryTestWorkingCopyBackupService", "LifecyclePhase", "Schemas", "TestServiceAccessor", "TestWorkingCopy", "URI", "UntitledTextEditorInput", "VSBuffer", "_asyncToGenerator", "_decorate", "_decorateMetadata", "_decorateParam", "_defineProperty", "assert", "bufferToReadable", "createEditorPart", "ensureNoDisposablesAreLeakedInTestSuite", "isWindows", "registerTestResourceEditor", "timeout", "toResource", "toTypedWorkingCopyId", "toUntypedWorkingCopyId", "workbenchInstantiationService", "workbenchTeardown"]
-Symbol reference IDs mismatch for "URI":
-after transform: SymbolId(1): [ReferenceId(109), ReferenceId(117), ReferenceId(156), ReferenceId(158), ReferenceId(160), ReferenceId(162)]
-rebuilt        : SymbolId(1): [ReferenceId(196), ReferenceId(198), ReferenceId(200), ReferenceId(202)]
-Symbol reference IDs mismatch for "IEditorService":
-after transform: SymbolId(2): [ReferenceId(23), ReferenceId(24), ReferenceId(67), ReferenceId(184), ReferenceId(358), ReferenceId(359)]
-rebuilt        : SymbolId(2): [ReferenceId(38), ReferenceId(60), ReferenceId(62), ReferenceId(95), ReferenceId(223)]
-Symbol reference IDs mismatch for "IEditorGroupsService":
-after transform: SymbolId(4): [ReferenceId(25), ReferenceId(26), ReferenceId(57), ReferenceId(176), ReferenceId(361), ReferenceId(362)]
-rebuilt        : SymbolId(3): [ReferenceId(40), ReferenceId(63), ReferenceId(65), ReferenceId(86), ReferenceId(216)]
-Symbol reference IDs mismatch for "EditorService":
-after transform: SymbolId(5): [ReferenceId(61), ReferenceId(64), ReferenceId(178), ReferenceId(181)]
-rebuilt        : SymbolId(4): [ReferenceId(92), ReferenceId(220)]
-Symbol reference IDs mismatch for "IWorkingCopyBackupService":
-after transform: SymbolId(7): [ReferenceId(11), ReferenceId(12), ReferenceId(51), ReferenceId(170), ReferenceId(340), ReferenceId(341)]
-rebuilt        : SymbolId(5): [ReferenceId(26), ReferenceId(42), ReferenceId(44), ReferenceId(80), ReferenceId(210)]
-Symbol reference IDs mismatch for "IFilesConfigurationService":
-after transform: SymbolId(10): [ReferenceId(13), ReferenceId(14), ReferenceId(343), ReferenceId(344)]
-rebuilt        : SymbolId(8): [ReferenceId(28), ReferenceId(45), ReferenceId(47)]
-Symbol reference IDs mismatch for "IWorkingCopyService":
-after transform: SymbolId(11): [ReferenceId(15), ReferenceId(16), ReferenceId(346), ReferenceId(347)]
-rebuilt        : SymbolId(9): [ReferenceId(30), ReferenceId(48), ReferenceId(50)]
-Symbol reference IDs mismatch for "ILogService":
-after transform: SymbolId(13): [ReferenceId(19), ReferenceId(20), ReferenceId(352), ReferenceId(353)]
-rebuilt        : SymbolId(10): [ReferenceId(34), ReferenceId(54), ReferenceId(56)]
-Symbol reference IDs mismatch for "ILifecycleService":
-after transform: SymbolId(14): [ReferenceId(17), ReferenceId(18), ReferenceId(349), ReferenceId(350)]
-rebuilt        : SymbolId(11): [ReferenceId(32), ReferenceId(51), ReferenceId(53)]
-Symbol reference IDs mismatch for "UntitledTextEditorInput":
-after transform: SymbolId(17): [ReferenceId(38), ReferenceId(87)]
-rebuilt        : SymbolId(13): [ReferenceId(67)]
-Symbol reference IDs mismatch for "InMemoryTestWorkingCopyBackupService":
-after transform: SymbolId(19): [ReferenceId(43), ReferenceId(46), ReferenceId(165)]
-rebuilt        : SymbolId(15): [ReferenceId(75), ReferenceId(205)]
-Symbol reference IDs mismatch for "TestServiceAccessor":
-after transform: SymbolId(21): [ReferenceId(40), ReferenceId(155), ReferenceId(1), ReferenceId(71), ReferenceId(188)]
-rebuilt        : SymbolId(17): [ReferenceId(99), ReferenceId(227)]
-Symbol reference IDs mismatch for "IWorkingCopyEditorService":
-after transform: SymbolId(32): [ReferenceId(21), ReferenceId(22), ReferenceId(355), ReferenceId(356)]
-rebuilt        : SymbolId(26): [ReferenceId(36), ReferenceId(57), ReferenceId(59)]
 Symbol span mismatch for "TestWorkingCopyBackupTracker":
 after transform: SymbolId(39): Span { start: 3208, end: 3236 }
 rebuilt        : SymbolId(38): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "TestWorkingCopyBackupTracker":
-after transform: SymbolId(39): [ReferenceId(42), ReferenceId(154), ReferenceId(74), ReferenceId(215), ReferenceId(376), ReferenceId(378)]
-rebuilt        : SymbolId(38): [ReferenceId(23), ReferenceId(66), ReferenceId(102), ReferenceId(254)]
 Symbol span mismatch for "TestWorkingCopyBackupTracker":
 after transform: SymbolId(136): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(39): Span { start: 3208, end: 3236 }
-Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(36), ReferenceId(39), ReferenceId(82), ReferenceId(114), ReferenceId(153), ReferenceId(282)]
-rebuilt        : [ReferenceId(327)]
 
 semantic Error: tasks/coverage/misc/pass/oxc-4449.ts
 Bindings mismatch:
@@ -275,9 +199,4 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-
-semantic Error: tasks/coverage/misc/pass/oxc-9215.ts
-Unresolved references mismatch:
-after transform: ["a", "b", "d", "e"]
-rebuilt        : ["a", "b", "e"]
 

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -2,22 +2,11 @@ commit: 7964e22f
 
 semantic_typescript Summary:
 AST Parsed     : 4720/4720 (100.00%)
-Positive Passed: 2644/4720 (56.02%)
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/2dArrays.ts
-Symbol reference IDs mismatch for "Cell":
-after transform: SymbolId(0): [ReferenceId(1)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch for "Ship":
-after transform: SymbolId(1): [ReferenceId(0)]
-rebuilt        : SymbolId(2): []
-
+Positive Passed: 3235/4720 (68.54%)
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/APISample_Watch.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["console", "formatHost", "os", "process", "reportDiagnostic", "reportWatchStatusChanged", "ts", "watchMain"]
 rebuilt        : ScopeId(0): ["formatHost", "reportDiagnostic", "reportWatchStatusChanged", "ts", "watchMain"]
-Symbol reference IDs mismatch for "ts":
-after transform: SymbolId(3): [ReferenceId(30), ReferenceId(36), ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(8), ReferenceId(10), ReferenceId(11), ReferenceId(28), ReferenceId(33), ReferenceId(38)]
-rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(8), ReferenceId(10), ReferenceId(11), ReferenceId(27), ReferenceId(31), ReferenceId(35)]
 Reference symbol mismatch for "console":
 after transform: SymbolId(1) "console"
 rebuilt        : <None>
@@ -31,7 +20,7 @@ Reference symbol mismatch for "console":
 after transform: SymbolId(1) "console"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Error", "ReadonlyArray", "require"]
+after transform: ["Error", "require"]
 rebuilt        : ["Error", "console", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/APISample_WatchWithDefaults.ts
@@ -52,9 +41,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/APISample_WatchWi
 Bindings mismatch:
 after transform: ScopeId(0): ["console", "ts", "watchMain"]
 rebuilt        : ScopeId(0): ["ts", "watchMain"]
-Symbol reference IDs mismatch for "ts":
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(32)]
-rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(30)]
 Reference symbol mismatch for "console":
 after transform: SymbolId(0) "console"
 rebuilt        : <None>
@@ -69,9 +55,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/APISample_compile
 Bindings mismatch:
 after transform: ScopeId(0): ["compile", "console", "os", "process", "ts"]
 rebuilt        : ScopeId(0): ["compile", "ts"]
-Symbol reference IDs mismatch for "ts":
-after transform: SymbolId(3): [ReferenceId(0), ReferenceId(1), ReferenceId(5), ReferenceId(8), ReferenceId(27), ReferenceId(28)]
-rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(5), ReferenceId(8), ReferenceId(27), ReferenceId(28)]
 Reference symbol mismatch for "console":
 after transform: SymbolId(1) "console"
 rebuilt        : <None>
@@ -95,17 +78,11 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/APISample_jsdoc.t
 Bindings mismatch:
 after transform: ScopeId(0): ["console", "getAllTags", "getAnnotations", "getReturnTypeFromJSDoc", "getSomeOtherTags", "parseCommentsIntoDefinition", "parseSpecificTags", "ts"]
 rebuilt        : ScopeId(0): ["getAllTags", "getAnnotations", "getReturnTypeFromJSDoc", "getSomeOtherTags", "parseCommentsIntoDefinition", "parseSpecificTags", "ts"]
-Symbol reference IDs mismatch for "ts":
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(19), ReferenceId(33), ReferenceId(45), ReferenceId(64), ReferenceId(76), ReferenceId(79), ReferenceId(21), ReferenceId(25), ReferenceId(47), ReferenceId(48), ReferenceId(50), ReferenceId(52), ReferenceId(54), ReferenceId(55), ReferenceId(57), ReferenceId(59), ReferenceId(66), ReferenceId(67), ReferenceId(69), ReferenceId(73), ReferenceId(75), ReferenceId(77), ReferenceId(80), ReferenceId(82), ReferenceId(85), ReferenceId(88), ReferenceId(90), ReferenceId(96)]
-rebuilt        : SymbolId(0): [ReferenceId(38), ReferenceId(39), ReferenceId(42), ReferenceId(44), ReferenceId(47), ReferenceId(53), ReferenceId(54), ReferenceId(56), ReferenceId(60), ReferenceId(62), ReferenceId(65), ReferenceId(68), ReferenceId(71), ReferenceId(73), ReferenceId(79)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/APISample_linter.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["console", "delint", "fileNames", "process", "readFileSync", "ts"]
 rebuilt        : ScopeId(0): ["delint", "fileNames", "ts"]
-Symbol reference IDs mismatch for "ts":
-after transform: SymbolId(3): [ReferenceId(0), ReferenceId(3), ReferenceId(40), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(11), ReferenceId(14), ReferenceId(15), ReferenceId(18), ReferenceId(23), ReferenceId(25), ReferenceId(28), ReferenceId(29), ReferenceId(32), ReferenceId(34), ReferenceId(37), ReferenceId(50), ReferenceId(54)]
-rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(11), ReferenceId(14), ReferenceId(19), ReferenceId(21), ReferenceId(24), ReferenceId(27), ReferenceId(29), ReferenceId(32), ReferenceId(44), ReferenceId(48)]
 Reference symbol mismatch for "console":
 after transform: SymbolId(1) "console"
 rebuilt        : <None>
@@ -123,9 +100,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/APISample_parseCo
 Bindings mismatch:
 after transform: ScopeId(0): ["console", "createProgram", "os", "printError", "process", "ts"]
 rebuilt        : ScopeId(0): ["createProgram", "printError", "ts"]
-Symbol reference IDs mismatch for "ts":
-after transform: SymbolId(3): [ReferenceId(0), ReferenceId(6), ReferenceId(7), ReferenceId(14), ReferenceId(22)]
-rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(13), ReferenceId(21)]
 Reference symbol mismatch for "console":
 after transform: SymbolId(1) "console"
 rebuilt        : <None>
@@ -151,9 +125,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/APISample_watcher
 Bindings mismatch:
 after transform: ScopeId(0): ["console", "currentDirectoryFiles", "fs", "path", "process", "ts", "watch"]
 rebuilt        : ScopeId(0): ["currentDirectoryFiles", "ts", "watch"]
-Symbol reference IDs mismatch for "ts":
-after transform: SymbolId(16): [ReferenceId(2), ReferenceId(3), ReferenceId(7), ReferenceId(16), ReferenceId(21), ReferenceId(27), ReferenceId(29), ReferenceId(60), ReferenceId(79)]
-rebuilt        : SymbolId(0): [ReferenceId(11), ReferenceId(16), ReferenceId(22), ReferenceId(24), ReferenceId(55), ReferenceId(74)]
 Reference symbol mismatch for "fs":
 after transform: SymbolId(2) "fs"
 rebuilt        : <None>
@@ -194,7 +165,7 @@ Reference symbol mismatch for "process":
 after transform: SymbolId(0) "process"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Date", "undefined"]
+after transform: ["undefined"]
 rebuilt        : ["console", "fs", "process", "undefined"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/acceptableAlias1.ts
@@ -210,19 +181,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "M":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(4), ReferenceId(5)]
-rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(4)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/accessorsEmit.ts
-Symbol reference IDs mismatch for "Result":
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/accessors_spec_section-4.5_inference.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(4), ReferenceId(7), ReferenceId(9), ReferenceId(0)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/aliasInaccessibleModule.ts
 Bindings mismatch:
@@ -258,14 +216,9 @@ Symbol span mismatch for "N":
 after transform: SymbolId(1): Span { start: 28, end: 29 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/allowJsCrossMonorepoPackage.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["x"]
-rebuilt        : ScopeId(0): []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImportsCanPaintCrossModuleDeclaration.ts
 Bindings mismatch:
-after transform: ScopeId(0): ["Color", "styled"]
+after transform: ScopeId(0): ["styled"]
 rebuilt        : ScopeId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/ambientClassDeclarationWithExtends.ts
@@ -416,12 +369,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/ambiguousOverload
 Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "_defineProperty", "f", "t", "x"]
 rebuilt        : ScopeId(0): ["A", "B", "_defineProperty", "t", "x"]
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(4), ReferenceId(0)]
-rebuilt        : SymbolId(1): [ReferenceId(1)]
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(1): [ReferenceId(2), ReferenceId(3), ReferenceId(5)]
-rebuilt        : SymbolId(2): []
 Reference symbol mismatch for "f":
 after transform: SymbolId(2) "f"
 rebuilt        : <None>
@@ -471,23 +418,8 @@ Reference symbol mismatch for "use":
 after transform: SymbolId(1) "use"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Array"]
+after transform: []
 rebuilt        : ["use"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/arrayConcat3.ts
-Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/arrayFind.ts
-Unresolved references mismatch:
-after transform: ["ReadonlyArray"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/arrayFlatMap.ts
-Unresolved references mismatch:
-after transform: ["ReadonlyArray"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/arrayIterationLibES5TargetDifferent.ts
 Bindings mismatch:
@@ -517,22 +449,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["aNumber", "aString", "anObject", "log"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/arrayToLocaleStringES2015.ts
-Unresolved references mismatch:
-after transform: ["Date", "Float32Array", "Float64Array", "Int16Array", "Int32Array", "Int8Array", "ReadonlyArray", "Uint16Array", "Uint32Array", "Uint8Array", "Uint8ClampedArray"]
-rebuilt        : ["Date", "Float32Array", "Float64Array", "Int16Array", "Int32Array", "Int8Array", "Uint16Array", "Uint32Array", "Uint8Array", "Uint8ClampedArray"]
-Unresolved reference IDs mismatch for "Date":
-after transform: [ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(15), ReferenceId(16), ReferenceId(26)]
-rebuilt        : [ReferenceId(6), ReferenceId(7), ReferenceId(14), ReferenceId(15)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/arrayToLocaleStringES2020.ts
-Unresolved references mismatch:
-after transform: ["BigInt", "BigInt64Array", "BigUint64Array", "Date", "Float32Array", "Float64Array", "Int16Array", "Int32Array", "Int8Array", "ReadonlyArray", "Uint16Array", "Uint32Array", "Uint8Array", "Uint8ClampedArray"]
-rebuilt        : ["BigInt", "BigInt64Array", "BigUint64Array", "Date", "Float32Array", "Float64Array", "Int16Array", "Int32Array", "Int8Array", "Uint16Array", "Uint32Array", "Uint8Array", "Uint8ClampedArray"]
-Unresolved reference IDs mismatch for "Date":
-after transform: [ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(15), ReferenceId(16), ReferenceId(24)]
-rebuilt        : [ReferenceId(6), ReferenceId(7), ReferenceId(14), ReferenceId(15)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/arrayTypeInSignatureOfInterfaceAndClass.ts
 Bindings mismatch:
@@ -564,30 +480,10 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["a", "value"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionParsingGenericInObject.ts
-Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
-rebuilt        : ["arguments", "require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionWithObjectLiteralBody5.ts
-Unresolved references mismatch:
-after transform: ["Error"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionWithObjectLiteralBody6.ts
-Unresolved references mismatch:
-after transform: ["Error"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/assertionFunctionWildcardImport1.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["assert"]
 rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/assertionFunctionWildcardImport2.ts
-Unresolved references mismatch:
-after transform: ["Error", "NonNullable", "undefined"]
-rebuilt        : ["Error", "undefined"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/assertionFunctionsCanNarrowByDiscriminant.ts
 Bindings mismatch:
@@ -600,7 +496,7 @@ Reference symbol mismatch for "assertEqual":
 after transform: SymbolId(3) "assertEqual"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["const"]
+after transform: []
 rebuilt        : ["assertEqual"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/assign1.ts
@@ -613,11 +509,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/assignToObjectTypeWithPrototypeProperty.ts
-Symbol reference IDs mismatch for "XEvent":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3)]
-rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/assignToPrototype1.ts
 Bindings mismatch:
@@ -640,14 +531,6 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "TokenType":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "TokenType":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(9)]
-rebuilt        : SymbolId(0): [ReferenceId(5)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatOnNew.ts
-Symbol reference IDs mismatch for "Foo":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2)]
-rebuilt        : SymbolId(0): [ReferenceId(1)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability1.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -837,17 +720,6 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "E":
 after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(8): [ReferenceId(5), ReferenceId(8), ReferenceId(12)]
-rebuilt        : SymbolId(6): [ReferenceId(17)]
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(9): [ReferenceId(6), ReferenceId(9), ReferenceId(14)]
-rebuilt        : SymbolId(7): [ReferenceId(19)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/assignmentToConditionalBrandedStringTemplateOrMapping.ts
-Unresolved references mismatch:
-after transform: ["Uppercase"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionContextuallyTypedReturns.ts
 Bindings mismatch:
@@ -872,21 +744,8 @@ Reference symbol mismatch for "h":
 after transform: SymbolId(12) "h"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "PromiseLike", "arguments", "require"]
+after transform: ["Promise", "arguments", "require"]
 rebuilt        : ["Promise", "arguments", "f", "g", "h", "require"]
-Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(3), ReferenceId(6), ReferenceId(10), ReferenceId(13), ReferenceId(19), ReferenceId(22), ReferenceId(23), ReferenceId(25)]
-rebuilt        : [ReferenceId(3), ReferenceId(7), ReferenceId(12), ReferenceId(16), ReferenceId(21), ReferenceId(25)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionReturnType.2.ts
-Unresolved references mismatch:
-after transform: ["Promise", "require"]
-rebuilt        : ["require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionReturnType.ts
-Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(0), ReferenceId(2), ReferenceId(6), ReferenceId(8), ReferenceId(11), ReferenceId(13), ReferenceId(17), ReferenceId(21), ReferenceId(23), ReferenceId(26), ReferenceId(28), ReferenceId(33), ReferenceId(38), ReferenceId(40), ReferenceId(44), ReferenceId(46), ReferenceId(51), ReferenceId(56), ReferenceId(58), ReferenceId(62), ReferenceId(64), ReferenceId(71), ReferenceId(80), ReferenceId(83), ReferenceId(90), ReferenceId(93)]
-rebuilt        : [ReferenceId(24), ReferenceId(32), ReferenceId(47), ReferenceId(55), ReferenceId(70), ReferenceId(78), ReferenceId(93), ReferenceId(101), ReferenceId(117), ReferenceId(126)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionsAndStrictNullChecks.ts
 Bindings mismatch:
@@ -899,7 +758,7 @@ Reference symbol mismatch for "resolve2":
 after transform: SymbolId(45) "resolve2"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
+after transform: ["arguments", "require"]
 rebuilt        : ["arguments", "require", "resolve1", "resolve2"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/asyncYieldStarContextualType.ts
@@ -925,7 +784,7 @@ Reference symbol mismatch for "g":
 after transform: SymbolId(10) "g"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["AsyncGenerator", "Generator", "Promise", "Symbol", "arguments", "require"]
+after transform: ["Symbol", "arguments", "require"]
 rebuilt        : ["arguments", "authorPromise", "g", "mapper", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals3.ts
@@ -1178,16 +1037,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["foo"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/awaitedTypeCrash.ts
-Unresolved references mismatch:
-after transform: ["AsyncGenerator", "Promise", "arguments", "require"]
-rebuilt        : ["arguments", "require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/awaitedTypeJQuery.ts
-Unresolved references mismatch:
-after transform: ["Awaited", "Element", "Error", "PromiseLike"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/badInferenceLowerPriorityThanGoodInference.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["canYouInferThis", "goofus", "result"]
@@ -1224,7 +1073,7 @@ Reference symbol mismatch for "pick":
 after transform: SymbolId(0) "pick"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Pick"]
+after transform: []
 rebuilt        : ["pick"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/binopAssignmentShouldHaveType.ts
@@ -1272,7 +1121,7 @@ Reference symbol mismatch for "realanys":
 after transform: SymbolId(14) "realanys"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Array", "Boolean"]
+after transform: ["Boolean"]
 rebuilt        : ["Boolean", "Bullean", "anys", "realanys"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/cachedContextualTypes.ts
@@ -1283,33 +1132,8 @@ Reference symbol mismatch for "createInstance":
 after transform: SymbolId(0) "createInstance"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["ConstructorParameters", "InstanceType"]
+after transform: []
 rebuilt        : ["createInstance"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution1.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["x"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution2.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["x"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution5.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["x"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/callOfConditionalTypeWithConcreteBranches.ts
-Unresolved references mismatch:
-after transform: ["Function", "Parameters"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/callsOnComplexSignatures.tsx
-Symbol reference IDs mismatch for "React":
-after transform: SymbolId(0): [ReferenceId(28), ReferenceId(32), ReferenceId(33), ReferenceId(36), ReferenceId(38), ReferenceId(42), ReferenceId(44), ReferenceId(46)]
-rebuilt        : SymbolId(0): [ReferenceId(24), ReferenceId(28), ReferenceId(31)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop1.ts
 Bindings mismatch:
@@ -1528,11 +1352,6 @@ Unresolved references mismatch:
 after transform: ["arguments"]
 rebuilt        : ["arguments", "use"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/caseInsensitiveFileSystemWithCapsImportTypeDeclarations.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["Broken", "TypeB"]
-rebuilt        : ScopeId(0): ["Broken"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/castExpressionParentheses.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["A", "a"]
@@ -1596,16 +1415,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["combineLatest"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/checkInterfaceBases.ts
-Unresolved references mismatch:
-after transform: ["JQueryEventObjectTest"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/checkSuperCallBeforeThisAccessing7.ts
-Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/checkSwitchStatementIfCaseTypeIsString.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["A", "use"]
@@ -1614,16 +1423,8 @@ Reference symbol mismatch for "use":
 after transform: SymbolId(0) "use"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Array"]
+after transform: []
 rebuilt        : ["use"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/circularConstructorWithReturn.ts
-Symbol reference IDs mismatch for "getPrismaClient":
-after transform: SymbolId(2): [ReferenceId(1)]
-rebuilt        : SymbolId(1): []
-Unresolved references mismatch:
-after transform: ["ReturnType"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/circularContextualMappedType.ts
 Bindings mismatch:
@@ -1666,13 +1467,8 @@ Reference symbol mismatch for "foo2":
 after transform: SymbolId(0) "foo2"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Capitalize"]
+after transform: []
 rebuilt        : ["foo2"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/circularReferenceInImport.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["Db", "foo"]
-rebuilt        : ScopeId(0): ["foo"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/circularTypeofWithFunctionModule.ts
 Scope flags mismatch:
@@ -1681,9 +1477,6 @@ rebuilt        : ScopeId(3): ScopeFlags(Function)
 Symbol flags mismatch for "maker":
 after transform: SymbolId(1): SymbolFlags(Function | ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(Function)
-Symbol reference IDs mismatch for "maker":
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(5), ReferenceId(6)]
-rebuilt        : SymbolId(1): [ReferenceId(0), ReferenceId(4), ReferenceId(5)]
 Symbol redeclarations mismatch for "maker":
 after transform: SymbolId(1): [Span { start: 44, end: 49 }, Span { start: 121, end: 126 }]
 rebuilt        : SymbolId(1): []
@@ -1696,7 +1489,7 @@ Reference symbol mismatch for "connect":
 after transform: SymbolId(24) "connect"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Exclude", "Extract", "Partial", "Pick"]
+after transform: []
 rebuilt        : ["connect"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/classDeclarationMergedInModuleWithContinuation.ts
@@ -1773,11 +1566,6 @@ Unresolved references mismatch:
 after transform: ["console"]
 rebuilt        : ["B", "console"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/classImplementsClass1.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(0): []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/classImplementsImportedInterface.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["M1", "M2"]
@@ -1799,9 +1587,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/classImplementsMe
 Bindings mismatch:
 after transform: ScopeId(0): ["MySettable"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Record"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/classMemberInitializerWithLamdaScoping5.ts
 Bindings mismatch:
@@ -1818,9 +1603,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/classNonUniqueSym
 Bindings mismatch:
 after transform: ScopeId(0): ["A", "Mix", "Mixer", "a", "e1"]
 rebuilt        : ScopeId(0): ["A", "Mixer"]
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(1): [ReferenceId(1)]
-rebuilt        : SymbolId(0): []
 Reference symbol mismatch for "a":
 after transform: SymbolId(0) "a"
 rebuilt        : <None>
@@ -1834,18 +1616,10 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["Mix", "a"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/classOrderBug.ts
-Symbol reference IDs mismatch for "foo":
-after transform: SymbolId(2): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(3): [ReferenceId(2)]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/classPropertyInferenceFromBroaderTypeConst.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "D", "DEFAULT", "_defineProperty", "c", "expectAB"]
 rebuilt        : ScopeId(0): ["C", "D", "DEFAULT", "_defineProperty"]
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(2): [ReferenceId(2)]
-rebuilt        : SymbolId(2): []
 Reference symbol mismatch for "expectAB":
 after transform: SymbolId(4) "expectAB"
 rebuilt        : <None>
@@ -1863,9 +1637,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/classReferencedIn
 Bindings mismatch:
 after transform: ScopeId(0): ["A", "string"]
 rebuilt        : ScopeId(0): ["A"]
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(18): [ReferenceId(18)]
-rebuilt        : SymbolId(0): []
 Reference symbol mismatch for "Class":
 after transform: SymbolId(5) "Class"
 rebuilt        : <None>
@@ -1876,18 +1647,10 @@ Unresolved references mismatch:
 after transform: ["JSON"]
 rebuilt        : ["Class", "JSON", "string"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/classVarianceCircularity.ts
-Symbol reference IDs mismatch for "Bar":
-after transform: SymbolId(2): [ReferenceId(0), ReferenceId(3), ReferenceId(4)]
-rebuilt        : SymbolId(3): [ReferenceId(1)]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/classVarianceResolveCircularity1.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "_defineProperty", "callme"]
 rebuilt        : ScopeId(0): ["Bar", "_defineProperty"]
-Symbol reference IDs mismatch for "Bar":
-after transform: SymbolId(0): [ReferenceId(2), ReferenceId(3)]
-rebuilt        : SymbolId(1): []
 Reference symbol mismatch for "callme":
 after transform: SymbolId(2) "callme"
 rebuilt        : <None>
@@ -1902,12 +1665,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/classVarianceReso
 Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "Foo", "_defineProperty", "callme"]
 rebuilt        : ScopeId(0): ["Bar", "Foo", "_defineProperty"]
-Symbol reference IDs mismatch for "Bar":
-after transform: SymbolId(0): [ReferenceId(8), ReferenceId(6)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch for "Foo":
-after transform: SymbolId(5): [ReferenceId(1), ReferenceId(3), ReferenceId(4), ReferenceId(5)]
-rebuilt        : SymbolId(2): [ReferenceId(3), ReferenceId(6)]
 Reference symbol mismatch for "callme":
 after transform: SymbolId(2) "callme"
 rebuilt        : <None>
@@ -1935,9 +1692,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(3), ReferenceId(4), ReferenceId(10), ReferenceId(11)]
-rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3), ReferenceId(9), ReferenceId(10)]
 Symbol redeclarations mismatch for "A":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 97, end: 98 }]
 rebuilt        : SymbolId(0): []
@@ -1955,9 +1709,6 @@ rebuilt        : ScopeId(3): ScopeFlags(Function)
 Symbol flags mismatch for "Foo":
 after transform: SymbolId(0): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(Class)
-Symbol reference IDs mismatch for "Foo":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(3), ReferenceId(4)]
-rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3)]
 Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(0): [Span { start: 6, end: 9 }, Span { start: 66, end: 69 }]
 rebuilt        : SymbolId(0): []
@@ -2018,12 +1769,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/coAndContraVarian
 Bindings mismatch:
 after transform: ScopeId(0): ["a", "actionA", "actionB", "b", "call", "fab", "foo", "printFn"]
 rebuilt        : ScopeId(0): ["actionA", "actionB", "call", "printFn"]
-Symbol reference IDs mismatch for "actionA":
-after transform: SymbolId(14): [ReferenceId(24), ReferenceId(29)]
-rebuilt        : SymbolId(0): [ReferenceId(11)]
-Symbol reference IDs mismatch for "actionB":
-after transform: SymbolId(15): [ReferenceId(25), ReferenceId(32)]
-rebuilt        : SymbolId(1): [ReferenceId(14)]
 Reference symbol mismatch for "foo":
 after transform: SymbolId(6) "foo"
 rebuilt        : <None>
@@ -2065,15 +1810,9 @@ rebuilt        : ScopeId(9): ScopeFlags(Function)
 Symbol flags mismatch for "SyntaxKind":
 after transform: SymbolId(36): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(10): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "SyntaxKind":
-after transform: SymbolId(36): [ReferenceId(52), ReferenceId(56), ReferenceId(59), ReferenceId(61), ReferenceId(63), ReferenceId(131)]
-rebuilt        : SymbolId(10): [ReferenceId(38)]
 Symbol flags mismatch for "SyntaxKind1":
 after transform: SymbolId(74): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(17): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "SyntaxKind1":
-after transform: SymbolId(74): [ReferenceId(94), ReferenceId(97), ReferenceId(99), ReferenceId(137)]
-rebuilt        : SymbolId(17): [ReferenceId(51)]
 Reference symbol mismatch for "cast":
 after transform: SymbolId(3) "cast"
 rebuilt        : <None>
@@ -2147,7 +1886,7 @@ Reference symbol mismatch for "isNodeArray":
 after transform: SymbolId(89) "isNodeArray"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Array"]
+after transform: []
 rebuilt        : ["assertNode", "canHaveLocals", "cast", "consume", "every", "isC", "isClassLike", "isExpression", "isNodeArray", "statement", "tryCast", "types", "useA"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences3.ts
@@ -2163,9 +1902,6 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "SyntaxKind":
 after transform: SymbolId(49): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "SyntaxKind":
-after transform: SymbolId(49): [ReferenceId(67), ReferenceId(72), ReferenceId(74), ReferenceId(76), ReferenceId(78), ReferenceId(80), ReferenceId(203)]
-rebuilt        : SymbolId(0): [ReferenceId(11)]
 Reference symbol mismatch for "buildOverload":
 after transform: SymbolId(47) "buildOverload"
 rebuilt        : <None>
@@ -2230,7 +1966,7 @@ Reference symbol mismatch for "isDecorator":
 after transform: SymbolId(72) "isDecorator"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Extract", "Parameters", "undefined"]
+after transform: ["undefined"]
 rebuilt        : ["DISALLOW_DECORATORS", "buildOverload", "every", "isArray", "isAssertClause", "isDecorator", "isExpression", "isImportClause", "isModifier", "modifiers", "undefined", "updateImportDeclaration"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences4.ts
@@ -2246,9 +1982,6 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "SyntaxKind":
 after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "SyntaxKind":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(27)]
-rebuilt        : SymbolId(0): [ReferenceId(5)]
 Reference symbol mismatch for "every":
 after transform: SymbolId(10) "every"
 rebuilt        : <None>
@@ -2279,7 +2012,7 @@ Reference symbol mismatch for "select":
 after transform: SymbolId(5) "select"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Array"]
+after transform: []
 rebuilt        : ["select"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences7.ts
@@ -2312,14 +2045,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["fn", "x", "y"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/collectionPatternNoError.ts
-Symbol reference IDs mismatch for "Message":
-after transform: SymbolId(3): [ReferenceId(6), ReferenceId(21), ReferenceId(0), ReferenceId(3), ReferenceId(4), ReferenceId(10)]
-rebuilt        : SymbolId(0): []
-Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenEnumWithEnumMemberConflict.ts
 Bindings mismatch:
@@ -2809,9 +2534,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "a":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(3)]
-rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(2)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndAmbientClassInGlobal.ts
 Bindings mismatch:
@@ -2904,16 +2626,6 @@ rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "foo":
 after transform: SymbolId(1): Span { start: 40, end: 43 }
 rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/commentEmitOnParenthesizedAssertionInReturnStatement.ts
-Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
-rebuilt        : [ReferenceId(1)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/commentEmitOnParenthesizedAssertionInReturnStatement2.ts
-Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(0), ReferenceId(1)]
-rebuilt        : [ReferenceId(1)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/commentInNamespaceDeclarationWithIdentifierPathName.ts
 Scope flags mismatch:
@@ -3073,9 +2785,6 @@ rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "AutomationMode":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "AutomationMode":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(11)]
-rebuilt        : SymbolId(0): [ReferenceId(5)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/complexNarrowingWithAny.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -3085,36 +2794,24 @@ rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "import44":
 after transform: SymbolId(0): Span { start: 3976, end: 3984 }
 rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "import44":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(364), ReferenceId(382), ReferenceId(383)]
-rebuilt        : SymbolId(1): [ReferenceId(2), ReferenceId(3), ReferenceId(649)]
 Symbol flags mismatch for "import45":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "import45":
 after transform: SymbolId(3): Span { start: 4059, end: 4067 }
 rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "import45":
-after transform: SymbolId(3): [ReferenceId(2), ReferenceId(5), ReferenceId(8), ReferenceId(11), ReferenceId(14), ReferenceId(17), ReferenceId(20), ReferenceId(23), ReferenceId(26), ReferenceId(29), ReferenceId(32), ReferenceId(35), ReferenceId(38), ReferenceId(41), ReferenceId(44), ReferenceId(47), ReferenceId(50), ReferenceId(53), ReferenceId(56), ReferenceId(59), ReferenceId(62), ReferenceId(76), ReferenceId(91), ReferenceId(106), ReferenceId(121), ReferenceId(136), ReferenceId(151), ReferenceId(166), ReferenceId(181), ReferenceId(196), ReferenceId(211), ReferenceId(226), ReferenceId(241), ReferenceId(256), ReferenceId(271), ReferenceId(286), ReferenceId(301), ReferenceId(316), ReferenceId(331), ReferenceId(346), ReferenceId(361), ReferenceId(372), ReferenceId(388), ReferenceId(389)]
-rebuilt        : SymbolId(5): [ReferenceId(8), ReferenceId(9), ReferenceId(361), ReferenceId(376), ReferenceId(391), ReferenceId(406), ReferenceId(421), ReferenceId(436), ReferenceId(451), ReferenceId(466), ReferenceId(481), ReferenceId(496), ReferenceId(511), ReferenceId(526), ReferenceId(541), ReferenceId(556), ReferenceId(571), ReferenceId(586), ReferenceId(601), ReferenceId(616), ReferenceId(631), ReferenceId(646), ReferenceId(657)]
 Symbol flags mismatch for "import46":
 after transform: SymbolId(8): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "import46":
 after transform: SymbolId(8): Span { start: 4200, end: 4208 }
 rebuilt        : SymbolId(11): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "import46":
-after transform: SymbolId(8): [ReferenceId(3), ReferenceId(6), ReferenceId(9), ReferenceId(12), ReferenceId(15), ReferenceId(18), ReferenceId(21), ReferenceId(24), ReferenceId(27), ReferenceId(30), ReferenceId(33), ReferenceId(36), ReferenceId(39), ReferenceId(42), ReferenceId(45), ReferenceId(48), ReferenceId(51), ReferenceId(54), ReferenceId(57), ReferenceId(60), ReferenceId(64), ReferenceId(79), ReferenceId(94), ReferenceId(109), ReferenceId(124), ReferenceId(139), ReferenceId(154), ReferenceId(169), ReferenceId(184), ReferenceId(199), ReferenceId(214), ReferenceId(229), ReferenceId(244), ReferenceId(259), ReferenceId(274), ReferenceId(289), ReferenceId(304), ReferenceId(319), ReferenceId(334), ReferenceId(349), ReferenceId(392), ReferenceId(393)]
-rebuilt        : SymbolId(11): [ReferenceId(12), ReferenceId(13), ReferenceId(349), ReferenceId(364), ReferenceId(379), ReferenceId(394), ReferenceId(409), ReferenceId(424), ReferenceId(439), ReferenceId(454), ReferenceId(469), ReferenceId(484), ReferenceId(499), ReferenceId(514), ReferenceId(529), ReferenceId(544), ReferenceId(559), ReferenceId(574), ReferenceId(589), ReferenceId(604), ReferenceId(619), ReferenceId(634)]
 Symbol flags mismatch for "import47":
 after transform: SymbolId(11): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(15): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "import47":
 after transform: SymbolId(11): Span { start: 4285, end: 4293 }
 rebuilt        : SymbolId(15): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "import47":
-after transform: SymbolId(11): [ReferenceId(4), ReferenceId(7), ReferenceId(10), ReferenceId(13), ReferenceId(16), ReferenceId(19), ReferenceId(22), ReferenceId(25), ReferenceId(28), ReferenceId(31), ReferenceId(34), ReferenceId(37), ReferenceId(40), ReferenceId(43), ReferenceId(46), ReferenceId(49), ReferenceId(52), ReferenceId(55), ReferenceId(58), ReferenceId(61), ReferenceId(70), ReferenceId(85), ReferenceId(100), ReferenceId(115), ReferenceId(130), ReferenceId(145), ReferenceId(160), ReferenceId(175), ReferenceId(190), ReferenceId(205), ReferenceId(220), ReferenceId(235), ReferenceId(250), ReferenceId(265), ReferenceId(280), ReferenceId(295), ReferenceId(310), ReferenceId(325), ReferenceId(340), ReferenceId(355), ReferenceId(396), ReferenceId(397)]
-rebuilt        : SymbolId(15): [ReferenceId(16), ReferenceId(17), ReferenceId(355), ReferenceId(370), ReferenceId(385), ReferenceId(400), ReferenceId(415), ReferenceId(430), ReferenceId(445), ReferenceId(460), ReferenceId(475), ReferenceId(490), ReferenceId(505), ReferenceId(520), ReferenceId(535), ReferenceId(550), ReferenceId(565), ReferenceId(580), ReferenceId(595), ReferenceId(610), ReferenceId(625), ReferenceId(640)]
 Symbol flags mismatch for "import48":
 after transform: SymbolId(14): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(19): SymbolFlags(BlockScopedVariable)
@@ -3148,13 +2845,8 @@ Reference symbol mismatch for "Func":
 after transform: SymbolId(3) "Func"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Exclude", "Extract", "Partial", "Pick", "Readonly"]
+after transform: []
 rebuilt        : ["Func"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/compositeContextualSignature.ts
-Unresolved references mismatch:
-after transform: ["ReadonlyArray", "console", "undefined"]
-rebuilt        : ["console", "undefined"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/compoundVarDecl1.ts
 Scope flags mismatch:
@@ -3222,9 +2914,6 @@ rebuilt        : ScopeId(8): ScopeFlags(Function)
 Symbol flags mismatch for "E":
 after transform: SymbolId(2): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "E":
-after transform: SymbolId(2): [ReferenceId(4), ReferenceId(8), ReferenceId(9), ReferenceId(11), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(35), ReferenceId(37), ReferenceId(38), ReferenceId(40), ReferenceId(41), ReferenceId(43), ReferenceId(44), ReferenceId(46), ReferenceId(50), ReferenceId(51), ReferenceId(52), ReferenceId(54), ReferenceId(55), ReferenceId(57), ReferenceId(58), ReferenceId(60), ReferenceId(61), ReferenceId(78)]
-rebuilt        : SymbolId(1): [ReferenceId(14), ReferenceId(15), ReferenceId(19), ReferenceId(24), ReferenceId(25), ReferenceId(32), ReferenceId(39), ReferenceId(41), ReferenceId(43), ReferenceId(45), ReferenceId(47), ReferenceId(50), ReferenceId(51), ReferenceId(52), ReferenceId(53), ReferenceId(54), ReferenceId(56), ReferenceId(58), ReferenceId(60), ReferenceId(62)]
 Symbol flags mismatch for "MyEnum":
 after transform: SymbolId(52): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(43): SymbolFlags(FunctionScopedVariable)
@@ -3250,7 +2939,7 @@ Reference symbol mismatch for "MyDeclaredEnum":
 after transform: SymbolId(57) "MyDeclaredEnum"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["const", "require"]
+after transform: ["require"]
 rebuilt        : ["E2", "MyDeclaredEnum", "computed", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/computedPropertiesWithSetterAssignment.ts
@@ -3282,7 +2971,7 @@ Reference symbol mismatch for "foo":
 after transform: SymbolId(6) "foo"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Iterable", "Set", "Symbol"]
+after transform: ["Symbol"]
 rebuilt        : ["Symbol", "foo"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/computedPropertyNameAndTypeParameterConflict.ts
@@ -3294,9 +2983,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/conditionalEquali
 Bindings mismatch:
 after transform: ScopeId(0): ["a", "b"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Date"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeBasedContextualTypeReturnTypeWidening.ts
 Bindings mismatch:
@@ -3323,11 +3009,6 @@ Bindings mismatch:
 after transform: ScopeId(0): ["MyRecord", "MySet"]
 rebuilt        : ScopeId(0): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts
-Unresolved references mismatch:
-after transform: ["Record"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeRelaxingConstraintAssignability.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["Elem", "f", "g"]
@@ -3336,13 +3017,8 @@ Reference symbol mismatch for "f":
 after transform: SymbolId(12) "f"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Partial", "undefined"]
+after transform: ["undefined"]
 rebuilt        : ["f", "undefined"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeSimplification.ts
-Unresolved references mismatch:
-after transform: ["Exclude"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeSubclassExtendsTypeParam.ts
 Bindings mismatch:
@@ -3357,13 +3033,8 @@ Reference symbol mismatch for "z":
 after transform: SymbolId(56) "z"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Exclude", "Extract", "Pick"]
+after transform: []
 rebuilt        : ["z"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/constDeclarationShadowedByVarDeclaration3.ts
-Unresolved reference IDs mismatch for "RegExp":
-after transform: [ReferenceId(0), ReferenceId(1)]
-rebuilt        : [ReferenceId(2)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/constDeclarations-ambient.ts
 Bindings mismatch:
@@ -3519,9 +3190,6 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "En":
 after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "En":
-after transform: SymbolId(0): [ReferenceId(2), ReferenceId(4), ReferenceId(7), ReferenceId(10), ReferenceId(13), ReferenceId(25)]
-rebuilt        : SymbolId(0): [ReferenceId(9), ReferenceId(12), ReferenceId(15), ReferenceId(18), ReferenceId(21)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/constEnumToStringNoComments.ts
 Bindings mismatch:
@@ -3545,17 +3213,6 @@ Symbol flags mismatch for "Foo":
 after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/constraintCheckInGenericBaseTypeReference.ts
-Symbol reference IDs mismatch for "Constraint":
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(3): [ReferenceId(4)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch for "TypeArg":
-after transform: SymbolId(4): [ReferenceId(2)]
-rebuilt        : SymbolId(4): []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/constructorOverloads5.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["M"]
@@ -3566,18 +3223,10 @@ Bindings mismatch:
 after transform: ScopeId(0): ["X", "Y", "anotherVar"]
 rebuilt        : ScopeId(0): ["anotherVar"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/constructorWithCapturedSuper.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2), ReferenceId(5), ReferenceId(11)]
-rebuilt        : SymbolId(1): [ReferenceId(1), ReferenceId(4), ReferenceId(10)]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/contextSensitiveReturnTypeInference.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["DEPS", "test"]
 rebuilt        : ScopeId(0): ["DEPS"]
-Symbol reference IDs mismatch for "DEPS":
-after transform: SymbolId(7): [ReferenceId(8), ReferenceId(6), ReferenceId(11), ReferenceId(15), ReferenceId(19), ReferenceId(22)]
-rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(7), ReferenceId(11), ReferenceId(15), ReferenceId(18)]
 Reference symbol mismatch for "test":
 after transform: SymbolId(1) "test"
 rebuilt        : <None>
@@ -3610,9 +3259,6 @@ rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
 Symbol span mismatch for "propName":
 after transform: SymbolId(16): Span { start: 526, end: 534 }
 rebuilt        : SymbolId(2): Span { start: 551, end: 559 }
-Symbol reference IDs mismatch for "propName":
-after transform: SymbolId(16): [ReferenceId(13), ReferenceId(14), ReferenceId(15)]
-rebuilt        : SymbolId(2): [ReferenceId(4)]
 Symbol redeclarations mismatch for "propName":
 after transform: SymbolId(16): [Span { start: 526, end: 534 }, Span { start: 551, end: 559 }]
 rebuilt        : SymbolId(2): []
@@ -3636,18 +3282,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/contextualOuterTy
 Bindings mismatch:
 after transform: ScopeId(0): ["f", "fn1", "fn2", "obj"]
 rebuilt        : ScopeId(0): ["fn1", "fn2", "obj"]
-Symbol reference IDs mismatch for "t":
-after transform: SymbolId(4): [ReferenceId(2), ReferenceId(3)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "t":
-after transform: SymbolId(10): [ReferenceId(5), ReferenceId(6)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "t":
-after transform: SymbolId(17): [ReferenceId(8), ReferenceId(9)]
-rebuilt        : SymbolId(5): []
-Symbol reference IDs mismatch for "t":
-after transform: SymbolId(23): [ReferenceId(11), ReferenceId(12)]
-rebuilt        : SymbolId(7): []
 Reference symbol mismatch for "f":
 after transform: SymbolId(0) "f"
 rebuilt        : <None>
@@ -3683,16 +3317,13 @@ Reference symbol mismatch for "effectFn":
 after transform: SymbolId(5) "effectFn"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Array"]
+after transform: []
 rebuilt        : ["Foo", "effectFn", "effectGen", "layerEffect"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/contextualParamTypeVsNestedReturnTypeInference2.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "effectFn", "effectGen", "layerEffect"]
 rebuilt        : ScopeId(0): ["Foo"]
-Symbol reference IDs mismatch for "Foo":
-after transform: SymbolId(52): [ReferenceId(62), ReferenceId(65)]
-rebuilt        : SymbolId(0): [ReferenceId(2)]
 Reference symbol mismatch for "Tag":
 after transform: SymbolId(30) "Tag"
 rebuilt        : <None>
@@ -3706,16 +3337,13 @@ Reference symbol mismatch for "effectFn":
 after transform: SymbolId(17) "effectFn"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Array", "Generator"]
+after transform: []
 rebuilt        : ["Tag", "effectFn", "effectGen", "layerEffect"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/contextualParamTypeVsNestedReturnTypeInference3.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "effectFn", "effectGen", "layerEffect"]
 rebuilt        : ScopeId(0): ["Foo"]
-Symbol reference IDs mismatch for "Foo":
-after transform: SymbolId(52): [ReferenceId(58), ReferenceId(61)]
-rebuilt        : SymbolId(0): [ReferenceId(2)]
 Reference symbol mismatch for "Tag":
 after transform: SymbolId(30) "Tag"
 rebuilt        : <None>
@@ -3729,16 +3357,13 @@ Reference symbol mismatch for "effectFn":
 after transform: SymbolId(17) "effectFn"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Array", "Generator"]
+after transform: []
 rebuilt        : ["Tag", "effectFn", "effectGen", "layerEffect"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/contextualParamTypeVsNestedReturnTypeInference4.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "effectFn", "effectGen", "layerEffect"]
 rebuilt        : ScopeId(0): ["Foo"]
-Symbol reference IDs mismatch for "Foo":
-after transform: SymbolId(44): [ReferenceId(54), ReferenceId(57)]
-rebuilt        : SymbolId(0): [ReferenceId(2)]
 Reference symbol mismatch for "Tag":
 after transform: SymbolId(22) "Tag"
 rebuilt        : <None>
@@ -3752,7 +3377,7 @@ Reference symbol mismatch for "effectFn":
 after transform: SymbolId(13) "effectFn"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Array", "Generator"]
+after transform: []
 rebuilt        : ["Tag", "effectFn", "effectGen", "layerEffect"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/contextualParameterAndSelfReferentialConstraint1.ts
@@ -3766,7 +3391,7 @@ Reference symbol mismatch for "repeat":
 after transform: SymbolId(16) "repeat"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Exclude"]
+after transform: []
 rebuilt        : ["pipe", "repeat"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/contextualPropertyOfGenericMappedType.ts
@@ -3779,11 +3404,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["f"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/contextualReturnTypeOfIIFE.ts
-Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
-rebuilt        : [ReferenceId(2)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/contextualReturnTypeOfIIFE2.ts
 Bindings mismatch:
@@ -3898,7 +3518,7 @@ Reference symbol mismatch for "Flex":
 after transform: SymbolId(21) "Flex"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Partial"]
+after transform: []
 rebuilt        : ["Flex", "styled"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/contextualTypeBasedOnIntersectionWithAnyInTheMix2.ts
@@ -3943,7 +3563,7 @@ Reference symbol mismatch for "ThemeSymbol":
 after transform: SymbolId(28) "ThemeSymbol"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Readonly", "Record", "Symbol", "ThisType"]
+after transform: []
 rebuilt        : ["ThemeSymbol", "app", "inject", "reactive"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/contextualTypeCaching.ts
@@ -3968,7 +3588,7 @@ Reference symbol mismatch for "DMap":
 after transform: SymbolId(0) "DMap"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Iterable"]
+after transform: []
 rebuilt        : ["DMap"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/contextualTypeOfIndexedAccessParameter.ts
@@ -3981,16 +3601,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["f"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/contextualTypeOnYield1.ts
-Unresolved references mismatch:
-after transform: ["Generator", "console"]
-rebuilt        : ["console"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/contextualTypeOnYield2.ts
-Unresolved references mismatch:
-after transform: ["Generator", "console"]
-rebuilt        : ["console"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/contextualTypeSelfReferencing.ts
 Bindings mismatch:
@@ -4007,40 +3617,23 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/contextualTypesNe
 Bindings mismatch:
 after transform: ScopeId(0): ["DEFAULT_TABS_TAG", "TabGroup"]
 rebuilt        : ScopeId(0): ["DEFAULT_TABS_TAG"]
-Symbol reference IDs mismatch for "DEFAULT_TABS_TAG":
-after transform: SymbolId(4): [ReferenceId(11), ReferenceId(15)]
-rebuilt        : SymbolId(0): []
 Reference symbol mismatch for "TabGroup":
 after transform: SymbolId(14) "TabGroup"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Event", "Omit", "const"]
+after transform: []
 rebuilt        : ["TabGroup"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/contextualTypesNegatedTypeLikeConstraintInGenericMappedType3.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["DEFAULT_TABS_TAG", "TabGroup"]
 rebuilt        : ScopeId(0): ["DEFAULT_TABS_TAG"]
-Symbol reference IDs mismatch for "DEFAULT_TABS_TAG":
-after transform: SymbolId(8): [ReferenceId(17), ReferenceId(21)]
-rebuilt        : SymbolId(0): []
 Reference symbol mismatch for "TabGroup":
 after transform: SymbolId(18) "TabGroup"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Event", "Exclude", "const"]
+after transform: []
 rebuilt        : ["TabGroup"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/contextualTypingArrayOfLambdas.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(2), ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(1): [ReferenceId(2), ReferenceId(5)]
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(1): [ReferenceId(3)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(2): [ReferenceId(4)]
-rebuilt        : SymbolId(4): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/contextualTypingFunctionReturningFunction.ts
 Bindings mismatch:
@@ -4064,11 +3657,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["f"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfConditionalExpression.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(4): [ReferenceId(2), ReferenceId(3), ReferenceId(4)]
-rebuilt        : SymbolId(4): [ReferenceId(4), ReferenceId(7)]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfOptionalMembers.tsx
 Bindings mismatch:
 after transform: ScopeId(0): ["App4", "JSX", "_jsxFileName", "_reactJsxRuntime", "a", "app", "app2", "app3", "foo", "y"]
@@ -4091,11 +3679,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["require", "undefined"]
 rebuilt        : ["App4", "app", "app2", "app3", "foo", "require", "undefined"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfTooShortOverloads.ts
-Unresolved references mismatch:
-after transform: ["RegExp"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/contextualTypingReturnStatementWithReturnTypeAnnotation.ts
 Bindings mismatch:
@@ -4128,16 +3711,8 @@ Reference symbol mismatch for "load":
 after transform: SymbolId(7) "load"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "Record", "arguments", "require"]
+after transform: ["Promise", "arguments", "require"]
 rebuilt        : ["Promise", "arguments", "createMachine", "load", "require"]
-Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(2), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(11), ReferenceId(12), ReferenceId(13)]
-rebuilt        : [ReferenceId(3), ReferenceId(7), ReferenceId(9)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypeGeneratorReturnTypeFromUnion.ts
-Unresolved references mismatch:
-after transform: ["AsyncGenerator", "Generator", "Promise", "require"]
-rebuilt        : ["Promise", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedBooleanLiterals.ts
 Bindings mismatch:
@@ -4190,21 +3765,10 @@ Unresolved references mismatch:
 after transform: ["require"]
 rebuilt        : ["Test", "require"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedJsxAttribute2.tsx
-Bindings mismatch:
-after transform: ScopeId(0): ["ComponentPropsWithRef", "ElementType", "React", "UnwrappedLink", "UnwrappedLink2", "_jsxFileName"]
-rebuilt        : ScopeId(0): ["React", "UnwrappedLink", "UnwrappedLink2", "_jsxFileName"]
-Unresolved references mismatch:
-after transform: ["Omit"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedJsxChildren.tsx
 Bindings mismatch:
 after transform: ScopeId(0): ["DropdownMenu", "React", "_jsxFileName"]
 rebuilt        : ScopeId(0): ["React", "_jsxFileName"]
-Symbol reference IDs mismatch for "React":
-after transform: SymbolId(0): [ReferenceId(6), ReferenceId(15), ReferenceId(16), ReferenceId(18), ReferenceId(21), ReferenceId(22), ReferenceId(24)]
-rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(3), ReferenceId(5), ReferenceId(8), ReferenceId(10), ReferenceId(12)]
 Reference symbol mismatch for "DropdownMenu":
 after transform: SymbolId(1) "DropdownMenu"
 rebuilt        : <None>
@@ -4212,16 +3776,13 @@ Reference symbol mismatch for "DropdownMenu":
 after transform: SymbolId(1) "DropdownMenu"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["JSX"]
+after transform: []
 rebuilt        : ["DropdownMenu"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedJsxChildren2.tsx
 Bindings mismatch:
 after transform: ScopeId(0): ["App", "React", "Subscribe", "TestComponentWithChildren", "TestComponentWithoutChildren", "_jsxFileName", "_result"]
 rebuilt        : ScopeId(0): ["App", "React", "_jsxFileName", "_result"]
-Symbol reference IDs mismatch for "React":
-after transform: SymbolId(0): [ReferenceId(6), ReferenceId(7), ReferenceId(14), ReferenceId(15), ReferenceId(29), ReferenceId(36), ReferenceId(38), ReferenceId(40), ReferenceId(42), ReferenceId(43), ReferenceId(44), ReferenceId(46)]
-rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(6), ReferenceId(10), ReferenceId(13), ReferenceId(18)]
 Reference symbol mismatch for "TestComponentWithChildren":
 after transform: SymbolId(1) "TestComponentWithChildren"
 rebuilt        : <None>
@@ -4232,7 +3793,7 @@ Reference symbol mismatch for "Subscribe":
 after transform: SymbolId(19) "Subscribe"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Math", "NoInfer", "console"]
+after transform: ["Math", "console"]
 rebuilt        : ["Math", "Subscribe", "TestComponentWithChildren", "TestComponentWithoutChildren", "console"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedOptionalProperty.ts
@@ -4266,7 +3827,7 @@ Reference symbol mismatch for "num":
 after transform: SymbolId(11) "num"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Record"]
+after transform: []
 rebuilt        : ["num", "test1"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedParametersWithInitializers3.ts
@@ -4291,19 +3852,13 @@ Reference symbol mismatch for "test":
 after transform: SymbolId(0) "test"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Record"]
+after transform: []
 rebuilt        : ["test"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedSymbolNamedProperties.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "ab", "f", "x"]
 rebuilt        : ScopeId(0): ["A", "B", "x"]
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(2), ReferenceId(10), ReferenceId(14)]
-rebuilt        : SymbolId(0): [ReferenceId(4), ReferenceId(8)]
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(1): [ReferenceId(3), ReferenceId(12)]
-rebuilt        : SymbolId(1): [ReferenceId(6)]
 Reference symbol mismatch for "f":
 after transform: SymbolId(4) "f"
 rebuilt        : <None>
@@ -4333,7 +3888,7 @@ Reference symbol mismatch for "foo":
 after transform: SymbolId(6) "foo"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Record"]
+after transform: []
 rebuilt        : ["foo"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/contravariantOnlyInferenceWithAnnotatedOptionalParameter.ts
@@ -4453,9 +4008,6 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "User":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "User":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(13)]
-rebuilt        : SymbolId(0): [ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(11)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowCommaExpressionAssertionWithinTernary.ts
 Bindings mismatch:
@@ -4533,7 +4085,7 @@ Reference symbol mismatch for "obj4":
 after transform: SymbolId(7) "obj4"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Record"]
+after transform: []
 rebuilt        : ["isObject1", "isObject2", "obj1", "obj2", "obj3", "obj4"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowForCatchAndFinally.ts
@@ -4550,7 +4102,7 @@ Reference symbol mismatch for "Aborter":
 after transform: SymbolId(8) "Aborter"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require", "undefined"]
+after transform: ["arguments", "require", "undefined"]
 rebuilt        : ["Aborter", "arguments", "require", "test1", "test2", "undefined"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowInitializedDestructuringVariables.ts
@@ -4568,9 +4120,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowInstan
 Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "Y", "_defineProperty", "ctor", "f1", "f2", "f3", "f4", "foo", "goo", "x"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "Y", "_defineProperty", "f1", "f2", "f3", "f4", "foo", "goo"]
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(8): [ReferenceId(38), ReferenceId(36), ReferenceId(37)]
-rebuilt        : SymbolId(9): [ReferenceId(30), ReferenceId(33)]
 Reference symbol mismatch for "x":
 after transform: SymbolId(17) "x"
 rebuilt        : <None>
@@ -4581,25 +4130,13 @@ Reference symbol mismatch for "x":
 after transform: SymbolId(17) "x"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Function", "Promise", "Set", "require"]
+after transform: ["Promise", "Set", "require"]
 rebuilt        : ["Promise", "Set", "ctor", "require", "x"]
-Unresolved reference IDs mismatch for "Set":
-after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(6), ReferenceId(10), ReferenceId(11), ReferenceId(13), ReferenceId(20), ReferenceId(21), ReferenceId(24), ReferenceId(27), ReferenceId(28), ReferenceId(30), ReferenceId(33)]
-rebuilt        : [ReferenceId(2), ReferenceId(5), ReferenceId(10), ReferenceId(19), ReferenceId(23), ReferenceId(26)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowInstanceofWithSymbolHasInstance.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(12): [ReferenceId(49), ReferenceId(47), ReferenceId(48)]
-rebuilt        : SymbolId(10): [ReferenceId(36), ReferenceId(39)]
-Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(1), ReferenceId(20)]
-rebuilt        : [ReferenceId(13)]
 Unresolved reference IDs mismatch for "Symbol":
 after transform: [ReferenceId(0), ReferenceId(2), ReferenceId(40), ReferenceId(45)]
 rebuilt        : [ReferenceId(30), ReferenceId(34)]
-Unresolved reference IDs mismatch for "Set":
-after transform: [ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(7), ReferenceId(10), ReferenceId(14), ReferenceId(15), ReferenceId(17), ReferenceId(24), ReferenceId(25), ReferenceId(28), ReferenceId(31), ReferenceId(32), ReferenceId(34), ReferenceId(37)]
-rebuilt        : [ReferenceId(2), ReferenceId(5), ReferenceId(10), ReferenceId(19), ReferenceId(23), ReferenceId(26)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowManyConsecutiveConditionsNoTimeout.ts
 Bindings mismatch:
@@ -4611,9 +4148,6 @@ rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "Choice":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "Choice":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
-rebuilt        : SymbolId(0): [ReferenceId(5), ReferenceId(6)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowPropertyDeclarations.ts
 Bindings mismatch:
@@ -4625,11 +4159,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["Error", "JSON"]
 rebuilt        : ["Error", "JSON", "require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowUnionContainingTypeParameter1.ts
-Unresolved references mismatch:
-after transform: ["Date"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowWithIncompleteTypes.ts
 Bindings mismatch:
@@ -4649,9 +4178,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/correlatedUnions.
 Bindings mismatch:
 after transform: ScopeId(0): ["ALL_BARS", "BAR_LOOKUP", "bar", "call", "clickEvent", "createEventListener", "data", "f1", "f2", "f3", "f4", "ff1", "foo", "func", "getConfigOrDefault", "getStringAndNumberFromOriginalAndMapped", "getValueConcrete", "handlers", "makeCompleteLookupMapping", "process", "processEvents", "processRecord", "r1", "r2", "ref", "renderField", "renderFuncs", "renderSelectField", "renderTextField", "scrollEvent", "xx"]
 rebuilt        : ScopeId(0): ["ALL_BARS", "BAR_LOOKUP", "call", "clickEvent", "createEventListener", "data", "f1", "f2", "f3", "f4", "ff1", "foo", "func", "getConfigOrDefault", "getStringAndNumberFromOriginalAndMapped", "getValueConcrete", "handlers", "process", "processEvents", "processRecord", "ref", "renderField", "renderFuncs", "renderSelectField", "renderTextField", "scrollEvent"]
-Symbol reference IDs mismatch for "BAR_LOOKUP":
-after transform: SymbolId(148): [ReferenceId(232)]
-rebuilt        : SymbolId(74): []
 Reference symbol mismatch for "r1":
 after transform: SymbolId(8) "r1"
 rebuilt        : <None>
@@ -4668,13 +4194,8 @@ Reference symbol mismatch for "makeCompleteLookupMapping":
 after transform: SymbolId(141) "makeCompleteLookupMapping"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["DocumentEventMap", "Partial", "ReadonlyArray", "Record", "Required", "console", "const", "document", "undefined"]
+after transform: ["console", "document", "undefined"]
 rebuilt        : ["bar", "console", "document", "makeCompleteLookupMapping", "r1", "r2", "undefined", "xx"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/customAsyncIterator.ts
-Unresolved references mismatch:
-after transform: ["AsyncIterator", "Error", "IteratorResult", "Promise", "require"]
-rebuilt        : ["Error", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileEnumUsedAsValue.ts
 Bindings mismatch:
@@ -4745,19 +4266,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m3":
 after transform: SymbolId(0): Span { start: 10, end: 12 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileForClassWithMultipleBaseClasses.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(2)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(1): [ReferenceId(3)]
-rebuilt        : SymbolId(1): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileForFunctionTypeAsTypeParameter.ts
-Symbol reference IDs mismatch for "X":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileGenericType2.ts
 Bindings mismatch:
@@ -4833,7 +4341,7 @@ Reference symbol mismatch for "templa":
 after transform: SymbolId(0) "templa"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["IElementController", "require"]
+after transform: ["require"]
 rebuilt        : ["require", "templa"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileImportChainInExportAssignment.ts
@@ -4857,16 +4365,8 @@ rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol span mismatch for "m2":
 after transform: SymbolId(0): Span { start: 10, end: 12 }
 rebuilt        : SymbolId(0): Span { start: 232, end: 234 }
-Symbol reference IDs mismatch for "m2":
-after transform: SymbolId(0): [ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5)]
-rebuilt        : SymbolId(0): [ReferenceId(1)]
 Symbol redeclarations mismatch for "m2":
 after transform: SymbolId(0): [Span { start: 10, end: 12 }, Span { start: 232, end: 234 }]
-rebuilt        : SymbolId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileImportedTypeUseInTypeArgPosition.ts
-Symbol reference IDs mismatch for "List":
-after transform: SymbolId(0): [ReferenceId(0)]
 rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileInternalAliases.ts
@@ -4927,9 +4427,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(11), ReferenceId(12)]
-rebuilt        : SymbolId(0): [ReferenceId(10), ReferenceId(11)]
 Symbol redeclarations mismatch for "A":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 60, end: 61 }]
 rebuilt        : SymbolId(0): []
@@ -4962,9 +4459,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFilePrivateMe
 Bindings mismatch:
 after transform: ScopeId(0): ["c1", "c2"]
 rebuilt        : ScopeId(0): ["c1"]
-Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileTypeofEnum.ts
 Bindings mismatch:
@@ -4976,35 +4470,20 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "days":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "days":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(18)]
-rebuilt        : SymbolId(0): [ReferenceId(15), ReferenceId(16), ReferenceId(17)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileTypeofFunction.ts
 Symbol span mismatch for "f":
 after transform: SymbolId(0): Span { start: 9, end: 10 }
 rebuilt        : SymbolId(0): Span { start: 75, end: 76 }
-Symbol reference IDs mismatch for "f":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(4)]
-rebuilt        : SymbolId(0): []
 Symbol redeclarations mismatch for "f":
 after transform: SymbolId(0): [Span { start: 9, end: 10 }, Span { start: 42, end: 43 }, Span { start: 75, end: 76 }]
 rebuilt        : SymbolId(0): []
 Symbol span mismatch for "g":
 after transform: SymbolId(3): Span { start: 110, end: 111 }
 rebuilt        : SymbolId(1): Span { start: 176, end: 177 }
-Symbol reference IDs mismatch for "g":
-after transform: SymbolId(3): [ReferenceId(3), ReferenceId(1)]
-rebuilt        : SymbolId(1): []
 Symbol redeclarations mismatch for "g":
 after transform: SymbolId(3): [Span { start: 110, end: 111 }, Span { start: 143, end: 144 }, Span { start: 176, end: 177 }]
 rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(6): [ReferenceId(6)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "foo":
-after transform: SymbolId(8): [ReferenceId(8), ReferenceId(9), ReferenceId(10)]
-rebuilt        : SymbolId(4): [ReferenceId(3)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileTypeofInAnonymousType.ts
 Scope flags mismatch:
@@ -5022,9 +4501,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1":
 after transform: SymbolId(0): Span { start: 10, end: 12 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "m1":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(12), ReferenceId(13)]
-rebuilt        : SymbolId(0): [ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19)]
 Symbol flags mismatch for "e":
 after transform: SymbolId(2): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
@@ -5044,18 +4520,12 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1":
 after transform: SymbolId(0): Span { start: 10, end: 12 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "m1":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(5), ReferenceId(6)]
-rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 Symbol flags mismatch for "m2":
 after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m2":
 after transform: SymbolId(4): Span { start: 90, end: 92 }
 rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "m2":
-after transform: SymbolId(4): [ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(7), ReferenceId(8)]
-rebuilt        : SymbolId(5): [ReferenceId(3), ReferenceId(4), ReferenceId(5)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileWithInternalModuleNameConflictsInExtendsClause1.ts
 Scope flags mismatch:
@@ -5079,9 +4549,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "X":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "X":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(15), ReferenceId(16)]
-rebuilt        : SymbolId(0): [ReferenceId(14), ReferenceId(15)]
 Symbol redeclarations mismatch for "X":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 61, end: 62 }]
 rebuilt        : SymbolId(0): []
@@ -5132,9 +4599,6 @@ rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(4): Span { start: 63, end: 64 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(4): [ReferenceId(0), ReferenceId(11), ReferenceId(13)]
-rebuilt        : SymbolId(2): [ReferenceId(10), ReferenceId(11)]
 Symbol flags mismatch for "B":
 after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
@@ -5167,9 +4631,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "X":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "X":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(15), ReferenceId(16)]
-rebuilt        : SymbolId(0): [ReferenceId(14), ReferenceId(15)]
 Symbol redeclarations mismatch for "X":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 61, end: 62 }, Span { start: 188, end: 189 }]
 rebuilt        : SymbolId(0): []
@@ -5202,12 +4663,6 @@ rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
 rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(1): [ReferenceId(10), ReferenceId(0), ReferenceId(1), ReferenceId(11)]
-rebuilt        : SymbolId(3): [ReferenceId(10)]
-Symbol reference IDs mismatch for "E":
-after transform: SymbolId(2): [ReferenceId(5), ReferenceId(2), ReferenceId(13)]
-rebuilt        : SymbolId(4): [ReferenceId(2)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declInput.ts
 Bindings mismatch:
@@ -5219,16 +4674,8 @@ rebuilt        : SymbolId(0): SymbolFlags(Class)
 Symbol span mismatch for "bar":
 after transform: SymbolId(0): Span { start: 10, end: 13 }
 rebuilt        : SymbolId(0): Span { start: 26, end: 29 }
-Symbol reference IDs mismatch for "bar":
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(0): []
 Symbol redeclarations mismatch for "bar":
 after transform: SymbolId(0): [Span { start: 10, end: 13 }, Span { start: 26, end: 29 }]
-rebuilt        : SymbolId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declInput3.ts
-Symbol reference IDs mismatch for "bar":
-after transform: SymbolId(1): [ReferenceId(0)]
 rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declInput4.ts
@@ -5241,9 +4688,6 @@ rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
 rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "E":
-after transform: SymbolId(2): [ReferenceId(2), ReferenceId(0), ReferenceId(6)]
-rebuilt        : SymbolId(4): [ReferenceId(2)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationAssertionNodeNotReusedWhenTypeNotEquivalent1.ts
 Bindings mismatch:
@@ -5259,53 +4703,8 @@ Reference symbol mismatch for "unwrap":
 after transform: SymbolId(10) "unwrap"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Record"]
+after transform: []
 rebuilt        : ["objWrapper", "stringWrapper", "unwrap"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitAliasExportStar.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["thing2", "things"]
-rebuilt        : ScopeId(0): ["thing2"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitAliasFromIndirectFile.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["FlatpickrFn", "fp"]
-rebuilt        : ScopeId(0): ["fp"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitAliasInlineing.ts
-Unresolved references mismatch:
-after transform: ["Omit"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitArrayTypesFromGenericArrayUsage.ts
-Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitBindingPatternWithReservedWord.ts
-Unresolved references mismatch:
-after transform: ["Partial", "Record"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitBindingPatternsFunctionExpr.ts
-Symbol reference IDs mismatch for "value":
-after transform: SymbolId(12): [ReferenceId(5), ReferenceId(6)]
-rebuilt        : SymbolId(11): [ReferenceId(0)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitClassMemberWithComputedPropertyName.ts
-Unresolved references mismatch:
-after transform: ["Symbol", "const"]
-rebuilt        : ["Symbol"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitClassMixinLocalClassDeclaration.ts
-Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(14): [ReferenceId(13), ReferenceId(14), ReferenceId(11)]
-rebuilt        : SymbolId(2): [ReferenceId(1)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedNameCausesImportToBePainted.ts
-Symbol reference IDs mismatch for "Key":
-after transform: SymbolId(0): [ReferenceId(1)]
-rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedNameConstEnumAlias.ts
 Bindings mismatch:
@@ -5326,7 +4725,7 @@ Reference symbol mismatch for "something":
 after transform: SymbolId(0) "something"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["const"]
+after transform: []
 rebuilt        : ["something"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedPropertyName1.ts
@@ -5350,9 +4749,6 @@ rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "Enum":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "Enum":
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitCrossFileCopiedGeneratedImportType.ts
 Unresolved references mismatch:
@@ -5409,11 +4805,6 @@ Symbol span mismatch for "m":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDistributiveConditionalWithInfer.ts
-Unresolved references mismatch:
-after transform: ["FlatArray"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDoesNotUseReexportedNamespaceAsLocal.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["_Q", "add", "x"]
@@ -5422,7 +4813,7 @@ Reference symbol mismatch for "add":
 after transform: SymbolId(1) "add"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise"]
+after transform: []
 rebuilt        : ["add"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitEnumReadonlyProperty.ts
@@ -5435,9 +4826,6 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "E":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "E":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(6)]
-rebuilt        : SymbolId(1): [ReferenceId(4), ReferenceId(6)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitEnumReferenceViaImportEquals.ts
 Bindings mismatch:
@@ -5452,9 +4840,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Translation":
 after transform: SymbolId(0): Span { start: 17, end: 28 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "Translation":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(4), ReferenceId(5)]
-rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(2)]
 Symbol redeclarations mismatch for "Translation":
 after transform: SymbolId(0): [Span { start: 17, end: 28 }, Span { start: 101, end: 112 }]
 rebuilt        : SymbolId(0): []
@@ -5464,9 +4849,6 @@ rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable)
 Symbol span mismatch for "TranslationKeyEnum":
 after transform: SymbolId(1): Span { start: 129, end: 147 }
 rebuilt        : SymbolId(2): Span { start: 198, end: 216 }
-Symbol reference IDs mismatch for "TranslationKeyEnum":
-after transform: SymbolId(1): [ReferenceId(1), ReferenceId(2)]
-rebuilt        : SymbolId(2): []
 Symbol redeclarations mismatch for "TranslationKeyEnum":
 after transform: SymbolId(1): [Span { start: 129, end: 147 }, Span { start: 198, end: 216 }]
 rebuilt        : SymbolId(2): []
@@ -5481,9 +4863,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable)
 Symbol span mismatch for "Point":
 after transform: SymbolId(0): Span { start: 17, end: 22 }
 rebuilt        : SymbolId(0): Span { start: 171, end: 176 }
-Symbol reference IDs mismatch for "Point":
-after transform: SymbolId(0): [ReferenceId(3), ReferenceId(6), ReferenceId(14), ReferenceId(0), ReferenceId(13), ReferenceId(15)]
-rebuilt        : SymbolId(0): [ReferenceId(4), ReferenceId(5)]
 Symbol redeclarations mismatch for "Point":
 after transform: SymbolId(0): [Span { start: 17, end: 22 }, Span { start: 171, end: 176 }]
 rebuilt        : SymbolId(0): []
@@ -5493,22 +4872,9 @@ rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable | ConstVariable)
 Symbol span mismatch for "Rect":
 after transform: SymbolId(1): Span { start: 93, end: 97 }
 rebuilt        : SymbolId(3): Span { start: 237, end: 241 }
-Symbol reference IDs mismatch for "Rect":
-after transform: SymbolId(1): [ReferenceId(9)]
-rebuilt        : SymbolId(3): []
 Symbol redeclarations mismatch for "Rect":
 after transform: SymbolId(1): [Span { start: 93, end: 97 }, Span { start: 237, end: 241 }]
 rebuilt        : SymbolId(3): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExportAliasVisibiilityMarking.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["Rank", "Suit"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExportAssignedNamespaceNoTripleSlashTypesReference.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["Component", "getComp"]
-rebuilt        : ScopeId(0): ["getComp"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends5.ts
 Scope flags mismatch:
@@ -5521,29 +4887,6 @@ Symbol span mismatch for "Test":
 after transform: SymbolId(0): Span { start: 10, end: 14 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitFirstTypeArgumentGenericFunctionType.ts
-Symbol reference IDs mismatch for "X":
-after transform: SymbolId(0): [ReferenceId(6), ReferenceId(9), ReferenceId(0), ReferenceId(2)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "Y":
-after transform: SymbolId(12): [ReferenceId(12), ReferenceId(14), ReferenceId(16), ReferenceId(19)]
-rebuilt        : SymbolId(7): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitForGlobalishSpecifierSymlink.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["_whatever", "a", "getA"]
-rebuilt        : ScopeId(0): ["a", "getA"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitForGlobalishSpecifierSymlink2.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["_whatever", "a", "getA"]
-rebuilt        : ScopeId(0): ["a", "getA"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitForModuleImportingModuleAugmentationRetainsImport.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["ParentThing", "child1"]
-rebuilt        : ScopeId(0): ["child1"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitFunctionDuplicateNamespace.ts
 Symbol span mismatch for "f":
 after transform: SymbolId(0): Span { start: 9, end: 10 }
@@ -5551,40 +4894,6 @@ rebuilt        : SymbolId(0): Span { start: 51, end: 52 }
 Symbol redeclarations mismatch for "f":
 after transform: SymbolId(0): [Span { start: 9, end: 10 }, Span { start: 30, end: 31 }, Span { start: 51, end: 52 }]
 rebuilt        : SymbolId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitGlobalThisPreserved.ts
-Symbol reference IDs mismatch for "a4":
-after transform: SymbolId(8): [ReferenceId(28)]
-rebuilt        : SymbolId(9): []
-Symbol reference IDs mismatch for "aObj":
-after transform: SymbolId(10): [ReferenceId(31)]
-rebuilt        : SymbolId(11): []
-Symbol reference IDs mismatch for "b4":
-after transform: SymbolId(27): [ReferenceId(52)]
-rebuilt        : SymbolId(26): []
-Symbol reference IDs mismatch for "bObj":
-after transform: SymbolId(29): [ReferenceId(55)]
-rebuilt        : SymbolId(28): []
-Symbol reference IDs mismatch for "c4":
-after transform: SymbolId(46): [ReferenceId(76)]
-rebuilt        : SymbolId(43): []
-Symbol reference IDs mismatch for "cObj":
-after transform: SymbolId(48): [ReferenceId(79)]
-rebuilt        : SymbolId(45): []
-Symbol reference IDs mismatch for "d4":
-after transform: SymbolId(68): [ReferenceId(101)]
-rebuilt        : SymbolId(63): []
-Unresolved references mismatch:
-after transform: ["ReturnType", "globalThis"]
-rebuilt        : ["globalThis"]
-Unresolved reference IDs mismatch for "globalThis":
-after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(8), ReferenceId(9), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(21), ReferenceId(22), ReferenceId(24), ReferenceId(25), ReferenceId(32), ReferenceId(34), ReferenceId(35), ReferenceId(38), ReferenceId(40), ReferenceId(41), ReferenceId(43), ReferenceId(44), ReferenceId(47), ReferenceId(49), ReferenceId(56), ReferenceId(58), ReferenceId(59), ReferenceId(62), ReferenceId(64), ReferenceId(65), ReferenceId(67), ReferenceId(68), ReferenceId(71), ReferenceId(73), ReferenceId(80), ReferenceId(81), ReferenceId(84), ReferenceId(85), ReferenceId(86), ReferenceId(90), ReferenceId(91), ReferenceId(94), ReferenceId(95), ReferenceId(102), ReferenceId(104), ReferenceId(105), ReferenceId(108), ReferenceId(110), ReferenceId(111), ReferenceId(113), ReferenceId(114), ReferenceId(116), ReferenceId(117), ReferenceId(119), ReferenceId(120), ReferenceId(121), ReferenceId(122)]
-rebuilt        : [ReferenceId(6), ReferenceId(13), ReferenceId(20), ReferenceId(27), ReferenceId(34), ReferenceId(41), ReferenceId(51), ReferenceId(59)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitHasTypesRefOnNamespaceUse.ts
-Unresolved references mismatch:
-after transform: ["NS"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitHigherOrderRetainedGenerics.ts
 Bindings mismatch:
@@ -5602,9 +4911,6 @@ rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
 Symbol span mismatch for "F":
 after transform: SymbolId(100): Span { start: 2588, end: 2589 }
 rebuilt        : SymbolId(4): Span { start: 2610, end: 2611 }
-Symbol reference IDs mismatch for "F":
-after transform: SymbolId(100): [ReferenceId(159), ReferenceId(161), ReferenceId(170), ReferenceId(176), ReferenceId(185), ReferenceId(191), ReferenceId(200), ReferenceId(210), ReferenceId(216), ReferenceId(225), ReferenceId(233), ReferenceId(234)]
-rebuilt        : SymbolId(4): [ReferenceId(2), ReferenceId(3)]
 Symbol redeclarations mismatch for "F":
 after transform: SymbolId(100): [Span { start: 2588, end: 2589 }, Span { start: 2610, end: 2611 }]
 rebuilt        : SymbolId(4): []
@@ -5614,9 +4920,6 @@ rebuilt        : SymbolId(11): SymbolFlags(FunctionScopedVariable)
 Symbol span mismatch for "F":
 after transform: SymbolId(146): Span { start: 3332, end: 3333 }
 rebuilt        : SymbolId(11): Span { start: 3354, end: 3355 }
-Symbol reference IDs mismatch for "F":
-after transform: SymbolId(146): [ReferenceId(242), ReferenceId(244), ReferenceId(250), ReferenceId(256), ReferenceId(265), ReferenceId(271), ReferenceId(277), ReferenceId(287), ReferenceId(293), ReferenceId(299), ReferenceId(308)]
-rebuilt        : SymbolId(11): [ReferenceId(11)]
 Symbol redeclarations mismatch for "F":
 after transform: SymbolId(146): [Span { start: 3332, end: 3333 }, Span { start: 3354, end: 3355 }]
 rebuilt        : SymbolId(11): []
@@ -5627,7 +4930,7 @@ Reference symbol mismatch for "dual":
 after transform: SymbolId(85) "dual"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Array", "IArguments", "Iterable", "Parameters"]
+after transform: []
 rebuilt        : ["dual"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitImportInExportAssignmentModule.ts
@@ -5673,11 +4976,6 @@ Symbol redeclarations mismatch for "Y":
 after transform: SymbolId(3): [Span { start: 128, end: 129 }, Span { start: 149, end: 150 }]
 rebuilt        : SymbolId(3): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitMappedTypeDistributivityPreservesConstraints.ts
-Unresolved references mismatch:
-after transform: ["Parameters", "Record"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitMappedTypePreservesTypeParameterConstraint.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["ZodLiteral", "ZodType", "buildSchema"]
@@ -5691,9 +4989,6 @@ rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable)
 Symbol span mismatch for "entriesOf":
 after transform: SymbolId(31): Span { start: 1339, end: 1348 }
 rebuilt        : SymbolId(2): Span { start: 1406, end: 1415 }
-Symbol reference IDs mismatch for "entriesOf":
-after transform: SymbolId(31): [ReferenceId(54)]
-rebuilt        : SymbolId(2): []
 Symbol redeclarations mismatch for "entriesOf":
 after transform: SymbolId(31): [Span { start: 1339, end: 1348 }, Span { start: 1406, end: 1415 }]
 rebuilt        : SymbolId(2): []
@@ -5703,15 +4998,9 @@ rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
 Symbol span mismatch for "o":
 after transform: SymbolId(33): Span { start: 1419, end: 1420 }
 rebuilt        : SymbolId(3): Span { start: 1437, end: 1438 }
-Symbol reference IDs mismatch for "o":
-after transform: SymbolId(33): [ReferenceId(51), ReferenceId(53), ReferenceId(55)]
-rebuilt        : SymbolId(3): [ReferenceId(1)]
 Symbol redeclarations mismatch for "o":
 after transform: SymbolId(33): [Span { start: 1419, end: 1420 }, Span { start: 1437, end: 1438 }]
 rebuilt        : SymbolId(3): []
-Unresolved references mismatch:
-after transform: ["Object", "Partial", "Pick", "Required"]
-rebuilt        : ["Object"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitMergedAliasWithConst.ts
 Bindings mismatch:
@@ -5720,15 +5009,9 @@ rebuilt        : ScopeId(0): ["Color"]
 Symbol flags mismatch for "Color":
 after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | TypeAlias)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable)
-Symbol reference IDs mismatch for "Color":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(2), ReferenceId(3)]
-rebuilt        : SymbolId(0): []
 Symbol redeclarations mismatch for "Color":
 after transform: SymbolId(0): [Span { start: 13, end: 18 }, Span { start: 100, end: 105 }]
 rebuilt        : SymbolId(0): []
-Unresolved references mismatch:
-after transform: ["const"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitMultipleComputedNamesSameDomain.ts
 Bindings mismatch:
@@ -5872,9 +5155,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "M":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(23), ReferenceId(24), ReferenceId(38), ReferenceId(39)]
-rebuilt        : SymbolId(0): [ReferenceId(18), ReferenceId(19), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(40), ReferenceId(41)]
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 243, end: 244 }]
 rebuilt        : SymbolId(0): []
@@ -5917,9 +5197,6 @@ rebuilt        : ScopeId(0): ["M", "v"]
 Bindings mismatch:
 after transform: ScopeId(3): ["C", "_M", "w"]
 rebuilt        : ScopeId(1): ["_M", "w"]
-Symbol reference IDs mismatch for "v":
-after transform: SymbolId(2): [ReferenceId(1)]
-rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "M":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
@@ -5937,25 +5214,9 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Bar":
 after transform: SymbolId(1): Span { start: 51, end: 54 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "Bar":
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(3), ReferenceId(4)]
-rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3)]
 Symbol redeclarations mismatch for "Bar":
 after transform: SymbolId(1): [Span { start: 51, end: 54 }, Span { start: 87, end: 90 }]
 rebuilt        : SymbolId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNestedGenerics.ts
-Symbol reference IDs mismatch for "p":
-after transform: SymbolId(2): [ReferenceId(2)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch for "x":
-after transform: SymbolId(8): [ReferenceId(5), ReferenceId(7)]
-rebuilt        : SymbolId(4): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNoInvalidCommentReuse3.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["_", "id", "object"]
-rebuilt        : ScopeId(0): ["_", "object"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNoNonRequiredParens.ts
 Bindings mismatch:
@@ -5967,23 +5228,6 @@ rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "Test":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "Test":
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(0): []
-Unresolved references mismatch:
-after transform: ["Extract"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNonExportedBindingPattern.ts
-Symbol reference IDs mismatch for "foo":
-after transform: SymbolId(1): [ReferenceId(1)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch for "renamed":
-after transform: SymbolId(3): [ReferenceId(3)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "c":
-after transform: SymbolId(6): [ReferenceId(5)]
-rebuilt        : SymbolId(4): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitOfFuncspace.ts
 Symbol flags mismatch for "ExpandoMerge":
@@ -5997,122 +5241,21 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitOp
 Bindings mismatch:
 after transform: ScopeId(0): ["createApi"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Capitalize"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitOptionalMappedTypePropertyNoStrictNullChecks2.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["createApi"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Capitalize"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitOptionalMappedTypePropertyNoStrictNullChecks3.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["createApi"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Capitalize"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPartialNodeReuseTypeOf.ts
-Symbol reference IDs mismatch for "nImported":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(3)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "nNotImported":
-after transform: SymbolId(1): [ReferenceId(1), ReferenceId(5)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch for "nPrivate":
-after transform: SymbolId(2): [ReferenceId(2), ReferenceId(4)]
-rebuilt        : SymbolId(2): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPartialNodeReuseTypeReferences.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["N", "o"]
 rebuilt        : ScopeId(0): ["o"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPartialReuseComputedProperty.ts
-Symbol reference IDs mismatch for "n":
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "poz":
-after transform: SymbolId(1): [ReferenceId(1)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch for "neg":
-after transform: SymbolId(2): [ReferenceId(2)]
-rebuilt        : SymbolId(2): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPreserveReferencedImports.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["Evt", "o"]
-rebuilt        : ScopeId(0): ["o"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPromise.ts
-Symbol reference IDs mismatch for "bluebird":
-after transform: SymbolId(0): [ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(37), ReferenceId(39), ReferenceId(1), ReferenceId(12), ReferenceId(41), ReferenceId(60)]
-rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(6), ReferenceId(23)]
-Symbol reference IDs mismatch for "func":
-after transform: SymbolId(15): [ReferenceId(28), ReferenceId(29)]
-rebuilt        : SymbolId(17): [ReferenceId(15)]
-Symbol reference IDs mismatch for "func":
-after transform: SymbolId(37): [ReferenceId(57), ReferenceId(58)]
-rebuilt        : SymbolId(34): [ReferenceId(32)]
-Unresolved references mismatch:
-after transform: ["Array", "arguments"]
-rebuilt        : ["arguments"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPropertyNumericStringKey.ts
-Unresolved references mismatch:
-after transform: ["const"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitQualifiedAliasTypeArgument.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["Q", "T", "create", "fun", "fun2"]
-rebuilt        : ScopeId(0): ["create", "fun", "fun2"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitRecursiveConditionalAliasPreserved.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["Power", "power"]
-rebuilt        : ScopeId(0): ["power"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitRedundantTripleSlashModuleAugmentation.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["Augmentation", "FooOptions", "Original"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitResolveTypesIfNotReusable.ts
-Symbol reference IDs mismatch for "u":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(2): [ReferenceId(4), ReferenceId(5)]
-rebuilt        : SymbolId(1): []
-Unresolved references mismatch:
-after transform: ["const"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitRetainedAnnotationRetainsImportInOutput.ts
-Symbol reference IDs mismatch for "E":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(4)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitReusesLambdaParameterNodes.ts
-Unresolved references mismatch:
-after transform: ["Omit", "Partial"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitScopeConsistency3.ts
-Symbol reference IDs mismatch for "v":
-after transform: SymbolId(3): [ReferenceId(0)]
-rebuilt        : SymbolId(3): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitShadowingInferNotRenamed.ts
-Unresolved references mismatch:
-after transform: ["Record"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitSpreadStringlyKeyedEnum.ts
 Bindings mismatch:
@@ -6135,34 +5278,6 @@ rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "TestEnum":
 after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "TestEnum":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(4)]
-rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(4)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeParameterNameShadowedInternally.ts
-Unresolved references mismatch:
-after transform: ["const"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeofRest.ts
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(1): [ReferenceId(0)]
-rebuilt        : SymbolId(1): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitUsingAlternativeContainingModules1.ts
-Unresolved references mismatch:
-after transform: ["Error", "Promise", "Readonly", "ReadonlyArray"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitUsingAlternativeContainingModules2.ts
-Unresolved references mismatch:
-after transform: ["Error", "Promise", "Readonly", "ReadonlyArray"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitUsingTypeAlias2.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["bar", "goodDeclaration", "shouldBeElided", "shouldReuseLocalName"]
-rebuilt        : ScopeId(0): ["bar", "goodDeclaration"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationFunctionTypeNonlocalShouldNotBeAnError.ts
 Scope flags mismatch:
@@ -6193,9 +5308,6 @@ rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol span mismatch for "m2":
 after transform: SymbolId(0): Span { start: 10, end: 12 }
 rebuilt        : SymbolId(0): Span { start: 233, end: 235 }
-Symbol reference IDs mismatch for "m2":
-after transform: SymbolId(0): [ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5)]
-rebuilt        : SymbolId(0): [ReferenceId(1)]
 Symbol redeclarations mismatch for "m2":
 after transform: SymbolId(0): [Span { start: 10, end: 12 }, Span { start: 233, end: 235 }]
 rebuilt        : SymbolId(0): []
@@ -6216,21 +5328,6 @@ Unresolved references mismatch:
 after transform: ["Object"]
 rebuilt        : []
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationsForFileShadowingGlobalNoError.ts
-Unresolved references mismatch:
-after transform: ["Node"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationsForIndirectTypeAliasReference.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["MAP", "MAP2", "StringHash", "StringHash2", "doSome"]
-rebuilt        : ScopeId(0): ["MAP", "MAP2", "doSome"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationsWithRecursiveInternalTypesProduceUniqueTypeParams.ts
-Unresolved reference IDs mismatch for "Object":
-after transform: [ReferenceId(10), ReferenceId(16), ReferenceId(34), ReferenceId(51), ReferenceId(54)]
-rebuilt        : [ReferenceId(0), ReferenceId(6), ReferenceId(11)]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declareDottedExtend.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["A", "D", "E", "ab"]
@@ -6250,11 +5347,6 @@ Bindings mismatch:
 after transform: ScopeId(0): ["M", "T"]
 rebuilt        : ScopeId(0): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declareExternalModuleWithExportAssignedFundule.ts
-Unresolved references mismatch:
-after transform: ["Function", "RegExp"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declareFileExportAssignment.ts
 Symbol flags mismatch for "m2":
 after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | NamespaceModule)
@@ -6262,9 +5354,6 @@ rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol span mismatch for "m2":
 after transform: SymbolId(0): Span { start: 10, end: 12 }
 rebuilt        : SymbolId(0): Span { start: 233, end: 235 }
-Symbol reference IDs mismatch for "m2":
-after transform: SymbolId(0): [ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5)]
-rebuilt        : SymbolId(0): [ReferenceId(1)]
 Symbol redeclarations mismatch for "m2":
 after transform: SymbolId(0): [Span { start: 10, end: 12 }, Span { start: 233, end: 235 }]
 rebuilt        : SymbolId(0): []
@@ -6276,22 +5365,9 @@ rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
 Symbol span mismatch for "m2":
 after transform: SymbolId(0): Span { start: 10, end: 12 }
 rebuilt        : SymbolId(1): Span { start: 241, end: 243 }
-Symbol reference IDs mismatch for "m2":
-after transform: SymbolId(0): [ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5)]
-rebuilt        : SymbolId(1): [ReferenceId(1)]
 Symbol redeclarations mismatch for "m2":
 after transform: SymbolId(0): [Span { start: 10, end: 12 }, Span { start: 241, end: 243 }]
 rebuilt        : SymbolId(1): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataElidedImport.ts
-Symbol reference IDs mismatch for "Observable":
-after transform: SymbolId(0): [ReferenceId(2), ReferenceId(4), ReferenceId(5)]
-rebuilt        : SymbolId(0): [ReferenceId(11), ReferenceId(13)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataElidedImportOnDeclare.ts
-Symbol reference IDs mismatch for "Observable":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(2), ReferenceId(3)]
-rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(5)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataNoStrictNull.ts
 Unresolved reference IDs mismatch for "String":
@@ -6324,21 +5400,16 @@ Reference flags mismatch for "Promise":
 after transform: ReferenceId(26): ReferenceFlags(Read | Type)
 rebuilt        : ReferenceId(33): ReferenceFlags(Read)
 Unresolved references mismatch:
-after transform: ["Function", "MethodDecorator", "Object", "Promise", "require"]
+after transform: ["Function", "Object", "Promise", "require"]
 rebuilt        : ["Function", "Object", "Promise", "decorator", "require"]
-Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(9), ReferenceId(17), ReferenceId(25), ReferenceId(26), ReferenceId(28), ReferenceId(29)]
-rebuilt        : [ReferenceId(12), ReferenceId(20), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataTypeOnlyExport.ts
-Symbol reference IDs mismatch for "Foo":
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/decoratorReferenceOnOtherProperty.ts
-Symbol reference IDs mismatch for "Yoha":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(4), ReferenceId(5)]
-rebuilt        : SymbolId(0): [ReferenceId(7), ReferenceId(9)]
+Symbol span mismatch for "Bar":
+after transform: SymbolId(2): Span { start: 97, end: 100 }
+rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
+Symbol span mismatch for "Bar":
+after transform: SymbolId(5): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(5): Span { start: 97, end: 100 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/decoratorReferences.ts
 Bindings mismatch:
@@ -6371,26 +5442,8 @@ Reference symbol mismatch for "console":
 after transform: SymbolId(0) "console"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Function", "PropertyDescriptor", "String", "require"]
+after transform: ["Function", "String", "require"]
 rebuilt        : ["Function", "String", "console", "require"]
-Unresolved reference IDs mismatch for "Function":
-after transform: [ReferenceId(0), ReferenceId(6)]
-rebuilt        : [ReferenceId(8)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/deeplyNestedConstraints.ts
-Unresolved references mismatch:
-after transform: ["ArrayLike", "Extract", "Record"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/deeplyNestedTemplateLiteralIntersection.ts
-Unresolved references mismatch:
-after transform: ["Partial"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/defaultDeclarationEmitDefaultImport.ts
-Symbol reference IDs mismatch for "Something":
-after transform: SymbolId(1): [ReferenceId(0)]
-rebuilt        : SymbolId(1): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/defaultNamedExportWithType1.ts
 Bindings mismatch:
@@ -6467,13 +5520,8 @@ Reference symbol mismatch for "f1":
 after transform: SymbolId(11) "f1"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Extract"]
+after transform: []
 rebuilt        : ["f1"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/deferredLookupTypeResolution2.ts
-Unresolved references mismatch:
-after transform: ["Extract"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/deleteExpressionMustBeOptional.ts
 Bindings mismatch:
@@ -6602,7 +5650,7 @@ Reference symbol mismatch for "b":
 after transform: SymbolId(7) "b"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Partial"]
+after transform: []
 rebuilt        : ["a", "b", "f", "g"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/destructureOfVariableSameAsShorthand.ts
@@ -6625,16 +5673,13 @@ Reference symbol mismatch for "get":
 after transform: SymbolId(2) "get"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
+after transform: ["arguments", "require"]
 rebuilt        : ["arguments", "get", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/destructureOptionalParameter.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["f1", "f2"]
 rebuilt        : ScopeId(0): ["f2"]
-Unresolved references mismatch:
-after transform: ["ParameterDecorator"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/destructuringInitializerContextualTypeFromContext.ts
 Bindings mismatch:
@@ -6646,11 +5691,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["JSON", "require", "undefined"]
 rebuilt        : ["JSON", "f", "require", "undefined"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/destructuringWithConstraint.ts
-Unresolved references mismatch:
-after transform: ["Readonly"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/discriminantNarrowingCouldBeCircular.ts
 Bindings mismatch:
@@ -6678,7 +5718,7 @@ Reference symbol mismatch for "isPlainObject2":
 after transform: SymbolId(15) "isPlainObject2"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Object", "PropertyKey", "Record"]
+after transform: ["Object"]
 rebuilt        : ["Object", "is", "isPlainObject2", "kPresentationInheritanceParents", "myObj2", "parentElementOrShadowHost"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/discriminantOrderIndependence.ts
@@ -6744,15 +5784,9 @@ rebuilt        : ScopeId(28): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "Types":
 after transform: SymbolId(20): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(16): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "Types":
-after transform: SymbolId(20): [ReferenceId(46), ReferenceId(47), ReferenceId(50), ReferenceId(52), ReferenceId(119)]
-rebuilt        : SymbolId(16): [ReferenceId(37), ReferenceId(39), ReferenceId(41)]
 Symbol flags mismatch for "BarEnum":
 after transform: SymbolId(46): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(28): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "BarEnum":
-after transform: SymbolId(46): [ReferenceId(78), ReferenceId(79), ReferenceId(85), ReferenceId(86), ReferenceId(125)]
-rebuilt        : SymbolId(28): [ReferenceId(62), ReferenceId(66), ReferenceId(67)]
 Reference symbol mismatch for "never":
 after transform: SymbolId(44) "never"
 rebuilt        : <None>
@@ -6760,7 +5794,7 @@ Reference symbol mismatch for "isType":
 after transform: SymbolId(57) "isType"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Partial", "Record", "console", "undefined"]
+after transform: ["console", "undefined"]
 rebuilt        : ["console", "isType", "never", "undefined"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/discriminantPropertyInference.ts
@@ -6827,9 +5861,6 @@ rebuilt        : ScopeId(13): ScopeFlags(Function)
 Symbol flags mismatch for "EnumTypeNode":
 after transform: SymbolId(10): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "EnumTypeNode":
-after transform: SymbolId(10): [ReferenceId(26), ReferenceId(28), ReferenceId(36)]
-rebuilt        : SymbolId(8): [ReferenceId(17)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/discriminateWithDivergentAccessors1.ts
 Bindings mismatch:
@@ -6861,9 +5892,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["Uint8Array"]
 rebuilt        : ["Uint8Array", "foo"]
-Unresolved reference IDs mismatch for "Uint8Array":
-after transform: [ReferenceId(0), ReferenceId(3)]
-rebuilt        : [ReferenceId(1)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/discriminateWithOptionalProperty1.ts
 Bindings mismatch:
@@ -6879,14 +5907,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["box"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/discriminateWithOptionalProperty2.ts
-Unresolved references mismatch:
-after transform: ["AsyncGenerator", "AsyncIterable", "IteratorResult", "Promise", "Symbol", "arguments", "require", "undefined"]
-rebuilt        : ["Promise", "Symbol", "arguments", "require", "undefined"]
-Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(0), ReferenceId(20), ReferenceId(34), ReferenceId(54)]
-rebuilt        : [ReferenceId(39)]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/discriminateWithOptionalProperty3.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["GraphQLError", "buildExecutionContext", "getVariableValues"]
@@ -6895,7 +5915,7 @@ Reference symbol mismatch for "getVariableValues":
 after transform: SymbolId(6) "getVariableValues"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Error", "ReadonlyArray"]
+after transform: ["Error"]
 rebuilt        : ["getVariableValues"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/discriminatedUnionJsxElement.tsx
@@ -6908,14 +5928,6 @@ rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol flags mismatch for "ListItemVariant":
 after transform: SymbolId(7): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "ListItemVariant":
-after transform: SymbolId(7): [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(4), ReferenceId(8), ReferenceId(11), ReferenceId(12), ReferenceId(24)]
-rebuilt        : SymbolId(6): [ReferenceId(5), ReferenceId(15)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/discriminatedUnionWithIndexSignature.ts
-Unresolved references mismatch:
-after transform: ["const"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/discriminatingUnionWithUnionPropertyAgainstUndefinedWithoutStrictNullChecks.ts
 Bindings mismatch:
@@ -6930,14 +5942,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["opts"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/divideAndConquerIntersections.ts
-Symbol reference IDs mismatch for "EventHub":
-after transform: SymbolId(32): [ReferenceId(80), ReferenceId(92), ReferenceId(99)]
-rebuilt        : SymbolId(3): [ReferenceId(8)]
-Unresolved references mismatch:
-after transform: ["Array", "Exclude", "Omit", "Partial", "Promise", "Record", "console"]
-rebuilt        : ["console"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/doNotEmitPinnedCommentOnNotEmittedNode.ts
 Bindings mismatch:
@@ -6965,13 +5969,8 @@ Reference symbol mismatch for "alt":
 after transform: SymbolId(4) "alt"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Array", "ReadonlyArray"]
+after transform: []
 rebuilt        : ["alt", "dearray"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts
-Unresolved references mismatch:
-after transform: ["Array", "AsyncIterator", "Iterator", "Map", "Math", "Number", "Object", "Promise", "Reflect", "Set", "String", "Symbol", "WeakMap"]
-rebuilt        : ["Array", "Math", "Number", "Object", "Promise", "Reflect", "String", "Symbol"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/dottedModuleName2.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -7070,11 +6069,6 @@ Symbol redeclarations mismatch for "Bar":
 after transform: SymbolId(6): [Span { start: 198, end: 201 }, Span { start: 235, end: 238 }]
 rebuilt        : SymbolId(4): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/doubleUnderscoreMappedTypes.ts
-Unresolved references mismatch:
-after transform: ["Partial"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/doubleUnderscoreReactNamespace.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["__foot", "_jsxFileName", "thing"]
@@ -7099,11 +6093,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["arr", "log"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/dtsEmitTripleSlashAvoidUnnecessaryResolutionMode.ts
-Unresolved references mismatch:
-after transform: ["NodeJS", "Promise", "arguments"]
-rebuilt        : ["arguments"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/duplicateAnonymousInners1.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -7190,21 +6179,6 @@ Symbol scope ID mismatch for "f":
 after transform: SymbolId(0): ScopeId(1)
 rebuilt        : SymbolId(0): ScopeId(0)
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/duplicatePackage_packageIdIncludesSubModule.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["Foo", "x"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/duplicatePackage_referenceTypes.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["Foo", "a", "foo"]
-rebuilt        : ScopeId(0): ["a", "foo"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/duplicatePackage_subModule.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["Foo", "a", "o"]
-rebuilt        : ScopeId(0): ["a", "o"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/duplicateVarAndImport.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["M"]
@@ -7215,9 +6189,6 @@ rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol redeclarations mismatch for "a":
 after transform: SymbolId(0): [Span { start: 50, end: 51 }, Span { start: 76, end: 77 }]
 rebuilt        : SymbolId(0): []
-Unresolved references mismatch:
-after transform: ["M"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/duplicateVariablesByScope.ts
 Scope flags mismatch:
@@ -7232,19 +6203,6 @@ rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/elidedEmbeddedStatementsReplacedWithSemicolon.ts
 'with' statements are not allowed
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/elidingImportNames.ts
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(0): [ReferenceId(1)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/emitClassExpressionInDeclarationFile.ts
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(2): [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(4)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch for "FooItem":
-after transform: SymbolId(5): [ReferenceId(8), ReferenceId(12)]
-rebuilt        : SymbolId(6): [ReferenceId(5)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/emitHelpersWithLocalCollisions.ts
 Bindings mismatch:
@@ -7388,11 +6346,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["a"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/emptyDeclarationEmitIsModule.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["Foo", "i"]
-rebuilt        : ScopeId(0): ["Foo"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/emptyEnum.ts
 Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(0x0)
@@ -7527,18 +6480,9 @@ rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(21)]
-rebuilt        : SymbolId(1): [ReferenceId(4)]
 Symbol flags mismatch for "B":
 after transform: SymbolId(3): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(3): [ReferenceId(1), ReferenceId(25)]
-rebuilt        : SymbolId(3): [ReferenceId(8)]
-Symbol reference IDs mismatch for "List":
-after transform: SymbolId(8): [ReferenceId(5), ReferenceId(9), ReferenceId(14), ReferenceId(7)]
-rebuilt        : SymbolId(5): [ReferenceId(10)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumLiteralsSubtypeReduction.ts
 Bindings mismatch:
@@ -7595,21 +6539,12 @@ rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "MyEnum":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "MyEnum":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(3), ReferenceId(6), ReferenceId(9), ReferenceId(2), ReferenceId(5), ReferenceId(8), ReferenceId(11), ReferenceId(25)]
-rebuilt        : SymbolId(0): [ReferenceId(7), ReferenceId(21), ReferenceId(23), ReferenceId(27), ReferenceId(29)]
 Symbol flags mismatch for "MyStringEnum":
 after transform: SymbolId(4): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "MyStringEnum":
-after transform: SymbolId(4): [ReferenceId(12), ReferenceId(14), ReferenceId(30)]
-rebuilt        : SymbolId(2): [ReferenceId(12), ReferenceId(31)]
 Symbol flags mismatch for "MyStringEnumWithEmpty":
 after transform: SymbolId(8): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "MyStringEnumWithEmpty":
-after transform: SymbolId(8): [ReferenceId(15), ReferenceId(17), ReferenceId(35)]
-rebuilt        : SymbolId(4): [ReferenceId(17), ReferenceId(33)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumNegativeLiteral1.ts
 Bindings mismatch:
@@ -7643,9 +6578,6 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "Enum":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "Enum":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(22)]
-rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(4)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumWithInfinityProperty.ts
 Bindings mismatch:
@@ -7761,13 +6693,8 @@ Reference symbol mismatch for "x":
 after transform: SymbolId(3) "x"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Error", "Function", "Object", "RangeError"]
+after transform: ["Error", "RangeError"]
 rebuilt        : ["Error", "RangeError", "x"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/es2017basicAsync.ts
-Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
-rebuilt        : ["arguments", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/es2018ObjectAssign.ts
 Bindings mismatch:
@@ -7777,7 +6704,7 @@ Reference symbol mismatch for "p":
 after transform: SymbolId(1) "p"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Object", "Promise"]
+after transform: ["Object"]
 rebuilt        : ["Object", "p"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ClassTest3.ts
@@ -7812,16 +6739,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["M"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ClassTest8.ts
-Symbol reference IDs mismatch for "Vector":
-after transform: SymbolId(5): [ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(22), ReferenceId(23), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(28), ReferenceId(30), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(36)]
-rebuilt        : SymbolId(6): [ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(20), ReferenceId(22), ReferenceId(24), ReferenceId(25)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ExportAssignment4.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["a"]
-rebuilt        : ScopeId(0): []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ExportClause.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Bindings mismatch:
@@ -7846,46 +6763,6 @@ Symbol span mismatch for "m":
 after transform: SymbolId(2): Span { start: 59, end: 60 }
 rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBinding.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["defaultBinding", "defaultBinding2", "x"]
-rebuilt        : ScopeId(0): ["defaultBinding", "x"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImport.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["a", "b", "defaultBinding1", "defaultBinding2", "defaultBinding3", "defaultBinding4", "defaultBinding5", "defaultBinding6", "m", "x", "x1", "y", "z"]
-rebuilt        : ScopeId(0): ["a", "b", "m", "x", "x1", "y", "z"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBinding1.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["defaultBinding", "nameSpaceBinding", "x"]
-rebuilt        : ScopeId(0): ["defaultBinding", "x"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ImportEqualsDeclaration2.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["a"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ImportNameSpaceImport.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["nameSpaceBinding", "nameSpaceBinding2", "x"]
-rebuilt        : ScopeId(0): ["nameSpaceBinding", "x"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ImportNameSpaceImportDts.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["nameSpaceBinding", "nameSpaceBinding2", "x"]
-rebuilt        : ScopeId(0): ["nameSpaceBinding", "x"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImport.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["a", "a1", "a11", "aaaa", "b", "bbbb", "m", "x", "x1", "x11", "xxxx", "y", "z", "z1", "z111", "z2", "z3"]
-rebuilt        : ScopeId(0): ["a", "a1", "a11", "b", "m", "x", "x1", "x11", "xxxx", "y", "z", "z1", "z111", "z2", "z3"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportDts.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["a", "a1", "a11", "aaaa", "b", "bbbb", "m", "x", "x1", "x11", "xxxx", "xxxx1", "xxxx2", "xxxx3", "xxxx4", "xxxx5", "xxxx6", "xxxx7", "xxxx8", "xxxx9", "y", "z", "z1", "z111", "z2", "z3"]
-rebuilt        : ScopeId(0): ["a", "a1", "a11", "b", "m", "x", "x1", "x11", "xxxx", "xxxx1", "xxxx2", "xxxx3", "xxxx4", "xxxx5", "xxxx6", "xxxx7", "xxxx8", "xxxx9", "y", "z", "z1", "z111", "z2", "z3"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportInIndirectExportAssignment.ts
 Symbol flags mismatch for "a":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
@@ -7893,11 +6770,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "a":
 after transform: SymbolId(0): Span { start: 17, end: 18 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportWithTypesAndValues.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["C", "C2", "I", "cVal"]
-rebuilt        : ScopeId(0): ["C", "cVal"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ModuleClassDeclaration.ts
 Symbol flags mismatch for "m1":
@@ -8266,57 +7138,11 @@ rebuilt        : SymbolId(6): []
 Symbol scope ID mismatch for "_class":
 after transform: SymbolId(8): ScopeId(0)
 rebuilt        : SymbolId(14): ScopeId(3)
-Unresolved references mismatch:
-after transform: ["DecoratorContext", "require"]
-rebuilt        : ["require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/esNextWeakRefs_IterableWeakMap.ts
-Unresolved references mismatch:
-after transform: ["FinalizationRegistry", "Generator", "Iterable", "Object", "Set", "Symbol", "WeakMap", "WeakRef", "undefined"]
-rebuilt        : ["FinalizationRegistry", "Object", "Set", "Symbol", "WeakMap", "WeakRef", "undefined"]
 Unresolved reference IDs mismatch for "Symbol":
 after transform: [ReferenceId(8), ReferenceId(74), ReferenceId(88), ReferenceId(91)]
 rebuilt        : [ReferenceId(93), ReferenceId(96)]
-Unresolved reference IDs mismatch for "WeakRef":
-after transform: [ReferenceId(0), ReferenceId(2), ReferenceId(11), ReferenceId(15), ReferenceId(33)]
-rebuilt        : [ReferenceId(26)]
-Unresolved reference IDs mismatch for "Set":
-after transform: [ReferenceId(1), ReferenceId(14)]
-rebuilt        : [ReferenceId(10)]
-Unresolved reference IDs mismatch for "WeakMap":
-after transform: [ReferenceId(5), ReferenceId(9), ReferenceId(127), ReferenceId(128), ReferenceId(129)]
-rebuilt        : [ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(7)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/eventEmitterPatternWithRecordOfFunction.ts
-Unresolved references mismatch:
-after transform: ["Function", "Record"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/excessPropertyCheckWithNestedArrayIntersection.ts
-Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/exhaustiveSwitchWithWideningLiteralTypes.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(1): [ReferenceId(1)]
-rebuilt        : SymbolId(2): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionContextualTypes.ts
-Unresolved references mismatch:
-after transform: ["Partial"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionExpressionsWithDynamicNames2.ts
-Symbol reference IDs mismatch for "mySymbol":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(4)]
-rebuilt        : SymbolId(0): [ReferenceId(2)]
-Unresolved references mismatch:
-after transform: ["Symbol", "const"]
-rebuilt        : ["Symbol"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionNestedAssigmentsDeclared.ts
 Symbol flags mismatch for "Foo":
@@ -8324,16 +7150,6 @@ after transform: SymbolId(0): SymbolFlags(Function | ValueModule | Ambient)
 rebuilt        : SymbolId(0): SymbolFlags(Function)
 Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(0): [Span { start: 9, end: 12 }, Span { start: 44, end: 47 }]
-rebuilt        : SymbolId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionSymbolProperty.ts
-Symbol reference IDs mismatch for "symb":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(4)]
-rebuilt        : SymbolId(0): [ReferenceId(2)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionSymbolPropertyJs.ts
-Symbol reference IDs mismatch for "symb":
-after transform: SymbolId(0): [ReferenceId(1)]
 rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/exportAssignValueAndType.ts
@@ -8349,9 +7165,6 @@ rebuilt        : SymbolId(1): Span { start: 155, end: 161 }
 Symbol redeclarations mismatch for "server":
 after transform: SymbolId(2): [Span { start: 85, end: 91 }, Span { start: 155, end: 161 }]
 rebuilt        : SymbolId(1): []
-Unresolved reference IDs mismatch for "Date":
-after transform: [ReferenceId(1), ReferenceId(2)]
-rebuilt        : [ReferenceId(0)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentEnum.ts
 Bindings mismatch:
@@ -8364,14 +7177,6 @@ Symbol flags mismatch for "E":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentMembersVisibleInAugmentation.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["foo"]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["T"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/exportDeclarationsInAmbientNamespaces.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["Q"]
@@ -8380,13 +7185,8 @@ Reference symbol mismatch for "Q":
 after transform: SymbolId(0) "Q"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Function"]
+after transform: []
 rebuilt        : ["Q"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/exportDefaultAsyncFunction.ts
-Unresolved references mismatch:
-after transform: ["Promise", "arguments"]
-rebuilt        : ["arguments"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/exportDefaultForNonInstantiatedModule.ts
 Bindings mismatch:
@@ -8484,9 +7284,6 @@ rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(5): Span { start: 245, end: 246 }
 rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "M":
-after transform: SymbolId(5): [ReferenceId(1), ReferenceId(2), ReferenceId(14), ReferenceId(15)]
-rebuilt        : SymbolId(6): [ReferenceId(13), ReferenceId(14), ReferenceId(15)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/exportImportNonInstantiatedModule.ts
 Bindings mismatch:
@@ -8501,9 +7298,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "B":
 after transform: SymbolId(2): Span { start: 64, end: 65 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(2): [ReferenceId(1), ReferenceId(4), ReferenceId(5)]
-rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(4)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/exportNamespaceDeclarationRetainsVisibility.ts
 Bindings mismatch:
@@ -8532,16 +7326,6 @@ rebuilt        : SymbolId(0): Span { start: 73, end: 76 }
 Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(0): [Span { start: 12, end: 15 }, Span { start: 42, end: 45 }, Span { start: 73, end: 76 }]
 rebuilt        : SymbolId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/exportSpecifierAndExportedMemberDeclaration.ts
-Unresolved references mismatch:
-after transform: ["X"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/exportVisibility.ts
-Symbol reference IDs mismatch for "Foo":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(0)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/extBaseClass1.ts
 Scope flags mismatch:
@@ -8681,9 +7465,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Events":
 after transform: SymbolId(0): Span { start: 10, end: 16 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "Events":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(4), ReferenceId(5)]
-rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3)]
 Symbol flags mismatch for "Consumer":
 after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
@@ -8723,11 +7504,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["setTimeout"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/fixCrashAliasLookupForDefauledImport.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["Foo", "bar"]
-rebuilt        : ScopeId(0): ["bar"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/fixingTypeParametersRepeatedly1.ts
 Bindings mismatch:
@@ -8773,45 +7549,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["closeFile", "openFile", "someOperation"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/flowInFinally1.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2)]
-rebuilt        : SymbolId(0): [ReferenceId(1)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/forAwaitForIntersection1.ts
-Symbol reference IDs mismatch for "A1":
-after transform: SymbolId(3): [ReferenceId(5)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "B1":
-after transform: SymbolId(4): [ReferenceId(6)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch for "A2":
-after transform: SymbolId(11): [ReferenceId(13)]
-rebuilt        : SymbolId(15): []
-Symbol reference IDs mismatch for "B2":
-after transform: SymbolId(12): [ReferenceId(14)]
-rebuilt        : SymbolId(16): []
-Symbol reference IDs mismatch for "A3":
-after transform: SymbolId(19): [ReferenceId(21)]
-rebuilt        : SymbolId(22): []
-Symbol reference IDs mismatch for "B3":
-after transform: SymbolId(20): [ReferenceId(22)]
-rebuilt        : SymbolId(23): []
-Symbol reference IDs mismatch for "A4":
-after transform: SymbolId(28): [ReferenceId(30)]
-rebuilt        : SymbolId(36): []
-Symbol reference IDs mismatch for "B4":
-after transform: SymbolId(29): [ReferenceId(31)]
-rebuilt        : SymbolId(37): []
-Unresolved references mismatch:
-after transform: ["AsyncIterable", "Iterable", "arguments", "require"]
-rebuilt        : ["arguments", "require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/forAwaitForUnion.ts
-Unresolved references mismatch:
-after transform: ["AsyncIterable", "Iterable", "arguments", "require"]
-rebuilt        : ["arguments", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/forInModule.ts
 Scope flags mismatch:
@@ -8891,30 +7628,9 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/forwardRefInTypeD
 Bindings mismatch:
 after transform: ScopeId(0): ["Cls1", "Cls2", "Foo5", "_defineProperty", "foo4", "obj1", "obj2", "s", "s1", "s2", "s3", "s4", "s5"]
 rebuilt        : ScopeId(0): ["Cls2", "_defineProperty", "obj2", "s1", "s2", "s3", "s4", "s5"]
-Symbol reference IDs mismatch for "s1":
-after transform: SymbolId(1): [ReferenceId(0)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch for "s2":
-after transform: SymbolId(3): [ReferenceId(1)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "s3":
-after transform: SymbolId(5): [ReferenceId(2)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch for "s4":
-after transform: SymbolId(7): [ReferenceId(3)]
-rebuilt        : SymbolId(4): []
 Symbol reference IDs mismatch for "s5":
 after transform: SymbolId(9): [ReferenceId(4)]
 rebuilt        : SymbolId(5): []
-Symbol reference IDs mismatch for "Cls2":
-after transform: SymbolId(12): [ReferenceId(6), ReferenceId(11)]
-rebuilt        : SymbolId(6): [ReferenceId(2)]
-Symbol reference IDs mismatch for "obj2":
-after transform: SymbolId(14): [ReferenceId(8)]
-rebuilt        : SymbolId(7): []
-Unresolved references mismatch:
-after transform: ["const", "require"]
-rebuilt        : ["require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/freshLiteralInference.ts
 Bindings mismatch:
@@ -8963,14 +7679,6 @@ rebuilt        : SymbolId(36): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m2":
 after transform: SymbolId(38): Span { start: 1210, end: 1212 }
 rebuilt        : SymbolId(36): Span { start: 0, end: 0 }
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/functionAssignabilityWithArrayLike01.ts
-Unresolved references mismatch:
-after transform: ["ArrayLike"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/functionCall5.ts
 Scope flags mismatch:
@@ -8982,9 +7690,6 @@ rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1":
 after transform: SymbolId(0): Span { start: 10, end: 12 }
 rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "m1":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(5), ReferenceId(6)]
-rebuilt        : SymbolId(1): [ReferenceId(4), ReferenceId(5), ReferenceId(6)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/functionDeclarationWithResolutionOfTypeOfSameName01.ts
 Bindings mismatch:
@@ -8996,17 +7701,9 @@ rebuilt        : SymbolId(0): SymbolFlags(Function)
 Symbol span mismatch for "f":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
 rebuilt        : SymbolId(0): Span { start: 26, end: 27 }
-Symbol reference IDs mismatch for "f":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
 Symbol redeclarations mismatch for "f":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 26, end: 27 }]
 rebuilt        : SymbolId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/functionExpressionAndLambdaMatchesFunction.ts
-Unresolved references mismatch:
-after transform: ["Function", "undefined"]
-rebuilt        : ["undefined"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/functionInIfStatementInModule.ts
 Bindings mismatch:
@@ -9272,11 +7969,6 @@ Symbol redeclarations mismatch for "foo":
 after transform: SymbolId(0): [Span { start: 9, end: 12 }, Span { start: 35, end: 38 }]
 rebuilt        : SymbolId(0): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/functionOverloadsOnGenericArity2.ts
-Unresolved references mismatch:
-after transform: ["Date"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/functionReturnTypeQuery.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["foo", "test1", "test2"]
@@ -9292,11 +7984,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "test":
 after transform: SymbolId(0): Span { start: 10, end: 14 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/functionsWithImplicitReturnTypeAssignableToUndefined.ts
-Unresolved references mismatch:
-after transform: ["Math", "Record"]
-rebuilt        : ["Math"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/funduleExportedClassIsUsedBeforeDeclaration.ts
 Bindings mismatch:
@@ -9326,11 +8013,6 @@ Bindings mismatch:
 after transform: ScopeId(0): ["Q"]
 rebuilt        : ScopeId(0): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericBaseClassLiteralProperty2.ts
-Symbol reference IDs mismatch for "CollectionItem2":
-after transform: SymbolId(0): [ReferenceId(4), ReferenceId(0), ReferenceId(3)]
-rebuilt        : SymbolId(1): []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericCallAtYieldExpressionInGenericCall2.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["fn", "offer"]
@@ -9348,7 +8030,7 @@ Reference symbol mismatch for "offer":
 after transform: SymbolId(5) "offer"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Array", "Generator", "IteratorResult", "ReadonlyArray", "Symbol"]
+after transform: ["Symbol"]
 rebuilt        : ["fn", "offer"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericCallAtYieldExpressionInGenericCall3.ts
@@ -9368,16 +8050,13 @@ Reference symbol mismatch for "gen":
 after transform: SymbolId(20) "gen"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Generator", "IteratorResult", "Promise", "ReadonlyArray", "Symbol"]
+after transform: ["Symbol"]
 rebuilt        : ["gen", "runPromise", "traverse"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericCallInferenceConditionalType1.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["f", "g", "h"]
 rebuilt        : ScopeId(0): ["h"]
-Symbol reference IDs mismatch for "h":
-after transform: SymbolId(8): [ReferenceId(8)]
-rebuilt        : SymbolId(0): []
 Reference symbol mismatch for "f":
 after transform: SymbolId(0) "f"
 rebuilt        : <None>
@@ -9392,12 +8071,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericCallInfere
 Bindings mismatch:
 after transform: ScopeId(0): ["WrappedComponent", "f", "g", "h", "wrapComponent"]
 rebuilt        : ScopeId(0): ["WrappedComponent", "h"]
-Symbol reference IDs mismatch for "WrappedComponent":
-after transform: SymbolId(9): [ReferenceId(7)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "h":
-after transform: SymbolId(21): [ReferenceId(16)]
-rebuilt        : SymbolId(2): []
 Reference symbol mismatch for "wrapComponent":
 after transform: SymbolId(4) "wrapComponent"
 rebuilt        : <None>
@@ -9415,23 +8088,17 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericCallInfere
 Bindings mismatch:
 after transform: ScopeId(0): ["ComponentWithForwardRef", "ComponentWithForwardRef2", "forwardRef"]
 rebuilt        : ScopeId(0): ["ComponentWithForwardRef"]
-Symbol reference IDs mismatch for "ComponentWithForwardRef":
-after transform: SymbolId(19): [ReferenceId(34), ReferenceId(36)]
-rebuilt        : SymbolId(0): []
 Reference symbol mismatch for "forwardRef":
 after transform: SymbolId(12) "forwardRef"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["HTMLElement", "Omit"]
+after transform: []
 rebuilt        : ["forwardRef"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericCallInferenceUsingThisTypeNoInvalidCacheReuseAfterMappedTypeApplication1.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["EffectTypeId", "XXX", "_defineProperty", "a", "b", "implement", "inner", "outer", "succeed"]
 rebuilt        : ScopeId(0): ["XXX", "_defineProperty", "a", "b"]
-Symbol reference IDs mismatch for "XXX":
-after transform: SymbolId(36): [ReferenceId(44), ReferenceId(46)]
-rebuilt        : SymbolId(1): []
 Reference symbol mismatch for "implement":
 after transform: SymbolId(29) "implement"
 rebuilt        : <None>
@@ -9445,16 +8112,8 @@ Reference symbol mismatch for "outer":
 after transform: SymbolId(40) "outer"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["ReadonlyArray"]
+after transform: []
 rebuilt        : ["implement", "inner", "outer", "succeed"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericCallWithFixedArguments.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(1)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(1): [ReferenceId(2)]
-rebuilt        : SymbolId(1): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericClassImplementingGenericInterfaceFromAnotherModule.ts
 Bindings mismatch:
@@ -9519,9 +8178,6 @@ rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "PortalFx":
 after transform: SymbolId(39): Span { start: 1500, end: 1508 }
 rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "PortalFx":
-after transform: SymbolId(39): [ReferenceId(42), ReferenceId(47), ReferenceId(50), ReferenceId(78), ReferenceId(79)]
-rebuilt        : SymbolId(10): [ReferenceId(33), ReferenceId(34)]
 Symbol flags mismatch for "ViewModels":
 after transform: SymbolId(40): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
@@ -9547,11 +8203,6 @@ Unresolved references mismatch:
 after transform: ["require"]
 rebuilt        : ["ko", "require"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericClasses4.ts
-Symbol reference IDs mismatch for "Vec2_T":
-after transform: SymbolId(0): [ReferenceId(4), ReferenceId(16), ReferenceId(19), ReferenceId(10), ReferenceId(12), ReferenceId(25), ReferenceId(27)]
-rebuilt        : SymbolId(0): [ReferenceId(4), ReferenceId(10)]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericClassesInModule.ts
 Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
@@ -9562,9 +8213,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Foo":
 after transform: SymbolId(0): Span { start: 10, end: 13 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "Foo":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(6), ReferenceId(7)]
-rebuilt        : SymbolId(0): [ReferenceId(4), ReferenceId(5), ReferenceId(6)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericConstraintOnExtendedBuiltinTypes.ts
 Scope flags mismatch:
@@ -9585,9 +8233,6 @@ rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "EndGate":
 after transform: SymbolId(0): Span { start: 18, end: 25 }
 rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "EndGate":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(13), ReferenceId(14), ReferenceId(21), ReferenceId(22)]
-rebuilt        : SymbolId(1): [ReferenceId(9), ReferenceId(10), ReferenceId(19), ReferenceId(20)]
 Symbol redeclarations mismatch for "EndGate":
 after transform: SymbolId(0): [Span { start: 18, end: 25 }, Span { start: 152, end: 159 }, Span { start: 344, end: 351 }]
 rebuilt        : SymbolId(1): []
@@ -9603,9 +8248,6 @@ rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Tweening":
 after transform: SymbolId(7): Span { start: 352, end: 360 }
 rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
-Unresolved references mismatch:
-after transform: ["ICloneable", "Tween", "require"]
-rebuilt        : ["Tween", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericConstraintOnExtendedBuiltinTypes2.ts
 Scope flags mismatch:
@@ -9626,9 +8268,6 @@ rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "EndGate":
 after transform: SymbolId(0): Span { start: 10, end: 17 }
 rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "EndGate":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(14), ReferenceId(15), ReferenceId(22), ReferenceId(23)]
-rebuilt        : SymbolId(1): [ReferenceId(9), ReferenceId(10), ReferenceId(19), ReferenceId(20)]
 Symbol redeclarations mismatch for "EndGate":
 after transform: SymbolId(0): [Span { start: 10, end: 17 }, Span { start: 144, end: 151 }, Span { start: 335, end: 342 }]
 rebuilt        : SymbolId(1): []
@@ -9644,9 +8283,6 @@ rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Tweening":
 after transform: SymbolId(7): Span { start: 343, end: 351 }
 rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
-Unresolved references mismatch:
-after transform: ["ICloneable", "Tween", "require"]
-rebuilt        : ["Tween", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericFunctionInference2.ts
 Bindings mismatch:
@@ -9690,9 +8326,6 @@ rebuilt        : SymbolId(2): Span { start: 122, end: 126 }
 Symbol redeclarations mismatch for "foo4":
 after transform: SymbolId(5): [Span { start: 81, end: 85 }, Span { start: 122, end: 126 }]
 rebuilt        : SymbolId(2): []
-Unresolved references mismatch:
-after transform: ["String"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericFunctionsAndConditionalInference.ts
 Bindings mismatch:
@@ -9736,11 +8369,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["f1"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericInferenceDefaultTypeParameterJsxReact.tsx
-Bindings mismatch:
-after transform: ScopeId(0): ["Component", "ComponentPropsWithRef", "ElementType", "React", "ReactNode", "_jsxFileName", "v1"]
-rebuilt        : ScopeId(0): ["Component", "React", "_jsxFileName", "v1"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericMethodOverspecialization.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["document", "elements", "names", "widths", "xxx"]
@@ -9776,17 +8404,6 @@ rebuilt        : SymbolId(0): Span { start: 110, end: 111 }
 Symbol redeclarations mismatch for "f":
 after transform: SymbolId(5): [Span { start: 68, end: 69 }, Span { start: 89, end: 90 }, Span { start: 110, end: 111 }]
 rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "C2":
-after transform: SymbolId(20): [ReferenceId(9), ReferenceId(12)]
-rebuilt        : SymbolId(2): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericPrototypeProperty2.ts
-Symbol reference IDs mismatch for "BaseEvent":
-after transform: SymbolId(1): [ReferenceId(2), ReferenceId(4)]
-rebuilt        : SymbolId(1): [ReferenceId(2)]
-Symbol reference IDs mismatch for "MyEvent":
-after transform: SymbolId(2): [ReferenceId(6)]
-rebuilt        : SymbolId(2): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericTemplateOverloadResolution.ts
 Bindings mismatch:
@@ -9799,7 +8416,7 @@ Reference symbol mismatch for "fooFn":
 after transform: SymbolId(4) "fooFn"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "TemplateStringsArray"]
+after transform: []
 rebuilt        : ["expect", "fooFn"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericsManyTypeParameters.ts
@@ -9812,9 +8429,6 @@ rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
 Symbol span mismatch for "a1":
 after transform: SymbolId(1): Span { start: 18, end: 20 }
 rebuilt        : SymbolId(4): Span { start: 724, end: 726 }
-Symbol reference IDs mismatch for "a1":
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(111)]
-rebuilt        : SymbolId(4): [ReferenceId(3)]
 Symbol redeclarations mismatch for "a1":
 after transform: SymbolId(1): [Span { start: 18, end: 20 }, Span { start: 724, end: 726 }]
 rebuilt        : SymbolId(4): []
@@ -9832,9 +8446,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "MyModule":
 after transform: SymbolId(17): Span { start: 441, end: 449 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/getParameterNameAtPosition.ts
 Bindings mismatch:
@@ -9847,13 +8458,8 @@ Reference symbol mismatch for "fn":
 after transform: SymbolId(9) "fn"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Function"]
+after transform: []
 rebuilt        : ["cases", "fn"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/getterSetterNonAccessor.ts
-Unresolved references mismatch:
-after transform: ["Object", "PropertyDescriptor"]
-rebuilt        : ["Object"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/global.ts
 Scope flags mismatch:
@@ -9865,11 +8471,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/globalFunctionAugmentationOverload.ts
-Unresolved references mismatch:
-after transform: ["Function"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/globalIsContextualKeyword.ts
 Bindings mismatch:
@@ -9887,18 +8488,10 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["f"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/homomorphicMappedTypeIntersectionAssignability.ts
-Unresolved references mismatch:
-after transform: ["Readonly"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/homomorphicMappedTypeNesting.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["fnBad"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/homomorphicMappedTypeWithNonHomomorphicInstantiationSpreadable1.ts
 Bindings mismatch:
@@ -9908,7 +8501,7 @@ Reference symbol mismatch for "func1":
 after transform: SymbolId(3) "func1"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["PropertyKey", "Record"]
+after transform: []
 rebuilt        : ["func1"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/icomparable.ts
@@ -9922,23 +8515,10 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["sort"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/identicalGenericConditionalsWithInferRelated.ts
-Unresolved references mismatch:
-after transform: ["Boolean", "Error", "Number", "String"]
-rebuilt        : ["Error"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/identityAndDivergentNormalizedTypes.ts
-Unresolved references mismatch:
-after transform: ["Extract", "Omit", "RequestInit", "require"]
-rebuilt        : ["require"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/identityRelationNeverTypes.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["State", "f1"]
 rebuilt        : ScopeId(0): ["f1"]
-Symbol reference IDs mismatch for "state":
-after transform: SymbolId(10): [ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(14)]
-rebuilt        : SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/implicitAnyGenericTypeInference.ts
 Bindings mismatch:
@@ -9963,7 +8543,7 @@ Reference symbol mismatch for "f6":
 after transform: SymbolId(24) "f6"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["AsyncGenerator", "Generator", "Promise", "PromiseLike", "require"]
+after transform: ["Promise", "require"]
 rebuilt        : ["Promise", "f1", "f2", "f3", "f4", "f5", "f6", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/importAliasAnExternalModuleInsideAnInternalModule.ts
@@ -10016,14 +8596,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "m":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(3)]
-rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(2)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/importAssertionsDeprecatedIgnored.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["json"]
-rebuilt        : ScopeId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/importDeclWithExportModifierInAmbientContext.ts
 Unresolved references mismatch:
@@ -10051,9 +8623,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable)
 Symbol span mismatch for "MyFunction":
 after transform: SymbolId(0): Span { start: 10, end: 20 }
 rebuilt        : SymbolId(0): Span { start: 52, end: 62 }
-Symbol reference IDs mismatch for "MyFunction":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(3)]
-rebuilt        : SymbolId(0): [ReferenceId(2)]
 Symbol redeclarations mismatch for "MyFunction":
 after transform: SymbolId(0): [Span { start: 10, end: 20 }, Span { start: 52, end: 62 }]
 rebuilt        : SymbolId(0): []
@@ -10085,11 +8654,6 @@ Symbol span mismatch for "C":
 after transform: SymbolId(7): Span { start: 290, end: 291 }
 rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember12.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A"]
-rebuilt        : ScopeId(0): []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/importOnAliasedIdentifiers.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Bindings mismatch:
@@ -10116,9 +8680,6 @@ rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
 Symbol span mismatch for "X":
 after transform: SymbolId(1): Span { start: 35, end: 36 }
 rebuilt        : SymbolId(2): Span { start: 66, end: 67 }
-Symbol reference IDs mismatch for "X":
-after transform: SymbolId(1): [ReferenceId(0)]
-rebuilt        : SymbolId(2): []
 Symbol redeclarations mismatch for "X":
 after transform: SymbolId(1): [Span { start: 35, end: 36 }, Span { start: 66, end: 67 }]
 rebuilt        : SymbolId(2): []
@@ -10128,27 +8689,6 @@ rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "B":
 after transform: SymbolId(2): Span { start: 84, end: 85 }
 rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "Z":
-after transform: SymbolId(5): [ReferenceId(3), ReferenceId(4)]
-rebuilt        : SymbolId(5): [ReferenceId(3)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/importPropertyFromMappedType.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["NotFound"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/importedAliasedConditionalTypeInstantiation.ts
-Unresolved references mismatch:
-after transform: ["Error", "Promise"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/inKeywordAndIntersection.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(1): [ReferenceId(1)]
-rebuilt        : SymbolId(2): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/inKeywordNarrowingWithNoUncheckedIndexedAccess.ts
 Bindings mismatch:
@@ -10158,40 +8698,13 @@ Reference symbol mismatch for "invariant":
 after transform: SymbolId(0) "invariant"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Record"]
+after transform: []
 rebuilt        : ["invariant"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/inKeywordTypeguard.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["A", "AWithMethod", "AWithOptionalProp", "B", "BWithMethod", "BWithOptionalProp", "C", "ClassWithUnionProp", "D", "NegativeClassTest", "UnreachableCodeDetection", "_defineProperty", "checkIsTouchDevice", "error", "f", "f1", "f10", "f11", "f12", "f13", "f14", "f15", "f16", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "foo", "isAOrB", "isHTMLTable", "narrowsToNever", "negativeClassesTest", "negativeIntersectionTest", "negativeMultipleClassesTest", "negativePropTest", "negativeTestClassesWithMemberMissingInBothClasses", "negativeTestClassesWithMembers", "positiveClassesTest", "positiveIntersectionTest", "positiveTestClassesWithOptionalProperties", "sym", "test1", "test2", "test3", "x"]
 rebuilt        : ScopeId(0): ["A", "AWithMethod", "AWithOptionalProp", "B", "BWithMethod", "BWithOptionalProp", "C", "ClassWithUnionProp", "D", "NegativeClassTest", "UnreachableCodeDetection", "_defineProperty", "checkIsTouchDevice", "f", "f1", "f10", "f11", "f12", "f13", "f14", "f15", "f16", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "foo", "isHTMLTable", "narrowsToNever", "negativeClassesTest", "negativeIntersectionTest", "negativeMultipleClassesTest", "negativePropTest", "negativeTestClassesWithMemberMissingInBothClasses", "negativeTestClassesWithMembers", "positiveClassesTest", "positiveIntersectionTest", "positiveTestClassesWithOptionalProperties", "sym", "test1", "test2", "test3"]
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(5), ReferenceId(27), ReferenceId(34), ReferenceId(40)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(1): [ReferenceId(1), ReferenceId(6), ReferenceId(28), ReferenceId(35), ReferenceId(41)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "AWithOptionalProp":
-after transform: SymbolId(6): [ReferenceId(10)]
-rebuilt        : SymbolId(7): []
-Symbol reference IDs mismatch for "BWithOptionalProp":
-after transform: SymbolId(7): [ReferenceId(11)]
-rebuilt        : SymbolId(8): []
-Symbol reference IDs mismatch for "AWithMethod":
-after transform: SymbolId(10): [ReferenceId(15), ReferenceId(20)]
-rebuilt        : SymbolId(11): []
-Symbol reference IDs mismatch for "BWithMethod":
-after transform: SymbolId(11): [ReferenceId(16), ReferenceId(21)]
-rebuilt        : SymbolId(12): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(16): [ReferenceId(29)]
-rebuilt        : SymbolId(17): []
-Symbol reference IDs mismatch for "D":
-after transform: SymbolId(17): [ReferenceId(30)]
-rebuilt        : SymbolId(18): []
-Symbol reference IDs mismatch for "ClassWithUnionProp":
-after transform: SymbolId(20): [ReferenceId(36)]
-rebuilt        : SymbolId(21): []
 Reference symbol mismatch for "error":
 after transform: SymbolId(34) "error"
 rebuilt        : <None>
@@ -10226,7 +8739,7 @@ Reference symbol mismatch for "x":
 after transform: SymbolId(41) "x"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Array", "Error", "Record", "Symbol", "Window", "globalThis", "require", "window"]
+after transform: ["Array", "Symbol", "require", "window"]
 rebuilt        : ["Array", "Symbol", "error", "isAOrB", "require", "window", "x"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/indexIntoEnum.ts
@@ -10246,11 +8759,6 @@ Symbol flags mismatch for "E":
 after transform: SymbolId(1): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/indexTypeNoSubstitutionTemplateLiteral.ts
-Symbol reference IDs mismatch for "Foo":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/indexedAccessAndNullableNarrowing.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["f1", "f2", "f3", "hasOwnProperty", "syncStoreProp"]
@@ -10259,7 +8767,7 @@ Reference symbol mismatch for "hasOwnProperty":
 after transform: SymbolId(16) "hasOwnProperty"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Partial", "PropertyKey", "Record", "undefined"]
+after transform: ["undefined"]
 rebuilt        : ["hasOwnProperty", "undefined"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/indexedAccessCanBeHighOrder.ts
@@ -10287,16 +8795,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["g"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/indexedAccessRetainsIndexSignature.ts
-Unresolved references mismatch:
-after transform: ["Pick"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/indexer3.ts
-Unresolved references mismatch:
-after transform: ["Date"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/indexingTypesWithNever.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["genericFn1", "genericFn2", "genericFn3", "key", "o0NameTest", "o0Test", "o1NameTest", "o1Test", "o2NameTest", "o2Test", "o3NameTest", "o3Test", "obj", "p0NameTest", "p0Test", "p1NameTest", "p1Test", "p2NameTest", "p2Test", "p3NameTest", "p3Test", "result3", "result4", "result5", "result6"]
@@ -10317,7 +8815,7 @@ Reference symbol mismatch for "key":
 after transform: SymbolId(22) "key"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Record", "Required"]
+after transform: []
 rebuilt        : ["genericFn1", "genericFn2", "genericFn3", "key", "obj"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/indirectTypeParameterReferences.ts
@@ -10342,11 +8840,6 @@ Unresolved references mismatch:
 after transform: ["Symbol"]
 rebuilt        : ["Symbol", "rand"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/inferConditionalConstraintMappedMember.ts
-Unresolved references mismatch:
-after transform: ["Pick"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/inferObjectTypeFromStringLiteralToKeyof.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["inference1", "inference2", "two", "x", "y"]
@@ -10366,14 +8859,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["inference1", "inference2", "two"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/inferParameterWithMethodCallInitializer.ts
-Symbol reference IDs mismatch for "Example":
-after transform: SymbolId(1): [ReferenceId(2), ReferenceId(4)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(2): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(2): [ReferenceId(0)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/inferPropertyWithContextSensitiveReturnStatement.ts
 Bindings mismatch:
@@ -10399,11 +8884,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["extractPrimitivesNew", "extractPrimitivesOld"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/inferSecondaryParameter.ts
-Unresolved references mismatch:
-after transform: ["Function"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/inferStringLiteralUnionForBindingElement.ts
 Bindings mismatch:
@@ -10436,21 +8916,10 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["f"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/inferTypeConstraintInstantiationCircularity.ts
-Unresolved references mismatch:
-after transform: ["Exclude"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/inferTypeParameterConstraints.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["BaseClass", "Klass", "_defineProperty", "m"]
 rebuilt        : ScopeId(0): ["BaseClass", "Klass", "_defineProperty"]
-Symbol reference IDs mismatch for "BaseClass":
-after transform: SymbolId(17): [ReferenceId(17), ReferenceId(19)]
-rebuilt        : SymbolId(1): [ReferenceId(2)]
-Symbol reference IDs mismatch for "Klass":
-after transform: SymbolId(19): [ReferenceId(28)]
-rebuilt        : SymbolId(2): []
 Reference symbol mismatch for "m":
 after transform: SymbolId(29) "m"
 rebuilt        : <None>
@@ -10501,21 +8970,18 @@ Reference symbol mismatch for "useCallback2":
 after transform: SymbolId(11) "useCallback2"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Function"]
+after transform: []
 rebuilt        : ["ex2", "ex3", "useCallback1", "useCallback2"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/inferenceContextualReturnTypeUnion2.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["findByLabelText", "queries"]
 rebuilt        : ScopeId(0): ["queries"]
-Symbol reference IDs mismatch for "queries":
-after transform: SymbolId(11): [ReferenceId(24)]
-rebuilt        : SymbolId(0): []
 Reference symbol mismatch for "findByLabelText":
 after transform: SymbolId(8) "findByLabelText"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Error", "HTMLElement", "Parameters", "Promise", "ReturnType"]
+after transform: []
 rebuilt        : ["findByLabelText"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/inferenceContextualReturnTypeUnion3.ts
@@ -10535,13 +9001,8 @@ Reference symbol mismatch for "deprecate":
 after transform: SymbolId(0) "deprecate"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Function", "Proxy", "Reflect"]
+after transform: ["Proxy", "Reflect"]
 rebuilt        : ["Proxy", "Reflect", "deprecate"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/inferenceContextualReturnTypeUnion4.ts
-Unresolved references mismatch:
-after transform: ["Promise"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/inferenceDoesNotAddUndefinedOrNull.ts
 Bindings mismatch:
@@ -10554,38 +9015,19 @@ Reference symbol mismatch for "toArray":
 after transform: SymbolId(8) "toArray"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["ReadonlyArray", "undefined"]
+after transform: ["undefined"]
 rebuilt        : ["toArray", "undefined"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/inferenceDoesntCompareAgainstUninstantiatedTypeParameter.ts
-Symbol reference IDs mismatch for "ConcreteClass":
-after transform: SymbolId(10): [ReferenceId(8), ReferenceId(11), ReferenceId(12)]
-rebuilt        : SymbolId(4): [ReferenceId(4), ReferenceId(7)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/inferenceErasedSignatures.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["SomeAbstractClass", "SomeBaseClass", "SomeClass", "_asyncToGenerator", "_defineProperty"]
 rebuilt        : ScopeId(0): ["SomeAbstractClass", "SomeClass", "_asyncToGenerator", "_defineProperty"]
-Symbol reference IDs mismatch for "SomeAbstractClass":
-after transform: SymbolId(4): [ReferenceId(8), ReferenceId(12), ReferenceId(15), ReferenceId(18)]
-rebuilt        : SymbolId(2): [ReferenceId(6)]
-Symbol reference IDs mismatch for "SomeClass":
-after transform: SymbolId(11): [ReferenceId(21), ReferenceId(23), ReferenceId(25)]
-rebuilt        : SymbolId(4): []
 Reference symbol mismatch for "SomeBaseClass":
 after transform: SymbolId(0) "SomeBaseClass"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "require"]
+after transform: ["require"]
 rebuilt        : ["SomeBaseClass", "require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/inferenceLimit.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["BrokenClass", "MyModule", "_asyncToGenerator"]
-rebuilt        : ScopeId(0): ["BrokenClass", "_asyncToGenerator"]
-Unresolved references mismatch:
-after transform: ["Array", "Promise"]
-rebuilt        : ["Promise"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/inferenceOptionalProperties.ts
 Bindings mismatch:
@@ -10604,7 +9046,7 @@ Reference symbol mismatch for "x2":
 after transform: SymbolId(4) "x2"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Partial", "Required"]
+after transform: []
 rebuilt        : ["test", "x1", "x2"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/inferenceOptionalPropertiesStrict.ts
@@ -10624,7 +9066,7 @@ Reference symbol mismatch for "x2":
 after transform: SymbolId(4) "x2"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Partial", "Required"]
+after transform: []
 rebuilt        : ["test", "x1", "x2"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/inferenceOptionalPropertiesToIndexSignatures.ts
@@ -10658,11 +9100,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["Math", "Object", "encodeURIComponent", "require"]
 rebuilt        : ["Math", "Object", "encodeURIComponent", "foo", "require", "x1", "x2", "x3", "x4"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/inferenceUnionOfObjectsMappedContextualType.ts
-Unresolved references mismatch:
-after transform: ["Date"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingObjectLiteralMethod1.ts
 Bindings mismatch:
@@ -10725,13 +9162,22 @@ Reference symbol mismatch for "t2":
 after transform: SymbolId(24) "t2"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["ReturnType", "parseInt"]
+after transform: ["parseInt"]
 rebuilt        : ["parseInt", "t", "t2"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/inferrenceInfiniteLoopWithSubtyping.ts
+Bindings mismatch:
+after transform: ScopeId(0): ["User"]
+rebuilt        : ScopeId(0): []
+Reference symbol mismatch for "User":
+after transform: SymbolId(1) "User"
+rebuilt        : <None>
+Reference symbol mismatch for "User":
+after transform: SymbolId(1) "User"
+rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Readonly"]
-rebuilt        : []
+after transform: []
+rebuilt        : ["User"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingTypes5.ts
 Symbol span mismatch for "from":
@@ -10740,14 +9186,6 @@ rebuilt        : SymbolId(0): Span { start: 244, end: 248 }
 Symbol redeclarations mismatch for "from":
 after transform: SymbolId(8): [Span { start: 149, end: 153 }, Span { start: 189, end: 193 }, Span { start: 244, end: 248 }]
 rebuilt        : SymbolId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/inheritanceOfGenericConstructorMethod1.ts
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(2): [ReferenceId(4), ReferenceId(5), ReferenceId(7), ReferenceId(9)]
-rebuilt        : SymbolId(1): [ReferenceId(2), ReferenceId(3), ReferenceId(4)]
-Unresolved references mismatch:
-after transform: ["Date"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/inheritanceOfGenericConstructorMethod2.ts
 Scope flags mismatch:
@@ -10769,14 +9207,6 @@ Symbol span mismatch for "N":
 after transform: SymbolId(4): Span { start: 75, end: 76 }
 rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticMembersCompatible.ts
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(3)]
-rebuilt        : SymbolId(1): [ReferenceId(2), ReferenceId(3)]
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(1): [ReferenceId(2), ReferenceId(5)]
-rebuilt        : SymbolId(2): [ReferenceId(5)]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/inheritedConstructorPropertyContextualType.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["Assignment", "Base"]
@@ -10788,25 +9218,10 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["Base"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/inheritedFunctionAssignmentCompatibility.ts
-Unresolved references mismatch:
-after transform: ["Function"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/initializersInAmbientEnums.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["E"]
 rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/inlineConditionalHasSimilarAssignability.ts
-Unresolved references mismatch:
-after transform: ["Extract"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/inlineMappedTypeModifierDeclarationEmit.ts
-Unresolved references mismatch:
-after transform: ["Exclude", "Pick"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/innerBoundLambdaEmit.ts
 Scope flags mismatch:
@@ -10818,9 +9233,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "M":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(3), ReferenceId(4)]
-rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/innerExtern.ts
 Bindings mismatch:
@@ -10869,28 +9281,6 @@ rebuilt        : SymbolId(1): Span { start: 107, end: 112 }
 Symbol redeclarations mismatch for "inner":
 after transform: SymbolId(1): [Span { start: 32, end: 37 }, Span { start: 77, end: 82 }, Span { start: 107, end: 112 }]
 rebuilt        : SymbolId(1): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/instanceAndStaticDeclarations1.ts
-Symbol reference IDs mismatch for "Point":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(9), ReferenceId(10), ReferenceId(15), ReferenceId(17)]
-rebuilt        : SymbolId(2): [ReferenceId(13), ReferenceId(15)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/instanceOfAssignability.ts
-Symbol reference IDs mismatch for "Derived1":
-after transform: SymbolId(1): [ReferenceId(14), ReferenceId(23), ReferenceId(11), ReferenceId(21)]
-rebuilt        : SymbolId(1): [ReferenceId(15), ReferenceId(21)]
-Symbol reference IDs mismatch for "Derived2":
-after transform: SymbolId(2): [ReferenceId(19), ReferenceId(16), ReferenceId(25)]
-rebuilt        : SymbolId(2): [ReferenceId(18), ReferenceId(24)]
-Symbol reference IDs mismatch for "Animal":
-after transform: SymbolId(3): [ReferenceId(27), ReferenceId(2)]
-rebuilt        : SymbolId(3): [ReferenceId(5)]
-Symbol reference IDs mismatch for "Mammal":
-after transform: SymbolId(4): [ReferenceId(28), ReferenceId(3)]
-rebuilt        : SymbolId(4): [ReferenceId(8)]
-Unresolved reference IDs mismatch for "Array":
-after transform: [ReferenceId(4), ReferenceId(5), ReferenceId(7), ReferenceId(32), ReferenceId(33), ReferenceId(35)]
-rebuilt        : [ReferenceId(12), ReferenceId(30)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/instanceofTypeAliasToGenericClass.ts
 Bindings mismatch:
@@ -10968,21 +9358,13 @@ Reference symbol mismatch for "assignPartial":
 after transform: SymbolId(104) "assignPartial"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Partial", "Promise", "alert"]
+after transform: ["Promise", "alert"]
 rebuilt        : ["Component", "GenericComponent", "Promise", "alert", "assignPartial", "createElement", "createElement2", "createReducer", "handler", "handlers", "invoke", "outerBoxOfString", "passContentsToFunc", "useStringOrNumber", "x"]
-Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(100), ReferenceId(102), ReferenceId(103), ReferenceId(105), ReferenceId(106), ReferenceId(108)]
-rebuilt        : [ReferenceId(28), ReferenceId(30), ReferenceId(32)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/instantiateCrossFileMerge.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["P"]
 rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/instantiatedBaseTypeConstraints.ts
-Symbol reference IDs mismatch for "Bar":
-after transform: SymbolId(4): [ReferenceId(5)]
-rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/instantiatedTypeAliasDisplay.ts
 Bindings mismatch:
@@ -11030,18 +9412,10 @@ Symbol redeclarations mismatch for "I4":
 after transform: SymbolId(3): [Span { start: 112, end: 114 }, Span { start: 123, end: 125 }]
 rebuilt        : SymbolId(2): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/interfaceExtendsClass1.ts
-Symbol reference IDs mismatch for "Control":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3)]
-rebuilt        : SymbolId(1): [ReferenceId(2), ReferenceId(3), ReferenceId(4)]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/interfaceMergedUnconstrainedNoErrorIrrespectiveOfOrder.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["ns"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["ReturnType"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasClass.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -11063,9 +9437,6 @@ rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "c":
 after transform: SymbolId(2): Span { start: 54, end: 55 }
 rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(3): [ReferenceId(1), ReferenceId(2)]
-rebuilt        : SymbolId(5): [ReferenceId(6)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasClassInsideLocalModuleWithExport.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -11154,9 +9525,6 @@ rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "c":
 after transform: SymbolId(5): Span { start: 108, end: 109 }
 rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(6): [ReferenceId(1), ReferenceId(2)]
-rebuilt        : SymbolId(6): [ReferenceId(13)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasEnumInsideLocalModuleWithExport.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -11181,9 +9549,6 @@ rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "c":
 after transform: SymbolId(5): Span { start: 122, end: 123 }
 rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(6): [ReferenceId(1), ReferenceId(2), ReferenceId(8)]
-rebuilt        : SymbolId(6): [ReferenceId(13), ReferenceId(15)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasEnumInsideLocalModuleWithoutExport.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -11208,9 +9573,6 @@ rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "c":
 after transform: SymbolId(5): Span { start: 122, end: 123 }
 rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(6): [ReferenceId(1), ReferenceId(2)]
-rebuilt        : SymbolId(6): [ReferenceId(13)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasFunction.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -11302,9 +9664,6 @@ rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "c":
 after transform: SymbolId(3): Span { start: 93, end: 94 }
 rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(4): [ReferenceId(1), ReferenceId(2)]
-rebuilt        : SymbolId(7): [ReferenceId(10)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasInitializedModuleInsideLocalModuleWithoutExport.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -11326,9 +9685,6 @@ rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "c":
 after transform: SymbolId(3): Span { start: 107, end: 108 }
 rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(4): [ReferenceId(1), ReferenceId(2)]
-rebuilt        : SymbolId(7): [ReferenceId(10)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasInitializedModuleInsideTopLevelModuleWithExport.ts
 Symbol flags mismatch for "a":
@@ -11343,9 +9699,6 @@ rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "b":
 after transform: SymbolId(1): Span { start: 42, end: 43 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(3): [ReferenceId(1), ReferenceId(2)]
-rebuilt        : SymbolId(5): [ReferenceId(9)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasInterface.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -11369,9 +9722,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasInte
 Bindings mismatch:
 after transform: ScopeId(0): ["a", "b", "x"]
 rebuilt        : ScopeId(0): ["b", "x"]
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(2): [ReferenceId(1)]
-rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasUninitializedModule.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -11402,9 +9752,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "c":
 after transform: SymbolId(3): Span { start: 130, end: 131 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(4): [ReferenceId(1), ReferenceId(4)]
-rebuilt        : SymbolId(2): [ReferenceId(2)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasUninitializedModuleInsideLocalModuleWithoutExport.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -11425,9 +9772,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasUnin
 Bindings mismatch:
 after transform: ScopeId(0): ["a", "x"]
 rebuilt        : ScopeId(0): ["x"]
-Unresolved references mismatch:
-after transform: ["a"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasVar.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -11513,11 +9857,6 @@ Symbol reference IDs mismatch for "A":
 after transform: SymbolId(3): [ReferenceId(0)]
 rebuilt        : SymbolId(2): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/intersectionConstraintReduction.ts
-Unresolved references mismatch:
-after transform: ["Extract"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/intersectionOfMixinConstructorTypeAndNonConstructorType.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["x"]
@@ -11537,7 +9876,7 @@ Reference symbol mismatch for "f":
 after transform: SymbolId(4) "f"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Readonly"]
+after transform: []
 rebuilt        : ["f"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/intersectionTypeNormalization.ts
@@ -11568,35 +9907,20 @@ rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "enums":
 after transform: SymbolId(27): Span { start: 1443, end: 1448 }
 rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "enums":
-after transform: SymbolId(27): [ReferenceId(103), ReferenceId(104), ReferenceId(117), ReferenceId(118)]
-rebuilt        : SymbolId(5): [ReferenceId(40), ReferenceId(41)]
 Symbol flags mismatch for "A":
 after transform: SymbolId(28): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(28): [ReferenceId(100), ReferenceId(112)]
-rebuilt        : SymbolId(7): [ReferenceId(17)]
 Symbol flags mismatch for "B":
 after transform: SymbolId(35): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(35): [ReferenceId(101), ReferenceId(114)]
-rebuilt        : SymbolId(9): [ReferenceId(28)]
 Symbol flags mismatch for "C":
 after transform: SymbolId(40): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(40): [ReferenceId(102), ReferenceId(116)]
-rebuilt        : SymbolId(11): [ReferenceId(39)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/intersectionWithConstructSignaturePrototypeResult.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["EmberObject"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Readonly"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/intersectionsAndOptionalProperties2.ts
 Bindings mismatch:
@@ -11662,23 +9986,10 @@ Unresolved references mismatch:
 after transform: ["undefined"]
 rebuilt        : ["ab_obj", "ab_primitive", "ac_obj", "ac_primitive", "undefined"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationsLiterals.ts
-Unresolved references mismatch:
-after transform: ["const"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationsStrictBuiltinIteratorReturn.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["a1", "a10", "a11", "a12", "a13", "a14", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9", "f1", "f10", "f11", "f12", "f13", "f14", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "x1", "x10", "x11", "x12", "x13", "x14", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9"]
 rebuilt        : ScopeId(0): ["a1", "a10", "a11", "a12", "a13", "a14", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9"]
-Unresolved references mismatch:
-after transform: ["BuiltinIteratorReturn", "Iterable", "IterableIterator"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesConstEnum.ts
-Unresolved references mismatch:
-after transform: ["EventName"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesImportConstEnum.ts
 Bindings mismatch:
@@ -11729,25 +10040,6 @@ Bindings mismatch:
 after transform: ScopeId(0): ["Event"]
 rebuilt        : ScopeId(0): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesSketchyAliasLocalMerge.ts
-Symbol flags mismatch for "FC":
-after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | Import)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "FC":
-after transform: SymbolId(0): Span { start: 9, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 34, end: 36 }
-Symbol reference IDs mismatch for "FC":
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(0): []
-Symbol redeclarations mismatch for "FC":
-after transform: SymbolId(0): [Span { start: 9, end: 11 }, Span { start: 34, end: 36 }]
-rebuilt        : SymbolId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/isolatedModules_resolveJsonModule_strict_outDir_commonJs.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["j"]
-rebuilt        : ScopeId(0): []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/iterableTReturnTNext.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["MyMap", "_source", "_wrapAsyncGenerator", "doubles", "map", "r1", "r2", "r3", "set", "source"]
@@ -11762,7 +10054,7 @@ Reference symbol mismatch for "set":
 after transform: SymbolId(1) "set"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Error", "Map", "MapIterator", "Number", "Set", "Symbol", "arguments", "require", "undefined"]
+after transform: ["Error", "Number", "Symbol", "arguments", "require", "undefined"]
 rebuilt        : ["Error", "Number", "Symbol", "arguments", "map", "require", "set", "undefined"]
 Unresolved reference IDs mismatch for "Symbol":
 after transform: [ReferenceId(10), ReferenceId(19)]
@@ -11781,21 +10073,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["p1", "shouldBeIdentity"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsDeclarationsWithDefaultAsNamespaceLikeMerge.ts
-Unresolved references mismatch:
-after transform: ["Record"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsDocDeclarationEmitDoesNotUseNodeModulesPathWithoutError.ts
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsEmitIntersectionProperty.ts
-Unresolved references mismatch:
-after transform: ["Readonly"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationDecoratorSyntax.ts
 Symbol span mismatch for "C":
@@ -11821,26 +10098,21 @@ Reference symbol mismatch for "Component":
 after transform: SymbolId(0) "Component"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Readonly"]
+after transform: []
 rebuilt        : ["Component"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsxChildrenSingleChildConfusableWithMultipleChildrenNoError.tsx
-Symbol reference IDs mismatch for "React":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(3), ReferenceId(7), ReferenceId(9), ReferenceId(11), ReferenceId(13)]
-rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(6), ReferenceId(8)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsxComplexSignatureHasApplicabilityError.tsx
 Bindings mismatch:
 after transform: ScopeId(0): ["React", "ReactSelectClass", "_jsxFileName", "_objectSpread", "createReactSingleSelect"]
 rebuilt        : ScopeId(0): ["React", "_jsxFileName", "_objectSpread", "createReactSingleSelect"]
 Symbol reference IDs mismatch for "React":
-after transform: SymbolId(0): [ReferenceId(17), ReferenceId(19), ReferenceId(44), ReferenceId(50), ReferenceId(54), ReferenceId(82), ReferenceId(85), ReferenceId(88), ReferenceId(102), ReferenceId(180), ReferenceId(196), ReferenceId(206), ReferenceId(209), ReferenceId(233), ReferenceId(236), ReferenceId(242)]
+after transform: SymbolId(0): [ReferenceId(44), ReferenceId(242)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 Reference symbol mismatch for "ReactSelectClass":
 after transform: SymbolId(20) "ReactSelectClass"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Array", "Exclude", "HTMLAnchorElement", "HTMLDivElement", "HTMLInputElement", "JSX", "Pick", "Promise", "undefined"]
+after transform: ["undefined"]
 rebuilt        : ["ReactSelectClass", "undefined"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx
@@ -11878,11 +10150,6 @@ Symbol span mismatch for "Element":
 after transform: SymbolId(5): Span { start: 358, end: 365 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsxEmptyExpressionNotCountedAsChild.tsx
-Symbol reference IDs mismatch for "React":
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(0): []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryIdentifier.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["Element", "JSX", "createElement", "toCamelCase"]
@@ -11910,18 +10177,10 @@ Symbol span mismatch for "Element":
 after transform: SymbolId(5): Span { start: 358, end: 365 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsxFragmentAndFactoryUsedOnFragmentUse.tsx
-Bindings mismatch:
-after transform: ScopeId(0): ["a", "element", "fragment"]
-rebuilt        : ScopeId(0): ["a"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsxFunctionTypeChildren.tsx
 Bindings mismatch:
 after transform: ScopeId(0): ["Comp", "React", "_jsx", "_jsxFileName", "_objectSpread", "bp", "el"]
 rebuilt        : ScopeId(0): ["React", "_jsx", "_jsxFileName", "_objectSpread", "bp", "el"]
-Symbol reference IDs mismatch for "React":
-after transform: SymbolId(0): [ReferenceId(2)]
-rebuilt        : SymbolId(0): []
 Reference symbol mismatch for "Comp":
 after transform: SymbolId(5) "Comp"
 rebuilt        : <None>
@@ -11929,7 +10188,7 @@ Reference symbol mismatch for "Comp":
 after transform: SymbolId(5) "Comp"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["JSX"]
+after transform: []
 rebuilt        : ["Comp"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsxGenericComponentWithSpreadingResultOfGenericFunction.tsx
@@ -11946,37 +10205,18 @@ Reference symbol mismatch for "otherProps":
 after transform: SymbolId(9) "otherProps"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Omit", "require"]
+after transform: ["require"]
 rebuilt        : ["GenericComponent", "omit", "otherProps", "require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsxInferenceProducesLiteralAsExpected.tsx
-Symbol reference IDs mismatch for "TestObject":
-after transform: SymbolId(4): [ReferenceId(11), ReferenceId(15)]
-rebuilt        : SymbolId(2): [ReferenceId(5)]
-Unresolved references mismatch:
-after transform: ["Function", "React"]
-rebuilt        : ["React"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsxIntrinsicElementsCompatability.tsx
-Unresolved references mismatch:
-after transform: ["JSX"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsxIntrinsicElementsExtendsRecord.tsx
 Bindings mismatch:
 after transform: ScopeId(0): ["JSX", "_jsxFileName", "_reactJsxRuntime"]
 rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
-Unresolved references mismatch:
-after transform: ["Record", "require"]
-rebuilt        : ["require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsxLibraryManagedAttributesUnusedGeneric.tsx
 Bindings mismatch:
 after transform: ScopeId(0): ["Comp", "React", "_jsxFileName", "jsx"]
 rebuilt        : ScopeId(0): ["React", "_jsxFileName"]
-Symbol reference IDs mismatch for "React":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(6)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
 Reference symbol mismatch for "Comp":
 after transform: SymbolId(16) "Comp"
 rebuilt        : <None>
@@ -11992,46 +10232,10 @@ Symbol redeclarations mismatch for "X":
 after transform: SymbolId(0): [Span { start: 13, end: 14 }, Span { start: 106, end: 107 }]
 rebuilt        : SymbolId(1): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceGlobalReexport.tsx
-Unresolved references mismatch:
-after transform: ["Exclude", "Extract", "Partial", "Pick"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceImplicitImportJSXNamespace.tsx
-Unresolved references mismatch:
-after transform: ["Exclude", "Extract", "Partial", "Pick"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceImplicitImportJSXNamespaceFromConfigPickedOverGlobalOne.tsx
-Unresolved references mismatch:
-after transform: ["JSX"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceImplicitImportJSXNamespaceFromPragmaPickedOverGlobalOne.tsx
-Unresolved references mismatch:
-after transform: ["JSX"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceReexports.tsx
 Bindings mismatch:
 after transform: ScopeId(0): ["JSX", "createElement"]
 rebuilt        : ScopeId(0): ["createElement"]
-Unresolved references mismatch:
-after transform: ["Record"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsxNamespacedNameNotComparedToNonMatchingIndexSignature.tsx
-Unresolved references mismatch:
-after transform: ["Function"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsxPartialSpread.tsx
-Symbol reference IDs mismatch for "Select":
-after transform: SymbolId(0): [ReferenceId(2), ReferenceId(3)]
-rebuilt        : SymbolId(3): [ReferenceId(3)]
-Unresolved references mismatch:
-after transform: ["Parameters", "Partial"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsxSpreadFirstUnionNoErrors.tsx
 Bindings mismatch:
@@ -12048,9 +10252,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/keyRemappingKeyof
 Bindings mismatch:
 after transform: ScopeId(0): ["setup"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Record"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/keyofModuleObjectHasCorrectKeys.ts
 Bindings mismatch:
@@ -12063,23 +10264,10 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["test"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/keyofObjectWithGlobalSymbolIncluded.ts
-Symbol reference IDs mismatch for "obj":
-after transform: SymbolId(0): [ReferenceId(2)]
-rebuilt        : SymbolId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/lambdaParameterWithTupleArgsHasCorrectAssignability.ts
-Symbol reference IDs mismatch for "GenericClass":
-after transform: SymbolId(5): [ReferenceId(10), ReferenceId(14), ReferenceId(12)]
-rebuilt        : SymbolId(1): [ReferenceId(2)]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/largeTupleTypes.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["ArrayValidator"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Array", "Exclude"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/letDeclarations2.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -12192,32 +10380,6 @@ rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "App":
 after transform: SymbolId(6): Span { start: 78, end: 81 }
 rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "Key":
-after transform: SymbolId(7): [ReferenceId(1), ReferenceId(3), ReferenceId(5), ReferenceId(7)]
-rebuilt        : SymbolId(6): [ReferenceId(17), ReferenceId(19), ReferenceId(21)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/localTypeParameterInferencePriority.ts
-Symbol reference IDs mismatch for "Table":
-after transform: SymbolId(4): [ReferenceId(14), ReferenceId(17), ReferenceId(22), ReferenceId(25)]
-rebuilt        : SymbolId(1): [ReferenceId(1), ReferenceId(3)]
-Unresolved references mismatch:
-after transform: ["Array", "Pick", "Record"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/mapConstructor.ts
-Unresolved references mismatch:
-after transform: ["Iterable", "Map"]
-rebuilt        : ["Map"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/mapConstructorOnReadonlyTuple.ts
-Unresolved references mismatch:
-after transform: ["Map", "WeakMap", "const"]
-rebuilt        : ["Map", "WeakMap"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/mapGroupBy.ts
-Unresolved reference IDs mismatch for "Set":
-after transform: [ReferenceId(4), ReferenceId(6)]
-rebuilt        : [ReferenceId(4)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/mappedToToIndexSignatureInference.ts
 Bindings mismatch:
@@ -12232,9 +10394,6 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "E":
 after transform: SymbolId(10): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "E":
-after transform: SymbolId(10): [ReferenceId(8), ReferenceId(10), ReferenceId(14)]
-rebuilt        : SymbolId(0): [ReferenceId(5), ReferenceId(7)]
 Reference symbol mismatch for "fn":
 after transform: SymbolId(0) "fn"
 rebuilt        : <None>
@@ -12245,13 +10404,8 @@ Reference symbol mismatch for "enumValues":
 after transform: SymbolId(6) "enumValues"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Record"]
+after transform: []
 rebuilt        : ["a", "enumValues", "fn"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/mappedTypeAndIndexSignatureRelation.ts
-Unresolved references mismatch:
-after transform: ["PropertyKey", "Record"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/mappedTypeContextualTypesApplied.ts
 Bindings mismatch:
@@ -12292,11 +10446,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/mappedTypeGeneric
 Bindings mismatch:
 after transform: ScopeId(0): ["usePrivateType"]
 rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/mappedTypeGenericInstantiationPreservesInlineForm.ts
-Unresolved references mismatch:
-after transform: ["Record", "Required"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/mappedTypeInferenceCircularity.ts
 Bindings mismatch:
@@ -12339,14 +10488,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["chain"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/mappedTypePartialConstraints.ts
-Symbol reference IDs mismatch for "MyClass":
-after transform: SymbolId(1): [ReferenceId(5), ReferenceId(3)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
-Unresolved references mismatch:
-after transform: ["Partial"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/mappedTypeRecursiveInference2.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["nestedTuple", "objectLiteral", "shallow", "type"]
@@ -12372,13 +10513,8 @@ Reference symbol mismatch for "TupleSchema":
 after transform: SymbolId(23) "TupleSchema"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Readonly"]
+after transform: []
 rebuilt        : ["TupleSchema"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/mappedTypeWithAsClauseAndLateBoundProperty2.ts
-Unresolved references mismatch:
-after transform: ["Exclude"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/mappedTypeWithNameClauseAppliedToArrayType.ts
 Bindings mismatch:
@@ -12396,7 +10532,7 @@ rebuilt        : ["doArrayStuff", "x"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/mergeMultipleInterfacesReexported.ts
 Bindings mismatch:
-after transform: ScopeId(0): ["EventList", "p012", "t"]
+after transform: ScopeId(0): ["p012", "t"]
 rebuilt        : ScopeId(0): ["t"]
 Reference symbol mismatch for "p012":
 after transform: SymbolId(1) "p012"
@@ -12466,17 +10602,6 @@ rebuilt        : SymbolId(0): []
 Unresolved references mismatch:
 after transform: ["a"]
 rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/mergedInstantiationAssignment.ts
-Symbol reference IDs mismatch for "GenericObject":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(2)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
-Symbol reference IDs mismatch for "GenericObjectWithoutSetter":
-after transform: SymbolId(4): [ReferenceId(5), ReferenceId(6)]
-rebuilt        : SymbolId(3): [ReferenceId(2)]
-Symbol reference IDs mismatch for "NormalObject":
-after transform: SymbolId(7): [ReferenceId(8), ReferenceId(9)]
-rebuilt        : SymbolId(5): [ReferenceId(4)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationCodeGen.ts
 Symbol flags mismatch for "X":
@@ -12741,14 +10866,6 @@ Symbol redeclarations mismatch for "M":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 56, end: 57 }]
 rebuilt        : SymbolId(0): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/metadataOfClassFromAlias.ts
-Symbol reference IDs mismatch for "SomeClass":
-after transform: SymbolId(0): [ReferenceId(2), ReferenceId(4), ReferenceId(5)]
-rebuilt        : SymbolId(0): [ReferenceId(4), ReferenceId(6)]
-Unresolved references mismatch:
-after transform: ["Object", "PropertyDecorator"]
-rebuilt        : ["Object"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/metadataOfUnion.ts
 Bindings mismatch:
 after transform: ScopeId(4): ["A", "B", "C", "D", "E"]
@@ -12756,48 +10873,20 @@ rebuilt        : ScopeId(5): ["E"]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(0x0)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(3): [ReferenceId(2)]
-rebuilt        : SymbolId(6): []
 Symbol flags mismatch for "E":
 after transform: SymbolId(5): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "E":
-after transform: SymbolId(5): [ReferenceId(6), ReferenceId(8), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(42), ReferenceId(47), ReferenceId(48), ReferenceId(49)]
-rebuilt        : SymbolId(8): [ReferenceId(30), ReferenceId(38), ReferenceId(39), ReferenceId(41)]
 Unresolved references mismatch:
 after transform: ["Boolean", "Number", "Object", "String", "require"]
 rebuilt        : ["Boolean", "Number", "Object", "require"]
 Unresolved reference IDs mismatch for "Boolean":
 after transform: [ReferenceId(22), ReferenceId(23), ReferenceId(28)]
 rebuilt        : [ReferenceId(14)]
-Unresolved reference IDs mismatch for "Object":
-after transform: [ReferenceId(0), ReferenceId(18), ReferenceId(29), ReferenceId(50), ReferenceId(54), ReferenceId(62)]
-rebuilt        : [ReferenceId(9), ReferenceId(19), ReferenceId(40), ReferenceId(46), ReferenceId(56)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/metadataOfUnionWithNull.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(3): [ReferenceId(10), ReferenceId(12)]
-rebuilt        : SymbolId(6): []
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(4): [ReferenceId(14), ReferenceId(31), ReferenceId(35), ReferenceId(40), ReferenceId(43), ReferenceId(46), ReferenceId(49), ReferenceId(52), ReferenceId(57), ReferenceId(62), ReferenceId(66), ReferenceId(70), ReferenceId(75)]
-rebuilt        : SymbolId(7): [ReferenceId(19), ReferenceId(24), ReferenceId(29), ReferenceId(33), ReferenceId(37), ReferenceId(41), ReferenceId(45), ReferenceId(50), ReferenceId(55), ReferenceId(60), ReferenceId(65), ReferenceId(70)]
 Unresolved references mismatch:
 after transform: ["Boolean", "Object", "String", "Symbol", "require"]
 rebuilt        : ["Boolean", "Object", "require"]
-Unresolved reference IDs mismatch for "Object":
-after transform: [ReferenceId(0), ReferenceId(29), ReferenceId(38), ReferenceId(55), ReferenceId(60), ReferenceId(64), ReferenceId(68), ReferenceId(73)]
-rebuilt        : [ReferenceId(18), ReferenceId(28), ReferenceId(49), ReferenceId(54), ReferenceId(59), ReferenceId(64), ReferenceId(69)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/metadataReferencedWithinFilteredUnion.ts
-Symbol reference IDs mismatch for "Class1":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(4), ReferenceId(11), ReferenceId(12)]
-rebuilt        : SymbolId(0): [ReferenceId(11), ReferenceId(13)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/missingSemicolonInModuleSpecifier.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["x"]
-rebuilt        : ScopeId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/missingTypeArguments3.ts
 Bindings mismatch:
@@ -12828,9 +10917,6 @@ rebuilt        : ScopeId(5): ScopeFlags(Function)
 Symbol flags mismatch for "E":
 after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "E":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(28)]
-rebuilt        : SymbolId(0): [ReferenceId(7), ReferenceId(9), ReferenceId(11), ReferenceId(15), ReferenceId(17), ReferenceId(19)]
 Symbol flags mismatch for "E2":
 after transform: SymbolId(9): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
@@ -12870,11 +10956,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["someNumber", "someString", "someValue", "unionOfEnum"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/mixinOverMappedTypeNoCrash.ts
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/mixingFunctionAndAmbientModule1.ts
 Scope flags mismatch:
@@ -13020,7 +11101,7 @@ Symbol span mismatch for "_modes":
 after transform: SymbolId(0): Span { start: 10, end: 16 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "_modes":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(5), ReferenceId(16), ReferenceId(17)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(16), ReferenceId(17)]
 rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3)]
 Symbol flags mismatch for "editor":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
@@ -13040,9 +11121,6 @@ rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Foo":
 after transform: SymbolId(16): Span { start: 697, end: 700 }
 rebuilt        : SymbolId(16): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "Foo":
-after transform: SymbolId(16): [ReferenceId(9), ReferenceId(22), ReferenceId(23)]
-rebuilt        : SymbolId(16): [ReferenceId(8), ReferenceId(9)]
 Symbol flags mismatch for "A1":
 after transform: SymbolId(21): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(22): SymbolFlags(BlockScopedVariable)
@@ -13066,7 +11144,7 @@ rebuilt        : ScopeId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationDoesInterfaceMergeOfReexport.ts
 Bindings mismatch:
-after transform: ScopeId(0): ["f", "ns"]
+after transform: ScopeId(0): ["f"]
 rebuilt        : ScopeId(0): []
 Reference symbol mismatch for "f":
 after transform: SymbolId(2) "f"
@@ -13093,26 +11171,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentatio
 Bindings mismatch:
 after transform: ScopeId(0): ["Root"]
 rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationDuringSyntheticDefaultCheck.ts
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationGlobal2.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A", "x", "y"]
-rebuilt        : ScopeId(0): ["x", "y"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationGlobal3.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationOfAlias.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["I", "f"]
-rebuilt        : ScopeId(0): ["f"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleCodeGenTest3.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -13155,11 +11213,6 @@ Symbol span mismatch for "Baz":
 after transform: SymbolId(0): Span { start: 17, end: 20 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleDeclarationExportStarShadowingGlobalIsNameable.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["func", "model"]
-rebuilt        : ScopeId(0): ["func"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleIdentifiers.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Scope flags mismatch:
@@ -13171,11 +11224,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleLocalImportNotIncorrectlyRedirected.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["ISpinButton"]
-rebuilt        : ScopeId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleMemberWithoutTypeAnnotation1.ts
 Scope flags mismatch:
@@ -13211,21 +11259,12 @@ rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Parser":
 after transform: SymbolId(1): Span { start: 21, end: 27 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "PositionedElement":
-after transform: SymbolId(5): [ReferenceId(3), ReferenceId(19)]
-rebuilt        : SymbolId(6): [ReferenceId(8)]
 Symbol flags mismatch for "Syntax":
 after transform: SymbolId(18): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(21): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Syntax":
 after transform: SymbolId(18): Span { start: 902, end: 908 }
 rebuilt        : SymbolId(21): Span { start: 0, end: 0 }
-Unresolved references mismatch:
-after transform: ["ISyntaxToken", "PositionedElement", "PositionedToken", "Syntax", "SyntaxNode"]
-rebuilt        : ["PositionedToken", "Syntax"]
-Unresolved reference IDs mismatch for "PositionedToken":
-after transform: [ReferenceId(5), ReferenceId(9)]
-rebuilt        : [ReferenceId(20)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleMemberWithoutTypeAnnotation2.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -13281,16 +11320,6 @@ Bindings mismatch:
 after transform: ScopeId(0): ["outer"]
 rebuilt        : ScopeId(0): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/modulePreserve2.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["esm"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/modulePreserve5.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["data1", "data2"]
-rebuilt        : ScopeId(0): ["data2"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/modulePreserveImportHelpers.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["A", "_decorate", "dec"]
@@ -13315,26 +11344,6 @@ rebuilt        : SymbolId(0): SymbolFlags(Class)
 Symbol redeclarations mismatch for "A":
 after transform: SymbolId(0): [Span { start: 6, end: 7 }, Span { start: 22, end: 23 }]
 rebuilt        : SymbolId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionAsTypeReferenceDirective.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["a2"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionAsTypeReferenceDirectiveAmbient.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["a2"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithExtensions_notSupported3.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["jsx"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithExtensions_withAmbientPresent.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["x"]
-rebuilt        : ScopeId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithRequire.ts
 Bindings mismatch:
@@ -13363,51 +11372,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_explicitNodeModulesImport.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["x"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_explicitNodeModulesImport_implicitAny.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["y"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_packageJson_notAtPackageRoot.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["x"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_packageJson_notAtPackageRoot_fakeScopedPackage.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["x"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_packageJson_scopedPackage.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["x"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_packageJson_yesAtPackageRoot.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["x"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_packageJson_yesAtPackageRoot_fakeScopedPackage.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["x"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_packageJson_yesAtPackageRoot_mainFieldInSubDirectory.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["x"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_relativeImportJsFile.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["b"]
-rebuilt        : ScopeId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleSameValueDuplicateExportedBindings2.ts
 Bindings mismatch:
@@ -13702,9 +11666,6 @@ rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(5): Span { start: 243, end: 244 }
 rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "M":
-after transform: SymbolId(5): [ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(37), ReferenceId(38), ReferenceId(41), ReferenceId(42)]
-rebuilt        : SymbolId(8): [ReferenceId(37), ReferenceId(38), ReferenceId(42), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(46), ReferenceId(47), ReferenceId(48)]
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(5): [Span { start: 243, end: 244 }, Span { start: 1079, end: 1080 }]
 rebuilt        : SymbolId(8): []
@@ -13728,11 +11689,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/module_augmentUninstantiatedModule2.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["ng"]
-rebuilt        : ScopeId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/multiModuleClodule1.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -13768,17 +11724,11 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/multiSignatureTyp
 Bindings mismatch:
 after transform: ScopeId(0): ["f1", "f2", "f3", "ok1", "ok2", "ok3", "ok4", "ok5", "ok6"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Function"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/multipleBaseInterfaesWithIncompatibleProperties2.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["http", "tls"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Partial"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/multipleInferenceContexts.ts
 Bindings mismatch:
@@ -13788,7 +11738,7 @@ Reference symbol mismatch for "Moon":
 after transform: SymbolId(8) "Moon"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["ThisType"]
+after transform: []
 rebuilt        : ["Moon"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/nameCollisionWithBlockScopedVariable1.ts
@@ -13837,9 +11787,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(8), ReferenceId(9)]
-rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(7), ReferenceId(8)]
 Symbol flags mismatch for "B":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
@@ -13857,14 +11804,6 @@ Bindings mismatch:
 after transform: ScopeId(0): ["Q", "Q2", "Q3", "Q4", "try1", "try2", "try3", "try4"]
 rebuilt        : ScopeId(0): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/narrowByBooleanComparison.ts
-Symbol reference IDs mismatch for "ACTOR_TYPE":
-after transform: SymbolId(16): [ReferenceId(46), ReferenceId(50)]
-rebuilt        : SymbolId(13): [ReferenceId(43)]
-Unresolved references mismatch:
-after transform: ["Array", "Error", "Function", "URIError", "console", "require"]
-rebuilt        : ["Array", "Error", "URIError", "console", "require"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue1.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["isA", "isB", "isSomeType", "processInput", "test1", "test2", "x"]
@@ -13875,9 +11814,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["RegExp"]
 rebuilt        : ["RegExp", "isSomeType"]
-Unresolved reference IDs mismatch for "RegExp":
-after transform: [ReferenceId(25), ReferenceId(30)]
-rebuilt        : [ReferenceId(19)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue2.ts
 Bindings mismatch:
@@ -13939,19 +11875,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["f"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/narrowByInstanceof.ts
-Symbol reference IDs mismatch for "Person":
-after transform: SymbolId(16): [ReferenceId(33), ReferenceId(28), ReferenceId(39)]
-rebuilt        : SymbolId(11): [ReferenceId(19)]
-Symbol reference IDs mismatch for "Car":
-after transform: SymbolId(17): [ReferenceId(34)]
-rebuilt        : SymbolId(12): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/narrowBySwitchDiscriminantUndefinedCase1.ts
-Unresolved references mismatch:
-after transform: ["Error", "Math", "const", "undefined"]
-rebuilt        : ["Error", "Math", "undefined"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/narrowUnknownByTypePredicate.ts
 Bindings mismatch:
@@ -14015,16 +11938,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["isA", "isNotNullish", "isNullish", "value1", "value2", "value3", "value4", "value5", "value6"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/narrowingAssignmentReadonlyRespectsAssertion.ts
-Unresolved references mismatch:
-after transform: ["Array", "ReadonlyArray", "console"]
-rebuilt        : ["Array", "console"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/narrowingByTypeofInSwitch.ts
-Unresolved references mismatch:
-after transform: ["Function"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/narrowingNoInfer1.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["_objectSpread", "m", "map", "something", "test2"]
@@ -14033,13 +11946,8 @@ Reference symbol mismatch for "test2":
 after transform: SymbolId(12) "test2"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["NoInfer", "const", "require"]
+after transform: ["require"]
 rebuilt        : ["require", "test2"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/narrowingPastLastAssignmentInModule.ts
-Unresolved references mismatch:
-after transform: ["Function"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/narrowingRestGenericCall.ts
 Bindings mismatch:
@@ -14112,7 +12020,7 @@ Reference symbol mismatch for "takeArray":
 after transform: SymbolId(0) "takeArray"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Array"]
+after transform: []
 rebuilt        : ["takeArray"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/narrowingUnionToUnion.ts
@@ -14204,19 +12112,13 @@ Reference symbol mismatch for "workingAgain":
 after transform: SymbolId(80) "workingAgain"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Record", "undefined"]
+after transform: ["undefined"]
 rebuilt        : ["assert", "broken", "isA", "isEmptyArray", "isEmptyStrOrUndefined", "isEmptyString", "isFalsy", "isMaybeEmptyArray", "isMaybeEmptyString", "isMaybeZero", "isMyDiscriminatedUnion", "isXSorY", "isZero", "undefined", "working", "workingAgain"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/nearbyIdenticalGenericLambdasAssignable.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["accA", "accB", "accC", "accL", "fA", "fB", "fC"]
 rebuilt        : ScopeId(0): ["fB", "fC"]
-Symbol reference IDs mismatch for "fB":
-after transform: SymbolId(2): [ReferenceId(4), ReferenceId(14), ReferenceId(20), ReferenceId(26), ReferenceId(32)]
-rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(9), ReferenceId(15), ReferenceId(21)]
-Symbol reference IDs mismatch for "fC":
-after transform: SymbolId(4): [ReferenceId(5), ReferenceId(16), ReferenceId(22), ReferenceId(28), ReferenceId(34)]
-rebuilt        : SymbolId(1): [ReferenceId(5), ReferenceId(11), ReferenceId(17), ReferenceId(23)]
 Reference symbol mismatch for "accA":
 after transform: SymbolId(11) "accA"
 rebuilt        : <None>
@@ -14282,11 +12184,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["call", "wrap"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/nestedHomomorphicMappedTypesWithArrayConstraint1.ts
-Unresolved references mismatch:
-after transform: ["Partial"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/nestedModulePrivateAccess.ts
 Scope flags mismatch:
@@ -14354,7 +12251,7 @@ Reference symbol mismatch for "hasZField":
 after transform: SymbolId(14) "hasZField"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Record"]
+after transform: []
 rebuilt        : ["direct", "hasZField", "nested", "nestedUnion"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/neverAsDiscriminantType.ts
@@ -14367,17 +12264,6 @@ rebuilt        : ScopeId(5): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "GatewayOpcode":
 after transform: SymbolId(14): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "GatewayOpcode":
-after transform: SymbolId(14): [ReferenceId(6), ReferenceId(11), ReferenceId(13), ReferenceId(16), ReferenceId(27), ReferenceId(28)]
-rebuilt        : SymbolId(5): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/noAsConstNameLookup.ts
-Symbol reference IDs mismatch for "FeatureRunner":
-after transform: SymbolId(4): [ReferenceId(1)]
-rebuilt        : SymbolId(2): []
-Unresolved references mismatch:
-after transform: ["Promise", "const"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/noCircularDefinitionOnExportOfPrivateInMergedNamespace.ts
 Symbol reference IDs mismatch for "cat":
@@ -14404,7 +12290,7 @@ Reference symbol mismatch for "optional":
 after transform: SymbolId(18) "optional"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Record"]
+after transform: []
 rebuilt        : ["object", "optional", "string"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/noCircularitySelfReferentialGetter2.ts
@@ -14421,7 +12307,7 @@ Reference symbol mismatch for "optional":
 after transform: SymbolId(18) "optional"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Record"]
+after transform: []
 rebuilt        : ["object", "optional", "string"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/noCollisionThisExpressionAndLocalVarInLambda.ts
@@ -14437,11 +12323,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["alert"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/noCrashOnThisTypeUsage.ts
-Unresolved references mismatch:
-after transform: ["Function"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/noCrashUMDMergedWithGlobalValue.ts
 Bindings mismatch:
@@ -14489,26 +12370,12 @@ rebuilt        : ScopeId(3): ScopeFlags(Function)
 Symbol flags mismatch for "Meat":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "Meat":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(4), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(11), ReferenceId(12), ReferenceId(21)]
-rebuilt        : SymbolId(0): [ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(9), ReferenceId(10), ReferenceId(12), ReferenceId(13), ReferenceId(15), ReferenceId(16)]
 Symbol flags mismatch for "A":
 after transform: SymbolId(12): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(11): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch for "B":
 after transform: SymbolId(16): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(13): SymbolFlags(FunctionScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/noUsedBeforeDefinedErrorInTypeContext.ts
-Symbol reference IDs mismatch for "foo":
-after transform: SymbolId(2): [ReferenceId(2)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "bar":
-after transform: SymbolId(4): [ReferenceId(4), ReferenceId(6)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "qwe":
-after transform: SymbolId(5): [ReferenceId(8)]
-rebuilt        : SymbolId(3): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/nodeModuleReexportFromDottedPath.ts
 Bindings mismatch:
@@ -14582,7 +12449,7 @@ Reference symbol mismatch for "exists":
 after transform: SymbolId(32) "exists"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["ReadonlyArray"]
+after transform: []
 rebuilt        : ["es", "exists", "filter", "pipe"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/nonInferrableTypePropagation3.ts
@@ -14613,28 +12480,10 @@ Unresolved references mismatch:
 after transform: ["Boolean"]
 rebuilt        : ["Boolean", "foo"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/nonNullReferenceMatching.ts
-Unresolved references mismatch:
-after transform: ["HTMLElement", "require"]
-rebuilt        : ["require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/nonNullableAndObjectIntersections.ts
-Unresolved references mismatch:
-after transform: ["NonNullable"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/nonNullableWithNullableGenericIndexedAccessArg.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["StateNode"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["NonNullable"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/nongenericConditionalNotPartiallyComputed.ts
-Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/nongenericPartialInstantiationsRelatedInBothDirections.ts
 Bindings mismatch:
@@ -14653,18 +12502,8 @@ Reference symbol mismatch for "cfoo":
 after transform: SymbolId(5) "cfoo"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Partial"]
+after transform: []
 rebuilt        : ["cafoo", "cfoo"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/nonnullAssertionPropegatesContextualType.ts
-Unresolved references mismatch:
-after transform: ["SVGRectElement", "document"]
-rebuilt        : ["document"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/nounusedTypeParameterConstraint.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["IEventSourcedEntity"]
-rebuilt        : ScopeId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/numericEnumMappedType.ts
 Bindings mismatch:
@@ -14691,21 +12530,12 @@ rebuilt        : ScopeId(3): ScopeFlags(Function)
 Symbol flags mismatch for "E1":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "E1":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(4), ReferenceId(5), ReferenceId(32)]
-rebuilt        : SymbolId(0): [ReferenceId(7), ReferenceId(8)]
 Symbol flags mismatch for "N1":
 after transform: SymbolId(17): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "N1":
-after transform: SymbolId(17): [ReferenceId(18), ReferenceId(38)]
-rebuilt        : SymbolId(6): [ReferenceId(23)]
 Symbol flags mismatch for "N2":
 after transform: SymbolId(20): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "N2":
-after transform: SymbolId(20): [ReferenceId(19), ReferenceId(44)]
-rebuilt        : SymbolId(8): [ReferenceId(31)]
 Reference symbol mismatch for "E2":
 after transform: SymbolId(4) "E2"
 rebuilt        : <None>
@@ -14732,9 +12562,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/objectAssignLikeN
 Bindings mismatch:
 after transform: ScopeId(0): ["assign", "data1", "defaultValue"]
 rebuilt        : ScopeId(0): ["data1", "defaultValue"]
-Symbol reference IDs mismatch for "data1":
-after transform: SymbolId(7): [ReferenceId(13), ReferenceId(17)]
-rebuilt        : SymbolId(1): []
 Reference symbol mismatch for "assign":
 after transform: SymbolId(2) "assign"
 rebuilt        : <None>
@@ -14781,11 +12608,6 @@ Unresolved references mismatch:
 after transform: ["Object"]
 rebuilt        : ["Object", "union"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/objectLitGetterSetter.ts
-Unresolved references mismatch:
-after transform: ["Object", "PropertyDescriptor", "eval"]
-rebuilt        : ["Object", "eval"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/objectLiteralArraySpecialization.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["create", "thing"]
@@ -14813,9 +12635,6 @@ rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol flags mismatch for "Strs":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "Strs":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(25)]
-rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7)]
 Symbol flags mismatch for "Nums":
 after transform: SymbolId(12): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(9): SymbolFlags(FunctionScopedVariable)
@@ -14831,7 +12650,7 @@ Reference symbol mismatch for "test":
 after transform: SymbolId(14) "test"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["File", "require"]
+after transform: ["require"]
 rebuilt        : ["require", "setupImages", "test"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/observableInferenceCanBeMade.ts
@@ -14847,11 +12666,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["from", "of"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/omitTypeTests01.ts
-Unresolved references mismatch:
-after transform: ["Omit"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/optionalAccessorsInInterface1.ts
 Bindings mismatch:
@@ -14893,16 +12707,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["a"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/optionalConstructorArgInSuper.ts
-Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(3): [ReferenceId(1), ReferenceId(2)]
-rebuilt        : SymbolId(3): [ReferenceId(1)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/optionalTupleElementsAndUndefined.ts
-Unresolved references mismatch:
-after transform: ["NonNullable"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/overload2.ts
 Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(0x0)
@@ -14913,24 +12717,15 @@ rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(5)]
-rebuilt        : SymbolId(0): [ReferenceId(1)]
 Symbol flags mismatch for "B":
 after transform: SymbolId(1): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(1): [ReferenceId(1), ReferenceId(7)]
-rebuilt        : SymbolId(2): [ReferenceId(3)]
 Symbol span mismatch for "foo":
 after transform: SymbolId(2): Span { start: 36, end: 39 }
 rebuilt        : SymbolId(4): Span { start: 92, end: 95 }
 Symbol redeclarations mismatch for "foo":
 after transform: SymbolId(2): [Span { start: 36, end: 39 }, Span { start: 56, end: 59 }, Span { start: 92, end: 95 }]
 rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(6): [ReferenceId(3)]
-rebuilt        : SymbolId(6): []
 Symbol span mismatch for "foo1":
 after transform: SymbolId(7): Span { start: 134, end: 138 }
 rebuilt        : SymbolId(7): Span { start: 192, end: 196 }
@@ -14979,24 +12774,7 @@ Symbol redeclarations mismatch for "x2":
 after transform: SymbolId(0): [Span { start: 9, end: 11 }, Span { start: 58, end: 60 }, Span { start: 108, end: 110 }]
 rebuilt        : SymbolId(0): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/overloadOnGenericArity.ts
-Unresolved references mismatch:
-after transform: ["Date"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/overloadOnGenericClassAndNonGenericClass.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(2), ReferenceId(9)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(1): [ReferenceId(5)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "X":
-after transform: SymbolId(3): [ReferenceId(3), ReferenceId(6)]
-rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch for "X1":
-after transform: SymbolId(5): [ReferenceId(1)]
-rebuilt        : SymbolId(5): []
 Symbol span mismatch for "f":
 after transform: SymbolId(7): Span { start: 123, end: 124 }
 rebuilt        : SymbolId(7): Span { start: 172, end: 173 }
@@ -15026,15 +12804,7 @@ Symbol span mismatch for "Bugs":
 after transform: SymbolId(0): Span { start: 10, end: 14 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/overloadResolutionWithAny.ts
-Unresolved references mismatch:
-after transform: ["RegExp"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/overloadReturnTypes.ts
-Symbol reference IDs mismatch for "Accessor":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(4), ReferenceId(5), ReferenceId(6)]
-rebuilt        : SymbolId(0): [ReferenceId(2)]
 Symbol span mismatch for "attr":
 after transform: SymbolId(1): Span { start: 28, end: 32 }
 rebuilt        : SymbolId(1): Span { start: 154, end: 158 }
@@ -15049,11 +12819,6 @@ rebuilt        : SymbolId(0): Span { start: 102, end: 104 }
 Symbol redeclarations mismatch for "x2":
 after transform: SymbolId(0): [Span { start: 9, end: 11 }, Span { start: 56, end: 58 }, Span { start: 102, end: 104 }]
 rebuilt        : SymbolId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/overloadedConstructorFixesInferencesAppropriately.ts
-Unresolved references mismatch:
-after transform: ["Exclude"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/overloadingOnConstantsInImplementation.ts
 Symbol span mismatch for "foo":
@@ -15085,13 +12850,8 @@ Reference symbol mismatch for "f":
 after transform: SymbolId(0) "f"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Number", "String"]
+after transform: []
 rebuilt        : ["f"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/overrideBaseIntersectionMethod.ts
-Symbol reference IDs mismatch for "Point":
-after transform: SymbolId(8): [ReferenceId(2), ReferenceId(8)]
-rebuilt        : SymbolId(4): [ReferenceId(6)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/parseEntityNameWithReservedWord.ts
 Bindings mismatch:
@@ -15103,17 +12863,11 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "Bool":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "Bool":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(5)]
-rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(4)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/parseGenericArrowRatherThanLeftShift.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["a", "b", "foo"]
 rebuilt        : ScopeId(0): ["b", "foo"]
-Unresolved references mismatch:
-after transform: ["ReturnType"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/parseJsxExtends1.ts
 Bindings mismatch:
@@ -15137,13 +12891,8 @@ Reference symbol mismatch for "keys":
 after transform: SymbolId(54) "keys"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Partial"]
+after transform: []
 rebuilt        : ["keys"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/partialTypeNarrowedToByTypeGuard.ts
-Unresolved references mismatch:
-after transform: ["Partial"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/partiallyAmbientClodule.ts
 Symbol flags mismatch for "foo":
@@ -15178,29 +12927,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["use"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/pathMappingWithoutBaseUrl1.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["p1"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/pathMappingWithoutBaseUrl2.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["p1"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/performanceComparisonOfStructurallyIdenticalInterfacesWithGenericSignatures.ts
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(57): [ReferenceId(111), ReferenceId(116), ReferenceId(121), ReferenceId(126), ReferenceId(131), ReferenceId(136), ReferenceId(141), ReferenceId(146), ReferenceId(151), ReferenceId(156), ReferenceId(161), ReferenceId(166), ReferenceId(171)]
-rebuilt        : SymbolId(3): []
-Unresolved references mismatch:
-after transform: ["PromiseLike", "undefined"]
-rebuilt        : ["undefined"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/pickOfLargeObjectUnionWorks.ts
-Unresolved references mismatch:
-after transform: ["Pick"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/preserveConstEnums.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["E", "Value", "Value2"]
@@ -15211,11 +12937,6 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "E":
 after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/prespecializedGenericMembers1.ts
-Symbol reference IDs mismatch for "Cat":
-after transform: SymbolId(1): [ReferenceId(1), ReferenceId(3)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/primitiveTypeAsmoduleName.ts
 Bindings mismatch:
@@ -15252,11 +12973,6 @@ Unresolved references mismatch:
 after transform: ["module"]
 rebuilt        : ["Bar", "module"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyCheckTypeOfFunction.ts
-Symbol reference IDs mismatch for "foo":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyCheckTypeOfInvisibleModuleError.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -15278,9 +12994,6 @@ rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Inner":
 after transform: SymbolId(1): Span { start: 32, end: 37 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "Inner":
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3)]
-rebuilt        : SymbolId(2): [ReferenceId(0), ReferenceId(1)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyCheckTypeOfInvisibleModuleNoError.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -15303,9 +13016,6 @@ rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Inner":
 after transform: SymbolId(1): Span { start: 32, end: 37 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "Inner":
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
-rebuilt        : SymbolId(2): [ReferenceId(0), ReferenceId(1)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyClass.ts
 Symbol flags mismatch for "m1":
@@ -15334,9 +13044,6 @@ rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "privateModule":
 after transform: SymbolId(10): Span { start: 1056, end: 1069 }
 rebuilt        : SymbolId(9): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "privateModule":
-after transform: SymbolId(10): [ReferenceId(4), ReferenceId(5), ReferenceId(12), ReferenceId(13), ReferenceId(18), ReferenceId(19), ReferenceId(36), ReferenceId(37)]
-rebuilt        : SymbolId(9): [ReferenceId(16), ReferenceId(17)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyFunc.ts
 Scope flags mismatch:
@@ -15348,15 +13055,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1":
 after transform: SymbolId(0): Span { start: 10, end: 12 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "C1_public":
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(10), ReferenceId(12), ReferenceId(18), ReferenceId(20), ReferenceId(21), ReferenceId(28), ReferenceId(30), ReferenceId(36), ReferenceId(37), ReferenceId(40), ReferenceId(41), ReferenceId(48), ReferenceId(50), ReferenceId(6), ReferenceId(7), ReferenceId(11), ReferenceId(13), ReferenceId(24), ReferenceId(25), ReferenceId(29), ReferenceId(31), ReferenceId(44), ReferenceId(45), ReferenceId(49), ReferenceId(51), ReferenceId(71)]
-rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(6), ReferenceId(7), ReferenceId(12), ReferenceId(13), ReferenceId(16), ReferenceId(17), ReferenceId(28), ReferenceId(29), ReferenceId(36), ReferenceId(37)]
-Symbol reference IDs mismatch for "C2_private":
-after transform: SymbolId(2): [ReferenceId(1), ReferenceId(4), ReferenceId(5), ReferenceId(14), ReferenceId(16), ReferenceId(19), ReferenceId(22), ReferenceId(23), ReferenceId(32), ReferenceId(34), ReferenceId(38), ReferenceId(39), ReferenceId(42), ReferenceId(43), ReferenceId(52), ReferenceId(54), ReferenceId(8), ReferenceId(9), ReferenceId(15), ReferenceId(17), ReferenceId(26), ReferenceId(27), ReferenceId(33), ReferenceId(35), ReferenceId(46), ReferenceId(47), ReferenceId(53), ReferenceId(55)]
-rebuilt        : SymbolId(3): [ReferenceId(4), ReferenceId(5), ReferenceId(8), ReferenceId(9), ReferenceId(14), ReferenceId(15), ReferenceId(18), ReferenceId(19), ReferenceId(32), ReferenceId(33), ReferenceId(40), ReferenceId(41)]
-Symbol reference IDs mismatch for "C6_public":
-after transform: SymbolId(43): [ReferenceId(56), ReferenceId(57), ReferenceId(58), ReferenceId(61), ReferenceId(63), ReferenceId(65), ReferenceId(66), ReferenceId(68), ReferenceId(59), ReferenceId(60), ReferenceId(62), ReferenceId(64), ReferenceId(67), ReferenceId(69)]
-rebuilt        : SymbolId(40): [ReferenceId(46), ReferenceId(47), ReferenceId(48), ReferenceId(49), ReferenceId(50), ReferenceId(51)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyFunctionCannotNameParameterTypeDeclFile.ts
 Symbol flags mismatch for "SpecializedWidget":
@@ -15384,39 +13082,18 @@ rebuilt        : ScopeId(41): ["_publicModule", "privateClass", "privateClassWit
 Bindings mismatch:
 after transform: ScopeId(142): ["_privateModule", "privateAmbientFunctionWithPrivateModuleParameterTypes", "privateAmbientFunctionWithPrivateParmeterTypes", "privateAmbientFunctionWithPublicParmeterTypes", "privateClass", "privateClassWithPrivateModuleParameterTypes", "privateClassWithWithPrivateParmeterTypes", "privateClassWithWithPublicParmeterTypes", "privateFunctionWithPrivateModuleParameterTypes", "privateFunctionWithPrivateParmeterTypes", "privateFunctionWithPublicParmeterTypes", "publicAmbientFunctionWithPrivateModuleParameterTypes", "publicAmbientFunctionWithPrivateParmeterTypes", "publicAmbientFunctionWithPublicParmeterTypes", "publicClass", "publicClassWithPrivateModuleParameterTypes", "publicClassWithWithPrivateParmeterTypes", "publicClassWithWithPublicParmeterTypes", "publicFunctionWithPrivateModuleParameterTypes", "publicFunctionWithPrivateParmeterTypes", "publicFunctionWithPublicParmeterTypes"]
 rebuilt        : ScopeId(82): ["_privateModule", "privateClass", "privateClassWithPrivateModuleParameterTypes", "privateClassWithWithPrivateParmeterTypes", "privateClassWithWithPublicParmeterTypes", "privateFunctionWithPrivateModuleParameterTypes", "privateFunctionWithPrivateParmeterTypes", "privateFunctionWithPublicParmeterTypes", "publicClass", "publicClassWithPrivateModuleParameterTypes", "publicClassWithWithPrivateParmeterTypes", "publicClassWithWithPublicParmeterTypes", "publicFunctionWithPrivateModuleParameterTypes", "publicFunctionWithPrivateParmeterTypes", "publicFunctionWithPublicParmeterTypes"]
-Symbol reference IDs mismatch for "privateClass":
-after transform: SymbolId(0): [ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(34), ReferenceId(35), ReferenceId(36), ReferenceId(37), ReferenceId(38), ReferenceId(39), ReferenceId(40), ReferenceId(48), ReferenceId(50), ReferenceId(52), ReferenceId(54), ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "publicClass":
-after transform: SymbolId(1): [ReferenceId(27), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(32), ReferenceId(33), ReferenceId(41), ReferenceId(42), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(46), ReferenceId(47), ReferenceId(49), ReferenceId(51), ReferenceId(53), ReferenceId(55), ReferenceId(1), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(57), ReferenceId(59), ReferenceId(69), ReferenceId(71)]
-rebuilt        : SymbolId(1): []
 Symbol flags mismatch for "publicModule":
 after transform: SymbolId(94): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(58): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "publicModule":
 after transform: SymbolId(94): Span { start: 4746, end: 4758 }
 rebuilt        : SymbolId(58): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "privateClass":
-after transform: SymbolId(95): [ReferenceId(100), ReferenceId(101), ReferenceId(102), ReferenceId(103), ReferenceId(104), ReferenceId(105), ReferenceId(106), ReferenceId(114), ReferenceId(115), ReferenceId(116), ReferenceId(117), ReferenceId(118), ReferenceId(119), ReferenceId(120), ReferenceId(128), ReferenceId(130), ReferenceId(132), ReferenceId(134), ReferenceId(80), ReferenceId(82), ReferenceId(84), ReferenceId(90), ReferenceId(91), ReferenceId(92), ReferenceId(93), ReferenceId(94)]
-rebuilt        : SymbolId(60): []
-Symbol reference IDs mismatch for "publicClass":
-after transform: SymbolId(96): [ReferenceId(107), ReferenceId(108), ReferenceId(109), ReferenceId(110), ReferenceId(111), ReferenceId(112), ReferenceId(113), ReferenceId(121), ReferenceId(122), ReferenceId(123), ReferenceId(124), ReferenceId(125), ReferenceId(126), ReferenceId(127), ReferenceId(129), ReferenceId(131), ReferenceId(133), ReferenceId(135), ReferenceId(81), ReferenceId(83), ReferenceId(85), ReferenceId(86), ReferenceId(87), ReferenceId(88), ReferenceId(89), ReferenceId(95), ReferenceId(96), ReferenceId(97), ReferenceId(98), ReferenceId(99), ReferenceId(137), ReferenceId(139), ReferenceId(149), ReferenceId(151), ReferenceId(241)]
-rebuilt        : SymbolId(61): [ReferenceId(13)]
 Symbol flags mismatch for "privateModule":
 after transform: SymbolId(189): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(118): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "privateModule":
 after transform: SymbolId(189): Span { start: 9967, end: 9980 }
 rebuilt        : SymbolId(118): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "privateModule":
-after transform: SymbolId(189): [ReferenceId(221), ReferenceId(222), ReferenceId(223), ReferenceId(224), ReferenceId(225), ReferenceId(226), ReferenceId(227), ReferenceId(233), ReferenceId(234), ReferenceId(235), ReferenceId(236), ReferenceId(237), ReferenceId(238), ReferenceId(239), ReferenceId(56), ReferenceId(58), ReferenceId(60), ReferenceId(61), ReferenceId(62), ReferenceId(63), ReferenceId(64), ReferenceId(65), ReferenceId(66), ReferenceId(67), ReferenceId(68), ReferenceId(70), ReferenceId(72), ReferenceId(73), ReferenceId(74), ReferenceId(75), ReferenceId(76), ReferenceId(77), ReferenceId(78), ReferenceId(79), ReferenceId(136), ReferenceId(138), ReferenceId(140), ReferenceId(141), ReferenceId(142), ReferenceId(143), ReferenceId(144), ReferenceId(145), ReferenceId(146), ReferenceId(147), ReferenceId(148), ReferenceId(150), ReferenceId(152), ReferenceId(153), ReferenceId(154), ReferenceId(155), ReferenceId(156), ReferenceId(157), ReferenceId(158), ReferenceId(159), ReferenceId(216), ReferenceId(218), ReferenceId(220), ReferenceId(228), ReferenceId(230), ReferenceId(232), ReferenceId(270), ReferenceId(271)]
-rebuilt        : SymbolId(118): [ReferenceId(66), ReferenceId(67)]
-Symbol reference IDs mismatch for "privateClass":
-after transform: SymbolId(190): [ReferenceId(180), ReferenceId(181), ReferenceId(182), ReferenceId(183), ReferenceId(184), ReferenceId(185), ReferenceId(186), ReferenceId(194), ReferenceId(195), ReferenceId(196), ReferenceId(197), ReferenceId(198), ReferenceId(199), ReferenceId(200), ReferenceId(208), ReferenceId(210), ReferenceId(212), ReferenceId(214), ReferenceId(160), ReferenceId(162), ReferenceId(164), ReferenceId(170), ReferenceId(171), ReferenceId(172), ReferenceId(173), ReferenceId(174)]
-rebuilt        : SymbolId(120): []
-Symbol reference IDs mismatch for "publicClass":
-after transform: SymbolId(191): [ReferenceId(187), ReferenceId(188), ReferenceId(189), ReferenceId(190), ReferenceId(191), ReferenceId(192), ReferenceId(193), ReferenceId(201), ReferenceId(202), ReferenceId(203), ReferenceId(204), ReferenceId(205), ReferenceId(206), ReferenceId(207), ReferenceId(209), ReferenceId(211), ReferenceId(213), ReferenceId(215), ReferenceId(161), ReferenceId(163), ReferenceId(165), ReferenceId(166), ReferenceId(167), ReferenceId(168), ReferenceId(169), ReferenceId(175), ReferenceId(176), ReferenceId(177), ReferenceId(178), ReferenceId(179), ReferenceId(217), ReferenceId(219), ReferenceId(229), ReferenceId(231), ReferenceId(257)]
-rebuilt        : SymbolId(121): [ReferenceId(41)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyGloClass.ts
 Scope flags mismatch:
@@ -15474,18 +13151,12 @@ rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1_M1_public":
 after transform: SymbolId(1): Span { start: 36, end: 48 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "c1":
-after transform: SymbolId(2): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(47)]
-rebuilt        : SymbolId(4): [ReferenceId(1), ReferenceId(2), ReferenceId(6)]
 Symbol flags mismatch for "m1_M2_private":
 after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1_M2_private":
 after transform: SymbolId(6): Span { start: 231, end: 244 }
 rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "c1":
-after transform: SymbolId(7): [ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(56)]
-rebuilt        : SymbolId(10): [ReferenceId(12), ReferenceId(13), ReferenceId(17)]
 Symbol flags mismatch for "glo_M1_public":
 after transform: SymbolId(31): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(34): SymbolFlags(BlockScopedVariable)
@@ -15495,9 +13166,6 @@ rebuilt        : SymbolId(34): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "glo_M1_public":
 after transform: SymbolId(31): [ReferenceId(31), ReferenceId(44), ReferenceId(45), ReferenceId(81), ReferenceId(82)]
 rebuilt        : SymbolId(34): [ReferenceId(61), ReferenceId(62)]
-Symbol reference IDs mismatch for "c1":
-after transform: SymbolId(32): [ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(77)]
-rebuilt        : SymbolId(36): [ReferenceId(55), ReferenceId(56), ReferenceId(60)]
 Symbol flags mismatch for "m2":
 after transform: SymbolId(59): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(40): SymbolFlags(BlockScopedVariable)
@@ -15524,15 +13192,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1":
 after transform: SymbolId(0): Span { start: 10, end: 12 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "C1_public":
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(16), ReferenceId(18), ReferenceId(20), ReferenceId(22), ReferenceId(24), ReferenceId(26), ReferenceId(28), ReferenceId(30), ReferenceId(32), ReferenceId(34), ReferenceId(55)]
-rebuilt        : SymbolId(2): [ReferenceId(1)]
-Symbol reference IDs mismatch for "C2_private":
-after transform: SymbolId(2): [ReferenceId(1), ReferenceId(3), ReferenceId(5), ReferenceId(7), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(23), ReferenceId(25), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33), ReferenceId(35)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch for "C5_public":
-after transform: SymbolId(21): [ReferenceId(36), ReferenceId(37), ReferenceId(38), ReferenceId(39), ReferenceId(40), ReferenceId(41), ReferenceId(42), ReferenceId(43), ReferenceId(44)]
-rebuilt        : SymbolId(4): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyImport.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -15575,18 +13234,12 @@ rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1_M1_public":
 after transform: SymbolId(1): Span { start: 43, end: 55 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "c1":
-after transform: SymbolId(2): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(79)]
-rebuilt        : SymbolId(4): [ReferenceId(1), ReferenceId(2), ReferenceId(6)]
 Symbol flags mismatch for "m1_M2_private":
 after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1_M2_private":
 after transform: SymbolId(6): Span { start: 238, end: 251 }
 rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "c1":
-after transform: SymbolId(7): [ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(88)]
-rebuilt        : SymbolId(10): [ReferenceId(12), ReferenceId(13), ReferenceId(17)]
 Symbol flags mismatch for "m2":
 after transform: SymbolId(31): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(34): SymbolFlags(BlockScopedVariable)
@@ -15602,36 +13255,24 @@ rebuilt        : SymbolId(36): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m2_M1_public":
 after transform: SymbolId(32): Span { start: 3220, end: 3232 }
 rebuilt        : SymbolId(36): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "c1":
-after transform: SymbolId(33): [ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(109)]
-rebuilt        : SymbolId(38): [ReferenceId(55), ReferenceId(56), ReferenceId(60)]
 Symbol flags mismatch for "m2_M2_private":
 after transform: SymbolId(37): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(42): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m2_M2_private":
 after transform: SymbolId(37): Span { start: 3415, end: 3428 }
 rebuilt        : SymbolId(42): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "c1":
-after transform: SymbolId(38): [ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(118)]
-rebuilt        : SymbolId(44): [ReferenceId(66), ReferenceId(67), ReferenceId(71)]
 Symbol flags mismatch for "glo_M1_public":
 after transform: SymbolId(62): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(68): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "glo_M1_public":
 after transform: SymbolId(62): Span { start: 6414, end: 6427 }
 rebuilt        : SymbolId(68): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "c1":
-after transform: SymbolId(63): [ReferenceId(52), ReferenceId(53), ReferenceId(54), ReferenceId(139)]
-rebuilt        : SymbolId(70): [ReferenceId(109), ReferenceId(110), ReferenceId(114)]
 Symbol flags mismatch for "glo_M3_private":
 after transform: SymbolId(67): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(74): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "glo_M3_private":
 after transform: SymbolId(67): Span { start: 6751, end: 6765 }
 rebuilt        : SymbolId(74): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "c1":
-after transform: SymbolId(68): [ReferenceId(55), ReferenceId(56), ReferenceId(57), ReferenceId(146)]
-rebuilt        : SymbolId(76): [ReferenceId(118), ReferenceId(119), ReferenceId(123)]
 Symbol flags mismatch for "m4":
 after transform: SymbolId(92): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(101): SymbolFlags(BlockScopedVariable)
@@ -15661,30 +13302,12 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1":
 after transform: SymbolId(0): Span { start: 17, end: 19 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "C1_public":
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(16), ReferenceId(18), ReferenceId(20), ReferenceId(22), ReferenceId(24), ReferenceId(26), ReferenceId(28), ReferenceId(30), ReferenceId(32), ReferenceId(34), ReferenceId(133)]
-rebuilt        : SymbolId(2): [ReferenceId(1)]
-Symbol reference IDs mismatch for "C2_private":
-after transform: SymbolId(2): [ReferenceId(1), ReferenceId(3), ReferenceId(5), ReferenceId(7), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(23), ReferenceId(25), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33), ReferenceId(35)]
-rebuilt        : SymbolId(3): []
 Symbol flags mismatch for "m2":
 after transform: SymbolId(21): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m2":
 after transform: SymbolId(21): Span { start: 1211, end: 1213 }
 rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "C1_public":
-after transform: SymbolId(22): [ReferenceId(36), ReferenceId(38), ReferenceId(40), ReferenceId(42), ReferenceId(44), ReferenceId(46), ReferenceId(48), ReferenceId(50), ReferenceId(52), ReferenceId(54), ReferenceId(56), ReferenceId(58), ReferenceId(60), ReferenceId(62), ReferenceId(64), ReferenceId(66), ReferenceId(68), ReferenceId(70), ReferenceId(137)]
-rebuilt        : SymbolId(6): [ReferenceId(5)]
-Symbol reference IDs mismatch for "C2_private":
-after transform: SymbolId(23): [ReferenceId(37), ReferenceId(39), ReferenceId(41), ReferenceId(43), ReferenceId(45), ReferenceId(47), ReferenceId(49), ReferenceId(51), ReferenceId(53), ReferenceId(55), ReferenceId(57), ReferenceId(59), ReferenceId(61), ReferenceId(63), ReferenceId(65), ReferenceId(67), ReferenceId(69), ReferenceId(71)]
-rebuilt        : SymbolId(7): []
-Symbol reference IDs mismatch for "C5_public":
-after transform: SymbolId(42): [ReferenceId(72), ReferenceId(74), ReferenceId(76), ReferenceId(78), ReferenceId(80), ReferenceId(82), ReferenceId(84), ReferenceId(86), ReferenceId(88), ReferenceId(90), ReferenceId(92), ReferenceId(94), ReferenceId(96), ReferenceId(98), ReferenceId(100), ReferenceId(102), ReferenceId(104), ReferenceId(106)]
-rebuilt        : SymbolId(8): []
-Symbol reference IDs mismatch for "C6_private":
-after transform: SymbolId(43): [ReferenceId(73), ReferenceId(75), ReferenceId(77), ReferenceId(79), ReferenceId(81), ReferenceId(83), ReferenceId(85), ReferenceId(87), ReferenceId(89), ReferenceId(91), ReferenceId(93), ReferenceId(95), ReferenceId(97), ReferenceId(99), ReferenceId(101), ReferenceId(103), ReferenceId(105), ReferenceId(107)]
-rebuilt        : SymbolId(9): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyInterfaceExtendsClauseDeclFile.ts
 Bindings mismatch:
@@ -15776,199 +13399,54 @@ rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "import_public":
 after transform: SymbolId(24): Span { start: 907, end: 920 }
 rebuilt        : SymbolId(20): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "im_public_i_private":
-after transform: SymbolId(29): [ReferenceId(18), ReferenceId(19), ReferenceId(126)]
-rebuilt        : SymbolId(26): [ReferenceId(57)]
-Symbol reference IDs mismatch for "im_public_mu_private":
-after transform: SymbolId(31): [ReferenceId(22), ReferenceId(23), ReferenceId(130)]
-rebuilt        : SymbolId(28): [ReferenceId(63)]
-Symbol reference IDs mismatch for "im_public_i_public":
-after transform: SymbolId(50): [ReferenceId(39), ReferenceId(40), ReferenceId(145)]
-rebuilt        : SymbolId(47): [ReferenceId(93)]
-Symbol reference IDs mismatch for "im_public_mu_public":
-after transform: SymbolId(52): [ReferenceId(43), ReferenceId(44), ReferenceId(149)]
-rebuilt        : SymbolId(49): [ReferenceId(99)]
 Symbol flags mismatch for "import_private":
 after transform: SymbolId(67): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(64): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "import_private":
 after transform: SymbolId(67): Span { start: 3843, end: 3857 }
 rebuilt        : SymbolId(64): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "im_private_i_private":
-after transform: SymbolId(72): [ReferenceId(60), ReferenceId(61), ReferenceId(166)]
-rebuilt        : SymbolId(70): [ReferenceId(131)]
-Symbol reference IDs mismatch for "im_private_mu_private":
-after transform: SymbolId(74): [ReferenceId(64), ReferenceId(65), ReferenceId(170)]
-rebuilt        : SymbolId(72): [ReferenceId(137)]
-Symbol reference IDs mismatch for "im_private_i_public":
-after transform: SymbolId(93): [ReferenceId(81), ReferenceId(82), ReferenceId(185)]
-rebuilt        : SymbolId(91): [ReferenceId(167)]
-Symbol reference IDs mismatch for "im_private_mu_public":
-after transform: SymbolId(95): [ReferenceId(85), ReferenceId(86), ReferenceId(189)]
-rebuilt        : SymbolId(93): [ReferenceId(173)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyTypeParameterOfFunction.ts
-Symbol reference IDs mismatch for "privateClass":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(32), ReferenceId(33), ReferenceId(34), ReferenceId(35), ReferenceId(40), ReferenceId(42)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "publicClass":
-after transform: SymbolId(1): [ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(36), ReferenceId(37), ReferenceId(38), ReferenceId(39), ReferenceId(41), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(46), ReferenceId(47), ReferenceId(48), ReferenceId(49)]
-rebuilt        : SymbolId(1): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyTypeParameterOfFunctionDeclFile.ts
-Symbol reference IDs mismatch for "privateClass":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(32), ReferenceId(33), ReferenceId(34), ReferenceId(35), ReferenceId(40), ReferenceId(42)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "publicClass":
-after transform: SymbolId(1): [ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(36), ReferenceId(37), ReferenceId(38), ReferenceId(39), ReferenceId(41), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(46), ReferenceId(47), ReferenceId(48), ReferenceId(49)]
-rebuilt        : SymbolId(1): []
 Symbol flags mismatch for "publicModule":
 after transform: SymbolId(86): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(18): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "publicModule":
 after transform: SymbolId(86): Span { start: 4741, end: 4753 }
 rebuilt        : SymbolId(18): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "privateClass":
-after transform: SymbolId(87): [ReferenceId(68), ReferenceId(69), ReferenceId(70), ReferenceId(71), ReferenceId(72), ReferenceId(73), ReferenceId(80), ReferenceId(81), ReferenceId(82), ReferenceId(83), ReferenceId(84), ReferenceId(85), ReferenceId(92), ReferenceId(93), ReferenceId(94), ReferenceId(95), ReferenceId(100), ReferenceId(101), ReferenceId(102), ReferenceId(103), ReferenceId(108), ReferenceId(110)]
-rebuilt        : SymbolId(20): []
-Symbol reference IDs mismatch for "publicClass":
-after transform: SymbolId(88): [ReferenceId(74), ReferenceId(75), ReferenceId(76), ReferenceId(77), ReferenceId(78), ReferenceId(79), ReferenceId(86), ReferenceId(87), ReferenceId(88), ReferenceId(89), ReferenceId(90), ReferenceId(91), ReferenceId(96), ReferenceId(97), ReferenceId(98), ReferenceId(99), ReferenceId(104), ReferenceId(105), ReferenceId(106), ReferenceId(107), ReferenceId(109), ReferenceId(111), ReferenceId(112), ReferenceId(113), ReferenceId(114), ReferenceId(115), ReferenceId(116), ReferenceId(117), ReferenceId(187)]
-rebuilt        : SymbolId(21): [ReferenceId(1)]
 Symbol flags mismatch for "privateModule":
 after transform: SymbolId(173): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(38): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "privateModule":
 after transform: SymbolId(173): Span { start: 10029, end: 10042 }
 rebuilt        : SymbolId(38): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "privateModule":
-after transform: SymbolId(173): [ReferenceId(50), ReferenceId(51), ReferenceId(52), ReferenceId(53), ReferenceId(54), ReferenceId(55), ReferenceId(56), ReferenceId(57), ReferenceId(58), ReferenceId(59), ReferenceId(60), ReferenceId(61), ReferenceId(62), ReferenceId(63), ReferenceId(64), ReferenceId(65), ReferenceId(66), ReferenceId(67), ReferenceId(118), ReferenceId(119), ReferenceId(120), ReferenceId(121), ReferenceId(122), ReferenceId(123), ReferenceId(124), ReferenceId(125), ReferenceId(126), ReferenceId(127), ReferenceId(128), ReferenceId(129), ReferenceId(130), ReferenceId(131), ReferenceId(132), ReferenceId(133), ReferenceId(134), ReferenceId(135), ReferenceId(220), ReferenceId(221)]
-rebuilt        : SymbolId(38): [ReferenceId(34), ReferenceId(35)]
-Symbol reference IDs mismatch for "privateClass":
-after transform: SymbolId(174): [ReferenceId(136), ReferenceId(137), ReferenceId(138), ReferenceId(139), ReferenceId(140), ReferenceId(141), ReferenceId(148), ReferenceId(149), ReferenceId(150), ReferenceId(151), ReferenceId(152), ReferenceId(153), ReferenceId(160), ReferenceId(161), ReferenceId(162), ReferenceId(163), ReferenceId(168), ReferenceId(169), ReferenceId(170), ReferenceId(171), ReferenceId(176), ReferenceId(178)]
-rebuilt        : SymbolId(40): []
-Symbol reference IDs mismatch for "publicClass":
-after transform: SymbolId(175): [ReferenceId(142), ReferenceId(143), ReferenceId(144), ReferenceId(145), ReferenceId(146), ReferenceId(147), ReferenceId(154), ReferenceId(155), ReferenceId(156), ReferenceId(157), ReferenceId(158), ReferenceId(159), ReferenceId(164), ReferenceId(165), ReferenceId(166), ReferenceId(167), ReferenceId(172), ReferenceId(173), ReferenceId(174), ReferenceId(175), ReferenceId(177), ReferenceId(179), ReferenceId(180), ReferenceId(181), ReferenceId(182), ReferenceId(183), ReferenceId(184), ReferenceId(185), ReferenceId(207)]
-rebuilt        : SymbolId(41): [ReferenceId(21)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyTypeParametersOfClass.ts
-Symbol reference IDs mismatch for "privateClass":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(8)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "publicClass":
-after transform: SymbolId(1): [ReferenceId(4), ReferenceId(12)]
-rebuilt        : SymbolId(1): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyTypeParametersOfClassDeclFile.ts
-Symbol reference IDs mismatch for "privateClass":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(8)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "publicClass":
-after transform: SymbolId(1): [ReferenceId(4), ReferenceId(12)]
-rebuilt        : SymbolId(1): []
 Symbol flags mismatch for "publicModule":
 after transform: SymbolId(26): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(18): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "publicModule":
 after transform: SymbolId(26): Span { start: 1172, end: 1184 }
 rebuilt        : SymbolId(18): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "privateClassInPublicModule":
-after transform: SymbolId(27): [ReferenceId(30), ReferenceId(38)]
-rebuilt        : SymbolId(20): []
-Symbol reference IDs mismatch for "publicClassInPublicModule":
-after transform: SymbolId(28): [ReferenceId(34), ReferenceId(42), ReferenceId(83)]
-rebuilt        : SymbolId(21): [ReferenceId(9)]
 Symbol flags mismatch for "privateModule":
 after transform: SymbolId(53): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(38): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "privateModule":
 after transform: SymbolId(53): Span { start: 2611, end: 2624 }
 rebuilt        : SymbolId(38): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "privateModule":
-after transform: SymbolId(53): [ReferenceId(22), ReferenceId(26), ReferenceId(52), ReferenceId(56), ReferenceId(102), ReferenceId(103)]
-rebuilt        : SymbolId(38): [ReferenceId(42), ReferenceId(43)]
-Symbol reference IDs mismatch for "privateClassInPrivateModule":
-after transform: SymbolId(54): [ReferenceId(60), ReferenceId(68)]
-rebuilt        : SymbolId(40): []
-Symbol reference IDs mismatch for "publicClassInPrivateModule":
-after transform: SymbolId(55): [ReferenceId(64), ReferenceId(72), ReferenceId(95)]
-rebuilt        : SymbolId(41): [ReferenceId(29)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyTypeParametersOfInterface.ts
-Symbol reference IDs mismatch for "privateClass":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(6), ReferenceId(10), ReferenceId(19), ReferenceId(23), ReferenceId(26), ReferenceId(32), ReferenceId(36), ReferenceId(45), ReferenceId(49)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "publicClass":
-after transform: SymbolId(1): [ReferenceId(8), ReferenceId(12), ReferenceId(13), ReferenceId(21), ReferenceId(25), ReferenceId(34), ReferenceId(38), ReferenceId(39), ReferenceId(47), ReferenceId(51)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch for "privateClassT":
-after transform: SymbolId(2): [ReferenceId(5), ReferenceId(7), ReferenceId(18), ReferenceId(20), ReferenceId(31), ReferenceId(33), ReferenceId(44), ReferenceId(46)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "publicClassT":
-after transform: SymbolId(4): [ReferenceId(3), ReferenceId(9), ReferenceId(11), ReferenceId(16), ReferenceId(22), ReferenceId(24), ReferenceId(29), ReferenceId(35), ReferenceId(37), ReferenceId(42), ReferenceId(48), ReferenceId(50), ReferenceId(54), ReferenceId(58)]
-rebuilt        : SymbolId(3): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyTypeParametersOfInterfaceDeclFile.ts
-Symbol reference IDs mismatch for "privateClass":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(6), ReferenceId(10), ReferenceId(19), ReferenceId(23), ReferenceId(26), ReferenceId(32), ReferenceId(36), ReferenceId(45), ReferenceId(49)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "publicClass":
-after transform: SymbolId(1): [ReferenceId(8), ReferenceId(12), ReferenceId(13), ReferenceId(21), ReferenceId(25), ReferenceId(34), ReferenceId(38), ReferenceId(39), ReferenceId(47), ReferenceId(51)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch for "privateClassT":
-after transform: SymbolId(2): [ReferenceId(5), ReferenceId(7), ReferenceId(18), ReferenceId(20), ReferenceId(31), ReferenceId(33), ReferenceId(44), ReferenceId(46)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "publicClassT":
-after transform: SymbolId(4): [ReferenceId(3), ReferenceId(9), ReferenceId(11), ReferenceId(16), ReferenceId(22), ReferenceId(24), ReferenceId(29), ReferenceId(35), ReferenceId(37), ReferenceId(42), ReferenceId(48), ReferenceId(50), ReferenceId(54), ReferenceId(58)]
-rebuilt        : SymbolId(3): []
 Symbol flags mismatch for "publicModule":
 after transform: SymbolId(28): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "publicModule":
 after transform: SymbolId(28): Span { start: 1976, end: 1988 }
 rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "privateClassInPublicModule":
-after transform: SymbolId(29): [ReferenceId(62), ReferenceId(68), ReferenceId(72), ReferenceId(81), ReferenceId(85), ReferenceId(88), ReferenceId(94), ReferenceId(98), ReferenceId(107), ReferenceId(111)]
-rebuilt        : SymbolId(6): []
-Symbol reference IDs mismatch for "publicClassInPublicModule":
-after transform: SymbolId(30): [ReferenceId(70), ReferenceId(74), ReferenceId(75), ReferenceId(83), ReferenceId(87), ReferenceId(96), ReferenceId(100), ReferenceId(101), ReferenceId(109), ReferenceId(113), ReferenceId(185)]
-rebuilt        : SymbolId(7): [ReferenceId(1)]
-Symbol reference IDs mismatch for "privateClassInPublicModuleT":
-after transform: SymbolId(31): [ReferenceId(67), ReferenceId(69), ReferenceId(80), ReferenceId(82), ReferenceId(93), ReferenceId(95), ReferenceId(106), ReferenceId(108)]
-rebuilt        : SymbolId(8): []
-Symbol reference IDs mismatch for "publicClassInPublicModuleT":
-after transform: SymbolId(33): [ReferenceId(65), ReferenceId(71), ReferenceId(73), ReferenceId(78), ReferenceId(84), ReferenceId(86), ReferenceId(91), ReferenceId(97), ReferenceId(99), ReferenceId(104), ReferenceId(110), ReferenceId(112), ReferenceId(116), ReferenceId(120), ReferenceId(187)]
-rebuilt        : SymbolId(9): [ReferenceId(3)]
 Symbol flags mismatch for "privateModule":
 after transform: SymbolId(57): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "privateModule":
 after transform: SymbolId(57): Span { start: 4811, end: 4824 }
 rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "privateModule":
-after transform: SymbolId(57): [ReferenceId(60), ReferenceId(61), ReferenceId(122), ReferenceId(123), ReferenceId(194), ReferenceId(195)]
-rebuilt        : SymbolId(10): [ReferenceId(10), ReferenceId(11)]
-Symbol reference IDs mismatch for "privateClassInPrivateModule":
-after transform: SymbolId(58): [ReferenceId(124), ReferenceId(130), ReferenceId(134), ReferenceId(143), ReferenceId(147), ReferenceId(150), ReferenceId(156), ReferenceId(160), ReferenceId(169), ReferenceId(173)]
-rebuilt        : SymbolId(12): []
-Symbol reference IDs mismatch for "publicClassInPrivateModule":
-after transform: SymbolId(59): [ReferenceId(132), ReferenceId(136), ReferenceId(137), ReferenceId(145), ReferenceId(149), ReferenceId(158), ReferenceId(162), ReferenceId(163), ReferenceId(171), ReferenceId(175), ReferenceId(191)]
-rebuilt        : SymbolId(13): [ReferenceId(7)]
-Symbol reference IDs mismatch for "privateClassInPrivateModuleT":
-after transform: SymbolId(60): [ReferenceId(129), ReferenceId(131), ReferenceId(142), ReferenceId(144), ReferenceId(155), ReferenceId(157), ReferenceId(168), ReferenceId(170)]
-rebuilt        : SymbolId(14): []
-Symbol reference IDs mismatch for "publicClassInPrivateModuleT":
-after transform: SymbolId(62): [ReferenceId(127), ReferenceId(133), ReferenceId(135), ReferenceId(140), ReferenceId(146), ReferenceId(148), ReferenceId(153), ReferenceId(159), ReferenceId(161), ReferenceId(166), ReferenceId(172), ReferenceId(174), ReferenceId(178), ReferenceId(182), ReferenceId(193)]
-rebuilt        : SymbolId(15): [ReferenceId(9)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/privatePropertyInUnion.ts
-Symbol reference IDs mismatch for "SyncableObject":
-after transform: SymbolId(1): [ReferenceId(1)]
-rebuilt        : SymbolId(1): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/promiseChaining.ts
-Symbol reference IDs mismatch for "Chain":
-after transform: SymbolId(0): [ReferenceId(3), ReferenceId(8)]
-rebuilt        : SymbolId(0): [ReferenceId(4)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/promiseType.ts
 Bindings mismatch:
@@ -16436,9 +13914,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["Error", "Promise", "arguments", "require", "undefined"]
 rebuilt        : ["Error", "Promise", "arguments", "p", "require", "undefined", "x"]
-Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(0), ReferenceId(9), ReferenceId(18), ReferenceId(34), ReferenceId(36), ReferenceId(49), ReferenceId(51), ReferenceId(73), ReferenceId(76), ReferenceId(89), ReferenceId(91), ReferenceId(104), ReferenceId(106), ReferenceId(128), ReferenceId(131), ReferenceId(153), ReferenceId(156), ReferenceId(169), ReferenceId(171), ReferenceId(184), ReferenceId(186), ReferenceId(199), ReferenceId(201), ReferenceId(203), ReferenceId(206), ReferenceId(208), ReferenceId(210), ReferenceId(213), ReferenceId(216), ReferenceId(218), ReferenceId(220), ReferenceId(222), ReferenceId(223), ReferenceId(225), ReferenceId(226), ReferenceId(228), ReferenceId(231), ReferenceId(233), ReferenceId(235), ReferenceId(238), ReferenceId(241), ReferenceId(243), ReferenceId(245), ReferenceId(247), ReferenceId(248), ReferenceId(250), ReferenceId(251), ReferenceId(252), ReferenceId(254), ReferenceId(255), ReferenceId(257), ReferenceId(258), ReferenceId(259), ReferenceId(261), ReferenceId(262), ReferenceId(263), ReferenceId(265), ReferenceId(266), ReferenceId(267), ReferenceId(268), ReferenceId(270), ReferenceId(271), ReferenceId(272)]
-rebuilt        : [ReferenceId(43), ReferenceId(70), ReferenceId(88), ReferenceId(90), ReferenceId(103), ReferenceId(105), ReferenceId(127), ReferenceId(130), ReferenceId(143), ReferenceId(145), ReferenceId(158), ReferenceId(160), ReferenceId(182), ReferenceId(185), ReferenceId(207), ReferenceId(210), ReferenceId(223), ReferenceId(225), ReferenceId(238), ReferenceId(240), ReferenceId(253), ReferenceId(255), ReferenceId(257), ReferenceId(260), ReferenceId(262), ReferenceId(264), ReferenceId(267), ReferenceId(270), ReferenceId(272), ReferenceId(274), ReferenceId(276), ReferenceId(277), ReferenceId(279), ReferenceId(280), ReferenceId(282), ReferenceId(285), ReferenceId(287), ReferenceId(289), ReferenceId(292), ReferenceId(295), ReferenceId(297), ReferenceId(299), ReferenceId(301), ReferenceId(302), ReferenceId(304), ReferenceId(305), ReferenceId(306), ReferenceId(308), ReferenceId(310), ReferenceId(312), ReferenceId(314)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/promiseTypeInference.ts
 Bindings mismatch:
@@ -16453,14 +13928,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["convert", "load"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/promiseTypeInferenceUnion.ts
-Unresolved references mismatch:
-after transform: ["Promise", "PromiseLike"]
-rebuilt        : ["Promise"]
-Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(4), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(11), ReferenceId(13), ReferenceId(14), ReferenceId(16), ReferenceId(17)]
-rebuilt        : [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(8), ReferenceId(10)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/promiseTypeStrictNull.ts
 Bindings mismatch:
@@ -16928,22 +14395,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["Error", "Promise", "arguments", "require", "undefined"]
 rebuilt        : ["Error", "Promise", "arguments", "p", "require", "undefined", "x"]
-Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(0), ReferenceId(9), ReferenceId(18), ReferenceId(34), ReferenceId(36), ReferenceId(49), ReferenceId(51), ReferenceId(73), ReferenceId(76), ReferenceId(89), ReferenceId(91), ReferenceId(104), ReferenceId(106), ReferenceId(128), ReferenceId(131), ReferenceId(153), ReferenceId(156), ReferenceId(169), ReferenceId(171), ReferenceId(184), ReferenceId(186), ReferenceId(199), ReferenceId(201), ReferenceId(203), ReferenceId(206), ReferenceId(208), ReferenceId(210), ReferenceId(213), ReferenceId(216), ReferenceId(218), ReferenceId(220), ReferenceId(222), ReferenceId(223), ReferenceId(225), ReferenceId(226), ReferenceId(228), ReferenceId(231), ReferenceId(233), ReferenceId(235), ReferenceId(238), ReferenceId(241), ReferenceId(243), ReferenceId(245), ReferenceId(247), ReferenceId(248), ReferenceId(250), ReferenceId(251)]
-rebuilt        : [ReferenceId(43), ReferenceId(70), ReferenceId(88), ReferenceId(90), ReferenceId(103), ReferenceId(105), ReferenceId(127), ReferenceId(130), ReferenceId(143), ReferenceId(145), ReferenceId(158), ReferenceId(160), ReferenceId(182), ReferenceId(185), ReferenceId(207), ReferenceId(210), ReferenceId(223), ReferenceId(225), ReferenceId(238), ReferenceId(240), ReferenceId(253), ReferenceId(255), ReferenceId(257), ReferenceId(260), ReferenceId(262), ReferenceId(264), ReferenceId(267), ReferenceId(270), ReferenceId(272), ReferenceId(274), ReferenceId(276), ReferenceId(277), ReferenceId(279), ReferenceId(280), ReferenceId(282), ReferenceId(285), ReferenceId(287), ReferenceId(289), ReferenceId(292), ReferenceId(295), ReferenceId(297), ReferenceId(299), ReferenceId(301), ReferenceId(302), ReferenceId(304), ReferenceId(305)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/promiseVoidErrorCallback.ts
-Unresolved references mismatch:
-after transform: ["Error", "Promise"]
-rebuilt        : ["Promise"]
-Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(0), ReferenceId(2)]
-rebuilt        : [ReferenceId(0)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/propTypeValidatorInference.ts
-Unresolved references mismatch:
-after transform: ["Error", "Exclude", "NonNullable", "Partial", "Pick"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/propagateNonInferrableType.ts
 Bindings mismatch:
@@ -16958,11 +14409,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["resolver", "wrapResolver"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/propertyAccessOnObjectLiteral.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/qualifiedName_ImportDeclarations-entity-names-referencing-a-var.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -16986,14 +14432,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/ramdaToolsNoInfin
 Bindings mismatch:
 after transform: ScopeId(0): ["Curry", "R", "Tools"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["NonNullable", "Parameters", "Record", "ReturnType"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/ramdaToolsNoInfinite2.ts
-Unresolved references mismatch:
-after transform: ["Exclude", "Function", "ReadonlyArray", "Required"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/reExportUndefined2.ts
 Bindings mismatch:
@@ -17017,23 +14455,10 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["print"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/reactHOCSpreadprops.tsx
-Symbol reference IDs mismatch for "React":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(11)]
-rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(2)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/reactReadonlyHOCAssignabilityReal.tsx
-Symbol reference IDs mismatch for "React":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(10)]
-rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/reactSFCAndFunctionResolvable.tsx
 Bindings mismatch:
 after transform: ScopeId(0): ["Checkbox", "OtherRadio", "Radio", "RandomComponent", "React", "_jsxFileName", "condition1", "condition2", "condition3"]
 rebuilt        : ScopeId(0): ["RandomComponent", "React", "_jsxFileName"]
-Symbol reference IDs mismatch for "React":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(14), ReferenceId(16)]
-rebuilt        : SymbolId(0): [ReferenceId(7), ReferenceId(10)]
 Reference symbol mismatch for "condition1":
 after transform: SymbolId(5) "condition1"
 rebuilt        : <None>
@@ -17063,9 +14488,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/reactTagNameCompo
 Bindings mismatch:
 after transform: ScopeId(0): ["React", "Tag", "_jsxFileName", "_objectSpread", "children", "classes", "rest"]
 rebuilt        : ScopeId(0): ["React", "_jsxFileName", "_objectSpread", "children", "classes", "rest"]
-Symbol reference IDs mismatch for "React":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(9)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
 Reference symbol mismatch for "Tag":
 after transform: SymbolId(1) "Tag"
 rebuilt        : <None>
@@ -17077,28 +14499,12 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/reactTagNameCompo
 Bindings mismatch:
 after transform: ScopeId(0): ["React", "Tag", "_jsxFileName", "_objectSpread", "children", "classes", "rest"]
 rebuilt        : ScopeId(0): ["React", "_jsxFileName", "_objectSpread", "children", "classes", "rest"]
-Symbol reference IDs mismatch for "React":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(11)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
 Reference symbol mismatch for "Tag":
 after transform: SymbolId(1) "Tag"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["HTMLElement"]
+after transform: []
 rebuilt        : ["Tag"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/reactTransitiveImportHasValidDeclaration.ts
-Unresolved references mismatch:
-after transform: ["HTMLDivElement", "React"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/readonlyFloat32ArrayAssignableWithFloat32Array.ts
-Unresolved references mismatch:
-after transform: ["Float32Array", "Readonly"]
-rebuilt        : ["Float32Array"]
-Unresolved reference IDs mismatch for "Float32Array":
-after transform: [ReferenceId(1), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(14), ReferenceId(15)]
-rebuilt        : [ReferenceId(9)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/reboundBaseClassSymbol.ts
 Scope flags mismatch:
@@ -17121,14 +14527,6 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "ActionType":
 after transform: SymbolId(3): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "ActionType":
-after transform: SymbolId(3): [ReferenceId(5), ReferenceId(7), ReferenceId(9), ReferenceId(11), ReferenceId(16), ReferenceId(18), ReferenceId(20), ReferenceId(22), ReferenceId(36)]
-rebuilt        : SymbolId(0): [ReferenceId(9), ReferenceId(12), ReferenceId(14), ReferenceId(16), ReferenceId(18)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/recursiveBaseConstructorCreation1.ts
-Symbol reference IDs mismatch for "C2":
-after transform: SymbolId(2): [ReferenceId(0), ReferenceId(2)]
-rebuilt        : SymbolId(2): [ReferenceId(1)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/recursiveBaseConstructorCreation2.ts
 Bindings mismatch:
@@ -17145,12 +14543,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/recursiveClassBas
 Bindings mismatch:
 after transform: ScopeId(0): ["Base", "Base1", "C", "Derived1", "p"]
 rebuilt        : ScopeId(0): ["Base1", "C", "Derived1"]
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(6): [ReferenceId(6)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "Derived1":
-after transform: SymbolId(8): [ReferenceId(7)]
-rebuilt        : SymbolId(2): []
 Reference symbol mismatch for "Base":
 after transform: SymbolId(3) "Base"
 rebuilt        : <None>
@@ -17193,11 +14585,6 @@ Symbol redeclarations mismatch for "C":
 after transform: SymbolId(1): [Span { start: 29, end: 30 }, Span { start: 56, end: 57 }]
 rebuilt        : SymbolId(2): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalCrash3.ts
-Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalEvaluationNonInfinite.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["a", "b", "x", "y"]
@@ -17211,27 +14598,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["a", "x"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalTypes2.ts
-Unresolved references mismatch:
-after transform: ["NonNullable", "Record"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/recursiveFieldSetting.ts
-Symbol reference IDs mismatch for "Recursive1":
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch for "Recursive2":
-after transform: SymbolId(2): [ReferenceId(1)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch for "Recursive3":
-after transform: SymbolId(3): [ReferenceId(2)]
-rebuilt        : SymbolId(4): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/recursiveFunctionTypes1.ts
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/recursiveInheritance2.ts
 Bindings mismatch:
@@ -17259,19 +14625,6 @@ after transform: SymbolId(0): Span { start: 17, end: 20 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(0): [Span { start: 17, end: 20 }, Span { start: 62, end: 65 }]
-rebuilt        : SymbolId(0): []
-Unresolved reference IDs mismatch for "C":
-after transform: [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(6)]
-rebuilt        : [ReferenceId(5)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/recursiveResolveDeclaredMembers.ts
-Unresolved references mismatch:
-after transform: ["E"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/recursiveSpecializationOfSignatures.ts
-Symbol reference IDs mismatch for "S0":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
 rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/recursiveTypeAliasWithSpreadConditionalReturnNotCircular.ts
@@ -17306,7 +14659,7 @@ Reference symbol mismatch for "opt3":
 after transform: SymbolId(23) "opt3"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Array"]
+after transform: []
 rebuilt        : ["opt1", "opt2", "opt3"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/recursivelySpecializedConstructorDeclaration.ts
@@ -17346,9 +14699,6 @@ rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "ItemList":
 after transform: SymbolId(3): Span { start: 33, end: 41 }
 rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "ViewModel":
-after transform: SymbolId(9): [ReferenceId(0), ReferenceId(8)]
-rebuilt        : SymbolId(10): [ReferenceId(4)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/reducibleIndexedAccessTypes.ts
 Bindings mismatch:
@@ -17360,9 +14710,6 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "Type":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "Type":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(10), ReferenceId(14), ReferenceId(33)]
-rebuilt        : SymbolId(0): [ReferenceId(7), ReferenceId(8)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/reexportNameAliasedAndHoisted.ts
 Bindings mismatch:
@@ -17376,21 +14723,6 @@ after transform: SymbolId(0): Span { start: 12, end: 18 }
 rebuilt        : SymbolId(0): Span { start: 39, end: 45 }
 Symbol redeclarations mismatch for "Sizing":
 after transform: SymbolId(0): [Span { start: 12, end: 18 }, Span { start: 39, end: 45 }]
-rebuilt        : SymbolId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/reexportWrittenCorrectlyInDeclaration.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["Test", "_defineProperty", "things"]
-rebuilt        : ScopeId(0): ["Test", "_defineProperty"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/regexpExecAndMatchTypeUsages.ts
-Unresolved references mismatch:
-after transform: ["Math", "RegExpExecArray", "RegExpMatchArray", "undefined"]
-rebuilt        : ["Math", "undefined"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/relatedViaDiscriminatedTypeNoError.ts
-Symbol reference IDs mismatch for "Model":
-after transform: SymbolId(0): [ReferenceId(3)]
 rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/relatedViaDiscriminatedTypeNoError2.ts
@@ -17413,31 +14745,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["x", "y"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithModuleEmitUndefined.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["b"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithModuleNodeResolutionEmitEs2015.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["b"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithModuleNodeResolutionEmitEsNext.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["b"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithModuleNodeResolutionEmitUndefined.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["b"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithoutEsModuleInterop.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["test"]
-rebuilt        : ScopeId(0): []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/reservedNameOnModuleImport.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["test"]
@@ -17456,9 +14763,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "bar":
 after transform: SymbolId(0): Span { start: 10, end: 13 }
 rebuilt        : SymbolId(0): Span { start: 22, end: 25 }
-Symbol reference IDs mismatch for "bar":
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(0): []
 Symbol redeclarations mismatch for "bar":
 after transform: SymbolId(0): [Span { start: 10, end: 13 }, Span { start: 22, end: 25 }]
 rebuilt        : SymbolId(0): []
@@ -17473,9 +14777,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "bar":
 after transform: SymbolId(1): Span { start: 28, end: 31 }
 rebuilt        : SymbolId(0): Span { start: 40, end: 43 }
-Symbol reference IDs mismatch for "bar":
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2)]
-rebuilt        : SymbolId(0): []
 Symbol redeclarations mismatch for "bar":
 after transform: SymbolId(1): [Span { start: 28, end: 31 }, Span { start: 40, end: 43 }]
 rebuilt        : SymbolId(0): []
@@ -17485,9 +14786,6 @@ rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "foo":
 after transform: SymbolId(0): Span { start: 10, end: 13 }
 rebuilt        : SymbolId(1): Span { start: 60, end: 63 }
-Symbol reference IDs mismatch for "foo":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(3)]
-rebuilt        : SymbolId(1): []
 Symbol redeclarations mismatch for "foo":
 after transform: SymbolId(0): [Span { start: 10, end: 13 }, Span { start: 60, end: 63 }]
 rebuilt        : SymbolId(1): []
@@ -17499,34 +14797,31 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "foo":
 after transform: SymbolId(0): Span { start: 18, end: 21 }
 rebuilt        : SymbolId(0): Span { start: 59, end: 62 }
-Symbol reference IDs mismatch for "foo":
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(0): []
 Symbol redeclarations mismatch for "foo":
 after transform: SymbolId(0): [Span { start: 18, end: 21 }, Span { start: 59, end: 62 }]
 rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/resolveNameWithNamspace.ts
-Unresolved references mismatch:
-after transform: ["Error"]
-rebuilt        : []
+Symbol flags mismatch for "myAssert":
+after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | NamespaceModule)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Symbol span mismatch for "myAssert":
+after transform: SymbolId(0): Span { start: 44, end: 52 }
+rebuilt        : SymbolId(0): Span { start: 91, end: 99 }
+Symbol redeclarations mismatch for "myAssert":
+after transform: SymbolId(0): [Span { start: 44, end: 52 }, Span { start: 91, end: 99 }]
+rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/resolveTypeAliasWithSameLetDeclarationName1.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["C"]
 rebuilt        : ScopeId(0): ["C", "baz"]
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "baz":
 after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | TypeAlias)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "baz":
 after transform: SymbolId(1): Span { start: 17, end: 20 }
 rebuilt        : SymbolId(1): Span { start: 30, end: 33 }
-Symbol reference IDs mismatch for "baz":
-after transform: SymbolId(1): [ReferenceId(1)]
-rebuilt        : SymbolId(1): []
 Symbol redeclarations mismatch for "baz":
 after transform: SymbolId(1): [Span { start: 17, end: 20 }, Span { start: 30, end: 33 }]
 rebuilt        : SymbolId(1): []
@@ -17535,17 +14830,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/restParamUsingMap
 Bindings mismatch:
 after transform: ScopeId(0): ["test"]
 rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/restParameterAssignmentCompatibility.ts
-Symbol reference IDs mismatch for "T":
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "S":
-after transform: SymbolId(2): [ReferenceId(1)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "T1":
-after transform: SymbolId(7): [ReferenceId(4)]
-rebuilt        : SymbolId(7): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/restUnion2.ts
 Bindings mismatch:
@@ -17567,11 +14851,6 @@ Unresolved references mismatch:
 after transform: ["require"]
 rebuilt        : ["nullUnion", "require", "undefinedUnion"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/returnInfiniteIntersection.ts
-Symbol reference IDs mismatch for "x":
-after transform: SymbolId(1): [ReferenceId(2), ReferenceId(3)]
-rebuilt        : SymbolId(1): [ReferenceId(1)]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/returnTypeInferenceContextualParameterTypesInGenerator1.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["Rpcs", "gen", "layerServerHandlers"]
@@ -17583,7 +14862,7 @@ Reference symbol mismatch for "gen":
 after transform: SymbolId(2) "gen"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Generator", "String"]
+after transform: ["String"]
 rebuilt        : ["Rpcs", "String", "gen"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/returnTypeInferenceContextualTypeIgnoreAnyUnknown1.ts
@@ -17663,9 +14942,6 @@ rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M2":
 after transform: SymbolId(6): Span { start: 155, end: 157 }
 rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
-Unresolved reference IDs mismatch for "Array":
-after transform: [ReferenceId(0), ReferenceId(2)]
-rebuilt        : [ReferenceId(0)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/reuseInnerModuleMember.ts
 Bindings mismatch:
@@ -17725,13 +15001,8 @@ Reference symbol mismatch for "test4":
 after transform: SymbolId(23) "test4"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Record"]
+after transform: []
 rebuilt        : ["create", "test1", "test2", "test4"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeAssignableToIndex.ts
-Unresolved references mismatch:
-after transform: ["Record"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeContextualTypesPerElementOfTupleConstraint.ts
 Bindings mismatch:
@@ -17741,7 +15012,7 @@ Reference symbol mismatch for "bindAll":
 after transform: SymbolId(2) "bindAll"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["EventTarget", "Extract", "HTMLButtonElement", "Parameters"]
+after transform: []
 rebuilt        : ["bindAll"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeDeepDeclarationEmit.ts
@@ -17789,7 +15060,7 @@ Reference symbol mismatch for "takeType":
 after transform: SymbolId(20) "takeType"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Boolean", "Readonly"]
+after transform: ["Boolean"]
 rebuilt        : ["Boolean", "fn1", "fn2", "fn3", "takeType"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeInferenceWidening2.ts
@@ -17800,7 +15071,7 @@ Reference symbol mismatch for "test1":
 after transform: SymbolId(0) "test1"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Record"]
+after transform: []
 rebuilt        : ["test1"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypePrimitiveConstraintProperty.ts
@@ -17834,7 +15105,7 @@ Reference symbol mismatch for "unionType":
 after transform: SymbolId(25) "unionType"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["const"]
+after transform: []
 rebuilt        : ["createExtractor", "isIdentifier", "isStringLiteral", "unionType"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/selfInLambdas.ts
@@ -17886,19 +15157,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["use"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/signatureCombiningRestParameters2.ts
-Unresolved reference IDs mismatch for "console":
-after transform: [ReferenceId(0), ReferenceId(1)]
-rebuilt        : [ReferenceId(0)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/signatureInstantiationWithRecursiveConstraints.ts
-Symbol reference IDs mismatch for "Foo":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(4)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "Bar":
-after transform: SymbolId(3): [ReferenceId(2), ReferenceId(5)]
-rebuilt        : SymbolId(2): [ReferenceId(0)]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/silentNeverPropagation.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["breaks", "convert", "createModule"]
@@ -17924,7 +15182,7 @@ Reference symbol mismatch for "ps":
 after transform: SymbolId(6) "ps"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Math", "Promise", "arguments", "require"]
+after transform: ["Math", "arguments", "require"]
 rebuilt        : ["Math", "arguments", "ps", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/sliceResultCast.ts
@@ -17976,9 +15234,6 @@ rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Bar":
 after transform: SymbolId(1): Span { start: 14, end: 17 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "Greeter":
-after transform: SymbolId(2): [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(5), ReferenceId(7), ReferenceId(13)]
-rebuilt        : SymbolId(4): [ReferenceId(1), ReferenceId(3), ReferenceId(6), ReferenceId(12)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringForObjectBindingPattern.ts
 Bindings mismatch:
@@ -18408,9 +15663,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/specedNoStackBlow
 Bindings mismatch:
 after transform: ScopeId(0): ["spected"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Array", "Partial", "ReadonlyArray"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/specializationOfExportedClass.ts
 Scope flags mismatch:
@@ -18424,12 +15676,6 @@ after transform: SymbolId(0): Span { start: 10, end: 11 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/specializedOverloadWithRestParameters.ts
-Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(2), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(0)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
-Symbol reference IDs mismatch for "Derived1":
-after transform: SymbolId(1): [ReferenceId(1), ReferenceId(4)]
-rebuilt        : SymbolId(1): []
 Symbol span mismatch for "f":
 after transform: SymbolId(2): Span { start: 76, end: 77 }
 rebuilt        : SymbolId(2): Span { start: 179, end: 180 }
@@ -18467,9 +15713,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/spreadObjectNoCir
 Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "_objectSpread", "b"]
 rebuilt        : ScopeId(0): ["Foo", "_objectSpread"]
-Symbol reference IDs mismatch for "Foo":
-after transform: SymbolId(2): [ReferenceId(0), ReferenceId(3)]
-rebuilt        : SymbolId(1): []
 Reference symbol mismatch for "b":
 after transform: SymbolId(1) "b"
 rebuilt        : <None>
@@ -18595,11 +15838,6 @@ Unresolved references mismatch:
 after transform: ["require"]
 rebuilt        : ["m", "require"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/spreadOfObjectLiteralAssignableToIndexSignature.ts
-Unresolved references mismatch:
-after transform: ["Record", "require", "undefined"]
-rebuilt        : ["require", "undefined"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/spreadsAndContextualTupleTypes.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["a1", "a2", "a3", "b1", "b2", "b3", "c1", "c2", "c3", "d1", "d2", "d3", "foo", "fx1", "fx2", "randomID", "staticPath1Level", "staticPath2Level", "staticPath3Level", "t3", "x1", "x2", "x3"]
@@ -18653,13 +15891,13 @@ Reference symbol mismatch for "foo":
 after transform: SymbolId(14) "foo"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["const"]
+after transform: []
 rebuilt        : ["foo", "fx1", "fx2"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/spuriousCircularityOnTypeImport.ts
-Unresolved references mismatch:
-after transform: ["Record"]
-rebuilt        : []
+Bindings mismatch:
+after transform: ScopeId(0): ["value2", "value3"]
+rebuilt        : ScopeId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/stableTypeOrdering.ts
 Bindings mismatch:
@@ -18671,15 +15909,9 @@ rebuilt        : ScopeId(6): ["Color"]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(0x0)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
-Symbol reference IDs mismatch for "Message":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(1): []
 Symbol flags mismatch for "Color":
 after transform: SymbolId(9): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(10): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "Color":
-after transform: SymbolId(9): [ReferenceId(7), ReferenceId(21)]
-rebuilt        : SymbolId(10): [ReferenceId(14)]
 Reference symbol mismatch for "person":
 after transform: SymbolId(18) "person"
 rebuilt        : <None>
@@ -18734,19 +15966,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["require"]
 rebuilt        : ["dec", "require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/staticInterfaceAssignmentCompat.ts
-Symbol reference IDs mismatch for "Shape":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(4)]
-rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/staticMethodWithTypeParameterExtendsClauseDeclFile.ts
-Symbol reference IDs mismatch for "privateClass":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "publicClass":
-after transform: SymbolId(1): [ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5)]
-rebuilt        : SymbolId(1): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/strictFunctionTypes1.ts
 Bindings mismatch:
@@ -18867,7 +16086,7 @@ Reference symbol mismatch for "acceptA":
 after transform: SymbolId(51) "acceptA"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Object", "ReadonlyArray"]
+after transform: []
 rebuilt        : ["a", "acceptA", "acceptUnion", "b", "coAndContra", "coAndContraArray", "f1", "f2", "f3", "f4", "fo", "foo", "fs", "fx", "never"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/strictModeEnumMemberNameReserved.ts
@@ -18880,14 +16099,6 @@ rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "E":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "E":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(5)]
-rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(4)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/strictNullNotNullIndexTypeShouldWork.ts
-Unresolved references mismatch:
-after transform: ["Readonly", "require"]
-rebuilt        : ["require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/stringLiteralObjectLiteralDeclaration1.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -18912,7 +16123,7 @@ Reference symbol mismatch for "someVal2":
 after transform: SymbolId(2) "someVal2"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Required"]
+after transform: []
 rebuilt        : ["someVal", "someVal2"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/structural1.ts
@@ -18937,36 +16148,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/subclassThisTypeAssignable02.ts
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(16): [ReferenceId(31), ReferenceId(33)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/substituteReturnTypeSatisfiesConstraint.ts
-Unresolved references mismatch:
-after transform: ["ReturnType"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/substitutionTypeForNonGenericIndexedAccessType.ts
-Unresolved references mismatch:
-after transform: ["Record"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/substitutionTypeNoMergeOfAssignableType.ts
-Unresolved references mismatch:
-after transform: ["Record"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/substitutionTypePassedToExtends.ts
-Unresolved references mismatch:
-after transform: ["Set"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/substitutionTypesCompareCorrectlyInRestrictiveInstances.ts
-Unresolved references mismatch:
-after transform: ["Exclude"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/substitutionTypesInIndexedAccessTypes.ts
 Bindings mismatch:
@@ -18998,11 +16179,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["isBar", "isNode"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/superAccessCastedCall.ts
-Unresolved references mismatch:
-after transform: ["Number", "require"]
-rebuilt        : ["require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/superAccessInFatArrow1.ts
 Scope flags mismatch:
@@ -19059,27 +16235,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["B"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/symbolLinkDeclarationEmitModuleNamesRootDir.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["Constructor"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/symbolMergeValueAndImportedType.ts
-Symbol flags mismatch for "X":
-after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | Import)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable)
-Symbol span mismatch for "X":
-after transform: SymbolId(0): Span { start: 9, end: 10 }
-rebuilt        : SymbolId(0): Span { start: 35, end: 36 }
-Symbol redeclarations mismatch for "X":
-after transform: SymbolId(0): [Span { start: 9, end: 10 }, Span { start: 35, end: 36 }]
-rebuilt        : SymbolId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/symlinkedWorkspaceDependenciesNoDirectLinkGeneratesDeepNonrelativeName.ts
-Unresolved references mismatch:
-after transform: ["ReturnType"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/taggedTemplateStringWithSymbolExpression01.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["foo", "result", "x"]
@@ -19090,21 +16245,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["foo"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/taggedTemplatesInDifferentScopes.ts
-Unresolved references mismatch:
-after transform: ["TemplateStringsArray"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/templateLiteralConstantEvaluation.ts
-Unresolved references mismatch:
-after transform: ["const"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/templateLiteralIntersection.ts
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(4)]
-rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/templateLiteralIntersection3.ts
 Bindings mismatch:
@@ -19126,7 +16266,7 @@ Reference symbol mismatch for "lowercasePath":
 after transform: SymbolId(3) "lowercasePath"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Lowercase"]
+after transform: []
 rebuilt        : ["lowercasePath", "options1", "path"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/templateLiteralIntersection4.ts
@@ -19137,7 +16277,7 @@ Reference symbol mismatch for "createStore":
 after transform: SymbolId(5) "createStore"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Capitalize", "Omit"]
+after transform: []
 rebuilt        : ["createStore"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/templateLiteralsAndDecoratorMetadata.ts
@@ -19170,16 +16310,6 @@ Bindings mismatch:
 after transform: ScopeId(0): ["sort"]
 rebuilt        : ScopeId(0): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/thisConditionalOnMethodReturnOfGenericInstance.ts
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(5): [ReferenceId(5), ReferenceId(8)]
-rebuilt        : SymbolId(3): [ReferenceId(6)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/thisInGenericStaticMembers.ts
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(6): [ReferenceId(7), ReferenceId(8), ReferenceId(10), ReferenceId(11)]
-rebuilt        : SymbolId(4): []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/thisIndexOnExistingReadonlyFieldIsNotNever.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["CoachMarkAnchorDecorator", "Component", "_defineProperty"]
@@ -19188,7 +16318,7 @@ Reference symbol mismatch for "Component":
 after transform: SymbolId(0) "Component"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Readonly", "require"]
+after transform: ["require"]
 rebuilt        : ["Component", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/this_inside-object-literal-getters-and-setters.ts
@@ -19224,9 +16354,6 @@ rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "SyntaxKind":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "SyntaxKind":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(32), ReferenceId(33), ReferenceId(34), ReferenceId(35), ReferenceId(36), ReferenceId(37), ReferenceId(38), ReferenceId(39), ReferenceId(40), ReferenceId(41), ReferenceId(42), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(46), ReferenceId(47), ReferenceId(48), ReferenceId(49), ReferenceId(50), ReferenceId(51), ReferenceId(52), ReferenceId(53), ReferenceId(54), ReferenceId(55), ReferenceId(56), ReferenceId(57), ReferenceId(58), ReferenceId(59), ReferenceId(60), ReferenceId(61), ReferenceId(62), ReferenceId(63), ReferenceId(64), ReferenceId(65), ReferenceId(66), ReferenceId(67), ReferenceId(68), ReferenceId(69), ReferenceId(70), ReferenceId(71), ReferenceId(72), ReferenceId(73), ReferenceId(74), ReferenceId(75), ReferenceId(76), ReferenceId(77), ReferenceId(78), ReferenceId(79), ReferenceId(80), ReferenceId(81), ReferenceId(82), ReferenceId(83), ReferenceId(84), ReferenceId(85), ReferenceId(86), ReferenceId(87), ReferenceId(88), ReferenceId(89), ReferenceId(90), ReferenceId(91), ReferenceId(92), ReferenceId(93), ReferenceId(94), ReferenceId(95), ReferenceId(96), ReferenceId(97), ReferenceId(98), ReferenceId(99)]
-rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/transformsElideNullUndefinedType.ts
 Bindings mismatch:
@@ -19277,9 +16404,6 @@ rebuilt        : SymbolId(1): SymbolFlags(Function)
 Symbol redeclarations mismatch for "createElement":
 after transform: SymbolId(2): [Span { start: 125, end: 138 }, Span { start: 243, end: 256 }]
 rebuilt        : SymbolId(1): []
-Unresolved references mismatch:
-after transform: ["Date", "React"]
-rebuilt        : ["React"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/tsxDefaultImports.ts
 Bindings mismatch:
@@ -19328,18 +16452,18 @@ Bindings mismatch:
 after transform: ScopeId(0): ["Button", "CustomButton", "React", "_jsxFileName", "_objectSpread"]
 rebuilt        : ScopeId(0): ["CustomButton", "React", "_jsxFileName", "_objectSpread"]
 Symbol reference IDs mismatch for "React":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(3), ReferenceId(7), ReferenceId(14)]
+after transform: SymbolId(0): [ReferenceId(3), ReferenceId(14)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 Reference symbol mismatch for "Button":
 after transform: SymbolId(3) "Button"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["HTMLButtonElement"]
+after transform: []
 rebuilt        : ["Button"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/tsxUnionMemberChecksFilterDataProps.tsx
 Bindings mismatch:
-after transform: ScopeId(0): ["Happy", "NotHappy", "React", "ReactElement", "RootHappy", "RootNotHappy", "_jsxFileName"]
+after transform: ScopeId(0): ["Happy", "NotHappy", "React", "RootHappy", "RootNotHappy", "_jsxFileName"]
 rebuilt        : ScopeId(0): ["React", "RootHappy", "RootNotHappy", "_jsxFileName"]
 Reference symbol mismatch for "NotHappy":
 after transform: SymbolId(2) "NotHappy"
@@ -19425,16 +16549,13 @@ Reference symbol mismatch for "set":
 after transform: SymbolId(10) "set"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Exclude", "Pick", "Required"]
+after transform: []
 rebuilt        : ["set"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeAliasDoesntMakeModuleInstantiated.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["m"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Function"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeAliasExport.ts
 Unresolved references mismatch:
@@ -19448,9 +16569,6 @@ rebuilt        : ScopeId(0): ["Mixin"]
 Symbol flags mismatch for "Mixin":
 after transform: SymbolId(0): SymbolFlags(Function | TypeAlias)
 rebuilt        : SymbolId(0): SymbolFlags(Function)
-Symbol reference IDs mismatch for "Mixin":
-after transform: SymbolId(0): [ReferenceId(3), ReferenceId(6)]
-rebuilt        : SymbolId(0): []
 Symbol redeclarations mismatch for "Mixin":
 after transform: SymbolId(0): [Span { start: 42, end: 47 }, Span { start: 152, end: 157 }]
 rebuilt        : SymbolId(0): []
@@ -19474,7 +16592,7 @@ Reference symbol mismatch for "arrayLikeOrIterable":
 after transform: SymbolId(5) "arrayLikeOrIterable"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["ArrayLike", "Iterable", "PropertyKey"]
+after transform: []
 rebuilt        : ["arrayLikeOrIterable", "hasOwnProperty"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowByUntypedField.ts
@@ -19491,7 +16609,7 @@ Reference symbol mismatch for "arrayLikeOrIterable":
 after transform: SymbolId(5) "arrayLikeOrIterable"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["ArrayLike", "Iterable", "PropertyKey"]
+after transform: []
 rebuilt        : ["arrayLikeOrIterable", "hasOwnProperty"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty11.ts
@@ -19507,9 +16625,6 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "E":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "E":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(10)]
-rebuilt        : SymbolId(0): [ReferenceId(5), ReferenceId(7), ReferenceId(9)]
 Reference symbol mismatch for "m":
 after transform: SymbolId(3) "m"
 rebuilt        : <None>
@@ -19533,9 +16648,6 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "E":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "E":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(8)]
-rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(5), ReferenceId(7)]
 Reference symbol mismatch for "m":
 after transform: SymbolId(3) "m"
 rebuilt        : <None>
@@ -19545,11 +16657,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["m"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty2.ts
-Unresolved references mismatch:
-after transform: ["const"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty6.ts
 Bindings mismatch:
@@ -19621,14 +16728,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["f"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeInferenceLiteralUnion.ts
-Symbol reference IDs mismatch for "NumCoercible":
-after transform: SymbolId(2): [ReferenceId(13), ReferenceId(15), ReferenceId(18)]
-rebuilt        : SymbolId(1): [ReferenceId(6)]
-Unresolved references mismatch:
-after transform: ["Array", "Date", "undefined"]
-rebuilt        : ["undefined"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeInferenceWithExcessPropertiesJsx.tsx
 Bindings mismatch:
 after transform: ScopeId(0): ["T", "_jsxFileName", "_reactJsxRuntime"]
@@ -19637,7 +16736,7 @@ Reference symbol mismatch for "T":
 after transform: SymbolId(6) "T"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["JSX", "require"]
+after transform: ["require"]
 rebuilt        : ["T", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeInferenceWithTypeAnnotation.ts
@@ -19651,34 +16750,10 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["f"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeOfYieldWithUnionInContextualReturnType.ts
-Unresolved references mismatch:
-after transform: ["AsyncGenerator", "Generator", "require"]
-rebuilt        : ["require"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeParameterDoesntBlockParameterLookup.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["f"]
 rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeParameterExtendingUnion1.ts
-Symbol reference IDs mismatch for "Animal":
-after transform: SymbolId(0): [ReferenceId(2), ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(1): [ReferenceId(1), ReferenceId(4)]
-Symbol reference IDs mismatch for "Cat":
-after transform: SymbolId(1): [ReferenceId(4)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "Dog":
-after transform: SymbolId(2): [ReferenceId(5)]
-rebuilt        : SymbolId(4): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeParameterExtendingUnion2.ts
-Symbol reference IDs mismatch for "Cat":
-after transform: SymbolId(1): [ReferenceId(2), ReferenceId(5)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "Dog":
-after transform: SymbolId(2): [ReferenceId(3), ReferenceId(6)]
-rebuilt        : SymbolId(4): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeParameterLeak.ts
 Bindings mismatch:
@@ -19691,23 +16766,10 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["f"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/typePartameterConstraintInstantiatedWithDefaultWhenCheckingDefault.ts
-Symbol reference IDs mismatch for "Identity":
-after transform: SymbolId(4): [ReferenceId(10), ReferenceId(3), ReferenceId(12), ReferenceId(18), ReferenceId(26)]
-rebuilt        : SymbolId(1): [ReferenceId(3)]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typePredicateAcceptingPartialOfRefinedType.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["includesAllRequiredOptions"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Partial"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/typePredicateFreshLiteralWidening.ts
-Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typePredicateWithThisParameter.ts
 Bindings mismatch:
@@ -19758,7 +16820,7 @@ Reference symbol mismatch for "fruit2":
 after transform: SymbolId(6) "fruit2"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["const"]
+after transform: []
 rebuilt        : ["fruit", "fruit2", "isOneOf"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typePredicatesInUnion2.ts
@@ -19781,11 +16843,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["f", "isNumber", "isString"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/typePredicatesOptionalChaining1.ts
-Unresolved references mismatch:
-after transform: ["NonNullable", "undefined"]
-rebuilt        : ["undefined"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typePredicatesOptionalChaining3.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["getBreedSizeWithFunction", "getBreedSizeWithoutFunction", "isNil"]
@@ -19797,61 +16854,6 @@ Unresolved references mismatch:
 after transform: ["undefined"]
 rebuilt        : ["isNil", "undefined"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives1.ts
-Unresolved references mismatch:
-after transform: ["$"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives10.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["$"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives13.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["$"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives2.ts
-Unresolved references mismatch:
-after transform: ["$"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives3.ts
-Unresolved references mismatch:
-after transform: ["$"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives4.ts
-Unresolved references mismatch:
-after transform: ["$"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives5.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["$"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives6.ts
-Unresolved references mismatch:
-after transform: ["$"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives7.ts
-Symbol reference IDs mismatch for "$":
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives8.ts
-Unresolved references mismatch:
-after transform: ["Lib"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives9.ts
-Unresolved references mismatch:
-after transform: ["Lib", "undefined"]
-rebuilt        : ["undefined"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeVal.ts
 Bindings mismatch:
 after transform: ScopeId(0): []
@@ -19862,9 +16864,6 @@ rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol span mismatch for "I":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
 rebuilt        : SymbolId(0): Span { start: 35, end: 36 }
-Symbol reference IDs mismatch for "I":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
 Symbol redeclarations mismatch for "I":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 35, end: 36 }]
 rebuilt        : SymbolId(0): []
@@ -19898,26 +16897,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["isA", "isB", "isC"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeVariableTypeGuards.ts
-Unresolved references mismatch:
-after transform: ["Partial", "Readonly"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/typedArrayConstructorOverloads.ts
-Unresolved references mismatch:
-after transform: ["ArrayBuffer", "BigInt64ArrayConstructor", "BigUint64ArrayConstructor", "Float16ArrayConstructor", "Float32ArrayConstructor", "Float64ArrayConstructor", "Int16ArrayConstructor", "Int32ArrayConstructor", "Int8ArrayConstructor", "Uint16ArrayConstructor", "Uint32ArrayConstructor", "Uint8ArrayConstructor", "Uint8ClampedArrayConstructor"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/typedArrays.ts
-Unresolved references mismatch:
-after transform: ["ArrayLike", "Float32Array", "Float64Array", "Int16Array", "Int32Array", "Int8Array", "Uint16Array", "Uint32Array", "Uint8Array", "Uint8ClampedArray"]
-rebuilt        : ["Float32Array", "Float64Array", "Int16Array", "Int32Array", "Int8Array", "Uint16Array", "Uint32Array", "Uint8Array", "Uint8ClampedArray"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeofImportInstantiationExpression.ts
-Unresolved references mismatch:
-after transform: ["Record"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeofInterface.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["j", "k"]
@@ -19925,33 +16904,11 @@ rebuilt        : ScopeId(0): ["I", "j", "k"]
 Symbol flags mismatch for "I":
 after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | Interface)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "I":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(0): []
 Symbol redeclarations mismatch for "I":
 after transform: SymbolId(0): [Span { start: 4, end: 5 }, Span { start: 32, end: 33 }]
 rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "k":
-after transform: SymbolId(1): [ReferenceId(2)]
-rebuilt        : SymbolId(1): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeofObjectInference.ts
-Symbol reference IDs mismatch for "val":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(6), ReferenceId(4), ReferenceId(10), ReferenceId(15), ReferenceId(17), ReferenceId(22)]
-rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(4), ReferenceId(7), ReferenceId(10)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeofStrictNull.ts
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeofStripsFreshness.ts
-Symbol reference IDs mismatch for "ALL":
-after transform: SymbolId(4): [ReferenceId(4)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "ANOTHER":
-after transform: SymbolId(7): [ReferenceId(8)]
-rebuilt        : SymbolId(2): []
 Reference symbol mismatch for "Collection":
 after transform: SymbolId(0) "Collection"
 rebuilt        : <None>
@@ -19961,19 +16918,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["Collection"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeofUsedBeforeBlockScoped.ts
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(6)]
-rebuilt        : SymbolId(1): [ReferenceId(2)]
-Symbol reference IDs mismatch for "o":
-after transform: SymbolId(4): [ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5)]
-rebuilt        : SymbolId(3): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/umdGlobalConflict.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["v1", "v2"]
-rebuilt        : ScopeId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/unaryPlus.ts
 Bindings mismatch:
@@ -20231,7 +17175,7 @@ Reference symbol mismatch for "a":
 after transform: SymbolId(34) "a"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Array", "Promise"]
+after transform: []
 rebuilt        : ["a", "tmp"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/unionOfEnumInference.ts
@@ -20244,20 +17188,6 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "Enum":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "Enum":
-after transform: SymbolId(0): [ReferenceId(2), ReferenceId(6), ReferenceId(7), ReferenceId(9), ReferenceId(0), ReferenceId(19)]
-rebuilt        : SymbolId(0): [ReferenceId(7)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/unionOfFunctionAndSignatureIsCallable.ts
-Symbol reference IDs mismatch for "c1":
-after transform: SymbolId(1): [ReferenceId(1), ReferenceId(3)]
-rebuilt        : SymbolId(1): [ReferenceId(0)]
-Symbol reference IDs mismatch for "c2":
-after transform: SymbolId(2): [ReferenceId(2), ReferenceId(4)]
-rebuilt        : SymbolId(2): [ReferenceId(1)]
-Unresolved references mismatch:
-after transform: ["Function"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/unionReductionMutualSubtypes.ts
 Bindings mismatch:
@@ -20271,9 +17201,15 @@ after transform: []
 rebuilt        : ["val"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/unionReductionWithStringMappingAndIdenticalBaseTypeExistsNoCrash.tsx
+Bindings mismatch:
+after transform: ScopeId(0): ["Comp", "React", "_jsxFileName", "displayEnum", "upperFirst"]
+rebuilt        : ScopeId(0): ["Comp", "React", "_jsxFileName", "displayEnum"]
+Reference symbol mismatch for "upperFirst":
+after transform: SymbolId(1) "upperFirst"
+rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Iterable", "JSX"]
-rebuilt        : []
+after transform: []
+rebuilt        : ["upperFirst"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/unionTypeParameterInference.ts
 Bindings mismatch:
@@ -20297,31 +17233,10 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["f"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/unionWithIndexSignature.ts
-Unresolved reference IDs mismatch for "Int32Array":
-after transform: [ReferenceId(6), ReferenceId(8), ReferenceId(11)]
-rebuilt        : [ReferenceId(2)]
-Unresolved reference IDs mismatch for "Uint8Array":
-after transform: [ReferenceId(7), ReferenceId(9), ReferenceId(13)]
-rebuilt        : [ReferenceId(4)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/uniqueSymbolAssignmentOnGlobalAugmentationSuceeds.ts
-Symbol reference IDs mismatch for "FOO_SYMBOL":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(5)]
-rebuilt        : SymbolId(0): [ReferenceId(2)]
-Unresolved references mismatch:
-after transform: ["Promise", "Symbol"]
-rebuilt        : ["Symbol"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/uniqueSymbolPropertyDeclarationEmit.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["Op"]
 rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/unknownPropertiesAreAssignableToObjectUnion.ts
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/unmatchedParameterPositions.ts
 Bindings mismatch:
@@ -20416,11 +17331,6 @@ Symbol redeclarations mismatch for "genericFunc":
 after transform: SymbolId(17): [Span { start: 523, end: 534 }, Span { start: 606, end: 617 }]
 rebuilt        : SymbolId(8): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsAndParametersTypeAliases.ts
-Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/unwitnessedTypeParameterVariance.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["a", "b", "foo"]
@@ -20458,46 +17368,6 @@ rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "C":
 after transform: SymbolId(7): Span { start: 239, end: 240 }
 rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(7): [ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(11), ReferenceId(12)]
-rebuilt        : SymbolId(6): [ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/validUseOfThisInSuper.ts
-Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(0): [ReferenceId(1)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/valueOfTypedArray.ts
-Unresolved reference IDs mismatch for "BigInt64Array":
-after transform: [ReferenceId(16), ReferenceId(17)]
-rebuilt        : [ReferenceId(8)]
-Unresolved reference IDs mismatch for "BigUint64Array":
-after transform: [ReferenceId(18), ReferenceId(19)]
-rebuilt        : [ReferenceId(9)]
-Unresolved reference IDs mismatch for "Uint8Array":
-after transform: [ReferenceId(2), ReferenceId(3)]
-rebuilt        : [ReferenceId(1)]
-Unresolved reference IDs mismatch for "Int16Array":
-after transform: [ReferenceId(4), ReferenceId(5)]
-rebuilt        : [ReferenceId(2)]
-Unresolved reference IDs mismatch for "Int32Array":
-after transform: [ReferenceId(8), ReferenceId(9)]
-rebuilt        : [ReferenceId(4)]
-Unresolved reference IDs mismatch for "Uint32Array":
-after transform: [ReferenceId(10), ReferenceId(11)]
-rebuilt        : [ReferenceId(5)]
-Unresolved reference IDs mismatch for "Uint16Array":
-after transform: [ReferenceId(6), ReferenceId(7)]
-rebuilt        : [ReferenceId(3)]
-Unresolved reference IDs mismatch for "Float32Array":
-after transform: [ReferenceId(12), ReferenceId(13)]
-rebuilt        : [ReferenceId(6)]
-Unresolved reference IDs mismatch for "Float64Array":
-after transform: [ReferenceId(14), ReferenceId(15)]
-rebuilt        : [ReferenceId(7)]
-Unresolved reference IDs mismatch for "Int8Array":
-after transform: [ReferenceId(0), ReferenceId(1)]
-rebuilt        : [ReferenceId(0)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/vardecl.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -20520,11 +17390,6 @@ rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m2":
 after transform: SymbolId(22): Span { start: 890, end: 892 }
 rebuilt        : SymbolId(16): Span { start: 0, end: 0 }
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/varianceCallbacksAndIndexedAccesses.ts
-Unresolved references mismatch:
-after transform: ["AddEventListenerOptions", "EventListenerOrEventListenerObject", "Window", "WindowEventMap"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/varianceCantBeStrictWhileStructureIsnt.ts
 Bindings mismatch:
@@ -20582,28 +17447,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["a", "a2", "b", "b2"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/varianceProblingAndZeroOrderIndexSignatureRelationsAlign.ts
-Symbol reference IDs mismatch for "Left":
-after transform: SymbolId(3): [ReferenceId(0)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch for "Right":
-after transform: SymbolId(13): [ReferenceId(3), ReferenceId(29)]
-rebuilt        : SymbolId(5): [ReferenceId(8)]
-Symbol reference IDs mismatch for "Type":
-after transform: SymbolId(23): [ReferenceId(51), ReferenceId(60)]
-rebuilt        : SymbolId(9): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/varianceProblingAndZeroOrderIndexSignatureRelationsAlign2.ts
-Symbol reference IDs mismatch for "Left":
-after transform: SymbolId(3): [ReferenceId(0)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch for "Right":
-after transform: SymbolId(13): [ReferenceId(3), ReferenceId(29)]
-rebuilt        : SymbolId(5): [ReferenceId(8)]
-Symbol reference IDs mismatch for "Type":
-after transform: SymbolId(23): [ReferenceId(51), ReferenceId(60)]
-rebuilt        : SymbolId(9): []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/variancePropagation.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["destination", "source"]
@@ -20612,33 +17455,8 @@ Reference symbol mismatch for "source":
 after transform: SymbolId(4) "source"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Readonly"]
+after transform: []
 rebuilt        : ["source"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/varianceRepeatedlyPropegatesWithUnreliableFlag.ts
-Unresolved references mismatch:
-after transform: ["Pick", "Record"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/verbatim-declarations-parameters.ts
-Unresolved references mismatch:
-after transform: ["Exclude"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/verbatimModuleSyntaxDefaultValue.ts
-Symbol reference IDs mismatch for "Task":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/verifyDefaultLib_dom.ts
-Unresolved references mismatch:
-after transform: ["HTMLElement"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/verifyDefaultLib_webworker.ts
-Unresolved references mismatch:
-after transform: ["Worker"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/visSyntax.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -20651,11 +17469,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/voidReturnIndexUnionInference.ts
-Unresolved references mismatch:
-after transform: ["Readonly", "undefined"]
-rebuilt        : ["undefined"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/voidUndefinedReduction.ts
 Bindings mismatch:
@@ -20679,7 +17492,7 @@ Reference symbol mismatch for "test":
 after transform: SymbolId(17) "test"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Readonly", "Record", "ThisType"]
+after transform: []
 rebuilt        : ["test"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/vueLikeDataAndPropsInference2.ts
@@ -20690,7 +17503,7 @@ Reference symbol mismatch for "test":
 after transform: SymbolId(17) "test"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Readonly", "Record", "ThisType"]
+after transform: []
 rebuilt        : ["test"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/wideningWithTopLevelTypeParameter.ts
@@ -20730,7 +17543,7 @@ Reference symbol mismatch for "g":
 after transform: SymbolId(0) "g"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Generator"]
+after transform: []
 rebuilt        : ["g"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientDeclarations.ts
@@ -20786,21 +17599,6 @@ Symbol span mismatch for "M2":
 after transform: SymbolId(6): Span { start: 182, end: 184 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientShorthand_duplicate.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["foo"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientShorthand_merging.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["bar", "foo"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction1_es2017.ts
-Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
-rebuilt        : ["arguments", "require"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncUnParenthesizedArrowFunction_es2017.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["_asyncToGenerator", "someOtherFunction", "x", "x1"]
@@ -20812,7 +17610,7 @@ Reference symbol mismatch for "someOtherFunction":
 after transform: SymbolId(0) "someOtherFunction"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
+after transform: ["arguments", "require"]
 rebuilt        : ["arguments", "require", "someOtherFunction"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncAwait_es2017.ts
@@ -20847,7 +17645,7 @@ Reference symbol mismatch for "p":
 after transform: SymbolId(2) "p"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
+after transform: ["arguments", "require"]
 rebuilt        : ["arguments", "mp", "p", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncUseStrict_es2017.ts
@@ -20861,7 +17659,7 @@ Reference symbol mismatch for "a":
 after transform: SymbolId(0) "a"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
+after transform: ["arguments", "require"]
 rebuilt        : ["a", "arguments", "p", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitBinaryExpression/awaitBinaryExpression1_es2017.ts
@@ -20881,7 +17679,7 @@ Reference symbol mismatch for "after":
 after transform: SymbolId(3) "after"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
+after transform: ["arguments", "require"]
 rebuilt        : ["a", "after", "arguments", "before", "p", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitBinaryExpression/awaitBinaryExpression2_es2017.ts
@@ -20901,7 +17699,7 @@ Reference symbol mismatch for "after":
 after transform: SymbolId(3) "after"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
+after transform: ["arguments", "require"]
 rebuilt        : ["a", "after", "arguments", "before", "p", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitBinaryExpression/awaitBinaryExpression3_es2017.ts
@@ -20921,7 +17719,7 @@ Reference symbol mismatch for "after":
 after transform: SymbolId(3) "after"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
+after transform: ["arguments", "require"]
 rebuilt        : ["a", "after", "arguments", "before", "p", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitBinaryExpression/awaitBinaryExpression4_es2017.ts
@@ -20941,7 +17739,7 @@ Reference symbol mismatch for "after":
 after transform: SymbolId(3) "after"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
+after transform: ["arguments", "require"]
 rebuilt        : ["a", "after", "arguments", "before", "p", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpression/awaitCallExpression1_es2017.ts
@@ -20967,7 +17765,7 @@ Reference symbol mismatch for "after":
 after transform: SymbolId(19) "after"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
+after transform: ["arguments", "require"]
 rebuilt        : ["a", "after", "arguments", "before", "fn", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpression/awaitCallExpression2_es2017.ts
@@ -20993,7 +17791,7 @@ Reference symbol mismatch for "after":
 after transform: SymbolId(19) "after"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
+after transform: ["arguments", "require"]
 rebuilt        : ["a", "after", "arguments", "before", "fn", "p", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpression/awaitCallExpression3_es2017.ts
@@ -21019,7 +17817,7 @@ Reference symbol mismatch for "after":
 after transform: SymbolId(19) "after"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
+after transform: ["arguments", "require"]
 rebuilt        : ["a", "after", "arguments", "before", "fn", "p", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpression/awaitCallExpression4_es2017.ts
@@ -21045,7 +17843,7 @@ Reference symbol mismatch for "after":
 after transform: SymbolId(19) "after"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
+after transform: ["arguments", "require"]
 rebuilt        : ["a", "after", "arguments", "before", "pfn", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpression/awaitCallExpression5_es2017.ts
@@ -21071,7 +17869,7 @@ Reference symbol mismatch for "after":
 after transform: SymbolId(19) "after"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
+after transform: ["arguments", "require"]
 rebuilt        : ["a", "after", "arguments", "before", "o", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpression/awaitCallExpression6_es2017.ts
@@ -21097,7 +17895,7 @@ Reference symbol mismatch for "after":
 after transform: SymbolId(19) "after"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
+after transform: ["arguments", "require"]
 rebuilt        : ["a", "after", "arguments", "before", "o", "p", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpression/awaitCallExpression7_es2017.ts
@@ -21123,7 +17921,7 @@ Reference symbol mismatch for "after":
 after transform: SymbolId(19) "after"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
+after transform: ["arguments", "require"]
 rebuilt        : ["a", "after", "arguments", "before", "o", "p", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpression/awaitCallExpression8_es2017.ts
@@ -21149,7 +17947,7 @@ Reference symbol mismatch for "after":
 after transform: SymbolId(19) "after"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
+after transform: ["arguments", "require"]
 rebuilt        : ["a", "after", "arguments", "before", "po", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitClassExpression_es2017.ts
@@ -21160,7 +17958,7 @@ Reference symbol mismatch for "p":
 after transform: SymbolId(1) "p"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
+after transform: ["arguments", "require"]
 rebuilt        : ["arguments", "p", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitInheritedPromise_es2017.ts
@@ -21171,33 +17969,8 @@ Reference symbol mismatch for "a":
 after transform: SymbolId(1) "a"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
+after transform: ["arguments", "require"]
 rebuilt        : ["a", "arguments", "require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration11_es2017.ts
-Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
-rebuilt        : ["arguments", "require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration14_es2017.ts
-Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
-rebuilt        : ["arguments", "require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration1_es2017.ts
-Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
-rebuilt        : ["arguments", "require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncAliasReturnType_es6.ts
-Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
-rebuilt        : ["arguments", "require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction1_es6.ts
-Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
-rebuilt        : ["arguments", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncUnParenthesizedArrowFunction_es6.ts
 Bindings mismatch:
@@ -21210,7 +17983,7 @@ Reference symbol mismatch for "someOtherFunction":
 after transform: SymbolId(0) "someOtherFunction"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
+after transform: ["arguments", "require"]
 rebuilt        : ["arguments", "require", "someOtherFunction"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncAwait_es6.ts
@@ -21245,7 +18018,7 @@ Reference symbol mismatch for "p":
 after transform: SymbolId(2) "p"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
+after transform: ["arguments", "require"]
 rebuilt        : ["arguments", "mp", "p", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncUseStrict_es6.ts
@@ -21259,7 +18032,7 @@ Reference symbol mismatch for "a":
 after transform: SymbolId(0) "a"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
+after transform: ["arguments", "require"]
 rebuilt        : ["a", "arguments", "p", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitBinaryExpression/awaitBinaryExpression1_es6.ts
@@ -21279,7 +18052,7 @@ Reference symbol mismatch for "after":
 after transform: SymbolId(3) "after"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
+after transform: ["arguments", "require"]
 rebuilt        : ["a", "after", "arguments", "before", "p", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitBinaryExpression/awaitBinaryExpression2_es6.ts
@@ -21299,7 +18072,7 @@ Reference symbol mismatch for "after":
 after transform: SymbolId(3) "after"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
+after transform: ["arguments", "require"]
 rebuilt        : ["a", "after", "arguments", "before", "p", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitBinaryExpression/awaitBinaryExpression3_es6.ts
@@ -21319,7 +18092,7 @@ Reference symbol mismatch for "after":
 after transform: SymbolId(3) "after"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
+after transform: ["arguments", "require"]
 rebuilt        : ["a", "after", "arguments", "before", "p", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitBinaryExpression/awaitBinaryExpression4_es6.ts
@@ -21339,7 +18112,7 @@ Reference symbol mismatch for "after":
 after transform: SymbolId(3) "after"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
+after transform: ["arguments", "require"]
 rebuilt        : ["a", "after", "arguments", "before", "p", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression1_es6.ts
@@ -21365,7 +18138,7 @@ Reference symbol mismatch for "after":
 after transform: SymbolId(19) "after"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
+after transform: ["arguments", "require"]
 rebuilt        : ["a", "after", "arguments", "before", "fn", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression2_es6.ts
@@ -21391,7 +18164,7 @@ Reference symbol mismatch for "after":
 after transform: SymbolId(19) "after"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
+after transform: ["arguments", "require"]
 rebuilt        : ["a", "after", "arguments", "before", "fn", "p", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression3_es6.ts
@@ -21417,7 +18190,7 @@ Reference symbol mismatch for "after":
 after transform: SymbolId(19) "after"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
+after transform: ["arguments", "require"]
 rebuilt        : ["a", "after", "arguments", "before", "fn", "p", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression4_es6.ts
@@ -21443,7 +18216,7 @@ Reference symbol mismatch for "after":
 after transform: SymbolId(19) "after"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
+after transform: ["arguments", "require"]
 rebuilt        : ["a", "after", "arguments", "before", "pfn", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression5_es6.ts
@@ -21469,7 +18242,7 @@ Reference symbol mismatch for "after":
 after transform: SymbolId(19) "after"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
+after transform: ["arguments", "require"]
 rebuilt        : ["a", "after", "arguments", "before", "o", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression6_es6.ts
@@ -21495,7 +18268,7 @@ Reference symbol mismatch for "after":
 after transform: SymbolId(19) "after"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
+after transform: ["arguments", "require"]
 rebuilt        : ["a", "after", "arguments", "before", "o", "p", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression7_es6.ts
@@ -21521,7 +18294,7 @@ Reference symbol mismatch for "after":
 after transform: SymbolId(19) "after"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
+after transform: ["arguments", "require"]
 rebuilt        : ["a", "after", "arguments", "before", "o", "p", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression8_es6.ts
@@ -21547,7 +18320,7 @@ Reference symbol mismatch for "after":
 after transform: SymbolId(19) "after"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
+after transform: ["arguments", "require"]
 rebuilt        : ["a", "after", "arguments", "before", "po", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitClassExpression_es6.ts
@@ -21558,7 +18331,7 @@ Reference symbol mismatch for "p":
 after transform: SymbolId(1) "p"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
+after transform: ["arguments", "require"]
 rebuilt        : ["arguments", "p", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitUnion_es6.ts
@@ -21581,46 +18354,8 @@ Reference symbol mismatch for "e":
 after transform: SymbolId(4) "e"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["PromiseLike", "arguments", "require"]
+after transform: ["arguments", "require"]
 rebuilt        : ["a", "arguments", "b", "c", "d", "e", "require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration11_es6.ts
-Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
-rebuilt        : ["arguments", "require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration14_es6.ts
-Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
-rebuilt        : ["arguments", "require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration1_es6.ts
-Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
-rebuilt        : ["arguments", "require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/asyncGenerators/asyncGeneratorGenericNonWrappedReturn.ts
-Unresolved references mismatch:
-after transform: ["AsyncGenerator", "arguments"]
-rebuilt        : ["arguments"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/asyncGenerators/asyncGeneratorPromiseNextType.ts
-Unresolved references mismatch:
-after transform: ["AsyncGenerator", "Promise", "arguments", "console", "require"]
-rebuilt        : ["Promise", "arguments", "console", "require"]
-Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(1), ReferenceId(3), ReferenceId(5), ReferenceId(10), ReferenceId(19), ReferenceId(20), ReferenceId(22), ReferenceId(27)]
-rebuilt        : [ReferenceId(10), ReferenceId(21), ReferenceId(30)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/constructorFunctionTypeIsAssignableToBaseType.ts
-Unresolved references mismatch:
-after transform: ["Object", "require"]
-rebuilt        : ["require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/constructorFunctionTypeIsAssignableToBaseType2.ts
-Unresolved references mismatch:
-after transform: ["Object", "require"]
-rebuilt        : ["require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/classExpression.ts
 Scope flags mismatch:
@@ -21667,26 +18402,6 @@ Symbol scope ID mismatch for "_Class2":
 after transform: SymbolId(9): ScopeId(4)
 rebuilt        : SymbolId(2): ScopeId(0)
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock11.ts
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(1): [ReferenceId(2)]
-rebuilt        : SymbolId(5): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock17.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(4): [ReferenceId(7), ReferenceId(0), ReferenceId(1), ReferenceId(13)]
-rebuilt        : SymbolId(5): [ReferenceId(24)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/constructorImplementationWithDefaultValues.ts
-Unresolved references mismatch:
-after transform: ["Date"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/classPropertyIsPublicByDefault.ts
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(10)]
-rebuilt        : SymbolId(1): [ReferenceId(3), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11)]
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/classTypes/genericSetterInClassType.ts
 Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
@@ -21697,27 +18412,6 @@ rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Generic":
 after transform: SymbolId(0): Span { start: 10, end: 17 }
 rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/classTypes/indexersInClassType.ts
-Unresolved references mismatch:
-after transform: ["Date", "Object", "require"]
-rebuilt        : ["require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassIncludesInheritedMembers.ts
-Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(4): [ReferenceId(1), ReferenceId(2), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10)]
-rebuilt        : SymbolId(5): [ReferenceId(5), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13)]
-Symbol reference IDs mismatch for "Derived2":
-after transform: SymbolId(13): [ReferenceId(14)]
-rebuilt        : SymbolId(14): []
-Unresolved references mismatch:
-after transform: ["Date", "Object", "require"]
-rebuilt        : ["require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassOverridesIndexersWithAssignmentCompatibility.ts
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/thisAndSuperInStaticMembers1.ts
 Bindings mismatch:
@@ -21758,11 +18452,6 @@ Symbol scope ID mismatch for "_set_accessor":
 after transform: SymbolId(7): ScopeId(2)
 rebuilt        : SymbolId(9): ScopeId(0)
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameComputedPropertyName1.ts
-Unresolved references mismatch:
-after transform: ["Record", "WeakMap", "console", "require"]
-rebuilt        : ["WeakMap", "console", "require"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameConstructorSignature.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["_classPrivateFieldInitSpec", "_classPrivateFieldSet", "_x"]
@@ -21774,21 +18463,6 @@ Symbol redeclarations mismatch for "C":
 after transform: SymbolId(1): [Span { start: 37, end: 38 }, Span { start: 185, end: 186 }]
 rebuilt        : SymbolId(3): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameFieldDestructuredBinding.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(3), ReferenceId(0)]
-rebuilt        : SymbolId(5): [ReferenceId(8)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameInLhsReceiverExpression.ts
-Symbol reference IDs mismatch for "Test":
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(5): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticFieldDestructuredBinding.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(12), ReferenceId(0), ReferenceId(25), ReferenceId(28)]
-rebuilt        : SymbolId(2): [ReferenceId(3), ReferenceId(16), ReferenceId(19)]
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/mixinAbstractClasses.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["AbstractBase", "ConcreteBase", "DerivedFromAbstract", "DerivedFromConcrete", "wasAbstract", "wasConcrete"]
@@ -21799,22 +18473,9 @@ rebuilt        : SymbolId(0): SymbolFlags(Function)
 Symbol span mismatch for "Mixin":
 after transform: SymbolId(0): Span { start: 10, end: 15 }
 rebuilt        : SymbolId(0): Span { start: 55, end: 60 }
-Symbol reference IDs mismatch for "Mixin":
-after transform: SymbolId(0): [ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(11)]
-rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(7)]
 Symbol redeclarations mismatch for "Mixin":
 after transform: SymbolId(0): [Span { start: 10, end: 15 }, Span { start: 55, end: 60 }]
 rebuilt        : SymbolId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/mixinAccessors1.ts
-Unresolved references mismatch:
-after transform: ["HTMLElement", "document"]
-rebuilt        : ["document"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/mixinAccessors4.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(4)]
-rebuilt        : SymbolId(0): [ReferenceId(2)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/mixinAccessors5.ts
 Bindings mismatch:
@@ -21825,18 +18486,12 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/mixinC
 Bindings mismatch:
 after transform: ScopeId(0): ["Base", "Derived", "Thing1", "Thing2", "Thing3", "_defineProperty", "f1", "f2"]
 rebuilt        : ScopeId(0): ["Base", "Derived", "Printable", "Tagged", "Thing1", "Thing2", "Thing3", "_defineProperty", "f1", "f2"]
-Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(3): [ReferenceId(5), ReferenceId(1)]
-rebuilt        : SymbolId(1): [ReferenceId(3)]
 Symbol flags mismatch for "Printable":
 after transform: SymbolId(10): SymbolFlags(BlockScopedVariable | ConstVariable | Interface)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable | ConstVariable)
 Symbol span mismatch for "Printable":
 after transform: SymbolId(10): Span { start: 247, end: 256 }
 rebuilt        : SymbolId(8): Span { start: 287, end: 296 }
-Symbol reference IDs mismatch for "Printable":
-after transform: SymbolId(10): [ReferenceId(8), ReferenceId(22)]
-rebuilt        : SymbolId(8): [ReferenceId(19)]
 Symbol redeclarations mismatch for "Printable":
 after transform: SymbolId(10): [Span { start: 247, end: 256 }, Span { start: 287, end: 296 }]
 rebuilt        : SymbolId(8): []
@@ -21846,17 +18501,9 @@ rebuilt        : SymbolId(12): SymbolFlags(Function)
 Symbol span mismatch for "Tagged":
 after transform: SymbolId(14): Span { start: 557, end: 563 }
 rebuilt        : SymbolId(12): Span { start: 596, end: 602 }
-Symbol reference IDs mismatch for "Tagged":
-after transform: SymbolId(14): [ReferenceId(14), ReferenceId(19), ReferenceId(21)]
-rebuilt        : SymbolId(12): [ReferenceId(16), ReferenceId(18)]
 Symbol redeclarations mismatch for "Tagged":
 after transform: SymbolId(14): [Span { start: 557, end: 563 }, Span { start: 596, end: 602 }]
 rebuilt        : SymbolId(12): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/mixinClassesAnonymous.ts
-Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(3): [ReferenceId(5), ReferenceId(1)]
-rebuilt        : SymbolId(1): [ReferenceId(3)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/mixinClassesMembers.ts
 Bindings mismatch:
@@ -21960,34 +18607,22 @@ Reference symbol mismatch for "classWithProperties":
 after transform: SymbolId(7) "classWithProperties"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["const"]
+after transform: []
 rebuilt        : ["classWithProperties"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty9.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["ApiEnum", "ApiEnumMember", "ApiItem"]
 rebuilt        : ScopeId(0): ["ApiEnum", "ApiEnumMember", "ApiItem", "ApiItemContainerMixin"]
-Symbol reference IDs mismatch for "ApiItem":
-after transform: SymbolId(7): [ReferenceId(9), ReferenceId(22), ReferenceId(5), ReferenceId(7), ReferenceId(10), ReferenceId(11), ReferenceId(13), ReferenceId(25)]
-rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(5)]
-Symbol reference IDs mismatch for "ApiEnumMember":
-after transform: SymbolId(8): [ReferenceId(27)]
-rebuilt        : SymbolId(1): []
 Symbol flags mismatch for "ApiItemContainerMixin":
 after transform: SymbolId(9): SymbolFlags(Function | Interface)
 rebuilt        : SymbolId(2): SymbolFlags(Function)
 Symbol span mismatch for "ApiItemContainerMixin":
 after transform: SymbolId(9): Span { start: 462, end: 483 }
 rebuilt        : SymbolId(2): Span { start: 558, end: 579 }
-Symbol reference IDs mismatch for "ApiItemContainerMixin":
-after transform: SymbolId(9): [ReferenceId(17), ReferenceId(19), ReferenceId(24)]
-rebuilt        : SymbolId(2): [ReferenceId(4)]
 Symbol redeclarations mismatch for "ApiItemContainerMixin":
 after transform: SymbolId(9): [Span { start: 462, end: 483 }, Span { start: 558, end: 579 }]
 rebuilt        : SymbolId(2): []
-Unresolved references mismatch:
-after transform: ["ReadonlyArray"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessor8.ts
 Bindings mismatch:
@@ -22045,9 +18680,6 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "TestType":
 after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "TestType":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(0), ReferenceId(4), ReferenceId(6), ReferenceId(14)]
-rebuilt        : SymbolId(0): [ReferenceId(5), ReferenceId(7), ReferenceId(9)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnumPropertyAccess3.ts
 Bindings mismatch:
@@ -22123,18 +18755,8 @@ Reference symbol mismatch for "f":
 after transform: SymbolId(0) "f"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["const"]
+after transform: []
 rebuilt        : ["f"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowBindingElement.ts
-Unresolved references mismatch:
-after transform: ["Error", "console", "const", "undefined"]
-rebuilt        : ["Error", "console", "undefined"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowComputedPropertyNames.ts
-Unresolved references mismatch:
-after transform: ["Record", "undefined"]
-rebuilt        : ["undefined"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowElementAccess2.ts
 Bindings mismatch:
@@ -22166,12 +18788,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/controlFlow/co
 Bindings mismatch:
 after transform: ScopeId(0): ["c", "keywordA", "keywordB", "stringB"]
 rebuilt        : ScopeId(0): ["keywordA", "keywordB", "stringB"]
-Symbol reference IDs mismatch for "keywordA":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(6)]
-rebuilt        : SymbolId(0): [ReferenceId(2)]
-Symbol reference IDs mismatch for "keywordB":
-after transform: SymbolId(1): [ReferenceId(1)]
-rebuilt        : SymbolId(1): []
 Reference symbol mismatch for "c":
 after transform: SymbolId(4) "c"
 rebuilt        : <None>
@@ -22200,29 +18816,10 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["c"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowForOfStatement.ts
-Unresolved references mismatch:
-after transform: ["RegExp"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowIfStatement.ts
-Symbol reference IDs mismatch for "x":
-after transform: SymbolId(15): [ReferenceId(29), ReferenceId(30)]
-rebuilt        : SymbolId(11): [ReferenceId(23)]
-Unresolved references mismatch:
-after transform: ["Error", "JSON", "RegExp"]
-rebuilt        : ["Error", "JSON"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowInOperator.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["a", "b", "c", "d", "uniqueID_54790", "uniqueID_54790_2", "uniqueID_54790_3"]
 rebuilt        : ScopeId(0): ["a", "b", "d", "uniqueID_54790", "uniqueID_54790_2", "uniqueID_54790_3"]
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(9), ReferenceId(13)]
-rebuilt        : SymbolId(0): [ReferenceId(5), ReferenceId(9)]
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(1): [ReferenceId(1)]
-rebuilt        : SymbolId(1): []
 Reference symbol mismatch for "c":
 after transform: SymbolId(5) "c"
 rebuilt        : <None>
@@ -22256,16 +18853,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["Error", "Number", "undefined"]
 rebuilt        : ["Error", "Number", "c", "undefined"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowInstanceOfGuardPrimitives.ts
-Unresolved reference IDs mismatch for "Date":
-after transform: [ReferenceId(0), ReferenceId(11)]
-rebuilt        : [ReferenceId(10)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowInstanceofExtendsFunction.ts
-Symbol reference IDs mismatch for "X":
-after transform: SymbolId(1): [ReferenceId(2), ReferenceId(5), ReferenceId(7), ReferenceId(9)]
-rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(6), ReferenceId(8)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowStringIndex.ts
 Bindings mismatch:
@@ -22336,14 +18923,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["envVar", "obj"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/controlFlow/dependentDestructuredVariablesFromNestedPatterns.ts
-Unresolved references mismatch:
-after transform: ["Awaited", "Error", "Math", "Promise", "String", "arguments", "const", "require", "undefined"]
-rebuilt        : ["Error", "Math", "Promise", "String", "arguments", "require", "undefined"]
-Unresolved reference IDs mismatch for "Error":
-after transform: [ReferenceId(0), ReferenceId(4), ReferenceId(15), ReferenceId(22), ReferenceId(29)]
-rebuilt        : [ReferenceId(17)]
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/controlFlow/dependentDestructuredVariablesWithExport.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["discriminator1", "discriminator2", "mutuallyEnabledPair", "value1", "value2"]
@@ -22362,9 +18941,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/controlFlow/ty
 Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "_defineProperty", "f1", "f2", "f3", "f4", "getFooOrNull", "getStringOrNumberOrNull", "match", "re"]
 rebuilt        : ScopeId(0): ["Foo", "_defineProperty", "f1", "f2", "f3", "f4", "match", "re"]
-Symbol reference IDs mismatch for "Foo":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(5), ReferenceId(6), ReferenceId(16)]
-rebuilt        : SymbolId(1): [ReferenceId(13)]
 Reference symbol mismatch for "getFooOrNull":
 after transform: SymbolId(1) "getFooOrNull"
 rebuilt        : <None>
@@ -22378,18 +18954,8 @@ Reference symbol mismatch for "getStringOrNumberOrNull":
 after transform: SymbolId(2) "getStringOrNumberOrNull"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Object", "RegExpExecArray", "require"]
+after transform: ["require"]
 rebuilt        : ["getFooOrNull", "getStringOrNumberOrNull", "require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/controlFlow/typeGuardsTypeParameters.ts
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(0): [ReferenceId(2), ReferenceId(5)]
-rebuilt        : SymbolId(1): [ReferenceId(3)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/anonymousClassAccessorsDeclarationEmit1.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(4): [ReferenceId(3)]
-rebuilt        : SymbolId(9): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/leaveOptionalParameterAsWritten.ts
 Symbol reference IDs mismatch for "a":
@@ -22400,29 +18966,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/declarationEmi
 Bindings mismatch:
 after transform: ScopeId(0): ["elem"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["HTMLElement"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typePredicates/declarationEmitThisPredicates01.ts
-Symbol reference IDs mismatch for "D":
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(1): [ReferenceId(0)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typePredicates/declarationEmitThisPredicatesWithPrivateName01.ts
-Symbol reference IDs mismatch for "D":
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(1): [ReferenceId(0)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typeReferenceRelatedFiles.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["FSWatcher", "f"]
-rebuilt        : ScopeId(0): ["f"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typeofImportTypeOnlyExport.ts
-Symbol reference IDs mismatch for "ClassMapDirective":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(4)]
-rebuilt        : SymbolId(0): [ReferenceId(2)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/decorators/class/constructor/parameter/decoratorOnClassConstructorParameter5.ts
 Symbol span mismatch for "BulkEditPreviewProvider":
@@ -22489,7 +19032,7 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Function", "TypedPropertyDescriptor", "require"]
+after transform: ["Function", "require"]
 rebuilt        : ["Function", "dec", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod14.ts
@@ -22552,12 +19095,6 @@ rebuilt        : ScopeId(8): ScopeFlags(Function | Arrow)
 Scope parent mismatch:
 after transform: ScopeId(6): Some(ScopeId(4))
 rebuilt        : ScopeId(8): Some(ScopeId(0))
-Symbol reference IDs mismatch for "C1":
-after transform: SymbolId(1): [ReferenceId(1), ReferenceId(14)]
-rebuilt        : SymbolId(6): [ReferenceId(17)]
-Symbol reference IDs mismatch for "C2":
-after transform: SymbolId(3): [ReferenceId(4), ReferenceId(27)]
-rebuilt        : SymbolId(9): [ReferenceId(32)]
 Reference symbol mismatch for "decorator":
 after transform: SymbolId(0) "decorator"
 rebuilt        : <None>
@@ -22576,7 +19113,7 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Function", "TypedPropertyDescriptor", "require"]
+after transform: ["Function", "require"]
 rebuilt        : ["Function", "dec", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod5.ts
@@ -22587,7 +19124,7 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Function", "TypedPropertyDescriptor", "require"]
+after transform: ["Function", "require"]
 rebuilt        : ["Function", "dec", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod7.ts
@@ -22598,7 +19135,7 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Function", "TypedPropertyDescriptor", "require"]
+after transform: ["Function", "require"]
 rebuilt        : ["Function", "dec", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty13.ts
@@ -22609,7 +19146,7 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Object", "PropertyDescriptor", "WeakMap", "require"]
+after transform: ["Object", "WeakMap", "require"]
 rebuilt        : ["Object", "WeakMap", "dec", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorInAmbientContext.ts
@@ -22706,11 +19243,6 @@ Symbol span mismatch for "C":
 after transform: SymbolId(49): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(9): Span { start: 20, end: 21 }
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpression2ES2020.ts
-Unresolved references mismatch:
-after transform: ["Promise"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpression4ES2020.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "_asyncToGenerator", "_defineProperty", "console"]
@@ -22756,24 +19288,14 @@ rebuilt        : ["directory", "getSpecifier", "moduleFile", "whatToLoad"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionDeclarationEmit3.ts
 Bindings mismatch:
-after transform: ScopeId(0): ["Zero", "getPath", "p0", "p1", "p2"]
+after transform: ScopeId(0): ["getPath", "p0", "p1", "p2"]
 rebuilt        : ScopeId(0): ["p0", "p1", "p2"]
 Reference symbol mismatch for "getPath":
 after transform: SymbolId(0) "getPath"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise"]
+after transform: []
 rebuilt        : ["getPath"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInCJS2.ts
-Unresolved references mismatch:
-after transform: ["Promise", "arguments", "require"]
-rebuilt        : ["arguments", "require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInCJS3.ts
-Unresolved references mismatch:
-after transform: ["Promise"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInCJS5.ts
 Bindings mismatch:
@@ -22803,7 +19325,7 @@ rebuilt        : ["arguments", "console"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionReturnPromiseOfAny.ts
 Bindings mismatch:
-after transform: ScopeId(0): ["ValidSomeCondition", "defaultModule", "directory", "getSpecifier", "j", "loadModule", "moduleFile", "p1", "p11", "p2", "p3", "whatToLoad"]
+after transform: ScopeId(0): ["ValidSomeCondition", "directory", "getSpecifier", "j", "loadModule", "moduleFile", "p1", "p11", "p2", "p3", "whatToLoad"]
 rebuilt        : ScopeId(0): ["j", "loadModule", "p1", "p11", "p2", "p3"]
 Reference symbol mismatch for "directory":
 after transform: SymbolId(4) "directory"
@@ -22833,7 +19355,7 @@ Reference symbol mismatch for "getSpecifier":
 after transform: SymbolId(1) "getSpecifier"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise"]
+after transform: []
 rebuilt        : ["ValidSomeCondition", "directory", "getSpecifier", "moduleFile", "whatToLoad"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/enums/enumBasics.ts
@@ -22894,9 +19416,6 @@ rebuilt        : ScopeId(9): ScopeFlags(Function)
 Symbol flags mismatch for "E1":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "E1":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(30)]
-rebuilt        : SymbolId(0): [ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10)]
 Symbol flags mismatch for "E2":
 after transform: SymbolId(7): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(5): SymbolFlags(FunctionScopedVariable)
@@ -23359,18 +19878,10 @@ Symbol flags mismatch for "Color":
 after transform: SymbolId(49): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(37): SymbolFlags(BlockScopedVariable)
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es2018/es2018IntlAPIs.ts
-Unresolved references mismatch:
-after transform: ["Intl", "console", "const"]
-rebuilt        : ["Intl", "console"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es2019/globalThisTypeIndexAccess.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["w_e"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["globalThis"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es2020/bigintMissingES2019.ts
 Bindings mismatch:
@@ -23413,21 +19924,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["test"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es2020/intlNumberFormatES2020.ts
-Unresolved reference IDs mismatch for "Intl":
-after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7)]
-rebuilt        : [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es2020/localesObjectArgument.ts
-Unresolved references mismatch:
-after transform: ["Date", "Intl", "Readonly"]
-rebuilt        : ["Date", "Intl"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es2020/modules/exportAsNamespace5.ts
-Symbol reference IDs mismatch for "ns":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es2021/logicalAssignment/logicalAssignment1.ts
 Bindings mismatch:
@@ -23617,16 +20113,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["x"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es2022/arbitraryModuleNamespaceIdentifiers/arbitraryModuleNamespaceIdentifiers_module.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["_Z", "importStarTestA", "importTest", "reimportTest", "someValue", "typeA", "typeB", "typeC", "valueX", "valueY", "valueZ"]
-rebuilt        : ScopeId(0): ["_Z", "importStarTestA", "importTest", "reimportTest", "someValue", "valueX", "valueY", "valueZ"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es2022/es2022IntlAPIs.ts
-Unresolved references mismatch:
-after transform: ["Intl", "const"]
-rebuilt        : ["Intl"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit3.ts
 Unresolved reference IDs mismatch for "Symbol":
 after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
@@ -23637,31 +20123,10 @@ Unresolved references mismatch:
 after transform: ["Symbol"]
 rebuilt        : []
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit6.ts
-Unresolved references mismatch:
-after transform: ["Symbol"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit7.ts
-Unresolved references mismatch:
-after transform: ["Symbol"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty11.ts
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(0): [ReferenceId(3), ReferenceId(4)]
-rebuilt        : SymbolId(0): [ReferenceId(1)]
-Unresolved references mismatch:
-after transform: ["Symbol"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty13.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "_Symbol$iterator", "_defineProperty", "bar", "foo", "i"]
 rebuilt        : ScopeId(0): ["C", "_Symbol$iterator", "_defineProperty", "i"]
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(0): [ReferenceId(4), ReferenceId(5), ReferenceId(7)]
-rebuilt        : SymbolId(2): [ReferenceId(6)]
 Reference symbol mismatch for "foo":
 after transform: SymbolId(2) "foo"
 rebuilt        : <None>
@@ -23671,17 +20136,11 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["Symbol", "require"]
 rebuilt        : ["Symbol", "bar", "foo", "require"]
-Unresolved reference IDs mismatch for "Symbol":
-after transform: [ReferenceId(0), ReferenceId(1)]
-rebuilt        : [ReferenceId(2)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty14.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "_Symbol$iterator", "_defineProperty", "bar", "foo", "i"]
 rebuilt        : ScopeId(0): ["C", "_Symbol$iterator", "_defineProperty", "i"]
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(0): [ReferenceId(4), ReferenceId(5), ReferenceId(7)]
-rebuilt        : SymbolId(2): [ReferenceId(6)]
 Reference symbol mismatch for "foo":
 after transform: SymbolId(2) "foo"
 rebuilt        : <None>
@@ -23691,17 +20150,11 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["Symbol", "require"]
 rebuilt        : ["Symbol", "bar", "foo", "require"]
-Unresolved reference IDs mismatch for "Symbol":
-after transform: [ReferenceId(0), ReferenceId(1)]
-rebuilt        : [ReferenceId(2)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty15.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "bar", "foo", "i"]
 rebuilt        : ScopeId(0): ["C", "i"]
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(6)]
-rebuilt        : SymbolId(0): [ReferenceId(1)]
 Reference symbol mismatch for "foo":
 after transform: SymbolId(2) "foo"
 rebuilt        : <None>
@@ -23709,16 +20162,13 @@ Reference symbol mismatch for "bar":
 after transform: SymbolId(5) "bar"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Symbol"]
+after transform: []
 rebuilt        : ["bar", "foo"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty16.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "_Symbol$iterator", "_defineProperty", "bar", "foo", "i"]
 rebuilt        : ScopeId(0): ["C", "_Symbol$iterator", "_defineProperty", "i"]
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(0): [ReferenceId(4), ReferenceId(5), ReferenceId(7)]
-rebuilt        : SymbolId(2): [ReferenceId(6)]
 Reference symbol mismatch for "foo":
 after transform: SymbolId(2) "foo"
 rebuilt        : <None>
@@ -23728,13 +20178,10 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["Symbol", "require"]
 rebuilt        : ["Symbol", "bar", "foo", "require"]
-Unresolved reference IDs mismatch for "Symbol":
-after transform: [ReferenceId(0), ReferenceId(1)]
-rebuilt        : [ReferenceId(2)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty20.ts
 Unresolved reference IDs mismatch for "Symbol":
-after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(5)]
+after transform: [ReferenceId(1), ReferenceId(3), ReferenceId(5)]
 rebuilt        : [ReferenceId(0), ReferenceId(2)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty22.ts
@@ -23750,21 +20197,6 @@ rebuilt        : ["Symbol", "foo"]
 Unresolved reference IDs mismatch for "Symbol":
 after transform: [ReferenceId(0), ReferenceId(9)]
 rebuilt        : [ReferenceId(1)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty23.ts
-Unresolved reference IDs mismatch for "Symbol":
-after transform: [ReferenceId(0), ReferenceId(2)]
-rebuilt        : [ReferenceId(0)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty37.ts
-Unresolved references mismatch:
-after transform: ["Symbol"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty38.ts
-Unresolved references mismatch:
-after transform: ["Symbol"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty40.ts
 Unresolved reference IDs mismatch for "Symbol":
@@ -23839,14 +20271,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/sy
 Bindings mismatch:
 after transform: ScopeId(0): ["mySymbol"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Symbol"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty61.ts
-Unresolved reference IDs mismatch for "Symbol":
-after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(6), ReferenceId(11)]
-rebuilt        : [ReferenceId(0), ReferenceId(5)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty8.ts
 Unresolved references mismatch:
@@ -23863,16 +20287,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["require"]
 rebuilt        : ["Factory", "require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames37_ES6.ts
-Symbol reference IDs mismatch for "Foo2":
-after transform: SymbolId(1): [ReferenceId(2), ReferenceId(0)]
-rebuilt        : SymbolId(2): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames41_ES6.ts
-Symbol reference IDs mismatch for "Foo2":
-after transform: SymbolId(1): [ReferenceId(0)]
-rebuilt        : SymbolId(2): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames47_ES6.ts
 Bindings mismatch:
@@ -23949,7 +20363,7 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Object", "TypedPropertyDescriptor"]
+after transform: ["Object"]
 rebuilt        : ["Object", "dec"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/decoratorOnClass1.es6.ts
@@ -24117,7 +20531,7 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Function", "TypedPropertyDescriptor"]
+after transform: ["Function"]
 rebuilt        : ["Function", "dec"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/method/parameter/decoratorOnClassMethodParameter1.es6.ts
@@ -24134,7 +20548,7 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Function", "Number", "Object"]
+after transform: ["Function", "Number"]
 rebuilt        : ["Function", "Number", "dec"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/property/decoratorOnClassProperty1.es6.ts
@@ -24193,11 +20607,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["yadda"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration10.ts
-Unresolved references mismatch:
-after transform: ["Partial", "Record"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringVoid.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["v"]
@@ -24208,26 +20617,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["v"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern15.ts
-Symbol reference IDs mismatch for "Bar":
-after transform: SymbolId(0): [ReferenceId(3), ReferenceId(0)]
-rebuilt        : SymbolId(1): [ReferenceId(2)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern20.ts
-Symbol reference IDs mismatch for "Bar":
-after transform: SymbolId(0): [ReferenceId(5), ReferenceId(0)]
-rebuilt        : SymbolId(1): [ReferenceId(2)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern3.ts
-Symbol reference IDs mismatch for "Bar":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(3), ReferenceId(4)]
-rebuilt        : SymbolId(1): [ReferenceId(2)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern4.ts
-Symbol reference IDs mismatch for "Bar":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(3), ReferenceId(4)]
-rebuilt        : SymbolId(1): [ReferenceId(2)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of58.ts
 Bindings mismatch:
@@ -24363,11 +20752,6 @@ Symbol span mismatch for "M":
 after transform: SymbolId(12): Span { start: 167, end: 168 }
 rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports5.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A", "f"]
-rebuilt        : ScopeId(0): ["f"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesWithModule.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Scope flags mismatch:
@@ -24417,9 +20801,6 @@ rebuilt        : SymbolId(4): Span { start: 339, end: 343 }
 Symbol redeclarations mismatch for "foo2":
 after transform: SymbolId(8): [Span { start: 227, end: 231 }, Span { start: 277, end: 281 }, Span { start: 339, end: 343 }]
 rebuilt        : SymbolId(4): []
-Unresolved references mismatch:
-after transform: ["TemplateStringsArray", "undefined"]
-rebuilt        : ["undefined"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution2_ES6.ts
 Symbol span mismatch for "foo1":
@@ -24434,9 +20815,6 @@ rebuilt        : SymbolId(4): Span { start: 339, end: 343 }
 Symbol redeclarations mismatch for "foo2":
 after transform: SymbolId(8): [Span { start: 227, end: 231 }, Span { start: 277, end: 281 }, Span { start: 339, end: 343 }]
 rebuilt        : SymbolId(4): []
-Unresolved references mismatch:
-after transform: ["TemplateStringsArray", "undefined"]
-rebuilt        : ["undefined"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplatesWithTypeArguments1.ts
 Bindings mismatch:
@@ -24455,7 +20833,7 @@ Reference symbol mismatch for "obj":
 after transform: SymbolId(26) "obj"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Array", "TemplateStringsArray"]
+after transform: []
 rebuilt        : ["f", "g", "obj"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorInAmbientContext6.ts
@@ -24468,11 +20846,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorOverloads4.ts
-Unresolved references mismatch:
-after transform: ["Iterable"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorOverloads5.ts
 Scope flags mismatch:
@@ -24490,69 +20863,6 @@ rebuilt        : SymbolId(2): Span { start: 112, end: 113 }
 Symbol redeclarations mismatch for "f":
 after transform: SymbolId(1): [Span { start: 27, end: 28 }, Span { start: 69, end: 70 }, Span { start: 112, end: 113 }]
 rebuilt        : SymbolId(2): []
-Unresolved references mismatch:
-after transform: ["Iterable"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck1.ts
-Unresolved references mismatch:
-after transform: ["Iterator"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck10.ts
-Unresolved references mismatch:
-after transform: ["IterableIterator"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck11.ts
-Unresolved references mismatch:
-after transform: ["IterableIterator"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck12.ts
-Unresolved references mismatch:
-after transform: ["IterableIterator"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck13.ts
-Unresolved references mismatch:
-after transform: ["IterableIterator"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck2.ts
-Unresolved references mismatch:
-after transform: ["Iterable"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck26.ts
-Unresolved references mismatch:
-after transform: ["IterableIterator"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck27.ts
-Unresolved references mismatch:
-after transform: ["IterableIterator"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck28.ts
-Unresolved references mismatch:
-after transform: ["IterableIterator", "Symbol"]
-rebuilt        : ["Symbol"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck29.ts
-Unresolved references mismatch:
-after transform: ["Iterable", "Iterator"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck3.ts
-Unresolved references mismatch:
-after transform: ["IterableIterator"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck30.ts
-Unresolved references mismatch:
-after transform: ["Iterable", "Iterator"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck45.ts
 Bindings mismatch:
@@ -24562,7 +20872,7 @@ Reference symbol mismatch for "foo":
 after transform: SymbolId(0) "foo"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Iterator", "undefined"]
+after transform: ["undefined"]
 rebuilt        : ["foo", "undefined"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck46.ts
@@ -24573,7 +20883,7 @@ Reference symbol mismatch for "foo":
 after transform: SymbolId(0) "foo"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Iterable", "Symbol", "undefined"]
+after transform: ["Symbol", "undefined"]
 rebuilt        : ["Symbol", "foo", "undefined"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck61.ts
@@ -24583,11 +20893,6 @@ rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol span mismatch for "C":
 after transform: SymbolId(2): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(3): Span { start: 42, end: 43 }
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck64.ts
-Unresolved references mismatch:
-after transform: ["Generator", "Iterable", "Iterator"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/accessors/esDecorators-classDeclaration-accessors-nonStaticPrivate.ts
 Bindings mismatch:
@@ -25046,9 +21351,6 @@ rebuilt        : SymbolId(10): Span { start: 300, end: 301 }
 Symbol span mismatch for "C":
 after transform: SymbolId(4): Span { start: 551, end: 552 }
 rebuilt        : SymbolId(12): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(4): [ReferenceId(8), ReferenceId(39), ReferenceId(41), ReferenceId(43)]
-rebuilt        : SymbolId(12): [ReferenceId(44), ReferenceId(45), ReferenceId(48)]
 Symbol span mismatch for "C":
 after transform: SymbolId(16): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(13): Span { start: 551, end: 552 }
@@ -25776,11 +22078,6 @@ Unresolved references mismatch:
 after transform: ["module"]
 rebuilt        : ["dec", "module"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/esDecorators-contextualTypes.2.ts
-Unresolved references mismatch:
-after transform: ["ClassMethodDecoratorContext", "Function", "console"]
-rebuilt        : ["Function", "console"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/esDecorators-contextualTypes.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "_C_brand", "_b_accessor_storage", "_b_accessor_storage2", "_c", "_classPrivateFieldGet", "_classPrivateFieldInitSpec", "_classPrivateFieldSet", "_classPrivateMethodInitSpec", "_decorate", "_decorateMetadata", "_defineProperty", "_f", "_g", "_get_a", "_get_b", "_get_x", "_get_y", "_set_a", "_set_b", "_set_x", "_set_y", "_y_accessor_storage", "_y_accessor_storage2", "_z"]
@@ -26120,7 +22417,7 @@ Reference symbol mismatch for "DecoratorProvider":
 after transform: SymbolId(0) "DecoratorProvider"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["DecoratorContext", "Function", "require"]
+after transform: ["Function", "require"]
 rebuilt        : ["DecoratorProvider", "Function", "instance", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/metadata/esDecoratorsMetadata1.ts
@@ -26191,15 +22488,9 @@ rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "AppType":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "AppType":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(5), ReferenceId(8), ReferenceId(12)]
-rebuilt        : SymbolId(0): [ReferenceId(22), ReferenceId(25), ReferenceId(29)]
 Symbol flags mismatch for "AppStyle":
 after transform: SymbolId(10): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "AppStyle":
-after transform: SymbolId(10): [ReferenceId(3), ReferenceId(6), ReferenceId(7), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(13), ReferenceId(14)]
-rebuilt        : SymbolId(2): [ReferenceId(23), ReferenceId(24), ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(30), ReferenceId(31)]
 Reference symbol mismatch for "foo":
 after transform: SymbolId(17) "foo"
 rebuilt        : <None>
@@ -26207,21 +22498,8 @@ Reference symbol mismatch for "foo":
 after transform: SymbolId(17) "foo"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Array", "Map"]
+after transform: ["Map"]
 rebuilt        : ["Map", "foo"]
-Unresolved reference IDs mismatch for "Map":
-after transform: [ReferenceId(0), ReferenceId(4)]
-rebuilt        : [ReferenceId(21)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/arrayLiterals/arrayLiterals2ES5.ts
-Unresolved references mismatch:
-after transform: ["Array", "Number", "String", "undefined"]
-rebuilt        : ["undefined"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/arrayLiterals/arrayLiterals2ES6.ts
-Unresolved references mismatch:
-after transform: ["Array", "Number", "String", "undefined"]
-rebuilt        : ["undefined"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/asOperator/asOpEmitParens.ts
 Bindings mismatch:
@@ -26299,14 +22577,6 @@ rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(6): Span { start: 103, end: 104 }
 rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
-Unresolved references mismatch:
-after transform: ["Object", "require"]
-rebuilt        : ["require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithConstrainedTypeParameter.ts
-Unresolved references mismatch:
-after transform: ["Record"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnOptionalProperty.ts
 Bindings mismatch:
@@ -26411,26 +22681,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["a", "b"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnProperty.ts
-Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3)]
-rebuilt        : SymbolId(1): [ReferenceId(2)]
-Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(1): [ReferenceId(4)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "A1":
-after transform: SymbolId(2): [ReferenceId(6)]
-rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch for "B1":
-after transform: SymbolId(3): [ReferenceId(8)]
-rebuilt        : SymbolId(5): []
-Symbol reference IDs mismatch for "A2":
-after transform: SymbolId(4): [ReferenceId(5), ReferenceId(7)]
-rebuilt        : SymbolId(6): [ReferenceId(10)]
-Symbol reference IDs mismatch for "B2":
-after transform: SymbolId(5): [ReferenceId(9)]
-rebuilt        : SymbolId(7): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithInvalidStaticToString.ts
 Bindings mismatch:
@@ -27012,13 +23262,8 @@ Reference symbol mismatch for "lhs0":
 after transform: SymbolId(32) "lhs0"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Symbol", "globalThis"]
+after transform: ["Symbol"]
 rebuilt        : ["A", "B", "Rhs10", "Rhs11", "Rhs12", "Rhs13", "Rhs7", "Rhs8", "Rhs9", "lhs0", "lhs1", "lhs2", "lhs3", "lhs4", "obj", "rhs0", "rhs1", "rhs14", "rhs15", "rhs2", "rhs3", "rhs4", "rhs5", "rhs6"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/commaOperator/commaOperatorWithSecondOperandAnyType.ts
-Unresolved references mismatch:
-after transform: ["Object", "undefined"]
-rebuilt        : ["undefined"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/functionExpressionContextualTyping1.ts
 Bindings mismatch:
@@ -27030,18 +23275,6 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "E":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "E":
-after transform: SymbolId(0): [ReferenceId(10), ReferenceId(29)]
-rebuilt        : SymbolId(0): [ReferenceId(5)]
-Symbol reference IDs mismatch for "a0":
-after transform: SymbolId(3): [ReferenceId(5)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "Class":
-after transform: SymbolId(8): [ReferenceId(1)]
-rebuilt        : SymbolId(5): []
-Unresolved references mismatch:
-after transform: ["Number"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/functionExpressionContextualTyping3.ts
 Bindings mismatch:
@@ -27054,11 +23287,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["f"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/iterableContextualTyping1.ts
-Unresolved references mismatch:
-after transform: ["Iterable"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/parenthesizedContexualTyping3.ts
 Symbol span mismatch for "tempFun":
 after transform: SymbolId(0): Span { start: 145, end: 152 }
@@ -27066,9 +23294,6 @@ rebuilt        : SymbolId(0): Span { start: 317, end: 324 }
 Symbol redeclarations mismatch for "tempFun":
 after transform: SymbolId(0): [Span { start: 145, end: 152 }, Span { start: 223, end: 230 }, Span { start: 317, end: 324 }]
 rebuilt        : SymbolId(0): []
-Unresolved references mismatch:
-after transform: ["TemplateStringsArray", "undefined"]
-rebuilt        : ["undefined"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/elementAccess/stringEnumInElementAccess01.ts
 Bindings mismatch:
@@ -27083,9 +23308,6 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "E":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "E":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(8)]
-rebuilt        : SymbolId(0): [ReferenceId(4)]
 Reference symbol mismatch for "item":
 after transform: SymbolId(5) "item"
 rebuilt        : <None>
@@ -27095,26 +23317,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["e", "item"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/callWithSpreadES6.ts
-Unresolved references mismatch:
-after transform: ["Function"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/newWithSpread.ts
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(10): [ReferenceId(0), ReferenceId(1), ReferenceId(45), ReferenceId(46), ReferenceId(48)]
-rebuilt        : SymbolId(6): [ReferenceId(36), ReferenceId(37), ReferenceId(39)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/newWithSpreadES6.ts
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(10): [ReferenceId(0), ReferenceId(1), ReferenceId(45), ReferenceId(46), ReferenceId(48)]
-rebuilt        : SymbolId(6): [ReferenceId(36), ReferenceId(37), ReferenceId(39)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceTransitiveConstraints.ts
-Unresolved reference IDs mismatch for "Date":
-after transform: [ReferenceId(0), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13)]
-rebuilt        : [ReferenceId(4), ReferenceId(5), ReferenceId(6)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/functions/contextuallyTypedFunctionExpressionsAndReturnAnnotations.ts
 Bindings mismatch:
@@ -27182,29 +23384,17 @@ rebuilt        : SymbolId(18): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M4":
 after transform: SymbolId(14): Span { start: 546, end: 548 }
 rebuilt        : SymbolId(18): Span { start: 0, end: 0 }
-Unresolved references mismatch:
-after transform: ["Date", "require"]
-rebuilt        : ["require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/newOperator/newOperatorConformance.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["C0", "C1", "T", "a", "anyCtor", "anyCtor1", "c1", "d", "fnVoid", "n", "nested", "newFn1", "newFn2", "t"]
 rebuilt        : ScopeId(0): ["C0", "C1", "T", "a", "anyCtor", "anyCtor1", "c1", "d", "fnVoid", "n", "nested", "nestedCtor", "newFn1", "newFn2", "t"]
-Symbol reference IDs mismatch for "C0":
-after transform: SymbolId(0): [ReferenceId(3), ReferenceId(4)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
-Symbol reference IDs mismatch for "T":
-after transform: SymbolId(4): [ReferenceId(5), ReferenceId(6)]
-rebuilt        : SymbolId(4): [ReferenceId(1)]
 Symbol flags mismatch for "nestedCtor":
 after transform: SymbolId(10): SymbolFlags(FunctionScopedVariable | Interface)
 rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
 Symbol span mismatch for "nestedCtor":
 after transform: SymbolId(10): Span { start: 197, end: 207 }
 rebuilt        : SymbolId(8): Span { start: 240, end: 250 }
-Symbol reference IDs mismatch for "nestedCtor":
-after transform: SymbolId(10): [ReferenceId(1), ReferenceId(2), ReferenceId(15)]
-rebuilt        : SymbolId(8): [ReferenceId(8)]
 Symbol redeclarations mismatch for "nestedCtor":
 after transform: SymbolId(10): [Span { start: 197, end: 207 }, Span { start: 240, end: 250 }]
 rebuilt        : SymbolId(8): []
@@ -27815,14 +24005,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["a1", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/objectLiterals/objectLiteralGettersAndSetters.ts
-Symbol reference IDs mismatch for "anyVar":
-after transform: SymbolId(33): [ReferenceId(11)]
-rebuilt        : SymbolId(30): []
-Unresolved references mismatch:
-after transform: ["Array", "Date", "undefined"]
-rebuilt        : ["undefined"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/callChain/callChain.2.ts
 Bindings mismatch:
@@ -28585,23 +24767,11 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "Color":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "Color":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(5), ReferenceId(3), ReferenceId(10), ReferenceId(15), ReferenceId(23)]
-rebuilt        : SymbolId(0): [ReferenceId(7)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardFunction.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "D", "_defineProperty", "a", "acceptingBoolean", "acceptingTypeGuardFunction", "b", "f1", "f2", "isA", "isB", "isC", "isC_multipleParams", "obj", "retC", "subType", "union", "union2", "union3"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "D", "_defineProperty", "a", "b", "f1", "obj", "subType", "union", "union2", "union3"]
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(34), ReferenceId(39), ReferenceId(0), ReferenceId(5), ReferenceId(14), ReferenceId(19), ReferenceId(25)]
-rebuilt        : SymbolId(1): [ReferenceId(3)]
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(1): [ReferenceId(2), ReferenceId(6), ReferenceId(15), ReferenceId(43), ReferenceId(44)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(2): [ReferenceId(3), ReferenceId(4), ReferenceId(21), ReferenceId(28), ReferenceId(30), ReferenceId(32), ReferenceId(35), ReferenceId(10), ReferenceId(20), ReferenceId(26), ReferenceId(42)]
-rebuilt        : SymbolId(3): []
 Reference symbol mismatch for "isC":
 after transform: SymbolId(7) "isC"
 rebuilt        : <None>
@@ -28640,15 +24810,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/ty
 Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "_defineProperty", "a", "funA", "funB", "funC", "funD", "funE", "isB", "isC", "retC", "test1", "test2", "test3"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "_defineProperty", "a", "test1", "test2", "test3"]
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(15)]
-rebuilt        : SymbolId(1): [ReferenceId(3)]
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(1): [ReferenceId(1), ReferenceId(22), ReferenceId(29)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(2): [ReferenceId(2), ReferenceId(3)]
-rebuilt        : SymbolId(3): []
 Reference symbol mismatch for "funA":
 after transform: SymbolId(9) "funA"
 rebuilt        : <None>
@@ -28682,29 +24843,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["require"]
 rebuilt        : ["funA", "funB", "funC", "funD", "funE", "isB", "isC", "require", "retC"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardFunctionOfFormThis.ts
-Symbol reference IDs mismatch for "RoyalGuard":
-after transform: SymbolId(0): [ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(12)]
-rebuilt        : SymbolId(1): [ReferenceId(3), ReferenceId(4)]
-Symbol reference IDs mismatch for "LeadGuard":
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(62)]
-rebuilt        : SymbolId(2): [ReferenceId(1)]
-Symbol reference IDs mismatch for "FollowerGuard":
-after transform: SymbolId(2): [ReferenceId(2), ReferenceId(3), ReferenceId(7), ReferenceId(63)]
-rebuilt        : SymbolId(3): [ReferenceId(2), ReferenceId(5)]
-Symbol reference IDs mismatch for "ArrowElite":
-after transform: SymbolId(8): [ReferenceId(22), ReferenceId(23)]
-rebuilt        : SymbolId(8): [ReferenceId(19)]
-Symbol reference IDs mismatch for "ArrowMedic":
-after transform: SymbolId(9): [ReferenceId(24), ReferenceId(25)]
-rebuilt        : SymbolId(9): [ReferenceId(21)]
-Symbol reference IDs mismatch for "MimicLeader":
-after transform: SymbolId(17): [ReferenceId(47), ReferenceId(48)]
-rebuilt        : SymbolId(13): [ReferenceId(37)]
-Symbol reference IDs mismatch for "MimicFollower":
-after transform: SymbolId(18): [ReferenceId(49), ReferenceId(50)]
-rebuilt        : SymbolId(14): [ReferenceId(38)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardIntersectionTypes.ts
 Bindings mismatch:
@@ -28747,18 +24885,8 @@ Reference symbol mismatch for "log":
 after transform: SymbolId(17) "log"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Object"]
+after transform: []
 rebuilt        : ["isX", "isY", "isZ", "log"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormExpr1AndExpr2.ts
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(6): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(23)]
-rebuilt        : SymbolId(7): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormExpr1OrExpr2.ts
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(6): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(19)]
-rebuilt        : SymbolId(7): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormFunctionEquality.ts
 Bindings mismatch:
@@ -28780,13 +24908,8 @@ Reference symbol mismatch for "isString1":
 after transform: SymbolId(0) "isString1"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Object"]
+after transform: []
 rebuilt        : ["isString1", "isString2"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfFunction.ts
-Unresolved references mismatch:
-after transform: ["Record"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInFunctionAndModuleBlock.ts
 Bindings mismatch:
@@ -28844,28 +24967,10 @@ Symbol span mismatch for "m3":
 after transform: SymbolId(29): Span { start: 2085, end: 2087 }
 rebuilt        : SymbolId(33): Span { start: 0, end: 0 }
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_asConstArrays.ts
-Unresolved references mismatch:
-after transform: ["const"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_contextualTyping3.ts
-Unresolved references mismatch:
-after transform: ["Function"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_ensureInterfaceImpl.ts
-Unresolved references mismatch:
-after transform: ["Record"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_propertyValueConformance1.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["checkM", "checkTruths", "m", "x", "x2"]
 rebuilt        : ScopeId(0): ["m", "x", "x2"]
-Symbol reference IDs mismatch for "x":
-after transform: SymbolId(5): [ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(7), ReferenceId(8)]
-rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(3), ReferenceId(5), ReferenceId(6)]
 Reference symbol mismatch for "checkTruths":
 after transform: SymbolId(1) "checkTruths"
 rebuilt        : <None>
@@ -28880,9 +24985,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/ty
 Bindings mismatch:
 after transform: ScopeId(0): ["checkM", "checkTruths", "m", "x", "x2"]
 rebuilt        : ScopeId(0): ["m", "x", "x2"]
-Symbol reference IDs mismatch for "x":
-after transform: SymbolId(5): [ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(7), ReferenceId(8)]
-rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(3), ReferenceId(5), ReferenceId(6)]
 Reference symbol mismatch for "checkTruths":
 after transform: SymbolId(1) "checkTruths"
 rebuilt        : <None>
@@ -29006,11 +25108,6 @@ Symbol flags mismatch for "E1":
 after transform: SymbolId(4): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignTypes.ts
-Unresolved references mismatch:
-after transform: ["Array", "Object", "require"]
-rebuilt        : ["require"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentMergedModule.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -29042,13 +25139,8 @@ after transform: ["module"]
 rebuilt        : ["M1", "module"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportTypeMergedWithExportStarAsNamespace.ts
-Symbol reference IDs mismatch for "Something":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithExtensions.ts
 Bindings mismatch:
-after transform: ScopeId(0): ["a"]
+after transform: ScopeId(0): ["of"]
 rebuilt        : ScopeId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/nameWithRelativePaths.ts
@@ -29060,24 +25152,14 @@ Symbol span mismatch for "M2":
 after transform: SymbolId(0): Span { start: 17, end: 19 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/rewriteRelativeImportExtensions/nodeModulesTsFiles.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["add"]
-rebuilt        : ScopeId(0): []
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/topLevelAwait.2.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["foo"]
 rebuilt        : ScopeId(0): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeAndNamespaceExportMerge.ts
-Symbol reference IDs mismatch for "Drink":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/ambient.ts
 Bindings mismatch:
-after transform: ScopeId(0): ["A", "B", "ns"]
+after transform: ScopeId(0): ["B", "ns"]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["A"]
@@ -29089,54 +25171,9 @@ after transform: ["Error"]
 rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportDeclaration.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportDeclaration_value.ts
-Unresolved references mismatch:
-after transform: ["A"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/implementsClause.ts
 Bindings mismatch:
-after transform: ScopeId(0): ["types"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importDefaultNamedType.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["type"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importDefaultNamedType2.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["from"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/mergedWithLocalValue.ts
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | TypeImport)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(0): Span { start: 14, end: 15 }
-rebuilt        : SymbolId(0): Span { start: 36, end: 37 }
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
-Symbol redeclarations mismatch for "A":
-after transform: SymbolId(0): [Span { start: 14, end: 15 }, Span { start: 36, end: 37 }]
-rebuilt        : SymbolId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/namespaceImportTypeQuery2.ts
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | Import)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(0): Span { start: 9, end: 10 }
-rebuilt        : SymbolId(0): Span { start: 31, end: 32 }
-Symbol redeclarations mismatch for "A":
-after transform: SymbolId(0): [Span { start: 9, end: 10 }, Span { start: 31, end: 32 }]
-rebuilt        : SymbolId(0): []
+after transform: ScopeId(0): ["A", "a"]
+rebuilt        : ScopeId(0): ["A"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/nestedNamespace.ts
 Symbol flags mismatch for "types":
@@ -29145,32 +25182,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "types":
 after transform: SymbolId(0): Span { start: 17, end: 22 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/preserveValueImports.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["D", "a", "b", "c"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/preserveValueImports_errors.ts
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/typeQuery.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A", "AConstructor"]
-rebuilt        : ScopeId(0): ["AConstructor"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnlyMerge1.ts
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | Import)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(0): Span { start: 9, end: 10 }
-rebuilt        : SymbolId(0): Span { start: 31, end: 32 }
-Symbol redeclarations mismatch for "A":
-after transform: SymbolId(0): [Span { start: 9, end: 10 }, Span { start: 31, end: 32 }]
-rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeValueMerge1.ts
 Bindings mismatch:
@@ -29195,26 +25206,6 @@ Symbol redeclarations mismatch for "B":
 after transform: SymbolId(1): [Span { start: 67, end: 68 }, Span { start: 83, end: 84 }]
 rebuilt        : SymbolId(1): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd-augmentation-1.ts
-Symbol reference IDs mismatch for "m":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(3)]
-rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd-augmentation-2.ts
-Unresolved reference IDs mismatch for "Math2d":
-after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(3)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd-augmentation-3.ts
-Symbol reference IDs mismatch for "m":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(3)]
-rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd-augmentation-4.ts
-Unresolved reference IDs mismatch for "Math2d":
-after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(3)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/verbatimModuleSyntaxConstEnum.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "E"]
@@ -29238,9 +25229,18 @@ after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/verbatimModuleSyntaxRestrictionsESM.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["CJSy", "CJSy3", "types"]
-rebuilt        : ScopeId(0): ["CJSy"]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch for "ns":
+after transform: SymbolId(0): SymbolFlags(ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "ns":
+after transform: SymbolId(0): Span { start: 17, end: 19 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "A":
+after transform: SymbolId(1): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/functions/functionOverloadCompatibilityWithVoid02.ts
 Symbol span mismatch for "f":
@@ -29257,24 +25257,6 @@ rebuilt        : SymbolId(0): Span { start: 38, end: 39 }
 Symbol redeclarations mismatch for "f":
 after transform: SymbolId(0): [Span { start: 9, end: 10 }, Span { start: 38, end: 39 }]
 rebuilt        : SymbolId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/functions/strictBindCallApply2.ts
-Symbol reference IDs mismatch for "fn":
-after transform: SymbolId(1): [ReferenceId(2), ReferenceId(3)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
-Unresolved references mismatch:
-after transform: ["ThisParameterType"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnTypeFallback.5.ts
-Unresolved references mismatch:
-after transform: ["IterableIterator"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnTypeIndirectReferenceToGlobalType.ts
-Unresolved references mismatch:
-after transform: ["Iterator"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/generators/generatorYieldContextualType.ts
 Bindings mismatch:
@@ -29295,9 +25277,6 @@ rebuilt        : ScopeId(6): ScopeFlags(Function)
 Symbol flags mismatch for "Directive":
 after transform: SymbolId(12): SymbolFlags(RegularEnum | ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "Directive":
-after transform: SymbolId(12): [ReferenceId(14), ReferenceId(16), ReferenceId(64), ReferenceId(18), ReferenceId(51), ReferenceId(54), ReferenceId(93), ReferenceId(94), ReferenceId(108)]
-rebuilt        : SymbolId(3): [ReferenceId(13), ReferenceId(15), ReferenceId(19), ReferenceId(20)]
 Symbol redeclarations mismatch for "Directive":
 after transform: SymbolId(12): [Span { start: 318, end: 327 }, Span { start: 381, end: 390 }]
 rebuilt        : SymbolId(3): []
@@ -29307,15 +25286,9 @@ rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "StepResult":
 after transform: SymbolId(28): Span { start: 1257, end: 1267 }
 rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "StepResult":
-after transform: SymbolId(28): [ReferenceId(25), ReferenceId(29), ReferenceId(36), ReferenceId(41), ReferenceId(46), ReferenceId(90), ReferenceId(96), ReferenceId(97)]
-rebuilt        : SymbolId(8): [ReferenceId(23), ReferenceId(24), ReferenceId(33)]
 Symbol redeclarations mismatch for "StepResult":
 after transform: SymbolId(28): [Span { start: 1257, end: 1267 }, Span { start: 1321, end: 1331 }]
 rebuilt        : SymbolId(8): []
-Symbol reference IDs mismatch for "step":
-after transform: SymbolId(53): [ReferenceId(83), ReferenceId(84), ReferenceId(86)]
-rebuilt        : SymbolId(20): [ReferenceId(27), ReferenceId(29)]
 Reference symbol mismatch for "f1":
 after transform: SymbolId(0) "f1"
 rebuilt        : <None>
@@ -29323,38 +25296,8 @@ Reference symbol mismatch for "f2":
 after transform: SymbolId(6) "f2"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["AsyncGenerator", "Generator", "Partial", "Record", "Symbol", "require"]
+after transform: ["Symbol", "require"]
 rebuilt        : ["Symbol", "f1", "f2", "require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/importAttributes/importAttributes11.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["a"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/importAttributes/importAttributes7.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["_asyncToGenerator", "_f", "a", "f"]
-rebuilt        : ScopeId(0): ["_asyncToGenerator", "_f", "f"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/importAttributes/importAttributes8.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["a"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/importDefer/importBindingDefer.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["defer"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/importDefer/importBindingDefer2.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["defer"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/importDefer/importDeferDeclaration.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["ns"]
-rebuilt        : ScopeId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/inferFromBindingPattern.ts
 Bindings mismatch:
@@ -29442,7 +25385,7 @@ Reference symbol mismatch for "Constructor":
 after transform: SymbolId(15) "Constructor"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Partial", "Readonly", "require"]
+after transform: ["require"]
 rebuilt        : ["Constructor", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/AmbientModuleAndNonAmbientClassWithSameNameAndCommonRoot.ts
@@ -29469,9 +25412,6 @@ rebuilt        : ScopeId(10): ScopeFlags(Function)
 Symbol flags mismatch for "Point":
 after transform: SymbolId(0): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(Class)
-Symbol reference IDs mismatch for "Point":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(3)]
-rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3)]
 Symbol redeclarations mismatch for "Point":
 after transform: SymbolId(0): [Span { start: 6, end: 11 }, Span { start: 138, end: 143 }]
 rebuilt        : SymbolId(0): []
@@ -29484,9 +25424,6 @@ rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Point":
 after transform: SymbolId(5): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(Class)
-Symbol reference IDs mismatch for "Point":
-after transform: SymbolId(5): [ReferenceId(1), ReferenceId(5), ReferenceId(6), ReferenceId(8)]
-rebuilt        : SymbolId(7): [ReferenceId(7), ReferenceId(8), ReferenceId(9)]
 Symbol redeclarations mismatch for "Point":
 after transform: SymbolId(5): [Span { start: 253, end: 258 }, Span { start: 408, end: 413 }]
 rebuilt        : SymbolId(7): []
@@ -29504,9 +25441,6 @@ rebuilt        : ScopeId(7): ScopeFlags(Function)
 Symbol flags mismatch for "Point":
 after transform: SymbolId(0): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(Class)
-Symbol reference IDs mismatch for "Point":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(14)]
-rebuilt        : SymbolId(1): [ReferenceId(4), ReferenceId(5), ReferenceId(6)]
 Symbol redeclarations mismatch for "Point":
 after transform: SymbolId(0): [Span { start: 6, end: 11 }, Span { start: 127, end: 132 }]
 rebuilt        : SymbolId(1): []
@@ -29519,9 +25453,6 @@ rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Point":
 after transform: SymbolId(5): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(Class)
-Symbol reference IDs mismatch for "Point":
-after transform: SymbolId(5): [ReferenceId(1), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(18)]
-rebuilt        : SymbolId(8): [ReferenceId(10), ReferenceId(12), ReferenceId(13), ReferenceId(14)]
 Symbol redeclarations mismatch for "Point":
 after transform: SymbolId(5): [Span { start: 227, end: 232 }, Span { start: 371, end: 376 }]
 rebuilt        : SymbolId(8): []
@@ -29539,9 +25470,6 @@ rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol flags mismatch for "enumdule":
 after transform: SymbolId(0): SymbolFlags(RegularEnum | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "enumdule":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(5), ReferenceId(6), ReferenceId(12)]
-rebuilt        : SymbolId(0): [ReferenceId(5), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13)]
 Symbol redeclarations mismatch for "enumdule":
 after transform: SymbolId(0): [Span { start: 5, end: 13 }, Span { start: 43, end: 51 }]
 rebuilt        : SymbolId(0): []
@@ -29573,9 +25501,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "enumdule":
 after transform: SymbolId(0): Span { start: 10, end: 18 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "enumdule":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(5), ReferenceId(6), ReferenceId(14), ReferenceId(15)]
-rebuilt        : SymbolId(0): [ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(12), ReferenceId(13), ReferenceId(14)]
 Symbol redeclarations mismatch for "enumdule":
 after transform: SymbolId(0): [Span { start: 10, end: 18 }, Span { start: 121, end: 129 }]
 rebuilt        : SymbolId(0): []
@@ -29704,9 +25629,6 @@ rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "E":
 after transform: SymbolId(14): Span { start: 528, end: 529 }
 rebuilt        : SymbolId(14): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(15): [ReferenceId(8), ReferenceId(9)]
-rebuilt        : SymbolId(16): [ReferenceId(15)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportClassWhichExtendsInterfaceWithInaccessibleType.ts
 Scope flags mismatch:
@@ -29764,9 +25686,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "Point":
-after transform: SymbolId(1): [ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(0), ReferenceId(1), ReferenceId(8)]
-rebuilt        : SymbolId(2): [ReferenceId(3), ReferenceId(5)]
 Symbol flags mismatch for "B":
 after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
@@ -29786,9 +25705,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "Point":
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
-rebuilt        : SymbolId(2): [ReferenceId(4), ReferenceId(5)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportVariableWithAccessibleTypeInTypeAnnotation.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -29857,9 +25773,6 @@ rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "C":
 after transform: SymbolId(7): Span { start: 275, end: 276 }
 rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(7): [ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(17), ReferenceId(18)]
-rebuilt        : SymbolId(6): [ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13)]
 Symbol flags mismatch for "X":
 after transform: SymbolId(12): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
@@ -29896,9 +25809,6 @@ rebuilt        : SymbolId(30): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(26): Span { start: 1040, end: 1041 }
 rebuilt        : SymbolId(30): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "M":
-after transform: SymbolId(26): [ReferenceId(8), ReferenceId(9), ReferenceId(44), ReferenceId(45)]
-rebuilt        : SymbolId(30): [ReferenceId(46), ReferenceId(47), ReferenceId(48)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/asiPreventsParsingAsNamespace03.ts
 Scope flags mismatch:
@@ -29967,9 +25877,6 @@ rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M2":
 after transform: SymbolId(6): Span { start: 238, end: 240 }
 rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "M2":
-after transform: SymbolId(6): [ReferenceId(1), ReferenceId(3), ReferenceId(14), ReferenceId(15)]
-rebuilt        : SymbolId(5): [ReferenceId(10), ReferenceId(11), ReferenceId(12)]
 Symbol redeclarations mismatch for "M2":
 after transform: SymbolId(6): [Span { start: 238, end: 240 }, Span { start: 323, end: 325 }]
 rebuilt        : SymbolId(5): []
@@ -29979,9 +25886,6 @@ rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "X":
 after transform: SymbolId(9): Span { start: 349, end: 350 }
 rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
-Unresolved references mismatch:
-after transform: ["C"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/reExportAliasMakesInstantiated.ts
 Bindings mismatch:
@@ -29997,25 +25901,7 @@ Unresolved references mismatch:
 after transform: ["mod1"]
 rebuilt        : ["mod2", "pack2"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocLinkTag1.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocLinkTag3.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A", "foo"]
-rebuilt        : ScopeId(0): ["foo"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocLinkTag4.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["a", "foo"]
-rebuilt        : ScopeId(0): ["foo"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocLinkTag9.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A", "Enum"]
-rebuilt        : ScopeId(0): ["Enum"]
 Bindings mismatch:
 after transform: ScopeId(1): ["Enum", "EnumValue"]
 rebuilt        : ScopeId(1): ["Enum"]
@@ -30030,11 +25916,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/seeTag1.
 Bindings mismatch:
 after transform: ScopeId(0): ["NS", "a", "b", "c"]
 rebuilt        : ScopeId(0): ["a", "b", "c"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty1.tsx
-Unresolved references mismatch:
-after transform: ["JSX", "require"]
-rebuilt        : ["require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty16.tsx
 Bindings mismatch:
@@ -30053,23 +25934,8 @@ Reference symbol mismatch for "Foo":
 after transform: SymbolId(4) "Foo"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["JSX"]
+after transform: []
 rebuilt        : ["Foo"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty3.tsx
-Unresolved references mismatch:
-after transform: ["JSX", "require"]
-rebuilt        : ["require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty6.tsx
-Unresolved references mismatch:
-after transform: ["JSX", "require"]
-rebuilt        : ["require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty8.tsx
-Unresolved references mismatch:
-after transform: ["JSX", "require"]
-rebuilt        : ["require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxIntersectionElementPropsType.tsx
 Bindings mismatch:
@@ -30079,23 +25945,8 @@ Reference symbol mismatch for "Component":
 after transform: SymbolId(2) "Component"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Readonly", "require"]
+after transform: ["require"]
 rebuilt        : ["Component", "require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxSubtleSkipContextSensitiveBug.tsx
-Unresolved references mismatch:
-after transform: ["Exclude", "Promise", "arguments"]
-rebuilt        : ["arguments"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/jsx/inline/inlineJsxAndJsxFragPragmaOverridesCompilerOptions.tsx
-Bindings mismatch:
-after transform: ScopeId(0): ["Fragment", "_jsxFileName", "createElement"]
-rebuilt        : ScopeId(0): ["_jsxFileName"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/jsx/inline/inlineJsxFactoryOverridesCompilerOption.tsx
-Bindings mismatch:
-after transform: ScopeId(0): ["_jsxFileName", "p"]
-rebuilt        : ScopeId(0): ["_jsxFileName"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxParsingError4.tsx
 Bindings mismatch:
@@ -30110,11 +25961,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["React"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformNestedSelfClosingChild.tsx
-Bindings mismatch:
-after transform: ScopeId(0): ["React", "_jsx", "_jsxFileName", "_jsxs"]
-rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName", "_jsxs"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution.tsx
 Bindings mismatch:
@@ -30276,14 +26122,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["React"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType9.tsx
-Symbol reference IDs mismatch for "React":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2)]
-rebuilt        : SymbolId(3): [ReferenceId(1)]
-Unresolved references mismatch:
-after transform: ["JSX", "require"]
-rebuilt        : ["require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxOpeningClosingNames.tsx
 Bindings mismatch:
@@ -30468,104 +26306,14 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["React"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionTypeComponent1.tsx
-Symbol reference IDs mismatch for "React":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(6), ReferenceId(11), ReferenceId(13), ReferenceId(15), ReferenceId(17)]
-rebuilt        : SymbolId(1): [ReferenceId(1), ReferenceId(2), ReferenceId(5), ReferenceId(7), ReferenceId(10), ReferenceId(11)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/allowImportingTypesDtsExtension.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["User", "getUser", "user"]
-rebuilt        : ScopeId(0): ["getUser", "user"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/bundler/bundlerDirectoryModule.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["test"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/bundler/bundlerImportESM.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["esm"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/customConditions.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["_"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/extensionLoadingPriority.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["a", "dir"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/resolutionModeTypeOnlyImport1.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["Default", "Import", "ImportRelative", "Require", "RequireRelative"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/resolvesWithoutExportsDiagnostic1.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["bar", "foo"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/scopedPackages.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["x", "y", "z"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/selfNameModuleAugmentation.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["simple"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/node/esmModuleExports2.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["Foo", "Foo2", "Foo3", "Oops"]
-rebuilt        : ScopeId(0): ["Foo", "Foo2", "Foo3"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit1.ts
-Unresolved references mismatch:
-after transform: ["RequireInterface"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit2.ts
-Unresolved references mismatch:
-after transform: ["ImportInterface"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit3.ts
-Unresolved references mismatch:
-after transform: ["RequireInterface"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit4.ts
-Unresolved references mismatch:
-after transform: ["ImportInterface"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit5.ts
-Unresolved references mismatch:
-after transform: ["ImportInterface", "RequireInterface"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit6.ts
-Symbol reference IDs mismatch for "obj":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit7.ts
-Unresolved references mismatch:
-after transform: ["const"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/nonjsExtensions/declarationFileForHtmlFileWithinDeclarationFile.ts
 Unresolved references mismatch:
-after transform: ["Document", "Element", "HTMLElement"]
+after transform: ["HTMLElement"]
 rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/nonjsExtensions/declarationFileForHtmlImport.ts
 Unresolved references mismatch:
-after transform: ["Document", "Element", "HTMLElement"]
+after transform: ["HTMLElement"]
 rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration17.ts
@@ -30770,16 +26518,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["A", "B", "C"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserOverloadOnConstants1.ts
-Unresolved references mismatch:
-after transform: ["HTMLCanvasElement", "HTMLDivElement", "HTMLElement", "HTMLSpanElement"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty1.ts
-Unresolved references mismatch:
-after transform: ["Symbol"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty2.ts
 Unresolved references mismatch:
 after transform: ["Symbol"]
@@ -30806,23 +26544,10 @@ Unresolved references mismatch:
 after transform: ["Symbol"]
 rebuilt        : []
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty9.ts
-Unresolved references mismatch:
-after transform: ["Symbol"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/salsa/inferingFromAny.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["a", "f1", "f10", "f11", "f12", "f13", "f14", "f15", "f16", "f17", "f18", "f19", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "t"]
 rebuilt        : ScopeId(0): ["a", "t"]
-Unresolved references mismatch:
-after transform: ["Partial"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/salsa/requireAssertsFromTypescript.ts
-Unresolved references mismatch:
-after transform: ["Error"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/salsa/sourceFileMergeWithFunction.ts
 Bindings mismatch:
@@ -30844,23 +26569,12 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/statements/Var
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
-Symbol reference IDs mismatch for "D":
-after transform: SymbolId(2): [ReferenceId(2), ReferenceId(4), ReferenceId(5), ReferenceId(13)]
-rebuilt        : SymbolId(2): [ReferenceId(18)]
 Symbol flags mismatch for "M":
 after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(6): Span { start: 201, end: 202 }
 rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsDeclarationEmit.2.ts
-Symbol reference IDs mismatch for "r1":
-after transform: SymbolId(0): [ReferenceId(1)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch for "r2":
-after transform: SymbolId(2): [ReferenceId(3)]
-rebuilt        : SymbolId(4): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsNamedEvaluationDecoratorsAndClassFields.ts
 Bindings mismatch:
@@ -30876,29 +26590,16 @@ Unresolved references mismatch:
 after transform: ["Symbol"]
 rebuilt        : ["Symbol", "dec"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/statements/for-inStatements/for-inStatementsArray.ts
-Unresolved references mismatch:
-after transform: ["Date"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/statements/throwStatements/throwStatements.ts
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
-Symbol reference IDs mismatch for "D":
-after transform: SymbolId(2): [ReferenceId(2), ReferenceId(4), ReferenceId(5), ReferenceId(21), ReferenceId(42)]
-rebuilt        : SymbolId(2): [ReferenceId(26), ReferenceId(46)]
 Symbol flags mismatch for "M":
 after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(6): Span { start: 215, end: 216 }
 rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.1.ts
-Unresolved references mismatch:
-after transform: ["AsyncIterable", "AsyncIterableIterator", "AsyncIterator", "Promise", "PromiseLike", "arguments", "require"]
-rebuilt        : ["Promise", "arguments", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/conditional/inferTypes2.ts
 Bindings mismatch:
@@ -30925,21 +26626,8 @@ Reference symbol mismatch for "x2":
 after transform: SymbolId(145) "x2"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise"]
+after transform: []
 rebuilt        : ["x1", "x2"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/conditional/variance.ts
-Symbol reference IDs mismatch for "Bar":
-after transform: SymbolId(6): [ReferenceId(8), ReferenceId(10), ReferenceId(11)]
-rebuilt        : SymbolId(5): [ReferenceId(4), ReferenceId(6)]
-Unresolved references mismatch:
-after transform: ["const", "require"]
-rebuilt        : ["require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/asyncFunctions/contextuallyTypeAsyncFunctionAwaitOperand.ts
-Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(0), ReferenceId(4)]
-rebuilt        : [ReferenceId(5)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/asyncFunctions/contextuallyTypeAsyncFunctionReturnType.ts
 Bindings mismatch:
@@ -30955,11 +26643,8 @@ Reference symbol mismatch for "scanMetadata":
 after transform: SymbolId(31) "scanMetadata"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Error", "Promise", "PromiseLike", "arguments"]
+after transform: ["Error", "Promise", "arguments"]
 rebuilt        : ["Error", "Promise", "arguments", "getProcessTree", "scanMetadata", "test"]
-Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(24), ReferenceId(31), ReferenceId(34), ReferenceId(37)]
-rebuilt        : [ReferenceId(10), ReferenceId(24), ReferenceId(30), ReferenceId(40)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/partiallyAnnotatedFunction/partiallyAnnotatedFunctionWitoutTypeParameter.ts
 Bindings mismatch:
@@ -31016,7 +26701,7 @@ Reference symbol mismatch for "iterableOfPromise":
 after transform: SymbolId(2) "iterableOfPromise"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["AsyncIterable", "Iterable", "Promise", "arguments", "require"]
+after transform: ["arguments", "require"]
 rebuilt        : ["arguments", "asyncIterable", "iterable", "iterableOfPromise", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionMemberOfUnionNarrowsCorrectly.ts
@@ -31057,17 +26742,6 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "E":
 after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "E":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(32), ReferenceId(33), ReferenceId(34), ReferenceId(35), ReferenceId(36), ReferenceId(37), ReferenceId(38), ReferenceId(39), ReferenceId(40), ReferenceId(41), ReferenceId(42), ReferenceId(43), ReferenceId(44), ReferenceId(58)]
-rebuilt        : SymbolId(0): [ReferenceId(13)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionTypeEquivalence.ts
-Symbol reference IDs mismatch for "ab":
-after transform: SymbolId(5): [ReferenceId(17)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "bc":
-after transform: SymbolId(6): [ReferenceId(20)]
-rebuilt        : SymbolId(3): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionTypeInference2.ts
 Bindings mismatch:
@@ -31115,7 +26789,7 @@ Reference symbol mismatch for "from":
 after transform: SymbolId(7) "from"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Array", "ReadonlyArray", "Set", "Symbol"]
+after transform: ["Array"]
 rebuilt        : ["Array", "a", "b", "from"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionsAndEmptyObjects.ts
@@ -31126,13 +26800,8 @@ Reference symbol mismatch for "mock":
 after transform: SymbolId(47) "mock"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Object", "Promise"]
+after transform: ["Object"]
 rebuilt        : ["Object", "mock"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/keyof/keyofIntersection.ts
-Unresolved references mismatch:
-after transform: ["Record"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/booleanLiteralTypes1.ts
 Bindings mismatch:
@@ -31181,9 +26850,6 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "Choice":
 after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "Choice":
-after transform: SymbolId(0): [ReferenceId(15), ReferenceId(22), ReferenceId(59), ReferenceId(63), ReferenceId(64), ReferenceId(65), ReferenceId(68), ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(70), ReferenceId(72), ReferenceId(82), ReferenceId(83), ReferenceId(86), ReferenceId(87), ReferenceId(96), ReferenceId(99), ReferenceId(100), ReferenceId(103), ReferenceId(105), ReferenceId(109), ReferenceId(111), ReferenceId(122)]
-rebuilt        : SymbolId(0): [ReferenceId(7), ReferenceId(52), ReferenceId(54), ReferenceId(63), ReferenceId(64), ReferenceId(66), ReferenceId(67), ReferenceId(74), ReferenceId(78), ReferenceId(80), ReferenceId(83), ReferenceId(85)]
 Reference symbol mismatch for "g":
 after transform: SymbolId(21) "g"
 rebuilt        : <None>
@@ -31216,9 +26882,6 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "Choice":
 after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "Choice":
-after transform: SymbolId(0): [ReferenceId(15), ReferenceId(22), ReferenceId(59), ReferenceId(63), ReferenceId(64), ReferenceId(65), ReferenceId(68), ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(70), ReferenceId(72), ReferenceId(82), ReferenceId(83), ReferenceId(86), ReferenceId(87), ReferenceId(96), ReferenceId(99), ReferenceId(100), ReferenceId(103), ReferenceId(105), ReferenceId(109), ReferenceId(111), ReferenceId(122)]
-rebuilt        : SymbolId(0): [ReferenceId(7), ReferenceId(52), ReferenceId(54), ReferenceId(63), ReferenceId(64), ReferenceId(66), ReferenceId(67), ReferenceId(74), ReferenceId(78), ReferenceId(80), ReferenceId(83), ReferenceId(85)]
 Reference symbol mismatch for "g":
 after transform: SymbolId(21) "g"
 rebuilt        : <None>
@@ -31254,21 +26917,12 @@ rebuilt        : SymbolId(62): SymbolFlags(BlockScopedVariable | ConstVariable)
 Symbol span mismatch for "FAILURE":
 after transform: SymbolId(65): Span { start: 2229, end: 2236 }
 rebuilt        : SymbolId(62): Span { start: 2256, end: 2263 }
-Symbol reference IDs mismatch for "FAILURE":
-after transform: SymbolId(65): [ReferenceId(66), ReferenceId(55), ReferenceId(58), ReferenceId(68)]
-rebuilt        : SymbolId(62): [ReferenceId(50), ReferenceId(54)]
 Symbol redeclarations mismatch for "FAILURE":
 after transform: SymbolId(65): [Span { start: 2229, end: 2236 }, Span { start: 2256, end: 2263 }]
 rebuilt        : SymbolId(62): []
-Symbol reference IDs mismatch for "langCodeSet":
-after transform: SymbolId(92): [ReferenceId(95), ReferenceId(97)]
-rebuilt        : SymbolId(79): [ReferenceId(70)]
 Symbol flags mismatch for "E":
 after transform: SymbolId(105): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(87): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "E":
-after transform: SymbolId(105): [ReferenceId(110), ReferenceId(111), ReferenceId(122)]
-rebuilt        : SymbolId(87): [ReferenceId(84), ReferenceId(86)]
 Reference symbol mismatch for "widening":
 after transform: SymbolId(51) "widening"
 rebuilt        : <None>
@@ -31291,7 +26945,7 @@ Reference symbol mismatch for "f":
 after transform: SymbolId(102) "f"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["NonNullable", "Object", "Record"]
+after transform: ["Object"]
 rebuilt        : ["Object", "f", "nonWidening", "widening"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/literalTypes2.ts
@@ -31307,9 +26961,6 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "E":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "E":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(4), ReferenceId(5), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(13), ReferenceId(30), ReferenceId(31), ReferenceId(35), ReferenceId(95)]
-rebuilt        : SymbolId(1): [ReferenceId(9), ReferenceId(13), ReferenceId(8), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(14), ReferenceId(15), ReferenceId(19), ReferenceId(44), ReferenceId(53), ReferenceId(57)]
 Reference symbol mismatch for "g1":
 after transform: SymbolId(98) "g1"
 rebuilt        : <None>
@@ -31376,7 +27027,7 @@ Reference symbol mismatch for "x":
 after transform: SymbolId(0) "x"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["const"]
+after transform: []
 rebuilt        : ["x"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/numericLiteralTypes1.ts
@@ -31439,7 +27090,7 @@ Reference symbol mismatch for "f":
 after transform: SymbolId(30) "f"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Capitalize"]
+after transform: []
 rebuilt        : ["createContainer", "f"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringEnumLiteralTypes1.ts
@@ -31455,9 +27106,6 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "Choice":
 after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "Choice":
-after transform: SymbolId(0): [ReferenceId(15), ReferenceId(22), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(48), ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(50), ReferenceId(52), ReferenceId(62), ReferenceId(63), ReferenceId(66), ReferenceId(67), ReferenceId(76), ReferenceId(79), ReferenceId(80), ReferenceId(83), ReferenceId(85), ReferenceId(89), ReferenceId(91), ReferenceId(99)]
-rebuilt        : SymbolId(0): [ReferenceId(4), ReferenceId(31), ReferenceId(33), ReferenceId(42), ReferenceId(43), ReferenceId(45), ReferenceId(46), ReferenceId(53), ReferenceId(57), ReferenceId(59), ReferenceId(62), ReferenceId(64)]
 Reference symbol mismatch for "g":
 after transform: SymbolId(18) "g"
 rebuilt        : <None>
@@ -31490,9 +27138,6 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "Choice":
 after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "Choice":
-after transform: SymbolId(0): [ReferenceId(15), ReferenceId(22), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(48), ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(50), ReferenceId(52), ReferenceId(62), ReferenceId(63), ReferenceId(66), ReferenceId(67), ReferenceId(76), ReferenceId(79), ReferenceId(80), ReferenceId(83), ReferenceId(85), ReferenceId(89), ReferenceId(91), ReferenceId(99)]
-rebuilt        : SymbolId(0): [ReferenceId(4), ReferenceId(31), ReferenceId(33), ReferenceId(42), ReferenceId(43), ReferenceId(45), ReferenceId(46), ReferenceId(53), ReferenceId(57), ReferenceId(59), ReferenceId(62), ReferenceId(64)]
 Reference symbol mismatch for "g":
 after transform: SymbolId(18) "g"
 rebuilt        : <None>
@@ -31512,11 +27157,6 @@ Unresolved references mismatch:
 after transform: ["Error"]
 rebuilt        : ["Error", "g"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringMappingDeferralInConditionalTypes.ts
-Unresolved references mismatch:
-after transform: ["Capitalize", "Lowercase"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringMappingReduction.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["_virtualOn", "virtualOn"]
@@ -31525,7 +27165,7 @@ Reference symbol mismatch for "_virtualOn":
 after transform: SymbolId(19) "_virtualOn"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Capitalize", "Lowercase"]
+after transform: []
 rebuilt        : ["_virtualOn"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/templateLiteralTypes6.ts
@@ -31549,14 +27189,6 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "E":
 after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "E":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(3), ReferenceId(7)]
-rebuilt        : SymbolId(0): [ReferenceId(3)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/localTypes/localTypes5.ts
-Unresolved references mismatch:
-after transform: ["Date"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/mapped/isomorphicMappedTypeInference.ts
 Bindings mismatch:
@@ -31593,23 +27225,8 @@ Reference symbol mismatch for "f24":
 after transform: SymbolId(111) "f24"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Partial", "Pick"]
+after transform: []
 rebuilt        : ["applySpec", "clone", "f20", "f21", "f22", "f23", "f24", "validate", "validateAndClone"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeConstraints.ts
-Unresolved references mismatch:
-after transform: ["Exclude", "Extract", "Pick", "Record", "require"]
-rebuilt        : ["require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeIndexSignatureModifiers.ts
-Unresolved references mismatch:
-after transform: ["Pick"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeModifiers.ts
-Unresolved references mismatch:
-after transform: ["Partial", "Pick", "Readonly"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeOverlappingStringEnumKeys.ts
 Bindings mismatch:
@@ -31627,18 +27244,9 @@ rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol flags mismatch for "TerrestrialAnimalTypes":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "TerrestrialAnimalTypes":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(11), ReferenceId(16)]
-rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(7)]
 Symbol flags mismatch for "AlienAnimalTypes":
 after transform: SymbolId(3): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "AlienAnimalTypes":
-after transform: SymbolId(3): [ReferenceId(1), ReferenceId(3), ReferenceId(12), ReferenceId(19)]
-rebuilt        : SymbolId(2): [ReferenceId(6), ReferenceId(8)]
-Unresolved references mismatch:
-after transform: ["Extract"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypes1.ts
 Bindings mismatch:
@@ -31657,7 +27265,7 @@ Reference symbol mismatch for "f4":
 after transform: SymbolId(56) "f4"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Array", "Date", "Number"]
+after transform: []
 rebuilt        : ["f1", "f2", "f3", "f4"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypes2.ts
@@ -31683,13 +27291,8 @@ Reference symbol mismatch for "proxify":
 after transform: SymbolId(40) "proxify"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Partial", "Pick", "Readonly", "Record"]
+after transform: []
 rebuilt        : ["assign", "freeze", "mapObject", "pick", "proxify"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypes4.ts
-Unresolved references mismatch:
-after transform: ["Partial", "Readonly"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypesArraysTuples.ts
 Bindings mismatch:
@@ -31750,13 +27353,8 @@ Reference symbol mismatch for "mapArray":
 after transform: SymbolId(86) "mapArray"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Array", "Partial", "Promise", "PromiseLike", "Readonly", "ReadonlyArray", "Required"]
+after transform: []
 rebuilt        : ["acceptArray", "all", "mapArray", "nonpartial", "unboxify", "x10", "x11", "x12", "x20", "x21", "x22"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypesGenericTuples.ts
-Unresolved references mismatch:
-after transform: ["Readonly"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypesGenericTuples2.ts
 Bindings mismatch:
@@ -31771,43 +27369,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["Promise"]
 rebuilt        : ["Promise", "getT"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithCallSignatureHidingMembersOfExtendedFunction.ts
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithConstructSignatureHidingMembersOfExtendedFunction.ts
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithStringNamedPropertyOfIllegalCharacters.ts
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(22)]
-rebuilt        : SymbolId(1): [ReferenceId(6)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/members/typesWithSpecializedCallSignatures.ts
-Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(4), ReferenceId(0), ReferenceId(1), ReferenceId(9), ReferenceId(13), ReferenceId(30)]
-rebuilt        : SymbolId(1): [ReferenceId(2), ReferenceId(5)]
-Symbol reference IDs mismatch for "Derived1":
-after transform: SymbolId(1): [ReferenceId(2), ReferenceId(7), ReferenceId(11), ReferenceId(26)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "Derived2":
-after transform: SymbolId(2): [ReferenceId(3), ReferenceId(8), ReferenceId(12), ReferenceId(28)]
-rebuilt        : SymbolId(4): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/members/typesWithSpecializedConstructSignatures.ts
-Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(6), ReferenceId(10), ReferenceId(22)]
-rebuilt        : SymbolId(1): [ReferenceId(2), ReferenceId(5)]
-Symbol reference IDs mismatch for "Derived1":
-after transform: SymbolId(1): [ReferenceId(4), ReferenceId(8)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "Derived2":
-after transform: SymbolId(2): [ReferenceId(5), ReferenceId(9), ReferenceId(20)]
-rebuilt        : SymbolId(4): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/namedTypes/genericInstantiationEquivalentToObjectLiteral.ts
 Bindings mismatch:
@@ -31828,11 +27389,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["f", "f2"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/namedTypes/optionalMethods.ts
-Symbol reference IDs mismatch for "Bar":
-after transform: SymbolId(6): [ReferenceId(10)]
-rebuilt        : SymbolId(6): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/never/neverInference.ts
 Bindings mismatch:
@@ -31894,9 +27450,6 @@ rebuilt        : ScopeId(31): ScopeFlags(Function)
 Scope flags mismatch:
 after transform: ScopeId(33): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(32): ScopeFlags(Function)
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(30): [ReferenceId(18)]
-rebuilt        : SymbolId(29): []
 Symbol flags mismatch for "M":
 after transform: SymbolId(35): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(34): SymbolFlags(BlockScopedVariable)
@@ -31922,16 +27475,6 @@ Symbol redeclarations mismatch for "e1":
 after transform: SymbolId(53): [Span { start: 1511, end: 1513 }, Span { start: 1530, end: 1532 }]
 rebuilt        : SymbolId(54): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesThatDifferOnlyByReturnType.ts
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithOptionalParameters.ts
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(8): [ReferenceId(6)]
-rebuilt        : SymbolId(8): []
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithOptionalParameters2.ts
 Symbol span mismatch for "foo":
 after transform: SymbolId(0): Span { start: 72, end: 75 }
@@ -31945,9 +27488,6 @@ rebuilt        : SymbolId(2): Span { start: 208, end: 212 }
 Symbol redeclarations mismatch for "foo2":
 after transform: SymbolId(3): [Span { start: 144, end: 148 }, Span { start: 170, end: 174 }, Span { start: 208, end: 212 }]
 rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(9): [ReferenceId(4)]
-rebuilt        : SymbolId(5): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/specializedSignatureIsSubtypeOfNonSpecializedSignature.ts
 Symbol span mismatch for "foo":
@@ -31956,22 +27496,11 @@ rebuilt        : SymbolId(0): Span { start: 170, end: 173 }
 Symbol redeclarations mismatch for "foo":
 after transform: SymbolId(0): [Span { start: 123, end: 126 }, Span { start: 145, end: 148 }, Span { start: 170, end: 173 }]
 rebuilt        : SymbolId(0): []
-Unresolved references mismatch:
-after transform: ["String"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/specializedSignatureWithOptional.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["f"]
 rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/constructSignatures/constructSignaturesWithOverloadsThatDifferOnlyByReturnType.ts
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(6), ReferenceId(11), ReferenceId(13), ReferenceId(18)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "C2":
-after transform: SymbolId(2): [ReferenceId(2), ReferenceId(4), ReferenceId(8), ReferenceId(12), ReferenceId(15)]
-rebuilt        : SymbolId(2): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/propertySignatures/propertyNamesOfReservedWords.ts
 Bindings mismatch:
@@ -31980,17 +27509,9 @@ rebuilt        : ScopeId(3): ["E"]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(0x0)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(1): []
 Symbol flags mismatch for "E":
 after transform: SymbolId(11): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(11): SymbolFlags(FunctionScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/primitives/boolean/validBooleanAssignments.ts
-Unresolved references mismatch:
-after transform: ["Boolean", "Object"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/primitives/number/validNumberAssignments.ts
 Bindings mismatch:
@@ -32002,17 +27523,6 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "E":
 after transform: SymbolId(4): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "E":
-after transform: SymbolId(4): [ReferenceId(4), ReferenceId(6), ReferenceId(12)]
-rebuilt        : SymbolId(4): [ReferenceId(6), ReferenceId(8)]
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/primitives/string/validStringAssignments.ts
-Unresolved references mismatch:
-after transform: ["Object", "String"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/primitives/stringLiteral/stringLiteralType.ts
 Symbol span mismatch for "f":
@@ -32021,19 +27531,6 @@ rebuilt        : SymbolId(1): Span { start: 67, end: 68 }
 Symbol redeclarations mismatch for "f":
 after transform: SymbolId(1): [Span { start: 23, end: 24 }, Span { start: 44, end: 45 }, Span { start: 67, end: 68 }]
 rebuilt        : SymbolId(1): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/primitives/undefined/validUndefinedValues.ts
-Unresolved reference IDs mismatch for "undefined":
-after transform: [ReferenceId(0), ReferenceId(2)]
-rebuilt        : [ReferenceId(1)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/rest/genericObjectRest.ts
-Symbol reference IDs mismatch for "sa":
-after transform: SymbolId(16): [ReferenceId(10), ReferenceId(13), ReferenceId(51)]
-rebuilt        : SymbolId(23): [ReferenceId(32), ReferenceId(37)]
-Symbol reference IDs mismatch for "sb":
-after transform: SymbolId(17): [ReferenceId(11), ReferenceId(14), ReferenceId(52)]
-rebuilt        : SymbolId(24): [ReferenceId(33), ReferenceId(38)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/rest/genericRestParameters2.ts
 Bindings mismatch:
@@ -32292,7 +27789,7 @@ Reference symbol mismatch for "t2":
 after transform: SymbolId(1) "t2"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["ConstructorParameters", "Function", "Parameters"]
+after transform: []
 rebuilt        : ["f10", "f11", "f12", "f13", "f20", "t1", "t2", "t3", "t4"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/rest/objectRest2.ts
@@ -32319,75 +27816,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["require"]
 rebuilt        : ["require", "suddenly"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/rest/objectRestReadonly.ts
-Unresolved references mismatch:
-after transform: ["Readonly", "require"]
-rebuilt        : ["require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeLiterals/arrayTypeOfTypeOf.ts
-Symbol reference IDs mismatch for "x":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(4)]
-rebuilt        : SymbolId(0): []
-Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeLiterals/functionLiteralForOverloads2.ts
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5)]
-rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-Symbol reference IDs mismatch for "D":
-after transform: SymbolId(4): [ReferenceId(6), ReferenceId(8), ReferenceId(10)]
-rebuilt        : SymbolId(2): [ReferenceId(2)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeLiterals/parenthesizedTypes.ts
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(5)]
-rebuilt        : SymbolId(0): []
-Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeQueryOnClass.ts
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(10), ReferenceId(12)]
-rebuilt        : SymbolId(1): [ReferenceId(5), ReferenceId(7)]
-Symbol reference IDs mismatch for "c":
-after transform: SymbolId(12): [ReferenceId(2)]
-rebuilt        : SymbolId(8): []
-Symbol reference IDs mismatch for "D":
-after transform: SymbolId(15): [ReferenceId(4), ReferenceId(5)]
-rebuilt        : SymbolId(11): []
-Symbol reference IDs mismatch for "d":
-after transform: SymbolId(18): [ReferenceId(6)]
-rebuilt        : SymbolId(13): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeQueryWithReservedWords.ts
-Symbol reference IDs mismatch for "Controller":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
-rebuilt        : SymbolId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofClass2.ts
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
-Symbol reference IDs mismatch for "D":
-after transform: SymbolId(8): [ReferenceId(2), ReferenceId(3)]
-rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch for "d":
-after transform: SymbolId(10): [ReferenceId(4)]
-rebuilt        : SymbolId(6): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpreadRepeatedComplexity.ts
-Unresolved references mismatch:
-after transform: ["Record", "require"]
-rebuilt        : ["require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpreadRepeatedNullCheckPerf.ts
-Unresolved references mismatch:
-after transform: ["Record", "require", "undefined"]
-rebuilt        : ["require", "undefined"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadContextualTypedBindingPattern.ts
 Bindings mismatch:
@@ -32456,30 +27884,6 @@ rebuilt        : SymbolId(0): Span { start: 599, end: 606 }
 Symbol redeclarations mismatch for "hasKind":
 after transform: SymbolId(4): [Span { start: 471, end: 478 }, Span { start: 535, end: 542 }, Span { start: 599, end: 606 }]
 rebuilt        : SymbolId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesInUnionTypes01.ts
-Symbol reference IDs mismatch for "x":
-after transform: SymbolId(1): [ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(14), ReferenceId(17)]
-rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(7), ReferenceId(11), ReferenceId(14)]
-Symbol reference IDs mismatch for "y":
-after transform: SymbolId(2): [ReferenceId(7), ReferenceId(9), ReferenceId(11), ReferenceId(15), ReferenceId(16)]
-rebuilt        : SymbolId(1): [ReferenceId(6), ReferenceId(8), ReferenceId(12), ReferenceId(13)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesInUnionTypes02.ts
-Symbol reference IDs mismatch for "x":
-after transform: SymbolId(1): [ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(14), ReferenceId(17)]
-rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(7), ReferenceId(11), ReferenceId(14)]
-Symbol reference IDs mismatch for "y":
-after transform: SymbolId(2): [ReferenceId(7), ReferenceId(9), ReferenceId(11), ReferenceId(15), ReferenceId(16)]
-rebuilt        : SymbolId(1): [ReferenceId(6), ReferenceId(8), ReferenceId(12), ReferenceId(13)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesInUnionTypes03.ts
-Symbol reference IDs mismatch for "x":
-after transform: SymbolId(1): [ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(7), ReferenceId(9), ReferenceId(13), ReferenceId(16)]
-rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(6), ReferenceId(10), ReferenceId(13)]
-Symbol reference IDs mismatch for "y":
-after transform: SymbolId(2): [ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(14), ReferenceId(15)]
-rebuilt        : SymbolId(1): [ReferenceId(5), ReferenceId(7), ReferenceId(11), ReferenceId(12)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloadAssignability03.ts
 Symbol span mismatch for "f":
@@ -32701,11 +28105,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["f", "h"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeAndConstraints.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(8)]
-rebuilt        : SymbolId(0): []
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInFunctions3.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["Base", "Test"]
@@ -32731,16 +28130,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["callsCallback", "isCorrect"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInInterfaces.ts
-Unresolved references mismatch:
-after transform: ["Date"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInTaggedTemplateCall.ts
-Unresolved references mismatch:
-after transform: ["TemplateStringsArray"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInTypePredicate.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["filter", "numbers"]
@@ -32756,9 +28145,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/tuple/na
 Bindings mismatch:
 after transform: ScopeId(0): ["a", "argumentsOfG", "argumentsOfGAsFirstArgument", "b", "c", "d", "f", "func", "g", "getArgsForInjection", "q", "r", "readSegment", "useState", "val", "x", "y"]
 rebuilt        : ScopeId(0): ["argumentsOfG", "argumentsOfGAsFirstArgument", "func", "readSegment", "useState", "val"]
-Symbol reference IDs mismatch for "readSegment":
-after transform: SymbolId(16): [ReferenceId(33)]
-rebuilt        : SymbolId(3): []
 Reference symbol mismatch for "a":
 after transform: SymbolId(2) "a"
 rebuilt        : <None>
@@ -32874,7 +28260,7 @@ Reference symbol mismatch for "g":
 after transform: SymbolId(31) "g"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Parameters"]
+after transform: []
 rebuilt        : ["a", "b", "c", "d", "f", "g", "getArgsForInjection", "q", "r", "x", "y"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/tuple/named/partiallyNamedTuples.ts
@@ -32890,11 +28276,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["input", "test"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/tuple/named/partiallyNamedTuples2.ts
-Unresolved references mismatch:
-after transform: ["Iterable"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/tuple/named/partiallyNamedTuples3.ts
 Bindings mismatch:
@@ -32918,11 +28299,8 @@ Reference symbol mismatch for "someDec":
 after transform: SymbolId(11) "someDec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Array", "ReadonlyArray", "require"]
+after transform: ["Array", "require"]
 rebuilt        : ["Array", "require", "someDec"]
-Unresolved reference IDs mismatch for "Array":
-after transform: [ReferenceId(0), ReferenceId(6), ReferenceId(10)]
-rebuilt        : [ReferenceId(8), ReferenceId(13)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/tuple/wideningTuples1.ts
 Bindings mismatch:
@@ -32996,7 +28374,7 @@ Reference symbol mismatch for "set":
 after transform: SymbolId(2) "set"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Iterable", "IterableIterator", "Map", "Set", "Symbol"]
+after transform: ["Symbol"]
 rebuilt        : ["Symbol", "array", "map", "set"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/constraintSatisfactionWithAny2.ts
@@ -33012,50 +28390,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["foo"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/constraintSatisfactionWithEmptyObject.ts
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction.ts
-Unresolved references mismatch:
-after transform: ["Date", "Function", "require"]
-rebuilt        : ["Function", "require"]
-Unresolved reference IDs mismatch for "Function":
-after transform: [ReferenceId(0), ReferenceId(6), ReferenceId(58)]
-rebuilt        : [ReferenceId(4)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/wrappedAndRecursiveConstraints.ts
-Unresolved references mismatch:
-after transform: ["Date"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/wrappedAndRecursiveConstraints2.ts
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(3), ReferenceId(4), ReferenceId(5)]
-rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithConstraints.ts
-Unresolved reference IDs mismatch for "Date":
-after transform: [ReferenceId(0), ReferenceId(6), ReferenceId(7), ReferenceId(10), ReferenceId(13), ReferenceId(16), ReferenceId(18), ReferenceId(24)]
-rebuilt        : [ReferenceId(12)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithConstraints2.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(49), ReferenceId(50), ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(13), ReferenceId(16), ReferenceId(18), ReferenceId(19), ReferenceId(23), ReferenceId(26), ReferenceId(27), ReferenceId(29), ReferenceId(30), ReferenceId(33), ReferenceId(34), ReferenceId(39), ReferenceId(40)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(1): [ReferenceId(12), ReferenceId(15), ReferenceId(17), ReferenceId(22), ReferenceId(42)]
-rebuilt        : SymbolId(1): [ReferenceId(9), ReferenceId(14)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithConstraints3.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(39), ReferenceId(0), ReferenceId(1), ReferenceId(12), ReferenceId(15), ReferenceId(18), ReferenceId(22), ReferenceId(26), ReferenceId(30)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(1): [ReferenceId(13), ReferenceId(16), ReferenceId(17), ReferenceId(23), ReferenceId(36), ReferenceId(38), ReferenceId(46)]
-rebuilt        : SymbolId(1): [ReferenceId(9), ReferenceId(15), ReferenceId(17), ReferenceId(22)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterConstModifiersReturnsAndYields.ts
 Bindings mismatch:
@@ -33167,7 +28501,7 @@ Reference symbol mismatch for "overloaded5":
 after transform: SymbolId(104) "overloaded5"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["AsyncGenerator", "Generator", "Math", "Promise", "require"]
+after transform: ["Math", "require"]
 rebuilt        : ["Math", "overloaded1", "overloaded2", "overloaded3", "overloaded4", "overloaded5", "require", "test1", "test2", "test3", "test4"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterConstModifiersReverseMappedTypes.ts
@@ -33204,11 +28538,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["test"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterUsedAsConstraint.ts
-Unresolved references mismatch:
-after transform: ["Date"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/anyAssignabilityInInheritance.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -33227,33 +28556,18 @@ rebuilt        : ScopeId(7): ScopeFlags(Function)
 Scope flags mismatch:
 after transform: ScopeId(41): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(10): ScopeFlags(Function)
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(28): [ReferenceId(22), ReferenceId(23)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch for "A2":
-after transform: SymbolId(32): [ReferenceId(27), ReferenceId(28)]
-rebuilt        : SymbolId(4): []
 Symbol flags mismatch for "E":
 after transform: SymbolId(49): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(5): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "E":
-after transform: SymbolId(49): [ReferenceId(39), ReferenceId(40), ReferenceId(68)]
-rebuilt        : SymbolId(5): [ReferenceId(30)]
 Symbol flags mismatch for "f":
 after transform: SymbolId(54): SymbolFlags(Function | ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(Function)
-Symbol reference IDs mismatch for "f":
-after transform: SymbolId(54): [ReferenceId(43), ReferenceId(44), ReferenceId(58), ReferenceId(59)]
-rebuilt        : SymbolId(7): [ReferenceId(34), ReferenceId(35)]
 Symbol redeclarations mismatch for "f":
 after transform: SymbolId(54): [Span { start: 1850, end: 1851 }, Span { start: 1868, end: 1869 }]
 rebuilt        : SymbolId(7): []
 Symbol flags mismatch for "CC":
 after transform: SymbolId(59): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(10): SymbolFlags(Class)
-Symbol reference IDs mismatch for "CC":
-after transform: SymbolId(59): [ReferenceId(47), ReferenceId(48), ReferenceId(61), ReferenceId(62)]
-rebuilt        : SymbolId(10): [ReferenceId(40), ReferenceId(41)]
 Symbol redeclarations mismatch for "CC":
 after transform: SymbolId(59): [Span { start: 2014, end: 2016 }, Span { start: 2043, end: 2045 }]
 rebuilt        : SymbolId(10): []
@@ -33309,7 +28623,7 @@ Reference symbol mismatch for "foo3":
 after transform: SymbolId(6) "foo3"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Date", "Object", "RegExp", "require"]
+after transform: ["require"]
 rebuilt        : ["foo2", "foo3", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/anyAssignableToEveryType2.ts
@@ -33327,39 +28641,21 @@ rebuilt        : ScopeId(7): ScopeFlags(Function)
 Scope flags mismatch:
 after transform: ScopeId(24): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(10): ScopeFlags(Function)
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(9): [ReferenceId(3)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch for "A2":
-after transform: SymbolId(11): [ReferenceId(5)]
-rebuilt        : SymbolId(2): []
 Symbol flags mismatch for "E":
 after transform: SymbolId(19): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "E":
-after transform: SymbolId(19): [ReferenceId(8), ReferenceId(26)]
-rebuilt        : SymbolId(3): [ReferenceId(6)]
 Symbol flags mismatch for "f":
 after transform: SymbolId(22): SymbolFlags(Function | ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(Function)
-Symbol reference IDs mismatch for "f":
-after transform: SymbolId(22): [ReferenceId(9), ReferenceId(16), ReferenceId(17)]
-rebuilt        : SymbolId(5): [ReferenceId(8), ReferenceId(9)]
 Symbol redeclarations mismatch for "f":
 after transform: SymbolId(22): [Span { start: 1018, end: 1019 }, Span { start: 1036, end: 1037 }]
 rebuilt        : SymbolId(5): []
 Symbol flags mismatch for "c":
 after transform: SymbolId(25): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(Class)
-Symbol reference IDs mismatch for "c":
-after transform: SymbolId(25): [ReferenceId(10), ReferenceId(19), ReferenceId(20)]
-rebuilt        : SymbolId(8): [ReferenceId(12), ReferenceId(13)]
 Symbol redeclarations mismatch for "c":
 after transform: SymbolId(25): [Span { start: 1133, end: 1134 }, Span { start: 1161, end: 1162 }]
 rebuilt        : SymbolId(8): []
-Unresolved references mismatch:
-after transform: ["Date", "Object", "RegExp", "require"]
-rebuilt        : ["require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembers.ts
 Scope flags mismatch:
@@ -33374,54 +28670,12 @@ rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "SimpleTypes":
 after transform: SymbolId(0): Span { start: 149, end: 160 }
 rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "S":
-after transform: SymbolId(1): [ReferenceId(0)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch for "T":
-after transform: SymbolId(2): [ReferenceId(1)]
-rebuilt        : SymbolId(4): []
 Symbol flags mismatch for "ObjectTypes":
 after transform: SymbolId(13): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(13): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "ObjectTypes":
 after transform: SymbolId(13): Span { start: 706, end: 717 }
 rebuilt        : SymbolId(13): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "S":
-after transform: SymbolId(14): [ReferenceId(42), ReferenceId(44)]
-rebuilt        : SymbolId(15): []
-Symbol reference IDs mismatch for "T":
-after transform: SymbolId(15): [ReferenceId(43), ReferenceId(45)]
-rebuilt        : SymbolId(16): []
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(22): [ReferenceId(50), ReferenceId(72), ReferenceId(75), ReferenceId(76), ReferenceId(78), ReferenceId(80)]
-rebuilt        : SymbolId(21): [ReferenceId(65), ReferenceId(68), ReferenceId(69), ReferenceId(71), ReferenceId(73)]
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(23): [ReferenceId(51), ReferenceId(69), ReferenceId(73), ReferenceId(74), ReferenceId(87)]
-rebuilt        : SymbolId(22): [ReferenceId(62), ReferenceId(66), ReferenceId(67), ReferenceId(80)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembers2.ts
-Symbol reference IDs mismatch for "S":
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch for "T":
-after transform: SymbolId(1): [ReferenceId(1)]
-rebuilt        : SymbolId(2): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembers3.ts
-Symbol reference IDs mismatch for "S":
-after transform: SymbolId(0): [ReferenceId(2)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch for "T":
-after transform: SymbolId(1): [ReferenceId(3)]
-rebuilt        : SymbolId(2): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembersNumericNames.ts
-Symbol reference IDs mismatch for "S":
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch for "T":
-after transform: SymbolId(1): [ReferenceId(1)]
-rebuilt        : SymbolId(2): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/intersectionIncludingPropFromGlobalAugmentation.ts
 Bindings mismatch:
@@ -33441,23 +28695,9 @@ rebuilt        : ScopeId(3): ["E"]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(0x0)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(1): []
 Symbol flags mismatch for "E":
 after transform: SymbolId(4): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "E":
-after transform: SymbolId(4): [ReferenceId(2), ReferenceId(24)]
-rebuilt        : SymbolId(4): [ReferenceId(5)]
-Unresolved references mismatch:
-after transform: ["Date", "Function", "Number", "Object", "String", "require"]
-rebuilt        : ["require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/bestCommonType/functionWithMultipleReturnStatements2.ts
-Unresolved reference IDs mismatch for "Object":
-after transform: [ReferenceId(1), ReferenceId(8), ReferenceId(9)]
-rebuilt        : [ReferenceId(1)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/bestCommonType/heterogeneousArrayLiterals.ts
 Scope flags mismatch:
@@ -33466,21 +28706,12 @@ rebuilt        : ScopeId(18): ScopeFlags(Function)
 Scope flags mismatch:
 after transform: ScopeId(29): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(32): ScopeFlags(Function)
-Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(14): [ReferenceId(47), ReferenceId(91), ReferenceId(92), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(27), ReferenceId(32), ReferenceId(113)]
-rebuilt        : SymbolId(15): [ReferenceId(3), ReferenceId(6)]
 Symbol flags mismatch for "Derived":
 after transform: SymbolId(15): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(16): SymbolFlags(Class)
-Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(15): [ReferenceId(48), ReferenceId(69), ReferenceId(70), ReferenceId(4), ReferenceId(30), ReferenceId(31), ReferenceId(116), ReferenceId(117)]
-rebuilt        : SymbolId(16): [ReferenceId(30), ReferenceId(31)]
 Symbol redeclarations mismatch for "Derived":
 after transform: SymbolId(15): [Span { start: 689, end: 696 }, Span { start: 845, end: 852 }]
 rebuilt        : SymbolId(16): []
-Symbol reference IDs mismatch for "Derived2":
-after transform: SymbolId(16): [ReferenceId(5)]
-rebuilt        : SymbolId(18): []
 Symbol flags mismatch for "WithContextualType":
 after transform: SymbolId(30): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(34): SymbolFlags(BlockScopedVariable)
@@ -33516,35 +28747,7 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["aOrB"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/instanceOf/narrowingConstrainedTypeVariable.ts
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(7), ReferenceId(3), ReferenceId(12)]
-rebuilt        : SymbolId(1): [ReferenceId(2), ReferenceId(6)]
-Symbol reference IDs mismatch for "D":
-after transform: SymbolId(6): [ReferenceId(8)]
-rebuilt        : SymbolId(6): []
-Symbol reference IDs mismatch for "E":
-after transform: SymbolId(13): [ReferenceId(17), ReferenceId(20)]
-rebuilt        : SymbolId(11): [ReferenceId(11)]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/arrayLiteralsWithRecursiveGenerics.ts
-Symbol reference IDs mismatch for "List":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(11), ReferenceId(12)]
-rebuilt        : SymbolId(1): [ReferenceId(3)]
-Symbol reference IDs mismatch for "DerivedList":
-after transform: SymbolId(2): [ReferenceId(19)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "MyList":
-after transform: SymbolId(4): [ReferenceId(8), ReferenceId(9), ReferenceId(13)]
-rebuilt        : SymbolId(4): []
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/recursiveTypesUsedAsFunctionParameters.ts
-Symbol reference IDs mismatch for "List":
-after transform: SymbolId(0): [ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(24), ReferenceId(27), ReferenceId(1), ReferenceId(2), ReferenceId(18), ReferenceId(31)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch for "MyList":
-after transform: SymbolId(2): [ReferenceId(16), ReferenceId(21), ReferenceId(29), ReferenceId(5), ReferenceId(6), ReferenceId(32)]
-rebuilt        : SymbolId(2): []
 Symbol span mismatch for "foo":
 after transform: SymbolId(4): Span { start: 129, end: 132 }
 rebuilt        : SymbolId(3): Span { start: 207, end: 210 }
@@ -33591,36 +28794,21 @@ rebuilt        : ScopeId(11): ScopeFlags(Function)
 Scope flags mismatch:
 after transform: ScopeId(12): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(14): ScopeFlags(Function)
-Symbol reference IDs mismatch for "C1":
-after transform: SymbolId(19): [ReferenceId(12)]
-rebuilt        : SymbolId(17): []
-Symbol reference IDs mismatch for "C2":
-after transform: SymbolId(22): [ReferenceId(16)]
-rebuilt        : SymbolId(20): []
 Symbol flags mismatch for "E":
 after transform: SymbolId(26): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(23): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch for "f":
 after transform: SymbolId(30): SymbolFlags(Function | ValueModule)
 rebuilt        : SymbolId(27): SymbolFlags(Function)
-Symbol reference IDs mismatch for "f":
-after transform: SymbolId(30): [ReferenceId(23), ReferenceId(38), ReferenceId(39)]
-rebuilt        : SymbolId(27): [ReferenceId(24), ReferenceId(25)]
 Symbol redeclarations mismatch for "f":
 after transform: SymbolId(30): [Span { start: 1216, end: 1217 }, Span { start: 1234, end: 1235 }]
 rebuilt        : SymbolId(27): []
 Symbol flags mismatch for "c":
 after transform: SymbolId(34): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(32): SymbolFlags(Class)
-Symbol reference IDs mismatch for "c":
-after transform: SymbolId(34): [ReferenceId(26), ReferenceId(41), ReferenceId(42)]
-rebuilt        : SymbolId(32): [ReferenceId(30), ReferenceId(31)]
 Symbol redeclarations mismatch for "c":
 after transform: SymbolId(34): [Span { start: 1345, end: 1346 }, Span { start: 1373, end: 1374 }]
 rebuilt        : SymbolId(32): []
-Unresolved references mismatch:
-after transform: ["Date", "Object", "require", "undefined"]
-rebuilt        : ["Date", "Object", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfAny.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -33637,39 +28825,21 @@ rebuilt        : ScopeId(7): ScopeFlags(Function)
 Scope flags mismatch:
 after transform: ScopeId(24): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(10): ScopeFlags(Function)
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(9): [ReferenceId(3)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch for "A2":
-after transform: SymbolId(11): [ReferenceId(5)]
-rebuilt        : SymbolId(2): []
 Symbol flags mismatch for "E":
 after transform: SymbolId(19): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "E":
-after transform: SymbolId(19): [ReferenceId(8), ReferenceId(25)]
-rebuilt        : SymbolId(3): [ReferenceId(6)]
 Symbol flags mismatch for "f":
 after transform: SymbolId(22): SymbolFlags(Function | ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(Function)
-Symbol reference IDs mismatch for "f":
-after transform: SymbolId(22): [ReferenceId(9), ReferenceId(15), ReferenceId(16)]
-rebuilt        : SymbolId(5): [ReferenceId(8), ReferenceId(9)]
 Symbol redeclarations mismatch for "f":
 after transform: SymbolId(22): [Span { start: 951, end: 952 }, Span { start: 969, end: 970 }]
 rebuilt        : SymbolId(5): []
 Symbol flags mismatch for "c":
 after transform: SymbolId(25): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(Class)
-Symbol reference IDs mismatch for "c":
-after transform: SymbolId(25): [ReferenceId(10), ReferenceId(18), ReferenceId(19)]
-rebuilt        : SymbolId(8): [ReferenceId(12), ReferenceId(13)]
 Symbol redeclarations mismatch for "c":
 after transform: SymbolId(25): [Span { start: 1066, end: 1067 }, Span { start: 1094, end: 1095 }]
 rebuilt        : SymbolId(8): []
-Unresolved references mismatch:
-after transform: ["Date", "Object", "RegExp", "require"]
-rebuilt        : ["require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignatures.ts
 Bindings mismatch:
@@ -33704,15 +28874,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRela
 Bindings mismatch:
 after transform: ScopeId(0): ["Base", "Derived", "Derived2", "OtherDerived", "_defineProperty", "foo1", "foo11", "foo15", "foo16", "foo17", "foo18", "foo2", "foo3", "foo4", "foo5", "foo6", "r1", "r11", "r11a", "r11arg", "r11arg2", "r11b", "r15", "r15a", "r15arg", "r15arg2", "r15b", "r16", "r16a", "r16arg", "r16arg2", "r16b", "r17", "r17arg", "r18", "r18arg", "r1a", "r1arg", "r1arg2", "r1b", "r2", "r2a", "r2arg", "r2arg2", "r2b", "r3", "r3a", "r3arg", "r3arg2", "r3b", "r4", "r4a", "r4arg", "r4arg2", "r4b", "r5", "r5a", "r5arg", "r5arg2", "r5b", "r6", "r6a", "r6arg", "r6arg2", "r6b"]
 rebuilt        : ScopeId(0): ["Base", "Derived", "Derived2", "OtherDerived", "_defineProperty", "r1", "r11", "r11a", "r11arg", "r11arg2", "r11b", "r15", "r15a", "r15arg", "r15arg2", "r15b", "r16", "r16a", "r16arg", "r16arg2", "r16b", "r17", "r17arg", "r18", "r18arg", "r1a", "r1arg", "r1arg2", "r1b", "r2", "r2a", "r2arg", "r2arg2", "r2b", "r3", "r3a", "r3arg", "r3arg2", "r3b", "r4", "r4a", "r4arg", "r4arg2", "r4b", "r5", "r5a", "r5arg", "r5arg2", "r5b", "r6", "r6a", "r6arg", "r6arg2", "r6b"]
-Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(12), ReferenceId(19), ReferenceId(23), ReferenceId(31), ReferenceId(38), ReferenceId(44), ReferenceId(96), ReferenceId(101), ReferenceId(137), ReferenceId(141), ReferenceId(0), ReferenceId(2), ReferenceId(114), ReferenceId(118)]
-rebuilt        : SymbolId(1): [ReferenceId(2), ReferenceId(8)]
-Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(1): [ReferenceId(14), ReferenceId(27), ReferenceId(35), ReferenceId(97), ReferenceId(103), ReferenceId(1)]
-rebuilt        : SymbolId(2): [ReferenceId(5)]
-Symbol reference IDs mismatch for "Derived2":
-after transform: SymbolId(2): [ReferenceId(41)]
-rebuilt        : SymbolId(4): []
 Reference symbol mismatch for "foo1":
 after transform: SymbolId(4) "foo1"
 rebuilt        : <None>
@@ -33754,15 +28915,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRela
 Bindings mismatch:
 after transform: ScopeId(0): ["Base", "Derived", "Derived2", "OtherDerived", "_defineProperty", "foo1", "foo11", "foo15", "foo16", "foo17", "foo18", "foo2", "foo3", "foo4", "foo5", "foo6", "r1", "r11", "r11a", "r11arg", "r11arg2", "r11b", "r15", "r15a", "r15arg", "r15arg2", "r15b", "r16", "r16a", "r16arg", "r16arg2", "r16b", "r17", "r17arg", "r18", "r18arg", "r1a", "r1arg", "r1arg2", "r1b", "r2", "r2a", "r2arg", "r2arg2", "r2b", "r3", "r3a", "r3arg", "r3arg2", "r3b", "r4", "r4a", "r4arg", "r4arg2", "r4b", "r5", "r5a", "r5arg", "r5arg2", "r5b", "r6", "r6a", "r6arg", "r6arg2", "r6b"]
 rebuilt        : ScopeId(0): ["Base", "Derived", "Derived2", "OtherDerived", "_defineProperty", "r1", "r11", "r11a", "r11arg", "r11arg2", "r11b", "r15", "r15a", "r15arg", "r15arg2", "r15b", "r16", "r16a", "r16arg", "r16arg2", "r16b", "r17", "r17arg", "r18", "r18arg", "r1a", "r1arg", "r1arg2", "r1b", "r2", "r2a", "r2arg", "r2arg2", "r2b", "r3", "r3a", "r3arg", "r3arg2", "r3b", "r4", "r4a", "r4arg", "r4arg2", "r4b", "r5", "r5a", "r5arg", "r5arg2", "r5b", "r6", "r6a", "r6arg", "r6arg2", "r6b"]
-Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(12), ReferenceId(19), ReferenceId(23), ReferenceId(31), ReferenceId(38), ReferenceId(44), ReferenceId(0), ReferenceId(2), ReferenceId(96), ReferenceId(101), ReferenceId(114), ReferenceId(118), ReferenceId(137), ReferenceId(141)]
-rebuilt        : SymbolId(1): [ReferenceId(2), ReferenceId(8)]
-Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(1): [ReferenceId(14), ReferenceId(27), ReferenceId(35), ReferenceId(1), ReferenceId(97), ReferenceId(103)]
-rebuilt        : SymbolId(2): [ReferenceId(5)]
-Symbol reference IDs mismatch for "Derived2":
-after transform: SymbolId(2): [ReferenceId(41)]
-rebuilt        : SymbolId(4): []
 Reference symbol mismatch for "foo1":
 after transform: SymbolId(4) "foo1"
 rebuilt        : <None>
@@ -33801,21 +28953,6 @@ after transform: ["require"]
 rebuilt        : ["foo1", "foo11", "foo15", "foo16", "foo17", "foo18", "foo2", "foo3", "foo4", "foo5", "foo6", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentity.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(2), ReferenceId(13), ReferenceId(15), ReferenceId(17), ReferenceId(19)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(1): [ReferenceId(3), ReferenceId(4), ReferenceId(14), ReferenceId(21), ReferenceId(23), ReferenceId(25), ReferenceId(27)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(2): [ReferenceId(5), ReferenceId(6), ReferenceId(16), ReferenceId(24), ReferenceId(30)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(5): [ReferenceId(9), ReferenceId(10), ReferenceId(20), ReferenceId(26), ReferenceId(32)]
-rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(6): [ReferenceId(11), ReferenceId(12), ReferenceId(28), ReferenceId(34)]
-rebuilt        : SymbolId(5): []
 Symbol span mismatch for "foo1":
 after transform: SymbolId(7): Span { start: 221, end: 225 }
 rebuilt        : SymbolId(6): Span { start: 272, end: 276 }
@@ -33926,24 +29063,9 @@ rebuilt        : ScopeId(7): ["E"]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(0x0)
 rebuilt        : ScopeId(7): ScopeFlags(Function)
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(4), ReferenceId(6), ReferenceId(8), ReferenceId(10)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(1): [ReferenceId(5), ReferenceId(12), ReferenceId(14), ReferenceId(16), ReferenceId(18)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(2): [ReferenceId(7), ReferenceId(15), ReferenceId(21)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(5): [ReferenceId(11), ReferenceId(17), ReferenceId(23)]
-rebuilt        : SymbolId(4): []
 Symbol flags mismatch for "E":
 after transform: SymbolId(6): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(5): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(8): [ReferenceId(19), ReferenceId(25)]
-rebuilt        : SymbolId(7): []
 Symbol span mismatch for "foo5":
 after transform: SymbolId(9): Span { start: 234, end: 238 }
 rebuilt        : SymbolId(8): Span { start: 282, end: 286 }
@@ -34010,26 +29132,8 @@ rebuilt        : SymbolId(28): Span { start: 1108, end: 1113 }
 Symbol redeclarations mismatch for "foo14":
 after transform: SymbolId(49): [Span { start: 1051, end: 1056 }, Span { start: 1073, end: 1078 }, Span { start: 1108, end: 1113 }]
 rebuilt        : SymbolId(28): []
-Unresolved references mismatch:
-after transform: ["Date", "RegExp", "require"]
-rebuilt        : ["require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithCallSignatures.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(4), ReferenceId(5), ReferenceId(16), ReferenceId(18), ReferenceId(20), ReferenceId(22)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(2): [ReferenceId(6), ReferenceId(7), ReferenceId(17), ReferenceId(24), ReferenceId(26), ReferenceId(28), ReferenceId(30)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(4): [ReferenceId(8), ReferenceId(9), ReferenceId(19), ReferenceId(27), ReferenceId(33), ReferenceId(35), ReferenceId(41)]
-rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(12): [ReferenceId(12), ReferenceId(13), ReferenceId(23), ReferenceId(29), ReferenceId(37)]
-rebuilt        : SymbolId(6): []
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(14): [ReferenceId(14), ReferenceId(15), ReferenceId(31), ReferenceId(39)]
-rebuilt        : SymbolId(7): []
 Symbol span mismatch for "foo1":
 after transform: SymbolId(16): Span { start: 379, end: 383 }
 rebuilt        : SymbolId(9): Span { start: 430, end: 434 }
@@ -34146,21 +29250,6 @@ after transform: SymbolId(88): [Span { start: 1933, end: 1938 }, Span { start: 1
 rebuilt        : SymbolId(45): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithCallSignatures2.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(6), ReferenceId(7), ReferenceId(18), ReferenceId(20), ReferenceId(22), ReferenceId(24)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(2): [ReferenceId(8), ReferenceId(9), ReferenceId(19), ReferenceId(26), ReferenceId(28), ReferenceId(30), ReferenceId(32)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(4): [ReferenceId(10), ReferenceId(11), ReferenceId(21), ReferenceId(29), ReferenceId(35), ReferenceId(37), ReferenceId(43)]
-rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(12): [ReferenceId(14), ReferenceId(15), ReferenceId(25), ReferenceId(31), ReferenceId(39)]
-rebuilt        : SymbolId(6): []
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(14): [ReferenceId(16), ReferenceId(17), ReferenceId(33), ReferenceId(41)]
-rebuilt        : SymbolId(7): []
 Symbol span mismatch for "foo1":
 after transform: SymbolId(16): Span { start: 378, end: 382 }
 rebuilt        : SymbolId(9): Span { start: 429, end: 433 }
@@ -34275,26 +29364,8 @@ rebuilt        : SymbolId(45): Span { start: 1969, end: 1974 }
 Symbol redeclarations mismatch for "foo15":
 after transform: SymbolId(88): [Span { start: 1902, end: 1907 }, Span { start: 1933, end: 1938 }, Span { start: 1969, end: 1974 }]
 rebuilt        : SymbolId(45): []
-Unresolved references mismatch:
-after transform: ["Date", "RegExp"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithCallSignaturesDifferingParamCounts.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(5), ReferenceId(6), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(23)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(2): [ReferenceId(7), ReferenceId(8), ReferenceId(18), ReferenceId(25), ReferenceId(27), ReferenceId(29), ReferenceId(31)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(5): [ReferenceId(9), ReferenceId(10), ReferenceId(20), ReferenceId(28), ReferenceId(34), ReferenceId(36), ReferenceId(42)]
-rebuilt        : SymbolId(5): []
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(14): [ReferenceId(13), ReferenceId(14), ReferenceId(24), ReferenceId(30), ReferenceId(38)]
-rebuilt        : SymbolId(8): []
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(17): [ReferenceId(15), ReferenceId(16), ReferenceId(32), ReferenceId(40)]
-rebuilt        : SymbolId(9): []
 Symbol span mismatch for "foo1":
 after transform: SymbolId(19): Span { start: 407, end: 411 }
 rebuilt        : SymbolId(11): Span { start: 458, end: 462 }
@@ -34411,9 +29482,6 @@ after transform: SymbolId(91): [Span { start: 1934, end: 1939 }, Span { start: 1
 rebuilt        : SymbolId(47): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithCallSignaturesDifferingParamCounts2.ts
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(5): [ReferenceId(4), ReferenceId(5), ReferenceId(11), ReferenceId(14)]
-rebuilt        : SymbolId(0): []
 Symbol span mismatch for "foo2":
 after transform: SymbolId(8): Span { start: 174, end: 178 }
 rebuilt        : SymbolId(1): Span { start: 225, end: 229 }
@@ -34464,21 +29532,6 @@ after transform: SymbolId(36): [Span { start: 805, end: 810 }, Span { start: 827
 rebuilt        : SymbolId(15): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithCallSignaturesWithOverloads.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(4), ReferenceId(5), ReferenceId(16), ReferenceId(18), ReferenceId(20), ReferenceId(22)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(4): [ReferenceId(6), ReferenceId(7), ReferenceId(17), ReferenceId(24), ReferenceId(26), ReferenceId(28), ReferenceId(30)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(8): [ReferenceId(8), ReferenceId(9), ReferenceId(19), ReferenceId(27), ReferenceId(33), ReferenceId(35), ReferenceId(41)]
-rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(22): [ReferenceId(12), ReferenceId(13), ReferenceId(23), ReferenceId(29), ReferenceId(37)]
-rebuilt        : SymbolId(6): []
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(25): [ReferenceId(14), ReferenceId(15), ReferenceId(31), ReferenceId(39)]
-rebuilt        : SymbolId(7): []
 Symbol span mismatch for "foo1":
 after transform: SymbolId(27): Span { start: 683, end: 687 }
 rebuilt        : SymbolId(9): Span { start: 734, end: 738 }
@@ -34603,18 +29656,6 @@ after transform: SymbolId(11): [Span { start: 288, end: 291 }, Span { start: 308
 rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithConstructSignatures.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(13), ReferenceId(15), ReferenceId(17), ReferenceId(19)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(2): [ReferenceId(5), ReferenceId(6), ReferenceId(14), ReferenceId(21), ReferenceId(23), ReferenceId(25)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(4): [ReferenceId(7), ReferenceId(8), ReferenceId(16), ReferenceId(24), ReferenceId(28), ReferenceId(30), ReferenceId(34)]
-rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(12): [ReferenceId(11), ReferenceId(12), ReferenceId(20), ReferenceId(26), ReferenceId(32)]
-rebuilt        : SymbolId(6): []
 Symbol span mismatch for "foo1":
 after transform: SymbolId(14): Span { start: 286, end: 290 }
 rebuilt        : SymbolId(7): Span { start: 337, end: 341 }
@@ -34713,18 +29754,6 @@ after transform: SymbolId(74): [Span { start: 1555, end: 1560 }, Span { start: 1
 rebuilt        : SymbolId(37): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithConstructSignatures2.ts
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(0): [ReferenceId(5), ReferenceId(6), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(21)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(2): [ReferenceId(7), ReferenceId(8), ReferenceId(18), ReferenceId(24), ReferenceId(26), ReferenceId(32)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(10): [ReferenceId(11), ReferenceId(12), ReferenceId(20), ReferenceId(28)]
-rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(12): [ReferenceId(13), ReferenceId(14), ReferenceId(22), ReferenceId(30)]
-rebuilt        : SymbolId(5): []
 Symbol span mismatch for "foo1b":
 after transform: SymbolId(14): Span { start: 376, end: 381 }
 rebuilt        : SymbolId(7): Span { start: 429, end: 434 }
@@ -34809,23 +29838,8 @@ rebuilt        : SymbolId(33): Span { start: 1598, end: 1603 }
 Symbol redeclarations mismatch for "foo15":
 after transform: SymbolId(66): [Span { start: 1531, end: 1536 }, Span { start: 1562, end: 1567 }, Span { start: 1598, end: 1603 }]
 rebuilt        : SymbolId(33): []
-Unresolved references mismatch:
-after transform: ["Date", "RegExp"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithConstructSignaturesDifferingParamCounts.ts
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(0): [ReferenceId(4), ReferenceId(5), ReferenceId(14), ReferenceId(16), ReferenceId(18), ReferenceId(20)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(3): [ReferenceId(6), ReferenceId(7), ReferenceId(17), ReferenceId(23), ReferenceId(25), ReferenceId(31)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(12): [ReferenceId(10), ReferenceId(11), ReferenceId(19), ReferenceId(27)]
-rebuilt        : SymbolId(6): []
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(15): [ReferenceId(12), ReferenceId(13), ReferenceId(21), ReferenceId(29)]
-rebuilt        : SymbolId(7): []
 Symbol span mismatch for "foo1b":
 after transform: SymbolId(17): Span { start: 405, end: 410 }
 rebuilt        : SymbolId(9): Span { start: 458, end: 463 }
@@ -34912,21 +29926,6 @@ after transform: SymbolId(69): [Span { start: 1560, end: 1565 }, Span { start: 1
 rebuilt        : SymbolId(35): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignatures.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(14), ReferenceId(15), ReferenceId(26), ReferenceId(28), ReferenceId(30), ReferenceId(32)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(3): [ReferenceId(16), ReferenceId(17), ReferenceId(27), ReferenceId(34), ReferenceId(36), ReferenceId(38), ReferenceId(40)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(6): [ReferenceId(18), ReferenceId(19), ReferenceId(29), ReferenceId(37), ReferenceId(43), ReferenceId(45), ReferenceId(51)]
-rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(15): [ReferenceId(22), ReferenceId(23), ReferenceId(33), ReferenceId(39), ReferenceId(47)]
-rebuilt        : SymbolId(6): []
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(18): [ReferenceId(24), ReferenceId(25), ReferenceId(41), ReferenceId(49)]
-rebuilt        : SymbolId(7): []
 Symbol span mismatch for "foo1":
 after transform: SymbolId(21): Span { start: 348, end: 352 }
 rebuilt        : SymbolId(9): Span { start: 399, end: 403 }
@@ -35043,21 +30042,6 @@ after transform: SymbolId(93): [Span { start: 1982, end: 1987 }, Span { start: 2
 rebuilt        : SymbolId(45): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignatures2.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(21), ReferenceId(22), ReferenceId(33), ReferenceId(35), ReferenceId(37), ReferenceId(39)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(5): [ReferenceId(23), ReferenceId(24), ReferenceId(34), ReferenceId(41), ReferenceId(43), ReferenceId(45), ReferenceId(47)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(10): [ReferenceId(25), ReferenceId(26), ReferenceId(36), ReferenceId(44), ReferenceId(50), ReferenceId(52), ReferenceId(58)]
-rebuilt        : SymbolId(6): []
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(25): [ReferenceId(29), ReferenceId(30), ReferenceId(40), ReferenceId(46), ReferenceId(54)]
-rebuilt        : SymbolId(9): []
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(30): [ReferenceId(31), ReferenceId(32), ReferenceId(48), ReferenceId(56)]
-rebuilt        : SymbolId(10): []
 Symbol span mismatch for "foo1":
 after transform: SymbolId(35): Span { start: 411, end: 415 }
 rebuilt        : SymbolId(13): Span { start: 462, end: 466 }
@@ -35174,21 +30158,6 @@ after transform: SymbolId(107): [Span { start: 2214, end: 2219 }, Span { start: 
 rebuilt        : SymbolId(49): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesDifferingByConstraints.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(14), ReferenceId(15), ReferenceId(32), ReferenceId(35), ReferenceId(38), ReferenceId(41)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(3): [ReferenceId(16), ReferenceId(18), ReferenceId(33), ReferenceId(43), ReferenceId(47), ReferenceId(51), ReferenceId(54)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(6): [ReferenceId(20), ReferenceId(22), ReferenceId(36), ReferenceId(49), ReferenceId(59), ReferenceId(62), ReferenceId(71)]
-rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(15): [ReferenceId(28), ReferenceId(29), ReferenceId(42), ReferenceId(53), ReferenceId(66)]
-rebuilt        : SymbolId(6): []
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(18): [ReferenceId(30), ReferenceId(31), ReferenceId(56), ReferenceId(69)]
-rebuilt        : SymbolId(7): []
 Symbol span mismatch for "foo1":
 after transform: SymbolId(21): Span { start: 788, end: 792 }
 rebuilt        : SymbolId(9): Span { start: 839, end: 843 }
@@ -35303,29 +30272,8 @@ rebuilt        : SymbolId(45): Span { start: 2518, end: 2523 }
 Symbol redeclarations mismatch for "foo15":
 after transform: SymbolId(93): [Span { start: 2459, end: 2464 }, Span { start: 2482, end: 2487 }, Span { start: 2518, end: 2523 }]
 rebuilt        : SymbolId(45): []
-Unresolved references mismatch:
-after transform: ["Array", "Boolean", "Date", "Number", "RegExp", "String"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesDifferingByConstraints2.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(32), ReferenceId(33), ReferenceId(56), ReferenceId(60), ReferenceId(75), ReferenceId(79)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(5): [ReferenceId(34), ReferenceId(37), ReferenceId(57), ReferenceId(81), ReferenceId(87), ReferenceId(93), ReferenceId(97)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(10): [ReferenceId(40), ReferenceId(43), ReferenceId(61), ReferenceId(64), ReferenceId(70), ReferenceId(90), ReferenceId(104), ReferenceId(108), ReferenceId(120)]
-rebuilt        : SymbolId(6): []
-Symbol reference IDs mismatch for "D":
-after transform: SymbolId(15): [ReferenceId(67), ReferenceId(73)]
-rebuilt        : SymbolId(9): []
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(30): [ReferenceId(52), ReferenceId(53), ReferenceId(80), ReferenceId(96), ReferenceId(114)]
-rebuilt        : SymbolId(12): []
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(35): [ReferenceId(54), ReferenceId(55), ReferenceId(100), ReferenceId(118)]
-rebuilt        : SymbolId(13): []
 Symbol span mismatch for "foo1":
 after transform: SymbolId(40): Span { start: 1010, end: 1014 }
 rebuilt        : SymbolId(16): Span { start: 1061, end: 1065 }
@@ -35452,35 +30400,8 @@ rebuilt        : SymbolId(56): Span { start: 3216, end: 3221 }
 Symbol redeclarations mismatch for "foo15":
 after transform: SymbolId(120): [Span { start: 3149, end: 3154 }, Span { start: 3172, end: 3177 }, Span { start: 3216, end: 3221 }]
 rebuilt        : SymbolId(56): []
-Unresolved references mismatch:
-after transform: ["Array", "Boolean", "Date", "Number", "RegExp", "String"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesDifferingByConstraints3.ts
-Symbol reference IDs mismatch for "One":
-after transform: SymbolId(0): [ReferenceId(5), ReferenceId(29)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch for "Two":
-after transform: SymbolId(1): [ReferenceId(33), ReferenceId(39), ReferenceId(40), ReferenceId(42), ReferenceId(43), ReferenceId(62), ReferenceId(63), ReferenceId(87), ReferenceId(88), ReferenceId(93), ReferenceId(94), ReferenceId(99), ReferenceId(100), ReferenceId(103), ReferenceId(104), ReferenceId(9)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(10): [ReferenceId(36), ReferenceId(37), ReferenceId(60), ReferenceId(64), ReferenceId(80), ReferenceId(84)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(15): [ReferenceId(38), ReferenceId(41), ReferenceId(61), ReferenceId(86), ReferenceId(92), ReferenceId(98), ReferenceId(102)]
-rebuilt        : SymbolId(6): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(20): [ReferenceId(44), ReferenceId(47), ReferenceId(65), ReferenceId(68), ReferenceId(74), ReferenceId(95), ReferenceId(109), ReferenceId(113), ReferenceId(125)]
-rebuilt        : SymbolId(9): []
-Symbol reference IDs mismatch for "D":
-after transform: SymbolId(25): [ReferenceId(71), ReferenceId(77)]
-rebuilt        : SymbolId(12): []
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(40): [ReferenceId(56), ReferenceId(57), ReferenceId(85), ReferenceId(101), ReferenceId(119)]
-rebuilt        : SymbolId(15): []
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(45): [ReferenceId(58), ReferenceId(59), ReferenceId(105), ReferenceId(123)]
-rebuilt        : SymbolId(16): []
 Symbol span mismatch for "foo1":
 after transform: SymbolId(50): Span { start: 1197, end: 1201 }
 rebuilt        : SymbolId(19): Span { start: 1248, end: 1252 }
@@ -35609,21 +30530,6 @@ after transform: SymbolId(130): [Span { start: 3267, end: 3272 }, Span { start: 
 rebuilt        : SymbolId(59): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesDifferingByReturnType.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(10), ReferenceId(11), ReferenceId(22), ReferenceId(24), ReferenceId(26), ReferenceId(28)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(3): [ReferenceId(12), ReferenceId(13), ReferenceId(23), ReferenceId(30), ReferenceId(32), ReferenceId(34), ReferenceId(36)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(6): [ReferenceId(14), ReferenceId(15), ReferenceId(25), ReferenceId(33), ReferenceId(39), ReferenceId(41), ReferenceId(47)]
-rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(15): [ReferenceId(18), ReferenceId(19), ReferenceId(29), ReferenceId(35), ReferenceId(43)]
-rebuilt        : SymbolId(6): []
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(18): [ReferenceId(20), ReferenceId(21), ReferenceId(37), ReferenceId(45)]
-rebuilt        : SymbolId(7): []
 Symbol span mismatch for "foo1":
 after transform: SymbolId(21): Span { start: 666, end: 670 }
 rebuilt        : SymbolId(9): Span { start: 717, end: 721 }
@@ -35738,26 +30644,8 @@ rebuilt        : SymbolId(45): Span { start: 2347, end: 2352 }
 Symbol redeclarations mismatch for "foo15":
 after transform: SymbolId(93): [Span { start: 2288, end: 2293 }, Span { start: 2311, end: 2316 }, Span { start: 2347, end: 2352 }]
 rebuilt        : SymbolId(45): []
-Unresolved references mismatch:
-after transform: ["Date", "RegExp"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesDifferingByReturnType2.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(17), ReferenceId(18), ReferenceId(35), ReferenceId(38), ReferenceId(41), ReferenceId(44)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(3): [ReferenceId(19), ReferenceId(21), ReferenceId(36), ReferenceId(46), ReferenceId(50), ReferenceId(54), ReferenceId(57)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(6): [ReferenceId(23), ReferenceId(25), ReferenceId(39), ReferenceId(52), ReferenceId(62), ReferenceId(65), ReferenceId(74)]
-rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(15): [ReferenceId(31), ReferenceId(32), ReferenceId(45), ReferenceId(56), ReferenceId(69)]
-rebuilt        : SymbolId(6): []
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(18): [ReferenceId(33), ReferenceId(34), ReferenceId(59), ReferenceId(72)]
-rebuilt        : SymbolId(7): []
 Symbol span mismatch for "foo1":
 after transform: SymbolId(21): Span { start: 757, end: 761 }
 rebuilt        : SymbolId(9): Span { start: 808, end: 812 }
@@ -35872,26 +30760,8 @@ rebuilt        : SymbolId(45): Span { start: 2396, end: 2401 }
 Symbol redeclarations mismatch for "foo15":
 after transform: SymbolId(93): [Span { start: 2339, end: 2344 }, Span { start: 2362, end: 2367 }, Span { start: 2396, end: 2401 }]
 rebuilt        : SymbolId(45): []
-Unresolved references mismatch:
-after transform: ["Date", "RegExp"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesDifferingTypeParameterCounts.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(14), ReferenceId(15), ReferenceId(26), ReferenceId(28), ReferenceId(30), ReferenceId(33)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(3): [ReferenceId(16), ReferenceId(17), ReferenceId(27), ReferenceId(35), ReferenceId(38), ReferenceId(40), ReferenceId(41), ReferenceId(43), ReferenceId(46), ReferenceId(49), ReferenceId(64), ReferenceId(65)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(7): [ReferenceId(18), ReferenceId(19), ReferenceId(29), ReferenceId(39), ReferenceId(48), ReferenceId(52), ReferenceId(63)]
-rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(24): [ReferenceId(22), ReferenceId(23), ReferenceId(34), ReferenceId(42), ReferenceId(57)]
-rebuilt        : SymbolId(6): []
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(31): [ReferenceId(24), ReferenceId(25), ReferenceId(44), ReferenceId(61)]
-rebuilt        : SymbolId(7): []
 Symbol span mismatch for "foo1":
 after transform: SymbolId(39): Span { start: 402, end: 406 }
 rebuilt        : SymbolId(9): Span { start: 453, end: 457 }
@@ -36006,14 +30876,8 @@ rebuilt        : SymbolId(45): Span { start: 2492, end: 2497 }
 Symbol redeclarations mismatch for "foo15":
 after transform: SymbolId(111): [Span { start: 2395, end: 2400 }, Span { start: 2418, end: 2423 }, Span { start: 2492, end: 2497 }]
 rebuilt        : SymbolId(45): []
-Unresolved references mismatch:
-after transform: ["Date", "RegExp"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesDifferingTypeParameterCounts2.ts
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(12): [ReferenceId(10), ReferenceId(11), ReferenceId(14), ReferenceId(18)]
-rebuilt        : SymbolId(0): []
 Symbol span mismatch for "foo1":
 after transform: SymbolId(19): Span { start: 180, end: 184 }
 rebuilt        : SymbolId(1): Span { start: 297, end: 301 }
@@ -36056,26 +30920,8 @@ rebuilt        : SymbolId(13): Span { start: 896, end: 901 }
 Symbol redeclarations mismatch for "foo15":
 after transform: SymbolId(43): [Span { start: 814, end: 819 }, Span { start: 867, end: 872 }, Span { start: 896, end: 901 }]
 rebuilt        : SymbolId(13): []
-Unresolved references mismatch:
-after transform: ["Date"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesDifferingTypeParameterNames.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(14), ReferenceId(15), ReferenceId(26), ReferenceId(28), ReferenceId(30), ReferenceId(32)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(3): [ReferenceId(16), ReferenceId(17), ReferenceId(27), ReferenceId(34), ReferenceId(36), ReferenceId(38), ReferenceId(40)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(6): [ReferenceId(18), ReferenceId(19), ReferenceId(29), ReferenceId(37), ReferenceId(43), ReferenceId(45), ReferenceId(51)]
-rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(15): [ReferenceId(22), ReferenceId(23), ReferenceId(33), ReferenceId(39), ReferenceId(47)]
-rebuilt        : SymbolId(6): []
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(18): [ReferenceId(24), ReferenceId(25), ReferenceId(41), ReferenceId(49)]
-rebuilt        : SymbolId(7): []
 Symbol span mismatch for "foo1":
 after transform: SymbolId(21): Span { start: 348, end: 352 }
 rebuilt        : SymbolId(9): Span { start: 399, end: 403 }
@@ -36192,21 +31038,6 @@ after transform: SymbolId(93): [Span { start: 1982, end: 1987 }, Span { start: 2
 rebuilt        : SymbolId(45): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesOptionalParams.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(21), ReferenceId(22), ReferenceId(33), ReferenceId(35), ReferenceId(37), ReferenceId(39)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(4): [ReferenceId(23), ReferenceId(24), ReferenceId(34), ReferenceId(41), ReferenceId(43), ReferenceId(45), ReferenceId(47)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(8): [ReferenceId(25), ReferenceId(26), ReferenceId(36), ReferenceId(44), ReferenceId(50), ReferenceId(52), ReferenceId(58)]
-rebuilt        : SymbolId(6): []
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(20): [ReferenceId(29), ReferenceId(30), ReferenceId(40), ReferenceId(46), ReferenceId(54)]
-rebuilt        : SymbolId(9): []
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(24): [ReferenceId(31), ReferenceId(32), ReferenceId(48), ReferenceId(56)]
-rebuilt        : SymbolId(10): []
 Symbol span mismatch for "foo1":
 after transform: SymbolId(28): Span { start: 688, end: 692 }
 rebuilt        : SymbolId(13): Span { start: 739, end: 743 }
@@ -36323,21 +31154,6 @@ after transform: SymbolId(100): [Span { start: 2331, end: 2336 }, Span { start: 
 rebuilt        : SymbolId(49): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesOptionalParams2.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(21), ReferenceId(22), ReferenceId(33), ReferenceId(35), ReferenceId(37), ReferenceId(39)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(5): [ReferenceId(23), ReferenceId(24), ReferenceId(34), ReferenceId(41), ReferenceId(43), ReferenceId(45), ReferenceId(47)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(10): [ReferenceId(25), ReferenceId(26), ReferenceId(36), ReferenceId(44), ReferenceId(50), ReferenceId(52), ReferenceId(58)]
-rebuilt        : SymbolId(6): []
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(25): [ReferenceId(29), ReferenceId(30), ReferenceId(40), ReferenceId(46), ReferenceId(54)]
-rebuilt        : SymbolId(9): []
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(30): [ReferenceId(31), ReferenceId(32), ReferenceId(48), ReferenceId(56)]
-rebuilt        : SymbolId(10): []
 Symbol span mismatch for "foo1":
 after transform: SymbolId(35): Span { start: 709, end: 713 }
 rebuilt        : SymbolId(13): Span { start: 760, end: 764 }
@@ -36454,21 +31270,6 @@ after transform: SymbolId(107): [Span { start: 2512, end: 2517 }, Span { start: 
 rebuilt        : SymbolId(49): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesOptionalParams3.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(21), ReferenceId(22), ReferenceId(33), ReferenceId(35), ReferenceId(37), ReferenceId(39)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(5): [ReferenceId(23), ReferenceId(24), ReferenceId(34), ReferenceId(41), ReferenceId(43), ReferenceId(45), ReferenceId(47)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(10): [ReferenceId(25), ReferenceId(26), ReferenceId(36), ReferenceId(44), ReferenceId(50), ReferenceId(52), ReferenceId(58)]
-rebuilt        : SymbolId(6): []
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(25): [ReferenceId(29), ReferenceId(30), ReferenceId(40), ReferenceId(46), ReferenceId(54)]
-rebuilt        : SymbolId(9): []
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(30): [ReferenceId(31), ReferenceId(32), ReferenceId(48), ReferenceId(56)]
-rebuilt        : SymbolId(10): []
 Symbol span mismatch for "foo1":
 after transform: SymbolId(35): Span { start: 706, end: 710 }
 rebuilt        : SymbolId(13): Span { start: 757, end: 761 }
@@ -36585,18 +31386,6 @@ after transform: SymbolId(107): [Span { start: 2503, end: 2508 }, Span { start: 
 rebuilt        : SymbolId(49): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesDifferingByConstraints.ts
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(0): [ReferenceId(12), ReferenceId(14), ReferenceId(28), ReferenceId(32), ReferenceId(36), ReferenceId(39)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(3): [ReferenceId(16), ReferenceId(18), ReferenceId(34), ReferenceId(44), ReferenceId(47)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(12): [ReferenceId(24), ReferenceId(25), ReferenceId(38), ReferenceId(51)]
-rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(15): [ReferenceId(26), ReferenceId(27), ReferenceId(41), ReferenceId(54)]
-rebuilt        : SymbolId(5): []
 Symbol span mismatch for "foo1b":
 after transform: SymbolId(18): Span { start: 770, end: 775 }
 rebuilt        : SymbolId(7): Span { start: 853, end: 858 }
@@ -36675,26 +31464,8 @@ rebuilt        : SymbolId(31): Span { start: 2027, end: 2032 }
 Symbol redeclarations mismatch for "foo14":
 after transform: SymbolId(66): [Span { start: 1962, end: 1967 }, Span { start: 1992, end: 1997 }, Span { start: 2027, end: 2032 }]
 rebuilt        : SymbolId(31): []
-Unresolved references mismatch:
-after transform: ["Array", "Boolean", "Number", "RegExp", "String"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesDifferingByConstraints2.ts
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(0): [ReferenceId(28), ReferenceId(31), ReferenceId(61), ReferenceId(67), ReferenceId(73), ReferenceId(77)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(5): [ReferenceId(34), ReferenceId(37), ReferenceId(50), ReferenceId(56), ReferenceId(70), ReferenceId(84), ReferenceId(88)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch for "D":
-after transform: SymbolId(10): [ReferenceId(53), ReferenceId(59)]
-rebuilt        : SymbolId(6): []
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(25): [ReferenceId(46), ReferenceId(47), ReferenceId(76), ReferenceId(94)]
-rebuilt        : SymbolId(9): []
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(30): [ReferenceId(48), ReferenceId(49), ReferenceId(80), ReferenceId(98)]
-rebuilt        : SymbolId(10): []
 Symbol span mismatch for "foo1b":
 after transform: SymbolId(35): Span { start: 973, end: 978 }
 rebuilt        : SymbolId(13): Span { start: 1086, end: 1091 }
@@ -36785,32 +31556,8 @@ rebuilt        : SymbolId(41): Span { start: 2625, end: 2630 }
 Symbol redeclarations mismatch for "foo14":
 after transform: SymbolId(91): [Span { start: 2552, end: 2557 }, Span { start: 2590, end: 2595 }, Span { start: 2625, end: 2630 }]
 rebuilt        : SymbolId(41): []
-Unresolved references mismatch:
-after transform: ["Array", "Boolean", "Number", "RegExp", "String"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesDifferingByConstraints3.ts
-Symbol reference IDs mismatch for "One":
-after transform: SymbolId(0): [ReferenceId(25)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch for "Two":
-after transform: SymbolId(1): [ReferenceId(29), ReferenceId(33), ReferenceId(34), ReferenceId(36), ReferenceId(37), ReferenceId(67), ReferenceId(68), ReferenceId(73), ReferenceId(74), ReferenceId(79), ReferenceId(80), ReferenceId(83), ReferenceId(84), ReferenceId(5)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(10): [ReferenceId(32), ReferenceId(35), ReferenceId(66), ReferenceId(72), ReferenceId(78), ReferenceId(82)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(15): [ReferenceId(38), ReferenceId(41), ReferenceId(54), ReferenceId(60), ReferenceId(75), ReferenceId(89), ReferenceId(93)]
-rebuilt        : SymbolId(6): []
-Symbol reference IDs mismatch for "D":
-after transform: SymbolId(20): [ReferenceId(57), ReferenceId(63)]
-rebuilt        : SymbolId(9): []
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(35): [ReferenceId(50), ReferenceId(51), ReferenceId(81), ReferenceId(99)]
-rebuilt        : SymbolId(12): []
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(40): [ReferenceId(52), ReferenceId(53), ReferenceId(85), ReferenceId(103)]
-rebuilt        : SymbolId(13): []
 Symbol span mismatch for "foo1b":
 after transform: SymbolId(45): Span { start: 1161, end: 1166 }
 rebuilt        : SymbolId(16): Span { start: 1234, end: 1239 }
@@ -36903,18 +31650,6 @@ after transform: SymbolId(101): [Span { start: 2672, end: 2677 }, Span { start: 
 rebuilt        : SymbolId(44): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesDifferingByReturnType.ts
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(0): [ReferenceId(10), ReferenceId(11), ReferenceId(22), ReferenceId(24), ReferenceId(26), ReferenceId(28)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(3): [ReferenceId(12), ReferenceId(13), ReferenceId(25), ReferenceId(31), ReferenceId(33), ReferenceId(39)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(12): [ReferenceId(16), ReferenceId(17), ReferenceId(20), ReferenceId(27), ReferenceId(35)]
-rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(15): [ReferenceId(18), ReferenceId(19), ReferenceId(21), ReferenceId(29), ReferenceId(37)]
-rebuilt        : SymbolId(5): []
 Symbol span mismatch for "foo1b":
 after transform: SymbolId(18): Span { start: 663, end: 668 }
 rebuilt        : SymbolId(7): Span { start: 732, end: 737 }
@@ -37005,23 +31740,8 @@ rebuilt        : SymbolId(35): Span { start: 2080, end: 2085 }
 Symbol redeclarations mismatch for "foo15":
 after transform: SymbolId(74): [Span { start: 2021, end: 2026 }, Span { start: 2044, end: 2049 }, Span { start: 2080, end: 2085 }]
 rebuilt        : SymbolId(35): []
-Unresolved references mismatch:
-after transform: ["Date", "RegExp"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesDifferingByReturnType2.ts
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(0): [ReferenceId(15), ReferenceId(17), ReferenceId(31), ReferenceId(35), ReferenceId(39), ReferenceId(42)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(3): [ReferenceId(19), ReferenceId(21), ReferenceId(37), ReferenceId(47), ReferenceId(50), ReferenceId(59)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(12): [ReferenceId(27), ReferenceId(28), ReferenceId(41), ReferenceId(54)]
-rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(15): [ReferenceId(29), ReferenceId(30), ReferenceId(44), ReferenceId(57)]
-rebuilt        : SymbolId(5): []
 Symbol span mismatch for "foo1b":
 after transform: SymbolId(18): Span { start: 738, end: 743 }
 rebuilt        : SymbolId(7): Span { start: 803, end: 808 }
@@ -37106,23 +31826,8 @@ rebuilt        : SymbolId(33): Span { start: 2009, end: 2014 }
 Symbol redeclarations mismatch for "foo15":
 after transform: SymbolId(70): [Span { start: 1952, end: 1957 }, Span { start: 1975, end: 1980 }, Span { start: 2009, end: 2014 }]
 rebuilt        : SymbolId(33): []
-Unresolved references mismatch:
-after transform: ["Date", "RegExp"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesDifferingTypeParameterCounts.ts
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(0): [ReferenceId(18), ReferenceId(19), ReferenceId(28), ReferenceId(31), ReferenceId(33), ReferenceId(34), ReferenceId(36), ReferenceId(39), ReferenceId(42), ReferenceId(3)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(4): [ReferenceId(20), ReferenceId(21), ReferenceId(32), ReferenceId(41), ReferenceId(45), ReferenceId(7), ReferenceId(12)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(21): [ReferenceId(24), ReferenceId(25), ReferenceId(35), ReferenceId(50)]
-rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(28): [ReferenceId(26), ReferenceId(27), ReferenceId(37), ReferenceId(54)]
-rebuilt        : SymbolId(5): []
 Symbol span mismatch for "foo1b":
 after transform: SymbolId(36): Span { start: 389, end: 394 }
 rebuilt        : SymbolId(7): Span { start: 474, end: 479 }
@@ -37201,23 +31906,8 @@ rebuilt        : SymbolId(31): Span { start: 1892, end: 1897 }
 Symbol redeclarations mismatch for "foo14":
 after transform: SymbolId(84): [Span { start: 1804, end: 1809 }, Span { start: 1857, end: 1862 }, Span { start: 1892, end: 1897 }]
 rebuilt        : SymbolId(31): []
-Unresolved references mismatch:
-after transform: ["Date", "RegExp"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesDifferingTypeParameterNames.ts
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(0): [ReferenceId(15), ReferenceId(16), ReferenceId(25), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(3), ReferenceId(9)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(3): [ReferenceId(17), ReferenceId(18), ReferenceId(28), ReferenceId(34), ReferenceId(36), ReferenceId(6), ReferenceId(12)]
-rebuilt        : SymbolId(2): [ReferenceId(0)]
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(12): [ReferenceId(21), ReferenceId(22), ReferenceId(30), ReferenceId(38)]
-rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(15): [ReferenceId(23), ReferenceId(24), ReferenceId(32), ReferenceId(40)]
-rebuilt        : SymbolId(5): []
 Symbol span mismatch for "foo1b":
 after transform: SymbolId(18): Span { start: 327, end: 332 }
 rebuilt        : SymbolId(7): Span { start: 396, end: 401 }
@@ -37298,18 +31988,6 @@ after transform: SymbolId(66): [Span { start: 1482, end: 1487 }, Span { start: 1
 rebuilt        : SymbolId(31): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesOptionalParams.ts
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(0): [ReferenceId(22), ReferenceId(23), ReferenceId(32), ReferenceId(34), ReferenceId(36), ReferenceId(38), ReferenceId(6), ReferenceId(14)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(4): [ReferenceId(24), ReferenceId(25), ReferenceId(35), ReferenceId(41), ReferenceId(43), ReferenceId(10), ReferenceId(18)]
-rebuilt        : SymbolId(3): [ReferenceId(0)]
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(16): [ReferenceId(28), ReferenceId(29), ReferenceId(37), ReferenceId(45)]
-rebuilt        : SymbolId(6): []
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(20): [ReferenceId(30), ReferenceId(31), ReferenceId(39), ReferenceId(47)]
-rebuilt        : SymbolId(7): []
 Symbol span mismatch for "foo1b":
 after transform: SymbolId(24): Span { start: 713, end: 718 }
 rebuilt        : SymbolId(10): Span { start: 782, end: 787 }
@@ -37390,18 +32068,6 @@ after transform: SymbolId(72): [Span { start: 1914, end: 1919 }, Span { start: 1
 rebuilt        : SymbolId(34): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesOptionalParams2.ts
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(0): [ReferenceId(26), ReferenceId(27), ReferenceId(36), ReferenceId(38), ReferenceId(40), ReferenceId(42), ReferenceId(6), ReferenceId(16)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(5): [ReferenceId(28), ReferenceId(29), ReferenceId(39), ReferenceId(45), ReferenceId(47), ReferenceId(11), ReferenceId(21)]
-rebuilt        : SymbolId(3): [ReferenceId(0)]
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(20): [ReferenceId(32), ReferenceId(33), ReferenceId(41), ReferenceId(49)]
-rebuilt        : SymbolId(6): []
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(25): [ReferenceId(34), ReferenceId(35), ReferenceId(43), ReferenceId(51)]
-rebuilt        : SymbolId(7): []
 Symbol span mismatch for "foo1b":
 after transform: SymbolId(30): Span { start: 744, end: 749 }
 rebuilt        : SymbolId(10): Span { start: 829, end: 834 }
@@ -37482,18 +32148,6 @@ after transform: SymbolId(78): [Span { start: 2024, end: 2029 }, Span { start: 2
 rebuilt        : SymbolId(34): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesOptionalParams3.ts
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(0): [ReferenceId(26), ReferenceId(27), ReferenceId(36), ReferenceId(38), ReferenceId(40), ReferenceId(42), ReferenceId(6), ReferenceId(16)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(5): [ReferenceId(28), ReferenceId(29), ReferenceId(39), ReferenceId(45), ReferenceId(47), ReferenceId(11), ReferenceId(21)]
-rebuilt        : SymbolId(3): [ReferenceId(0)]
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(20): [ReferenceId(32), ReferenceId(33), ReferenceId(41), ReferenceId(49)]
-rebuilt        : SymbolId(6): []
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(25): [ReferenceId(34), ReferenceId(35), ReferenceId(43), ReferenceId(51)]
-rebuilt        : SymbolId(7): []
 Symbol span mismatch for "foo1b":
 after transform: SymbolId(30): Span { start: 742, end: 747 }
 rebuilt        : SymbolId(10): Span { start: 827, end: 832 }
@@ -37574,27 +32228,6 @@ after transform: SymbolId(78): [Span { start: 2050, end: 2055 }, Span { start: 2
 rebuilt        : SymbolId(34): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithNumericIndexers1.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(23), ReferenceId(25), ReferenceId(1)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(1): [ReferenceId(5), ReferenceId(6), ReferenceId(16), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(37), ReferenceId(2)]
-rebuilt        : SymbolId(1): [ReferenceId(1)]
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(2): [ReferenceId(7), ReferenceId(8), ReferenceId(18), ReferenceId(30), ReferenceId(40)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "PA":
-after transform: SymbolId(5): [ReferenceId(20), ReferenceId(36), ReferenceId(46)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch for "PB":
-after transform: SymbolId(6): [ReferenceId(22), ReferenceId(38), ReferenceId(48)]
-rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(7): [ReferenceId(11), ReferenceId(12), ReferenceId(26), ReferenceId(32), ReferenceId(42)]
-rebuilt        : SymbolId(5): []
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(8): [ReferenceId(13), ReferenceId(14), ReferenceId(34), ReferenceId(44)]
-rebuilt        : SymbolId(6): []
 Symbol span mismatch for "foo1":
 after transform: SymbolId(9): Span { start: 337, end: 341 }
 rebuilt        : SymbolId(7): Span { start: 388, end: 392 }
@@ -37735,33 +32368,6 @@ after transform: SymbolId(97): [Span { start: 2206, end: 2211 }, Span { start: 2
 rebuilt        : SymbolId(51): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithNumericIndexers2.ts
-Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(39), ReferenceId(0), ReferenceId(1), ReferenceId(7)]
-rebuilt        : SymbolId(1): [ReferenceId(2)]
-Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(1): [ReferenceId(26), ReferenceId(50), ReferenceId(2), ReferenceId(4), ReferenceId(8), ReferenceId(9)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(2): [ReferenceId(10), ReferenceId(11), ReferenceId(22), ReferenceId(24), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33), ReferenceId(5)]
-rebuilt        : SymbolId(4): [ReferenceId(5)]
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(3): [ReferenceId(12), ReferenceId(13), ReferenceId(23), ReferenceId(35), ReferenceId(37), ReferenceId(40), ReferenceId(42), ReferenceId(44), ReferenceId(46), ReferenceId(6)]
-rebuilt        : SymbolId(5): [ReferenceId(6)]
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(4): [ReferenceId(14), ReferenceId(15), ReferenceId(25), ReferenceId(38), ReferenceId(49)]
-rebuilt        : SymbolId(6): []
-Symbol reference IDs mismatch for "PA":
-after transform: SymbolId(7): [ReferenceId(28), ReferenceId(45), ReferenceId(56)]
-rebuilt        : SymbolId(7): []
-Symbol reference IDs mismatch for "PB":
-after transform: SymbolId(8): [ReferenceId(30), ReferenceId(47), ReferenceId(58)]
-rebuilt        : SymbolId(8): []
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(9): [ReferenceId(18), ReferenceId(19), ReferenceId(34), ReferenceId(41), ReferenceId(52)]
-rebuilt        : SymbolId(9): []
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(10): [ReferenceId(20), ReferenceId(21), ReferenceId(43), ReferenceId(54)]
-rebuilt        : SymbolId(10): []
 Symbol span mismatch for "foo1":
 after transform: SymbolId(11): Span { start: 420, end: 424 }
 rebuilt        : SymbolId(11): Span { start: 471, end: 475 }
@@ -37902,27 +32508,6 @@ after transform: SymbolId(99): [Span { start: 2262, end: 2267 }, Span { start: 2
 rebuilt        : SymbolId(55): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithNumericIndexers3.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(23), ReferenceId(25), ReferenceId(1)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(1): [ReferenceId(5), ReferenceId(6), ReferenceId(16), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(37), ReferenceId(2)]
-rebuilt        : SymbolId(1): [ReferenceId(1)]
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(2): [ReferenceId(7), ReferenceId(8), ReferenceId(18), ReferenceId(30), ReferenceId(40)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "PA":
-after transform: SymbolId(5): [ReferenceId(20), ReferenceId(36), ReferenceId(46)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch for "PB":
-after transform: SymbolId(6): [ReferenceId(22), ReferenceId(38), ReferenceId(48)]
-rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(7): [ReferenceId(11), ReferenceId(12), ReferenceId(26), ReferenceId(32), ReferenceId(42)]
-rebuilt        : SymbolId(5): []
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(8): [ReferenceId(13), ReferenceId(14), ReferenceId(34), ReferenceId(44)]
-rebuilt        : SymbolId(6): []
 Symbol span mismatch for "foo1":
 after transform: SymbolId(9): Span { start: 337, end: 341 }
 rebuilt        : SymbolId(7): Span { start: 388, end: 392 }
@@ -38063,21 +32648,6 @@ after transform: SymbolId(97): [Span { start: 2176, end: 2181 }, Span { start: 2
 rebuilt        : SymbolId(51): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithOptionality.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(5), ReferenceId(7)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(1): [ReferenceId(9), ReferenceId(11)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(2): [ReferenceId(14)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(5): [ReferenceId(3), ReferenceId(4), ReferenceId(8), ReferenceId(12), ReferenceId(16)]
-rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(6): [ReferenceId(18)]
-rebuilt        : SymbolId(5): []
 Symbol span mismatch for "foo2":
 after transform: SymbolId(7): Span { start: 223, end: 227 }
 rebuilt        : SymbolId(6): Span { start: 274, end: 278 }
@@ -38134,27 +32704,6 @@ after transform: SymbolId(39): [Span { start: 884, end: 889 }, Span { start: 906
 rebuilt        : SymbolId(22): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithPrivates.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(23), ReferenceId(25), ReferenceId(1)]
-rebuilt        : SymbolId(1): [ReferenceId(4)]
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(1): [ReferenceId(5), ReferenceId(6), ReferenceId(16), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(37), ReferenceId(2)]
-rebuilt        : SymbolId(2): [ReferenceId(5)]
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(2): [ReferenceId(7), ReferenceId(8), ReferenceId(18), ReferenceId(30), ReferenceId(40)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch for "PA":
-after transform: SymbolId(5): [ReferenceId(20), ReferenceId(36), ReferenceId(46)]
-rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch for "PB":
-after transform: SymbolId(6): [ReferenceId(22), ReferenceId(38), ReferenceId(48)]
-rebuilt        : SymbolId(5): []
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(7): [ReferenceId(11), ReferenceId(12), ReferenceId(26), ReferenceId(32), ReferenceId(42)]
-rebuilt        : SymbolId(6): []
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(8): [ReferenceId(13), ReferenceId(14), ReferenceId(34), ReferenceId(44)]
-rebuilt        : SymbolId(7): []
 Symbol span mismatch for "foo1":
 after transform: SymbolId(9): Span { start: 293, end: 297 }
 rebuilt        : SymbolId(8): Span { start: 344, end: 348 }
@@ -38295,12 +32844,6 @@ after transform: SymbolId(97): [Span { start: 2198, end: 2203 }, Span { start: 2
 rebuilt        : SymbolId(52): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithPrivates2.ts
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(7), ReferenceId(9), ReferenceId(15), ReferenceId(16), ReferenceId(1), ReferenceId(12)]
-rebuilt        : SymbolId(1): [ReferenceId(2), ReferenceId(4)]
-Symbol reference IDs mismatch for "D":
-after transform: SymbolId(2): [ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(17), ReferenceId(18), ReferenceId(14)]
-rebuilt        : SymbolId(2): [ReferenceId(6)]
 Symbol span mismatch for "foo1":
 after transform: SymbolId(4): Span { start: 118, end: 122 }
 rebuilt        : SymbolId(3): Span { start: 182, end: 186 }
@@ -38339,21 +32882,6 @@ after transform: SymbolId(25): [Span { start: 690, end: 694 }, Span { start: 727
 rebuilt        : SymbolId(14): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithPublics.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(2), ReferenceId(13), ReferenceId(15), ReferenceId(17), ReferenceId(19)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(1): [ReferenceId(3), ReferenceId(4), ReferenceId(14), ReferenceId(21), ReferenceId(23), ReferenceId(25), ReferenceId(27)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(2): [ReferenceId(5), ReferenceId(6), ReferenceId(16), ReferenceId(24), ReferenceId(30)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(5): [ReferenceId(9), ReferenceId(10), ReferenceId(20), ReferenceId(26), ReferenceId(32)]
-rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(6): [ReferenceId(11), ReferenceId(12), ReferenceId(28), ReferenceId(34)]
-rebuilt        : SymbolId(5): []
 Symbol span mismatch for "foo1":
 after transform: SymbolId(7): Span { start: 242, end: 246 }
 rebuilt        : SymbolId(6): Span { start: 293, end: 297 }
@@ -38458,27 +32986,6 @@ after transform: SymbolId(71): [Span { start: 1607, end: 1612 }, Span { start: 1
 rebuilt        : SymbolId(38): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithStringIndexers.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(23), ReferenceId(25), ReferenceId(1)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(1): [ReferenceId(5), ReferenceId(6), ReferenceId(16), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(37), ReferenceId(2)]
-rebuilt        : SymbolId(1): [ReferenceId(1)]
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(2): [ReferenceId(7), ReferenceId(8), ReferenceId(18), ReferenceId(30), ReferenceId(40)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "PA":
-after transform: SymbolId(5): [ReferenceId(20), ReferenceId(36), ReferenceId(46)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch for "PB":
-after transform: SymbolId(6): [ReferenceId(22), ReferenceId(38), ReferenceId(48)]
-rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(7): [ReferenceId(11), ReferenceId(12), ReferenceId(26), ReferenceId(32), ReferenceId(42)]
-rebuilt        : SymbolId(5): []
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(8): [ReferenceId(13), ReferenceId(14), ReferenceId(34), ReferenceId(44)]
-rebuilt        : SymbolId(6): []
 Symbol span mismatch for "foo1":
 after transform: SymbolId(9): Span { start: 339, end: 343 }
 rebuilt        : SymbolId(7): Span { start: 390, end: 394 }
@@ -38619,33 +33126,6 @@ after transform: SymbolId(97): [Span { start: 2208, end: 2213 }, Span { start: 2
 rebuilt        : SymbolId(51): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithStringIndexers2.ts
-Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(39), ReferenceId(0), ReferenceId(1), ReferenceId(7)]
-rebuilt        : SymbolId(1): [ReferenceId(2)]
-Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(1): [ReferenceId(26), ReferenceId(50), ReferenceId(2), ReferenceId(4), ReferenceId(8), ReferenceId(9)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(2): [ReferenceId(10), ReferenceId(11), ReferenceId(22), ReferenceId(24), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33), ReferenceId(5)]
-rebuilt        : SymbolId(4): [ReferenceId(5)]
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(3): [ReferenceId(12), ReferenceId(13), ReferenceId(23), ReferenceId(35), ReferenceId(37), ReferenceId(40), ReferenceId(42), ReferenceId(44), ReferenceId(46), ReferenceId(6)]
-rebuilt        : SymbolId(5): [ReferenceId(6)]
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(4): [ReferenceId(14), ReferenceId(15), ReferenceId(25), ReferenceId(38), ReferenceId(49)]
-rebuilt        : SymbolId(6): []
-Symbol reference IDs mismatch for "PA":
-after transform: SymbolId(7): [ReferenceId(28), ReferenceId(45), ReferenceId(56)]
-rebuilt        : SymbolId(7): []
-Symbol reference IDs mismatch for "PB":
-after transform: SymbolId(8): [ReferenceId(30), ReferenceId(47), ReferenceId(58)]
-rebuilt        : SymbolId(8): []
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(9): [ReferenceId(18), ReferenceId(19), ReferenceId(34), ReferenceId(41), ReferenceId(52)]
-rebuilt        : SymbolId(9): []
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(10): [ReferenceId(20), ReferenceId(21), ReferenceId(43), ReferenceId(54)]
-rebuilt        : SymbolId(10): []
 Symbol span mismatch for "foo1":
 after transform: SymbolId(11): Span { start: 422, end: 426 }
 rebuilt        : SymbolId(11): Span { start: 473, end: 477 }
@@ -38825,9 +33305,6 @@ rebuilt        : SymbolId(8): []
 Symbol flags mismatch for "E":
 after transform: SymbolId(21): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(10): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "E":
-after transform: SymbolId(21): [ReferenceId(0), ReferenceId(1), ReferenceId(5)]
-rebuilt        : SymbolId(10): [ReferenceId(3)]
 Symbol span mismatch for "foo6":
 after transform: SymbolId(23): Span { start: 522, end: 526 }
 rebuilt        : SymbolId(12): Span { start: 564, end: 568 }
@@ -38866,9 +33343,6 @@ rebuilt        : SymbolId(9): Span { start: 553, end: 559 }
 Symbol redeclarations mismatch for "inner2":
 after transform: SymbolId(26): [Span { start: 471, end: 477 }, Span { start: 498, end: 504 }, Span { start: 553, end: 559 }]
 rebuilt        : SymbolId(9): []
-Unresolved references mismatch:
-after transform: ["Date"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/bivariantInferences.ts
 Bindings mismatch:
@@ -38881,7 +33355,7 @@ Reference symbol mismatch for "b":
 after transform: SymbolId(5) "b"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["ReadonlyArray"]
+after transform: []
 rebuilt        : ["a", "b"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/discriminatedUnionInference.ts
@@ -38898,33 +33372,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["foo"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithArrayLiteralArgs.ts
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithConstraintsTypeArgumentInference.ts
-Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(5), ReferenceId(12), ReferenceId(17), ReferenceId(56), ReferenceId(0), ReferenceId(2), ReferenceId(22), ReferenceId(29), ReferenceId(61), ReferenceId(90), ReferenceId(116), ReferenceId(120), ReferenceId(124)]
-rebuilt        : SymbolId(1): [ReferenceId(2)]
-Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(1): [ReferenceId(13), ReferenceId(18), ReferenceId(39), ReferenceId(47), ReferenceId(57), ReferenceId(1), ReferenceId(3), ReferenceId(23), ReferenceId(30), ReferenceId(52), ReferenceId(62), ReferenceId(91), ReferenceId(100), ReferenceId(108), ReferenceId(113), ReferenceId(117), ReferenceId(121), ReferenceId(125)]
-rebuilt        : SymbolId(2): [ReferenceId(5)]
-Symbol reference IDs mismatch for "Derived2":
-after transform: SymbolId(2): [ReferenceId(43), ReferenceId(48), ReferenceId(4), ReferenceId(53), ReferenceId(104), ReferenceId(109), ReferenceId(114)]
-rebuilt        : SymbolId(4): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGenericSignatureArguments.ts
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(20): [ReferenceId(14), ReferenceId(21), ReferenceId(15), ReferenceId(22)]
-rebuilt        : SymbolId(16): [ReferenceId(6), ReferenceId(10)]
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(21): [ReferenceId(16), ReferenceId(19), ReferenceId(17), ReferenceId(20)]
-rebuilt        : SymbolId(17): [ReferenceId(7), ReferenceId(9)]
-Unresolved references mismatch:
-after transform: ["Date", "Object", "RegExp"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithOverloadedFunctionTypedArguments.ts
 Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
@@ -38938,9 +33385,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "NonGenericParameter":
 after transform: SymbolId(0): Span { start: 196, end: 215 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(3)]
-rebuilt        : SymbolId(2): [ReferenceId(2)]
 Symbol flags mismatch for "GenericParameter":
 after transform: SymbolId(12): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
@@ -38958,9 +33402,6 @@ rebuilt        : SymbolId(32): SymbolFlags(BlockScopedVariable | ConstVariable)
 Symbol span mismatch for "fn":
 after transform: SymbolId(119): Span { start: 1594, end: 1596 }
 rebuilt        : SymbolId(32): Span { start: 1621, end: 1623 }
-Symbol reference IDs mismatch for "fn":
-after transform: SymbolId(119): [ReferenceId(118)]
-rebuilt        : SymbolId(32): []
 Symbol redeclarations mismatch for "fn":
 after transform: SymbolId(119): [Span { start: 1594, end: 1596 }, Span { start: 1621, end: 1623 }]
 rebuilt        : SymbolId(32): []
@@ -39070,13 +33511,8 @@ Reference symbol mismatch for "s":
 after transform: SymbolId(21) "s"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Array"]
+after transform: []
 rebuilt        : ["f1", "f2", "f3", "s"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/intraExpressionInferencesJsx.tsx
-Unresolved references mismatch:
-after transform: ["Partial", "Record"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/keyofInferenceIntersectsResults.ts
 Bindings mismatch:
@@ -39105,11 +33541,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["Error"]
 rebuilt        : ["ConflictTarget", "Error"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/noInferRedeclaration.ts
-Unresolved references mismatch:
-after transform: ["NoInfer"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/unionAndIntersectionInference3.ts
 Bindings mismatch:
@@ -39185,7 +33616,7 @@ Reference symbol mismatch for "b":
 after transform: SymbolId(77) "b"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["AsyncIterator", "Iterable", "Iterator", "Omit", "Promise", "PromiseLike", "arguments"]
+after transform: ["arguments"]
 rebuilt        : ["MyComponent", "a", "ab", "arguments", "b", "concatMaybe", "f1", "f2", "foo", "foo1", "foo2", "g1", "g2", "sa", "sx", "withRouter"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/widenedTypes/strictNullChecksNoWidening.ts
@@ -39215,9 +33646,6 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "AnimalType":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "AnimalType":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(5), ReferenceId(9), ReferenceId(16), ReferenceId(19), ReferenceId(26), ReferenceId(29), ReferenceId(37)]
-rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(6), ReferenceId(10), ReferenceId(16), ReferenceId(19), ReferenceId(25), ReferenceId(28)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeCallSignatures7.ts
 Bindings mismatch:
@@ -39229,11 +33657,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["f"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeIndexSignature.ts
-Unresolved references mismatch:
-after transform: ["Date"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarationsErrors.ts
 Bindings mismatch:

--- a/tasks/coverage/snapshots/transformer_misc.snap
+++ b/tasks/coverage/snapshots/transformer_misc.snap
@@ -1,3 +1,3 @@
 transformer_misc Summary:
-AST Parsed     : 69/69 (100.00%)
-Positive Passed: 69/69 (100.00%)
+AST Parsed     : 70/70 (100.00%)
+Positive Passed: 70/70 (100.00%)

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1,10 +1,11 @@
 commit: 1fb0b771
 
-Passed: 700/1165
+Passed: 742/1165
 
 # All Passed:
 * babel-plugin-transform-logical-assignment-operators
 * babel-plugin-transform-export-namespace-from
+* babel-plugin-transform-optional-chaining
 * babel-plugin-transform-optional-catch-binding
 * babel-plugin-transform-react-display-name
 
@@ -192,7 +193,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-class-properties (212/269)
+# babel-plugin-transform-class-properties (214/269)
 * assumption-constantSuper/complex-super-class/input.js
 x Output mismatch
 
@@ -231,16 +232,6 @@ x Output mismatch
 
 * class-name-tdz/typescript-type/input.ts
 x Output mismatch
-
-* compile-to-class/constructor-collision-ignores-types/input.js
-Unresolved references mismatch:
-after transform: ["T", "babelHelpers"]
-rebuilt        : ["babelHelpers"]
-
-* compile-to-class/constructor-collision-ignores-types-loose/input.js
-Unresolved references mismatch:
-after transform: ["T"]
-rebuilt        : []
 
 * nested-class/super-call-in-decorator/input.js
 x Output mismatch
@@ -898,23 +889,6 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-optional-chaining (42/45)
-* transparent-expr-wrappers/ts-as-function-call-loose/input.ts
-Unresolved references mismatch:
-after transform: ["A", "B", "foo"]
-rebuilt        : ["foo"]
-
-* transparent-expr-wrappers/ts-as-member-expression/input.ts
-Unresolved references mismatch:
-after transform: ["ExampleType", "ExampleType2", "a"]
-rebuilt        : ["a"]
-
-* transparent-expr-wrappers/ts-parenthesized-expression-member-call/input.ts
-Unresolved references mismatch:
-after transform: ["ExampleType", "o"]
-rebuilt        : ["o"]
-
-
 # babel-plugin-transform-async-generator-functions (19/20)
 * async-generators/class-private-method/input.js
 x Output mismatch
@@ -1085,14 +1059,9 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-preset-typescript (8/12)
+# babel-preset-typescript (9/12)
 * node-extensions/import-in-cts/input.cts
 x Output mismatch
-
-* node-extensions/type-assertion-in-ts/input.ts
-Unresolved references mismatch:
-after transform: ["T", "x"]
-rebuilt        : ["x"]
 
 * opts/rewriteImportExtensions/input.ts
 x Output mismatch
@@ -1101,17 +1070,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-typescript (54/157)
-* cast/as-expression/input.ts
-Unresolved references mismatch:
-after transform: ["T", "x"]
-rebuilt        : ["x"]
-
-* cast/type-assertion/input.ts
-Unresolved references mismatch:
-after transform: ["T", "x"]
-rebuilt        : ["x"]
-
+# babel-plugin-transform-typescript (90/157)
 * class/accessor-allowDeclareFields-false/input.ts
 
   x TS(18010): An accessibility modifier cannot be used with a private
@@ -1161,11 +1120,6 @@ rebuilt        : ["x"]
   help: Allowed modifiers are: private, protected, public, static, abstract,
         override
 
-
-* class/head/input.ts
-Unresolved references mismatch:
-after transform: ["D", "I"]
-rebuilt        : ["D"]
 
 * class/parameter-properties-late-super/input.ts
 x Output mismatch
@@ -1456,9 +1410,6 @@ x Output mismatch
 Symbol flags mismatch for "N":
 after transform: SymbolId(0): SymbolFlags(Class | NamespaceModule | Ambient)
 rebuilt        : SymbolId(0): SymbolFlags(Class)
-Symbol reference IDs mismatch for "N":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2)]
-rebuilt        : SymbolId(0): [ReferenceId(1)]
 Symbol redeclarations mismatch for "N":
 after transform: SymbolId(0): [Span { start: 13, end: 14 }, Span { start: 83, end: 84 }]
 rebuilt        : SymbolId(0): []
@@ -1470,18 +1421,12 @@ rebuilt        : SymbolId(0): SymbolFlags(Function)
 Symbol span mismatch for "Signal":
 after transform: SymbolId(0): Span { start: 14, end: 20 }
 rebuilt        : SymbolId(0): Span { start: 54, end: 60 }
-Symbol reference IDs mismatch for "Signal":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(3)]
-rebuilt        : SymbolId(0): [ReferenceId(1)]
 Symbol redeclarations mismatch for "Signal":
 after transform: SymbolId(0): [Span { start: 14, end: 20 }, Span { start: 54, end: 60 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "Signal2":
 after transform: SymbolId(3): SymbolFlags(Class | Function | Ambient)
 rebuilt        : SymbolId(2): SymbolFlags(Function)
-Symbol reference IDs mismatch for "Signal2":
-after transform: SymbolId(3): [ReferenceId(4), ReferenceId(7)]
-rebuilt        : SymbolId(2): [ReferenceId(3)]
 Symbol redeclarations mismatch for "Signal2":
 after transform: SymbolId(3): [Span { start: 147, end: 154 }, Span { start: 225, end: 232 }]
 rebuilt        : SymbolId(2): []
@@ -1522,42 +1467,9 @@ rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "None":
 after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "None":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2)]
-rebuilt        : SymbolId(0): [ReferenceId(1)]
-
-* exports/imported-types/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A", "B", "C"]
-rebuilt        : ScopeId(0): ["C"]
-
-* exports/imported-types-only-remove-type-imports/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A", "B", "C"]
-rebuilt        : ScopeId(0): ["C"]
 
 * exports/interface/input.ts
 x Output mismatch
-
-* exports/issue-9916-1/input.ts
-Unresolved references mismatch:
-after transform: ["PromiseLike"]
-rebuilt        : []
-
-* exports/issue-9916-2/input.ts
-Unresolved references mismatch:
-after transform: ["PromiseLike"]
-rebuilt        : []
-
-* exports/issue-9916-3/input.ts
-Unresolved references mismatch:
-after transform: ["PromiseLike"]
-rebuilt        : []
-
-* exports/type-only-export-specifier-1/input.ts
-Symbol reference IDs mismatch for "Foo":
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(0): []
 
 * function/overloads/input.ts
 Symbol span mismatch for "f":
@@ -1575,65 +1487,7 @@ Symbol redeclarations mismatch for "f":
 after transform: SymbolId(0): [Span { start: 9, end: 10 }, Span { start: 29, end: 30 }]
 rebuilt        : SymbolId(0): []
 
-* imports/elide-preact/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["FooBar", "Fragment", "h", "x"]
-rebuilt        : ScopeId(0): ["x"]
-
-* imports/elide-preact-no-1/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["Fragment", "h", "render"]
-rebuilt        : ScopeId(0): ["Fragment", "h"]
-
-* imports/elide-preact-no-2/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["Fragment", "render"]
-rebuilt        : ScopeId(0): ["Fragment"]
-
-* imports/elide-react/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["React", "x"]
-rebuilt        : ScopeId(0): ["x"]
-
-* imports/elide-type-referenced-in-imports-equal-no/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["nsa", "nsb"]
-rebuilt        : ScopeId(0): []
-
-* imports/elide-typeof/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A", "x"]
-rebuilt        : ScopeId(0): ["x"]
-
-* imports/elision/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A", "B", "C", "D", "Used", "Used2", "Used3", "x", "y", "z"]
-rebuilt        : ScopeId(0): ["Used", "Used2", "Used3", "x", "y", "z"]
-
-* imports/elision-export-type/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A", "B", "T", "T1"]
-rebuilt        : ScopeId(0): ["A", "B"]
-
-* imports/elision-locations/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A", "B", "C", "Class", "D", "E", "F", "G", "H", "x", "y"]
-rebuilt        : ScopeId(0): ["A", "Class", "x", "y"]
-
-* imports/elision-qualifiedname/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A", "x"]
-rebuilt        : ScopeId(0): ["x"]
-
-* imports/elision-rename/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["B", "x"]
-rebuilt        : ScopeId(0): ["x"]
-
 * imports/enum-id/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A", "Enum"]
-rebuilt        : ScopeId(0): ["Enum"]
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "Enum"]
 rebuilt        : ScopeId(1): ["Enum"]
@@ -1655,86 +1509,13 @@ Symbol flags mismatch for "Enum":
 after transform: SymbolId(1): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
 
-* imports/import-removed-exceptions/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["H", "I", "I2", "J", "a", "b", "c2", "d", "d2", "e", "e4"]
-rebuilt        : ScopeId(0): []
-
-* imports/import-type/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A", "B", "T", "Types"]
-rebuilt        : ScopeId(0): []
-
-* imports/import-type-func-with-duplicate-name/input.ts
-Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(Function | TypeImport)
-rebuilt        : SymbolId(0): SymbolFlags(Function)
-Symbol span mismatch for "Foo":
-after transform: SymbolId(0): Span { start: 13, end: 16 }
-rebuilt        : SymbolId(0): Span { start: 70, end: 73 }
-Symbol redeclarations mismatch for "Foo":
-after transform: SymbolId(0): [Span { start: 13, end: 16 }, Span { start: 70, end: 73 }]
-rebuilt        : SymbolId(0): []
-Symbol flags mismatch for "Foo2":
-after transform: SymbolId(1): SymbolFlags(Function | TypeImport)
-rebuilt        : SymbolId(1): SymbolFlags(Function)
-Symbol span mismatch for "Foo2":
-after transform: SymbolId(1): Span { start: 43, end: 47 }
-rebuilt        : SymbolId(1): Span { start: 87, end: 91 }
-Symbol redeclarations mismatch for "Foo2":
-after transform: SymbolId(1): [Span { start: 43, end: 47 }, Span { start: 87, end: 91 }]
-rebuilt        : SymbolId(1): []
-
-* imports/import-type-not-removed/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A", "B"]
-rebuilt        : ScopeId(0): []
-
-* imports/only-remove-type-imports/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["H", "I", "I2", "J", "K1", "K2", "L1", "L2", "L3", "a", "b", "c2", "d", "d2", "e", "e4", "x"]
-rebuilt        : ScopeId(0): ["L2", "a", "b", "c2", "d", "d2", "e", "e4", "x"]
-
-* imports/property-signature/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A", "obj"]
-rebuilt        : ScopeId(0): ["obj"]
-
-* imports/type-only-export-specifier-1/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["bar", "baz", "foo"]
-rebuilt        : ScopeId(0): []
-
 * imports/type-only-export-specifier-2/input.ts
 x Output mismatch
 
-* imports/type-only-import-specifier-1/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["Foo1", "Foo2"]
-rebuilt        : ScopeId(0): ["Foo1"]
-
-* imports/type-only-import-specifier-2/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["Foo1", "Foo2"]
-rebuilt        : ScopeId(0): []
-
-* imports/type-only-import-specifier-3/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["Foo1", "Foo2"]
-rebuilt        : ScopeId(0): []
-
-* imports/type-only-import-specifier-4/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A"]
-rebuilt        : ScopeId(0): []
-
 * namespace/alias/input.ts
 Bindings mismatch:
-after transform: ScopeId(0): ["AliasModule", "LongNameModule", "babel", "bar", "baz", "node", "some", "str"]
+after transform: ScopeId(0): ["AliasModule", "LongNameModule", "bar", "baz", "node", "some", "str"]
 rebuilt        : ScopeId(0): ["AliasModule", "bar", "baz", "node", "some", "str"]
-Symbol reference IDs mismatch for "AliasModule":
-after transform: SymbolId(8): [ReferenceId(2), ReferenceId(3), ReferenceId(4)]
-rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(2)]
 Reference symbol mismatch for "LongNameModule":
 after transform: SymbolId(0) "LongNameModule"
 rebuilt        : <None>
@@ -2341,31 +2122,6 @@ x Output mismatch
 
 * regression/15768/input.ts
 x Output mismatch
-
-* type-arguments/call/input.ts
-Unresolved references mismatch:
-after transform: ["T", "f"]
-rebuilt        : ["f"]
-
-* type-arguments/expr/input.ts
-Unresolved references mismatch:
-after transform: ["T", "f"]
-rebuilt        : ["f"]
-
-* type-arguments/new/input.ts
-Unresolved references mismatch:
-after transform: ["C", "T"]
-rebuilt        : ["C"]
-
-* type-arguments/optional-call/input.ts
-Unresolved references mismatch:
-after transform: ["Q", "T", "f", "x"]
-rebuilt        : ["f", "x"]
-
-* type-arguments/tagged-template/input.ts
-Unresolved references mismatch:
-after transform: ["T", "f"]
-rebuilt        : ["f"]
 
 
 # babel-preset-react (4/10)

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 1fb0b771
 
-Passed: 239/397
+Passed: 244/397
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -34,7 +34,7 @@ after transform: SymbolId(1) "C"
 rebuilt        : SymbolId(3) "C"
 
 
-# babel-plugin-transform-class-properties (26/33)
+# babel-plugin-transform-class-properties (28/33)
 * private-field-resolve-to-method/input.js
 x Output mismatch
 
@@ -52,26 +52,11 @@ Symbol reference IDs mismatch for "KEY1":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2)]
 rebuilt        : SymbolId(1): []
 
-* typescript/optional-call/input.ts
-Symbol reference IDs mismatch for "X":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), ReferenceId(11), ReferenceId(16)]
-rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(8), ReferenceId(14)]
 
-* typescript/optional-member/input.ts
-Symbol reference IDs mismatch for "X":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), ReferenceId(9), ReferenceId(12)]
-rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), ReferenceId(10)]
-
-
-# babel-plugin-transform-typescript (23/60)
+# babel-plugin-transform-typescript (26/60)
 * allow-declare-fields-false/input.ts
 Unresolved references mismatch:
 after transform: ["dce"]
-rebuilt        : []
-
-* class-property-definition/input.ts
-Unresolved references mismatch:
-after transform: ["const"]
 rebuilt        : []
 
 * computed-constant-value/input.ts
@@ -343,9 +328,6 @@ rebuilt        : SymbolId(8): SymbolFlags(Function)
 Symbol span mismatch for "T":
 after transform: SymbolId(9): Span { start: 205, end: 206 }
 rebuilt        : SymbolId(8): Span { start: 226, end: 227 }
-Symbol reference IDs mismatch for "T":
-after transform: SymbolId(9): [ReferenceId(8), ReferenceId(9)]
-rebuilt        : SymbolId(8): [ReferenceId(9)]
 Symbol redeclarations mismatch for "T":
 after transform: SymbolId(9): [Span { start: 205, end: 206 }, Span { start: 226, end: 227 }]
 rebuilt        : SymbolId(8): []
@@ -403,9 +385,6 @@ rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "N2":
 after transform: SymbolId(4): Span { start: 145, end: 147 }
 rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "Foo":
-after transform: SymbolId(5): [ReferenceId(2)]
-rebuilt        : SymbolId(7): []
 
 * namespace/redeclaration-with-enum/input.ts
 Scope flags mismatch:
@@ -592,27 +571,10 @@ Symbol flags mismatch for "Foo":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
-* preserve-import-=/input.js
-Symbol reference IDs mismatch for "Foo":
-after transform: SymbolId(1): [ReferenceId(1)]
-rebuilt        : SymbolId(1): []
-
 * redeclarations/input.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["A"]
 rebuilt        : ScopeId(0): ["A", "B", "T"]
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | Import)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(0): Span { start: 57, end: 58 }
-rebuilt        : SymbolId(0): Span { start: 79, end: 80 }
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
-Symbol redeclarations mismatch for "A":
-after transform: SymbolId(0): [Span { start: 57, end: 58 }, Span { start: 79, end: 80 }]
-rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "T":
 after transform: SymbolId(1): SymbolFlags(Import | TypeAlias)
 rebuilt        : SymbolId(1): SymbolFlags(Import)
@@ -620,16 +582,10 @@ Symbol redeclarations mismatch for "T":
 after transform: SymbolId(1): [Span { start: 149, end: 150 }, Span { start: 170, end: 171 }]
 rebuilt        : SymbolId(1): []
 Symbol flags mismatch for "B":
-after transform: SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable | Import | TypeAlias)
+after transform: SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable | TypeAlias)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable)
-Symbol span mismatch for "B":
-after transform: SymbolId(2): Span { start: 267, end: 268 }
-rebuilt        : SymbolId(2): Span { start: 289, end: 290 }
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(2): [ReferenceId(3), ReferenceId(4)]
-rebuilt        : SymbolId(2): [ReferenceId(2)]
 Symbol redeclarations mismatch for "B":
-after transform: SymbolId(2): [Span { start: 267, end: 268 }, Span { start: 289, end: 290 }, Span { start: 304, end: 305 }]
+after transform: SymbolId(2): [Span { start: 289, end: 290 }, Span { start: 304, end: 305 }]
 rebuilt        : SymbolId(2): []
 
 * remove-class-properties-without-initializer/input.ts
@@ -642,16 +598,11 @@ Bindings mismatch:
 after transform: ScopeId(0): ["D", "a", "b", "bar", "c"]
 rebuilt        : ScopeId(0): ["a", "b", "bar", "c"]
 Unresolved reference IDs mismatch for "foo":
-after transform: [ReferenceId(0), ReferenceId(3), ReferenceId(6)]
+after transform: [ReferenceId(0), ReferenceId(6)]
 rebuilt        : [ReferenceId(0)]
 
 * ts-declaration-empty-output/input.d.ts
 x Output mismatch
-
-* ts-private-field-with-remove-class-fields-without-initializer/input.ts
-Unresolved references mismatch:
-after transform: ["ArrayBufferView", "Transferable", "WeakMap", "babelHelpers", "kTransferable", "kValue"]
-rebuilt        : ["WeakMap", "babelHelpers", "kTransferable", "kValue"]
 
 * use-define-for-class-fields/input.ts
 Unresolved references mismatch:
@@ -700,7 +651,7 @@ Reference symbol mismatch for "property":
 after transform: SymbolId(0) "property"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["PropertyDescriptor", "babelHelpers"]
+after transform: ["babelHelpers"]
 rebuilt        : ["babelHelpers", "property"]
 
 * oxc/accessor-with-class-properties/input.ts
@@ -726,7 +677,7 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["PropertyDescriptor", "WeakMap", "babelHelpers"]
+after transform: ["WeakMap", "babelHelpers"]
 rebuilt        : ["WeakMap", "a", "babelHelpers", "dec"]
 
 * oxc/class-without-name-with-decorated_class/input.ts
@@ -755,9 +706,6 @@ after transform: SymbolId(1): ScopeId(1)
 rebuilt        : SymbolId(1): ScopeId(0)
 
 * oxc/metadata/abstract-class/input.ts
-Symbol reference IDs mismatch for "Dependency":
-after transform: SymbolId(1): [ReferenceId(1), ReferenceId(2), ReferenceId(3)]
-rebuilt        : SymbolId(1): [ReferenceId(5), ReferenceId(7)]
 Symbol span mismatch for "AbstractClass":
 after transform: SymbolId(2): Span { start: 69, end: 82 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
@@ -783,9 +731,6 @@ after transform: ["Object", "babelHelpers"]
 rebuilt        : ["Ambient", "Object", "babelHelpers", "dec"]
 
 * oxc/metadata/bound-type-reference/input.ts
-Symbol reference IDs mismatch for "BoundTypeReference":
-after transform: SymbolId(0): [ReferenceId(3), ReferenceId(1), ReferenceId(4), ReferenceId(5), ReferenceId(6)]
-rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(7), ReferenceId(9)]
 Symbol span mismatch for "Example":
 after transform: SymbolId(1): Span { start: 87, end: 94 }
 rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
@@ -841,16 +786,13 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["ClassDecorator", "String", "babelHelpers"]
+after transform: ["String", "babelHelpers"]
 rebuilt        : ["String", "babelHelpers", "dec"]
 
 * oxc/metadata/cross-file-imported-enum/input.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["Source", "StringEnum", "dec"]
 rebuilt        : ScopeId(0): ["Source", "StringEnum"]
-Symbol reference IDs mismatch for "StringEnum":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(2), ReferenceId(3)]
-rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(5)]
 Reference symbol mismatch for "dec":
 after transform: SymbolId(1) "dec"
 rebuilt        : <None>
@@ -910,59 +852,32 @@ rebuilt        : ScopeId(9): ScopeFlags(Function)
 Symbol flags mismatch for "StringEnum":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "StringEnum":
-after transform: SymbolId(0): [ReferenceId(21), ReferenceId(5), ReferenceId(27)]
-rebuilt        : SymbolId(0): [ReferenceId(3)]
 Symbol flags mismatch for "TemplateStringEnum":
 after transform: SymbolId(3): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "TemplateStringEnum":
-after transform: SymbolId(3): [ReferenceId(7), ReferenceId(31)]
-rebuilt        : SymbolId(2): [ReferenceId(7)]
 Symbol flags mismatch for "NumberEnum":
 after transform: SymbolId(6): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "NumberEnum":
-after transform: SymbolId(6): [ReferenceId(22), ReferenceId(9), ReferenceId(23), ReferenceId(37)]
-rebuilt        : SymbolId(4): [ReferenceId(13), ReferenceId(53)]
 Symbol flags mismatch for "UnaryEnum":
 after transform: SymbolId(9): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "UnaryEnum":
-after transform: SymbolId(9): [ReferenceId(11), ReferenceId(45)]
-rebuilt        : SymbolId(6): [ReferenceId(21)]
 Symbol flags mismatch for "UnaryOtherEnum":
 after transform: SymbolId(14): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(9): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "UnaryOtherEnum":
-after transform: SymbolId(14): [ReferenceId(13), ReferenceId(53)]
-rebuilt        : SymbolId(9): [ReferenceId(32)]
 Symbol flags mismatch for "AutoIncrementEnum":
 after transform: SymbolId(18): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(11): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "AutoIncrementEnum":
-after transform: SymbolId(18): [ReferenceId(15), ReferenceId(61)]
-rebuilt        : SymbolId(11): [ReferenceId(40)]
 Symbol flags mismatch for "MixedEnum":
 after transform: SymbolId(22): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(13): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "MixedEnum":
-after transform: SymbolId(22): [ReferenceId(17), ReferenceId(66)]
-rebuilt        : SymbolId(13): [ReferenceId(45)]
 Symbol flags mismatch for "ComputedEnum":
 after transform: SymbolId(25): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(15): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "ComputedEnum":
-after transform: SymbolId(25): [ReferenceId(19), ReferenceId(72)]
-rebuilt        : SymbolId(15): [ReferenceId(52)]
 
 * oxc/metadata/erased-import-no-type-keyword/input.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["Source", "T", "dec"]
 rebuilt        : ScopeId(0): ["Source", "T"]
-Symbol reference IDs mismatch for "T":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(2), ReferenceId(3)]
-rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(5)]
 Reference symbol mismatch for "dec":
 after transform: SymbolId(1) "dec"
 rebuilt        : <None>
@@ -974,14 +889,11 @@ rebuilt        : ["Object", "babelHelpers", "dec"]
 Bindings mismatch:
 after transform: ScopeId(0): ["LaterClass", "Source", "dec"]
 rebuilt        : ScopeId(0): ["LaterClass", "Source"]
-Symbol reference IDs mismatch for "LaterClass":
-after transform: SymbolId(5): [ReferenceId(2), ReferenceId(3), ReferenceId(4)]
-rebuilt        : SymbolId(1): [ReferenceId(3), ReferenceId(5)]
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Object", "PropertyDescriptor", "babelHelpers"]
+after transform: ["Object", "babelHelpers"]
 rebuilt        : ["Object", "babelHelpers", "dec"]
 
 * oxc/metadata/getter-setter-method/input.ts
@@ -1007,16 +919,13 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Function", "Number", "Object", "PropertyDescriptor", "String", "babelHelpers"]
+after transform: ["Function", "Number", "Object", "String", "babelHelpers"]
 rebuilt        : ["Function", "Number", "Object", "String", "babelHelpers", "dec"]
 
 * oxc/metadata/imports/input.ts
 Bindings mismatch:
-after transform: ScopeId(0): ["Bar", "Cls", "Foo", "Zoo", "dec"]
+after transform: ScopeId(0): ["Cls", "Foo", "dec"]
 rebuilt        : ScopeId(0): ["Cls", "Foo"]
-Symbol reference IDs mismatch for "Foo":
-after transform: SymbolId(0): [ReferenceId(2), ReferenceId(3), ReferenceId(12), ReferenceId(13)]
-rebuilt        : SymbolId(0): [ReferenceId(10), ReferenceId(12)]
 Symbol span mismatch for "Cls":
 after transform: SymbolId(7): Span { start: 145, end: 148 }
 rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
@@ -1027,16 +936,13 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(3) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Object", "PropertyDescriptor", "babelHelpers", "console"]
+after transform: ["Object", "babelHelpers", "console"]
 rebuilt        : ["Object", "babelHelpers", "console", "dec"]
 
 * oxc/metadata/namespace-imported-enum/input.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["NS", "Source", "dec"]
 rebuilt        : ScopeId(0): ["NS", "Source"]
-Symbol reference IDs mismatch for "NS":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4)]
-rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(6)]
 Reference symbol mismatch for "dec":
 after transform: SymbolId(1) "dec"
 rebuilt        : <None>
@@ -1172,7 +1078,7 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Array", "ReadonlyArray", "babelHelpers"]
+after transform: ["Array", "babelHelpers"]
 rebuilt        : ["Array", "babelHelpers", "dec"]
 
 * oxc/metadata/readonly-array-interface-shadow/input.ts
@@ -1190,9 +1096,6 @@ rebuilt        : ["Object", "babelHelpers", "dec"]
 Bindings mismatch:
 after transform: ScopeId(0): ["A", "Foo", "dec"]
 rebuilt        : ScopeId(0): ["A", "Foo"]
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(1): [ReferenceId(4), ReferenceId(5), ReferenceId(6)]
-rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(8)]
 Symbol span mismatch for "Foo":
 after transform: SymbolId(2): Span { start: 72, end: 75 }
 rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
@@ -1203,7 +1106,7 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["ClassDecorator", "Error", "Object", "babelHelpers"]
+after transform: ["Error", "Object", "babelHelpers"]
 rebuilt        : ["Error", "Object", "babelHelpers", "dec"]
 
 * oxc/metadata/this/input.ts
@@ -1240,9 +1143,6 @@ rebuilt        : ReferenceId(5): ReferenceFlags(Read)
 Reference flags mismatch for "UnboundTypeReference":
 after transform: ReferenceId(3): ReferenceFlags(Read | Type)
 rebuilt        : ReferenceId(7): ReferenceFlags(Read)
-Unresolved reference IDs mismatch for "UnboundTypeReference":
-after transform: [ReferenceId(1), ReferenceId(2), ReferenceId(3)]
-rebuilt        : [ReferenceId(5), ReferenceId(7)]
 
 * oxc/metadata/without-decorator/input.ts
 Symbol span mismatch for "C":
@@ -1268,9 +1168,6 @@ rebuilt        : SymbolId(3): [ReferenceId(4), ReferenceId(8)]
 Symbol span mismatch for "Foo":
 after transform: SymbolId(3): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(4): Span { start: 103, end: 106 }
-Unresolved references mismatch:
-after transform: ["ClassDecorator", "babelHelpers", "console"]
-rebuilt        : ["babelHelpers", "console"]
 
 * oxc/static-field-with-class-properties/input.ts
 Symbol span mismatch for "Foo":
@@ -1282,9 +1179,6 @@ rebuilt        : SymbolId(3): [ReferenceId(4), ReferenceId(6), ReferenceId(10)]
 Symbol span mismatch for "Foo":
 after transform: SymbolId(3): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(4): Span { start: 103, end: 106 }
-Unresolved references mismatch:
-after transform: ["ClassDecorator", "babelHelpers", "console"]
-rebuilt        : ["babelHelpers", "console"]
 
 * oxc/with-class-private-properties/input.ts
 Symbol span mismatch for "C":
@@ -1319,7 +1213,7 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["TypedPropertyDescriptor", "babelHelpers"]
+after transform: ["babelHelpers"]
 rebuilt        : ["babelHelpers", "dec"]
 
 * typescript/accessor/decoratorOnClassAccessor2/input.ts
@@ -1330,7 +1224,7 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["TypedPropertyDescriptor", "babelHelpers"]
+after transform: ["babelHelpers"]
 rebuilt        : ["babelHelpers", "dec"]
 
 * typescript/accessor/decoratorOnClassAccessor3/input.ts
@@ -1353,7 +1247,7 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["TypedPropertyDescriptor", "babelHelpers"]
+after transform: ["babelHelpers"]
 rebuilt        : ["babelHelpers", "dec"]
 
 * typescript/accessor/decoratorOnClassAccessor5/input.ts
@@ -1364,7 +1258,7 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["TypedPropertyDescriptor", "babelHelpers"]
+after transform: ["babelHelpers"]
 rebuilt        : ["babelHelpers", "dec"]
 
 * typescript/accessor/decoratorOnClassAccessor6/input.ts
@@ -1445,7 +1339,7 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Function", "babelHelpers"]
+after transform: ["babelHelpers"]
 rebuilt        : ["babelHelpers", "dec"]
 
 * typescript/constructor/parameter/decoratorOnClassConstructorParameter4/input.ts
@@ -1620,7 +1514,7 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Function", "babelHelpers"]
+after transform: ["babelHelpers"]
 rebuilt        : ["babelHelpers", "dec"]
 
 * typescript/decoratorOnClass9/input.ts
@@ -1634,7 +1528,7 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["TypedPropertyDescriptor", "babelHelpers"]
+after transform: ["babelHelpers"]
 rebuilt        : ["babelHelpers", "dec"]
 
 * typescript/method/decoratorOnClassMethod10/input.ts
@@ -1645,7 +1539,7 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Function", "babelHelpers"]
+after transform: ["babelHelpers"]
 rebuilt        : ["babelHelpers", "dec"]
 
 * typescript/method/decoratorOnClassMethod11/input.ts
@@ -1665,7 +1559,7 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["TypedPropertyDescriptor", "babelHelpers"]
+after transform: ["babelHelpers"]
 rebuilt        : ["babelHelpers", "dec"]
 
 * typescript/method/decoratorOnClassMethod14/input.ts
@@ -1735,7 +1629,7 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["TypedPropertyDescriptor", "babelHelpers"]
+after transform: ["babelHelpers"]
 rebuilt        : ["babelHelpers", "dec"]
 
 * typescript/method/decoratorOnClassMethod3/input.ts
@@ -1758,7 +1652,7 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["TypedPropertyDescriptor", "babelHelpers"]
+after transform: ["babelHelpers"]
 rebuilt        : ["babelHelpers", "dec"]
 
 * typescript/method/decoratorOnClassMethod5/input.ts
@@ -1769,7 +1663,7 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["TypedPropertyDescriptor", "babelHelpers"]
+after transform: ["babelHelpers"]
 rebuilt        : ["babelHelpers", "dec"]
 
 * typescript/method/decoratorOnClassMethod6/input.ts
@@ -1780,7 +1674,7 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["TypedPropertyDescriptor", "babelHelpers"]
+after transform: ["babelHelpers"]
 rebuilt        : ["babelHelpers", "dec"]
 
 * typescript/method/decoratorOnClassMethod7/input.ts
@@ -1791,7 +1685,7 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["TypedPropertyDescriptor", "babelHelpers"]
+after transform: ["babelHelpers"]
 rebuilt        : ["babelHelpers", "dec"]
 
 * typescript/method/decoratorOnClassMethod8/input.ts
@@ -1826,7 +1720,7 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["TypedPropertyDescriptor", "babelHelpers"]
+after transform: ["babelHelpers"]
 rebuilt        : ["babelHelpers", "dec"]
 
 * typescript/method/parameter/decoratorOnClassMethodParameter1/input.ts
@@ -1837,21 +1731,18 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Object", "babelHelpers"]
+after transform: ["babelHelpers"]
 rebuilt        : ["babelHelpers", "dec"]
 
 * typescript/method/parameter/decoratorOnClassMethodParameter2/input.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "dec"]
 rebuilt        : ScopeId(0): ["C"]
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(4): [ReferenceId(1), ReferenceId(4)]
-rebuilt        : SymbolId(0): [ReferenceId(3)]
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Object", "babelHelpers"]
+after transform: ["babelHelpers"]
 rebuilt        : ["babelHelpers", "dec"]
 
 * typescript/method/parameter/decoratorOnClassMethodParameter3/input.ts
@@ -1862,7 +1753,7 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "babelHelpers"]
+after transform: ["babelHelpers"]
 rebuilt        : ["babelHelpers", "dec"]
 
 * typescript/method/parameter/decoratorOnClassMethodThisParameter/input.ts
@@ -1890,7 +1781,7 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["PropertyDescriptor", "babelHelpers"]
+after transform: ["babelHelpers"]
 rebuilt        : ["babelHelpers", "dec"]
 
 * typescript/property/decoratorOnClassProperty1/input.ts
@@ -1945,7 +1836,7 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["PropertyDescriptor", "babelHelpers"]
+after transform: ["babelHelpers"]
 rebuilt        : ["babelHelpers", "dec"]
 
 * typescript/property/decoratorOnClassProperty2/input.ts
@@ -1979,7 +1870,7 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Function", "babelHelpers"]
+after transform: ["babelHelpers"]
 rebuilt        : ["babelHelpers", "dec"]
 
 * typescript/property/decoratorOnClassProperty7/input.ts
@@ -1990,7 +1881,7 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Function", "babelHelpers"]
+after transform: ["babelHelpers"]
 rebuilt        : ["babelHelpers", "dec"]
 
 


### PR DESCRIPTION
## Summary

Keep transformer semantic data in sync when TypeScript-only syntax is removed.

This change:

- removes resolved and unresolved references belonging only to stripped TypeScript syntax
- removes bindings for erased type-only and unused imports
- preserves runtime bindings when a type import is merged with a value declaration
- promotes the surviving declaration’s symbol flags, span, and redeclaration metadata
- adds coverage for type imports merged with runtime declarations
- refreshes semantic and transformer conformance snapshots

## Motivation

We are preparing to change the AST shape, including adding and rearranging scopes.

Currently, transformer semantic snapshots contain thousands of lines of mismatches caused by stale bindings and references from TypeScript syntax that has already been removed from the AST. That creates a large amount of unrelated snapshot noise.

With that noise present, snapshot changes caused by the upcoming AST work would be difficult to review: a real scope or semantic regression could easily be hidden among mechanical churn.

This PR fixes the underlying semantic inconsistencies first, giving us a much cleaner baseline for reviewing future AST and scope changes. It is not intended to change emitted JavaScript.