### PR TITLE
perf(react_compiler): compile out debug printers

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
@@ -11,12 +11,10 @@
 use crate::react_compiler_diagnostics::CompilerError;
 use crate::react_compiler_diagnostics::CompilerErrorDetail;
 use crate::react_compiler_diagnostics::ErrorCategory;
-use crate::react_compiler_hir::HirFunction;
 use crate::react_compiler_hir::ReactFunctionType;
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::environment::OutputMode;
 use crate::react_compiler_hir::environment_config::EnvironmentConfig;
-use crate::react_compiler_hir::print::PrintFormatter;
 use crate::react_compiler_inference::align_method_call_scopes;
 use crate::react_compiler_inference::align_object_method_scopes;
 use crate::react_compiler_inference::align_reactive_scopes_to_block_scopes_hir;
@@ -51,7 +49,6 @@ use crate::react_compiler_reactive_scopes::build_reactive_function;
 use crate::react_compiler_reactive_scopes::codegen_function;
 use crate::react_compiler_reactive_scopes::extract_scope_declarations_from_destructuring;
 use crate::react_compiler_reactive_scopes::merge_reactive_scopes_that_invalidate_together;
-use crate::react_compiler_reactive_scopes::print_reactive_function::debug_reactive_function_with_formatter;
 use crate::react_compiler_reactive_scopes::promote_used_temporaries;
 use crate::react_compiler_reactive_scopes::propagate_early_returns;
 use crate::react_compiler_reactive_scopes::prune_always_invalidating_scopes;
@@ -90,6 +87,32 @@ use super::compile_result::OutlinedFunction;
 use super::imports::ProgramContext;
 use super::plugin_options::CompilerOutputMode;
 use crate::react_compiler::debug_print;
+
+#[cfg(feature = "debug")]
+macro_rules! log_reactive_debug {
+    ($context:expr, $name:literal, $reactive_fn:expr, $env:expr) => {
+        if $context.debug_enabled {
+            fn hir_formatter<'h>(
+                fmt: &mut crate::react_compiler_hir::print::PrintFormatter<'_, 'h>,
+                func: &crate::react_compiler_hir::HirFunction<'h>,
+            ) {
+                debug_print::format_hir_function_into(fmt, func);
+            }
+
+            let debug = crate::react_compiler_reactive_scopes::print_reactive_function::debug_reactive_function_with_formatter(
+                $reactive_fn,
+                $env,
+                Some(&hir_formatter),
+            );
+            $context.log_debug(DebugLogEntry::new($name, debug));
+        }
+    };
+}
+
+#[cfg(not(feature = "debug"))]
+macro_rules! log_reactive_debug {
+    ($context:expr, $name:literal, $reactive_fn:expr, $env:expr) => {};
+}
 
 /// Run the compilation pipeline on a single function.
 ///
@@ -560,15 +583,7 @@ pub fn compile_fn<'a>(
 
     let mut reactive_fn = build_reactive_function(&hir, &env)?;
 
