### PR TITLE
perf(transformer): avoid cloning refresh options

### DIFF
--- a/crates/oxc_transformer/src/jsx/mod.rs
+++ b/crates/oxc_transformer/src/jsx/mod.rs
@@ -48,10 +48,10 @@ impl<'a> Jsx<'a> {
         if options.jsx_plugin || options.development {
             options.conform();
         }
+        let refresh = options.refresh.take();
         let JsxOptions {
             jsx_plugin, display_name_plugin, jsx_self_plugin, jsx_source_plugin, ..
         } = options;
-        let refresh = options.refresh.clone();
         Self {
             implementation: JsxImpl::new(options, object_rest_spread_options, ast, source_type),
             display_name: ReactDisplayName::new(),
@@ -60,7 +60,7 @@ impl<'a> Jsx<'a> {
             self_plugin: jsx_self_plugin,
             source_plugin: jsx_source_plugin,
             refresh_plugin: refresh.is_some(),
-            refresh: ReactRefresh::new(&refresh.unwrap_or_default(), ast),
+            refresh: ReactRefresh::new(refresh.as_ref(), ast),
         }
     }
 }

--- a/crates/oxc_transformer/src/jsx/options.rs
+++ b/crates/oxc_transformer/src/jsx/options.rs
@@ -203,6 +203,9 @@ pub struct ReactRefreshOptions {
     pub emit_full_signatures: bool,
 }
 
+pub(super) const DEFAULT_REFRESH_REG: &str = "$RefreshReg$";
+pub(super) const DEFAULT_REFRESH_SIG: &str = "$RefreshSig$";
+
 impl Default for ReactRefreshOptions {
     fn default() -> Self {
         Self {
@@ -214,9 +217,9 @@ impl Default for ReactRefreshOptions {
 }
 
 fn default_refresh_reg() -> String {
-    String::from("$RefreshReg$")
+    String::from(DEFAULT_REFRESH_REG)
 }
 
 fn default_refresh_sig() -> String {
-    String::from("$RefreshSig$")
+    String::from(DEFAULT_REFRESH_SIG)
 }

--- a/crates/oxc_transformer/src/jsx/refresh.rs
+++ b/crates/oxc_transformer/src/jsx/refresh.rs
@@ -30,7 +30,7 @@ use crate::{
     common::var_declarations::VarDeclarationsStore, context::TraverseCtx, state::TransformState,
 };
 
-use super::options::ReactRefreshOptions;
+use super::options::{DEFAULT_REFRESH_REG, DEFAULT_REFRESH_SIG, ReactRefreshOptions};
 
 /// Parse a string into a `RefreshIdentifierResolver` and convert it into an `Expression`
 #[derive(Debug)]
@@ -136,11 +136,13 @@ pub struct ReactRefresh<'a> {
 }
 
 impl<'a> ReactRefresh<'a> {
-    pub fn new(options: &ReactRefreshOptions, ast: &AstBuilder<'a>) -> Self {
+    pub fn new(options: Option<&ReactRefreshOptions>, ast: &AstBuilder<'a>) -> Self {
+        let refresh_reg = options.map_or(DEFAULT_REFRESH_REG, |options| &options.refresh_reg);
+        let refresh_sig = options.map_or(DEFAULT_REFRESH_SIG, |options| &options.refresh_sig);
         Self {
-            refresh_reg: RefreshIdentifierResolver::parse(&options.refresh_reg, ast),
-            refresh_sig: RefreshIdentifierResolver::parse(&options.refresh_sig, ast),
-            emit_full_signatures: options.emit_full_signatures,
+            refresh_reg: RefreshIdentifierResolver::parse(refresh_reg, ast),
+            refresh_sig: RefreshIdentifierResolver::parse(refresh_sig, ast),
+            emit_full_signatures: options.is_some_and(|options| options.emit_full_signatures),
             registrations: Vec::default(),
             last_signature: None,
             function_signature_keys: FxHashMap::default(),

--- a/tasks/track_memory_allocations/allocs_transformer.snap
+++ b/tasks/track_memory_allocations/allocs_transformer.snap
@@ -1,16 +1,16 @@
 File                       | File size      || Sys allocs     | Sys reallocs   || Arena allocs   | Arena reallocs 
 ---------------------------------------------------------------------------------------------------------------------------
-checker.ts                 | 2.92 MB        ||             20 |              0 ||           1959 |              5
+checker.ts                 | 2.92 MB        ||             18 |              0 ||           1959 |              5
 
-App.tsx                    | 415.34 kB      ||             25 |              2 ||            618 |             17
+App.tsx                    | 415.34 kB      ||             23 |              2 ||            618 |             17
 
-RadixUIAdoptionSection.jsx | 2.52 kB        ||             21 |              2 ||            258 |             13
+RadixUIAdoptionSection.jsx | 2.52 kB        ||             19 |              2 ||            258 |             13
 
-pdf.mjs                    | 567.30 kB      ||             15 |              0 ||              2 |              0
+pdf.mjs                    | 567.30 kB      ||             13 |              0 ||              2 |              0
 
-antd.js                    | 6.69 MB        ||             15 |              0 ||              2 |              0
+antd.js                    | 6.69 MB        ||             13 |              0 ||              2 |              0
 
-binder.ts                  | 193.08 kB      ||             17 |              0 ||            154 |              0
+binder.ts                  | 193.08 kB      ||             15 |              0 ||            154 |              0
 
-kitchen-sink.tsx           | 732.90 kB      ||            184 |              3 ||           6132 |            280
+kitchen-sink.tsx           | 732.90 kB      ||            182 |              3 ||           6132 |            280
 


### PR DESCRIPTION
## Summary

Avoid cloning React Refresh options while creating the JSX transformer. `Jsx::new` now takes the optional configuration from `JsxOptions` and supplies a reference to `ReactRefresh`.

`ReactRefresh` derives its configured identifiers and `emit_full_signatures` directly from that optional reference, retaining the existing `$RefreshReg$`/`$RefreshSig$` defaults when no options are provided. This removes clone work from transformer initialization without changing behavior.
