### PR TITLE
refactor(react_compiler): skip only functions that use `using` instead of the whole file

### DIFF
--- a/crates/oxc_react_compiler/fixtures/using-declaration-skips-only-that-function.tsx
+++ b/crates/oxc_react_compiler/fixtures/using-declaration-skips-only-that-function.tsx
@@ -1,0 +1,11 @@
+// `using`/`await using` disposal semantics aren't preserved yet, so `WithUsing` is
+// skipped and emitted unchanged, while the structurally identical `Clean` component
+// in the same file is still compiled.
+function WithUsing(props) {
+  using resource = props.acquire();
+  return <div onClick={() => props.onClick()}>{props.text}</div>;
+}
+
+function Clean(props) {
+  return <div onClick={() => props.onClick()}>{props.text}</div>;
+}

--- a/crates/oxc_react_compiler/src/lib.rs
+++ b/crates/oxc_react_compiler/src/lib.rs
@@ -19,7 +19,7 @@ mod react_compiler_validation;
 use crate::react_compiler::entrypoint::compile_result::CompileResult;
 use crate::react_compiler::entrypoint::imports::get_react_compiler_runtime_module;
 use crate::react_compiler::entrypoint::program::compile_program;
-use prefilter::{has_react_like_functions, has_resource_management_declarations};
+use prefilter::has_react_like_functions;
 use scope::ScopeResolver;
 
 // Re-exported so integrations needn't depend on the upstream `react_compiler` crates.
@@ -124,11 +124,6 @@ fn compile<'a>(
     if !matches!(options.compilation_mode.as_str(), "all" | "annotation")
         && !has_react_like_functions(program)
     {
-        return (None, Diagnostics::default());
-    }
-
-    // `using`/`await using` disposal semantics aren't preserved yet — skip the file.
-    if has_resource_management_declarations(program) {
         return (None, Diagnostics::default());
     }
 

--- a/crates/oxc_react_compiler/src/prefilter.rs
+++ b/crates/oxc_react_compiler/src/prefilter.rs
@@ -5,7 +5,7 @@
 
 use oxc_ast::ast::{
     ArrowFunctionExpression, AssignmentExpression, AssignmentTarget, BindingPattern,
-    CallExpression, Class, Expression, Function, Program, VariableDeclaration, VariableDeclarator,
+    CallExpression, Class, Expression, Function, Program, VariableDeclarator,
 };
 use oxc_ast_visit::{Visit, walk};
 use oxc_semantic::ScopeFlags;
@@ -13,12 +13,6 @@ use oxc_semantic::ScopeFlags;
 /// Whether the program contains a component (Uppercase name) or hook (`use[A-Z0-9]`).
 pub fn has_react_like_functions(program: &Program) -> bool {
     let mut visitor = ReactLikeVisitor { found: false, current_name: None };
-    visitor.visit_program(program);
-    visitor.found
-}
-
-pub fn has_resource_management_declarations(program: &Program) -> bool {
-    let mut visitor = ResourceManagementVisitor { found: false };
     visitor.visit_program(program);
     visitor.found
 }
@@ -39,23 +33,6 @@ fn is_component_wrapper(callee: &Expression) -> bool {
 struct ReactLikeVisitor<'a> {
     found: bool,
     current_name: Option<&'a str>,
-}
-
-struct ResourceManagementVisitor {
-    found: bool,
-}
-
-impl<'a> Visit<'a> for ResourceManagementVisitor {
-    fn visit_variable_declaration(&mut self, decl: &VariableDeclaration<'a>) {
-        if self.found {
-            return;
-        }
-        if decl.kind.is_using() {
-            self.found = true;
-            return;
-        }
-        walk::walk_variable_declaration(self, decl);
-    }
 }
 
 impl<'a> Visit<'a> for ReactLikeVisitor<'a> {

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
@@ -129,7 +129,7 @@ pub fn compile_fn<'a>(
     env_config: &EnvironmentConfig,
     context: &mut ProgramContext,
     source_text: &str,
-) -> Result<CodegenFunction<'a>, CompilerError> {
+) -> Result<Option<CodegenFunction<'a>>, CompilerError> {
     let mut env = Environment::with_config(env_config.clone());
     env.fn_type = fn_type;
     env.output_mode = match mode {
@@ -153,6 +153,13 @@ pub fn compile_fn<'a>(
     // not other recorded (non-Invariant) errors.
     if env.has_invariant_errors() {
         return Err(env.take_invariant_errors());
+    }
+
+    // Lowering flags this when the function uses `using`/`await using`, whose disposal
+    // semantics aren't preserved yet. Skip compiling it silently — no diagnostic — so
+    // other functions in the file still compile.
+    if env.skip_compilation {
+        return Ok(None);
     }
 
     if context.debug_enabled {
@@ -743,7 +750,7 @@ pub fn compile_fn<'a>(
         context.merge_uid_known_names(&uid_names);
     }
 
-    Ok(CodegenFunction {
+    Ok(Some(CodegenFunction {
         loc: codegen_result.loc,
         id: codegen_result.id,
         name_hint: codegen_result.name_hint,
@@ -757,7 +764,7 @@ pub fn compile_fn<'a>(
         pruned_memo_blocks: codegen_result.pruned_memo_blocks,
         pruned_memo_values: codegen_result.pruned_memo_values,
         outlined: compiled_outlined,
-    })
+    }))
 }
 
 /// Compile an outlined function's codegen AST through the full pipeline.

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -1188,7 +1188,7 @@ fn try_compile_function<'a>(
     env_config: &EnvironmentConfig,
     context: &mut ProgramContext,
     source_text: &str,
