### PR TITLE
refactor(react-compiler): mutate transform input safely

### DIFF
--- a/crates/oxc_react_compiler/Cargo.toml
+++ b/crates/oxc_react_compiler/Cargo.toml
@@ -37,6 +37,7 @@ oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }
 oxc_diagnostics = { workspace = true }
+oxc_parser = { workspace = true }
 oxc_semantic = { workspace = true }
 oxc_span = { workspace = true }
 oxc_syntax = { workspace = true }
@@ -49,10 +50,8 @@ rustc-hash = { workspace = true }
 cow-utils = { workspace = true }
 
 [dev-dependencies]
-# The example and integration tests parse source and print the compiled program; the
-# library itself takes an already-parsed `Program` and never parses or codegens.
+# The example and integration tests print the compiled program.
 oxc_codegen = { workspace = true }
-oxc_parser = { workspace = true }
 
 # Snapshot testing of the compiler over the upstream fixture corpus (tests/snapshot.rs).
 insta = { workspace = true, features = ["glob"] }

--- a/crates/oxc_react_compiler/examples/react_compiler.rs
+++ b/crates/oxc_react_compiler/examples/react_compiler.rs
@@ -17,7 +17,6 @@ use std::path::Path;
 use oxc_allocator::Allocator;
 use oxc_codegen::Codegen;
 use oxc_parser::Parser;
-use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
 
 use oxc_react_compiler::{PluginOptions, transform};
@@ -38,14 +37,7 @@ fn main() {
 
     let allocator = Allocator::default();
     let mut program = Parser::new(&allocator, &source_text, source_type).parse().program;
-
-    let mut result = {
-        let semantic = SemanticBuilder::new().with_build_nodes(true).build(&program).semantic;
-        transform(&program, &semantic, &allocator, PluginOptions::default())
-    };
-    if let Some(compiled) = result.program.take() {
-        program = compiled;
-    }
+    let result = transform(&mut program, &allocator, PluginOptions::default());
 
     if !result.diagnostics.is_empty() {
         println!("Diagnostics:\n");

--- a/crates/oxc_react_compiler/src/lib.rs
+++ b/crates/oxc_react_compiler/src/lib.rs
@@ -16,9 +16,10 @@ mod react_compiler_typeinference;
 mod react_compiler_utils;
 mod react_compiler_validation;
 
-use crate::react_compiler::entrypoint::compile_result::CompileResult;
 use crate::react_compiler::entrypoint::imports::get_react_compiler_runtime_module;
-use crate::react_compiler::entrypoint::program::compile_program;
+use crate::react_compiler::entrypoint::program::{
+    CompileProgramResult, apply_compiled_program, compile_program,
+};
 use prefilter::{has_react_like_functions, has_resource_management_declarations};
 use scope::ScopeResolver;
 
@@ -39,7 +40,8 @@ pub use crate::react_compiler_utils::FxIndexMap;
 
 use oxc_ast::ast::Program;
 use oxc_diagnostics::Diagnostics;
-use oxc_semantic::Semantic;
+use oxc_parser::Parser;
+use oxc_semantic::{Semantic, SemanticBuilder};
 use oxc_span::GetSpan;
 use rustc_hash::FxHashSet;
 
@@ -65,15 +67,8 @@ impl Default for PluginOptions {
     }
 }
 
-#[derive(Default)]
-pub struct TransformResult<'a> {
-    /// The rewritten program, when the compiler memoized something.
-    ///
-    /// Callers that want in-place behavior should replace their original
-    /// `Program` with this value after the borrowed `Semantic` has gone out of
-    /// scope.
-    pub program: Option<Program<'a>>,
-    /// Whether `program` contains a rewritten program. `false` means the
+pub struct TransformResult {
+    /// Whether the program was rewritten. `false` means the
     /// compiler made no changes — no React-like functions, a bail-out, or
     /// nothing to memoize.
     pub changed: bool,
@@ -88,69 +83,81 @@ pub struct LintResult {
     pub diagnostics: Diagnostics,
 }
 
-/// Run the React Compiler on a pre-parsed program, returning a rewritten
-/// program when it memoizes something.
+/// Run the React Compiler on a pre-parsed program, rewriting it in place when
+/// it memoizes something.
 ///
 /// Must run **first**, on the pristine AST, before any other transform. The
-/// borrowed `semantic` must have been built from that same pristine AST with
-/// `SemanticBuilder::with_build_nodes(true)`.
+/// semantic model is built from that same pristine AST with
+/// `SemanticBuilder::with_build_nodes(true)` before any mutation is applied.
 pub fn transform<'a>(
-    program: &Program<'a>,
-    semantic: &Semantic<'_>,
+    program: &mut Program<'a>,
     allocator: &'a Allocator,
     options: PluginOptions,
-) -> TransformResult<'a> {
-    let (program, diagnostics) = compile(program, semantic, allocator, options);
-    let changed = program.is_some();
-    TransformResult { program, changed, diagnostics }
+) -> TransformResult {
+    let ast_builder = oxc_ast::builder::AstBuilder::new(allocator);
+    let semantic_program = parse_semantic_program(program, allocator);
+    let semantic = SemanticBuilder::new().with_build_nodes(true).build(semantic_program).semantic;
+    let result = compile(&ast_builder, semantic_program, &semantic, options);
+    drop(semantic);
+
+    match result {
+        CompileProgramResult::Success { compiled, diagnostics } => {
+            let changed = compiled.is_some();
+            if let Some(compiled) = compiled {
+                apply_compiled_program(&ast_builder, program, *compiled);
+                preserve_top_level_comments(program, allocator);
+            }
+            TransformResult { changed, diagnostics }
+        }
+        CompileProgramResult::Error { diagnostics } => {
+            TransformResult { changed: false, diagnostics }
+        }
+    }
 }
 