-    fn hir_formatter<'h>(fmt: &mut PrintFormatter<'_, 'h>, func: &HirFunction<'h>) {
-        debug_print::format_hir_function_into(fmt, func);
-    }
-
-    if context.debug_enabled {
-        let debug_reactive =
-            debug_reactive_function_with_formatter(&reactive_fn, &env, Some(&hir_formatter));
-        context.log_debug(DebugLogEntry::new("BuildReactiveFunction", debug_reactive));
-    }
+    log_reactive_debug!(context, "BuildReactiveFunction", &reactive_fn, &env);
 
     assert_well_formed_break_targets(&reactive_fn, &env);
     if context.debug_enabled {
@@ -577,11 +592,7 @@ pub fn compile_fn<'a>(
 
     prune_unused_labels(&mut reactive_fn, &env)?;
 
-    if context.debug_enabled {
-        let debug_prune_labels_reactive =
-            debug_reactive_function_with_formatter(&reactive_fn, &env, Some(&hir_formatter));
-        context.log_debug(DebugLogEntry::new("PruneUnusedLabels", debug_prune_labels_reactive));
-    }
+    log_reactive_debug!(context, "PruneUnusedLabels", &reactive_fn, &env);
 
     assert_scope_instructions_within_scopes(&reactive_fn, &env)?;
     if context.debug_enabled {
@@ -591,87 +602,43 @@ pub fn compile_fn<'a>(
 
     prune_non_escaping_scopes(&mut reactive_fn, &mut env)?;
 
-    if context.debug_enabled {
-        let debug =
-            debug_reactive_function_with_formatter(&reactive_fn, &env, Some(&hir_formatter));
-        context.log_debug(DebugLogEntry::new("PruneNonEscapingScopes", debug));
-    }
+    log_reactive_debug!(context, "PruneNonEscapingScopes", &reactive_fn, &env);
 
     prune_non_reactive_dependencies(&mut reactive_fn, &mut env);
 
-    if context.debug_enabled {
-        let debug_prune_non_reactive =
-            debug_reactive_function_with_formatter(&reactive_fn, &env, Some(&hir_formatter));
-        context.log_debug(DebugLogEntry::new(
-            "PruneNonReactiveDependencies",
-            debug_prune_non_reactive,
-        ));
-    }
+    log_reactive_debug!(context, "PruneNonReactiveDependencies", &reactive_fn, &env);
 
     prune_unused_scopes(&mut reactive_fn, &env)?;
 
-    if context.debug_enabled {
-        let debug_prune_unused_scopes =
-            debug_reactive_function_with_formatter(&reactive_fn, &env, Some(&hir_formatter));
-        context.log_debug(DebugLogEntry::new("PruneUnusedScopes", debug_prune_unused_scopes));
-    }
+    log_reactive_debug!(context, "PruneUnusedScopes", &reactive_fn, &env);
 
     merge_reactive_scopes_that_invalidate_together(&mut reactive_fn, &mut env)?;
 
-    if context.debug_enabled {
-        let debug =
-            debug_reactive_function_with_formatter(&reactive_fn, &env, Some(&hir_formatter));
-        context.log_debug(DebugLogEntry::new("MergeReactiveScopesThatInvalidateTogether", debug));
-    }
+    log_reactive_debug!(context, "MergeReactiveScopesThatInvalidateTogether", &reactive_fn, &env);
 
     prune_always_invalidating_scopes(&mut reactive_fn, &env)?;
 
-    if context.debug_enabled {
-        let debug_prune_always_inv =
-            debug_reactive_function_with_formatter(&reactive_fn, &env, Some(&hir_formatter));
-        context
-            .log_debug(DebugLogEntry::new("PruneAlwaysInvalidatingScopes", debug_prune_always_inv));
-    }
+    log_reactive_debug!(context, "PruneAlwaysInvalidatingScopes", &reactive_fn, &env);
 
     propagate_early_returns(&mut reactive_fn, &mut env);
 
-    if context.debug_enabled {
-        let debug =
-            debug_reactive_function_with_formatter(&reactive_fn, &env, Some(&hir_formatter));
-        context.log_debug(DebugLogEntry::new("PropagateEarlyReturns", debug));
-    }
+    log_reactive_debug!(context, "PropagateEarlyReturns", &reactive_fn, &env);
 
     prune_unused_lvalues(&mut reactive_fn, &env);
 
-    if context.debug_enabled {
-        let debug_prune_lvalues =
-            debug_reactive_function_with_formatter(&reactive_fn, &env, Some(&hir_formatter));
-        context.log_debug(DebugLogEntry::new("PruneUnusedLValues", debug_prune_lvalues));
-    }
+    log_reactive_debug!(context, "PruneUnusedLValues", &reactive_fn, &env);
 
     promote_used_temporaries(&mut reactive_fn, &mut env);
 
-    if context.debug_enabled {
-        let debug =
-            debug_reactive_function_with_formatter(&reactive_fn, &env, Some(&hir_formatter));
-        context.log_debug(DebugLogEntry::new("PromoteUsedTemporaries", debug));
-    }
+    log_reactive_debug!(context, "PromoteUsedTemporaries", &reactive_fn, &env);
 
     extract_scope_declarations_from_destructuring(&mut reactive_fn, &mut env)?;
 
-    if context.debug_enabled {
-        let debug =
-            debug_reactive_function_with_formatter(&reactive_fn, &env, Some(&hir_formatter));
-        context.log_debug(DebugLogEntry::new("ExtractScopeDeclarationsFromDestructuring", debug));
-    }
+    log_reactive_debug!(context, "ExtractScopeDeclarationsFromDestructuring", &reactive_fn, &env);
 
     stabilize_block_ids(&mut reactive_fn, &mut env);
 
-    if context.debug_enabled {
-        let debug_stabilize =
-            debug_reactive_function_with_formatter(&reactive_fn, &env, Some(&hir_formatter));
-        context.log_debug(DebugLogEntry::new("StabilizeBlockIds", debug_stabilize));
-    }
+    log_reactive_debug!(context, "StabilizeBlockIds", &reactive_fn, &env);
 
     let unique_identifiers = rename_variables(&mut reactive_fn, &mut env);
 
@@ -679,19 +646,11 @@ pub fn compile_fn<'a>(
         context.add_new_reference(name.clone());
     }
 
-    if context.debug_enabled {
-        let debug =
-            debug_reactive_function_with_formatter(&reactive_fn, &env, Some(&hir_formatter));
-        context.log_debug(DebugLogEntry::new("RenameVariables", debug));
-    }
+    log_reactive_debug!(context, "RenameVariables", &reactive_fn, &env);
 
     prune_hoisted_contexts(&mut reactive_fn, &env)?;
 
-    if context.debug_enabled {
-        let debug =
-            debug_reactive_function_with_formatter(&reactive_fn, &env, Some(&hir_formatter));
-        context.log_debug(DebugLogEntry::new("PruneHoistedContexts", debug));
-    }
+    log_reactive_debug!(context, "PruneHoistedContexts", &reactive_fn, &env);
 
     if env.config.enable_preserve_existing_memoization_guarantees
         || env.config.validate_preserve_existing_memoization_guarantees

--- a/crates/oxc_react_compiler/src/react_compiler/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/mod.rs
@@ -8,16 +8,9 @@ pub mod debug_print;
 pub mod debug_print {
     use crate::react_compiler_hir::HirFunction;
     use crate::react_compiler_hir::environment::Environment;
-    use crate::react_compiler_hir::print::PrintFormatter;
 
     pub fn debug_hir<'h>(_hir: &HirFunction<'h>, _env: &Environment<'h>) -> String {
         String::new()
-    }
-
-    pub fn format_hir_function_into<'h>(
-        _reactive_fmt: &mut PrintFormatter<'_, 'h>,
-        _func: &HirFunction<'h>,
-    ) {
     }
 }
 

