### PR TITLE
fix(transformer): preserve generated class binding spans

### DIFF
--- a/crates/oxc_transformer/src/decorator/legacy/mod.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/mod.rs
@@ -889,11 +889,17 @@ impl<'a> LegacyDecorator<'a> {
         // Now: `class C {}` -> `let C = class C {}`
         // After: `class C {}` -> `let C = class {}`
         let class_binding = class.id.as_ref().map(|ident| {
-            let new_class_binding =
-                ctx.generate_binding(ident.name, class.scope_id(), SymbolFlags::Class);
+            let binding_span = ident.span;
+            let new_class_binding = ctx.generate_spanned_binding(
+                ident.name,
+                binding_span,
+                class.scope_id(),
+                SymbolFlags::Class,
+            );
             let old_class_symbol_id = ident.symbol_id.replace(Some(new_class_binding.symbol_id));
             let old_class_symbol_id = old_class_symbol_id.expect("class always has a symbol id");
 
+            ctx.scoping_mut().set_symbol_span(old_class_symbol_id, binding_span);
             *ctx.scoping_mut().symbol_flags_mut(old_class_symbol_id) =
                 SymbolFlags::BlockScopedVariable;
             BoundIdentifier::new(ident.name, old_class_symbol_id)
@@ -1005,6 +1011,7 @@ impl<'a> LegacyDecorator<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Statement<'a> {
         let span = class.span;
+        let binding_span = ctx.scoping().symbol_span(binding.symbol_id);
         class.r#type = ClassType::ClassExpression;
         let initializer = Self::get_class_initializer(
             Expression::ClassExpression(class.take_in_box(ctx)),
@@ -1014,7 +1021,7 @@ impl<'a> LegacyDecorator<'a> {
         let declarator = VariableDeclarator::new(
             SPAN,
             VariableDeclarationKind::Let,
-            binding.create_binding_pattern(ctx),
+            binding.create_spanned_binding_pattern(binding_span, ctx),
             NONE,
             Some(initializer),
             false,

--- a/crates/oxc_traverse/src/context/mod.rs
+++ b/crates/oxc_traverse/src/context/mod.rs
@@ -377,6 +377,21 @@ impl<'a, State> TraverseCtx<'a, State> {
         self.scoping.generate_binding(name, scope_id, flags)
     }
 
+    /// Generate binding with a source span.
+    ///
+    /// Creates a symbol with the provided name, span, and flags and adds it to the specified scope.
+    ///
+    /// This is a shortcut for `ctx.scoping.generate_spanned_binding`.
+    pub fn generate_spanned_binding(
+        &mut self,
+        name: Ident<'a>,
+        span: Span,
+        scope_id: ScopeId,
+        flags: SymbolFlags,
+    ) -> BoundIdentifier<'a> {
+        self.scoping.generate_spanned_binding(name, span, scope_id, flags)
+    }
+
     /// Generate binding in current scope.
     ///
     /// Creates a symbol with the provided name and flags and adds it to the current scope.

--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -4,7 +4,7 @@ use oxc_allocator::{Allocator, ArenaVec};
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_semantic::{NodeId, Reference, Scoping};
-use oxc_span::SPAN;
+use oxc_span::{SPAN, Span};
 use oxc_str::Ident;
 use oxc_syntax::{
     reference::{ReferenceFlags, ReferenceId},
@@ -237,7 +237,19 @@ impl<'a> TraverseScoping<'a> {
         scope_id: ScopeId,
         flags: SymbolFlags,
     ) -> SymbolId {
-        let symbol_id = self.scoping.create_symbol(SPAN, name, flags, scope_id, NodeId::DUMMY);
+        self.add_spanned_binding(name, SPAN, scope_id, flags)
+    }
+
+    /// Add binding to `ScopeTree` and `SymbolTable` with a source span.
+    #[inline]
+    pub(crate) fn add_spanned_binding(
+        &mut self,
+        name: Ident<'_>,
+        span: Span,
+        scope_id: ScopeId,
+        flags: SymbolFlags,
+    ) -> SymbolId {
+        let symbol_id = self.scoping.create_symbol(span, name, flags, scope_id, NodeId::DUMMY);
         self.scoping.add_binding(scope_id, name, symbol_id);
 
         symbol_id
@@ -252,7 +264,20 @@ impl<'a> TraverseScoping<'a> {
         scope_id: ScopeId,
         flags: SymbolFlags,
     ) -> BoundIdentifier<'a> {
-        let symbol_id = self.add_binding(name, scope_id, flags);
+        self.generate_spanned_binding(name, SPAN, scope_id, flags)
+    }
+
+    /// Generate binding with a source span.
+    ///
+    /// Creates a symbol with the provided name, span, and flags and adds it to the specified scope.
+    pub fn generate_spanned_binding(
+        &mut self,
+        name: Ident<'a>,
+        span: Span,
+        scope_id: ScopeId,
+        flags: SymbolFlags,
+    ) -> BoundIdentifier<'a> {
+        let symbol_id = self.add_spanned_binding(name, span, scope_id, flags);
         BoundIdentifier::new(name, symbol_id)
     }
 

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -2,25 +2,13 @@ commit: 1fb0b771
 
 semantic_babel Summary:
 AST Parsed     : 2236/2236 (100.00%)
-Positive Passed: 2128/2236 (95.17%)
+Positive Passed: 2129/2236 (95.21%)
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/decorators/decorators-after-export/input.js
-Symbol span mismatch for "C":
-after transform: SymbolId(0): Span { start: 65, end: 66 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(1): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(2): Span { start: 65, end: 66 }
 Symbol flags mismatch for "_default":
 after transform: SymbolId(3): SymbolFlags(Class)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/decorators/decorators-before-export/input.js
-Symbol span mismatch for "C":
-after transform: SymbolId(0): Span { start: 65, end: 66 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(1): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(2): Span { start: 65, end: 66 }
 Symbol flags mismatch for "_default":
 after transform: SymbolId(3): SymbolFlags(Class)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
@@ -210,14 +198,6 @@ semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescr
 Bindings mismatch:
 after transform: ScopeId(0): ["x"]
 rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/decorators/type-arguments/input.ts
-Symbol span mismatch for "Test":
-after transform: SymbolId(0): Span { start: 27, end: 31 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
-Symbol span mismatch for "Test":
-after transform: SymbolId(1): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(2): Span { start: 27, end: 31 }
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/const/input.ts
 Symbol flags mismatch for "E":

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -1,6 +1,6 @@
 semantic_misc Summary:
 AST Parsed     : 70/70 (100.00%)
-Positive Passed: 62/70 (88.57%)
+Positive Passed: 64/70 (91.43%)
 semantic Error: tasks/coverage/misc/pass/declare-let-private.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["private"]
@@ -78,18 +78,6 @@ rebuilt        : ScopeId(496): Some(ScopeId(484))
 Symbol reference IDs mismatch for "_decorateMetadata":
 after transform: SymbolId(200): [ReferenceId(167), ReferenceId(171), ReferenceId(175), ReferenceId(176), ReferenceId(186), ReferenceId(187), ReferenceId(193), ReferenceId(194), ReferenceId(195), ReferenceId(199), ReferenceId(200), ReferenceId(201), ReferenceId(227), ReferenceId(229), ReferenceId(230), ReferenceId(236), ReferenceId(237), ReferenceId(238), ReferenceId(266), ReferenceId(268), ReferenceId(269), ReferenceId(275), ReferenceId(276), ReferenceId(277), ReferenceId(305), ReferenceId(307), ReferenceId(308), ReferenceId(314), ReferenceId(315), ReferenceId(316), ReferenceId(344), ReferenceId(346), ReferenceId(347), ReferenceId(353), ReferenceId(354), ReferenceId(355), ReferenceId(383), ReferenceId(387), ReferenceId(388), ReferenceId(396), ReferenceId(397), ReferenceId(398), ReferenceId(426), ReferenceId(428), ReferenceId(429), ReferenceId(435), ReferenceId(436), ReferenceId(437), ReferenceId(465), ReferenceId(469), ReferenceId(470), ReferenceId(478), ReferenceId(479), ReferenceId(480), ReferenceId(508), ReferenceId(510), ReferenceId(511), ReferenceId(517), ReferenceId(518), ReferenceId(519), ReferenceId(547), ReferenceId(551), ReferenceId(552), ReferenceId(560), ReferenceId(561), ReferenceId(562), ReferenceId(590), ReferenceId(592), ReferenceId(593), ReferenceId(599), ReferenceId(600), ReferenceId(601), ReferenceId(629), ReferenceId(633), ReferenceId(634), ReferenceId(642), ReferenceId(643), ReferenceId(644), ReferenceId(672), ReferenceId(674), ReferenceId(675), ReferenceId(681), ReferenceId(682), ReferenceId(683), ReferenceId(840), ReferenceId(844), ReferenceId(845), ReferenceId(853), ReferenceId(854), ReferenceId(855), ReferenceId(877), ReferenceId(881), ReferenceId(882), ReferenceId(892), ReferenceId(896), ReferenceId(897), ReferenceId(903), ReferenceId(904), ReferenceId(905), ReferenceId(909), ReferenceId(910), ReferenceId(911), ReferenceId(917), ReferenceId(918), ReferenceId(919), ReferenceId(921), ReferenceId(922), ReferenceId(923), ReferenceId(925), ReferenceId(926), ReferenceId(927), ReferenceId(931), ReferenceId(932), ReferenceId(933), ReferenceId(935), ReferenceId(936), ReferenceId(937), ReferenceId(939), ReferenceId(940), ReferenceId(941), ReferenceId(945), ReferenceId(946), ReferenceId(947), ReferenceId(949), ReferenceId(950), ReferenceId(951), ReferenceId(953), ReferenceId(954), ReferenceId(955)]
 rebuilt        : SymbolId(7): [ReferenceId(168), ReferenceId(172), ReferenceId(176), ReferenceId(178), ReferenceId(181), ReferenceId(183), ReferenceId(186), ReferenceId(188), ReferenceId(189), ReferenceId(192), ReferenceId(194), ReferenceId(195), ReferenceId(290), ReferenceId(294), ReferenceId(296), ReferenceId(299), ReferenceId(301), ReferenceId(302), ReferenceId(363), ReferenceId(367), ReferenceId(369), ReferenceId(372), ReferenceId(374), ReferenceId(375), ReferenceId(436), ReferenceId(440), ReferenceId(442), ReferenceId(445), ReferenceId(447), ReferenceId(448), ReferenceId(624), ReferenceId(631), ReferenceId(633), ReferenceId(639), ReferenceId(641), ReferenceId(642), ReferenceId(776), ReferenceId(780), ReferenceId(782), ReferenceId(785), ReferenceId(787), ReferenceId(788), ReferenceId(809), ReferenceId(813), ReferenceId(815), ReferenceId(818), ReferenceId(822), ReferenceId(824), ReferenceId(827), ReferenceId(829), ReferenceId(830), ReferenceId(833), ReferenceId(835), ReferenceId(836), ReferenceId(840), ReferenceId(842), ReferenceId(843), ReferenceId(846), ReferenceId(848), ReferenceId(849), ReferenceId(853), ReferenceId(855), ReferenceId(856)]
-Symbol span mismatch for "Inner5":
-after transform: SymbolId(57): Span { start: 4573, end: 4579 }
-rebuilt        : SymbolId(100): Span { start: 0, end: 0 }
-Symbol span mismatch for "Inner5":
-after transform: SymbolId(194): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(101): Span { start: 4573, end: 4579 }
-Symbol span mismatch for "Inner4":
-after transform: SymbolId(126): Span { start: 12166, end: 12172 }
-rebuilt        : SymbolId(292): Span { start: 0, end: 0 }
-Symbol span mismatch for "Inner4":
-after transform: SymbolId(328): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(293): Span { start: 12166, end: 12172 }
 Unresolved reference IDs mismatch for "Function":
 after transform: [ReferenceId(192), ReferenceId(198), ReferenceId(235), ReferenceId(274), ReferenceId(313), ReferenceId(352), ReferenceId(395), ReferenceId(434), ReferenceId(477), ReferenceId(516), ReferenceId(559), ReferenceId(598), ReferenceId(641), ReferenceId(680), ReferenceId(852), ReferenceId(902), ReferenceId(908), ReferenceId(916), ReferenceId(920), ReferenceId(924), ReferenceId(930), ReferenceId(934), ReferenceId(938), ReferenceId(944), ReferenceId(948), ReferenceId(952)]
 rebuilt        : [ReferenceId(187), ReferenceId(193), ReferenceId(300), ReferenceId(373), ReferenceId(446), ReferenceId(640), ReferenceId(786), ReferenceId(828), ReferenceId(834), ReferenceId(841), ReferenceId(847), ReferenceId(854)]
@@ -101,22 +89,6 @@ semantic Error: tasks/coverage/misc/pass/oxc-13284.ts
 Symbol reference IDs mismatch for "_super":
 after transform: SymbolId(18): [ReferenceId(14)]
 rebuilt        : SymbolId(9): []
-
-semantic Error: tasks/coverage/misc/pass/oxc-2562.ts
-Symbol span mismatch for "HooksController":
-after transform: SymbolId(0): Span { start: 67, end: 82 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
-Symbol span mismatch for "HooksController":
-after transform: SymbolId(1): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(2): Span { start: 67, end: 82 }
-
-semantic Error: tasks/coverage/misc/pass/oxc-3948-1.ts
-Symbol span mismatch for "TestWorkingCopyBackupTracker":
-after transform: SymbolId(39): Span { start: 3208, end: 3236 }
-rebuilt        : SymbolId(38): Span { start: 0, end: 0 }
-Symbol span mismatch for "TestWorkingCopyBackupTracker":
-after transform: SymbolId(136): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(39): Span { start: 3208, end: 3236 }
 
 semantic Error: tasks/coverage/misc/pass/oxc-4449.ts
 Bindings mismatch:

--- a/tasks/coverage/snapshots/semantic_test262.snap
+++ b/tasks/coverage/snapshots/semantic_test262.snap
@@ -2,7 +2,7 @@ commit: de8e621c
 
 semantic_test262 Summary:
 AST Parsed     : 47240/47240 (100.00%)
-Positive Passed: 47114/47240 (99.73%)
+Positive Passed: 47122/47240 (99.75%)
 semantic Error: tasks/coverage/test262/test/language/expressions/class/cpn-class-expr-fields-computed-property-name-from-arrow-function-expression.js
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function | Arrow)
@@ -418,70 +418,6 @@ rebuilt        : ScopeId(2): ScopeFlags(Function)
 Scope parent mismatch:
 after transform: ScopeId(4): Some(ScopeId(1))
 rebuilt        : ScopeId(2): Some(ScopeId(0))
-
-semantic Error: tasks/coverage/test262/test/language/statements/class/decorator/syntax/class-valid/decorator-member-expr-private-identifier.js
-Symbol span mismatch for "D":
-after transform: SymbolId(1): Span { start: 1551, end: 1552 }
-rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
-Symbol span mismatch for "D":
-after transform: SymbolId(10): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(11): Span { start: 1551, end: 1552 }
-
-semantic Error: tasks/coverage/test262/test/language/statements/class/decorator/syntax/valid/decorator-call-expr-identifier-reference-yield.js
-Symbol span mismatch for "C":
-after transform: SymbolId(2): Span { start: 1436, end: 1437 }
-rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(3): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(4): Span { start: 1436, end: 1437 }
-
-semantic Error: tasks/coverage/test262/test/language/statements/class/decorator/syntax/valid/decorator-call-expr-identifier-reference.js
-Symbol span mismatch for "C":
-after transform: SymbolId(8): Span { start: 1654, end: 1655 }
-rebuilt        : SymbolId(9): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(9): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(10): Span { start: 1654, end: 1655 }
-
-semantic Error: tasks/coverage/test262/test/language/statements/class/decorator/syntax/valid/decorator-member-expr-decorator-member-expr.js
-Symbol span mismatch for "C":
-after transform: SymbolId(1): Span { start: 1377, end: 1378 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(2): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(3): Span { start: 1377, end: 1378 }
-
-semantic Error: tasks/coverage/test262/test/language/statements/class/decorator/syntax/valid/decorator-member-expr-identifier-reference-yield.js
-Symbol span mismatch for "C":
-after transform: SymbolId(1): Span { start: 1050, end: 1051 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(2): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(3): Span { start: 1050, end: 1051 }
-
-semantic Error: tasks/coverage/test262/test/language/statements/class/decorator/syntax/valid/decorator-member-expr-identifier-reference.js
-Symbol span mismatch for "C":
-after transform: SymbolId(7): Span { start: 1238, end: 1239 }
-rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(8): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(9): Span { start: 1238, end: 1239 }
-
-semantic Error: tasks/coverage/test262/test/language/statements/class/decorator/syntax/valid/decorator-parenthesized-expr-identifier-reference-yield.js
-Symbol span mismatch for "C":
-after transform: SymbolId(1): Span { start: 1639, end: 1640 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(2): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(3): Span { start: 1639, end: 1640 }
-
-semantic Error: tasks/coverage/test262/test/language/statements/class/decorator/syntax/valid/decorator-parenthesized-expr-identifier-reference.js
-Symbol span mismatch for "C":
-after transform: SymbolId(7): Span { start: 1739, end: 1740 }
-rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(8): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(9): Span { start: 1739, end: 1740 }
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/elements/arrow-body-derived-cls-direct-eval-contains-superproperty-1.js
 Scope flags mismatch:

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -2,7 +2,7 @@ commit: 7964e22f
 
 semantic_typescript Summary:
 AST Parsed     : 4720/4720 (100.00%)
-Positive Passed: 3244/4720 (68.73%)
+Positive Passed: 3251/4720 (68.88%)
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/APISample_Watch.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["console", "formatHost", "os", "process", "reportDiagnostic", "reportWatchStatusChanged", "ts", "watchMain"]
@@ -2143,18 +2143,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/commentOnDecorate
 Bindings mismatch:
 after transform: ScopeId(0): ["AnotherRomote", "Remote", "_decorate", "_decorateMetadata", "decorator"]
 rebuilt        : ScopeId(0): ["AnotherRomote", "Remote", "_decorate", "_decorateMetadata"]
-Symbol span mismatch for "Remote":
-after transform: SymbolId(2): Span { start: 97, end: 103 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
-Symbol span mismatch for "Remote":
-after transform: SymbolId(4): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(3): Span { start: 97, end: 103 }
-Symbol span mismatch for "AnotherRomote":
-after transform: SymbolId(3): Span { start: 161, end: 174 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
-Symbol span mismatch for "AnotherRomote":
-after transform: SymbolId(7): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(5): Span { start: 161, end: 174 }
 Reference symbol mismatch for "decorator":
 after transform: SymbolId(0) "decorator"
 rebuilt        : <None>
@@ -4334,24 +4322,10 @@ Unresolved references mismatch:
 after transform: ["Function", "Object", "Promise", "require"]
 rebuilt        : ["Function", "Object", "Promise", "decorator", "require"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataTypeOnlyExport.ts
-Symbol span mismatch for "Bar":
-after transform: SymbolId(2): Span { start: 97, end: 100 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
-Symbol span mismatch for "Bar":
-after transform: SymbolId(5): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(5): Span { start: 97, end: 100 }
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/decoratorReferences.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "_decorate", "_decorateMetadata", "_decorateParam", "y"]
 rebuilt        : ScopeId(0): ["C", "_decorate", "_decorateMetadata", "_decorateParam"]
-Symbol span mismatch for "C":
-after transform: SymbolId(3): Span { start: 198, end: 199 }
-rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(10): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(4): Span { start: 198, end: 199 }
 Reference symbol mismatch for "y":
 after transform: SymbolId(0) "y"
 rebuilt        : <None>
@@ -5031,12 +5005,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/emitHelpersWithLo
 Bindings mismatch:
 after transform: ScopeId(0): ["A", "__decorate", "__decorate2", "_objectSpread", "dec", "o", "y"]
 rebuilt        : ScopeId(0): ["A", "__decorate2", "_objectSpread", "o", "y"]
-Symbol span mismatch for "A":
-after transform: SymbolId(2): Span { start: 57, end: 58 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
-Symbol span mismatch for "A":
-after transform: SymbolId(5): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(3): Span { start: 57, end: 58 }
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -8094,14 +8062,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["p1", "shouldBeIdentity"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationDecoratorSyntax.ts
-Symbol span mismatch for "C":
-after transform: SymbolId(0): Span { start: 16, end: 17 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(1): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(2): Span { start: 16, end: 17 }
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsdocAccessEnumType.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "E"]
@@ -8972,12 +8932,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/modulePreserveImp
 Bindings mismatch:
 after transform: ScopeId(0): ["A", "_decorate", "dec"]
 rebuilt        : ScopeId(0): ["A", "_decorate"]
-Symbol span mismatch for "A":
-after transform: SymbolId(1): Span { start: 42, end: 43 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
-Symbol span mismatch for "A":
-after transform: SymbolId(2): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(2): Span { start: 42, end: 43 }
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -12990,24 +12944,12 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/staticInitializer
 Bindings mismatch:
 after transform: ScopeId(0): ["C1", "C2", "_C", "_C2", "_decorate", "_defineProperty", "dec"]
 rebuilt        : ScopeId(0): ["C1", "C2", "_C", "_C2", "_decorate", "_defineProperty"]
-Symbol span mismatch for "C1":
-after transform: SymbolId(1): Span { start: 90, end: 92 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C1":
 after transform: SymbolId(1): [ReferenceId(1), ReferenceId(5), ReferenceId(7), ReferenceId(9)]
 rebuilt        : SymbolId(4): [ReferenceId(4), ReferenceId(6), ReferenceId(10)]
-Symbol span mismatch for "C1":
-after transform: SymbolId(3): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(5): Span { start: 90, end: 92 }
-Symbol span mismatch for "C2":
-after transform: SymbolId(2): Span { start: 141, end: 143 }
-rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C2":
 after transform: SymbolId(2): [ReferenceId(3), ReferenceId(13), ReferenceId(15)]
 rebuilt        : SymbolId(6): [ReferenceId(13), ReferenceId(17)]
-Symbol span mismatch for "C2":
-after transform: SymbolId(7): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(7): Span { start: 141, end: 143 }
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -13382,12 +13324,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/tslibReExportHelp
 Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "_decorate", "decorator"]
 rebuilt        : ScopeId(0): ["Foo", "_decorate"]
-Symbol span mismatch for "Foo":
-after transform: SymbolId(1): Span { start: 52, end: 55 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
-Symbol span mismatch for "Foo":
-after transform: SymbolId(2): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(2): Span { start: 52, end: 55 }
 Reference symbol mismatch for "decorator":
 after transform: SymbolId(0) "decorator"
 rebuilt        : <None>
@@ -15833,15 +15769,9 @@ after transform: ScopeId(0): ["elem"]
 rebuilt        : ScopeId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/decorators/class/constructor/parameter/decoratorOnClassConstructorParameter5.ts
-Symbol span mismatch for "BulkEditPreviewProvider":
-after transform: SymbolId(1): Span { start: 106, end: 129 }
-rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "BulkEditPreviewProvider":
 after transform: SymbolId(1): [ReferenceId(0), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(14)]
 rebuilt        : SymbolId(5): [ReferenceId(7), ReferenceId(9), ReferenceId(11), ReferenceId(18)]
-Symbol span mismatch for "BulkEditPreviewProvider":
-after transform: SymbolId(4): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(6): Span { start: 106, end: 129 }
 Reference symbol mismatch for "IFoo":
 after transform: SymbolId(0) "IFoo"
 rebuilt        : <None>
@@ -15853,15 +15783,9 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/decorators/cla
 Bindings mismatch:
 after transform: ScopeId(0): ["Something", "Testing123", "_Testing", "_decorate", "_defineProperty", "forwardRef"]
 rebuilt        : ScopeId(0): ["Testing123", "_Testing", "_decorate", "_defineProperty"]
-Symbol span mismatch for "Testing123":
-after transform: SymbolId(3): Span { start: 119, end: 129 }
-rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "Testing123":
 after transform: SymbolId(3): [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(13)]
 rebuilt        : SymbolId(3): [ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(10), ReferenceId(11), ReferenceId(12)]
-Symbol span mismatch for "Testing123":
-after transform: SymbolId(4): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(4): Span { start: 119, end: 129 }
 Reference symbol mismatch for "Something":
 after transform: SymbolId(2) "Something"
 rebuilt        : <None>
@@ -15873,12 +15797,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/decorators/cla
 Bindings mismatch:
 after transform: ScopeId(0): ["Something", "Testing123", "_decorate", "forwardRef"]
 rebuilt        : ScopeId(0): ["Testing123", "_decorate"]
-Symbol span mismatch for "Testing123":
-after transform: SymbolId(3): Span { start: 119, end: 129 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
-Symbol span mismatch for "Testing123":
-after transform: SymbolId(4): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(2): Span { start: 119, end: 129 }
 Reference symbol mismatch for "Something":
 after transform: SymbolId(2) "Something"
 rebuilt        : <None>
@@ -16098,12 +16016,6 @@ rebuilt        : ScopeId(26): ScopeFlags(Function | Arrow)
 Scope parent mismatch:
 after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(26): Some(ScopeId(0))
-Symbol span mismatch for "C":
-after transform: SymbolId(0): Span { start: 20, end: 21 }
-rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(49): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(9): Span { start: 20, end: 21 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpression4ES2020.ts
 Bindings mismatch:
@@ -16977,12 +16889,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/decorators
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "_decorate", "c", "dec"]
 rebuilt        : ScopeId(0): ["C", "_decorate", "c"]
-Symbol span mismatch for "C":
-after transform: SymbolId(3): Span { start: 51, end: 52 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(5): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(2): Span { start: 51, end: 52 }
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -16994,12 +16900,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/decorators
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "_decorate", "c", "dec"]
 rebuilt        : ScopeId(0): ["C", "_decorate", "c"]
-Symbol span mismatch for "C":
-after transform: SymbolId(3): Span { start: 58, end: 59 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(5): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(2): Span { start: 58, end: 59 }
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -17011,12 +16911,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/decorators
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "_decorate", "c", "dec"]
 rebuilt        : ScopeId(0): ["C", "_decorate", "c"]
-Symbol span mismatch for "C":
-after transform: SymbolId(3): Span { start: 66, end: 67 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(5): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(2): Span { start: 66, end: 67 }
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -17042,15 +16936,9 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/decorators
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "_C", "_decorate", "_defineProperty", "c", "dec"]
 rebuilt        : ScopeId(0): ["C", "_C", "_decorate", "_defineProperty", "c"]
-Symbol span mismatch for "C":
-after transform: SymbolId(3): Span { start: 51, end: 52 }
-rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(3): [ReferenceId(3), ReferenceId(4), ReferenceId(6), ReferenceId(8), ReferenceId(10)]
 rebuilt        : SymbolId(3): [ReferenceId(5), ReferenceId(6), ReferenceId(10), ReferenceId(11)]
-Symbol span mismatch for "C":
-after transform: SymbolId(5): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(4): Span { start: 51, end: 52 }
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -17062,15 +16950,9 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/decorators
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "_C", "_decorate", "_defineProperty", "c", "dec"]
 rebuilt        : ScopeId(0): ["C", "_C", "_decorate", "_defineProperty", "c"]
-Symbol span mismatch for "C":
-after transform: SymbolId(3): Span { start: 58, end: 59 }
-rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(3): [ReferenceId(3), ReferenceId(4), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(13)]
 rebuilt        : SymbolId(3): [ReferenceId(3), ReferenceId(4), ReferenceId(8), ReferenceId(9), ReferenceId(10)]
-Symbol span mismatch for "C":
-after transform: SymbolId(5): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(4): Span { start: 58, end: 59 }
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -17082,15 +16964,9 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/decorators
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "_C", "_decorate", "_defineProperty", "c", "dec"]
 rebuilt        : ScopeId(0): ["C", "_C", "_decorate", "_defineProperty", "c"]
-Symbol span mismatch for "C":
-after transform: SymbolId(3): Span { start: 66, end: 67 }
-rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(3): [ReferenceId(3), ReferenceId(4), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(13)]
 rebuilt        : SymbolId(3): [ReferenceId(3), ReferenceId(4), ReferenceId(8), ReferenceId(9), ReferenceId(10)]
-Symbol span mismatch for "C":
-after transform: SymbolId(5): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(4): Span { start: 66, end: 67 }
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -17409,14 +17285,6 @@ Unresolved references mismatch:
 after transform: ["Symbol", "undefined"]
 rebuilt        : ["Symbol", "foo", "undefined"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck61.ts
-Symbol span mismatch for "C":
-after transform: SymbolId(1): Span { start: 42, end: 43 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(2): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(3): Span { start: 42, end: 43 }
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/accessors/esDecorators-classDeclaration-accessors-nonStaticPrivate.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "_C_brand", "_classPrivateMethodInitSpec", "_decorate", "_decorateMetadata", "_get_method", "_set_method", "dec"]
@@ -17435,12 +17303,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/c
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "D", "_D", "_assertClassBrand", "_decorate", "_decorateMetadata", "_get_method", "_get_method2", "_set_method", "_set_method2", "_toSetter", "dec"]
 rebuilt        : ScopeId(0): ["C", "D", "_D", "_assertClassBrand", "_decorate", "_decorateMetadata", "_get_method", "_get_method2", "_set_method", "_set_method2", "_toSetter"]
-Symbol span mismatch for "D":
-after transform: SymbolId(3): Span { start: 137, end: 138 }
-rebuilt        : SymbolId(9): Span { start: 0, end: 0 }
-Symbol span mismatch for "D":
-after transform: SymbolId(14): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(10): Span { start: 137, end: 138 }
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -17458,12 +17320,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/c
 Bindings mismatch:
 after transform: ScopeId(0): ["Base", "C", "_C", "_decorate", "_superPropGet", "dec", "method"]
 rebuilt        : ScopeId(0): ["C", "_C", "_decorate", "_superPropGet", "method"]
-Symbol span mismatch for "C":
-after transform: SymbolId(4): Span { start: 125, end: 126 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(5): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(5): Span { start: 125, end: 126 }
 Reference symbol mismatch for "Base":
 after transform: SymbolId(1) "Base"
 rebuilt        : <None>
@@ -17478,24 +17334,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/c
 Bindings mismatch:
 after transform: ScopeId(0): ["C1", "C2", "C3", "_C", "_C2", "_C3", "_decorate", "_superPropGet", "dec"]
 rebuilt        : ScopeId(0): ["C1", "C2", "C3", "_C", "_C2", "_C3", "_decorate", "_superPropGet"]
-Symbol span mismatch for "C1":
-after transform: SymbolId(1): Span { start: 97, end: 99 }
-rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
-Symbol span mismatch for "C1":
-after transform: SymbolId(4): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(6): Span { start: 97, end: 99 }
-Symbol span mismatch for "C2":
-after transform: SymbolId(2): Span { start: 239, end: 241 }
-rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
-Symbol span mismatch for "C2":
-after transform: SymbolId(8): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(8): Span { start: 239, end: 241 }
-Symbol span mismatch for "C3":
-after transform: SymbolId(3): Span { start: 389, end: 391 }
-rebuilt        : SymbolId(9): Span { start: 0, end: 0 }
-Symbol span mismatch for "C3":
-after transform: SymbolId(10): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(10): Span { start: 389, end: 391 }
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -17513,12 +17351,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/c
 Bindings mismatch:
 after transform: ScopeId(0): ["Base", "C", "_C", "_decorate", "_super$x", "_super$x10", "_super$x11", "_super$x12", "_super$x13", "_super$x14", "_super$x15", "_super$x16", "_super$x17", "_super$x18", "_super$x2", "_super$x3", "_super$x4", "_super$x5", "_super$x6", "_super$x7", "_super$x8", "_super$x9", "_superPropGet", "_superPropSet", "dec", "x"]
 rebuilt        : ScopeId(0): ["C", "_C", "_decorate", "_super$x", "_super$x10", "_super$x11", "_super$x12", "_super$x13", "_super$x14", "_super$x15", "_super$x16", "_super$x17", "_super$x18", "_super$x2", "_super$x3", "_super$x4", "_super$x5", "_super$x6", "_super$x7", "_super$x8", "_super$x9", "_superPropGet", "_superPropSet", "x"]
-Symbol span mismatch for "C":
-after transform: SymbolId(3): Span { start: 96, end: 97 }
-rebuilt        : SymbolId(23): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(4): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(24): Span { start: 96, end: 97 }
 Reference symbol mismatch for "Base":
 after transform: SymbolId(1) "Base"
 rebuilt        : <None>
@@ -17533,12 +17365,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/c
 Bindings mismatch:
 after transform: ScopeId(0): ["Base", "C", "_C", "_decorate", "_defineProperty", "_superPropGet", "dec", "method"]
 rebuilt        : ScopeId(0): ["C", "_C", "_decorate", "_defineProperty", "_superPropGet", "method"]
-Symbol span mismatch for "C":
-after transform: SymbolId(4): Span { start: 127, end: 128 }
-rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(5): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(6): Span { start: 127, end: 128 }
 Reference symbol mismatch for "Base":
 after transform: SymbolId(1) "Base"
 rebuilt        : <None>
@@ -17553,24 +17379,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/c
 Bindings mismatch:
 after transform: ScopeId(0): ["Base", "C1", "C2", "C3", "_C", "_C2", "_C3", "_decorate", "_defineProperty", "_super$x", "_super$x10", "_super$x11", "_super$x12", "_super$x13", "_super$x14", "_super$x15", "_super$x16", "_super$x17", "_super$x18", "_super$x2", "_super$x3", "_super$x4", "_super$x5", "_super$x6", "_super$x7", "_super$x8", "_super$x9", "_superPropGet", "_superPropSet", "dec", "x"]
 rebuilt        : ScopeId(0): ["C1", "C2", "C3", "_C", "_C2", "_C3", "_decorate", "_defineProperty", "_super$x", "_super$x10", "_super$x11", "_super$x12", "_super$x13", "_super$x14", "_super$x15", "_super$x16", "_super$x17", "_super$x18", "_super$x2", "_super$x3", "_super$x4", "_super$x5", "_super$x6", "_super$x7", "_super$x8", "_super$x9", "_superPropGet", "_superPropSet", "x"]
-Symbol span mismatch for "C1":
-after transform: SymbolId(3): Span { start: 96, end: 98 }
-rebuilt        : SymbolId(26): Span { start: 0, end: 0 }
-Symbol span mismatch for "C1":
-after transform: SymbolId(6): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(27): Span { start: 96, end: 98 }
-Symbol span mismatch for "C2":
-after transform: SymbolId(4): Span { start: 389, end: 391 }
-rebuilt        : SymbolId(28): Span { start: 0, end: 0 }
-Symbol span mismatch for "C2":
-after transform: SymbolId(18): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(29): Span { start: 389, end: 391 }
-Symbol span mismatch for "C3":
-after transform: SymbolId(5): Span { start: 709, end: 711 }
-rebuilt        : SymbolId(30): Span { start: 0, end: 0 }
-Symbol span mismatch for "C3":
-after transform: SymbolId(26): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(31): Span { start: 709, end: 711 }
 Reference symbol mismatch for "Base":
 after transform: SymbolId(1) "Base"
 rebuilt        : <None>
@@ -17597,12 +17405,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/c
 Bindings mismatch:
 after transform: ScopeId(0): ["Base", "C", "_decorate", "_decorateMetadata", "_defineProperty", "dec"]
 rebuilt        : ScopeId(0): ["C", "_decorate", "_decorateMetadata", "_defineProperty"]
-Symbol span mismatch for "C":
-after transform: SymbolId(4): Span { start: 195, end: 196 }
-rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(9): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(4): Span { start: 195, end: 196 }
 Reference symbol mismatch for "Base":
 after transform: SymbolId(1) "Base"
 rebuilt        : <None>
@@ -17617,12 +17419,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/c
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "_C", "_a_accessor_storage", "_decorate", "_defineProperty", "dec"]
 rebuilt        : ScopeId(0): ["C", "_C", "_a_accessor_storage", "_decorate", "_defineProperty"]
-Symbol span mismatch for "C":
-after transform: SymbolId(1): Span { start: 34, end: 35 }
-rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(4): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(4): Span { start: 34, end: 35 }
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -17634,15 +17430,9 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/c
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "_C", "_assertClassBrand", "_classPrivateFieldInitSpec", "_decorate", "_decorateMetadata", "_defineProperty", "_get_x", "_get_z", "_method", "_set_x", "_set_z", "_y", "_z_accessor_storage", "_z_accessor_storage2", "dec"]
 rebuilt        : ScopeId(0): ["C", "_C", "_assertClassBrand", "_classPrivateFieldInitSpec", "_decorate", "_decorateMetadata", "_defineProperty", "_get_x", "_get_z", "_method", "_set_x", "_set_z", "_y", "_z_accessor_storage2"]
-Symbol span mismatch for "C":
-after transform: SymbolId(1): Span { start: 57, end: 58 }
-rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(1): [ReferenceId(80), ReferenceId(86), ReferenceId(33), ReferenceId(38), ReferenceId(44), ReferenceId(48), ReferenceId(54), ReferenceId(56), ReferenceId(59), ReferenceId(65), ReferenceId(70), ReferenceId(76), ReferenceId(91), ReferenceId(93)]
 rebuilt        : SymbolId(6): [ReferenceId(26), ReferenceId(33), ReferenceId(41), ReferenceId(47), ReferenceId(54), ReferenceId(62), ReferenceId(69), ReferenceId(77), ReferenceId(83), ReferenceId(90), ReferenceId(91), ReferenceId(96)]
-Symbol span mismatch for "C":
-after transform: SymbolId(19): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(7): Span { start: 57, end: 58 }
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -17717,15 +17507,9 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/c
 Bindings mismatch:
 after transform: ScopeId(0): ["Example", "_decorate", "deco"]
 rebuilt        : ScopeId(0): ["Example", "_decorate"]
-Symbol span mismatch for "Example":
-after transform: SymbolId(1): Span { start: 43, end: 50 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "Example":
 after transform: SymbolId(1): [Span { start: 43, end: 50 }, Span { start: 93, end: 100 }]
 rebuilt        : SymbolId(1): []
-Symbol span mismatch for "Example":
-after transform: SymbolId(4): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(2): Span { start: 43, end: 50 }
 Reference symbol mismatch for "deco":
 after transform: SymbolId(0) "deco"
 rebuilt        : <None>
@@ -17737,12 +17521,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/c
 Bindings mismatch:
 after transform: ScopeId(0): ["Example", "_decorate", "deco"]
 rebuilt        : ScopeId(0): ["Example", "_decorate"]
-Symbol span mismatch for "Example":
-after transform: SymbolId(1): Span { start: 43, end: 50 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
-Symbol span mismatch for "Example":
-after transform: SymbolId(2): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(2): Span { start: 43, end: 50 }
 Reference symbol mismatch for "deco":
 after transform: SymbolId(0) "deco"
 rebuilt        : <None>
@@ -17760,24 +17538,6 @@ rebuilt        : ScopeId(7): ScopeFlags(Function | Arrow)
 Scope parent mismatch:
 after transform: ScopeId(4): Some(ScopeId(3))
 rebuilt        : ScopeId(7): Some(ScopeId(0))
-Symbol span mismatch for "A":
-after transform: SymbolId(2): Span { start: 119, end: 120 }
-rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
-Symbol span mismatch for "A":
-after transform: SymbolId(9): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(8): Span { start: 119, end: 120 }
-Symbol span mismatch for "B":
-after transform: SymbolId(3): Span { start: 300, end: 301 }
-rebuilt        : SymbolId(9): Span { start: 0, end: 0 }
-Symbol span mismatch for "B":
-after transform: SymbolId(12): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(10): Span { start: 300, end: 301 }
-Symbol span mismatch for "C":
-after transform: SymbolId(4): Span { start: 551, end: 552 }
-rebuilt        : SymbolId(12): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(16): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(13): Span { start: 551, end: 552 }
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -17821,15 +17581,9 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/c
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "_C", "_assertClassBrand", "_classPrivateFieldInitSpec", "_decorate", "_decorateMetadata", "_defineProperty", "_get_x", "_get_z", "_method", "_set_x", "_set_z", "_y", "_z_accessor_storage", "_z_accessor_storage2", "dec"]
 rebuilt        : ScopeId(0): ["C", "_C", "_assertClassBrand", "_classPrivateFieldInitSpec", "_decorate", "_decorateMetadata", "_defineProperty", "_get_x", "_get_z", "_method", "_set_x", "_set_z", "_y", "_z_accessor_storage2"]
-Symbol span mismatch for "C":
-after transform: SymbolId(1): Span { start: 39, end: 40 }
-rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(1): [ReferenceId(80), ReferenceId(86), ReferenceId(33), ReferenceId(38), ReferenceId(44), ReferenceId(48), ReferenceId(54), ReferenceId(56), ReferenceId(59), ReferenceId(65), ReferenceId(70), ReferenceId(76), ReferenceId(91), ReferenceId(93)]
 rebuilt        : SymbolId(6): [ReferenceId(26), ReferenceId(33), ReferenceId(41), ReferenceId(47), ReferenceId(54), ReferenceId(62), ReferenceId(69), ReferenceId(77), ReferenceId(83), ReferenceId(90), ReferenceId(91), ReferenceId(96)]
-Symbol span mismatch for "C":
-after transform: SymbolId(19): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(7): Span { start: 39, end: 40 }
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -17977,12 +17731,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/c
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "D", "_D", "_decorate", "_decorateMetadata", "_field", "_field1_accessor_storage", "_field1_accessor_storage2", "_field2", "_field2_computed_accessor_storage", "_field3_computed_accessor_storage", "dec", "field3"]
 rebuilt        : ScopeId(0): ["C", "D", "_D", "_decorate", "_decorateMetadata", "_field", "_field1_accessor_storage", "_field1_accessor_storage2", "_field2", "_field2_computed_accessor_storage", "_field3_computed_accessor_storage", "field3"]
-Symbol span mismatch for "D":
-after transform: SymbolId(3): Span { start: 199, end: 200 }
-rebuilt        : SymbolId(13): Span { start: 0, end: 0 }
-Symbol span mismatch for "D":
-after transform: SymbolId(16): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(14): Span { start: 199, end: 200 }
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -18003,12 +17751,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/c
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "D", "_D", "_assertClassBrand", "_decorate", "_decorateMetadata", "_field", "_field2", "dec"]
 rebuilt        : ScopeId(0): ["C", "D", "_D", "_assertClassBrand", "_decorate", "_decorateMetadata", "_field", "_field2"]
-Symbol span mismatch for "D":
-after transform: SymbolId(2): Span { start: 76, end: 77 }
-rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
-Symbol span mismatch for "D":
-after transform: SymbolId(9): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(7): Span { start: 76, end: 77 }
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -18023,12 +17765,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/c
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "D", "_D", "_assertClassBrand", "_decorate", "_decorateMetadata", "_field1_accessor_storage", "_field1_accessor_storage2", "_get_field", "_get_field2", "_set_field", "_set_field2", "_toSetter", "dec"]
 rebuilt        : ScopeId(0): ["C", "D", "_D", "_assertClassBrand", "_decorate", "_decorateMetadata", "_field1_accessor_storage", "_field1_accessor_storage2", "_get_field", "_get_field2", "_set_field", "_set_field2", "_toSetter"]
-Symbol span mismatch for "D":
-after transform: SymbolId(2): Span { start: 85, end: 86 }
-rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
-Symbol span mismatch for "D":
-after transform: SymbolId(16): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(11): Span { start: 85, end: 86 }
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -18054,12 +17790,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/c
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "D", "_decorate", "_decorateMetadata", "_method", "_method2", "dec"]
 rebuilt        : ScopeId(0): ["C", "D", "_decorate", "_decorateMetadata", "_method", "_method2"]
-Symbol span mismatch for "D":
-after transform: SymbolId(2): Span { start: 77, end: 78 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
-Symbol span mismatch for "D":
-after transform: SymbolId(7): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(5): Span { start: 77, end: 78 }
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -18599,12 +18329,6 @@ rebuilt        : ScopeId(42): ScopeFlags(Function | Arrow)
 Scope parent mismatch:
 after transform: ScopeId(34): Some(ScopeId(2))
 rebuilt        : ScopeId(42): Some(ScopeId(0))
-Symbol span mismatch for "C":
-after transform: SymbolId(0): Span { start: 23, end: 24 }
-rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(75): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(11): Span { start: 23, end: 24 }
 Symbol redeclarations mismatch for "_y_accessor_storage2":
 after transform: SymbolId(55): []
 rebuilt        : SymbolId(30): [Span { start: 0, end: 0 }, Span { start: 0, end: 0 }]
@@ -18613,84 +18337,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/e
 Bindings mismatch:
 after transform: ScopeId(0): ["_decorate", "_decorateMetadata", "g", "h", "x"]
 rebuilt        : ScopeId(0): ["_decorate", "_decorateMetadata"]
-Symbol span mismatch for "C":
-after transform: SymbolId(7): Span { start: 121, end: 122 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(33): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(3): Span { start: 121, end: 122 }
-Symbol span mismatch for "C":
-after transform: SymbolId(8): Span { start: 143, end: 144 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(35): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(5): Span { start: 143, end: 144 }
-Symbol span mismatch for "C":
-after transform: SymbolId(9): Span { start: 165, end: 166 }
-rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(36): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(7): Span { start: 165, end: 166 }
-Symbol span mismatch for "C":
-after transform: SymbolId(10): Span { start: 194, end: 195 }
-rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(37): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(9): Span { start: 194, end: 195 }
-Symbol span mismatch for "C":
-after transform: SymbolId(11): Span { start: 223, end: 224 }
-rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(38): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(11): Span { start: 223, end: 224 }
-Symbol span mismatch for "C":
-after transform: SymbolId(12): Span { start: 254, end: 255 }
-rebuilt        : SymbolId(12): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(39): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(13): Span { start: 254, end: 255 }
-Symbol span mismatch for "C":
-after transform: SymbolId(13): Span { start: 279, end: 280 }
-rebuilt        : SymbolId(14): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(40): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(15): Span { start: 279, end: 280 }
-Symbol span mismatch for "C":
-after transform: SymbolId(14): Span { start: 306, end: 307 }
-rebuilt        : SymbolId(16): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(41): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(17): Span { start: 306, end: 307 }
-Symbol span mismatch for "C":
-after transform: SymbolId(15): Span { start: 329, end: 330 }
-rebuilt        : SymbolId(18): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(42): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(19): Span { start: 329, end: 330 }
-Symbol span mismatch for "C":
-after transform: SymbolId(16): Span { start: 354, end: 355 }
-rebuilt        : SymbolId(20): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(43): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(21): Span { start: 354, end: 355 }
-Symbol span mismatch for "C":
-after transform: SymbolId(17): Span { start: 379, end: 380 }
-rebuilt        : SymbolId(22): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(44): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(23): Span { start: 379, end: 380 }
-Symbol span mismatch for "C":
-after transform: SymbolId(18): Span { start: 405, end: 406 }
-rebuilt        : SymbolId(24): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(45): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(25): Span { start: 405, end: 406 }
-Symbol span mismatch for "C":
-after transform: SymbolId(19): Span { start: 433, end: 434 }
-rebuilt        : SymbolId(26): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(46): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(27): Span { start: 433, end: 434 }
 Reference symbol mismatch for "x":
 after transform: SymbolId(0) "x"
 rebuilt        : <None>
@@ -18816,44 +18462,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["Function", "require"]
 rebuilt        : ["DecoratorProvider", "Function", "instance", "require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/metadata/esDecoratorsMetadata1.ts
-Symbol span mismatch for "C":
-after transform: SymbolId(5): Span { start: 144, end: 145 }
-rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(8): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(8): Span { start: 144, end: 145 }
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/metadata/esDecoratorsMetadata2.ts
-Symbol span mismatch for "C":
-after transform: SymbolId(5): Span { start: 144, end: 145 }
-rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(9): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(8): Span { start: 144, end: 145 }
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/metadata/esDecoratorsMetadata3.ts
-Symbol span mismatch for "C":
-after transform: SymbolId(6): Span { start: 225, end: 226 }
-rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(9): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(9): Span { start: 225, end: 226 }
-Symbol span mismatch for "D":
-after transform: SymbolId(7): Span { start: 260, end: 261 }
-rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
-Symbol span mismatch for "D":
-after transform: SymbolId(11): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(11): Span { start: 260, end: 261 }
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/metadata/esDecoratorsMetadata4.ts
-Symbol span mismatch for "C":
-after transform: SymbolId(7): Span { start: 366, end: 367 }
-rebuilt        : SymbolId(9): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(10): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(10): Span { start: 366, end: 367 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/metadata/esDecoratorsMetadata5.ts
 Bindings mismatch:

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 1fb0b771
 
-Passed: 247/398
+Passed: 254/398
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -469,7 +469,7 @@ x Output mismatch
 x Output mismatch
 
 
-# legacy-decorators (12/106)
+# legacy-decorators (19/106)
 * oxc/accessor/input.ts
 x Output mismatch
 
@@ -524,14 +524,6 @@ Symbol flags mismatch for "_default":
 after transform: SymbolId(1): SymbolFlags(Class)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 
-* oxc/metadata/abstract-class/input.ts
-Symbol span mismatch for "AbstractClass":
-after transform: SymbolId(2): Span { start: 69, end: 82 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
-Symbol span mismatch for "AbstractClass":
-after transform: SymbolId(4): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(3): Span { start: 69, end: 82 }
-
 * oxc/metadata/ambient-declared-class/input.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["Ambient", "Source", "dec"]
@@ -548,22 +540,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["Object", "babelHelpers"]
 rebuilt        : ["Ambient", "Object", "babelHelpers", "dec"]
-
-* oxc/metadata/bound-type-reference/input.ts
-Symbol span mismatch for "Example":
-after transform: SymbolId(1): Span { start: 87, end: 94 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
-Symbol span mismatch for "Example":
-after transform: SymbolId(3): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(2): Span { start: 87, end: 94 }
-
-* oxc/metadata/class-and-method-decorators/input.ts
-Symbol span mismatch for "Problem":
-after transform: SymbolId(4): Span { start: 90, end: 97 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
-Symbol span mismatch for "Problem":
-after transform: SymbolId(5): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(5): Span { start: 90, end: 97 }
 
 * oxc/metadata/class-expression-via-const/input.ts
 Bindings mismatch:
@@ -595,12 +571,6 @@ rebuilt        : ["Object", "babelHelpers", "dec"]
 Bindings mismatch:
 after transform: ScopeId(0): ["MyService", "dec"]
 rebuilt        : ScopeId(0): ["MyService"]
-Symbol span mismatch for "MyService":
-after transform: SymbolId(1): Span { start: 54, end: 63 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol span mismatch for "MyService":
-after transform: SymbolId(7): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(1): Span { start: 54, end: 63 }
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -721,12 +691,6 @@ rebuilt        : ["Function", "Number", "Object", "String", "babelHelpers", "dec
 Bindings mismatch:
 after transform: ScopeId(0): ["Cls", "Foo", "dec"]
 rebuilt        : ScopeId(0): ["Cls", "Foo"]
-Symbol span mismatch for "Cls":
-after transform: SymbolId(7): Span { start: 145, end: 148 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
-Symbol span mismatch for "Cls":
-after transform: SymbolId(12): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(2): Span { start: 145, end: 148 }
 Reference symbol mismatch for "dec":
 after transform: SymbolId(3) "dec"
 rebuilt        : <None>
@@ -778,12 +742,6 @@ rebuilt        : [ReferenceId(8)]
 Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "methodDecorator", "paramDecorator"]
 rebuilt        : ScopeId(0): ["Foo"]
-Symbol span mismatch for "Foo":
-after transform: SymbolId(4): Span { start: 107, end: 110 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol span mismatch for "Foo":
-after transform: SymbolId(11): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(1): Span { start: 107, end: 110 }
 Reference symbol mismatch for "methodDecorator":
 after transform: SymbolId(0) "methodDecorator"
 rebuilt        : <None>
@@ -828,18 +786,12 @@ rebuilt        : ScopeId(4): []
 Symbol reference IDs mismatch for "dec":
 after transform: SymbolId(0): [ReferenceId(4), ReferenceId(0), ReferenceId(1), ReferenceId(3)]
 rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(10)]
-Symbol span mismatch for "Cls":
-after transform: SymbolId(4): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(1): Span { start: 46, end: 49 }
 Symbol scope ID mismatch for "Cls":
 after transform: SymbolId(4): ScopeId(1)
 rebuilt        : SymbolId(1): ScopeId(0)
 Symbol reference IDs mismatch for "Cls":
 after transform: SymbolId(4): []
 rebuilt        : SymbolId(1): [ReferenceId(2), ReferenceId(7)]
-Symbol span mismatch for "Cls2":
-after transform: SymbolId(5): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(2): Span { start: 116, end: 120 }
 Symbol scope ID mismatch for "Cls2":
 after transform: SymbolId(5): ScopeId(3)
 rebuilt        : SymbolId(2): ScopeId(0)
@@ -891,26 +843,12 @@ rebuilt        : ["Object", "babelHelpers", "dec"]
 Bindings mismatch:
 after transform: ScopeId(0): ["A", "Foo", "dec"]
 rebuilt        : ScopeId(0): ["A", "Foo"]
-Symbol span mismatch for "Foo":
-after transform: SymbolId(2): Span { start: 72, end: 75 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
-Symbol span mismatch for "Foo":
-after transform: SymbolId(4): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(2): Span { start: 72, end: 75 }
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["Error", "Object", "babelHelpers"]
 rebuilt        : ["Error", "Object", "babelHelpers", "dec"]
-
-* oxc/metadata/this/input.ts
-Symbol span mismatch for "Example":
-after transform: SymbolId(0): Span { start: 6, end: 13 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol span mismatch for "Example":
-after transform: SymbolId(2): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(1): Span { start: 6, end: 13 }
 
 * oxc/metadata/typescript-syntax/input.ts
 
@@ -926,26 +864,12 @@ rebuilt        : SymbolId(1): Span { start: 6, end: 13 }
 
 
 * oxc/metadata/unbound-type-reference/input.ts
-Symbol span mismatch for "Example":
-after transform: SymbolId(0): Span { start: 6, end: 13 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol span mismatch for "Example":
-after transform: SymbolId(2): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(1): Span { start: 6, end: 13 }
 Reference flags mismatch for "UnboundTypeReference":
 after transform: ReferenceId(2): ReferenceFlags(Read | Type)
 rebuilt        : ReferenceId(5): ReferenceFlags(Read)
 Reference flags mismatch for "UnboundTypeReference":
 after transform: ReferenceId(3): ReferenceFlags(Read | Type)
 rebuilt        : ReferenceId(7): ReferenceFlags(Read)
-
-* oxc/metadata/without-decorator/input.ts
-Symbol span mismatch for "C":
-after transform: SymbolId(2): Span { start: 106, end: 107 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(3): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(3): Span { start: 106, end: 107 }
 
 * oxc/static-field/input.ts
 Scope flags mismatch:
@@ -954,46 +878,14 @@ rebuilt        : ScopeId(4): ScopeFlags(StrictMode | ClassStaticBlock)
 Scope parent mismatch:
 after transform: ScopeId(4): Some(ScopeId(0))
 rebuilt        : ScopeId(4): Some(ScopeId(3))
-Symbol span mismatch for "Foo":
-after transform: SymbolId(2): Span { start: 103, end: 106 }
-rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "Foo":
 after transform: SymbolId(2): [ReferenceId(4), ReferenceId(6), ReferenceId(8)]
 rebuilt        : SymbolId(3): [ReferenceId(4), ReferenceId(8)]
-Symbol span mismatch for "Foo":
-after transform: SymbolId(3): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(4): Span { start: 103, end: 106 }
 
 * oxc/static-field-with-class-properties/input.ts
-Symbol span mismatch for "Foo":
-after transform: SymbolId(2): Span { start: 103, end: 106 }
-rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "Foo":
 after transform: SymbolId(2): [ReferenceId(4), ReferenceId(6), ReferenceId(8), ReferenceId(10)]
 rebuilt        : SymbolId(3): [ReferenceId(4), ReferenceId(6), ReferenceId(10)]
-Symbol span mismatch for "Foo":
-after transform: SymbolId(3): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(4): Span { start: 103, end: 106 }
-
-* oxc/with-class-private-properties/input.ts
-Symbol span mismatch for "C":
-after transform: SymbolId(0): Span { start: 11, end: 12 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(5): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(1): Span { start: 11, end: 12 }
-Symbol span mismatch for "D":
-after transform: SymbolId(1): Span { start: 85, end: 86 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
-Symbol span mismatch for "D":
-after transform: SymbolId(6): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(3): Span { start: 85, end: 86 }
-Symbol span mismatch for "E":
-after transform: SymbolId(2): Span { start: 167, end: 168 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
-Symbol span mismatch for "E":
-after transform: SymbolId(7): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(5): Span { start: 167, end: 168 }
 
 * oxc/with-class-private-properties-unnamed-default-export/input.ts
 Symbol flags mismatch for "_default":
@@ -1074,14 +966,6 @@ x Output mismatch
 * typescript/accessor/decoratorOnClassAccessor8/input.ts
 x Output mismatch
 
-* typescript/constructableDecoratorOnClass01/input.ts
-Symbol span mismatch for "C":
-after transform: SymbolId(1): Span { start: 74, end: 75 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(2): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(2): Span { start: 74, end: 75 }
-
 * typescript/constructor/decoratorOnClassConstructor1/input.ts
 x Output mismatch
 
@@ -1089,24 +973,6 @@ x Output mismatch
 Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "dec"]
 rebuilt        : ScopeId(0): ["A", "B", "C"]
-Symbol span mismatch for "A":
-after transform: SymbolId(1): Span { start: 139, end: 140 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol span mismatch for "A":
-after transform: SymbolId(5): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(1): Span { start: 139, end: 140 }
-Symbol span mismatch for "B":
-after transform: SymbolId(2): Span { start: 157, end: 158 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
-Symbol span mismatch for "B":
-after transform: SymbolId(6): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(3): Span { start: 157, end: 158 }
-Symbol span mismatch for "C":
-after transform: SymbolId(4): Span { start: 205, end: 206 }
-rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(7): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(6): Span { start: 205, end: 206 }
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -1124,12 +990,6 @@ rebuilt        : ["Number", "babelHelpers", "dec"]
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "dec"]
 rebuilt        : ScopeId(0): ["C"]
-Symbol span mismatch for "C":
-after transform: SymbolId(4): Span { start: 155, end: 156 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(6): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(1): Span { start: 155, end: 156 }
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -1169,12 +1029,6 @@ x Output mismatch
 Bindings mismatch:
 after transform: ScopeId(0): ["Something", "Testing123", "forwardRef"]
 rebuilt        : ScopeId(0): ["Testing123"]
-Symbol span mismatch for "Testing123":
-after transform: SymbolId(3): Span { start: 241, end: 251 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol span mismatch for "Testing123":
-after transform: SymbolId(4): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(1): Span { start: 241, end: 251 }
 Reference symbol mismatch for "Something":
 after transform: SymbolId(2) "Something"
 rebuilt        : <None>
@@ -1189,12 +1043,6 @@ x Output mismatch
 Bindings mismatch:
 after transform: ScopeId(0): ["Something", "Testing123", "forwardRef"]
 rebuilt        : ScopeId(0): ["Testing123"]
-Symbol span mismatch for "Testing123":
-after transform: SymbolId(3): Span { start: 239, end: 249 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol span mismatch for "Testing123":
-after transform: SymbolId(4): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(1): Span { start: 239, end: 249 }
 Reference symbol mismatch for "Something":
 after transform: SymbolId(2) "Something"
 rebuilt        : <None>
@@ -1214,12 +1062,6 @@ rebuilt        : ScopeId(4): Some(ScopeId(0))
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "dec"]
 rebuilt        : ScopeId(0): ["C"]
-Symbol span mismatch for "C":
-after transform: SymbolId(3): Span { start: 99, end: 100 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(4): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(1): Span { start: 99, end: 100 }
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -1231,12 +1073,6 @@ rebuilt        : ["babelHelpers", "dec"]
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "dec"]
 rebuilt        : ScopeId(0): ["C"]
-Symbol span mismatch for "C":
-after transform: SymbolId(3): Span { start: 127, end: 128 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(4): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(1): Span { start: 127, end: 128 }
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -1248,12 +1084,6 @@ rebuilt        : ["babelHelpers", "dec"]
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "dec"]
 rebuilt        : ScopeId(0): ["C"]
-Symbol span mismatch for "C":
-after transform: SymbolId(3): Span { start: 127, end: 128 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(4): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(1): Span { start: 127, end: 128 }
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -1265,12 +1095,6 @@ rebuilt        : ["babelHelpers", "dec"]
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "dec"]
 rebuilt        : ScopeId(0): ["C"]
-Symbol span mismatch for "C":
-after transform: SymbolId(3): Span { start: 107, end: 108 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(4): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(1): Span { start: 107, end: 108 }
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -1282,12 +1106,6 @@ rebuilt        : ["babelHelpers", "dec"]
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "dec"]
 rebuilt        : ScopeId(0): ["C"]
-Symbol span mismatch for "C":
-after transform: SymbolId(3): Span { start: 107, end: 108 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(4): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(1): Span { start: 107, end: 108 }
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -1299,12 +1117,6 @@ rebuilt        : ["babelHelpers", "dec"]
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "dec"]
 rebuilt        : ScopeId(0): ["C"]
-Symbol span mismatch for "C":
-after transform: SymbolId(3): Span { start: 134, end: 135 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(4): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(1): Span { start: 134, end: 135 }
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>


### PR DESCRIPTION
## Summary

- preserve outer and inner class binding spans during legacy decorator lowering
- add a span-aware traversal binding generator for transformed source-backed bindings
- update semantic coverage snapshots, removing stale `Span { start: 0, end: 0 }` mismatches