-/// Shared compile pipeline behind [`transform`] and [`lint`]. Borrows `program`
-/// (so `lint` can stay read-only) and returns the compiled OXC program — `None`
-/// when nothing was compiled — together with diagnostics and logger events.
+fn parse_semantic_program<'a>(program: &Program<'a>, allocator: &'a Allocator) -> &'a Program<'a> {
+    allocator
+        .alloc(Parser::new(allocator, program.source_text, program.source_type).parse().program)
+}
+
+/// Shared compile preparation behind [`transform`] and [`lint`]. It borrows the
+/// program read-only and returns an optional prepared in-place transform.
 fn compile<'a>(
+    ast_builder: &oxc_ast::builder::AstBuilder<'a>,
     program: &Program<'a>,
-    semantic: &Semantic<'_>,
-    allocator: &'a Allocator,
+    semantic: &Semantic<'a>,
     options: PluginOptions,
-) -> (Option<Program<'a>>, Diagnostics) {
+) -> CompileProgramResult<'a> {
     // Check for existing runtime imports (file already compiled).
     if has_memo_cache_function_import(program, &get_react_compiler_runtime_module(&options.target))
     {
-        return (None, Diagnostics::default());
+        return CompileProgramResult::Success {
+            compiled: None,
+            diagnostics: Diagnostics::default(),
+        };
     }
 
     // Skip files with no React-like functions, unless the mode compiles everything.
     if !matches!(options.compilation_mode.as_str(), "all" | "annotation")
         && !has_react_like_functions(program)
     {
-        return (None, Diagnostics::default());
+        return CompileProgramResult::Success {
+            compiled: None,
+            diagnostics: Diagnostics::default(),
+        };
     }
 
     // `using`/`await using` disposal semantics aren't preserved yet — skip the file.
     if has_resource_management_declarations(program) {
-        return (None, Diagnostics::default());
+        return CompileProgramResult::Success {
+            compiled: None,
+            diagnostics: Diagnostics::default(),
+        };
     }
 
-    // The codegen back-end builds oxc nodes directly via this `AstBuilder`, and the
-    // compiled program is spliced/returned as an arena-allocated `Program<'a>`.
-    let ast_builder = oxc_ast::builder::AstBuilder::new(allocator);
     let scope = ScopeResolver::new(semantic, program);
     // Function discovery and lowering both walk the oxc `Program` directly.
