### PR TITLE
fix(formatter): print `;` before jsdoc type-cast parens with no-semi

### DIFF
--- a/crates/oxc_formatter/src/ast_nodes/generated/format.rs
+++ b/crates/oxc_formatter/src/ast_nodes/generated/format.rs
@@ -1999,8 +1999,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, EmptyStatement> {
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExpressionStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f);
         if is_suppressed {
+            self.format_leading_comments(f);
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
@@ -4411,6 +4411,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSUnionType<'a>> {
             "(".fmt(f);
         }
         if is_suppressed {
+            self.format_leading_comments(f);
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -75,6 +75,7 @@ use crate::{
         string::{FormatLiteralStringToken, StringLiteralParentKind},
         suppressed::FormatSuppressedNode,
         tailwindcss::{tailwind_context_for_string_literal, write_tailwind_string_literal},
+        typecast::is_type_cast_node,
     },
     write,
 };
@@ -539,6 +540,11 @@ fn expression_statement_needs_semicolon<'a>(
                     }
                     _ => false,
                 }
+                // A type cast comment forces parentheses around the expression,
+                // so the line starts with `(` even though `needs_parentheses` is false:
+                // `/** @type {string} */ (this.s).length`
+                // Checked last: this scans source text/comments, unlike the checks above.
+                || is_type_cast_node(expr, f).is_some()
         }
         ExpressionLeftSide::AssignmentTarget(assignment) => {
             matches!(
@@ -563,12 +569,27 @@ fn expression_statement_needs_semicolon<'a>(
 impl<'a> FormatWrite<'a> for AstNode<'a, ExpressionStatement<'a>> {
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         let span = self.span();
-        // Check if we need a leading semicolon to prevent ASI issues
-        if f.options().semicolons == Semicolons::AsNeeded
-            && expression_statement_needs_semicolon(self, f)
+        // Check if we need a leading semicolon to prevent ASI issues.
+        // Leading comments are printed here rather than in the generated `fmt`
+        // so the semicolon can go before a type cast comment;
+        // otherwise the cast is detached from its expression and the parentheses get dropped on the next format:
+        // `;/** @type {string[]} */ ([]).forEach(...)`
+        let needs_semicolon = f.options().semicolons == Semicolons::AsNeeded
+            && expression_statement_needs_semicolon(self, f);
+        let leading_comments = f.context().comments().comments_before(span.start);
+        // Split off a trailing type cast comment so the semicolon lands before it
+        let split = if needs_semicolon
+            && leading_comments.last().is_some_and(|last| f.comments().is_type_cast_comment(last))
         {
+            leading_comments.len() - 1
+        } else {
+            leading_comments.len()
+        };
+        write!(f, FormatLeadingComments::Comments(&leading_comments[..split]));
+        if needs_semicolon {
             write!(f, ";");
         }
+        write!(f, FormatLeadingComments::Comments(&leading_comments[split..]));
 
         if f.comments().has_trailing_suppression_comment(span.end) {
             // Preserve original text when the statement has an inline suppression comment:

--- a/crates/oxc_formatter/src/source_text.rs
+++ b/crates/oxc_formatter/src/source_text.rs
@@ -90,9 +90,10 @@ impl SourceTextExt for SourceText<'_> {
             && comment.end <= start
         {
             start = comment.start;
-        } else if start != 0 && matches!(bytes.get((start - 1) as usize).copied(), Some(b';')) {
-            // Skip leading semicolon if present
-            // `;(function() {});`
+        }
+        // Skip leading semicolon if present
+        // `;(function() {});` or `;/* comment */ (function() {});`
+        if start != 0 && matches!(bytes.get((start - 1) as usize).copied(), Some(b';')) {
             start -= 1;
         }
 

--- a/crates/oxc_formatter/tests/fixtures/js/semicolons/type-cast-comment.js
+++ b/crates/oxc_formatter/tests/fixtures/js/semicolons/type-cast-comment.js
@@ -1,0 +1,6 @@
+;/** @type {string[]} */ (['foo', 'bar']).forEach(doStuff)
+;/** @type {(token: Token)=>void} */ (onToken)(token)
+;/** @type {string} */ (foo).length
+;/* 2 */ /** @type {{bar: string[]}} */ ({}).bar.forEach(doStuff)
+;/* not a type cast comment */ ([])(token)
+;/* don't need leading semicolon */ (foo)(token)

--- a/crates/oxc_formatter/tests/fixtures/js/semicolons/type-cast-comment.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/semicolons/type-cast-comment.js.snap
@@ -1,0 +1,53 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+;/** @type {string[]} */ (['foo', 'bar']).forEach(doStuff)
+;/** @type {(token: Token)=>void} */ (onToken)(token)
+;/** @type {string} */ (foo).length
+;/* 2 */ /** @type {{bar: string[]}} */ ({}).bar.forEach(doStuff)
+;/* not a type cast comment */ ([])(token)
+;/* don't need leading semicolon */ (foo)(token)
+
+==================== Output ====================
+------------------------------
+{ printWidth: 80, semi: true }
+------------------------------
+/** @type {string[]} */ (["foo", "bar"]).forEach(doStuff);
+/** @type {(token: Token)=>void} */ (onToken)(token);
+/** @type {string} */ (foo).length;
+/* 2 */ /** @type {{bar: string[]}} */ ({}).bar.forEach(doStuff);
+/* not a type cast comment */ [](token);
+/* don't need leading semicolon */ foo(token);
+
+-------------------------------
+{ printWidth: 100, semi: true }
+-------------------------------
+/** @type {string[]} */ (["foo", "bar"]).forEach(doStuff);
+/** @type {(token: Token)=>void} */ (onToken)(token);
+/** @type {string} */ (foo).length;
+/* 2 */ /** @type {{bar: string[]}} */ ({}).bar.forEach(doStuff);
+/* not a type cast comment */ [](token);
+/* don't need leading semicolon */ foo(token);
+
+-------------------------------
+{ printWidth: 80, semi: false }
+-------------------------------
+;/** @type {string[]} */ (["foo", "bar"]).forEach(doStuff)
+;/** @type {(token: Token)=>void} */ (onToken)(token)
+;/** @type {string} */ (foo).length
+/* 2 */ ;/** @type {{bar: string[]}} */ ({}).bar.forEach(doStuff)
+/* not a type cast comment */ ;[](token)
+/* don't need leading semicolon */ foo(token)
+
+--------------------------------
+{ printWidth: 100, semi: false }
+--------------------------------
+;/** @type {string[]} */ (["foo", "bar"]).forEach(doStuff)
+;/** @type {(token: Token)=>void} */ (onToken)(token)
+;/** @type {string} */ (foo).length
+/* 2 */ ;/** @type {{bar: string[]}} */ ({}).bar.forEach(doStuff)
+/* not a type cast comment */ ;[](token)
+/* don't need leading semicolon */ foo(token)
+
+===================== End =====================

--- a/tasks/ast_tools/src/generators/formatter/format.rs
+++ b/tasks/ast_tools/src/generators/formatter/format.rs
@@ -31,7 +31,10 @@ const AST_NODE_WITHOUT_PRINTING_COMMENTS_LIST: &[&str] = &[
     "TemplateElement",
 ];
 
-const AST_NODE_WITHOUT_PRINTING_LEADING_COMMENTS_LIST: &[&str] = &["TSUnionType"];
+// `ExpressionStatement` prints leading comments in its `write` implementation,
+// so the ASI-guard semicolon can be printed before a leading type cast comment.
+const AST_NODE_WITHOUT_PRINTING_LEADING_COMMENTS_LIST: &[&str] =
+    &["TSUnionType", "ExpressionStatement"];
 
 const AST_NODE_NEEDS_PARENTHESES: &[&str] = &[
     "TSTypeAssertion",
@@ -170,20 +173,24 @@ fn generate_struct_implementation(
 
         let write_implementation = if suppressed_check.is_none() {
             write_call
-        } else if trailing_comments.is_none() {
-            quote! {
-                if is_suppressed {
-                     self.format_leading_comments(f);
-                    FormatSuppressedNode(self.span()).fmt(f);
-                     self.format_trailing_comments(f);
-                } else {
-                    #write_call
-                }
-            }
         } else {
+            // When `fmt` doesn't print leading/trailing comments itself,
+            // the suppressed path still has to print them, or the suppression comment would be lost.
+            let suppressed_leading_comments = do_not_print_leading_comment.then(|| {
+                quote! {
+                    self.format_leading_comments(f);
+                }
+            });
+            let suppressed_trailing_comments = do_not_print_comment.then(|| {
+                quote! {
+                    self.format_trailing_comments(f);
+                }
+            });
             quote! {
                 if is_suppressed {
+                    #suppressed_leading_comments
                     FormatSuppressedNode(self.span()).fmt(f);
+                    #suppressed_trailing_comments
                 } else {
                     #write_call
                 }

--- a/tasks/coverage/snapshots/formatter_typescript.snap
+++ b/tasks/coverage/snapshots/formatter_typescript.snap
@@ -2,7 +2,7 @@ commit: 7964e22f
 
 formatter_typescript Summary:
 AST Parsed     : 9779/9779 (100.00%)
-Positive Passed: 9727/9779 (99.47%)
+Positive Passed: 9728/9779 (99.48%)
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/amdLikeInputDeclarationEmit.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/castExpressionParentheses.ts
@@ -92,8 +92,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optional
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorAssignability.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/yieldStatementNoAsiAfterTransform.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocSatisfiesTag3.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution8.tsx
 

--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,4 +1,4 @@
-js compatibility: 737/808 (91.21%), 23 files skipped
+js compatibility: 742/808 (91.83%), 23 files skipped
 
 # Failed
 
@@ -17,7 +17,6 @@ js compatibility: 737/808 (91.21%), 23 files skipped
 | js/comments/dangling.js | 💥💥 | 69.23% |
 | js/comments/empty-statements.js | 💥💥 | 90.91% |
 | js/comments/if.js | 💥💥 | 97.99% |
-| js/comments/jsdoc.js | 💥✨ | 46.15% |
 | js/comments/return-statement-2.js | 💥💥 | 77.78% |
 | js/comments/return-statement.js | 💥💥 | 97.25% |
 | js/comments/between-head-and-body/between-head-and-body.js | 💥 | 33.10% |
@@ -29,10 +28,6 @@ js compatibility: 737/808 (91.21%), 23 files skipped
 | js/comments/while-like/with.js | 💥 | 65.45% |
 | js/comments-closure-typecast/closure-compiler-type-cast.js | 💥 | 88.00% |
 | js/comments-closure-typecast/iife.js | 💥 | 76.92% |
-| js/comments-closure-typecast/no-semi/comments.js | 💥 | 70.59% |
-| js/comments-closure-typecast/no-semi/multiline.js | 💥 | 80.00% |
-| js/comments-closure-typecast/no-semi/not-on-same-line.js | 💥 | 84.85% |
-| js/comments-closure-typecast/no-semi/with-other-comments.js | 💥 | 50.00% |
 | js/explicit-resource-management/using-declarations.js | 💥 | 87.50% |
 | js/explicit-resource-management/valid-await-using-comments.js | 💥 | 80.00% |
 | js/explicit-resource-management/valid-for-using-declaration.js | 💥 | 66.67% |


### PR DESCRIPTION
Follows https://github.com/prettier/prettier/blob/79f6cdfd9873a91be9b25c9c6a41d26dcd9a6656/changelog_unreleased/javascript/18751.md

```js
;/** @type {string[]} */ (["foo", "bar"]).forEach(doStuff)
```

With `no-semi`, this `;` should stay the same position.

Also fixes minor bugs and idempotency issues.