### PR TITLE
fix(oxfmt): destroy existing Tinypool before re-initialising in LSP mode

### DIFF
--- a/apps/oxfmt/src-js/cli/worker-proxy.ts
+++ b/apps/oxfmt/src-js/cli/worker-proxy.ts
@@ -12,6 +12,10 @@ import type {
 let pool: Tinypool | null = null;
 
 export async function initExternalFormatter(numThreads: number): Promise<void> {
+  if (pool !== null) {
+    await pool.destroy();
+    pool = null;
+  }
   pool = new Tinypool({
     filename: new URL("./cli-worker.js", import.meta.url).href,
     minThreads: numThreads,


### PR DESCRIPTION
## Problem

`initExternalFormatter()` creates a new `Tinypool` instance each time it is called. In `--lsp` mode the process stays alive indefinitely, and the Rust side calls `initExternalFormatter()` again on config reload or project switch. The old pool and its `child_process` workers are never destroyed, so they accumulate.

Observed in production: **1,500+ orphaned `node tinypool/.../process.js` processes, 30+ GB RAM** after several hours of normal LSP usage.

## Fix

Add the same guard that `disposeExternalFormatter()` already applies on CLI exit — if a pool exists, destroy it before constructing the new one:

```ts
export async function initExternalFormatter(numThreads: number): Promise<void> {
  if (pool !== null) {
    await pool.destroy();
    pool = null;
  }
  pool = new Tinypool({ ... });
}
```

Fixes #24147