-    let result = compile_program(&ast_builder, program, &scope, options);
-
-    let (program_ast, diagnostics) = match result {
-        CompileResult::Success { ast, diagnostics, .. } => (ast, diagnostics),
-        CompileResult::Error { diagnostics, .. } => (None, diagnostics),
-    };
-
-    let compiled = program_ast.map(|mut compiled: Program<'a>| {
-        compiled.source_type = program.source_type;
-        preserve_comments(&mut compiled, program, allocator);
-        compiled
-    });
-
-    (compiled, diagnostics)
+    compile_program(ast_builder, program, &scope, options)
 }
 
 fn has_memo_cache_function_import(program: &Program<'_>, module_name: &str) -> bool {
@@ -183,38 +190,25 @@ fn has_memo_cache_function_import(program: &Program<'_>, module_name: &str) -> b
     false
 }
 
-/// Carry over the comments attached to top-level statements of the compiled
-/// program, so codegen can re-emit them. The `react_compiler_ast` roundtrip
-/// drops comments, so we reuse the ones from the original `source` program
-/// (already parsed) rather than re-parsing the source.
-fn preserve_comments<'a>(
-    compiled: &mut Program<'a>,
-    source: &Program<'a>,
-    allocator: &'a Allocator,
-) {
-    // Keep only comments attached to a top-level statement; inner comments have
-    // `attached_to` positions that match no top-level statement.
+/// Preserve the old cloned-output comment behavior after an in-place transform:
+/// codegen should see only comments attached to top-level statements.
+fn preserve_top_level_comments<'a>(program: &mut Program<'a>, allocator: &'a Allocator) {
     let mut top_level_starts = FxHashSet::default();
     top_level_starts.insert(0u32);
-    for stmt in &compiled.body {
+    for stmt in &program.body {
         let start = stmt.span().start;
         if start > 0 {
             top_level_starts.insert(start);
         }
     }
 
-    // Copy only comments attached to top-level statements.
-    let mut comments = ArenaVec::with_capacity_in(source.comments.len(), &allocator);
-    for comment in &source.comments {
+    let mut comments = ArenaVec::with_capacity_in(program.comments.len(), &allocator);
+    for comment in &program.comments {
         if top_level_starts.contains(&comment.attached_to) {
             comments.push(*comment);
         }
     }
-    compiled.comments = comments;
-
-    // Codegen reads comment content from `source_text` via span offsets, so the
-    // compiled program must point at the same source as the original.
-    compiled.source_text = source.source_text;
+    program.comments = comments;
 }
 
 /// Lint a pre-parsed program — like [`transform`] but read-only: it collects
@@ -224,13 +218,17 @@ fn preserve_comments<'a>(
 /// `SemanticBuilder::with_build_nodes(true)`.
 pub fn lint<'a>(
     program: &Program<'a>,
-    semantic: &Semantic<'_>,
+    semantic: &Semantic<'a>,
     allocator: &'a Allocator,
     options: PluginOptions,
 ) -> LintResult {
     let mut options = options;
     options.no_emit = true;
 
-    let (_program, diagnostics) = compile(program, semantic, allocator, options);
+    let ast_builder = oxc_ast::builder::AstBuilder::new(allocator);
+    let diagnostics = match compile(&ast_builder, program, semantic, options) {
+        CompileProgramResult::Success { diagnostics, .. }
+        | CompileProgramResult::Error { diagnostics } => diagnostics,
+    };
     LintResult { diagnostics }
 }

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/compile_result.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/compile_result.rs
@@ -1,25 +1,5 @@
-use oxc_diagnostics::Diagnostics;
-
 use crate::react_compiler_diagnostics::SourceLocation;
 use crate::react_compiler_hir::ReactFunctionType;
-
-/// Main result type returned by the compile function.
-///
-/// Stage 2: the compiled program is an arena-allocated oxc
-/// [`oxc_ast::ast::Program`] (lifetime `'a` of the arena), built directly by the
-/// codegen back-end (see `compile_program`) instead of the former Babel `File`.
-#[derive(Debug)]
-pub enum CompileResult<'a> {
-    /// Compilation succeeded (or no functions needed compilation).
-    /// `ast` is None if no changes were made to the program.
-    Success {
-        ast: Option<oxc_ast::ast::Program<'a>>,
-        /// Errors and warnings accumulated during compilation.
-        diagnostics: Diagnostics,
-    },
-    /// A fatal error occurred and panicThreshold dictates it should throw.
-    Error { diagnostics: Diagnostics },
-}
 
 /// Debug log entry for debugLogIRs support.
 /// Currently only supports the 'debug' variant (string values).

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -16,6 +16,7 @@
 
 use cow_utils::CowUtils;
 use oxc_ast::ast as oxc;