--- a/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
@@ -1,9 +1,14 @@
+// HIR metadata such as source locations and type annotations is consumed by
+// the debug IR printers. Those printers are compiled only with `debug`.
+#![cfg_attr(not(feature = "debug"), allow(dead_code))]
+
 pub mod default_module_type_provider;
 pub mod dominator;
 pub mod environment;
 pub mod environment_config;
 pub mod globals;
 pub mod object_shape;
+#[cfg(feature = "debug")]
 pub mod print;
 pub mod raw;
 pub mod reactive;

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/mod.rs
@@ -16,6 +16,7 @@ mod build_reactive_function;
 pub mod codegen_reactive_function;
 mod extract_scope_declarations_from_destructuring;
 mod merge_reactive_scopes_that_invalidate_together;
+#[cfg(feature = "debug")]
 pub mod print_reactive_function;
 mod promote_used_temporaries;
 mod propagate_early_returns;


### PR DESCRIPTION
Compile React Compiler HIR/reactive debug printers only with the `debug` feature. This keeps default oxlint release builds from linking debug-only formatting code and reduces the stripped release binary by 49,568 bytes on aarch64-apple-darwin.

Validated with:
- `cargo check -p oxc_react_compiler`
- `cargo check -p oxc_react_compiler --features debug`
- `cargo build -p oxlint --release --features allocator`