### PR TITLE
fix(formatter_css): keep comment inside sass config list

### DIFF
--- a/crates/oxc_formatter_css/AGENTS.md
+++ b/crates/oxc_formatter_css/AGENTS.md
@@ -229,6 +229,13 @@ Notable divergences are:
     and emits non-compiling output for `key: 2 * ($a + $b)` inside `$var:` declarations (dart-sass: `Undefined operation "2 * (3px,)"`)
   - Prettier's own #18530 (math siblings in args) / #19091 (single-node scalars) fixed subsets of this;
     we extend the same rule to every non-comma-list, so these stay inline
+- SCSS: An own-line trailing comment before a list's closing `)` keeps its own line
+  - Applies to maps AND `@use`/`@forward with (...)` configs (`$e: 5\n  // c\n)` stays as-is;
+    for maps the trailing comma is also kept)
+  - Prettier pulls the comment up onto the last item's line (`$e: 5 // c`, a `lineSuffix`
+    artifact of its comma-group printing) and drops the map's trailing comma
+  - Same-line trailing comments still glue (matching Prettier);
+    moving an own-line comment up would destroy the author's visual grouping
 - SCSS: A map whose FIRST item is preceded by a block comment always breaks one-per-line
   - Prettier stops treating it as a map item (the comment becomes `groups[0]`, so `isKeyValuePairInParenGroupNode` fails) and inlines it when it fits: `$b: (/* c */ a: 1);`
   - We reproduce the map-item-ness loss for the trailing comma (dropped, like Prettier)

--- a/crates/oxc_formatter_css/src/print/scss.rs
+++ b/crates/oxc_formatter_css/src/print/scss.rs
@@ -7,12 +7,11 @@ use oxc_css_parser::ast::{
     SassMixin, SassModuleConfig, SassParameters, SassUnaryOperatorKind, SassUse,
     SassUseNamespaceKind, SassVariableDeclaration,
 };
-
 use oxc_formatter_core::{
     Buffer,
     builders::{
         dedent, empty_line, expand_parent, group, hard_line_break, if_group_breaks, indent,
-        soft_line_break, soft_line_break_or_space, space, text,
+        line_suffix, soft_line_break, soft_line_break_or_space, space, text,
     },
     write,
 };
@@ -832,18 +831,50 @@ pub(super) fn write_sass_forward<'a>(forward: &SassForward<'a>, f: &mut CssForma
     }
 }
 
-/// `with ($var: value, ...)`: configurations always break, one item per line,
-/// without a trailing comma.
+/// `with ($var: value, ...)`:
+/// configurations always break, one item per line, without a trailing comma.
+///
+/// Comments follow Prettier's comma-group handling:
+/// - a leading `//` comment sits on its own line
+/// - a leading block comment glues to its item
+/// - a same-line trailing comment stays at the end of the item's line
+/// - and a blank line after an item's comma is preserved
+///
+/// EXCEPT an own-line trailing comment, which keeps its own line
+/// (consistent with the map printer; Prettier pulls it up — see "Known divergences").
 fn write_sass_module_config<'a>(config: &SassModuleConfig<'a>, f: &mut CssFormatter<'_, 'a>) {
     let source = f.context().source_text();
+    // Comments between the module path and `with` stay glued to the head
+    // (`@use "a" /* c */ with (`).
+    write_config_trailing_comments(to_span(&config.with_span).start, f);
     write!(f, [space(), "with", space(), "("]);
     let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
         write!(f, hard_line_break());
         for (i, item) in config.items.iter().enumerate() {
+            let item_span = to_span(&item.span);
             if i > 0 {
-                write!(f, ",");
-                write!(f, hard_line_break());
+                // Prettier's `isNextLineEmpty` after an item:
+                // a blank line after the comma survives, measured up to the next item or its first leading comment.
+                let comma_end = to_span(&config.comma_spans[i - 1]).end;
+                // Clamped: an own-line comment left pending by the previous
+                // item's trailing flush can start BEFORE the comma.
+                let next_start = f
+                    .context()
+                    .comments()
+                    .iter_before(item_span.start)
+                    .next()
+                    .map_or(item_span.start, |c| c.span.start)
+                    .max(comma_end);
+                if comments::classify_gap(source.bytes_range(comma_end, next_start))
+                    == comments::Gap::Blank
+                {
+                    write!(f, empty_line());
+                } else {
+                    write!(f, hard_line_break());
+                }
             }
+            // Leading comments: `//` on its own line, block glued inline
+            value::flush_value_comments(item_span.start, f);
             let span = to_span(item.variable.span());
             write!(f, [text(source.text_for(&span)), ":", space()]);
             // No first-argument gate here (cf. `write_function`):
@@ -856,7 +887,56 @@ fn write_sass_module_config<'a>(config: &SassModuleConfig<'a>, f: &mut CssFormat
                 write!(f, space());
                 write!(f, text(source.text_for(&span)));
             }
+            if i + 1 < config.items.len() {
+                // An own-line comment before the comma stays pending and
+                // leads the next item instead.
+                write_config_trailing_comments(to_span(&config.comma_spans[i]).start, f);
+                write!(f, ",");
+            } else {
+                // Comments before `)` (past a trailing comma, which is dropped):
+                // same-line ones glue to the last item, own-line ones keep their line.
+                let bound = to_span(&config.span).end;
+                let mut prev_end =
+                    write_config_trailing_comments(bound, f).unwrap_or(item_span.end);
+                for &comment in f.context().comments().take_before(bound) {
+                    comments::write_gap(source.bytes_range(prev_end, comment.span.start), f);
+                    comments::write_single_comment(comment, f);
+                    prev_end = comment.span.end;
+                }
+            }
         }
     });
     write!(f, [indent(&body), hard_line_break(), ")"]);
