### PR TITLE
chore(oxfmt): update prettier to 3.9.4

### DIFF
--- a/apps/oxfmt/package.json
+++ b/apps/oxfmt/package.json
@@ -20,7 +20,7 @@
     "generate-config-types": "node scripts/generate-config-types.ts"
   },
   "dependencies": {
-    "prettier": "3.9.1",
+    "prettier": "3.9.4",
     "prettier-plugin-svelte": "4.1.1",
     "prettier-plugin-tailwindcss": "0.0.0-insiders.2b6f3c2",
     "tinypool": "2.1.0"

--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -326,13 +326,7 @@ export type True = true;
 export type AllowConstantLoopConditions = boolean | AllowConstantLoopConditionsMode;
 export type AllowConstantLoopConditionsMode = "never" | "always" | "only-allowed-literals";
 export type Modifier =
-  | "private"
-  | "private readonly"
-  | "protected"
-  | "protected readonly"
-  | "public"
-  | "public readonly"
-  | "readonly";
+  "private" | "private readonly" | "protected" | "protected readonly" | "public" | "public readonly" | "readonly";
 export type Prefer2 = "class-property" | "parameter-property";
 /**
  * Represents the different ways `ignorePrimitives` can be specified in JSON.
@@ -897,9 +891,7 @@ export interface DummyRuleMap {
   "func-style"?: RuleNoConfig | [AllowWarnDeny, Style] | [AllowWarnDeny, Style, FuncStyleConfig];
   "getter-return"?: RuleNoConfig | [AllowWarnDeny, GetterReturn];
   "grouped-accessor-pairs"?:
-    | RuleNoConfig
-    | [AllowWarnDeny, PairOrder]
-    | [AllowWarnDeny, PairOrder, GroupedAccessorPairsConfig];
+    RuleNoConfig | [AllowWarnDeny, PairOrder] | [AllowWarnDeny, PairOrder, GroupedAccessorPairsConfig];
   "guard-for-in"?: RuleNoConfig;
   "id-length"?: RuleNoConfig | [AllowWarnDeny, IdLengthConfig];
   "id-match"?: RuleNoConfig | [AllowWarnDeny, string] | [AllowWarnDeny, string, IdMatchOptions];
@@ -944,9 +936,7 @@ export interface DummyRuleMap {
   "import/prefer-default-export"?: RuleNoConfig | [AllowWarnDeny, PreferDefaultExport];
   "import/unambiguous"?: RuleNoConfig;
   "init-declarations"?:
-    | RuleNoConfig
-    | [AllowWarnDeny, AlwaysNever]
-    | [AllowWarnDeny, AlwaysNever, InitDeclarationsConfig];
+    RuleNoConfig | [AllowWarnDeny, AlwaysNever] | [AllowWarnDeny, AlwaysNever, InitDeclarationsConfig];
   "jest/consistent-test-it"?: RuleNoConfig | [AllowWarnDeny, ConsistentTestItConfig];
   "jest/expect-expect"?: RuleNoConfig | [AllowWarnDeny, ExpectExpectConfig];
   "jest/max-expects"?: RuleNoConfig | [AllowWarnDeny, MaxExpectsConfig];
@@ -1055,14 +1045,11 @@ export interface DummyRuleMap {
   "jsx-a11y/no-autofocus"?: RuleNoConfig | [AllowWarnDeny, NoAutofocus];
   "jsx-a11y/no-distracting-elements"?: RuleNoConfig | [AllowWarnDeny, NoDistractingElementsConfig];
   "jsx-a11y/no-interactive-element-to-noninteractive-role"?:
-    | RuleNoConfig
-    | [AllowWarnDeny, NoInteractiveElementToNoninteractiveRoleConfig];
+    RuleNoConfig | [AllowWarnDeny, NoInteractiveElementToNoninteractiveRoleConfig];
   "jsx-a11y/no-noninteractive-element-interactions"?:
-    | RuleNoConfig
-    | [AllowWarnDeny, NoNoninteractiveElementInteractionsConfig];
+    RuleNoConfig | [AllowWarnDeny, NoNoninteractiveElementInteractionsConfig];
   "jsx-a11y/no-noninteractive-element-to-interactive-role"?:
-    | RuleNoConfig
-    | [AllowWarnDeny, NoNoninteractiveElementToInteractiveRoleConfig];
+    RuleNoConfig | [AllowWarnDeny, NoNoninteractiveElementToInteractiveRoleConfig];
   "jsx-a11y/no-noninteractive-tabindex"?: RuleNoConfig | [AllowWarnDeny, NoNoninteractiveTabindexConfig];
   "jsx-a11y/no-redundant-roles"?: RuleNoConfig | [AllowWarnDeny, NoRedundantRolesConfig];
   "jsx-a11y/no-static-element-interactions"?: RuleNoConfig | [AllowWarnDeny, NoStaticElementInteractionsConfig];
@@ -1072,9 +1059,7 @@ export interface DummyRuleMap {
   "jsx-a11y/scope"?: RuleNoConfig;
   "jsx-a11y/tabindex-no-positive"?: RuleNoConfig;
   "logical-assignment-operators"?:
-    | RuleNoConfig
-    | [AllowWarnDeny, AlwaysNever]
-    | [AllowWarnDeny, AlwaysNever, LogicalAssignmentOperatorsConfig];
+    RuleNoConfig | [AllowWarnDeny, AlwaysNever] | [AllowWarnDeny, AlwaysNever, LogicalAssignmentOperatorsConfig];
   "max-classes-per-file"?: RuleNoConfig | [AllowWarnDeny, MaxClassesPerFileConfigEnum];
   "max-depth"?: RuleNoConfig | [AllowWarnDeny, MaxDepthConfigEnum];
   "max-lines"?: RuleNoConfig | [AllowWarnDeny, MaxLinesConfigEnum];
@@ -1186,8 +1171,7 @@ export interface DummyRuleMap {
   "no-restricted-exports"?: RuleNoConfig | [AllowWarnDeny, NoRestrictedExportsConfig];
   "no-restricted-globals"?: DummyRule;
   "no-restricted-imports"?:
-    | RuleNoConfig
-    | [AllowWarnDeny, NoRestrictedImportsConfigEnum, ...NoRestrictedImportsConfigEnum[]];
+    RuleNoConfig | [AllowWarnDeny, NoRestrictedImportsConfigEnum, ...NoRestrictedImportsConfigEnum[]];
   "no-restricted-properties"?: RuleNoConfig | [AllowWarnDeny, PropertyDetails, ...PropertyDetails[]];
   "no-return-assign"?: RuleNoConfig | [AllowWarnDeny, NoReturnAssignMode];
   "no-script-url"?: RuleNoConfig;
@@ -1243,9 +1227,7 @@ export interface DummyRuleMap {
   "node/no-process-env"?: RuleNoConfig | [AllowWarnDeny, NoProcessEnvConfig];
   "node/no-sync"?: RuleNoConfig | [AllowWarnDeny, NoSyncConfig];
   "object-shorthand"?:
-    | RuleNoConfig
-    | [AllowWarnDeny, ShorthandType]
-    | [AllowWarnDeny, ShorthandType, ObjectShorthandOptions];
+    RuleNoConfig | [AllowWarnDeny, ShorthandType] | [AllowWarnDeny, ShorthandType, ObjectShorthandOptions];
   "operator-assignment"?: RuleNoConfig | [AllowWarnDeny, AlwaysNever];
   "oxc/approx-constant"?: RuleNoConfig;
   "oxc/bad-array-method-on-arguments"?: RuleNoConfig;
@@ -1442,8 +1424,7 @@ export interface DummyRuleMap {
   "typescript/no-restricted-types"?: RuleNoConfig | [AllowWarnDeny, NoRestrictedTypesConfig];
   "typescript/no-this-alias"?: RuleNoConfig | [AllowWarnDeny, NoThisAliasConfig];
   "typescript/no-unnecessary-boolean-literal-compare"?:
-    | RuleNoConfig
-    | [AllowWarnDeny, NoUnnecessaryBooleanLiteralCompareConfig];
+    RuleNoConfig | [AllowWarnDeny, NoUnnecessaryBooleanLiteralCompareConfig];
   "typescript/no-unnecessary-condition"?: RuleNoConfig | [AllowWarnDeny, NoUnnecessaryConditionConfig];
   "typescript/no-unnecessary-parameter-property-assignment"?: RuleNoConfig;
   "typescript/no-unnecessary-qualifier"?: RuleNoConfig;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,14 +72,14 @@ importers:
   apps/oxfmt:
     dependencies:
       prettier:
-        specifier: 3.9.1
-        version: 3.9.1
+        specifier: 3.9.4
+        version: 3.9.4
       prettier-plugin-svelte:
         specifier: 4.1.1
-        version: 4.1.1(prettier@3.9.1)(svelte@5.56.4(@typescript-eslint/types@8.62.0))
+        version: 4.1.1(prettier@3.9.4)(svelte@5.56.4(@typescript-eslint/types@8.62.0))
       prettier-plugin-tailwindcss:
         specifier: 0.0.0-insiders.2b6f3c2
-        version: 0.0.0-insiders.2b6f3c2(prettier-plugin-svelte@4.1.1(prettier@3.9.1)(svelte@5.56.4(@typescript-eslint/types@8.62.0)))(prettier@3.9.1)
+        version: 0.0.0-insiders.2b6f3c2(prettier-plugin-svelte@4.1.1(prettier@3.9.4)(svelte@5.56.4(@typescript-eslint/types@8.62.0)))(prettier@3.9.4)
       tinypool:
         specifier: 2.1.0
         version: 2.1.0
@@ -4535,13 +4535,8 @@ packages:
       prettier-plugin-svelte:
         optional: true
 
-  prettier@3.8.4:
-    resolution: {integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==}
-    engines: {node: '>=14'}
-    hasBin: true
-
-  prettier@3.9.1:
-    resolution: {integrity: sha512-ppiDo2CSwexck1eyZUwJHg/N3nf1+6IRCv7W/VJ5vaLnVCmB7+3CdRfMwoCHBBX6xTrREDTksZ4OZl5SSf4zXA==}
+  prettier@3.9.4:
+    resolution: {integrity: sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -8536,7 +8531,7 @@ snapshots:
       js-yaml: 4.2.0
       lodash: 4.17.21
       minimist: 1.2.8
-      prettier: 3.8.4
+      prettier: 3.9.4
       tinyglobby: 0.2.17
 
   json-schema-traverse@0.4.1: {}
@@ -8994,20 +8989,18 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-svelte@4.1.1(prettier@3.9.1)(svelte@5.56.4(@typescript-eslint/types@8.62.0)):
+  prettier-plugin-svelte@4.1.1(prettier@3.9.4)(svelte@5.56.4(@typescript-eslint/types@8.62.0)):
     dependencies:
-      prettier: 3.9.1
+      prettier: 3.9.4
       svelte: 5.56.4(@typescript-eslint/types@8.62.0)
 
-  prettier-plugin-tailwindcss@0.0.0-insiders.2b6f3c2(prettier-plugin-svelte@4.1.1(prettier@3.9.1)(svelte@5.56.4(@typescript-eslint/types@8.62.0)))(prettier@3.9.1):
+  prettier-plugin-tailwindcss@0.0.0-insiders.2b6f3c2(prettier-plugin-svelte@4.1.1(prettier@3.9.4)(svelte@5.56.4(@typescript-eslint/types@8.62.0)))(prettier@3.9.4):
     dependencies:
-      prettier: 3.9.1
+      prettier: 3.9.4
     optionalDependencies:
-      prettier-plugin-svelte: 4.1.1(prettier@3.9.1)(svelte@5.56.4(@typescript-eslint/types@8.62.0))
+      prettier-plugin-svelte: 4.1.1(prettier@3.9.4)(svelte@5.56.4(@typescript-eslint/types@8.62.0))
 
-  prettier@3.8.4: {}
-
-  prettier@3.9.1: {}
+  prettier@3.9.4: {}
 
   pretty-format@27.5.1:
     dependencies:


### PR DESCRIPTION
Update to the latest before our release.

`apps/oxlint/src-js/package/config.generated.ts` should be re-generated since `json-shcema-to-typescript` depends on Prettier.