+use oxc_diagnostics::Diagnostics;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::Span;
 use rustc_hash::FxHashMap;
@@ -32,7 +33,6 @@ use oxc_allocator::GetAllocator;
 use oxc_syntax::scope::ScopeId;
 
 use super::compile_result::CodegenFunction;
-use super::compile_result::CompileResult;
 use super::imports::ProgramContext;
 use super::imports::validate_restricted_imports;
 use super::pipeline;
@@ -87,6 +87,25 @@ enum CompileSourceKind {
     Original,
     #[allow(dead_code)]
     Outlined,
+}
+
+/// A prepared transform that can be applied after all immutable AST borrows
+/// from semantic analysis and function discovery have been dropped.
+pub struct CompiledProgram<'a> {
+    replacements: Vec<OxcReplacement<'a>>,
+    context: ProgramContext,
+}
+
+/// Main result type returned by the compile preparation step.
+pub enum CompileProgramResult<'a> {
+    /// Compilation succeeded, possibly with a prepared in-place transform.
+    Success {
+        compiled: Option<Box<CompiledProgram<'a>>>,
+        /// Errors and warnings accumulated during compilation.
+        diagnostics: Diagnostics,
+    },
+    /// A fatal error occurred and panicThreshold dictates it should throw.
+    Error { diagnostics: Diagnostics },
 }
 
 // -----------------------------------------------------------------------
@@ -1141,13 +1160,13 @@ fn log_error(err: &CompilerError, fn_loc: Option<Span>, context: &mut ProgramCon
 }
 
 /// Handle an error according to the panicThreshold setting.
-/// Returns Some(CompileResult::Error) if the error should be surfaced as fatal,
+/// Returns Some(CompileProgramResult::Error) if the error should be surfaced as fatal,
 /// otherwise returns None (error was logged only).
 fn handle_error<'a>(
     err: &CompilerError,
     fn_loc: Option<Span>,
     context: &mut ProgramContext,
-) -> Option<CompileResult<'a>> {
+) -> Option<CompileProgramResult<'a>> {
     // Log the error
     log_error(err, fn_loc, context);
 
@@ -1166,7 +1185,7 @@ fn handle_error<'a>(
     if should_panic || is_config_error {
         // The per-detail diagnostics were already pushed by `log_error`; the fatal
         // result just carries them. (The old JS-shim summary is dropped.)
-        Some(CompileResult::Error { diagnostics: std::mem::take(&mut context.diagnostics) })
+        Some(CompileProgramResult::Error { diagnostics: std::mem::take(&mut context.diagnostics) })
     } else {
         None
     }
@@ -1220,7 +1239,7 @@ fn try_compile_function<'a>(
 ///
 /// Returns `Ok(Some(codegen_fn))` when the function was compiled and should be applied,
 /// `Ok(None)` when the function was skipped or lint-only,
-/// or `Err(CompileResult)` if a fatal error should short-circuit the program.
+/// or `Err(CompileProgramResult)` if a fatal error should short-circuit the program.
 #[allow(clippy::result_large_err)]
 fn process_fn<'a>(
     ast: &oxc_ast::builder::AstBuilder<'a>,
@@ -1230,7 +1249,7 @@ fn process_fn<'a>(
     env_config: &EnvironmentConfig,
     context: &mut ProgramContext,
     source_text: &str,