+}
+
+/// Emits pending SAME-LINE comments before `upper_bound` glued to the just-printed
+/// content (`$a: 1 /* c */,`); an own-line comment stops the loop and stays pending.
+/// Inline `//` comments ride a `line_suffix`,
+/// so a following `,` lands before the comment text (Prettier prints `$a: 1, // c`).
+/// Returns the end offset of the last emitted comment.
+fn write_config_trailing_comments<'a>(
+    upper_bound: u32,
+    f: &mut CssFormatter<'_, 'a>,
+) -> Option<u32> {
+    let mut last_end = None;
+    while let Some(comment) = f.context().comments().peek() {
+        if comment.span.end > upper_bound
+            || value::comment_is_own_line(comment, f.context().source_text())
+        {
+            break;
+        }
+        f.context().comments().take_before(comment.span.end);
+        if comment.inline {
+            let content = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                write!(f, space());
+                comments::write_single_comment(comment, f);
+            });
+            write!(f, line_suffix(&content));
+        } else {
+            write!(f, space());
+            comments::write_single_comment(comment, f);
+        }
+        last_end = Some(comment.span.end);
+    }
+    last_end
 }

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/module-config-comments.scss
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/module-config-comments.scss
@@ -1,0 +1,39 @@
+// oxc-project/oxc#24193: comments inside `@use ... with (...)` were dropped.
+// Prettier's comma-group handling: a leading `//` comment gets its own line,
+// a leading block comment glues to its item, a same-line trailing comment stays
+// at the end of the item's line, and a blank line after an item's comma is
+// preserved.
+@use "bootstrap" with (
+  // Colors
+  $primary: variables.$primary,
+  $secondary: variables.$secondary,
+
+  // Components
+  $box-shadow: variables.$box-shadow,
+
+  /* Spacing */
+  $spacer: variables.$spacer
+);
+// A trailing `//` after a comma moves to its own line before the next item.
+// KNOWN DIVERGENCE (see AGENTS.md): the own-line `// before close` keeps its
+// own line, consistent with the map printer; Prettier pulls it up to the last
+// item's line (`$e: 5 // before close`).
+@use "a" with (
+  $a: 1, // trailing
+  $b: 2,
+
+  $c: 3,
+  /* block */ $d: 4,
+  $e: 5
+  // before close
+);
+// Comment between the path and `with` stays glued to the head.
+@use "b" /* c */ with (
+  $a: 1
+);
+// `@forward` shares the config printer (`!default` is allowed there).
+@forward "c" with (
+  // lead
+  $a: 1 !default,
+  $b: 2 !default // last
+);

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/module-config-comments.scss.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/module-config-comments.scss.snap
@@ -1,0 +1,132 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// oxc-project/oxc#24193: comments inside `@use ... with (...)` were dropped.
+// Prettier's comma-group handling: a leading `//` comment gets its own line,
+// a leading block comment glues to its item, a same-line trailing comment stays
+// at the end of the item's line, and a blank line after an item's comma is
+// preserved.
+@use "bootstrap" with (
+  // Colors
+  $primary: variables.$primary,
+  $secondary: variables.$secondary,
+
+  // Components
+  $box-shadow: variables.$box-shadow,
+
+  /* Spacing */
+  $spacer: variables.$spacer
+);
+// A trailing `//` after a comma moves to its own line before the next item.
+// KNOWN DIVERGENCE (see AGENTS.md): the own-line `// before close` keeps its
+// own line, consistent with the map printer; Prettier pulls it up to the last
+// item's line (`$e: 5 // before close`).
+@use "a" with (
+  $a: 1, // trailing
+  $b: 2,
+
+  $c: 3,
+  /* block */ $d: 4,
+  $e: 5
+  // before close
+);
+// Comment between the path and `with` stays glued to the head.
+@use "b" /* c */ with (
+  $a: 1
+);
+// `@forward` shares the config printer (`!default` is allowed there).
+@forward "c" with (
+  // lead
+  $a: 1 !default,
+  $b: 2 !default // last
+);
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// oxc-project/oxc#24193: comments inside `@use ... with (...)` were dropped.
+// Prettier's comma-group handling: a leading `//` comment gets its own line,
+// a leading block comment glues to its item, a same-line trailing comment stays
+// at the end of the item's line, and a blank line after an item's comma is
+// preserved.
+@use "bootstrap" with (
+  // Colors
+  $primary: variables.$primary,
+  $secondary: variables.$secondary,
+
+  // Components
+  $box-shadow: variables.$box-shadow,
+
+  /* Spacing */ $spacer: variables.$spacer
+);
+// A trailing `//` after a comma moves to its own line before the next item.
+// KNOWN DIVERGENCE (see AGENTS.md): the own-line `// before close` keeps its
+// own line, consistent with the map printer; Prettier pulls it up to the last
+// item's line (`$e: 5 // before close`).
+@use "a" with (
+  $a: 1,
+  // trailing
+  $b: 2,
+
+  $c: 3,
+  /* block */ $d: 4,
+  $e: 5
+  // before close
+);
+// Comment between the path and `with` stays glued to the head.
+@use "b" /* c */ with (
+  $a: 1
+);
+// `@forward` shares the config printer (`!default` is allowed there).
+@forward "c" with (
+  // lead
+  $a: 1 !default,
+  $b: 2 !default // last
+);
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// oxc-project/oxc#24193: comments inside `@use ... with (...)` were dropped.
+// Prettier's comma-group handling: a leading `//` comment gets its own line,
+// a leading block comment glues to its item, a same-line trailing comment stays
+// at the end of the item's line, and a blank line after an item's comma is
+// preserved.
+@use "bootstrap" with (
+  // Colors
+  $primary: variables.$primary,
+  $secondary: variables.$secondary,
+
+  // Components
+  $box-shadow: variables.$box-shadow,
+
+  /* Spacing */ $spacer: variables.$spacer
+);
+// A trailing `//` after a comma moves to its own line before the next item.
+// KNOWN DIVERGENCE (see AGENTS.md): the own-line `// before close` keeps its
+// own line, consistent with the map printer; Prettier pulls it up to the last
+// item's line (`$e: 5 // before close`).
+@use "a" with (
+  $a: 1,
+  // trailing
+  $b: 2,
+
+  $c: 3,
+  /* block */ $d: 4,
+  $e: 5
+  // before close
+);
+// Comment between the path and `with` stays glued to the head.
+@use "b" /* c */ with (
+  $a: 1
+);
+// `@forward` shares the config printer (`!default` is allowed there).
+@forward "c" with (
+  // lead
+  $a: 1 !default,
+  $b: 2 !default // last
+);
+
+===================== End =====================


### PR DESCRIPTION
Fixes #24193

Now comments inside `@use`/`@forward` + `with ()` are preserved.
