### PR TITLE
fix(tasks): use native TLS only on macOS

### DIFF
--- a/tasks/common/Cargo.toml
+++ b/tasks/common/Cargo.toml
@@ -19,4 +19,7 @@ oxc_span = { workspace = true }
 project-root = { workspace = true }
 similar = { workspace = true, features = ["inline"] }
 
-ureq = { workspace = true, features = ["json", "native-tls", "rustls"] }
+ureq = { workspace = true, features = ["json", "rustls"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+ureq = { workspace = true, features = ["native-tls"] }

--- a/tasks/common/src/request.rs
+++ b/tasks/common/src/request.rs
@@ -5,6 +5,13 @@ use ureq::{
     tls::{PemItem, RootCerts, TlsConfig, TlsProvider, parse_pem},
 };
 
+// Warp's TLS proxy requires the macOS platform verifier, while using native TLS on Linux pulls
+// OpenSSL into cross-target builds.
+#[cfg(target_os = "macos")]
+const TLS_PROVIDER: TlsProvider = TlsProvider::NativeTls;
+#[cfg(not(target_os = "macos"))]
+const TLS_PROVIDER: TlsProvider = TlsProvider::Rustls;
+
 /// detect proxy from environment variable in following order:
 /// HTTPS_PROXY | https_proxy | HTTP_PROXY | http_proxy | ALL_PROXY | all_proxy
 fn detect_proxy() -> Option<Proxy> {
@@ -54,7 +61,7 @@ fn tls_config_from_env() -> Option<TlsConfig> {
     assert!(!certificates.is_empty(), "SSL_CERT_FILE {} contains no certificates", path.display());
     Some(
         TlsConfig::builder()
-            .provider(TlsProvider::NativeTls)
+            .provider(TLS_PROVIDER)
             .root_certs(RootCerts::from(certificates))
             .build(),
     )


### PR DESCRIPTION
## Summary

- use the native TLS backend on macOS so HTTPS requests work with Warp and custom roots from `SSL_CERT_FILE`
- use Rustls on other targets so Linux cross-builds do not pull in `openssl-sys`
- keep the existing proxy detection and custom certificate bundle handling

## Root cause

#24178 enabled `ureq/native-tls` for all targets. On macOS this is needed for Warp because Rustls/webpki rejects part of the intercepted certificate chain with `UnsupportedSignatureAlgorithmForPublicKeyContext`.

Enabling native TLS globally also adds `native-tls -> openssl-sys` to the 32-bit and big-endian Linux dependency graphs. Those cross images do not provide target OpenSSL development files, so the builds fail before tests run.

The TLS provider and feature are now selected by target: macOS uses the platform verifier through native TLS, while all other targets continue to use Rustls.