-) -> Result<Option<CodegenFunction<'a>>, CompileResult<'a>> {
+) -> Result<Option<CodegenFunction<'a>>, CompileProgramResult<'a>> {
     // Parse directives from the function body
     let opt_in_result =
         try_find_directive_enabling_memoization(&source.body_directives, &context.opts);
@@ -2517,18 +2536,14 @@ fn ox_clone_original_fn_as_expression<'a>(
     finder.found.map(|e| e.clone_in(ast.allocator()))
 }
 
-/// Splice every compiled oxc function into a clone of the original oxc program and
-/// add the required imports. Returns the final memoized program.
+/// Splice every compiled oxc function into the original oxc program and add the
+/// required imports.
 fn ox_splice_program<'a>(
     ast: &oxc_ast::builder::AstBuilder<'a>,
-    oxc_program: &oxc_ast::ast::Program<'a>,
+    program: &mut oxc_ast::ast::Program<'a>,
     replacements: &[OxcReplacement<'a>],
     context: &mut ProgramContext,
-) -> oxc_ast::ast::Program<'a> {
-    use oxc_allocator::CloneIn;
-
-    let mut program = oxc_program.clone_in(ast.allocator());
-
+) {
     // Outlined function declarations are placed differently depending on the
     // original function's syntactic kind, mirroring `insertNewOutlinedFunctionNode`
     // in TS `Program.ts`:
@@ -2557,16 +2572,16 @@ fn ox_splice_program<'a>(
         }
 
         if let Some(ref gating_config) = replacement.gating {
-            ox_apply_gated_conditional(ast, &mut program, replacement, gating_config, context);
+            ox_apply_gated_conditional(ast, program, replacement, gating_config, context);
         } else if let Some(node_id) = replacement.fn_node_id {
             let mut visitor =
                 OxcReplaceFnVisitor { ast, node_id, codegen: &replacement.codegen_fn, done: false };
-            oxc_ast_visit::VisitMut::visit_program(&mut visitor, &mut program);
+            oxc_ast_visit::VisitMut::visit_program(&mut visitor, program);
         }
 
         if !sibling_outlined_decls.is_empty() {
             if let Some(node_id) = replacement.fn_node_id {
-                ox_insert_outlined_after(&mut program, node_id, sibling_outlined_decls);
+                ox_insert_outlined_after(program, node_id, sibling_outlined_decls);
             }
         }
     }
@@ -2584,12 +2599,21 @@ fn ox_splice_program<'a>(
             old_name: "useMemoCache",
             new_name: &import_spec.name,
         };
-        oxc_ast_visit::VisitMut::visit_program(&mut visitor, &mut program);
+        oxc_ast_visit::VisitMut::visit_program(&mut visitor, program);
     }
 
-    ox_add_imports_to_program(ast, &mut program, context);
+    ox_add_imports_to_program(ast, program, context);
+}
 
-    program
+/// Apply a prepared transform to the program after compile-time borrows have
+/// been dropped.
+pub fn apply_compiled_program<'a>(
+    ast: &oxc_ast::builder::AstBuilder<'a>,
+    program: &mut oxc_ast::ast::Program<'a>,
+    compiled: CompiledProgram<'a>,
+) {
+    let CompiledProgram { replacements, mut context } = compiled;
+    ox_splice_program(ast, program, &replacements, &mut context);
 }
 
 /// Insert outlined function declarations immediately after the top-level statement
@@ -2797,8 +2821,9 @@ fn ox_is_non_namespaced_import(import: &oxc_ast::ast::ImportDeclaration) -> bool
 /// Main entry point for the React Compiler.
 ///
 /// Receives a full program AST, scope information (unused for now), and resolved options.
-/// Returns a CompileResult indicating whether the AST was modified,
-/// along with any logger events.
+/// Returns diagnostics plus an optional prepared transform. The prepared transform
+/// is applied by [`apply_compiled_program`] after all immutable AST borrows from
+/// semantic analysis have been dropped.
 ///
 /// This function implements the logic from the TS entrypoint (Program.ts):
 /// - validateRestrictedImports: check for blocklisted imports