-) -> Result<CodegenFunction<'a>, CompilerError> {
+) -> Result<Option<CodegenFunction<'a>>, CompilerError> {
     // Check for suppressions that affect this function
     if let (Some(start), Some(end)) = (source.fn_start, source.fn_end) {
         let affecting = filter_suppressions_that_affect_function(&context.suppressions, start, end);
@@ -1279,7 +1279,10 @@ fn process_fn<'a>(
             }
             Ok(None)
         }
-        Ok(codegen_fn) => {
+        // Lowering silently declined to compile this function (e.g. it uses
+        // `using`/`await using`); nothing to emit, and no diagnostic.
+        Ok(None) => Ok(None),
+        Ok(Some(codegen_fn)) => {
             // Functions opted out via directive are skipped; nothing to emit.
             if !context.opts.ignore_use_no_forget && opt_out.is_some() {
                 // Do NOT register the memo cache import here — it is registered in

--- a/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
@@ -58,6 +58,12 @@ pub struct Environment<'a> {
     // Error accumulation
     pub errors: CompilerError,
 
+    // Set during lowering when the function uses syntax the compiler can't handle
+    // yet (currently `using`/`await using`, whose disposal semantics aren't
+    // preserved). Signals the pipeline to skip compiling this function silently —
+    // no diagnostic — while other functions in the file still compile.
+    pub skip_compilation: bool,
+
     // Function type classification (Component, Hook, Other)
     pub fn_type: ReactFunctionType,
 
@@ -176,6 +182,7 @@ impl<'a> Environment<'a> {
             scopes: Vec::new(),
             functions: Vec::new(),
             errors: CompilerError::new(),
+            skip_compilation: false,
             fn_type: ReactFunctionType::Other,
             output_mode: OutputMode::Client,
             instrument_fn_name: None,

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -6695,6 +6695,14 @@ fn lower_variable_declaration<'a>(
         })?;
         // Treat `var` as `let` so references to the variable don't break
     }
+    if matches!(var_decl.kind, VK::Using | VK::AwaitUsing) {
+        // `using`/`await using` disposal semantics aren't preserved yet. Flag the
+        // function to be skipped (silently, no diagnostic) once lowering finishes,
+        // rather than miscompiling it. It's still lowered as `const` below so the HIR
+        // stays valid until the pipeline checks the flag. Other functions in the file
+        // are unaffected.
+        builder.environment_mut().skip_compilation = true;
+    }
     let kind = match var_decl.kind {
         VK::Let | VK::Var => InstructionKind::Let,
         VK::Const | VK::Using | VK::AwaitUsing => InstructionKind::Const,

--- a/crates/oxc_react_compiler/tests/snapshots/using-declaration-skips-only-that-function.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/using-declaration-skips-only-that-function.snap
@@ -1,0 +1,33 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/using-declaration-skips-only-that-function.tsx
+---
+import { c as _c } from "react/compiler-runtime";
+// `using`/`await using` disposal semantics aren't preserved yet, so `WithUsing` is
+// skipped and emitted unchanged, while the structurally identical `Clean` component
+// in the same file is still compiled.
+function WithUsing(props) {
+	using resource = props.acquire();
+	return <div onClick={() => props.onClick()}>{props.text}</div>;
+}
+function Clean(props) {
+	const $ = _c(5);
+	let t0;
+	if ($[0] !== props) {
+		t0 = () => props.onClick();
+		$[0] = props;
+		$[1] = t0;
+	} else {
+		t0 = $[1];
+	}
+	let t1;
+	if ($[2] !== props.text || $[3] !== t0) {
+		t1 = <div onClick={t0}>{props.text}</div>;
+		$[2] = props.text;
+		$[3] = t0;
+		$[4] = t1;
+	} else {
+		t1 = $[4];
+	}
+	return t1;
+}


### PR DESCRIPTION
## Summary

`using`/`await using` disposal semantics aren't preserved by the React Compiler yet, so any file containing them was skipped entirely by a whole-program `ResourceManagementVisitor` pre-pass — a `using` *anywhere* in the file dropped *every* component in it.

This detects `using` during lowering instead. `lower_variable_declaration` already visits every variable declaration (including those in nested closures), so it sets a `skip_compilation` flag on the `Environment`; `compile_fn` checks it after lowering and returns `Ok(None)` — a silent, per-function skip with no diagnostic — so sibling functions still compile.

## Details

- Removes `ResourceManagementVisitor` and the whole-file gate in `compile()`; reuses the existing lowering traversal rather than adding a new visitor.
- The skip is silent (no diagnostic), unlike a `record_error` bail.
- Top-level `using` is untouched: the compiler only rewrites function bodies, so a module-scope `using` is preserved verbatim while the file's components still compile.
- Adds a fixture where a `using`-containing component is emitted unchanged and a structurally identical sibling component is memoized.

Before: any `using` → whole file skipped. After: only the enclosing function is skipped.

## Performance

CodSpeed reports a large regression on `react_compiler[kitchen-sink.tsx]` (19ms → 429ms) and `linter[kitchen-sink.tsx]` (166ms → 542ms). This reflects correct behavior, not a code inefficiency:

- `kitchen-sink.tsx` is a ~21k-line file with ~90 React components, and it contains `using`/`await using` in two small **non-React** helper functions (`exerciseUsing`/`exerciseAwaitUsing`).
- On `main` the whole-program pre-pass saw that `using` and skipped the **entire file**, so the benchmark was measuring parse + semantic + skip — it never actually compiled anything.
- With this PR the 90 components compile normally (the 429ms is their real cost). The two `using` helpers aren't even compile candidates in the default `infer` mode, so the per-function skip never fires for them here.

Files that do **not** contain `using` are unaffected — identical performance. The regression is confined to files that mix `using` with React components (a rare combination), which now correctly compile instead of being discarded wholesale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)