### PR TITLE
fix(formatter): omit unneeded `;` for type members with `no-semi`

### DIFF
--- a/crates/oxc_formatter/src/print/class.rs
+++ b/crates/oxc_formatter/src/print/class.rs
@@ -19,6 +19,7 @@ use crate::{
     utils::{
         assignment_like::AssignmentLike,
         format_node_without_trailing_comments::FormatNodeWithoutTrailingComments,
+        is_keyword_property_key,
         object::{format_property_key, should_preserve_quote},
     },
     write,
@@ -543,7 +544,7 @@ impl<'a, 'b> FormatClassElementWithSemicolon<'a, 'b> {
         if let ClassElement::PropertyDefinition(def) = element.as_ref()
             && def.value.is_none()
             && def.type_annotation.is_none()
-            && matches!(&def.key, PropertyKey::StaticIdentifier(ident) if matches!(ident.name.as_str(), "static" | "get" | "set") )
+            && is_keyword_property_key(&def.key)
         {
             return true;
         }

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -70,6 +70,7 @@ use crate::{
         conditional::ConditionalLike,
         expression::ExpressionLeftSide,
         format_node_without_trailing_comments::FormatNodeWithoutTrailingComments,
+        is_keyword_property_key,
         object::{format_property_key, should_preserve_quote},
         statement_body::FormatStatementBody,
         string::{FormatLiteralStringToken, StringLiteralParentKind},
@@ -1588,22 +1589,18 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatTSSignature<'a, '_> {
                 }
             }
             Semicolons::AsNeeded => {
-                // Needs semicolon anyway when:
-                // 1. It's a non-computed property signature with type annotation followed by
-                //    a call signature that has type parameters
-                //    e.g for: `a: string; <T>() => void`
-                // 2. It's a non-computed property signature without type annotation followed by
-                //    a call signature or method signature
-                //    e.g for: `a; () => void` or `a; method(): void`
+                // Needs semicolon anyway when omitting it would change how the members parse:
+                // 1. It's a property signature without type annotation named `static`, `get` or `set`,
+                //    which would otherwise parse as a modifier or accessor of the following member
+                // 2. It's a property signature without type annotation followed by
+                //    a call signature, e.g. `a` + `(): void` -> `a(): void`
                 let needs_semicolon = matches!(
-                    self.signature.as_ref(), TSSignature::TSPropertySignature(property) if !property.computed
-                    && self.next_signature.is_some_and(|signature| match signature.as_ref() {
-                        TSSignature::TSCallSignatureDeclaration(call) => {
-                            property.type_annotation.is_none() || call.type_parameters.is_some()
-                        }
-                        TSSignature::TSMethodSignature(_) => property.type_annotation.is_none(),
-                        _ => false,
-                    })
+                    self.signature.as_ref(), TSSignature::TSPropertySignature(property)
+                    if property.type_annotation.is_none()
+                    && (is_keyword_property_key(&property.key)
+                        || self.next_signature.is_some_and(|next| {
+                            matches!(next.as_ref(), TSSignature::TSCallSignatureDeclaration(_))
+                        }))
                 );
 
                 if needs_semicolon {

--- a/crates/oxc_formatter/src/utils/mod.rs
+++ b/crates/oxc_formatter/src/utils/mod.rs
@@ -14,9 +14,19 @@ pub mod tailwindcss;
 pub mod typecast;
 pub mod typescript;
 
-use oxc_ast::ast::CallExpression;
+use oxc_ast::ast::{CallExpression, PropertyKey};
 
 use crate::ast_nodes::{AstNode, AstNodes};
+
+/// Tests if the property key is an identifier named `static`, `get` or `set`,
+/// which would parse as a modifier or accessor of the following member
+/// if the separating semicolon were omitted, e.g. `get` + `<T>(): T` -> `get <T>(): T`.
+/// Computed keys are never `StaticIdentifier`, so they need no extra check.
+///
+/// Used by the class and interface member no-semi rules, like Prettier's `isKeywordProperty`.
+pub fn is_keyword_property_key(key: &PropertyKey<'_>) -> bool {
+    matches!(key, PropertyKey::StaticIdentifier(ident) if matches!(ident.name.as_str(), "static" | "get" | "set"))
+}
 
 /// Tests if expression is a long curried call
 ///

--- a/tasks/coverage/snapshots/formatter_typescript.snap
+++ b/tasks/coverage/snapshots/formatter_typescript.snap
@@ -2,7 +2,7 @@ commit: 7964e22f
 
 formatter_typescript Summary:
 AST Parsed     : 9779/9779 (100.00%)
-Positive Passed: 9728/9779 (99.48%)
+Positive Passed: 9729/9779 (99.49%)
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/amdLikeInputDeclarationEmit.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/castExpressionParentheses.ts
@@ -103,5 +103,3 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/pedantic/noUnchecked
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/returnStatements/returnStatementNoAsiAfterTransform.ts
 
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/propertySignatures/propertyNamesOfReservedWords.ts
-'static' modifier cannot appear on a type member.

--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -1,4 +1,4 @@
-ts compatibility: 597/663 (90.05%), 19 files skipped
+ts compatibility: 599/663 (90.35%), 19 files skipped
 
 # Failed
 
@@ -34,8 +34,6 @@ ts compatibility: 597/663 (90.05%), 19 files skipped
 | typescript/conformance/types/union/unionTypeCallSignatures.ts | 💥 | 85.25% |
 | typescript/conformance/types/union/unionTypeConstructSignatures.ts | 💥 | 91.62% |
 | typescript/conformance/types/union/unionTypeIndexSignature.ts | 💥 | 83.64% |
-| typescript/interface/no-semi/14040.ts | 💥 | 97.47% |
-| typescript/interface/no-semi/18858.ts | 💥 | 94.44% |
 | typescript/interface2/comments-ts-only/18278.ts | 💥 | 95.65% |
 | typescript/intersection/intersection-parens.ts | 💥💥 | 85.64% |
 | typescript/intersection/consistent-with-flow/intersection-parens.ts | 💥 | 67.44% |


### PR DESCRIPTION
Also checked with `tsc`, this can be omitted.

```ts
interface H1 {
  foo: X /* ; */
  <T>(): T
}
```