### PR TITLE
fix(transformer): correct span for lowered namespace symbol

### DIFF
--- a/crates/oxc_transformer/src/typescript/namespace.rs
+++ b/crates/oxc_transformer/src/typescript/namespace.rs
@@ -282,7 +282,9 @@ impl<'a> TypeScriptNamespace {
         }
 
         if !Self::is_redeclaration_namespace(&ident, ctx) {
-            let declaration = Self::create_variable_declaration(&binding, span, ctx);
+            let binding_span = ident.span;
+            ctx.scoping_mut().set_symbol_span(binding.symbol_id, binding_span);
+            let declaration = Self::create_variable_declaration(&binding, span, binding_span, ctx);
             if is_export {
                 let export_named_decl =
                     ExportNamedDeclaration::boxed_plain_declaration(span, declaration, ctx);
@@ -310,11 +312,12 @@ impl<'a> TypeScriptNamespace {
     fn create_variable_declaration(
         binding: &BoundIdentifier<'a>,
         span: Span,
+        binding_span: Span,
         ctx: &TraverseCtx<'a>,
     ) -> Declaration<'a> {
         let kind = VariableDeclarationKind::Let;
         let declarations = {
-            let pattern = binding.create_binding_pattern(ctx);
+            let pattern = binding.create_spanned_binding_pattern(binding_span, ctx);
             let decl = VariableDeclarator::new(span, kind, pattern, NONE, None, false, ctx);
             ArenaVec::from_value_in(decl, ctx)
         };

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -334,9 +334,6 @@ semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescr
 Symbol flags mismatch for "N":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "N":
-after transform: SymbolId(1): Span { start: 37, end: 38 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/function/declare/input.ts
 Bindings mismatch:
@@ -365,9 +362,6 @@ semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescr
 Symbol flags mismatch for "N":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "N":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/body-declare/input.ts
 Bindings mismatch:
@@ -392,15 +386,9 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "N":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "N":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "X":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "X":
-after transform: SymbolId(2): Span { start: 53, end: 54 }
-rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/body-import-equals-internal/input.ts
 Bindings mismatch:
@@ -522,9 +510,6 @@ rebuilt        : ScopeId(0): ["bar"]
 Symbol flags mismatch for "bar":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "bar":
-after transform: SymbolId(1): Span { start: 32, end: 35 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-class-interface/input.ts
 Bindings mismatch:

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -175,9 +175,6 @@ rebuilt        : ScopeId(1): ["X", "_M"]
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/aliasInaccessibleModule.ts
 Bindings mismatch:
@@ -186,23 +183,14 @@ rebuilt        : ScopeId(1): ["X", "_M"]
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/aliasInaccessibleModule2.ts
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "N":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "N":
-after transform: SymbolId(1): Span { start: 28, end: 29 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImportsCanPaintCrossModuleDeclaration.ts
 Bindings mismatch:
@@ -216,9 +204,6 @@ rebuilt        : ScopeId(0): ["D", "d"]
 Symbol flags mismatch for "D":
 after transform: SymbolId(3): SymbolFlags(Class | ValueModule | Ambient)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "D":
-after transform: SymbolId(3): Span { start: 97, end: 98 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "D":
 after transform: SymbolId(3): [Span { start: 97, end: 98 }, Span { start: 124, end: 125 }]
 rebuilt        : SymbolId(0): []
@@ -362,9 +347,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/anonterface.ts
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/anyAndUnknownHaveFalsyComponents.ts
 Bindings mismatch:
@@ -438,9 +420,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionInEx
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts
 Bindings mismatch:
@@ -479,9 +458,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/assign1.ts
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/assignToPrototype1.ts
 Bindings mismatch:
@@ -509,15 +485,9 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "__test1__":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "__test1__":
-after transform: SymbolId(0): Span { start: 10, end: 19 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "__test2__":
 after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "__test2__":
-after transform: SymbolId(6): Span { start: 220, end: 229 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability10.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -525,15 +495,9 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "__test1__":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "__test1__":
-after transform: SymbolId(0): Span { start: 10, end: 19 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "__test2__":
 after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "__test2__":
-after transform: SymbolId(6): Span { start: 220, end: 229 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability3.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -542,15 +506,9 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "__test1__":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "__test1__":
-after transform: SymbolId(0): Span { start: 10, end: 19 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "__test2__":
 after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "__test2__":
-after transform: SymbolId(6): Span { start: 220, end: 229 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability5.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -558,15 +516,9 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "__test1__":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "__test1__":
-after transform: SymbolId(0): Span { start: 10, end: 19 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "__test2__":
 after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "__test2__":
-after transform: SymbolId(6): Span { start: 220, end: 229 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability6.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -574,15 +526,9 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "__test1__":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "__test1__":
-after transform: SymbolId(0): Span { start: 10, end: 19 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "__test2__":
 after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "__test2__":
-after transform: SymbolId(6): Span { start: 220, end: 229 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability7.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -590,15 +536,9 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "__test1__":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "__test1__":
-after transform: SymbolId(0): Span { start: 10, end: 19 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "__test2__":
 after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "__test2__":
-after transform: SymbolId(6): Span { start: 220, end: 229 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability8.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -606,15 +546,9 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "__test1__":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "__test1__":
-after transform: SymbolId(0): Span { start: 10, end: 19 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "__test2__":
 after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "__test2__":
-after transform: SymbolId(6): Span { start: 220, end: 229 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability9.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -622,15 +556,9 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "__test1__":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "__test1__":
-after transform: SymbolId(0): Span { start: 10, end: 19 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "__test2__":
 after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "__test2__":
-after transform: SymbolId(6): Span { start: 220, end: 229 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/assignmentNonObjectTypeConstraints.ts
 Bindings mismatch:
@@ -735,9 +663,6 @@ rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "B":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "B":
-after transform: SymbolId(2): Span { start: 72, end: 73 }
-rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/augmentedTypesClass3.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -782,9 +707,6 @@ rebuilt        : SymbolId(3): []
 Symbol flags mismatch for "m3e":
 after transform: SymbolId(6): SymbolFlags(Class | ValueModule | Ambient)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m3e":
-after transform: SymbolId(6): Span { start: 198, end: 201 }
-rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "m3e":
 after transform: SymbolId(6): [Span { start: 198, end: 201 }, Span { start: 239, end: 242 }]
 rebuilt        : SymbolId(8): []
@@ -825,36 +747,24 @@ rebuilt        : ScopeId(10): ["m4d"]
 Symbol flags mismatch for "m4a":
 after transform: SymbolId(1): SymbolFlags(RegularEnum | ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m4a":
-after transform: SymbolId(1): Span { start: 80, end: 83 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "m4a":
 after transform: SymbolId(1): [Span { start: 80, end: 83 }, Span { start: 104, end: 107 }]
 rebuilt        : SymbolId(1): []
 Symbol flags mismatch for "m4b":
 after transform: SymbolId(4): SymbolFlags(RegularEnum | ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m4b":
-after transform: SymbolId(4): Span { start: 127, end: 130 }
-rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "m4b":
 after transform: SymbolId(4): [Span { start: 127, end: 130 }, Span { start: 158, end: 161 }]
 rebuilt        : SymbolId(5): []
 Symbol flags mismatch for "m4d":
 after transform: SymbolId(10): SymbolFlags(RegularEnum | ValueModule)
 rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m4d":
-after transform: SymbolId(10): Span { start: 245, end: 248 }
-rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "m4d":
 after transform: SymbolId(10): [Span { start: 245, end: 248 }, Span { start: 280, end: 283 }]
 rebuilt        : SymbolId(10): []
 Symbol flags mismatch for "m5":
 after transform: SymbolId(13): SymbolFlags(NamespaceModule | ValueModule)
 rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m5":
-after transform: SymbolId(13): Span { start: 328, end: 330 }
-rebuilt        : SymbolId(14): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "m5":
 after transform: SymbolId(13): [Span { start: 328, end: 330 }, Span { start: 363, end: 365 }]
 rebuilt        : SymbolId(14): []
@@ -948,9 +858,6 @@ rebuilt        : ScopeId(0): ["Test"]
 Symbol flags mismatch for "Test":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Test":
-after transform: SymbolId(1): Span { start: 45, end: 49 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Reference symbol mismatch for "console":
 after transform: SymbolId(0) "console"
 rebuilt        : <None>
@@ -1262,9 +1169,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/chainedImportAlia
 Symbol flags mismatch for "m":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m":
-after transform: SymbolId(0): Span { start: 17, end: 18 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/checkInfiniteExpansionTermination2.ts
 Bindings mismatch:
@@ -1356,9 +1260,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 107, end: 108 }]
 rebuilt        : SymbolId(0): []
@@ -1384,9 +1285,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/classExtendingQua
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/classFunctionMerging.ts
 Bindings mismatch:
@@ -1420,9 +1318,6 @@ rebuilt        : ScopeId(0): ["M2"]
 Symbol flags mismatch for "M2":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M2":
-after transform: SymbolId(2): Span { start: 74, end: 76 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Unresolved references mismatch:
 after transform: ["M1"]
 rebuilt        : []
@@ -1524,18 +1419,12 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "A":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 97, end: 98 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "B":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "B":
-after transform: SymbolId(2): Span { start: 122, end: 123 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/cloduleAndTypeParameters.ts
 Symbol flags mismatch for "Foo":
@@ -1575,9 +1464,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "C":
 after transform: SymbolId(1): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(Class)
@@ -1867,9 +1753,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 141, end: 142 }, Span { start: 274, end: 275 }, Span { start: 401, end: 402 }, Span { start: 512, end: 513 }]
 rebuilt        : SymbolId(1): []
@@ -1879,9 +1762,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 111, end: 112 }, Span { start: 198, end: 199 }]
 rebuilt        : SymbolId(0): []
@@ -1893,9 +1773,6 @@ rebuilt        : ScopeId(2): ["e"]
 Symbol flags mismatch for "m1":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m1":
-after transform: SymbolId(0): Span { start: 10, end: 12 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "e":
 after transform: SymbolId(1): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
@@ -1905,9 +1782,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 79, end: 80 }, Span { start: 157, end: 158 }]
 rebuilt        : SymbolId(0): []
@@ -1916,41 +1790,26 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenM
 Symbol flags mismatch for "m1":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m1":
-after transform: SymbolId(0): Span { start: 10, end: 12 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m2":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m2":
-after transform: SymbolId(3): Span { start: 79, end: 81 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithMemberInterfaceConflict.ts
 Symbol flags mismatch for "m1":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m1":
-after transform: SymbolId(0): Span { start: 10, end: 12 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithMemberVariable.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Symbol flags mismatch for "m1":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m1":
-after transform: SymbolId(0): Span { start: 10, end: 12 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithMethodChildren.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 94, end: 95 }, Span { start: 199, end: 200 }, Span { start: 330, end: 331 }]
 rebuilt        : SymbolId(0): []
@@ -1960,66 +1819,39 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 113, end: 114 }, Span { start: 228, end: 229 }, Span { start: 344, end: 345 }, Span { start: 474, end: 475 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "m1":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m1":
-after transform: SymbolId(2): Span { start: 50, end: 52 }
-rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m2":
 after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m2":
-after transform: SymbolId(5): Span { start: 131, end: 133 }
-rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m3":
 after transform: SymbolId(9): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m3":
-after transform: SymbolId(9): Span { start: 246, end: 248 }
-rebuilt        : SymbolId(14): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m3":
 after transform: SymbolId(13): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m3":
-after transform: SymbolId(13): Span { start: 380, end: 382 }
-rebuilt        : SymbolId(20): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m4":
 after transform: SymbolId(17): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(25): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m4":
-after transform: SymbolId(17): Span { start: 492, end: 494 }
-rebuilt        : SymbolId(25): Span { start: 0, end: 0 }
 Symbol flags mismatch for "M":
 after transform: SymbolId(18): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(27): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(18): Span { start: 515, end: 516 }
-rebuilt        : SymbolId(27): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithModuleReopening.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Symbol flags mismatch for "m1":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m1":
-after transform: SymbolId(0): Span { start: 10, end: 12 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "m1":
 after transform: SymbolId(0): [Span { start: 10, end: 12 }, Span { start: 78, end: 80 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "m2":
 after transform: SymbolId(7): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m2":
-after transform: SymbolId(7): Span { start: 192, end: 194 }
-rebuilt        : SymbolId(9): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "m2":
 after transform: SymbolId(7): [Span { start: 192, end: 194 }, Span { start: 308, end: 310 }]
 rebuilt        : SymbolId(9): []
@@ -2028,17 +1860,11 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenM
 Symbol flags mismatch for "m1":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m1":
-after transform: SymbolId(0): Span { start: 10, end: 12 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithUnicodeNames.ts
 Symbol flags mismatch for "才能ソЫⅨ蒤郳र\u{94d}क\u{94d}ड\u{94d}राüışğİliيونيكودöÄüß才能ソЫⅨ蒤郳र\u{94d}क\u{94d}ड\u{94d}राüışğİliيونيكودöÄüßAbcd123":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "才能ソЫⅨ蒤郳र\u{94d}क\u{94d}ड\u{94d}राüışğİliيونيكودöÄüß才能ソЫⅨ蒤郳र\u{94d}क\u{94d}ड\u{94d}राüışğİliيونيكودöÄüßAbcd123":
-after transform: SymbolId(0): Span { start: 10, end: 173 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAmbientClass.ts
 Bindings mismatch:
@@ -2050,9 +1876,6 @@ rebuilt        : ScopeId(1): ["_m"]
 Symbol flags mismatch for "m2":
 after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m2":
-after transform: SymbolId(5): Span { start: 153, end: 155 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAmbientEnum.ts
 Bindings mismatch:
@@ -2064,9 +1887,6 @@ rebuilt        : ScopeId(1): ["_m"]
 Symbol flags mismatch for "m2":
 after transform: SymbolId(13): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m2":
-after transform: SymbolId(13): Span { start: 285, end: 287 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAmbientFunction.ts
 Bindings mismatch:
@@ -2078,9 +1898,6 @@ rebuilt        : ScopeId(1): ["_m", "a"]
 Symbol flags mismatch for "m2":
 after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m2":
-after transform: SymbolId(5): Span { start: 193, end: 195 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAmbientFunctionInGlobalFile.ts
 Bindings mismatch:
@@ -2092,9 +1909,6 @@ rebuilt        : ScopeId(1): ["_m", "a"]
 Symbol flags mismatch for "m4":
 after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m4":
-after transform: SymbolId(5): Span { start: 175, end: 177 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAmbientVar.ts
 Bindings mismatch:
@@ -2106,43 +1920,25 @@ rebuilt        : ScopeId(1): ["_m", "a"]
 Symbol flags mismatch for "m2":
 after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m2":
-after transform: SymbolId(5): Span { start: 157, end: 159 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndFunctionInGlobalFile.ts
 Symbol flags mismatch for "m3":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m3":
-after transform: SymbolId(2): Span { start: 92, end: 94 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m4":
 after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m4":
-after transform: SymbolId(5): Span { start: 215, end: 217 }
-rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndInternalModuleAliasInGlobalFile.ts
 Symbol flags mismatch for "mOfGloalFile":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "mOfGloalFile":
-after transform: SymbolId(0): Span { start: 10, end: 22 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m1":
 after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m1":
-after transform: SymbolId(4): Span { start: 161, end: 163 }
-rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m2":
 after transform: SymbolId(7): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m2":
-after transform: SymbolId(7): Span { start: 291, end: 293 }
-rebuilt        : SymbolId(9): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterClassConstructor.ts
 Bindings mismatch:
@@ -2201,9 +1997,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "a":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "a":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndAmbientClassInGlobal.ts
 Bindings mismatch:
@@ -2253,9 +2046,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpr
 Symbol flags mismatch for "_this":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "_this":
-after transform: SymbolId(0): Span { start: 10, end: 15 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndParameter.ts
 Bindings mismatch:
@@ -2284,29 +2074,17 @@ rebuilt        : ScopeId(0): ["f", "foo"]
 Symbol flags mismatch for "foo":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "foo":
-after transform: SymbolId(1): Span { start: 40, end: 43 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/commentInNamespaceDeclarationWithIdentifierPathName.ts
 Symbol flags mismatch for "hello":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "hello":
-after transform: SymbolId(0): Span { start: 10, end: 15 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "hi":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "hi":
-after transform: SymbolId(1): Span { start: 16, end: 18 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "world":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "world":
-after transform: SymbolId(2): Span { start: 19, end: 24 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/commentLeadingCloseBrace.ts
 Bindings mismatch:
@@ -2437,51 +2215,27 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "import44":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "import44":
-after transform: SymbolId(0): Span { start: 3976, end: 3984 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol flags mismatch for "import45":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "import45":
-after transform: SymbolId(3): Span { start: 4059, end: 4067 }
-rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol flags mismatch for "import46":
 after transform: SymbolId(8): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "import46":
-after transform: SymbolId(8): Span { start: 4200, end: 4208 }
-rebuilt        : SymbolId(11): Span { start: 0, end: 0 }
 Symbol flags mismatch for "import47":
 after transform: SymbolId(11): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(15): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "import47":
-after transform: SymbolId(11): Span { start: 4285, end: 4293 }
-rebuilt        : SymbolId(15): Span { start: 0, end: 0 }
 Symbol flags mismatch for "import48":
 after transform: SymbolId(14): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(19): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "import48":
-after transform: SymbolId(14): Span { start: 4365, end: 4373 }
-rebuilt        : SymbolId(19): Span { start: 0, end: 0 }
 Symbol flags mismatch for "import49":
 after transform: SymbolId(17): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(23): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "import49":
-after transform: SymbolId(17): Span { start: 4513, end: 4521 }
-rebuilt        : SymbolId(23): Span { start: 0, end: 0 }
 Symbol flags mismatch for "import50":
 after transform: SymbolId(19): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(26): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "import50":
-after transform: SymbolId(19): Span { start: 4872, end: 4880 }
-rebuilt        : SymbolId(26): Span { start: 0, end: 0 }
 Symbol flags mismatch for "import51":
 after transform: SymbolId(22): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(30): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "import51":
-after transform: SymbolId(22): Span { start: 4946, end: 4954 }
-rebuilt        : SymbolId(30): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/complicatedIndexesOfIntersectionsAreInferencable.ts
 Bindings mismatch:
@@ -2498,9 +2252,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/compoundVarDecl1.
 Symbol flags mismatch for "Foo":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Foo":
-after transform: SymbolId(0): Span { start: 10, end: 13 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/computedEnumMemberSyntacticallyString.ts
 Missing ReferenceId: "Foo"
@@ -2670,9 +2421,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/constDeclarations
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 22, end: 23 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/constEnumDeclarations.ts
 Bindings mismatch:
@@ -2703,9 +2451,6 @@ rebuilt        : ScopeId(2): ["ConstFooEnum"]
 Symbol flags mismatch for "ConstEnumOnlyModule":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "ConstEnumOnlyModule":
-after transform: SymbolId(0): Span { start: 17, end: 36 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "ConstFooEnum":
 after transform: SymbolId(1): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
@@ -2726,9 +2471,6 @@ rebuilt        : ScopeId(3): ["A"]
 Symbol flags mismatch for "Outer":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Outer":
-after transform: SymbolId(0): Span { start: 10, end: 15 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "Outer":
 after transform: SymbolId(0): [Span { start: 10, end: 15 }, Span { start: 53, end: 58 }]
 rebuilt        : SymbolId(0): []
@@ -2738,9 +2480,6 @@ rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "B":
 after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "B":
-after transform: SymbolId(4): Span { start: 104, end: 105 }
-rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/constEnumPreserveEmitNamedExport1.ts
 Bindings mismatch:
@@ -3811,9 +3550,6 @@ rebuilt        : ScopeId(1): ["_m", "server"]
 Symbol flags mismatch for "m3":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m3":
-after transform: SymbolId(0): Span { start: 10, end: 12 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileGenericType2.ts
 Bindings mismatch:
@@ -3822,33 +3558,18 @@ rebuilt        : ScopeId(0): ["_defineProperty"]
 Symbol flags mismatch for "dom":
 after transform: SymbolId(16): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "dom":
-after transform: SymbolId(16): Span { start: 661, end: 664 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "mvc":
 after transform: SymbolId(17): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "mvc":
-after transform: SymbolId(17): Span { start: 665, end: 668 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Symbol flags mismatch for "dom":
 after transform: SymbolId(20): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "dom":
-after transform: SymbolId(20): Span { start: 934, end: 937 }
-rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
 Symbol flags mismatch for "mvc":
 after transform: SymbolId(21): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "mvc":
-after transform: SymbolId(21): Span { start: 938, end: 941 }
-rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
 Symbol flags mismatch for "composite":
 after transform: SymbolId(22): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "composite":
-after transform: SymbolId(22): Span { start: 942, end: 951 }
-rebuilt        : SymbolId(12): Span { start: 0, end: 0 }
 Reference symbol mismatch for "templa":
 after transform: SymbolId(0) "templa"
 rebuilt        : <None>
@@ -3875,15 +3596,9 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileImportCha
 Symbol flags mismatch for "m":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "c":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "c":
-after transform: SymbolId(1): Span { start: 35, end: 36 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileImportModuleWithExportAssignment.ts
 Symbol flags mismatch for "m2":
@@ -3902,61 +3617,37 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "m":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m1":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m1":
-after transform: SymbolId(2): Span { start: 53, end: 55 }
-rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m2":
 after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m2":
-after transform: SymbolId(5): Span { start: 142, end: 144 }
-rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileModuleAssignmentInObjectLiteralProperty.ts
 Symbol flags mismatch for "m1":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m1":
-after transform: SymbolId(0): Span { start: 10, end: 12 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileModuleContinuation.ts
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(NamespaceModule | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "A":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 60, end: 61 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "B":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "B":
-after transform: SymbolId(3): Span { start: 62, end: 63 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "C":
 after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "C":
-after transform: SymbolId(4): Span { start: 64, end: 65 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileModuleWithPropertyOfTypeModule.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Symbol flags mismatch for "m":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFilePrivateMethodOverloads.ts
 Bindings mismatch:
@@ -3992,9 +3683,6 @@ rebuilt        : ScopeId(3): ["e"]
 Symbol flags mismatch for "m1":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m1":
-after transform: SymbolId(0): Span { start: 10, end: 12 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "e":
 after transform: SymbolId(2): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
@@ -4005,15 +3693,9 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "m1":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m1":
-after transform: SymbolId(0): Span { start: 10, end: 12 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m2":
 after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m2":
-after transform: SymbolId(4): Span { start: 90, end: 92 }
-rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileWithInternalModuleNameConflictsInExtendsClause1.ts
 Bindings mismatch:
@@ -4022,96 +3704,57 @@ rebuilt        : ScopeId(4): ["W", "_C"]
 Symbol flags mismatch for "X":
 after transform: SymbolId(0): SymbolFlags(NamespaceModule | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "X":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "X":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 61, end: 62 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "A":
 after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(4): Span { start: 63, end: 64 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "B":
 after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "B":
-after transform: SymbolId(5): Span { start: 65, end: 66 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Symbol flags mismatch for "C":
 after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "C":
-after transform: SymbolId(6): Span { start: 67, end: 68 }
-rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileWithInternalModuleNameConflictsInExtendsClause2.ts
 Symbol flags mismatch for "X":
 after transform: SymbolId(0): SymbolFlags(NamespaceModule | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "X":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "X":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 61, end: 62 }, Span { start: 161, end: 162 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "A":
 after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(4): Span { start: 63, end: 64 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "B":
 after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "B":
-after transform: SymbolId(5): Span { start: 65, end: 66 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Symbol flags mismatch for "C":
 after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "C":
-after transform: SymbolId(6): Span { start: 67, end: 68 }
-rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileWithInternalModuleNameConflictsInExtendsClause3.ts
 Symbol flags mismatch for "X":
 after transform: SymbolId(0): SymbolFlags(NamespaceModule | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "X":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "X":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 61, end: 62 }, Span { start: 188, end: 189 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "A":
 after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(4): Span { start: 63, end: 64 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "B":
 after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "B":
-after transform: SymbolId(5): Span { start: 65, end: 66 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Symbol flags mismatch for "C":
 after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "C":
-after transform: SymbolId(6): Span { start: 67, end: 68 }
-rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declInput-2.ts
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declInput.ts
 Bindings mismatch:
@@ -4131,9 +3774,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/declInput4.ts
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationAssertionNodeNotReusedWhenTypeNotEquivalent1.ts
 Bindings mismatch:
@@ -4195,18 +3835,12 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringObjectLiteralPattern2.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Symbol flags mismatch for "m":
 after transform: SymbolId(10): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m":
-after transform: SymbolId(10): Span { start: 233, end: 234 }
-rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringOptionalBindingParametersInOverloads.ts
 Symbol span mismatch for "foo":
@@ -4227,9 +3861,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "m":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDoesNotUseReexportedNamespaceAsLocal.ts
 Bindings mismatch:
@@ -4260,9 +3891,6 @@ rebuilt        : ScopeId(1): ["TranslationKeyEnum", "_Translation"]
 Symbol flags mismatch for "Translation":
 after transform: SymbolId(0): SymbolFlags(Interface | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Translation":
-after transform: SymbolId(0): Span { start: 17, end: 28 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "Translation":
 after transform: SymbolId(0): [Span { start: 17, end: 28 }, Span { start: 101, end: 112 }]
 rebuilt        : SymbolId(0): []
@@ -4303,9 +3931,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitEx
 Symbol flags mismatch for "Test":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Test":
-after transform: SymbolId(0): Span { start: 10, end: 14 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitFunctionDuplicateNamespace.ts
 Symbol span mismatch for "f":
@@ -4358,15 +3983,9 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "m":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "c":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "c":
-after transform: SymbolId(1): Span { start: 35, end: 36 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "c":
 after transform: SymbolId(1): [ReferenceId(0), ReferenceId(5), ReferenceId(7)]
 rebuilt        : SymbolId(2): [ReferenceId(2), ReferenceId(3)]
@@ -4451,9 +4070,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNa
 Symbol flags mismatch for "f":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "f":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNameConflicts2.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -4464,51 +4080,30 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "X":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "X":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "X":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 160, end: 161 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "Y":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Y":
-after transform: SymbolId(1): Span { start: 12, end: 13 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "base":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "base":
-after transform: SymbolId(2): Span { start: 14, end: 18 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Symbol flags mismatch for "M":
 after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(5): Span { start: 93, end: 94 }
-rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
 Symbol flags mismatch for "E":
 after transform: SymbolId(7): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "Y":
 after transform: SymbolId(8): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Y":
-after transform: SymbolId(8): Span { start: 162, end: 163 }
-rebuilt        : SymbolId(14): Span { start: 0, end: 0 }
 Symbol flags mismatch for "base":
 after transform: SymbolId(9): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "base":
-after transform: SymbolId(9): Span { start: 164, end: 168 }
-rebuilt        : SymbolId(16): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Z":
 after transform: SymbolId(10): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(18): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Z":
-after transform: SymbolId(10): Span { start: 169, end: 170 }
-rebuilt        : SymbolId(18): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNameConflicts3.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -4524,39 +4119,24 @@ rebuilt        : ScopeId(13): ["D"]
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 243, end: 244 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "D":
 after transform: SymbolId(1): SymbolFlags(Interface | ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "D":
-after transform: SymbolId(1): Span { start: 35, end: 36 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "D":
 after transform: SymbolId(1): [Span { start: 35, end: 36 }, Span { start: 62, end: 63 }]
 rebuilt        : SymbolId(2): []
 Symbol flags mismatch for "C":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "C":
-after transform: SymbolId(3): Span { start: 125, end: 126 }
-rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol flags mismatch for "E":
 after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "E":
-after transform: SymbolId(5): Span { start: 188, end: 189 }
-rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
 Symbol flags mismatch for "P":
 after transform: SymbolId(7): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "P":
-after transform: SymbolId(7): Span { start: 245, end: 246 }
-rebuilt        : SymbolId(12): Span { start: 0, end: 0 }
 Symbol flags mismatch for "D":
 after transform: SymbolId(10): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
@@ -4572,9 +4152,6 @@ rebuilt        : ScopeId(1): ["_M", "w"]
 Symbol flags mismatch for "M":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(3): Span { start: 84, end: 85 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNamespaceMergedWithInterfaceNestedFunction.ts
 Bindings mismatch:
@@ -4583,9 +4160,6 @@ rebuilt        : ScopeId(0): ["Bar"]
 Symbol flags mismatch for "Bar":
 after transform: SymbolId(1): SymbolFlags(Interface | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Bar":
-after transform: SymbolId(1): Span { start: 51, end: 54 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "Bar":
 after transform: SymbolId(1): [Span { start: 51, end: 54 }, Span { start: 87, end: 90 }]
 rebuilt        : SymbolId(0): []
@@ -4646,9 +4220,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationFuncti
 Symbol flags mismatch for "foo":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "foo":
-after transform: SymbolId(0): Span { start: 10, end: 13 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationImportTypeAliasInferredAndEmittable.ts
 Bindings mismatch:
@@ -5330,9 +4901,6 @@ rebuilt        : ScopeId(0): ["A", "AA", "tmpError", "tmpOK"]
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "A":
 after transform: SymbolId(0): [ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(10), ReferenceId(11), ReferenceId(28), ReferenceId(29)]
 rebuilt        : SymbolId(0): [ReferenceId(5), ReferenceId(6), ReferenceId(15), ReferenceId(25), ReferenceId(26)]
@@ -5342,33 +4910,18 @@ rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "B":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "B":
-after transform: SymbolId(1): Span { start: 12, end: 13 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "AA":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "AA":
-after transform: SymbolId(3): Span { start: 58, end: 60 }
-rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol flags mismatch for "B":
 after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "B":
-after transform: SymbolId(4): Span { start: 80, end: 81 }
-rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
 Symbol flags mismatch for "B":
 after transform: SymbolId(8): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(13): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "B":
-after transform: SymbolId(8): Span { start: 176, end: 177 }
-rebuilt        : SymbolId(13): Span { start: 0, end: 0 }
 Symbol flags mismatch for "C":
 after transform: SymbolId(9): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(15): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "C":
-after transform: SymbolId(9): Span { start: 178, end: 179 }
-rebuilt        : SymbolId(15): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/doubleUnderscoreEnumEmit.ts
 Bindings mismatch:
@@ -5417,9 +4970,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "Foo":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Foo":
-after transform: SymbolId(0): Span { start: 10, end: 13 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(0): [Span { start: 10, end: 13 }, Span { start: 154, end: 157 }]
 rebuilt        : SymbolId(0): []
@@ -5428,33 +4978,21 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/duplicateAnonymou
 Symbol flags mismatch for "F":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "F":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "F":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 56, end: 57 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "Foo":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Foo":
-after transform: SymbolId(3): Span { start: 135, end: 138 }
-rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(3): [Span { start: 135, end: 138 }, Span { start: 183, end: 186 }]
 rebuilt        : SymbolId(5): []
 Symbol flags mismatch for "Gar":
 after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Gar":
-after transform: SymbolId(6): Span { start: 264, end: 267 }
-rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Foo":
 after transform: SymbolId(7): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Foo":
-after transform: SymbolId(7): Span { start: 284, end: 287 }
-rebuilt        : SymbolId(12): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(7): [Span { start: 284, end: 287 }, Span { start: 348, end: 351 }]
 rebuilt        : SymbolId(12): []
@@ -5485,9 +5023,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/duplicateVariable
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 74, end: 75 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/elidedEmbeddedStatementsReplacedWithSemicolon.ts
 'with' statements are not allowed
@@ -5513,21 +5048,12 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/emitMemberAccessE
 Symbol flags mismatch for "Microsoft":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Microsoft":
-after transform: SymbolId(0): Span { start: 85, end: 94 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "PeopleAtWork":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "PeopleAtWork":
-after transform: SymbolId(1): Span { start: 95, end: 107 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Model":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Model":
-after transform: SymbolId(2): Span { start: 108, end: 113 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/emitTopOfFileTripleSlashCommentOnNotEmittedNodeIfRemoveCommentsIsFalse.ts
 Bindings mismatch:
@@ -5656,18 +5182,12 @@ rebuilt        : ScopeId(4): ["MyEnum"]
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "MyEnum":
 after transform: SymbolId(1): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "N":
 after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "N":
-after transform: SymbolId(4): Span { start: 128, end: 129 }
-rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol flags mismatch for "MyEnum":
 after transform: SymbolId(5): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
@@ -5912,9 +5432,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ClassTest3.ts
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ClassTest4.ts
 Bindings mismatch:
@@ -5945,9 +5462,6 @@ rebuilt        : ScopeId(0): ["c", "m", "x"]
 Symbol flags mismatch for "m":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m":
-after transform: SymbolId(2): Span { start: 38, end: 39 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ExportClauseWithoutModuleSpecifier.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -5957,45 +5471,27 @@ rebuilt        : ScopeId(0): ["c", "m", "x"]
 Symbol flags mismatch for "m":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m":
-after transform: SymbolId(2): Span { start: 59, end: 60 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportInIndirectExportAssignment.ts
 Symbol flags mismatch for "a":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "a":
-after transform: SymbolId(0): Span { start: 17, end: 18 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ModuleClassDeclaration.ts
 Symbol flags mismatch for "m1":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m1":
-after transform: SymbolId(2): Span { start: 541, end: 543 }
-rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m2":
 after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m2":
-after transform: SymbolId(5): Span { start: 1246, end: 1248 }
-rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ModuleConst.ts
 Symbol flags mismatch for "m1":
 after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m1":
-after transform: SymbolId(6): Span { start: 119, end: 121 }
-rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m2":
 after transform: SymbolId(13): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m2":
-after transform: SymbolId(13): Span { start: 251, end: 253 }
-rebuilt        : SymbolId(14): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ModuleConstEnumDeclaration.ts
 Bindings mismatch:
@@ -6025,9 +5521,6 @@ rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch for "m1":
 after transform: SymbolId(10): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m1":
-after transform: SymbolId(10): Span { start: 128, end: 130 }
-rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 Symbol flags mismatch for "e3":
 after transform: SymbolId(11): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
@@ -6037,9 +5530,6 @@ rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "m2":
 after transform: SymbolId(23): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m2":
-after transform: SymbolId(23): Span { start: 344, end: 346 }
-rebuilt        : SymbolId(16): Span { start: 0, end: 0 }
 Symbol flags mismatch for "e5":
 after transform: SymbolId(24): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(18): SymbolFlags(BlockScopedVariable)
@@ -6075,9 +5565,6 @@ rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch for "m1":
 after transform: SymbolId(10): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m1":
-after transform: SymbolId(10): Span { start: 128, end: 130 }
-rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 Symbol flags mismatch for "e3":
 after transform: SymbolId(11): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
@@ -6087,9 +5574,6 @@ rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "m2":
 after transform: SymbolId(23): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m2":
-after transform: SymbolId(23): Span { start: 344, end: 346 }
-rebuilt        : SymbolId(16): Span { start: 0, end: 0 }
 Symbol flags mismatch for "e5":
 after transform: SymbolId(24): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(18): SymbolFlags(BlockScopedVariable)
@@ -6125,9 +5609,6 @@ rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch for "m1":
 after transform: SymbolId(10): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m1":
-after transform: SymbolId(10): Span { start: 116, end: 118 }
-rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 Symbol flags mismatch for "e3":
 after transform: SymbolId(11): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
@@ -6137,9 +5618,6 @@ rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "m2":
 after transform: SymbolId(23): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m2":
-after transform: SymbolId(23): Span { start: 320, end: 322 }
-rebuilt        : SymbolId(16): Span { start: 0, end: 0 }
 Symbol flags mismatch for "e5":
 after transform: SymbolId(24): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(18): SymbolFlags(BlockScopedVariable)
@@ -6151,36 +5629,21 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ModuleFunction
 Symbol flags mismatch for "m1":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m1":
-after transform: SymbolId(2): Span { start: 79, end: 81 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m2":
 after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m2":
-after transform: SymbolId(5): Span { start: 206, end: 208 }
-rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ModuleInternalImport.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Symbol flags mismatch for "m":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m":
-after transform: SymbolId(0): Span { start: 17, end: 18 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m1":
 after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m1":
-after transform: SymbolId(5): Span { start: 121, end: 123 }
-rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m2":
 after transform: SymbolId(10): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m2":
-after transform: SymbolId(10): Span { start: 230, end: 232 }
-rebuilt        : SymbolId(12): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ModuleLet.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -6192,15 +5655,9 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "m1":
 after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m1":
-after transform: SymbolId(6): Span { start: 111, end: 113 }
-rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m2":
 after transform: SymbolId(13): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m2":
-after transform: SymbolId(13): Span { start: 235, end: 237 }
-rebuilt        : SymbolId(14): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ModuleModuleDeclaration.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -6212,39 +5669,21 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "m1":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m1":
-after transform: SymbolId(0): Span { start: 17, end: 19 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "innerExportedModule":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "innerExportedModule":
-after transform: SymbolId(3): Span { start: 82, end: 101 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Symbol flags mismatch for "innerNonExportedModule":
 after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "innerNonExportedModule":
-after transform: SymbolId(6): Span { start: 178, end: 200 }
-rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m2":
 after transform: SymbolId(9): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m2":
-after transform: SymbolId(9): Span { start: 268, end: 270 }
-rebuilt        : SymbolId(12): Span { start: 0, end: 0 }
 Symbol flags mismatch for "innerExportedModule":
 after transform: SymbolId(12): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "innerExportedModule":
-after transform: SymbolId(12): Span { start: 333, end: 352 }
-rebuilt        : SymbolId(16): Span { start: 0, end: 0 }
 Symbol flags mismatch for "innerNonExportedModule":
 after transform: SymbolId(15): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "innerNonExportedModule":
-after transform: SymbolId(15): Span { start: 429, end: 451 }
-rebuilt        : SymbolId(20): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ModuleVariableStatement.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -6256,15 +5695,9 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "m1":
 after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m1":
-after transform: SymbolId(6): Span { start: 111, end: 113 }
-rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m2":
 after transform: SymbolId(13): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m2":
-after transform: SymbolId(13): Span { start: 235, end: 237 }
-rebuilt        : SymbolId(14): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/esDecoratorsClassFieldsCrash.ts
 Bindings mismatch:
@@ -6346,9 +5779,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/exportDefaultProp
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "B":
 after transform: SymbolId(1): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(Class)
@@ -6373,9 +5803,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/exportEqualsPrope
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "B":
 after transform: SymbolId(1): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(Class)
@@ -6396,9 +5823,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "K":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "K":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "L":
 after transform: SymbolId(1): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(Class)
@@ -6408,9 +5832,6 @@ rebuilt        : SymbolId(2): []
 Symbol flags mismatch for "M":
 after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(5): Span { start: 245, end: 246 }
-rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/exportImportNonInstantiatedModule.ts
 Bindings mismatch:
@@ -6419,9 +5840,6 @@ rebuilt        : ScopeId(0): ["B", "x"]
 Symbol flags mismatch for "B":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "B":
-after transform: SymbolId(2): Span { start: 64, end: 65 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/exportNamespaceDeclarationRetainsVisibility.ts
 Bindings mismatch:
@@ -6455,18 +5873,12 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/extBaseClass1.ts
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 110, end: 111 }]
 rebuilt        : SymbolId(1): []
 Symbol flags mismatch for "N":
 after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "N":
-after transform: SymbolId(4): Span { start: 165, end: 166 }
-rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/externFunc.ts
 Bindings mismatch:
@@ -6495,18 +5907,12 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "M2":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M2":
-after transform: SymbolId(0): Span { start: 10, end: 12 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/externalModuleResolution2.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Symbol flags mismatch for "M2":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M2":
-after transform: SymbolId(0): Span { start: 10, end: 12 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/externalModuleWithoutCompilerFlag1.ts
 Bindings mismatch:
@@ -6523,9 +5929,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "X":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "X":
-after transform: SymbolId(3): Span { start: 62, end: 63 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/fakeInfinity3.ts
 Bindings mismatch:
@@ -6537,9 +5940,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "X":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "X":
-after transform: SymbolId(3): Span { start: 62, end: 63 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/fallFromLastCase1.ts
 Bindings mismatch:
@@ -6565,15 +5965,9 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/fatArrowSelf.ts
 Symbol flags mismatch for "Events":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Events":
-after transform: SymbolId(0): Span { start: 10, end: 16 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Consumer":
 after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Consumer":
-after transform: SymbolId(6): Span { start: 223, end: 231 }
-rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/fatArrowfunctionAsType.ts
 Bindings mismatch:
@@ -6657,9 +6051,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/forInModule.ts
 Symbol flags mismatch for "Foo":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Foo":
-after transform: SymbolId(0): Span { start: 10, end: 13 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/forLoopEndingMultilineComments.ts
 Bindings mismatch:
@@ -6770,17 +6161,11 @@ rebuilt        : SymbolId(31): []
 Symbol flags mismatch for "m2":
 after transform: SymbolId(38): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(36): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m2":
-after transform: SymbolId(38): Span { start: 1210, end: 1212 }
-rebuilt        : SymbolId(36): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/functionCall5.ts
 Symbol flags mismatch for "m1":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m1":
-after transform: SymbolId(0): Span { start: 10, end: 12 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/functionDeclarationWithResolutionOfTypeOfSameName01.ts
 Bindings mismatch:
@@ -6806,9 +6191,6 @@ rebuilt        : ScopeId(2): []
 Symbol flags mismatch for "Midori":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Midori":
-after transform: SymbolId(0): Span { start: 12, end: 18 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol scope ID mismatch for "Foo":
 after transform: SymbolId(1): ScopeId(2)
 rebuilt        : SymbolId(2): ScopeId(1)
@@ -6823,15 +6205,9 @@ rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "Bar":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Bar":
-after transform: SymbolId(3): Span { start: 63, end: 66 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Baz":
 after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Baz":
-after transform: SymbolId(5): Span { start: 118, end: 121 }
-rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/functionOverloads10.ts
 Symbol span mismatch for "foo":
@@ -7054,9 +6430,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/functionTypeArgum
 Symbol flags mismatch for "test":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "test":
-after transform: SymbolId(0): Span { start: 10, end: 14 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/funduleExportedClassIsUsedBeforeDeclaration.ts
 Bindings mismatch:
@@ -7192,9 +6565,6 @@ rebuilt        : ScopeId(0): ["bar"]
 Symbol flags mismatch for "bar":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "bar":
-after transform: SymbolId(3): Span { start: 61, end: 64 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericClassPropertyInheritanceSpecialization.ts
 Bindings mismatch:
@@ -7203,45 +6573,24 @@ rebuilt        : ScopeId(0): ["Portal", "PortalFx", "ViewModel", "_definePropert
 Symbol flags mismatch for "Portal":
 after transform: SymbolId(32): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Portal":
-after transform: SymbolId(32): Span { start: 1081, end: 1087 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Controls":
 after transform: SymbolId(33): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Controls":
-after transform: SymbolId(33): Span { start: 1088, end: 1096 }
-rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Validators":
 after transform: SymbolId(34): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Validators":
-after transform: SymbolId(34): Span { start: 1097, end: 1107 }
-rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol flags mismatch for "PortalFx":
 after transform: SymbolId(39): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "PortalFx":
-after transform: SymbolId(39): Span { start: 1500, end: 1508 }
-rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
 Symbol flags mismatch for "ViewModels":
 after transform: SymbolId(40): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "ViewModels":
-after transform: SymbolId(40): Span { start: 1509, end: 1519 }
-rebuilt        : SymbolId(12): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Controls":
 after transform: SymbolId(41): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Controls":
-after transform: SymbolId(41): Span { start: 1520, end: 1528 }
-rebuilt        : SymbolId(14): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Validators":
 after transform: SymbolId(42): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Validators":
-after transform: SymbolId(42): Span { start: 1529, end: 1539 }
-rebuilt        : SymbolId(16): Span { start: 0, end: 0 }
 Reference symbol mismatch for "ko":
 after transform: SymbolId(30) "ko"
 rebuilt        : <None>
@@ -7253,55 +6602,34 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericClassesInM
 Symbol flags mismatch for "Foo":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Foo":
-after transform: SymbolId(0): Span { start: 10, end: 13 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericConstraintOnExtendedBuiltinTypes.ts
 Symbol flags mismatch for "EndGate":
 after transform: SymbolId(0): SymbolFlags(NamespaceModule | ValueModule | Ambient)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "EndGate":
-after transform: SymbolId(0): Span { start: 18, end: 25 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "EndGate":
 after transform: SymbolId(0): [Span { start: 18, end: 25 }, Span { start: 152, end: 159 }, Span { start: 344, end: 351 }]
 rebuilt        : SymbolId(1): []
 Symbol flags mismatch for "Tweening":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Tweening":
-after transform: SymbolId(3): Span { start: 160, end: 168 }
-rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Tweening":
 after transform: SymbolId(7): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Tweening":
-after transform: SymbolId(7): Span { start: 352, end: 360 }
-rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericConstraintOnExtendedBuiltinTypes2.ts
 Symbol flags mismatch for "EndGate":
 after transform: SymbolId(0): SymbolFlags(NamespaceModule | ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "EndGate":
-after transform: SymbolId(0): Span { start: 10, end: 17 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "EndGate":
 after transform: SymbolId(0): [Span { start: 10, end: 17 }, Span { start: 144, end: 151 }, Span { start: 335, end: 342 }]
 rebuilt        : SymbolId(1): []
 Symbol flags mismatch for "Tweening":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Tweening":
-after transform: SymbolId(3): Span { start: 152, end: 160 }
-rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Tweening":
 after transform: SymbolId(7): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Tweening":
-after transform: SymbolId(7): Span { start: 343, end: 351 }
-rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericFunctionInference2.ts
 Bindings mismatch:
@@ -7459,9 +6787,6 @@ rebuilt        : ScopeId(0): ["MyModule"]
 Symbol flags mismatch for "MyModule":
 after transform: SymbolId(17): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "MyModule":
-after transform: SymbolId(17): Span { start: 441, end: 449 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/getParameterNameAtPosition.ts
 Bindings mismatch:
@@ -7481,9 +6806,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/global.ts
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/globalIsContextualKeyword.ts
 Bindings mismatch:
@@ -7563,9 +6885,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/importAliasAnExte
 Symbol flags mismatch for "m":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m":
-after transform: SymbolId(0): Span { start: 17, end: 18 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/importAliasWithDottedName.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -7573,30 +6892,18 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "N":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "N":
-after transform: SymbolId(2): Span { start: 57, end: 58 }
-rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol flags mismatch for "A":
 after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(4): Span { start: 106, end: 107 }
-rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/importAndVariableDeclarationConflict2.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Symbol flags mismatch for "m":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/importDeclWithExportModifierInAmbientContext.ts
 Unresolved references mismatch:
@@ -7633,18 +6940,12 @@ rebuilt        : ScopeId(0): ["A", "C"]
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "A":
 after transform: SymbolId(0): [ReferenceId(1), ReferenceId(2), ReferenceId(8), ReferenceId(9)]
 rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(7)]
 Symbol flags mismatch for "C":
 after transform: SymbolId(7): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "C":
-after transform: SymbolId(7): Span { start: 290, end: 291 }
-rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/importOnAliasedIdentifiers.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -7654,9 +6955,6 @@ rebuilt        : ScopeId(1): ["X", "_A"]
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "A":
 after transform: SymbolId(0): [ReferenceId(1), ReferenceId(2), ReferenceId(5), ReferenceId(6)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
@@ -7672,9 +6970,6 @@ rebuilt        : SymbolId(2): []
 Symbol flags mismatch for "B":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "B":
-after transform: SymbolId(2): Span { start: 84, end: 85 }
-rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/inKeywordNarrowingWithNoUncheckedIndexedAccess.ts
 Bindings mismatch:
@@ -7732,9 +7027,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/indexIntoEnum.ts
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "E":
 after transform: SymbolId(1): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
@@ -8171,15 +7463,9 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/inheritanceOfGene
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "N":
 after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "N":
-after transform: SymbolId(4): Span { start: 75, end: 76 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/inheritedConstructorPropertyContextualType.ts
 Bindings mismatch:
@@ -8201,9 +7487,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/innerBoundLambdaE
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/innerExtern.ts
 Bindings mismatch:
@@ -8212,15 +7495,9 @@ rebuilt        : ScopeId(1): ["B", "_A"]
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol flags mismatch for "B":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "B":
-after transform: SymbolId(3): Span { start: 104, end: 105 }
-rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Reference symbol mismatch for "BB":
 after transform: SymbolId(1) "BB"
 rebuilt        : <None>
@@ -8232,9 +7509,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/innerFunc.ts
 Symbol flags mismatch for "M":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(2): Span { start: 85, end: 86 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/innerOverloads.ts
 Symbol span mismatch for "inner":
@@ -8274,9 +7548,6 @@ rebuilt        : ScopeId(8): ["InferFunctionTypes", "_N"]
 Symbol flags mismatch for "N1":
 after transform: SymbolId(62): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "N1":
-after transform: SymbolId(62): Span { start: 1772, end: 1774 }
-rebuilt        : SymbolId(14): Span { start: 0, end: 0 }
 Reference symbol mismatch for "handlers":
 after transform: SymbolId(6) "handlers"
 rebuilt        : <None>
@@ -8384,73 +7655,43 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "a":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "a":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "c":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "c":
-after transform: SymbolId(2): Span { start: 54, end: 55 }
-rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasClassInsideLocalModuleWithExport.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Symbol flags mismatch for "x":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "x":
-after transform: SymbolId(0): Span { start: 17, end: 18 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m2":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m2":
-after transform: SymbolId(3): Span { start: 125, end: 127 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m3":
 after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m3":
-after transform: SymbolId(4): Span { start: 151, end: 153 }
-rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasClassInsideLocalModuleWithoutExport.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Symbol flags mismatch for "x":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "x":
-after transform: SymbolId(0): Span { start: 17, end: 18 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m2":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m2":
-after transform: SymbolId(3): Span { start: 125, end: 127 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m3":
 after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m3":
-after transform: SymbolId(4): Span { start: 151, end: 153 }
-rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasClassInsideTopLevelModuleWithExport.ts
 Symbol flags mismatch for "x":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "x":
-after transform: SymbolId(0): Span { start: 17, end: 18 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasClassInsideTopLevelModuleWithoutExport.ts
 Symbol flags mismatch for "x":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "x":
-after transform: SymbolId(0): Span { start: 17, end: 18 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasEnum.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -8460,18 +7701,12 @@ rebuilt        : ScopeId(2): ["weekend"]
 Symbol flags mismatch for "a":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "a":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "weekend":
 after transform: SymbolId(1): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "c":
 after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "c":
-after transform: SymbolId(5): Span { start: 108, end: 109 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasEnumInsideLocalModuleWithExport.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -8481,18 +7716,12 @@ rebuilt        : ScopeId(2): ["weekend"]
 Symbol flags mismatch for "a":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "a":
-after transform: SymbolId(0): Span { start: 17, end: 18 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "weekend":
 after transform: SymbolId(1): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "c":
 after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "c":
-after transform: SymbolId(5): Span { start: 122, end: 123 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasEnumInsideLocalModuleWithoutExport.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -8502,18 +7731,12 @@ rebuilt        : ScopeId(2): ["weekend"]
 Symbol flags mismatch for "a":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "a":
-after transform: SymbolId(0): Span { start: 17, end: 18 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "weekend":
 after transform: SymbolId(1): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "c":
 after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "c":
-after transform: SymbolId(5): Span { start: 122, end: 123 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasFunction.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -8521,15 +7744,9 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "a":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "a":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "c":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "c":
-after transform: SymbolId(3): Span { start: 88, end: 89 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasFunctionInsideLocalModuleWithExport.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -8537,94 +7754,55 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "a":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "a":
-after transform: SymbolId(0): Span { start: 17, end: 18 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "c":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "c":
-after transform: SymbolId(3): Span { start: 102, end: 103 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasFunctionInsideLocalModuleWithoutExport.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Symbol flags mismatch for "a":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "a":
-after transform: SymbolId(0): Span { start: 17, end: 18 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "c":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "c":
-after transform: SymbolId(3): Span { start: 102, end: 103 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasFunctionInsideTopLevelModuleWithoutExport.ts
 Symbol flags mismatch for "a":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "a":
-after transform: SymbolId(0): Span { start: 17, end: 18 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasInitializedModule.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Symbol flags mismatch for "a":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "a":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "b":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "b":
-after transform: SymbolId(1): Span { start: 35, end: 36 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "c":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "c":
-after transform: SymbolId(3): Span { start: 93, end: 94 }
-rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasInitializedModuleInsideLocalModuleWithoutExport.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Symbol flags mismatch for "a":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "a":
-after transform: SymbolId(0): Span { start: 17, end: 18 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "b":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "b":
-after transform: SymbolId(1): Span { start: 42, end: 43 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "c":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "c":
-after transform: SymbolId(3): Span { start: 107, end: 108 }
-rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasInitializedModuleInsideTopLevelModuleWithExport.ts
 Symbol flags mismatch for "a":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "a":
-after transform: SymbolId(0): Span { start: 17, end: 18 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "b":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "b":
-after transform: SymbolId(1): Span { start: 42, end: 43 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasInterface.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -8634,9 +7812,6 @@ rebuilt        : ScopeId(0): ["c"]
 Symbol flags mismatch for "c":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "c":
-after transform: SymbolId(2): Span { start: 58, end: 59 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Unresolved references mismatch:
 after transform: ["a"]
 rebuilt        : []
@@ -8654,9 +7829,6 @@ rebuilt        : ScopeId(0): ["c"]
 Symbol flags mismatch for "c":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "c":
-after transform: SymbolId(3): Span { start: 116, end: 117 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Unresolved references mismatch:
 after transform: ["a"]
 rebuilt        : []
@@ -8669,9 +7841,6 @@ rebuilt        : ScopeId(0): ["c"]
 Symbol flags mismatch for "c":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "c":
-after transform: SymbolId(3): Span { start: 130, end: 131 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasUninitializedModuleInsideLocalModuleWithoutExport.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -8681,9 +7850,6 @@ rebuilt        : ScopeId(0): ["c"]
 Symbol flags mismatch for "c":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "c":
-after transform: SymbolId(3): Span { start: 130, end: 131 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Unresolved references mismatch:
 after transform: ["a"]
 rebuilt        : []
@@ -8699,48 +7865,30 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "a":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "a":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "c":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "c":
-after transform: SymbolId(2): Span { start: 50, end: 51 }
-rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasVarInsideTopLevelModuleWithoutExport.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Symbol flags mismatch for "a":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "a":
-after transform: SymbolId(0): Span { start: 17, end: 18 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasWithDottedNameEmit.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Symbol flags mismatch for "a":
 after transform: SymbolId(0): SymbolFlags(NamespaceModule | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "a":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "a":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 50, end: 51 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "b":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "b":
-after transform: SymbolId(1): Span { start: 12, end: 13 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "c":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "c":
-after transform: SymbolId(2): Span { start: 14, end: 15 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Unresolved references mismatch:
 after transform: ["b"]
 rebuilt        : []
@@ -8752,9 +7900,6 @@ rebuilt        : ScopeId(0): ["B"]
 Symbol flags mismatch for "B":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "B":
-after transform: SymbolId(2): Span { start: 64, end: 65 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "A":
 after transform: SymbolId(3): [ReferenceId(0)]
 rebuilt        : SymbolId(2): []
@@ -8794,9 +7939,6 @@ rebuilt        : ScopeId(6): ["C"]
 Symbol flags mismatch for "enums":
 after transform: SymbolId(27): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "enums":
-after transform: SymbolId(27): Span { start: 1443, end: 1448 }
-rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol flags mismatch for "A":
 after transform: SymbolId(28): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
@@ -9018,9 +8160,6 @@ rebuilt        : ScopeId(0): ["Element", "createElement", "toCamelCase"]
 Symbol flags mismatch for "Element":
 after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Element":
-after transform: SymbolId(5): Span { start: 358, end: 365 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryIdentifier.ts
 Bindings mismatch:
@@ -9029,9 +8168,6 @@ rebuilt        : ScopeId(0): ["Element", "createElement", "toCamelCase"]
 Symbol flags mismatch for "Element":
 after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Element":
-after transform: SymbolId(5): Span { start: 358, end: 365 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryIdentifierAsParameter.ts
 Bindings mismatch:
@@ -9045,9 +8181,6 @@ rebuilt        : ScopeId(0): ["Element", "createElement", "toCamelCase"]
 Symbol flags mismatch for "Element":
 after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Element":
-after transform: SymbolId(5): Span { start: 358, end: 365 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsxFunctionTypeChildren.tsx
 Bindings mismatch:
@@ -9146,17 +8279,11 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/letKeepNamesOfTopLevelItems.ts
 Symbol flags mismatch for "A":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(3): Span { start: 48, end: 49 }
-rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/literalWideningWithCompoundLikeAssignments.ts
 Bindings mismatch:
@@ -9225,18 +8352,12 @@ rebuilt        : ScopeId(2): ["Key"]
 Symbol flags mismatch for "Keyboard":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Keyboard":
-after transform: SymbolId(0): Span { start: 10, end: 18 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Key":
 after transform: SymbolId(1): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "App":
 after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "App":
-after transform: SymbolId(6): Span { start: 78, end: 81 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/mappedToToIndexSignatureInference.ts
 Bindings mismatch:
@@ -9409,18 +8530,12 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 101, end: 102 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "f":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "f":
-after transform: SymbolId(3): Span { start: 126, end: 127 }
-rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/mergedEnumDeclarationCodeGen.ts
 Bindings mismatch:
@@ -9443,129 +8558,75 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/mergedModuleDecla
 Symbol flags mismatch for "X":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "X":
-after transform: SymbolId(0): Span { start: 17, end: 18 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "X":
 after transform: SymbolId(0): [Span { start: 17, end: 18 }, Span { start: 172, end: 173 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "Y":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Y":
-after transform: SymbolId(1): Span { start: 42, end: 43 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Y":
 after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Y":
-after transform: SymbolId(4): Span { start: 197, end: 198 }
-rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationCodeGen2.ts
 Symbol flags mismatch for "my":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "my":
-after transform: SymbolId(0): Span { start: 10, end: 12 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "my":
 after transform: SymbolId(0): [Span { start: 10, end: 12 }, Span { start: 66, end: 68 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "data":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "data":
-after transform: SymbolId(1): Span { start: 13, end: 17 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "foo":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "foo":
-after transform: SymbolId(2): Span { start: 18, end: 21 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Symbol flags mismatch for "data":
 after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "data":
-after transform: SymbolId(4): Span { start: 69, end: 73 }
-rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationCodeGen3.ts
 Symbol flags mismatch for "my":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "my":
-after transform: SymbolId(0): Span { start: 10, end: 12 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "my":
 after transform: SymbolId(0): [Span { start: 10, end: 12 }, Span { start: 62, end: 64 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "data":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "data":
-after transform: SymbolId(1): Span { start: 13, end: 17 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "data":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "data":
-after transform: SymbolId(3): Span { start: 65, end: 69 }
-rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 Symbol flags mismatch for "foo":
 after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "foo":
-after transform: SymbolId(4): Span { start: 70, end: 73 }
-rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationCodeGen4.ts
 Symbol flags mismatch for "superContain":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "superContain":
-after transform: SymbolId(0): Span { start: 10, end: 22 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "contain":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "contain":
-after transform: SymbolId(1): Span { start: 46, end: 53 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "my":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "my":
-after transform: SymbolId(2): Span { start: 81, end: 83 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "my":
 after transform: SymbolId(2): [Span { start: 81, end: 83 }, Span { start: 217, end: 219 }]
 rebuilt        : SymbolId(4): []
 Symbol flags mismatch for "buz":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "buz":
-after transform: SymbolId(3): Span { start: 84, end: 87 }
-rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 Symbol flags mismatch for "data":
 after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "data":
-after transform: SymbolId(4): Span { start: 119, end: 123 }
-rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
 Symbol flags mismatch for "buz":
 after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "buz":
-after transform: SymbolId(6): Span { start: 220, end: 223 }
-rebuilt        : SymbolId(12): Span { start: 0, end: 0 }
 Symbol flags mismatch for "data":
 after transform: SymbolId(7): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "data":
-after transform: SymbolId(7): Span { start: 255, end: 259 }
-rebuilt        : SymbolId(14): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationCodeGen5.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -9575,36 +8636,21 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 94, end: 95 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "buz":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "buz":
-after transform: SymbolId(1): Span { start: 12, end: 15 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "plop":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "plop":
-after transform: SymbolId(2): Span { start: 16, end: 20 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Symbol flags mismatch for "buz":
 after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "buz":
-after transform: SymbolId(5): Span { start: 96, end: 99 }
-rebuilt        : SymbolId(9): Span { start: 0, end: 0 }
 Symbol flags mismatch for "plop":
 after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "plop":
-after transform: SymbolId(6): Span { start: 100, end: 104 }
-rebuilt        : SymbolId(11): Span { start: 0, end: 0 }
 Symbol flags mismatch for "plop":
 after transform: SymbolId(10): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
@@ -9614,9 +8660,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 56, end: 57 }]
 rebuilt        : SymbolId(0): []
@@ -9716,9 +8759,6 @@ rebuilt        : ScopeId(7): ["_E"]
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "My":
 after transform: SymbolId(1): SymbolFlags(Function | ValueModule | Ambient)
 rebuilt        : SymbolId(2): SymbolFlags(Function)
@@ -9731,9 +8771,6 @@ rebuilt        : SymbolId(2): []
 Symbol flags mismatch for "B":
 after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "B":
-after transform: SymbolId(4): Span { start: 121, end: 122 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Symbol flags mismatch for "My":
 after transform: SymbolId(5): SymbolFlags(Function | ValueModule | Ambient)
 rebuilt        : SymbolId(6): SymbolFlags(Function)
@@ -9746,21 +8783,12 @@ rebuilt        : SymbolId(6): []
 Symbol flags mismatch for "C":
 after transform: SymbolId(9): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "C":
-after transform: SymbolId(9): Span { start: 258, end: 259 }
-rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
 Symbol flags mismatch for "D":
 after transform: SymbolId(13): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "D":
-after transform: SymbolId(13): Span { start: 375, end: 376 }
-rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
 Symbol flags mismatch for "E":
 after transform: SymbolId(18): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "E":
-after transform: SymbolId(18): Span { start: 526, end: 527 }
-rebuilt        : SymbolId(12): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/modFunctionCrash.ts
 Bindings mismatch:
@@ -9810,45 +8838,27 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleAliasInterf
 Symbol flags mismatch for "_modes":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "_modes":
-after transform: SymbolId(0): Span { start: 10, end: 16 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "_modes":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(16), ReferenceId(17)]
 rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3)]
 Symbol flags mismatch for "editor":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "editor":
-after transform: SymbolId(3): Span { start: 171, end: 177 }
-rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol flags mismatch for "editor2":
 after transform: SymbolId(11): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "editor2":
-after transform: SymbolId(11): Span { start: 502, end: 509 }
-rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Foo":
 after transform: SymbolId(16): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Foo":
-after transform: SymbolId(16): Span { start: 697, end: 700 }
-rebuilt        : SymbolId(16): Span { start: 0, end: 0 }
 Symbol flags mismatch for "A1":
 after transform: SymbolId(21): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(22): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A1":
-after transform: SymbolId(21): Span { start: 814, end: 816 }
-rebuilt        : SymbolId(22): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "A1":
 after transform: SymbolId(21): [ReferenceId(11), ReferenceId(28), ReferenceId(29)]
 rebuilt        : SymbolId(22): [ReferenceId(14), ReferenceId(15)]
 Symbol flags mismatch for "B1":
 after transform: SymbolId(24): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(25): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "B1":
-after transform: SymbolId(24): Span { start: 886, end: 888 }
-rebuilt        : SymbolId(25): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleAndInterfaceSharingName4.ts
 Bindings mismatch:
@@ -9890,9 +8900,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "Baz":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Baz":
-after transform: SymbolId(0): Span { start: 10, end: 13 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleCodeGenTest5.ts
 Bindings mismatch:
@@ -9913,64 +8920,40 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "Baz":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Baz":
-after transform: SymbolId(0): Span { start: 17, end: 20 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleIdentifiers.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleMemberWithoutTypeAnnotation1.ts
 Symbol flags mismatch for "TypeScript":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "TypeScript":
-after transform: SymbolId(0): Span { start: 10, end: 20 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "TypeScript":
 after transform: SymbolId(0): [Span { start: 10, end: 20 }, Span { start: 152, end: 162 }, Span { start: 544, end: 554 }, Span { start: 891, end: 901 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "Parser":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Parser":
-after transform: SymbolId(1): Span { start: 21, end: 27 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Syntax":
 after transform: SymbolId(18): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(21): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Syntax":
-after transform: SymbolId(18): Span { start: 902, end: 908 }
-rebuilt        : SymbolId(21): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleMemberWithoutTypeAnnotation2.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Symbol flags mismatch for "TypeScript":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "TypeScript":
-after transform: SymbolId(0): Span { start: 10, end: 20 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "CompilerDiagnostics":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "CompilerDiagnostics":
-after transform: SymbolId(1): Span { start: 44, end: 63 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleMerge.ts
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(0): Span { start: 104, end: 105 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "A":
 after transform: SymbolId(0): [Span { start: 104, end: 105 }, Span { start: 233, end: 234 }]
 rebuilt        : SymbolId(0): []
@@ -9979,9 +8962,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleNoEmit.ts
 Symbol flags mismatch for "Foo":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Foo":
-after transform: SymbolId(0): Span { start: 10, end: 13 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleOuterQualification.ts
 Bindings mismatch:
@@ -10053,67 +9033,37 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleScopingBug.
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "X":
 after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "X":
-after transform: SymbolId(6): Span { start: 213, end: 214 }
-rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleSharesNameWithImportDeclarationInsideIt.ts
 Symbol flags mismatch for "Z":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Z":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "M":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(1): Span { start: 12, end: 13 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "A":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(3): Span { start: 81, end: 82 }
-rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol flags mismatch for "M":
 after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(4): Span { start: 83, end: 84 }
-rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleSharesNameWithImportDeclarationInsideIt2.ts
 Symbol flags mismatch for "Z":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Z":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "M":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(1): Span { start: 12, end: 13 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "A":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(3): Span { start: 81, end: 82 }
-rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol flags mismatch for "M":
 after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(4): Span { start: 83, end: 84 }
-rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleSharesNameWithImportDeclarationInsideIt4.ts
 Bindings mismatch:
@@ -10122,27 +9072,15 @@ rebuilt        : ScopeId(5): ["M", "_M2", "bar"]
 Symbol flags mismatch for "Z":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Z":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "M":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(1): Span { start: 12, end: 13 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "A":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(3): Span { start: 81, end: 82 }
-rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol flags mismatch for "M":
 after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(4): Span { start: 83, end: 84 }
-rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
 Symbol flags mismatch for "M":
 after transform: SymbolId(5): SymbolFlags(FunctionScopedVariable | Interface)
 rebuilt        : SymbolId(9): SymbolFlags(FunctionScopedVariable)
@@ -10157,30 +9095,18 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleSharesNameW
 Symbol flags mismatch for "Z":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Z":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "Z":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(7), ReferenceId(8)]
 rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(7)]
 Symbol flags mismatch for "M":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(1): Span { start: 12, end: 13 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "A":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(3): Span { start: 81, end: 82 }
-rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol flags mismatch for "M":
 after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(4): Span { start: 83, end: 84 }
-rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleUnassignedVariable.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -10188,9 +9114,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "Bar":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Bar":
-after transform: SymbolId(0): Span { start: 10, end: 13 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleVariables.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -10200,9 +9123,6 @@ rebuilt        : ScopeId(0): ["M", "x"]
 Symbol flags mismatch for "M":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(2): Span { start: 49, end: 50 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(2): [Span { start: 49, end: 50 }, Span { start: 114, end: 115 }, Span { start: 157, end: 158 }]
 rebuilt        : SymbolId(1): []
@@ -10232,30 +9152,18 @@ rebuilt        : ScopeId(8): ["E"]
 Symbol flags mismatch for "OuterMod":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "OuterMod":
-after transform: SymbolId(0): Span { start: 10, end: 18 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol flags mismatch for "OuterInnerMod":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "OuterInnerMod":
-after transform: SymbolId(2): Span { start: 96, end: 109 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Symbol flags mismatch for "M":
 after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(5): Span { start: 243, end: 244 }
-rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(5): [Span { start: 243, end: 244 }, Span { start: 1079, end: 1080 }]
 rebuilt        : SymbolId(8): []
 Symbol flags mismatch for "InnerMod":
 after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "InnerMod":
-after transform: SymbolId(6): Span { start: 266, end: 274 }
-rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
 Symbol flags mismatch for "E":
 after transform: SymbolId(8): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(13): SymbolFlags(BlockScopedVariable)
@@ -10264,9 +9172,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleWithTryStat
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/multiModuleClodule1.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -10311,9 +9216,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/nameCollisionWith
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 49, end: 50 }]
 rebuilt        : SymbolId(0): []
@@ -10322,9 +9224,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/namedFunctionExpr
 Symbol flags mismatch for "Variables":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Variables":
-after transform: SymbolId(0): Span { start: 10, end: 19 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/namespaces1.ts
 Bindings mismatch:
@@ -10335,15 +9234,9 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/namespaces2.ts
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "B":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "B":
-after transform: SymbolId(1): Span { start: 35, end: 36 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/namespacesDeclaration1.ts
 Bindings mismatch:
@@ -10740,23 +9633,14 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/nestedModulePriva
 Symbol flags mismatch for "a":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "a":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "b":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "b":
-after transform: SymbolId(2): Span { start: 51, end: 52 }
-rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/nestedSelf.ts
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/nestedTypeVariableInfersLiteral.ts
 Bindings mismatch:
@@ -11295,17 +10179,11 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/overloadResolutio
 Symbol flags mismatch for "Bugs":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Bugs":
-after transform: SymbolId(0): Span { start: 10, end: 14 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/overloadResolutionOverNonCTObjectLit.ts
 Symbol flags mismatch for "Bugs":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Bugs":
-after transform: SymbolId(0): Span { start: 10, end: 14 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/overloadReturnTypes.ts
 Symbol span mismatch for "attr":
@@ -11455,9 +10333,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyCannotName
 Symbol flags mismatch for "SpecializedWidget":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "SpecializedWidget":
-after transform: SymbolId(2): Span { start: 123, end: 140 }
-rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyCheckExternalModuleExportAssignmentOfGenericClass.ts
 Reference symbol mismatch for "Bar":
@@ -11476,15 +10351,9 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "Outer":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Outer":
-after transform: SymbolId(0): Span { start: 10, end: 15 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Inner":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Inner":
-after transform: SymbolId(1): Span { start: 32, end: 37 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyCheckTypeOfInvisibleModuleNoError.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -11492,67 +10361,40 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "Outer":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Outer":
-after transform: SymbolId(0): Span { start: 10, end: 15 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Inner":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Inner":
-after transform: SymbolId(1): Span { start: 32, end: 37 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyClass.ts
 Symbol flags mismatch for "m1":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m1":
-after transform: SymbolId(0): Span { start: 17, end: 19 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m2":
 after transform: SymbolId(17): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m2":
-after transform: SymbolId(17): Span { start: 1051, end: 1053 }
-rebuilt        : SymbolId(16): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyClassImplementsClauseDeclFile.ts
 Symbol flags mismatch for "publicModule":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "publicModule":
-after transform: SymbolId(0): Span { start: 17, end: 29 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "privateModule":
 after transform: SymbolId(10): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "privateModule":
-after transform: SymbolId(10): Span { start: 1056, end: 1069 }
-rebuilt        : SymbolId(9): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyFunc.ts
 Symbol flags mismatch for "m1":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m1":
-after transform: SymbolId(0): Span { start: 10, end: 12 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyFunctionCannotNameParameterTypeDeclFile.ts
 Symbol flags mismatch for "SpecializedWidget":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "SpecializedWidget":
-after transform: SymbolId(2): Span { start: 123, end: 140 }
-rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyFunctionCannotNameReturnTypeDeclFile.ts
 Symbol flags mismatch for "SpecializedWidget":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "SpecializedWidget":
-after transform: SymbolId(2): Span { start: 123, end: 140 }
-rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyFunctionParameterDeclFile.ts
 Bindings mismatch:
@@ -11567,23 +10409,14 @@ rebuilt        : ScopeId(82): ["_privateModule", "privateClass", "privateClassWi
 Symbol flags mismatch for "publicModule":
 after transform: SymbolId(94): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(58): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "publicModule":
-after transform: SymbolId(94): Span { start: 4746, end: 4758 }
-rebuilt        : SymbolId(58): Span { start: 0, end: 0 }
 Symbol flags mismatch for "privateModule":
 after transform: SymbolId(189): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(118): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "privateModule":
-after transform: SymbolId(189): Span { start: 9967, end: 9980 }
-rebuilt        : SymbolId(118): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyGloClass.ts
 Symbol flags mismatch for "m1":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m1":
-after transform: SymbolId(0): Span { start: 10, end: 12 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyGloImport.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -11603,42 +10436,24 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "m1":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m1":
-after transform: SymbolId(0): Span { start: 10, end: 12 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m1_M1_public":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m1_M1_public":
-after transform: SymbolId(1): Span { start: 36, end: 48 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m1_M2_private":
 after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m1_M2_private":
-after transform: SymbolId(6): Span { start: 231, end: 244 }
-rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
 Symbol flags mismatch for "glo_M1_public":
 after transform: SymbolId(31): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(34): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "glo_M1_public":
-after transform: SymbolId(31): Span { start: 3187, end: 3200 }
-rebuilt        : SymbolId(34): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "glo_M1_public":
 after transform: SymbolId(31): [ReferenceId(31), ReferenceId(44), ReferenceId(45), ReferenceId(81), ReferenceId(82)]
 rebuilt        : SymbolId(34): [ReferenceId(61), ReferenceId(62)]
 Symbol flags mismatch for "m2":
 after transform: SymbolId(59): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(40): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m2":
-after transform: SymbolId(59): Span { start: 4973, end: 4975 }
-rebuilt        : SymbolId(40): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m4":
 after transform: SymbolId(60): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(42): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m4":
-after transform: SymbolId(60): Span { start: 5040, end: 5042 }
-rebuilt        : SymbolId(42): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyGloInterface.ts
 Bindings mismatch:
@@ -11647,9 +10462,6 @@ rebuilt        : ScopeId(0): ["C5_public", "m1"]
 Symbol flags mismatch for "m1":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m1":
-after transform: SymbolId(0): Span { start: 10, end: 12 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyImport.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -11683,72 +10495,39 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "m1":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m1":
-after transform: SymbolId(0): Span { start: 17, end: 19 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m1_M1_public":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m1_M1_public":
-after transform: SymbolId(1): Span { start: 43, end: 55 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m1_M2_private":
 after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m1_M2_private":
-after transform: SymbolId(6): Span { start: 238, end: 251 }
-rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m2":
 after transform: SymbolId(31): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(34): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m2":
-after transform: SymbolId(31): Span { start: 3194, end: 3196 }
-rebuilt        : SymbolId(34): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "m2":
 after transform: SymbolId(31): [Span { start: 3194, end: 3196 }, Span { start: 12472, end: 12474 }]
 rebuilt        : SymbolId(34): []
 Symbol flags mismatch for "m2_M1_public":
 after transform: SymbolId(32): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(36): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m2_M1_public":
-after transform: SymbolId(32): Span { start: 3220, end: 3232 }
-rebuilt        : SymbolId(36): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m2_M2_private":
 after transform: SymbolId(37): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(42): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m2_M2_private":
-after transform: SymbolId(37): Span { start: 3415, end: 3428 }
-rebuilt        : SymbolId(42): Span { start: 0, end: 0 }
 Symbol flags mismatch for "glo_M1_public":
 after transform: SymbolId(62): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(68): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "glo_M1_public":
-after transform: SymbolId(62): Span { start: 6414, end: 6427 }
-rebuilt        : SymbolId(68): Span { start: 0, end: 0 }
 Symbol flags mismatch for "glo_M3_private":
 after transform: SymbolId(67): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(74): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "glo_M3_private":
-after transform: SymbolId(67): Span { start: 6751, end: 6765 }
-rebuilt        : SymbolId(74): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m4":
 after transform: SymbolId(92): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(101): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m4":
-after transform: SymbolId(92): Span { start: 12539, end: 12541 }
-rebuilt        : SymbolId(101): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m3":
 after transform: SymbolId(94): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(104): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m3":
-after transform: SymbolId(94): Span { start: 12643, end: 12645 }
-rebuilt        : SymbolId(104): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m4":
 after transform: SymbolId(95): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(106): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m4":
-after transform: SymbolId(95): Span { start: 12710, end: 12712 }
-rebuilt        : SymbolId(106): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyInterface.ts
 Bindings mismatch:
@@ -11757,15 +10536,9 @@ rebuilt        : ScopeId(0): ["C5_public", "C6_private", "m1", "m2"]
 Symbol flags mismatch for "m1":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m1":
-after transform: SymbolId(0): Span { start: 17, end: 19 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m2":
 after transform: SymbolId(21): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m2":
-after transform: SymbolId(21): Span { start: 1211, end: 1213 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyInterfaceExtendsClauseDeclFile.ts
 Bindings mismatch:
@@ -11818,87 +10591,51 @@ rebuilt        : ScopeId(9): ["e_public"]
 Symbol flags mismatch for "m_private":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m_private":
-after transform: SymbolId(0): Span { start: 30, end: 39 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "e_private":
 after transform: SymbolId(2): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "mi_private":
 after transform: SymbolId(8): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "mi_private":
-after transform: SymbolId(8): Span { start: 317, end: 327 }
-rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m_public":
 after transform: SymbolId(12): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m_public":
-after transform: SymbolId(12): Span { start: 489, end: 497 }
-rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
 Symbol flags mismatch for "e_public":
 after transform: SymbolId(14): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(13): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "mi_public":
 after transform: SymbolId(20): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(17): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "mi_public":
-after transform: SymbolId(20): Span { start: 756, end: 765 }
-rebuilt        : SymbolId(17): Span { start: 0, end: 0 }
 Symbol flags mismatch for "import_public":
 after transform: SymbolId(24): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "import_public":
-after transform: SymbolId(24): Span { start: 907, end: 920 }
-rebuilt        : SymbolId(20): Span { start: 0, end: 0 }
 Symbol flags mismatch for "import_private":
 after transform: SymbolId(67): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(64): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "import_private":
-after transform: SymbolId(67): Span { start: 3843, end: 3857 }
-rebuilt        : SymbolId(64): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyTypeParameterOfFunctionDeclFile.ts
 Symbol flags mismatch for "publicModule":
 after transform: SymbolId(86): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(18): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "publicModule":
-after transform: SymbolId(86): Span { start: 4741, end: 4753 }
-rebuilt        : SymbolId(18): Span { start: 0, end: 0 }
 Symbol flags mismatch for "privateModule":
 after transform: SymbolId(173): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(38): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "privateModule":
-after transform: SymbolId(173): Span { start: 10029, end: 10042 }
-rebuilt        : SymbolId(38): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyTypeParametersOfClassDeclFile.ts
 Symbol flags mismatch for "publicModule":
 after transform: SymbolId(26): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(18): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "publicModule":
-after transform: SymbolId(26): Span { start: 1172, end: 1184 }
-rebuilt        : SymbolId(18): Span { start: 0, end: 0 }
 Symbol flags mismatch for "privateModule":
 after transform: SymbolId(53): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(38): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "privateModule":
-after transform: SymbolId(53): Span { start: 2611, end: 2624 }
-rebuilt        : SymbolId(38): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyTypeParametersOfInterfaceDeclFile.ts
 Symbol flags mismatch for "publicModule":
 after transform: SymbolId(28): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "publicModule":
-after transform: SymbolId(28): Span { start: 1976, end: 1988 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Symbol flags mismatch for "privateModule":
 after transform: SymbolId(57): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "privateModule":
-after transform: SymbolId(57): Span { start: 4811, end: 4824 }
-rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/promiseType.ts
 Bindings mismatch:
@@ -12870,9 +11607,6 @@ rebuilt        : ScopeId(0): ["Alpha", "x"]
 Symbol flags mismatch for "Alpha":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Alpha":
-after transform: SymbolId(0): Span { start: 10, end: 15 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "Alpha":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(4)]
 rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(2), ReferenceId(3)]
@@ -12959,9 +11693,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/reboundBaseClassS
 Symbol flags mismatch for "Foo":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Foo":
-after transform: SymbolId(1): Span { start: 37, end: 40 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/recursiveArrayNotCircular.ts
 Bindings mismatch:
@@ -13000,18 +11731,12 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/recursiveClassIns
 Symbol flags mismatch for "TypeScript2":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "TypeScript2":
-after transform: SymbolId(0): Span { start: 10, end: 21 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/recursiveCloduleReference.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "C":
 after transform: SymbolId(1): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(Class)
@@ -13054,9 +11779,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/recursiveMods.ts
 Symbol flags mismatch for "Foo":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Foo":
-after transform: SymbolId(0): Span { start: 17, end: 20 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(0): [Span { start: 17, end: 20 }, Span { start: 62, end: 65 }]
 rebuilt        : SymbolId(0): []
@@ -13100,27 +11822,15 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/recursivelySpecia
 Symbol flags mismatch for "MsPortal":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "MsPortal":
-after transform: SymbolId(0): Span { start: 10, end: 18 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Controls":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Controls":
-after transform: SymbolId(1): Span { start: 19, end: 27 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Base":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Base":
-after transform: SymbolId(2): Span { start: 28, end: 32 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Symbol flags mismatch for "ItemList":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "ItemList":
-after transform: SymbolId(3): Span { start: 33, end: 41 }
-rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/reducibleIndexedAccessTypes.ts
 Bindings mismatch:
@@ -13346,15 +12056,9 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/returnTypeParamet
 Symbol flags mismatch for "M1":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M1":
-after transform: SymbolId(0): Span { start: 10, end: 12 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "M2":
 after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M2":
-after transform: SymbolId(6): Span { start: 155, end: 157 }
-rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/reuseInnerModuleMember.ts
 Bindings mismatch:
@@ -13552,9 +12256,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/separate1-2.ts
 Symbol flags mismatch for "X":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "X":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/shebangBeforeReferences.ts
 Bindings mismatch:
@@ -13610,31 +12311,19 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/sourceMap-FileWit
 Symbol flags mismatch for "Shapes":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Shapes":
-after transform: SymbolId(1): Span { start: 78, end: 84 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/sourceMapForFunctionInInternalModuleWithCommentPrecedingStatement01.ts
 Symbol flags mismatch for "Q":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Q":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationClasses.ts
 Symbol flags mismatch for "Foo":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Foo":
-after transform: SymbolId(0): Span { start: 10, end: 13 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Bar":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Bar":
-after transform: SymbolId(1): Span { start: 14, end: 17 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringForObjectBindingPattern.ts
 Bindings mismatch:
@@ -14009,38 +12698,23 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidati
 Symbol flags mismatch for "m":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m":
-after transform: SymbolId(0): Span { start: 17, end: 18 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationModule.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Symbol flags mismatch for "m2":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m2":
-after transform: SymbolId(0): Span { start: 10, end: 12 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m3":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m3":
-after transform: SymbolId(2): Span { start: 52, end: 54 }
-rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m4":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m4":
-after transform: SymbolId(3): Span { start: 71, end: 73 }
-rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/sourcemapValidationDuplicateNames.ts
 Symbol flags mismatch for "m1":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m1":
-after transform: SymbolId(0): Span { start: 10, end: 12 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "m1":
 after transform: SymbolId(0): [Span { start: 10, end: 12 }, Span { start: 70, end: 72 }]
 rebuilt        : SymbolId(0): []
@@ -14054,9 +12728,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/specializationOfE
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/specializedOverloadWithRestParameters.ts
 Symbol span mismatch for "f":
@@ -14482,9 +13153,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "m1":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m1":
-after transform: SymbolId(0): Span { start: 10, end: 12 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/stripMembersOptionality.ts
 Bindings mismatch:
@@ -14504,18 +13172,12 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/structural1.ts
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/structuralTypeInDeclareFileForModule.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/substitutionTypesInIndexedAccessTypes.ts
 Bindings mismatch:
@@ -14552,9 +13214,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/superAccessInFatA
 Symbol flags mismatch for "test":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "test":
-after transform: SymbolId(0): Span { start: 10, end: 14 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatDerivesFromGenericType1.ts
 Bindings mismatch:
@@ -14663,9 +13322,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/testContainerList
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(0): Span { start: 38, end: 39 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/testTypings.ts
 Bindings mismatch:
@@ -14687,18 +13343,12 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/this_inside-objec
 Symbol flags mismatch for "ObjectLiteral":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "ObjectLiteral":
-after transform: SymbolId(0): Span { start: 10, end: 23 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/topLevel.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Symbol flags mismatch for "M":
 after transform: SymbolId(7): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(7): Span { start: 336, end: 337 }
-rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/trackedSymbolsNoCrash.ts
 Bindings mismatch:
@@ -15032,17 +13682,11 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsI
 Symbol flags mismatch for "Foo":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Foo":
-after transform: SymbolId(0): Span { start: 17, end: 20 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeGuardOnContainerTypeNoHang.ts
 Symbol flags mismatch for "TypeGuards":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "TypeGuards":
-after transform: SymbolId(0): Span { start: 17, end: 27 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeInferenceCacheInvalidation.ts
 Bindings mismatch:
@@ -15450,9 +14094,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/unexportedInstanc
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 67, end: 68 }]
 rebuilt        : SymbolId(0): []
@@ -15594,26 +14235,17 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "Validation":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Validation":
-after transform: SymbolId(0): Span { start: 10, end: 20 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/unusedInterfaceinNamespace4.ts
 Symbol flags mismatch for "Validation":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Validation":
-after transform: SymbolId(0): Span { start: 10, end: 20 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/unusedInterfaceinNamespace5.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Symbol flags mismatch for "Validation":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Validation":
-after transform: SymbolId(0): Span { start: 10, end: 20 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/unusedLocalProperty.ts
 Bindings mismatch:
@@ -15630,9 +14262,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsAndPa
 Symbol flags mismatch for "N":
 after transform: SymbolId(29): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(29): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "N":
-after transform: SymbolId(29): Span { start: 2046, end: 2047 }
-rebuilt        : SymbolId(29): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsAndParametersOverloadSignatures.ts
 Symbol span mismatch for "func":
@@ -15670,15 +14299,9 @@ rebuilt        : ScopeId(1): ["Point", "_A", "x"]
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "C":
 after transform: SymbolId(7): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "C":
-after transform: SymbolId(7): Span { start: 239, end: 240 }
-rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/vardecl.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -15695,9 +14318,6 @@ rebuilt        : ScopeId(1): ["C", "C2", "_m", "a", "a2", "b", "b2", "b22", "b22
 Symbol flags mismatch for "m2":
 after transform: SymbolId(22): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m2":
-after transform: SymbolId(22): Span { start: 890, end: 892 }
-rebuilt        : SymbolId(16): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/varianceCantBeStrictWhileStructureIsnt.ts
 Bindings mismatch:
@@ -15771,9 +14391,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/voidUndefinedReduction.ts
 Bindings mismatch:
@@ -15888,15 +14505,9 @@ rebuilt        : ScopeId(2): ["_M2"]
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "M2":
 after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M2":
-after transform: SymbolId(6): Span { start: 182, end: 184 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncUnParenthesizedArrowFunction_es2017.ts
 Bindings mismatch:
@@ -15919,9 +14530,6 @@ rebuilt        : ScopeId(0): ["C", "M", "_asyncToGenerator", "_f", "_f2", "_f3",
 Symbol flags mismatch for "M":
 after transform: SymbolId(19): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(33): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(19): Span { start: 916, end: 917 }
-rebuilt        : SymbolId(33): Span { start: 0, end: 0 }
 Reference symbol mismatch for "p":
 after transform: SymbolId(2) "p"
 rebuilt        : <None>
@@ -16283,9 +14891,6 @@ rebuilt        : ScopeId(0): ["C", "M", "_asyncToGenerator", "_f", "_f2", "_f3",
 Symbol flags mismatch for "M":
 after transform: SymbolId(19): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(33): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(19): Span { start: 916, end: 917 }
-rebuilt        : SymbolId(33): Span { start: 0, end: 0 }
 Reference symbol mismatch for "p":
 after transform: SymbolId(2) "p"
 rebuilt        : <None>
@@ -16642,9 +15247,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/classE
 Symbol flags mismatch for "M":
 after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(4): Span { start: 70, end: 71 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classWithStaticFieldInParameterBindingPattern.3.ts
 Bindings mismatch:
@@ -16684,9 +15286,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/member
 Symbol flags mismatch for "Generic":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Generic":
-after transform: SymbolId(0): Span { start: 10, end: 17 }
-rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/thisAndSuperInStaticMembers1.ts
 Bindings mismatch:
@@ -17888,9 +16487,6 @@ rebuilt        : ScopeId(21): ["Color"]
 Symbol flags mismatch for "M1":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M1":
-after transform: SymbolId(0): Span { start: 186, end: 188 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "EImpl1":
 after transform: SymbolId(1): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
@@ -17906,9 +16502,6 @@ rebuilt        : SymbolId(5): []
 Symbol flags mismatch for "M2":
 after transform: SymbolId(16): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M2":
-after transform: SymbolId(16): Span { start: 576, end: 578 }
-rebuilt        : SymbolId(9): Span { start: 0, end: 0 }
 Symbol flags mismatch for "EComp2":
 after transform: SymbolId(17): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
@@ -17918,9 +16511,6 @@ rebuilt        : SymbolId(11): []
 Symbol flags mismatch for "M3":
 after transform: SymbolId(25): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(15): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M3":
-after transform: SymbolId(25): Span { start: 959, end: 961 }
-rebuilt        : SymbolId(15): Span { start: 0, end: 0 }
 Symbol flags mismatch for "EInit":
 after transform: SymbolId(26): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(17): SymbolFlags(BlockScopedVariable)
@@ -17930,45 +16520,30 @@ rebuilt        : SymbolId(17): []
 Symbol flags mismatch for "M4":
 after transform: SymbolId(32): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M4":
-after transform: SymbolId(32): Span { start: 1115, end: 1117 }
-rebuilt        : SymbolId(20): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Color":
 after transform: SymbolId(33): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(22): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "M5":
 after transform: SymbolId(37): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(24): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M5":
-after transform: SymbolId(37): Span { start: 1175, end: 1177 }
-rebuilt        : SymbolId(24): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Color":
 after transform: SymbolId(38): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(26): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "M6":
 after transform: SymbolId(42): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(28): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M6":
-after transform: SymbolId(42): Span { start: 1236, end: 1238 }
-rebuilt        : SymbolId(28): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "M6":
 after transform: SymbolId(42): [Span { start: 1236, end: 1238 }, Span { start: 1298, end: 1300 }]
 rebuilt        : SymbolId(28): []
 Symbol flags mismatch for "A":
 after transform: SymbolId(43): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(30): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(43): Span { start: 1239, end: 1240 }
-rebuilt        : SymbolId(30): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Color":
 after transform: SymbolId(44): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(32): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "A":
 after transform: SymbolId(48): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(35): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(48): Span { start: 1324, end: 1325 }
-rebuilt        : SymbolId(35): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Color":
 after transform: SymbolId(49): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(37): SymbolFlags(BlockScopedVariable)
@@ -18294,26 +16869,17 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/sy
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty49.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty50.ts
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty51.ts
 Bindings mismatch:
@@ -18322,17 +16888,11 @@ rebuilt        : ScopeId(1): ["C", "_M"]
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty56.ts
 Symbol flags mismatch for "M":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(1): Span { start: 51, end: 52 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty60.ts
 Bindings mismatch:
@@ -18681,9 +17241,6 @@ rebuilt        : SymbolId(5): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch for "M":
 after transform: SymbolId(12): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(12): Span { start: 118, end: 119 }
-rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports1.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -18705,9 +17262,6 @@ rebuilt        : SymbolId(5): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch for "M":
 after transform: SymbolId(12): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(12): Span { start: 118, end: 119 }
-rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports3-es6.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -18729,9 +17283,6 @@ rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "M":
 after transform: SymbolId(12): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(12): Span { start: 167, end: 168 }
-rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports3.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -18753,18 +17304,12 @@ rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "M":
 after transform: SymbolId(12): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(12): Span { start: 167, end: 168 }
-rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesWithModule.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Symbol flags mismatch for "m":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m":
-after transform: SymbolId(0): Span { start: 28, end: 29 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "m":
 after transform: SymbolId(0): [Span { start: 28, end: 29 }, Span { start: 63, end: 64 }]
 rebuilt        : SymbolId(0): []
@@ -18774,9 +17319,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "m":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "m":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 45, end: 46 }]
 rebuilt        : SymbolId(0): []
@@ -18833,17 +17375,11 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpre
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorOverloads5.ts
 Symbol flags mismatch for "M":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol span mismatch for "f":
 after transform: SymbolId(1): Span { start: 27, end: 28 }
 rebuilt        : SymbolId(2): Span { start: 112, end: 113 }
@@ -20423,9 +18959,6 @@ rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch for "M":
 after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(6): Span { start: 103, end: 104 }
-rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnOptionalProperty.ts
 Bindings mismatch:
@@ -21194,27 +19727,15 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "M1":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M1":
-after transform: SymbolId(1): Span { start: 168, end: 170 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "M2":
 after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M2":
-after transform: SymbolId(4): Span { start: 250, end: 252 }
-rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 Symbol flags mismatch for "M3":
 after transform: SymbolId(12): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(15): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M3":
-after transform: SymbolId(12): Span { start: 511, end: 513 }
-rebuilt        : SymbolId(15): Span { start: 0, end: 0 }
 Symbol flags mismatch for "M4":
 after transform: SymbolId(14): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(18): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M4":
-after transform: SymbolId(14): Span { start: 546, end: 548 }
-rebuilt        : SymbolId(18): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/newOperator/newOperatorConformance.ts
 Bindings mismatch:
@@ -22749,33 +21270,18 @@ rebuilt        : SymbolId(19): ScopeId(9)
 Symbol flags mismatch for "m":
 after transform: SymbolId(21): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(21): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m":
-after transform: SymbolId(21): Span { start: 1655, end: 1656 }
-rebuilt        : SymbolId(21): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m2":
 after transform: SymbolId(23): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(24): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m2":
-after transform: SymbolId(23): Span { start: 1711, end: 1713 }
-rebuilt        : SymbolId(24): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m1":
 after transform: SymbolId(26): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(28): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m1":
-after transform: SymbolId(26): Span { start: 2025, end: 2027 }
-rebuilt        : SymbolId(28): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m2":
 after transform: SymbolId(28): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(31): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m2":
-after transform: SymbolId(28): Span { start: 2082, end: 2084 }
-rebuilt        : SymbolId(31): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m3":
 after transform: SymbolId(29): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(33): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "m3":
-after transform: SymbolId(29): Span { start: 2085, end: 2087 }
-rebuilt        : SymbolId(33): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_propertyValueConformance1.ts
 Bindings mismatch:
@@ -22818,27 +21324,18 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "M":
 after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(5): Span { start: 150, end: 151 }
-rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherType.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Symbol flags mismatch for "M":
 after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(5): Span { start: 150, end: 151 }
-rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/voidOperator/voidOperatorWithBooleanType.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Symbol flags mismatch for "M":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(3): Span { start: 179, end: 180 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/voidOperator/voidOperatorWithEnumType.ts
 Bindings mismatch:
@@ -22856,26 +21353,17 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "M":
 after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(4): Span { start: 199, end: 200 }
-rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/voidOperator/voidOperatorWithStringType.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Symbol flags mismatch for "M":
 after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(4): Span { start: 209, end: 210 }
-rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/asiPreventsParsingAsAmbientExternalModule02.ts
 Symbol flags mismatch for "container":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "container":
-after transform: SymbolId(2): Span { start: 52, end: 61 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/commonJSImportNotAsPrimaryExpression.ts
 Bindings mismatch:
@@ -22894,18 +21382,12 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "Foo":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Foo":
-after transform: SymbolId(0): Span { start: 10, end: 13 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(0): [Span { start: 10, end: 13 }, Span { start: 87, end: 90 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "Test":
 after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Test":
-after transform: SymbolId(5): Span { start: 157, end: 161 }
-rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportDeclaredModule.ts
 Bindings mismatch:
@@ -22928,9 +21410,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "M2":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M2":
-after transform: SymbolId(0): Span { start: 17, end: 19 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/topLevelAwait.2.ts
 Bindings mismatch:
@@ -22954,9 +21433,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModule
 Symbol flags mismatch for "types":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "types":
-after transform: SymbolId(0): Span { start: 17, end: 22 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeValueMerge1.ts
 Bindings mismatch:
@@ -23001,9 +21477,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModule
 Symbol flags mismatch for "ns":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "ns":
-after transform: SymbolId(0): Span { start: 17, end: 19 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "A":
 after transform: SymbolId(1): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
@@ -23040,9 +21513,6 @@ rebuilt        : SymbolId(3): []
 Symbol flags mismatch for "StepResult":
 after transform: SymbolId(28): SymbolFlags(TypeAlias | ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "StepResult":
-after transform: SymbolId(28): Span { start: 1257, end: 1267 }
-rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "StepResult":
 after transform: SymbolId(28): [Span { start: 1257, end: 1267 }, Span { start: 1321, end: 1331 }]
 rebuilt        : SymbolId(8): []
@@ -23149,9 +21619,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModule
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithStaticFunctionAndNonExportedFunctionThatShareAName.ts
 Symbol flags mismatch for "Point":
@@ -23163,9 +21630,6 @@ rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "A":
 after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(4): Span { start: 232, end: 233 }
-rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Point":
 after transform: SymbolId(5): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(Class)
@@ -23183,9 +21647,6 @@ rebuilt        : SymbolId(1): []
 Symbol flags mismatch for "A":
 after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(4): Span { start: 206, end: 207 }
-rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Point":
 after transform: SymbolId(5): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(Class)
@@ -23208,9 +21669,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModule
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ModuleAndEnumWithSameNameAndCommonRoot.ts
 Bindings mismatch:
@@ -23219,9 +21677,6 @@ rebuilt        : ScopeId(4): ["enumdule"]
 Symbol flags mismatch for "enumdule":
 after transform: SymbolId(0): SymbolFlags(RegularEnum | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "enumdule":
-after transform: SymbolId(0): Span { start: 10, end: 18 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "enumdule":
 after transform: SymbolId(0): [Span { start: 10, end: 18 }, Span { start: 121, end: 129 }]
 rebuilt        : SymbolId(0): []
@@ -23236,15 +21691,9 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Utils":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Utils":
-after transform: SymbolId(2): Span { start: 109, end: 114 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesThatMergeEachWithExportedInterfacesOfTheSameName.ts
 Bindings mismatch:
@@ -23255,35 +21704,20 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModule
 Symbol flags mismatch for "Root":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Root":
-after transform: SymbolId(0): Span { start: 10, end: 14 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "A":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(1): Span { start: 38, end: 39 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Utils":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Utils":
-after transform: SymbolId(3): Span { start: 157, end: 162 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesWithTheSameNameAndSameCommonRoot.ts
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Utils":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Utils":
-after transform: SymbolId(2): Span { start: 109, end: 114 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/codeGeneration/importStatements.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -23293,38 +21727,23 @@ rebuilt        : ScopeId(0): ["A", "C", "D", "E"]
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "A":
 after transform: SymbolId(0): [ReferenceId(1), ReferenceId(2), ReferenceId(5), ReferenceId(7), ReferenceId(14), ReferenceId(15)]
 rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(7), ReferenceId(10), ReferenceId(14)]
 Symbol flags mismatch for "C":
 after transform: SymbolId(7): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "C":
-after transform: SymbolId(7): Span { start: 291, end: 292 }
-rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 Symbol flags mismatch for "D":
 after transform: SymbolId(11): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "D":
-after transform: SymbolId(11): Span { start: 461, end: 462 }
-rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
 Symbol flags mismatch for "E":
 after transform: SymbolId(14): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "E":
-after transform: SymbolId(14): Span { start: 528, end: 529 }
-rebuilt        : SymbolId(14): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportClassWhichExtendsInterfaceWithInaccessibleType.ts
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportInterfaceWithAccessibleTypesInTypeParameterConstraintsClassHeritageListMemberTypeAnnotations.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -23332,9 +21751,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportInterfaceWithInaccessibleTypeInIndexerTypeAnnotations.ts
 Bindings mismatch:
@@ -23347,24 +21763,15 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportModuleWithAccessibleTypesOnItsExportedMembers.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "B":
 after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "B":
-after transform: SymbolId(4): Span { start: 128, end: 129 }
-rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportObjectLiteralAndObjectTypeLiteralWithAccessibleTypesInMemberTypeAnnotations.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -23372,18 +21779,12 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportVariableWithAccessibleTypeInTypeAnnotation.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportVariableWithInaccessibleTypeInTypeAnnotation.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -23391,9 +21792,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/importDeclarations/exportImportAlias.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -23404,21 +21802,12 @@ rebuilt        : ScopeId(1): ["Point", "_A", "x"]
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(0): Span { start: 36, end: 37 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "C":
 after transform: SymbolId(7): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "C":
-after transform: SymbolId(7): Span { start: 275, end: 276 }
-rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 Symbol flags mismatch for "X":
 after transform: SymbolId(12): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "X":
-after transform: SymbolId(12): Span { start: 439, end: 440 }
-rebuilt        : SymbolId(12): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Y":
 after transform: SymbolId(13): SymbolFlags(Function | ValueModule)
 rebuilt        : SymbolId(14): SymbolFlags(Function)
@@ -23428,15 +21817,9 @@ rebuilt        : SymbolId(14): []
 Symbol flags mismatch for "Z":
 after transform: SymbolId(17): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(19): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Z":
-after transform: SymbolId(17): Span { start: 642, end: 643 }
-rebuilt        : SymbolId(19): Span { start: 0, end: 0 }
 Symbol flags mismatch for "K":
 after transform: SymbolId(21): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(24): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "K":
-after transform: SymbolId(21): Span { start: 803, end: 804 }
-rebuilt        : SymbolId(24): Span { start: 0, end: 0 }
 Symbol flags mismatch for "L":
 after transform: SymbolId(22): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(26): SymbolFlags(Class)
@@ -23446,65 +21829,41 @@ rebuilt        : SymbolId(26): []
 Symbol flags mismatch for "M":
 after transform: SymbolId(26): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(30): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(26): Span { start: 1040, end: 1041 }
-rebuilt        : SymbolId(30): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/asiPreventsParsingAsNamespace03.ts
 Symbol flags mismatch for "container":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "container":
-after transform: SymbolId(2): Span { start: 49, end: 58 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/asiPreventsParsingAsNamespace05.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Symbol flags mismatch for "a":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "a":
-after transform: SymbolId(1): Span { start: 30, end: 31 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol flags mismatch for "b":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "b":
-after transform: SymbolId(2): Span { start: 32, end: 33 }
-rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/nestedModules.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(NamespaceModule | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "A":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 104, end: 105 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "B":
 after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "B":
-after transform: SymbolId(4): Span { start: 129, end: 130 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "M2":
 after transform: SymbolId(6): SymbolFlags(NamespaceModule | ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M2":
-after transform: SymbolId(6): Span { start: 238, end: 240 }
-rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "M2":
 after transform: SymbolId(6): [Span { start: 238, end: 240 }, Span { start: 323, end: 325 }]
 rebuilt        : SymbolId(5): []
 Symbol flags mismatch for "X":
 after transform: SymbolId(9): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "X":
-after transform: SymbolId(9): Span { start: 349, end: 350 }
-rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/reExportAliasMakesInstantiated.ts
 Bindings mismatch:
@@ -24136,9 +22495,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/statements/Var
 Symbol flags mismatch for "M":
 after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(6): Span { start: 201, end: 202 }
-rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsNamedEvaluationDecoratorsAndClassFields.ts
 Bindings mismatch:
@@ -24158,9 +22514,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/statements/thr
 Symbol flags mismatch for "M":
 after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(6): Span { start: 215, end: 216 }
-rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/conditional/inferTypes2.ts
 Bindings mismatch:
@@ -24969,9 +23322,6 @@ rebuilt        : ScopeId(31): ["e1"]
 Symbol flags mismatch for "M":
 after transform: SymbolId(35): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(34): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "M":
-after transform: SymbolId(35): Span { start: 962, end: 963 }
-rebuilt        : SymbolId(34): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m1":
 after transform: SymbolId(44): SymbolFlags(Function | ValueModule)
 rebuilt        : SymbolId(43): SymbolFlags(Function)
@@ -25433,15 +23783,9 @@ rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "Consts1":
 after transform: SymbolId(10): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Consts1":
-after transform: SymbolId(10): Span { start: 807, end: 814 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Consts2":
 after transform: SymbolId(21): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Consts2":
-after transform: SymbolId(21): Span { start: 1271, end: 1278 }
-rebuilt        : SymbolId(14): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloads02.ts
 Symbol span mismatch for "getFalsyPrimitive":
@@ -25453,15 +23797,9 @@ rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "Consts1":
 after transform: SymbolId(9): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Consts1":
-after transform: SymbolId(9): Span { start: 745, end: 752 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Consts2":
 after transform: SymbolId(20): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Consts2":
-after transform: SymbolId(20): Span { start: 1178, end: 1185 }
-rebuilt        : SymbolId(14): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloads04.ts
 Bindings mismatch:
@@ -25815,9 +24153,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeAlia
 Symbol flags mismatch for "container":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "container":
-after transform: SymbolId(3): Span { start: 42, end: 51 }
-rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/builtinIteratorReturn.ts
 Bindings mismatch:
@@ -26135,15 +24470,9 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRela
 Symbol flags mismatch for "SimpleTypes":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "SimpleTypes":
-after transform: SymbolId(0): Span { start: 149, end: 160 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol flags mismatch for "ObjectTypes":
 after transform: SymbolId(13): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(13): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "ObjectTypes":
-after transform: SymbolId(13): Span { start: 706, end: 717 }
-rebuilt        : SymbolId(13): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/intersectionIncludingPropFromGlobalAugmentation.ts
 Bindings mismatch:
@@ -26174,9 +24503,6 @@ rebuilt        : SymbolId(16): []
 Symbol flags mismatch for "WithContextualType":
 after transform: SymbolId(30): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(34): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "WithContextualType":
-after transform: SymbolId(30): Span { start: 1467, end: 1485 }
-rebuilt        : SymbolId(34): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/independentPropertyVariance.ts
 Bindings mismatch:
@@ -26289,9 +24615,6 @@ rebuilt        : ScopeId(1): ["_CallSignature", "r", "r2", "r3", "r4"]
 Symbol flags mismatch for "CallSignature":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "CallSignature":
-after transform: SymbolId(0): Span { start: 10, end: 23 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Reference symbol mismatch for "foo1":
 after transform: SymbolId(1) "foo1"
 rebuilt        : <None>
@@ -30808,15 +29131,9 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRela
 Symbol flags mismatch for "NonGenericParameter":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "NonGenericParameter":
-after transform: SymbolId(0): Span { start: 196, end: 215 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "GenericParameter":
 after transform: SymbolId(12): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "GenericParameter":
-after transform: SymbolId(12): Span { start: 458, end: 474 }
-rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericContextualTypes1.ts
 Bindings mismatch:

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1470,213 +1470,108 @@ rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "N":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "N":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "N":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "N":
-after transform: SymbolId(1): Span { start: 26, end: 27 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "constructor":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "constructor":
-after transform: SymbolId(3): Span { start: 50, end: 61 }
-rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol flags mismatch for "length":
 after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "length":
-after transform: SymbolId(5): Span { start: 84, end: 90 }
-rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
 Symbol flags mismatch for "concat":
 after transform: SymbolId(7): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "concat":
-after transform: SymbolId(7): Span { start: 113, end: 119 }
-rebuilt        : SymbolId(11): Span { start: 0, end: 0 }
 Symbol flags mismatch for "copyWithin":
 after transform: SymbolId(9): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "copyWithin":
-after transform: SymbolId(9): Span { start: 142, end: 152 }
-rebuilt        : SymbolId(14): Span { start: 0, end: 0 }
 Symbol flags mismatch for "fill":
 after transform: SymbolId(11): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(17): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "fill":
-after transform: SymbolId(11): Span { start: 175, end: 179 }
-rebuilt        : SymbolId(17): Span { start: 0, end: 0 }
 Symbol flags mismatch for "find":
 after transform: SymbolId(13): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "find":
-after transform: SymbolId(13): Span { start: 202, end: 206 }
-rebuilt        : SymbolId(20): Span { start: 0, end: 0 }
 Symbol flags mismatch for "findIndex":
 after transform: SymbolId(15): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(23): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "findIndex":
-after transform: SymbolId(15): Span { start: 229, end: 238 }
-rebuilt        : SymbolId(23): Span { start: 0, end: 0 }
 Symbol flags mismatch for "lastIndexOf":
 after transform: SymbolId(17): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(26): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "lastIndexOf":
-after transform: SymbolId(17): Span { start: 261, end: 272 }
-rebuilt        : SymbolId(26): Span { start: 0, end: 0 }
 Symbol flags mismatch for "pop":
 after transform: SymbolId(19): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(29): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "pop":
-after transform: SymbolId(19): Span { start: 295, end: 298 }
-rebuilt        : SymbolId(29): Span { start: 0, end: 0 }
 Symbol flags mismatch for "push":
 after transform: SymbolId(21): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(32): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "push":
-after transform: SymbolId(21): Span { start: 321, end: 325 }
-rebuilt        : SymbolId(32): Span { start: 0, end: 0 }
 Symbol flags mismatch for "reverse":
 after transform: SymbolId(23): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(35): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "reverse":
-after transform: SymbolId(23): Span { start: 348, end: 355 }
-rebuilt        : SymbolId(35): Span { start: 0, end: 0 }
 Symbol flags mismatch for "shift":
 after transform: SymbolId(25): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(38): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "shift":
-after transform: SymbolId(25): Span { start: 378, end: 383 }
-rebuilt        : SymbolId(38): Span { start: 0, end: 0 }
 Symbol flags mismatch for "unshift":
 after transform: SymbolId(27): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(41): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "unshift":
-after transform: SymbolId(27): Span { start: 406, end: 413 }
-rebuilt        : SymbolId(41): Span { start: 0, end: 0 }
 Symbol flags mismatch for "slice":
 after transform: SymbolId(29): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(44): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "slice":
-after transform: SymbolId(29): Span { start: 436, end: 441 }
-rebuilt        : SymbolId(44): Span { start: 0, end: 0 }
 Symbol flags mismatch for "sort":
 after transform: SymbolId(31): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(47): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "sort":
-after transform: SymbolId(31): Span { start: 464, end: 468 }
-rebuilt        : SymbolId(47): Span { start: 0, end: 0 }
 Symbol flags mismatch for "splice":
 after transform: SymbolId(33): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(50): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "splice":
-after transform: SymbolId(33): Span { start: 491, end: 497 }
-rebuilt        : SymbolId(50): Span { start: 0, end: 0 }
 Symbol flags mismatch for "includes":
 after transform: SymbolId(35): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(53): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "includes":
-after transform: SymbolId(35): Span { start: 520, end: 528 }
-rebuilt        : SymbolId(53): Span { start: 0, end: 0 }
 Symbol flags mismatch for "indexOf":
 after transform: SymbolId(37): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(56): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "indexOf":
-after transform: SymbolId(37): Span { start: 551, end: 558 }
-rebuilt        : SymbolId(56): Span { start: 0, end: 0 }
 Symbol flags mismatch for "join":
 after transform: SymbolId(39): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(59): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "join":
-after transform: SymbolId(39): Span { start: 581, end: 585 }
-rebuilt        : SymbolId(59): Span { start: 0, end: 0 }
 Symbol flags mismatch for "keys":
 after transform: SymbolId(41): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(62): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "keys":
-after transform: SymbolId(41): Span { start: 608, end: 612 }
-rebuilt        : SymbolId(62): Span { start: 0, end: 0 }
 Symbol flags mismatch for "entries":
 after transform: SymbolId(43): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(65): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "entries":
-after transform: SymbolId(43): Span { start: 635, end: 642 }
-rebuilt        : SymbolId(65): Span { start: 0, end: 0 }
 Symbol flags mismatch for "values":
 after transform: SymbolId(45): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(68): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "values":
-after transform: SymbolId(45): Span { start: 665, end: 671 }
-rebuilt        : SymbolId(68): Span { start: 0, end: 0 }
 Symbol flags mismatch for "forEach":
 after transform: SymbolId(47): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(71): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "forEach":
-after transform: SymbolId(47): Span { start: 694, end: 701 }
-rebuilt        : SymbolId(71): Span { start: 0, end: 0 }
 Symbol flags mismatch for "filter":
 after transform: SymbolId(49): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(74): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "filter":
-after transform: SymbolId(49): Span { start: 724, end: 730 }
-rebuilt        : SymbolId(74): Span { start: 0, end: 0 }
 Symbol flags mismatch for "map":
 after transform: SymbolId(51): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(77): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "map":
-after transform: SymbolId(51): Span { start: 753, end: 756 }
-rebuilt        : SymbolId(77): Span { start: 0, end: 0 }
 Symbol flags mismatch for "every":
 after transform: SymbolId(53): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(80): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "every":
-after transform: SymbolId(53): Span { start: 779, end: 784 }
-rebuilt        : SymbolId(80): Span { start: 0, end: 0 }
 Symbol flags mismatch for "some":
 after transform: SymbolId(55): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(83): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "some":
-after transform: SymbolId(55): Span { start: 807, end: 811 }
-rebuilt        : SymbolId(83): Span { start: 0, end: 0 }
 Symbol flags mismatch for "reduce":
 after transform: SymbolId(57): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(86): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "reduce":
-after transform: SymbolId(57): Span { start: 834, end: 840 }
-rebuilt        : SymbolId(86): Span { start: 0, end: 0 }
 Symbol flags mismatch for "reduceRight":
 after transform: SymbolId(59): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(89): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "reduceRight":
-after transform: SymbolId(59): Span { start: 863, end: 874 }
-rebuilt        : SymbolId(89): Span { start: 0, end: 0 }
 Symbol flags mismatch for "toLocaleString":
 after transform: SymbolId(61): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(92): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "toLocaleString":
-after transform: SymbolId(61): Span { start: 897, end: 911 }
-rebuilt        : SymbolId(92): Span { start: 0, end: 0 }
 Symbol flags mismatch for "toString":
 after transform: SymbolId(63): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(95): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "toString":
-after transform: SymbolId(63): Span { start: 934, end: 942 }
-rebuilt        : SymbolId(95): Span { start: 0, end: 0 }
 Symbol flags mismatch for "flat":
 after transform: SymbolId(65): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(98): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "flat":
-after transform: SymbolId(65): Span { start: 965, end: 969 }
-rebuilt        : SymbolId(98): Span { start: 0, end: 0 }
 Symbol flags mismatch for "flatMap":
 after transform: SymbolId(67): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(101): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "flatMap":
-after transform: SymbolId(67): Span { start: 992, end: 999 }
-rebuilt        : SymbolId(101): Span { start: 0, end: 0 }
 
 * namespace/declare/input.ts
 Bindings mismatch:
@@ -1685,17 +1580,11 @@ rebuilt        : ScopeId(1): ["_N"]
 Symbol flags mismatch for "N":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "N":
-after transform: SymbolId(0): Span { start: 17, end: 18 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 * namespace/declare-global-nested-namespace/input.ts
 Symbol flags mismatch for "X":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "X":
-after transform: SymbolId(2): Span { start: 70, end: 71 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 * namespace/empty-removed/input.ts
 Bindings mismatch:
@@ -1710,77 +1599,44 @@ rebuilt        : ScopeId(4): ["_d"]
 Symbol flags mismatch for "a":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "a":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "a":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(4), ReferenceId(5)]
 rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3)]
 Symbol flags mismatch for "c":
 after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "c":
-after transform: SymbolId(2): Span { start: 43, end: 44 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "WithTypes":
 after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "WithTypes":
-after transform: SymbolId(6): Span { start: 107, end: 116 }
-rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol flags mismatch for "d":
 after transform: SymbolId(13): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "d":
-after transform: SymbolId(13): Span { start: 224, end: 225 }
-rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
 Symbol flags mismatch for "WithValues":
 after transform: SymbolId(15): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "WithValues":
-after transform: SymbolId(15): Span { start: 262, end: 272 }
-rebuilt        : SymbolId(9): Span { start: 0, end: 0 }
 Symbol flags mismatch for "a":
 after transform: SymbolId(16): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "a":
-after transform: SymbolId(16): Span { start: 287, end: 288 }
-rebuilt        : SymbolId(11): Span { start: 0, end: 0 }
 Symbol flags mismatch for "b":
 after transform: SymbolId(18): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "b":
-after transform: SymbolId(18): Span { start: 316, end: 317 }
-rebuilt        : SymbolId(14): Span { start: 0, end: 0 }
 Symbol flags mismatch for "B":
 after transform: SymbolId(19): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "c":
 after transform: SymbolId(20): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(18): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "c":
-after transform: SymbolId(20): Span { start: 344, end: 345 }
-rebuilt        : SymbolId(18): Span { start: 0, end: 0 }
 Symbol flags mismatch for "d":
 after transform: SymbolId(22): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(21): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "d":
-after transform: SymbolId(22): Span { start: 378, end: 379 }
-rebuilt        : SymbolId(21): Span { start: 0, end: 0 }
 Symbol flags mismatch for "e":
 after transform: SymbolId(24): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(24): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "e":
-after transform: SymbolId(24): Span { start: 402, end: 403 }
-rebuilt        : SymbolId(24): Span { start: 0, end: 0 }
 
 * namespace/export/input.ts
 Symbol flags mismatch for "N":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "N":
-after transform: SymbolId(0): Span { start: 17, end: 18 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 * namespace/export-type-only/input.ts
 Bindings mismatch:
@@ -1791,9 +1647,6 @@ rebuilt        : ScopeId(0): []
 Symbol flags mismatch for "N":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "N":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "N":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 33, end: 34 }]
 rebuilt        : SymbolId(0): []
@@ -1838,9 +1691,6 @@ rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "C":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "C":
-after transform: SymbolId(1): Span { start: 45, end: 46 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "M":
 after transform: SymbolId(4): SymbolFlags(Function | ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(Function)
@@ -1865,9 +1715,6 @@ rebuilt        : SymbolId(14): []
 Symbol flags mismatch for "G":
 after transform: SymbolId(14): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(17): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "G":
-after transform: SymbolId(14): Span { start: 350, end: 351 }
-rebuilt        : SymbolId(17): Span { start: 0, end: 0 }
 Symbol flags mismatch for "L":
 after transform: SymbolId(16): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
@@ -1882,9 +1729,6 @@ rebuilt        : ScopeId(2): ["G"]
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "A":
-after transform: SymbolId(0): Span { start: 17, end: 18 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "G":
 after transform: SymbolId(3): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
@@ -1893,59 +1737,32 @@ rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "X":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "X":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Y":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Y":
-after transform: SymbolId(1): Span { start: 12, end: 13 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "proj":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "proj":
-after transform: SymbolId(3): Span { start: 51, end: 55 }
-rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol flags mismatch for "data":
 after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "data":
-after transform: SymbolId(4): Span { start: 56, end: 60 }
-rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
 Symbol flags mismatch for "util":
 after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "util":
-after transform: SymbolId(5): Span { start: 61, end: 65 }
-rebuilt        : SymbolId(9): Span { start: 0, end: 0 }
 Symbol flags mismatch for "api":
 after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "api":
-after transform: SymbolId(6): Span { start: 66, end: 69 }
-rebuilt        : SymbolId(11): Span { start: 0, end: 0 }
 
 * namespace/same-name/input.ts
 Symbol flags mismatch for "N":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "N":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "_N7":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "_N7":
-after transform: SymbolId(1): Span { start: 26, end: 29 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "N":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "N":
-after transform: SymbolId(3): Span { start: 59, end: 60 }
-rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "N":
 after transform: SymbolId(3): [Span { start: 59, end: 60 }, Span { start: 115, end: 116 }, Span { start: 166, end: 167 }]
 rebuilt        : SymbolId(5): []
@@ -1957,9 +1774,6 @@ rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "N":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "N":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 * optimize-const-enums/custom-values-exported/input.ts
 x Output mismatch

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -254,9 +254,6 @@ rebuilt        : ScopeId(0): ["Bar", "Foo", "Func", "Im", "Name", "Ok", "T"]
 Symbol flags mismatch for "Name":
 after transform: SymbolId(7): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Name":
-after transform: SymbolId(7): Span { start: 116, end: 120 }
-rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol flags mismatch for "T":
 after transform: SymbolId(9): SymbolFlags(Function | TypeAlias)
 rebuilt        : SymbolId(8): SymbolFlags(Function)
@@ -271,9 +268,6 @@ rebuilt        : SymbolId(8): []
 Symbol flags mismatch for "N1":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "N1":
-after transform: SymbolId(1): Span { start: 31, end: 33 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 
 * namespace/import-=/input.ts
 Symbol reference IDs mismatch for "A":
@@ -282,29 +276,17 @@ rebuilt        : SymbolId(0): [ReferenceId(2)]
 Symbol flags mismatch for "N1":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "N1":
-after transform: SymbolId(1): Span { start: 31, end: 33 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol flags mismatch for "N2":
 after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "N2":
-after transform: SymbolId(4): Span { start: 130, end: 132 }
-rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 
 * namespace/preserve-import-=/input.ts
 Symbol flags mismatch for "N1":
 after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "N1":
-after transform: SymbolId(1): Span { start: 34, end: 36 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol flags mismatch for "N2":
 after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "N2":
-after transform: SymbolId(4): Span { start: 145, end: 147 }
-rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 
 * namespace/redeclaration-with-enum/input.ts
 Bindings mismatch:
@@ -313,9 +295,6 @@ rebuilt        : ScopeId(2): ["x"]
 Symbol flags mismatch for "x":
 after transform: SymbolId(0): SymbolFlags(RegularEnum | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "x":
-after transform: SymbolId(0): Span { start: 10, end: 11 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "x":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 39, end: 40 }]
 rebuilt        : SymbolId(0): []
@@ -333,9 +312,6 @@ rebuilt        : ScopeId(0): ["Foo"]
 Symbol flags mismatch for "Foo":
 after transform: SymbolId(0): SymbolFlags(Interface | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Foo":
-after transform: SymbolId(0): Span { start: 17, end: 20 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(0): [Span { start: 17, end: 20 }, Span { start: 41, end: 44 }]
 rebuilt        : SymbolId(0): []
@@ -347,9 +323,6 @@ rebuilt        : ScopeId(0): ["Foo"]
 Symbol flags mismatch for "Foo":
 after transform: SymbolId(0): SymbolFlags(TypeAlias | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Foo":
-after transform: SymbolId(0): Span { start: 12, end: 15 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(0): [Span { start: 12, end: 15 }, Span { start: 39, end: 42 }, Span { start: 87, end: 90 }]
 rebuilt        : SymbolId(0): []
@@ -358,9 +331,6 @@ rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "Foo":
 after transform: SymbolId(0): SymbolFlags(NamespaceModule | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol span mismatch for "Foo":
-after transform: SymbolId(0): Span { start: 17, end: 20 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(0): [Span { start: 17, end: 20 }, Span { start: 62, end: 65 }]
 rebuilt        : SymbolId(0): []


### PR DESCRIPTION
## Summary

- preserve source spans when TypeScript namespace declarations are lowered to variable bindings
- update semantic coverage snapshots, removing stale `Span { start: 0, end: 0 }` mismatches