### PR TITLE
feat(semantic): add `Scoping::set_symbol_span`

### DIFF
--- a/crates/oxc_semantic/src/scoping.rs
+++ b/crates/oxc_semantic/src/scoping.rs
@@ -345,6 +345,12 @@ impl Scoping {
         *self.symbol_table.symbol_spans(symbol_id)
     }
 
+    /// Set the span of `symbol_id`.
+    #[inline]
+    pub fn set_symbol_span(&mut self, symbol_id: SymbolId, span: Span) {
+        *self.symbol_table.symbol_spans_mut(symbol_id) = span;
+    }
+
     /// Get the identifier name a symbol is bound to.
     #[inline]
     pub fn symbol_name(&self, symbol_id: SymbolId) -> &str {


### PR DESCRIPTION
## Summary

- adds a new method on semantic's `Scoping` allowing setting the span of a symbol
- this will be used in #24222