### PR TITLE
chore(ci): run measurement jobs when Cargo.lock or rust-toolchain changes

### DIFF
--- a/.github/scripts/check-changes.js
+++ b/.github/scripts/check-changes.js
@@ -68,6 +68,17 @@ function shouldRunInclude(changedFiles, packages, paths) {
     }
   }
 
+  // Dependency or toolchain updates can change any crate's behavior
+  // (e.g. num-bigint 0.5 changed parser allocation counts) — always run.
+  if (
+    changedFiles.some(
+      (file) => file === "Cargo.lock" || file === "rust-toolchain.toml" || file === "Cargo.toml",
+    )
+  ) {
+    console.error("Cargo.lock or rust-toolchain.toml changed - will run");
+    return true;
+  }
+
   // If no changed files are in crates/, cargo tree check cannot match — skip it
   if (!changedFiles.some((file) => file.startsWith("crates/"))) {
     console.error("No files changed in crates/ - will skip");


### PR DESCRIPTION
### Summary

The include-mode filter in `check-changes.js` short-circuits to "skip" when no changed files are under `crates/`, so it never reaches the cargo tree dependency check for `Cargo.lock`-only dependency updates or `rust-toolchain.toml` bumps. Conformance, Minsize, Allocations, and Linter timings are all gated on this filter.

This is how #24192 (`num-bigint` 0.4.6 → 0.5.1) landed with a stale parser allocation snapshot: the update changed BigInt-literal parsing allocation counts, the Allocations job never re-measured on main, and the mismatch surfaced on an unrelated PR (#24098). The snapshot itself is fixed in #24198.

This PR treats `Cargo.lock` and `rust-toolchain.toml` changes as affecting every crate, so measurement jobs always re-run on dependency and toolchain updates. The cost is that renovate dependency PRs now run these four jobs; dependency updates are exactly the class of change that can shift measured behavior, so that is the intended behavior. Exclude-mode and paths-only jobs are unaffected (exclude mode already runs on such changes by construction).

### Trade-off

For Conformance specifically this closes a correctness gap, not just a snapshot-staleness one: a dependency update that changes parser/transformer behavior currently skips conformance entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)