### PR TITLE
chore(react_compiler): add React LICENSE

### DIFF
--- a/crates/oxc_react_compiler/LICENSE
+++ b/crates/oxc_react_compiler/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) Meta Platforms, Inc. and affiliates.
+Copyright (c) 2026-present VoidZero Inc. & Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Add React's MIT `LICENSE` to `crates/oxc_react_compiler`.

The crate vendors the React Compiler core in-tree under `src/react_compiler_*` (from the MIT fork at `oxc-project/forked-react-compiler`), so it should carry React's copyright notice. The file is byte-for-byte identical to [react/react `main` LICENSE](https://github.com/react/react/blob/main/LICENSE) (MIT, © Meta Platforms, Inc. and affiliates).

This matches existing convention in the repo — the root `THIRD-PARTY-LICENSE` already reproduces this exact Meta MIT text for `eslint-plugin-react-hooks`.