@@ -2811,7 +2836,7 @@ pub fn compile_program<'a, 'p>(
     oxc_program: &'p oxc_ast::ast::Program<'a>,
     scope: &ScopeResolver<'_, '_>,
     options: PluginOptions,
-) -> CompileResult<'a> {
+) -> CompileProgramResult<'a> {
     // Compute output mode once, up front
     let output_mode = CompilerOutputMode::from_opts(&options);
 
@@ -2854,7 +2879,7 @@ pub fn compile_program<'a, 'p>(
         if let Some(result) = handle_error(&err, None, &mut context) {
             return result;
         }
-        return CompileResult::Success { ast: None, diagnostics: context.diagnostics };
+        return CompileProgramResult::Success { compiled: None, diagnostics: context.diagnostics };
     }
 
     // Pre-register instrumentation imports to get stable local names.
@@ -2932,7 +2957,7 @@ pub fn compile_program<'a, 'p>(
             ));
             handle_error(&err, None, &mut context);
         }
-        return CompileResult::Success { ast: None, diagnostics: context.diagnostics };
+        return CompileProgramResult::Success { compiled: None, diagnostics: context.diagnostics };
     }
 
     // Convert compiled functions to owned oxc replacements (dropping the borrows of
@@ -2970,13 +2995,13 @@ pub fn compile_program<'a, 'p>(
         // (e.g., variable shadowing renames in lint mode). Imports are NOT added
         // when there are no replacements — matching TS behavior where
         // addImportsToProgram is only called when compiledFns.length > 0.
-        return CompileResult::Success { ast: None, diagnostics: context.diagnostics };
+        return CompileProgramResult::Success { compiled: None, diagnostics: context.diagnostics };
     }
 
-    // Build the memoized oxc program: splice each compiled oxc function in for its
-    // original (matched by `span.start == fn_node_id`), apply gating, insert outlined
-    // functions, and add the memo-cache / gating imports.
-    let compiled_program = ox_splice_program(ast, oxc_program, &replacements, &mut context);
+    let diagnostics = std::mem::take(&mut context.diagnostics);
 
-    CompileResult::Success { ast: Some(compiled_program), diagnostics: context.diagnostics }
+    CompileProgramResult::Success {
+        compiled: Some(Box::new(CompiledProgram { replacements, context })),
+        diagnostics,
+    }
 }

--- a/crates/oxc_react_compiler/tests/snapshot.rs
+++ b/crates/oxc_react_compiler/tests/snapshot.rs
@@ -31,7 +31,6 @@ use oxc_react_compiler::{
     HookTypeConfig, InstrumentationConfig, ObjectTypeConfig, PluginOptions, TypeConfig,
     TypeReferenceConfig, ValueKind, transform,
 };
-use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
 
 #[test]
