### PR TITLE
fix(linter): use direct binding symbol ids

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_param_reassign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_param_reassign.rs
@@ -123,9 +123,7 @@ impl Rule for NoParamReassign {
 
         let symbol_table = ctx.scoping();
         for ident in param.pattern.get_binding_identifiers() {
-            let Some(symbol_id) = ident.symbol_id.get() else {
-                continue;
-            };
+            let symbol_id = ident.symbol_id();
 
             let declaration_id = symbol_table.symbol_declaration(symbol_id);
             let name = symbol_table.symbol_name(symbol_id);

--- a/crates/oxc_linter/src/rules/eslint/preserve_caught_error.rs
+++ b/crates/oxc_linter/src/rules/eslint/preserve_caught_error.rs
@@ -234,9 +234,7 @@ fn is_catch_parameter(expr: &Expression, catch_param: &BindingPattern, ctx: &Lin
         return false;
     };
 
-    let Some(catch_symbol_id) = binding.symbol_id.get() else {
-        return false;
-    };
+    let catch_symbol_id = binding.symbol_id();
 
     let Expression::Identifier(ident) = expr else {
         return false;

--- a/crates/oxc_linter/src/rules/react/jsx_no_literals.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_literals.rs
@@ -179,7 +179,7 @@ impl JsxNoLiterals {
 
         for prop in &obj.properties {
             if let BindingPattern::BindingIdentifier(local) = &prop.value
-                && local.symbol_id.get() == Some(symbol_id)
+                && local.symbol_id() == symbol_id
                 && let PropertyKey::StaticIdentifier(key) = &prop.key
             {
                 return Some(key.name.to_compact_str());

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_error_capture_stack_trace.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_error_capture_stack_trace.rs
@@ -138,10 +138,8 @@ fn get_error_subclass_if_in_constructor<'a>(
             }
             AstKind::Class(class) => {
                 if found_constructor && is_error_class(class, ctx) {
-                    if let Some(id) = class.id.as_ref()
-                        && let Some(symbol_id) = id.symbol_id.get()
-                    {
-                        return ClassInfo::Named(symbol_id);
+                    if let Some(id) = class.id.as_ref() {
+                        return ClassInfo::Named(id.symbol_id());
                     }
                     return ClassInfo::Anonymous;
                 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_default_parameters.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_default_parameters.rs
@@ -401,9 +401,7 @@ fn check_no_extra_references<'a>(
         return false;
     };
 
-    let Some(symbol_id) = binding_ident.symbol_id.get() else {
-        return false;
-    };
+    let symbol_id = binding_ident.symbol_id();
 
     let references: Vec<_> = ctx.scoping().get_resolved_references(symbol_id).collect();
 
@@ -424,9 +422,7 @@ fn check_no_extra_references_assignment<'a>(
         return false;
     };
 
-    let Some(symbol_id) = binding_ident.symbol_id.get() else {
-        return false;
-    };
+    let symbol_id = binding_ident.symbol_id();
 
     let (has_matching_read, writes) = ctx.scoping().get_resolved_references(symbol_id).fold(
         (false, 0usize),

--- a/crates/oxc_linter/src/rules/unicorn/prefer_set_has.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_set_has.rs
@@ -151,9 +151,7 @@ impl Rule for PreferSetHas {
             return;
         };
 
-        let Some(symbol_id) = ident.symbol_id.get() else {
-            return;
-        };
+        let symbol_id = ident.symbol_id();
 
         let module_record = ctx.module_record();
         if module_record.exported_bindings.contains_key(ident.name.as_str())

--- a/crates/oxc_linter/src/rules/vue/no_dupe_keys.rs
+++ b/crates/oxc_linter/src/rules/vue/no_dupe_keys.rs
@@ -378,9 +378,7 @@ fn collect_props_bindings<'a>(
 fn collect_binding_symbol_ids(pattern: &BindingPattern, ids: &mut Vec<SymbolId>) {
     match pattern {
         BindingPattern::BindingIdentifier(id) => {
-            if let Some(sym) = id.symbol_id.get() {
-                ids.push(sym);
-            }
+            ids.push(id.symbol_id());
         }
         BindingPattern::ObjectPattern(obj) => {
             for prop in &obj.properties {

--- a/crates/oxc_linter/src/rules/vue/no_expose_after_await.rs
+++ b/crates/oxc_linter/src/rules/vue/no_expose_after_await.rs
@@ -127,11 +127,11 @@ fn check_setup_in_object<'a>(obj_expr: &ObjectExpression<'a>, ctx: &LintContext<
                 return None;
             }
             let binding_id = prop.value.get_binding_identifier()?;
-            binding_id.symbol_id.get().map(ExposeBinding::Expose)
+            Some(ExposeBinding::Expose(binding_id.symbol_id()))
         }),
         // `setup(_, ctx)` — whole context bound to a name
         BindingPattern::BindingIdentifier(binding_id) => {
-            binding_id.symbol_id.get().map(ExposeBinding::Ctx)
+            Some(ExposeBinding::Ctx(binding_id.symbol_id()))
         }
         _ => None,
     };

--- a/crates/oxc_linter/src/rules/vue/require_slots_as_functions.rs
+++ b/crates/oxc_linter/src/rules/vue/require_slots_as_functions.rs
@@ -120,9 +120,8 @@ fn verify(node: &AstNode<'_>, report_span: Span, ctx: &LintContext<'_>) {
         AstKind::VariableDeclarator(var)
             if var.init.as_ref().is_some_and(|init| init.span() == node.kind().span()) =>
         {
-            if let Some(binding_ident) = var.id.get_binding_identifier()
-                && let Some(symbol_id) = binding_ident.symbol_id.get()
-            {
+            if let Some(binding_ident) = var.id.get_binding_identifier() {
+                let symbol_id = binding_ident.symbol_id();
                 follow_references(symbol_id, report_span, ctx);
             }
         }


### PR DESCRIPTION
## Summary
- replace binding `symbol_id.get()` calls with direct `symbol_id()` access
- remove impossible unset-symbol handling during linting