### PR TITLE
fix(formatter_css): use fill IR for `@forward` members

### DIFF
--- a/crates/oxc_formatter_css/AGENTS.md
+++ b/crates/oxc_formatter_css/AGENTS.md
@@ -201,6 +201,18 @@ Notable divergences are:
 - `@nest <selector-list>` continuation lines indent at +2 (same class as the `:not(...)` entry above)
   - Prettier lands at +4 (comma-separated selectors) / +6 (wrapped selector parts) — an artifact of its generic at-rule params indent
   - Ours matches how selector lists indent everywhere else; layout-only, deprecated syntax, triggers only on width overflow
+- SCSS: `@forward` with `show`/`hide` members AND a `with (...)` config
+  - Prettier parses the whole prelude as ONE comma list, so the config's forced break spills into the member commas
+    (`show b,\n  c with (` even when the head fits) and the config body lands one level deeper (+4 body / +2 `)`)
+  - We break members only on width overflow (fill, matching Prettier's break positions when no config is present)
+    and keep the config at the standalone `with (...)` indent (+2 body / 0 `)`, same as `@use`)
+  - Layout-only, rare combo; pinned in `forward-members-wrap.scss`
+- SCSS: `@use`/`@forward` head seams (`as <ns>`, `as <prefix>-*`, `show`/`hide` before the FIRST member) never break
+  - Prettier treats every top-level space in the value-parsed params as a `line`,
+    so an overflowing `@use "path" as long-name;` breaks before `as` at +2
+    (and a no-comma overflow inside one chunk breaks after `show` at +4)
+  - We break only at the member commas; an overflow confined to the head stays on one line
+  - Same overflow class as the members fix, bounded to these two printers; extend the group over the seams if reported
 - `<general-enclosed>` media preludes (`@media (not all)`, `(screen and (color))` unparsable as `<media-condition>`) normalize whitespace fully
   - Source gap → one space, paren inner edges tight
   - Prettier only collapses space RUNS inside the unparsable paren, leaving `(not ( screen and ( color ) ))`

--- a/crates/oxc_formatter_css/src/print/scss.rs
+++ b/crates/oxc_formatter_css/src/print/scss.rs
@@ -818,13 +818,24 @@ pub(super) fn write_sass_forward<'a>(forward: &SassForward<'a>, f: &mut CssForma
                 write!(f, [space(), "hide", space()]);
             }
         }
-        for (i, member) in visibility.members.iter().enumerate() {
-            if i > 0 {
-                write!(f, [",", space()]);
+        // Members are fill chunks (Prettier's no-open paren-group params path):
+        // pack as many per line as fit, continuation lines indent at +2.
+        let members = &visibility.members;
+        let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+            let mut filler = f.fill();
+            for (i, member) in members.iter().enumerate() {
+                let entry = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                    let span = to_span(member.span());
+                    write!(f, text(source.text_for(&span)));
+                    if i + 1 < members.len() {
+                        write!(f, ",");
+                    }
+                });
+                filler.entry(&soft_line_break_or_space(), &entry);
             }