@@ -63,21 +62,14 @@ fn run_fixture(source: &str) -> String {
 
     let allocator = Allocator::default();
     let parsed = Parser::new(&allocator, source, source_type).parse();
+    let parse_diagnostics = parsed.diagnostics;
     let mut program = parsed.program;
 
     let mut out = String::new();
     // Surface parse failures rather than silently compiling a recovered/dummy AST.
-    push_diagnostics(&mut out, "Parse errors", parsed.diagnostics.as_slice());
+    push_diagnostics(&mut out, "Parse errors", parse_diagnostics.as_slice());
 
-    // `transform` borrows a `Semantic` built from the pristine program; scope the
-    // borrow so it ends before we swap in the compiled program.
-    let mut result = {
-        let semantic = SemanticBuilder::new().with_build_nodes(true).build(&program).semantic;
-        transform(&program, &semantic, &allocator, options)
-    };
-    if let Some(compiled) = result.program.take() {
-        program = compiled;
-    }
+    let result = transform(&mut program, &allocator, options);
 
     push_diagnostics(&mut out, "Diagnostics", result.diagnostics.as_slice());
     // Mirror the upstream `snap` runner, which always re-emits the program as
@@ -88,7 +80,7 @@ fn run_fixture(source: &str) -> String {
     // the `No changes.` marker. The marker is kept only when a non-lint run reports
     // an error (parse failure or compile diagnostic), where upstream emits no code —
     // and echoing a parse-recovered AST would be misleading.
-    let clean = parsed.diagnostics.is_empty() && result.diagnostics.as_slice().is_empty();
+    let clean = parse_diagnostics.is_empty() && result.diagnostics.as_slice().is_empty();
     if result.changed || clean || lint_mode {
         out.push_str(&Codegen::new().build(&program).code);
     } else {

--- a/crates/oxc_react_compiler/tests/transform.rs
+++ b/crates/oxc_react_compiler/tests/transform.rs
@@ -13,22 +13,16 @@ fn options() -> PluginOptions {
     PluginOptions::default()
 }
 
-/// Parse `source_text` then run the compiler in place, returning the
-/// (possibly rewritten) program together with the result.
+/// Parse `source_text` then run the compiler, returning the result with the
+/// possibly rewritten program.
 fn transform_source<'a>(
     source_text: &'a str,
     source_type: SourceType,
     allocator: &'a Allocator,
     options: PluginOptions,
-) -> (Program<'a>, TransformResult<'a>) {
+) -> (Program<'a>, TransformResult) {
     let mut program = Parser::new(allocator, source_text, source_type).parse().program;
-    let mut result = {
-        let semantic = SemanticBuilder::new().with_build_nodes(true).build(&program).semantic;
-        transform(&program, &semantic, allocator, options)
-    };
-    if let Some(compiled) = result.program.take() {
-        program = compiled;
-    }
+    let result = transform(&mut program, allocator, options);
     (program, result)
 }
 

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -228,14 +228,10 @@ impl<'a> Transformer<'a> {
         let Some(options) = self.react_compiler.take() else {
             return (scoping, Diagnostics::new());
         };
-        let mut result = {
-            let semantic = SemanticBuilder::new().with_build_nodes(true).build(program).semantic;
-            react_compiler_transform(program, &semantic, self.allocator, options)
-        };
+        let result = react_compiler_transform(program, self.allocator, options);
         if !result.changed {
             return (scoping, result.diagnostics);
         }
-        *program = result.program.take().expect("changed result should include a program");
         let scoping =
             SemanticBuilder::new().with_enum_eval(true).build(program).semantic.into_scoping();
         (scoping, result.diagnostics)

--- a/tasks/benchmark/benches/react_compiler.rs
+++ b/tasks/benchmark/benches/react_compiler.rs
@@ -2,7 +2,6 @@ use oxc_allocator::Allocator;
 use oxc_benchmark::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use oxc_parser::{Parser, ParserReturn};
 use oxc_react_compiler::{PluginOptions, transform};
-use oxc_semantic::SemanticBuilder;
 use oxc_tasks_common::TestFiles;
 
 fn bench_react_compiler(criterion: &mut Criterion) {
@@ -25,21 +24,11 @@ fn bench_react_compiler(criterion: &mut Criterion) {
                 allocator.reset();
 
                 // Create a fresh AST for each iteration. The compiler builds
-                // semantic data and allocates the compiled program in the same arena.
+                // semantic data and mutates the program in the same arena.
                 let ParserReturn { mut program, .. } =
                     Parser::new(&allocator, source_text, source_type).parse();
 
-                runner.run(|| {
-                    let mut result = {
-                        let semantic =
-                            SemanticBuilder::new().with_build_nodes(true).build(&program).semantic;
-                        transform(&program, &semantic, &allocator, options.clone())
-                    };
-                    if let Some(compiled) = result.program.take() {
-                        program = compiled;
-                    }
-                    result
-                });
+                runner.run(|| transform(&mut program, &allocator, options.clone()));
             });
         });
     }


### PR DESCRIPTION
AI-assisted.

Refactors React Compiler transform to mutate the caller-provided AST without unsafe semantic construction at call sites. Lint remains read-only.

Checked with:
- `just fmt`
- `cargo lint -- -D warnings`
- `cargo test -p oxc_react_compiler`
- `cargo test -p oxc_linter react_compiler`
- `cargo check -p oxc_transformer --features react_compiler`
- `cargo check -p oxc_benchmark --features react_compiler --bench react_compiler`
- `cargo check -p oxc_react_compiler -p oxc_linter`