### PR TITLE
fix(formatter): print space for `ForStatement`.`update` only if exists

### DIFF
--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -717,7 +717,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForStatement<'a>> {
                         test,
                         (update.is_none()).then_some(FormatCommentForEmptyStatement(body)),
                         ";",
-                        soft_line_break_or_space(),
+                        update.is_some().then_some(soft_line_break_or_space()),
                         update,
                         FormatCommentForEmptyStatement(body)
                     ))),

--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,4 +1,4 @@
-js compatibility: 742/808 (91.83%), 23 files skipped
+js compatibility: 749/808 (92.70%), 23 files skipped
 
 # Failed
 
@@ -28,21 +28,14 @@ js compatibility: 742/808 (91.83%), 23 files skipped
 | js/comments/while-like/with.js | 💥 | 65.45% |
 | js/comments-closure-typecast/closure-compiler-type-cast.js | 💥 | 88.00% |
 | js/comments-closure-typecast/iife.js | 💥 | 76.92% |
-| js/explicit-resource-management/using-declarations.js | 💥 | 87.50% |
 | js/explicit-resource-management/valid-await-using-comments.js | 💥 | 80.00% |
-| js/explicit-resource-management/valid-for-using-declaration.js | 💥 | 66.67% |
-| js/explicit-resource-management/valid-using-as-identifier-for-init.js | 💥 | 0.00% |
 | js/for/9812-2.js | 💥 | 58.33% |
 | js/for/continue-and-break-comment-1.js | 💥 | 97.89% |
 | js/for/continue-and-break-comment-without-blocks.js | 💥 | 41.51% |
-| js/for/for.js | 💥 | 71.43% |
-| js/for/in.js | 💥 | 41.67% |
-| js/for/parentheses.js | 💥 | 59.18% |
 | js/for-of/comments.js | 💥 | 50.00% |
 | js/function/iife.js | 💥 | 14.89% |
 | js/function/issue-12967.js | 💥 | 0.00% |
 | js/identifier/for-of/let.js | 💥 | 92.31% |
-| js/identifier/parentheses/let.js | 💥💥 | 99.09% |
 | js/if/blank-lines.js | 💥 | 94.83% |
 | js/if/comment-between-condition-and-body.js | 💥 | 92.11% |
 | js/if/if_comments.js | 💥 | 91.89% |


### PR DESCRIPTION
`for (i;t;) {}` should be `for (i; t;) {}`, not `for (i; t; ) {}`.