-            let span = to_span(member.span());
-            write!(f, text(source.text_for(&span)));
-        }
+            filler.finish();
+        });
+        write!(f, group(&indent(&body)));
     }
     if let Some(config) = &forward.config {
         write_sass_module_config(config, f);

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/forward-members-wrap.scss
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/forward-members-wrap.scss
@@ -1,0 +1,19 @@
+// `@forward` show/hide members are fill chunks: pack as many per line as fit,
+// continuation lines indent at +2 (Prettier's no-open paren-group params path).
+@forward "src/list" show list-remove, list-append, list-prepend, list-insert, list-delete;
+@forward "src/list" hide list-remove, list-append, list-prepend, list-insert, list-delete;
+@forward "src/library" as lib-* show gray-scale-colors, brand-colors, spacing-tokens, typography;
+@forward "src/list" show aa, bb;
+@forward "module/with/very/long/path/name" show first-member-name, second-member-name, third-member-name, fourth-member-name, fifth-member-name;
+// KNOWN DIVERGENCE (members + config, see AGENTS.md): Prettier treats the whole
+// prelude as one comma list, so the config's forced break spills into the member
+// commas (`show b,\n  c with (`) and the config body lands one level deeper
+// (+4 body / +2 `)`). We keep the head inline while it fits and keep the config
+// at the standalone `with (...)` indent (+2 body / 0 `)`) — both statements
+// below deviate from Prettier in those two ways.
+@forward "a" show b, c with (
+  $a: 1
+);
+@forward "src/library" show gray-scale-colors, brand-colors, spacing-tokens, typography-rules with (
+  $base: 10px
+);

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/forward-members-wrap.scss.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/forward-members-wrap.scss.snap
@@ -1,0 +1,78 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// `@forward` show/hide members are fill chunks: pack as many per line as fit,
+// continuation lines indent at +2 (Prettier's no-open paren-group params path).
+@forward "src/list" show list-remove, list-append, list-prepend, list-insert, list-delete;
+@forward "src/list" hide list-remove, list-append, list-prepend, list-insert, list-delete;
+@forward "src/library" as lib-* show gray-scale-colors, brand-colors, spacing-tokens, typography;
+@forward "src/list" show aa, bb;
+@forward "module/with/very/long/path/name" show first-member-name, second-member-name, third-member-name, fourth-member-name, fifth-member-name;
+// KNOWN DIVERGENCE (members + config, see AGENTS.md): Prettier treats the whole
+// prelude as one comma list, so the config's forced break spills into the member
+// commas (`show b,\n  c with (`) and the config body lands one level deeper
+// (+4 body / +2 `)`). We keep the head inline while it fits and keep the config
+// at the standalone `with (...)` indent (+2 body / 0 `)`) — both statements
+// below deviate from Prettier in those two ways.
+@forward "a" show b, c with (
+  $a: 1
+);
+@forward "src/library" show gray-scale-colors, brand-colors, spacing-tokens, typography-rules with (
+  $base: 10px
+);
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// `@forward` show/hide members are fill chunks: pack as many per line as fit,
+// continuation lines indent at +2 (Prettier's no-open paren-group params path).
+@forward "src/list" show list-remove, list-append, list-prepend, list-insert,
+  list-delete;
+@forward "src/list" hide list-remove, list-append, list-prepend, list-insert,
+  list-delete;
+@forward "src/library" as lib-* show gray-scale-colors, brand-colors,
+  spacing-tokens, typography;
+@forward "src/list" show aa, bb;
+@forward "module/with/very/long/path/name" show first-member-name,
+  second-member-name, third-member-name, fourth-member-name, fifth-member-name;
+// KNOWN DIVERGENCE (members + config, see AGENTS.md): Prettier treats the whole
+// prelude as one comma list, so the config's forced break spills into the member
+// commas (`show b,\n  c with (`) and the config body lands one level deeper
+// (+4 body / +2 `)`). We keep the head inline while it fits and keep the config
+// at the standalone `with (...)` indent (+2 body / 0 `)`) — both statements
+// below deviate from Prettier in those two ways.
+@forward "a" show b, c with (
+  $a: 1
+);
+@forward "src/library" show gray-scale-colors, brand-colors, spacing-tokens,
+  typography-rules with (
+  $base: 10px
+);
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// `@forward` show/hide members are fill chunks: pack as many per line as fit,
+// continuation lines indent at +2 (Prettier's no-open paren-group params path).
+@forward "src/list" show list-remove, list-append, list-prepend, list-insert, list-delete;
+@forward "src/list" hide list-remove, list-append, list-prepend, list-insert, list-delete;
+@forward "src/library" as lib-* show gray-scale-colors, brand-colors, spacing-tokens, typography;
+@forward "src/list" show aa, bb;
+@forward "module/with/very/long/path/name" show first-member-name, second-member-name,
+  third-member-name, fourth-member-name, fifth-member-name;
+// KNOWN DIVERGENCE (members + config, see AGENTS.md): Prettier treats the whole
+// prelude as one comma list, so the config's forced break spills into the member
+// commas (`show b,\n  c with (`) and the config body lands one level deeper
+// (+4 body / +2 `)`). We keep the head inline while it fits and keep the config
+// at the standalone `with (...)` indent (+2 body / 0 `)`) — both statements
+// below deviate from Prettier in those two ways.
+@forward "a" show b, c with (
+  $a: 1
+);
+@forward "src/library" show gray-scale-colors, brand-colors, spacing-tokens, typography-rules with (
+  $base: 10px
+);
+
+===================== End =====================


### PR DESCRIPTION
This will ensure that line breaks are inserted taking `printWidth` into account.