### PR TITLE
fix(formatter): add parens around `await/yield` with `<T>`

### DIFF
--- a/crates/oxc_formatter/src/parentheses/expression.rs
+++ b/crates/oxc_formatter/src/parentheses/expression.rs
@@ -1162,7 +1162,8 @@ fn await_or_yield_needs_parens(span: Span, node: &AstNodes<'_>) -> bool {
             | AstNodes::SpreadElement(_)
             | AstNodes::LogicalExpression(_)
             | AstNodes::BinaryExpression(_)
-            | AstNodes::PrivateInExpression(_),
+            | AstNodes::PrivateInExpression(_)
+            | AstNodes::TSInstantiationExpression(_),
     ) {
         return true;
     }

--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -1,4 +1,4 @@
-ts compatibility: 595/663 (89.74%), 19 files skipped
+ts compatibility: 597/663 (90.05%), 19 files skipped
 
 # Failed
 
@@ -43,8 +43,6 @@ ts compatibility: 595/663 (89.74%), 19 files skipped
 | typescript/new/parentheses.ts | 💥 | 0.00% |
 | typescript/non-null/optional-chain.ts | 💥 | 85.00% |
 | typescript/object-type/comments/11307.ts | 💥 | 66.67% |
-| typescript/parentheses/await.ts | 💥 | 66.67% |
-| typescript/parentheses/yield.ts | 💥 | 50.00% |
 | typescript/property-signature/consistent-with-flow/comments.ts | 💥 | 80.00% |
 | typescript/property-signature/consistent-with-flow/union.ts | 💥 | 80.00% |
 | typescript/quote-props/enums.ts | 💥💥✨ | 56.86% |


### PR DESCRIPTION
Follows https://github.com/prettier/prettier@79f6cdf/changelog_unreleased/typescript/19442.md

