### PR TITLE
fix(transformer): correct symbol flags for lowered namespaces

### DIFF
--- a/crates/oxc_transformer/src/typescript/namespace.rs
+++ b/crates/oxc_transformer/src/typescript/namespace.rs
@@ -5,7 +5,7 @@ use oxc_span::{SPAN, Span};
 use oxc_syntax::{
     operator::{AssignmentOperator, LogicalOperator},
     scope::{ScopeFlags, ScopeId},
-    symbol::SymbolFlags,
+    symbol::{SymbolFlags, SymbolId},
 };
 use oxc_traverse::{BoundIdentifier, Traverse};
 
@@ -19,11 +19,30 @@ use super::{
 pub struct TypeScriptNamespace {
     // Options
     allow_namespaces: bool,
+    pending_symbol_flags: Vec<(SymbolId, SymbolFlags)>,
 }
 
 impl TypeScriptNamespace {
     pub fn new(options: &TypeScriptOptions) -> Self {
-        Self { allow_namespaces: options.allow_namespaces }
+        Self { allow_namespaces: options.allow_namespaces, pending_symbol_flags: Vec::new() }
+    }
+
+    fn pending_symbol_flags_mut(
+        &mut self,
+        symbol_id: SymbolId,
+        initial_flags: SymbolFlags,
+    ) -> &mut SymbolFlags {
+        if let Some(index) = self.pending_symbol_flags.iter().position(|&(id, _)| id == symbol_id) {
+            return &mut self.pending_symbol_flags[index].1;
+        }
+        self.pending_symbol_flags.push((symbol_id, initial_flags));
+        &mut self.pending_symbol_flags.last_mut().unwrap().1
+    }
+
+    fn apply_pending_symbol_flags(&mut self, ctx: &mut TraverseCtx<'_>) {
+        for (symbol_id, flags) in self.pending_symbol_flags.drain(..) {
+            *ctx.scoping_mut().symbol_flags_mut(symbol_id) = flags;
+        }
     }
 }
 
@@ -85,13 +104,13 @@ impl<'a> Traverse<'a, TransformState<'a>> for TypeScriptNamespace {
         }
 
         program.body = new_stmts;
+        self.apply_pending_symbol_flags(ctx);
     }
 }
 
 impl<'a> TypeScriptNamespace {
-    #[expect(clippy::self_only_used_in_recursion)]
     fn handle_nested(
-        &self,
+        &mut self,
         decl: ArenaBox<'a, TSModuleDeclaration<'a>>,
         is_export: bool,
         parent_stmts: &mut ArenaVec<'a, Statement<'a>>,
@@ -281,10 +300,16 @@ impl<'a> TypeScriptNamespace {
             }
         }
 
-        if !Self::is_redeclaration_namespace(&ident, ctx) {
-            let binding_span = ident.span;
-            ctx.scoping_mut().set_symbol_span(binding.symbol_id, binding_span);
-            let declaration = Self::create_variable_declaration(&binding, span, binding_span, ctx);
+        if Self::is_redeclaration_namespace(&ident, ctx) {
+            let symbol_id = ident.symbol_id();
+            let initial_flags = ctx.scoping().symbol_flags(symbol_id);
+            let flags = self.pending_symbol_flags_mut(symbol_id, initial_flags);
+            *flags -= SymbolFlags::ValueModule | SymbolFlags::NamespaceModule;
+        } else {
+            *self.pending_symbol_flags_mut(binding.symbol_id, SymbolFlags::BlockScopedVariable) =
+                SymbolFlags::BlockScopedVariable;
+            ctx.scoping_mut().set_symbol_span(binding.symbol_id, ident.span);
+            let declaration = Self::create_variable_declaration(&binding, span, ident.span, ctx);
             if is_export {
                 let export_named_decl =
                     ExportNamedDeclaration::boxed_plain_declaration(span, declaration, ctx);

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -2,7 +2,7 @@ commit: 1fb0b771
 
 semantic_babel Summary:
 AST Parsed     : 2236/2236 (100.00%)
-Positive Passed: 2129/2236 (95.21%)
+Positive Passed: 2131/2236 (95.30%)
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/decorators/decorators-after-export/input.js
 Symbol flags mismatch for "_default":
 after transform: SymbolId(3): SymbolFlags(Class)
@@ -310,11 +310,6 @@ Symbol flags mismatch for "D":
 after transform: SymbolId(3): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/export/nested-same-name/input.ts
-Symbol flags mismatch for "N":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/function/declare/input.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["f"]
@@ -338,11 +333,6 @@ Bindings mismatch:
 after transform: ScopeId(0): ["B", "b"]
 rebuilt        : ScopeId(0): []
 
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/body/input.ts
-Symbol flags mismatch for "N":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/body-declare/input.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["N"]
@@ -363,12 +353,6 @@ rebuilt        : ScopeId(0): []
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/body-export-named-declaration/input.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "N":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "X":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/body-import-equals-internal/input.ts
 Bindings mismatch:
@@ -487,9 +471,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Bindings mismatch:
 after transform: ScopeId(0): ["bar", "foo"]
 rebuilt        : ScopeId(0): ["bar"]
-Symbol flags mismatch for "bar":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-class-interface/input.ts
 Bindings mismatch:

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -2,7 +2,7 @@ commit: 7964e22f
 
 semantic_typescript Summary:
 AST Parsed     : 4720/4720 (100.00%)
-Positive Passed: 3251/4720 (68.88%)
+Positive Passed: 3349/4720 (70.95%)
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/APISample_Watch.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["console", "formatHost", "os", "process", "reportDiagnostic", "reportWatchStatusChanged", "ts", "watchMain"]
@@ -172,25 +172,11 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/acceptableAlias1.
 Bindings mismatch:
 after transform: ScopeId(1): ["N", "X", "_M"]
 rebuilt        : ScopeId(1): ["X", "_M"]
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/aliasInaccessibleModule.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["N", "X", "_M"]
 rebuilt        : ScopeId(1): ["X", "_M"]
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/aliasInaccessibleModule2.ts
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "N":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImportsCanPaintCrossModuleDeclaration.ts
 Bindings mismatch:
@@ -201,9 +187,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/ambientClassDecla
 Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "D", "d"]
 rebuilt        : ScopeId(0): ["D", "d"]
-Symbol flags mismatch for "D":
-after transform: SymbolId(3): SymbolFlags(Class | ValueModule | Ambient)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "D":
 after transform: SymbolId(3): [Span { start: 97, end: 98 }, Span { start: 124, end: 125 }]
 rebuilt        : SymbolId(0): []
@@ -343,11 +326,6 @@ Unresolved references mismatch:
 after transform: ["require"]
 rebuilt        : ["f", "require"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/anonterface.ts
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/anyAndUnknownHaveFalsyComponents.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["_objectSpread", "foo1", "foo2", "isTreeHeader1", "isTreeHeader2", "x1", "x2", "y1", "y2"]
@@ -416,11 +394,6 @@ Bindings mismatch:
 after transform: ScopeId(0): ["Data", "WinJS"]
 rebuilt        : ScopeId(0): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionInExpressionStatement2.ts
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["a", "test", "value"]
@@ -454,11 +427,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["assertEqual"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/assign1.ts
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/assignToPrototype1.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["Point"]
@@ -482,83 +450,35 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompata
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "__test1__":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "__test2__":
-after transform: SymbolId(6): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability10.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "__test1__":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "__test2__":
-after transform: SymbolId(6): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability3.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "__test1__":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "__test2__":
-after transform: SymbolId(6): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability5.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "__test1__":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "__test2__":
-after transform: SymbolId(6): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability6.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "__test1__":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "__test2__":
-after transform: SymbolId(6): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability7.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "__test1__":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "__test2__":
-after transform: SymbolId(6): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability8.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "__test1__":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "__test2__":
-after transform: SymbolId(6): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability9.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "__test1__":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "__test2__":
-after transform: SymbolId(6): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/assignmentNonObjectTypeConstraints.ts
 Bindings mismatch:
@@ -636,33 +556,21 @@ rebuilt        : ["arguments", "authorPromise", "g", "mapper", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals3.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "foo":
-after transform: SymbolId(0): SymbolFlags(Function | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(Function)
 Symbol redeclarations mismatch for "foo":
 after transform: SymbolId(0): [Span { start: 9, end: 12 }, Span { start: 28, end: 31 }]
 rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals4.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "foo":
-after transform: SymbolId(0): SymbolFlags(Class | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(Class)
 Symbol redeclarations mismatch for "foo":
 after transform: SymbolId(0): [Span { start: 6, end: 9 }, Span { start: 23, end: 26 }]
 rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals6.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "foo":
-after transform: SymbolId(0): SymbolFlags(Class | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(Class)
 Symbol redeclarations mismatch for "foo":
 after transform: SymbolId(0): [Span { start: 6, end: 9 }, Span { start: 23, end: 26 }]
 rebuilt        : SymbolId(0): []
-Symbol flags mismatch for "B":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/augmentedTypesClass3.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -672,15 +580,9 @@ rebuilt        : SymbolId(0): SymbolFlags(Class)
 Symbol redeclarations mismatch for "c5":
 after transform: SymbolId(0): [Span { start: 27, end: 29 }, Span { start: 61, end: 63 }]
 rebuilt        : SymbolId(0): []
-Symbol flags mismatch for "c5a":
-after transform: SymbolId(1): SymbolFlags(Class | ValueModule)
-rebuilt        : SymbolId(1): SymbolFlags(Class)
 Symbol redeclarations mismatch for "c5a":
 after transform: SymbolId(1): [Span { start: 91, end: 94 }, Span { start: 126, end: 129 }]
 rebuilt        : SymbolId(1): []
-Symbol flags mismatch for "c5b":
-after transform: SymbolId(3): SymbolFlags(Class | ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(Class)
 Symbol redeclarations mismatch for "c5b":
 after transform: SymbolId(3): [Span { start: 168, end: 171 }, Span { start: 203, end: 206 }]
 rebuilt        : SymbolId(4): []
@@ -692,21 +594,12 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Bindings mismatch:
 after transform: ScopeId(0): ["m3b", "m3c", "m3d", "m3e", "m3f", "m3g"]
 rebuilt        : ScopeId(0): ["m3b", "m3c", "m3e"]
-Symbol flags mismatch for "m3b":
-after transform: SymbolId(0): SymbolFlags(Class | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(Class)
 Symbol redeclarations mismatch for "m3b":
 after transform: SymbolId(0): [Span { start: 6, end: 9 }, Span { start: 34, end: 37 }]
 rebuilt        : SymbolId(0): []
-Symbol flags mismatch for "m3c":
-after transform: SymbolId(2): SymbolFlags(Class | ValueModule)
-rebuilt        : SymbolId(3): SymbolFlags(Class)
 Symbol redeclarations mismatch for "m3c":
 after transform: SymbolId(2): [Span { start: 60, end: 63 }, Span { start: 88, end: 91 }]
 rebuilt        : SymbolId(3): []
-Symbol flags mismatch for "m3e":
-after transform: SymbolId(6): SymbolFlags(Class | ValueModule | Ambient)
-rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "m3e":
 after transform: SymbolId(6): [Span { start: 198, end: 201 }, Span { start: 239, end: 242 }]
 rebuilt        : SymbolId(8): []
@@ -744,27 +637,15 @@ rebuilt        : ScopeId(6): ["m4c"]
 Bindings mismatch:
 after transform: ScopeId(14): ["One", "m4d"]
 rebuilt        : ScopeId(10): ["m4d"]
-Symbol flags mismatch for "m4a":
-after transform: SymbolId(1): SymbolFlags(RegularEnum | ValueModule)
-rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "m4a":
 after transform: SymbolId(1): [Span { start: 80, end: 83 }, Span { start: 104, end: 107 }]
 rebuilt        : SymbolId(1): []
-Symbol flags mismatch for "m4b":
-after transform: SymbolId(4): SymbolFlags(RegularEnum | ValueModule)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "m4b":
 after transform: SymbolId(4): [Span { start: 127, end: 130 }, Span { start: 158, end: 161 }]
 rebuilt        : SymbolId(5): []
-Symbol flags mismatch for "m4d":
-after transform: SymbolId(10): SymbolFlags(RegularEnum | ValueModule)
-rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "m4d":
 after transform: SymbolId(10): [Span { start: 245, end: 248 }, Span { start: 280, end: 283 }]
 rebuilt        : SymbolId(10): []
-Symbol flags mismatch for "m5":
-after transform: SymbolId(13): SymbolFlags(NamespaceModule | ValueModule)
-rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "m5":
 after transform: SymbolId(13): [Span { start: 328, end: 330 }, Span { start: 363, end: 365 }]
 rebuilt        : SymbolId(14): []
@@ -855,9 +736,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/binopAssignmentSh
 Bindings mismatch:
 after transform: ScopeId(0): ["Test", "console"]
 rebuilt        : ScopeId(0): ["Test"]
-Symbol flags mismatch for "Test":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Reference symbol mismatch for "console":
 after transform: SymbolId(0) "console"
 rebuilt        : <None>
@@ -1165,11 +1043,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["A", "a"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/chainedImportAlias.ts
-Symbol flags mismatch for "m":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/checkInfiniteExpansionTermination2.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["combineLatest", "fn"]
@@ -1237,9 +1110,6 @@ after transform: []
 rebuilt        : ["foo2"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/circularTypeofWithFunctionModule.ts
-Symbol flags mismatch for "maker":
-after transform: SymbolId(1): SymbolFlags(Function | ValueModule)
-rebuilt        : SymbolId(1): SymbolFlags(Function)
 Symbol redeclarations mismatch for "maker":
 after transform: SymbolId(1): [Span { start: 44, end: 49 }, Span { start: 121, end: 126 }]
 rebuilt        : SymbolId(1): []
@@ -1257,15 +1127,9 @@ rebuilt        : ["connect"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/classDeclarationMergedInModuleWithContinuation.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 107, end: 108 }]
 rebuilt        : SymbolId(0): []
-Symbol flags mismatch for "N":
-after transform: SymbolId(1): SymbolFlags(Class | ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(Class)
 Symbol redeclarations mismatch for "N":
 after transform: SymbolId(1): [Span { start: 31, end: 32 }, Span { start: 58, end: 59 }]
 rebuilt        : SymbolId(2): []
@@ -1280,11 +1144,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["require"]
 rebuilt        : ["console", "require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/classExtendingQualifiedName2.ts
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/classFunctionMerging.ts
 Bindings mismatch:
@@ -1315,9 +1174,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/classImplementsIm
 Bindings mismatch:
 after transform: ScopeId(0): ["M1", "M2"]
 rebuilt        : ScopeId(0): ["M2"]
-Symbol flags mismatch for "M2":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Unresolved references mismatch:
 after transform: ["M1"]
 rebuilt        : []
@@ -1416,20 +1272,11 @@ rebuilt        : ["callme"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/cloduleAcrossModuleDefinitions.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "A":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 97, end: 98 }]
 rebuilt        : SymbolId(0): []
-Symbol flags mismatch for "B":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/cloduleAndTypeParameters.ts
-Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(Class | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(Class)
 Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(0): [Span { start: 6, end: 9 }, Span { start: 66, end: 69 }]
 rebuilt        : SymbolId(0): []
@@ -1449,9 +1296,6 @@ after transform: []
 rebuilt        : ["$"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/cloduleWithPriorUninstantiatedModule.ts
-Symbol flags mismatch for "Moclodule":
-after transform: SymbolId(0): SymbolFlags(Class | NamespaceModule | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(Class)
 Symbol span mismatch for "Moclodule":
 after transform: SymbolId(0): Span { start: 50, end: 59 }
 rebuilt        : SymbolId(0): Span { start: 135, end: 144 }
@@ -1461,12 +1305,6 @@ rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/cloduleWithRecursiveReference.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "C":
-after transform: SymbolId(1): SymbolFlags(Class | ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(Class)
 Symbol redeclarations mismatch for "C":
 after transform: SymbolId(1): [Span { start: 29, end: 30 }, Span { start: 55, end: 56 }]
 rebuilt        : SymbolId(2): []
@@ -1750,18 +1588,12 @@ rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithAccessorChildren.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 141, end: 142 }, Span { start: 274, end: 275 }, Span { start: 401, end: 402 }, Span { start: 512, end: 513 }]
 rebuilt        : SymbolId(1): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithConstructorChildren.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 111, end: 112 }, Span { start: 198, end: 199 }]
 rebuilt        : SymbolId(0): []
@@ -1770,101 +1602,39 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenM
 Bindings mismatch:
 after transform: ScopeId(2): ["e", "m1", "m2"]
 rebuilt        : ScopeId(2): ["e"]
-Symbol flags mismatch for "m1":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "e":
 after transform: SymbolId(1): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithFunctionChildren.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 79, end: 80 }, Span { start: 157, end: 158 }]
 rebuilt        : SymbolId(0): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithMemberClassConflict.ts
-Symbol flags mismatch for "m1":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m2":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithMemberInterfaceConflict.ts
-Symbol flags mismatch for "m1":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithMemberVariable.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "m1":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithMethodChildren.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 94, end: 95 }, Span { start: 199, end: 200 }, Span { start: 330, end: 331 }]
 rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithModuleChildren.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 113, end: 114 }, Span { start: 228, end: 229 }, Span { start: 344, end: 345 }, Span { start: 474, end: 475 }]
 rebuilt        : SymbolId(0): []
-Symbol flags mismatch for "m1":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m2":
-after transform: SymbolId(5): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m3":
-after transform: SymbolId(9): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m3":
-after transform: SymbolId(13): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m4":
-after transform: SymbolId(17): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(25): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "M":
-after transform: SymbolId(18): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(27): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithModuleReopening.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "m1":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "m1":
 after transform: SymbolId(0): [Span { start: 10, end: 12 }, Span { start: 78, end: 80 }]
 rebuilt        : SymbolId(0): []
-Symbol flags mismatch for "m2":
-after transform: SymbolId(7): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "m2":
 after transform: SymbolId(7): [Span { start: 192, end: 194 }, Span { start: 308, end: 310 }]
 rebuilt        : SymbolId(9): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithPrivateMember.ts
-Symbol flags mismatch for "m1":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithUnicodeNames.ts
-Symbol flags mismatch for "才能ソЫⅨ蒤郳र\u{94d}क\u{94d}ड\u{94d}राüışğİliيونيكودöÄüß才能ソЫⅨ蒤郳र\u{94d}क\u{94d}ड\u{94d}राüışğİliيونيكودöÄüßAbcd123":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAmbientClass.ts
 Bindings mismatch:
@@ -1873,9 +1643,6 @@ rebuilt        : ScopeId(0): ["m2"]
 Bindings mismatch:
 after transform: ScopeId(6): ["_m", "exports", "require"]
 rebuilt        : ScopeId(1): ["_m"]
-Symbol flags mismatch for "m2":
-after transform: SymbolId(5): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAmbientEnum.ts
 Bindings mismatch:
@@ -1884,9 +1651,6 @@ rebuilt        : ScopeId(0): ["m2"]
 Bindings mismatch:
 after transform: ScopeId(6): ["_m", "exports", "require"]
 rebuilt        : ScopeId(1): ["_m"]
-Symbol flags mismatch for "m2":
-after transform: SymbolId(13): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAmbientFunction.ts
 Bindings mismatch:
@@ -1895,9 +1659,6 @@ rebuilt        : ScopeId(0): ["m2"]
 Bindings mismatch:
 after transform: ScopeId(6): ["_m", "a", "exports", "require"]
 rebuilt        : ScopeId(1): ["_m", "a"]
-Symbol flags mismatch for "m2":
-after transform: SymbolId(5): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAmbientFunctionInGlobalFile.ts
 Bindings mismatch:
@@ -1906,9 +1667,6 @@ rebuilt        : ScopeId(0): ["m4"]
 Bindings mismatch:
 after transform: ScopeId(6): ["_m", "a", "exports", "require"]
 rebuilt        : ScopeId(1): ["_m", "a"]
-Symbol flags mismatch for "m4":
-after transform: SymbolId(5): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAmbientVar.ts
 Bindings mismatch:
@@ -1917,28 +1675,6 @@ rebuilt        : ScopeId(0): ["m2"]
 Bindings mismatch:
 after transform: ScopeId(2): ["_m", "a", "exports", "require"]
 rebuilt        : ScopeId(1): ["_m", "a"]
-Symbol flags mismatch for "m2":
-after transform: SymbolId(5): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndFunctionInGlobalFile.ts
-Symbol flags mismatch for "m3":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m4":
-after transform: SymbolId(5): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndInternalModuleAliasInGlobalFile.ts
-Symbol flags mismatch for "mOfGloalFile":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m1":
-after transform: SymbolId(4): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m2":
-after transform: SymbolId(7): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterClassConstructor.ts
 Bindings mismatch:
@@ -1994,9 +1730,6 @@ rebuilt        : ["console"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndAliasInGlobal.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "a":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndAmbientClassInGlobal.ts
 Bindings mismatch:
@@ -2042,11 +1775,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["alert"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndModuleInGlobal.ts
-Symbol flags mismatch for "_this":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndParameter.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "Foo1", "Foo2", "Foo3", "Foo4", "console", "f1", "f2", "f3", "f4"]
@@ -2071,20 +1799,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/commentEmitAtEndO
 Bindings mismatch:
 after transform: ScopeId(0): ["empty", "f", "foo"]
 rebuilt        : ScopeId(0): ["f", "foo"]
-Symbol flags mismatch for "foo":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/commentInNamespaceDeclarationWithIdentifierPathName.ts
-Symbol flags mismatch for "hello":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "hi":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "world":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/commentLeadingCloseBrace.ts
 Bindings mismatch:
@@ -2200,30 +1914,6 @@ rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/complexNarrowingWithAny.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "import44":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "import45":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "import46":
-after transform: SymbolId(8): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "import47":
-after transform: SymbolId(11): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(15): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "import48":
-after transform: SymbolId(14): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(19): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "import49":
-after transform: SymbolId(17): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(23): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "import50":
-after transform: SymbolId(19): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(26): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "import51":
-after transform: SymbolId(22): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(30): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/complicatedIndexesOfIntersectionsAreInferencable.ts
 Bindings mismatch:
@@ -2235,11 +1925,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["Func"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/compoundVarDecl1.ts
-Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/computedEnumMemberSyntacticallyString.ts
 Missing ReferenceId: "Foo"
@@ -2405,11 +2090,6 @@ Bindings mismatch:
 after transform: ScopeId(0): ["M", "c1", "c2", "c3", "c4", "c5"]
 rebuilt        : ScopeId(0): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/constDeclarations2.ts
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/constEnumDeclarations.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "C", "E"]
@@ -2436,9 +2116,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/constEnumNamespac
 Bindings mismatch:
 after transform: ScopeId(2): ["ConstFooEnum", "Here", "Some", "Values"]
 rebuilt        : ScopeId(2): ["ConstFooEnum"]
-Symbol flags mismatch for "ConstEnumOnlyModule":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "ConstFooEnum":
 after transform: SymbolId(1): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
@@ -2456,18 +2133,12 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Bindings mismatch:
 after transform: ScopeId(3): ["A", "X"]
 rebuilt        : ScopeId(3): ["A"]
-Symbol flags mismatch for "Outer":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "Outer":
 after transform: SymbolId(0): [Span { start: 10, end: 15 }, Span { start: 53, end: 58 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "A":
 after transform: SymbolId(2): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "B":
-after transform: SymbolId(4): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/constEnumPreserveEmitNamedExport1.ts
 Bindings mismatch:
@@ -3535,29 +3206,11 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Bindings mismatch:
 after transform: ScopeId(1): ["_m", "m2", "server"]
 rebuilt        : ScopeId(1): ["_m", "server"]
-Symbol flags mismatch for "m3":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileGenericType2.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["_defineProperty", "templa"]
 rebuilt        : ScopeId(0): ["_defineProperty"]
-Symbol flags mismatch for "dom":
-after transform: SymbolId(16): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "mvc":
-after transform: SymbolId(17): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "dom":
-after transform: SymbolId(20): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "mvc":
-after transform: SymbolId(21): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "composite":
-after transform: SymbolId(22): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
 Reference symbol mismatch for "templa":
 after transform: SymbolId(0) "templa"
 rebuilt        : <None>
@@ -3580,14 +3233,6 @@ Unresolved references mismatch:
 after transform: ["require"]
 rebuilt        : ["require", "templa"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileImportChainInExportAssignment.ts
-Symbol flags mismatch for "m":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "c":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileImportModuleWithExportAssignment.ts
 Symbol flags mismatch for "m2":
 after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | NamespaceModule)
@@ -3602,40 +3247,14 @@ rebuilt        : SymbolId(0): []
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileInternalAliases.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "m":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m1":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m2":
-after transform: SymbolId(5): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileModuleAssignmentInObjectLiteralProperty.ts
-Symbol flags mismatch for "m1":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileModuleContinuation.ts
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(NamespaceModule | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "A":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 60, end: 61 }]
 rebuilt        : SymbolId(0): []
-Symbol flags mismatch for "B":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "C":
-after transform: SymbolId(4): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileModuleWithPropertyOfTypeModule.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "m":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFilePrivateMethodOverloads.ts
 Bindings mismatch:
@@ -3668,9 +3287,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileTypeofInA
 Bindings mismatch:
 after transform: ScopeId(3): ["e", "holiday", "weekday", "weekend"]
 rebuilt        : ScopeId(3): ["e"]
-Symbol flags mismatch for "m1":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "e":
 after transform: SymbolId(2): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
@@ -3678,71 +3294,24 @@ rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileTypeofModule.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "m1":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m2":
-after transform: SymbolId(4): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileWithInternalModuleNameConflictsInExtendsClause1.ts
 Bindings mismatch:
 after transform: ScopeId(8): ["A", "W", "_C"]
 rebuilt        : ScopeId(4): ["W", "_C"]
-Symbol flags mismatch for "X":
-after transform: SymbolId(0): SymbolFlags(NamespaceModule | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "X":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 61, end: 62 }]
 rebuilt        : SymbolId(0): []
-Symbol flags mismatch for "A":
-after transform: SymbolId(4): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "B":
-after transform: SymbolId(5): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "C":
-after transform: SymbolId(6): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileWithInternalModuleNameConflictsInExtendsClause2.ts
-Symbol flags mismatch for "X":
-after transform: SymbolId(0): SymbolFlags(NamespaceModule | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "X":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 61, end: 62 }, Span { start: 161, end: 162 }]
 rebuilt        : SymbolId(0): []
-Symbol flags mismatch for "A":
-after transform: SymbolId(4): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "B":
-after transform: SymbolId(5): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "C":
-after transform: SymbolId(6): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileWithInternalModuleNameConflictsInExtendsClause3.ts
-Symbol flags mismatch for "X":
-after transform: SymbolId(0): SymbolFlags(NamespaceModule | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "X":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 61, end: 62 }, Span { start: 188, end: 189 }]
 rebuilt        : SymbolId(0): []
-Symbol flags mismatch for "A":
-after transform: SymbolId(4): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "B":
-after transform: SymbolId(5): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "C":
-after transform: SymbolId(6): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declInput-2.ts
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declInput.ts
 Bindings mismatch:
@@ -3757,11 +3326,6 @@ rebuilt        : SymbolId(0): Span { start: 26, end: 29 }
 Symbol redeclarations mismatch for "bar":
 after transform: SymbolId(0): [Span { start: 10, end: 13 }, Span { start: 26, end: 29 }]
 rebuilt        : SymbolId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declInput4.ts
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationAssertionNodeNotReusedWhenTypeNotEquivalent1.ts
 Bindings mismatch:
@@ -3820,15 +3384,9 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringArrayPattern3.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringObjectLiteralPattern2.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "m":
-after transform: SymbolId(10): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringOptionalBindingParametersInOverloads.ts
 Symbol span mismatch for "foo":
@@ -3846,9 +3404,6 @@ rebuilt        : SymbolId(2): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringPrivacyError.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "m":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDoesNotUseReexportedNamespaceAsLocal.ts
 Bindings mismatch:
@@ -3871,14 +3426,8 @@ rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitEnumReferenceViaImportEquals.ts
 Bindings mismatch:
-after transform: ScopeId(0): []
-rebuilt        : ScopeId(0): ["Translation"]
-Bindings mismatch:
 after transform: ScopeId(2): ["_Translation"]
 rebuilt        : ScopeId(1): ["TranslationKeyEnum", "_Translation"]
-Symbol flags mismatch for "Translation":
-after transform: SymbolId(0): SymbolFlags(Interface | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "Translation":
 after transform: SymbolId(0): [Span { start: 17, end: 28 }, Span { start: 101, end: 112 }]
 rebuilt        : SymbolId(0): []
@@ -3914,11 +3463,6 @@ rebuilt        : SymbolId(3): Span { start: 237, end: 241 }
 Symbol redeclarations mismatch for "Rect":
 after transform: SymbolId(1): [Span { start: 93, end: 97 }, Span { start: 237, end: 241 }]
 rebuilt        : SymbolId(3): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends5.ts
-Symbol flags mismatch for "Test":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitFunctionDuplicateNamespace.ts
 Symbol span mismatch for "f":
@@ -3968,12 +3512,6 @@ rebuilt        : ["dual"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitImportInExportAssignmentModule.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "m":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "c":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol reference IDs mismatch for "c":
 after transform: SymbolId(1): [ReferenceId(0), ReferenceId(5), ReferenceId(7)]
 rebuilt        : SymbolId(2): [ReferenceId(2), ReferenceId(3)]
@@ -4055,9 +3593,17 @@ after transform: []
 rebuilt        : ["x", "y"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNameConflicts.ts
-Symbol flags mismatch for "f":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
+Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
+Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
+Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
+Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
+Bindings mismatch:
+after transform: ScopeId(15): ["C", "N", "_Q", "c", "f"]
+rebuilt        : ScopeId(13): ["C", "N", "_Q", "f"]
+Symbol redeclarations mismatch for "M":
+after transform: SymbolId(1): [Span { start: 75, end: 76 }, Span { start: 351, end: 352 }, Span { start: 764, end: 765 }]
+rebuilt        : SymbolId(1): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNameConflicts2.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -4065,33 +3611,12 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "X":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "X":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 160, end: 161 }]
 rebuilt        : SymbolId(0): []
-Symbol flags mismatch for "Y":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "base":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "M":
-after transform: SymbolId(5): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "E":
 after transform: SymbolId(7): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "Y":
-after transform: SymbolId(8): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "base":
-after transform: SymbolId(9): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "Z":
-after transform: SymbolId(10): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(18): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNameConflicts3.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -4099,32 +3624,14 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Bindings mismatch:
-after transform: ScopeId(1): ["C", "E", "_M"]
-rebuilt        : ScopeId(1): ["C", "D", "E", "_M"]
-Bindings mismatch:
 after transform: ScopeId(14): ["D", "f"]
 rebuilt        : ScopeId(13): ["D"]
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 243, end: 244 }]
 rebuilt        : SymbolId(0): []
-Symbol flags mismatch for "D":
-after transform: SymbolId(1): SymbolFlags(Interface | ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "D":
 after transform: SymbolId(1): [Span { start: 35, end: 36 }, Span { start: 62, end: 63 }]
 rebuilt        : SymbolId(2): []
-Symbol flags mismatch for "C":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "E":
-after transform: SymbolId(5): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "P":
-after transform: SymbolId(7): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "D":
 after transform: SymbolId(10): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
@@ -4137,17 +3644,8 @@ rebuilt        : ScopeId(0): ["M", "v"]
 Bindings mismatch:
 after transform: ScopeId(3): ["C", "_M", "w"]
 rebuilt        : ScopeId(1): ["_M", "w"]
-Symbol flags mismatch for "M":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNamespaceMergedWithInterfaceNestedFunction.ts
-Bindings mismatch:
-after transform: ScopeId(0): []
-rebuilt        : ScopeId(0): ["Bar"]
-Symbol flags mismatch for "Bar":
-after transform: SymbolId(1): SymbolFlags(Interface | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "Bar":
 after transform: SymbolId(1): [Span { start: 51, end: 54 }, Span { start: 87, end: 90 }]
 rebuilt        : SymbolId(0): []
@@ -4202,11 +3700,6 @@ after transform: ScopeId(1): ["Test1", "Test2", "TestEnum"]
 rebuilt        : ScopeId(1): ["TestEnum"]
 Symbol flags mismatch for "TestEnum":
 after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationFunctionTypeNonlocalShouldNotBeAnError.ts
-Symbol flags mismatch for "foo":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationImportTypeAliasInferredAndEmittable.ts
@@ -4872,44 +4365,23 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Bindings mismatch:
 after transform: ScopeId(0): ["A", "AA", "M", "tmpError", "tmpOK"]
 rebuilt        : ScopeId(0): ["A", "AA", "tmpError", "tmpOK"]
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol reference IDs mismatch for "A":
 after transform: SymbolId(0): [ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(10), ReferenceId(11), ReferenceId(28), ReferenceId(29)]
 rebuilt        : SymbolId(0): [ReferenceId(5), ReferenceId(6), ReferenceId(15), ReferenceId(25), ReferenceId(26)]
 Symbol redeclarations mismatch for "A":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 174, end: 175 }]
 rebuilt        : SymbolId(0): []
-Symbol flags mismatch for "B":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "AA":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "B":
-after transform: SymbolId(4): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "B":
-after transform: SymbolId(8): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(13): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "C":
-after transform: SymbolId(9): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(15): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/doubleUnderscoreEnumEmit.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["(Anonymous class)", "(Anonymous function)", "Foo", "__a", "__call"]
 rebuilt        : ScopeId(1): ["Foo"]
 Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(RegularEnum | ValueModule)
+after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(0): [Span { start: 5, end: 8 }, Span { start: 117, end: 120 }]
 rebuilt        : SymbolId(0): []
-Symbol flags mismatch for "Bar":
-after transform: SymbolId(6): SymbolFlags(Function | ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(Function)
 Symbol redeclarations mismatch for "Bar":
 after transform: SymbolId(6): [Span { start: 198, end: 201 }, Span { start: 235, end: 238 }]
 rebuilt        : SymbolId(4): []
@@ -4941,32 +4413,17 @@ rebuilt        : ["arr", "log"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/duplicateAnonymousInners1.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(0): [Span { start: 10, end: 13 }, Span { start: 154, end: 157 }]
 rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/duplicateAnonymousModuleClasses.ts
-Symbol flags mismatch for "F":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "F":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 56, end: 57 }]
 rebuilt        : SymbolId(0): []
-Symbol flags mismatch for "Foo":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(3): [Span { start: 135, end: 138 }, Span { start: 183, end: 186 }]
 rebuilt        : SymbolId(5): []
-Symbol flags mismatch for "Gar":
-after transform: SymbolId(6): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "Foo":
-after transform: SymbolId(7): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(7): [Span { start: 284, end: 287 }, Span { start: 348, end: 351 }]
 rebuilt        : SymbolId(12): []
@@ -4993,11 +4450,6 @@ Symbol redeclarations mismatch for "a":
 after transform: SymbolId(0): [Span { start: 50, end: 51 }, Span { start: 76, end: 77 }]
 rebuilt        : SymbolId(0): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/duplicateVariablesByScope.ts
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/elidedEmbeddedStatementsReplacedWithSemicolon.ts
 'with' statements are not allowed
 
@@ -5013,15 +4465,9 @@ after transform: []
 rebuilt        : ["dec"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/emitMemberAccessExpression.ts
-Symbol flags mismatch for "Microsoft":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "PeopleAtWork":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "Model":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
+Bindings mismatch:
+after transform: ScopeId(0): ["Microsoft", "OData"]
+rebuilt        : ScopeId(0): ["Microsoft"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/emitTopOfFileTripleSlashCommentOnNotEmittedNodeIfRemoveCommentsIsFalse.ts
 Bindings mismatch:
@@ -5147,15 +4593,9 @@ rebuilt        : ScopeId(2): ["MyEnum"]
 Bindings mismatch:
 after transform: ScopeId(4): ["FOO", "MyEnum"]
 rebuilt        : ScopeId(4): ["MyEnum"]
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "MyEnum":
 after transform: SymbolId(1): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "N":
-after transform: SymbolId(4): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "MyEnum":
 after transform: SymbolId(5): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
@@ -5396,11 +4836,6 @@ Unresolved references mismatch:
 after transform: ["Object"]
 rebuilt        : ["Object", "p"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ClassTest3.ts
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ClassTest4.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["Point"]
@@ -5427,39 +4862,12 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Bindings mismatch:
 after transform: ScopeId(0): ["c", "m", "uninstantiated", "x"]
 rebuilt        : ScopeId(0): ["c", "m", "x"]
-Symbol flags mismatch for "m":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ExportClauseWithoutModuleSpecifier.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Bindings mismatch:
 after transform: ScopeId(0): ["c", "m", "uninstantiated", "x"]
 rebuilt        : ScopeId(0): ["c", "m", "x"]
-Symbol flags mismatch for "m":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportInIndirectExportAssignment.ts
-Symbol flags mismatch for "a":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ModuleClassDeclaration.ts
-Symbol flags mismatch for "m1":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m2":
-after transform: SymbolId(5): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ModuleConst.ts
-Symbol flags mismatch for "m1":
-after transform: SymbolId(6): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m2":
-after transform: SymbolId(13): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ModuleConstEnumDeclaration.ts
 Bindings mismatch:
@@ -5486,18 +4894,12 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "e2":
 after transform: SymbolId(4): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "m1":
-after transform: SymbolId(10): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "e3":
 after transform: SymbolId(11): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "e4":
 after transform: SymbolId(15): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m2":
-after transform: SymbolId(23): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "e5":
 after transform: SymbolId(24): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(18): SymbolFlags(BlockScopedVariable)
@@ -5530,18 +4932,12 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "e2":
 after transform: SymbolId(4): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "m1":
-after transform: SymbolId(10): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "e3":
 after transform: SymbolId(11): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "e4":
 after transform: SymbolId(15): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m2":
-after transform: SymbolId(23): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "e5":
 after transform: SymbolId(24): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(18): SymbolFlags(BlockScopedVariable)
@@ -5574,18 +4970,12 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "e2":
 after transform: SymbolId(4): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "m1":
-after transform: SymbolId(10): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "e3":
 after transform: SymbolId(11): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "e4":
 after transform: SymbolId(15): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m2":
-after transform: SymbolId(23): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "e5":
 after transform: SymbolId(24): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(18): SymbolFlags(BlockScopedVariable)
@@ -5593,25 +4983,8 @@ Symbol flags mismatch for "e6":
 after transform: SymbolId(28): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ModuleFunctionDeclaration.ts
-Symbol flags mismatch for "m1":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m2":
-after transform: SymbolId(5): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ModuleInternalImport.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "m":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m1":
-after transform: SymbolId(5): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m2":
-after transform: SymbolId(10): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ModuleLet.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -5620,12 +4993,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "m1":
-after transform: SymbolId(6): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m2":
-after transform: SymbolId(13): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ModuleModuleDeclaration.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -5634,24 +5001,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "m1":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "innerExportedModule":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "innerNonExportedModule":
-after transform: SymbolId(6): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m2":
-after transform: SymbolId(9): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "innerExportedModule":
-after transform: SymbolId(12): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "innerNonExportedModule":
-after transform: SymbolId(15): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ModuleVariableStatement.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -5660,12 +5009,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "m1":
-after transform: SymbolId(6): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m2":
-after transform: SymbolId(13): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/esDecoratorsClassFieldsCrash.ts
 Bindings mismatch:
@@ -5744,12 +5087,6 @@ after transform: ScopeId(0): ["x"]
 rebuilt        : ScopeId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/exportDefaultProperty.ts
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "B":
-after transform: SymbolId(1): SymbolFlags(Class | ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(Class)
 Symbol redeclarations mismatch for "B":
 after transform: SymbolId(1): [Span { start: 31, end: 32 }, Span { start: 84, end: 85 }]
 rebuilt        : SymbolId(2): []
@@ -5768,12 +5105,6 @@ after transform: ScopeId(0): ["io"]
 rebuilt        : ScopeId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/exportEqualsProperty.ts
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "B":
-after transform: SymbolId(1): SymbolFlags(Class | ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(Class)
 Symbol redeclarations mismatch for "B":
 after transform: SymbolId(1): [Span { start: 31, end: 32 }, Span { start: 84, end: 85 }]
 rebuilt        : SymbolId(2): []
@@ -5788,26 +5119,14 @@ rebuilt        : SymbolId(1): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/exportImportAndClodule.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "K":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "L":
-after transform: SymbolId(1): SymbolFlags(Class | ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(Class)
 Symbol redeclarations mismatch for "L":
 after transform: SymbolId(1): [Span { start: 31, end: 32 }, Span { start: 107, end: 108 }]
 rebuilt        : SymbolId(2): []
-Symbol flags mismatch for "M":
-after transform: SymbolId(5): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/exportImportNonInstantiatedModule.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "x"]
 rebuilt        : ScopeId(0): ["B", "x"]
-Symbol flags mismatch for "B":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/exportNamespaceDeclarationRetainsVisibility.ts
 Bindings mismatch:
@@ -5838,15 +5157,9 @@ after transform: SymbolId(0): [Span { start: 12, end: 15 }, Span { start: 42, en
 rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/extBaseClass1.ts
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 110, end: 111 }]
 rebuilt        : SymbolId(1): []
-Symbol flags mismatch for "N":
-after transform: SymbolId(4): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/externFunc.ts
 Bindings mismatch:
@@ -5872,15 +5185,9 @@ rebuilt        : ["EM"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/externalModuleResolution.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "M2":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/externalModuleResolution2.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "M2":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/externalModuleWithoutCompilerFlag1.ts
 Bindings mismatch:
@@ -5894,9 +5201,6 @@ rebuilt        : ScopeId(1): ["Foo"]
 Symbol flags mismatch for "Foo":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "X":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/fakeInfinity3.ts
 Bindings mismatch:
@@ -5905,9 +5209,6 @@ rebuilt        : ScopeId(1): ["Foo"]
 Symbol flags mismatch for "Foo":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "X":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/fallFromLastCase1.ts
 Bindings mismatch:
@@ -5928,14 +5229,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["use"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/fatArrowSelf.ts
-Symbol flags mismatch for "Events":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "Consumer":
-after transform: SymbolId(6): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/fatArrowfunctionAsType.ts
 Bindings mismatch:
@@ -6014,11 +5307,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["closeFile", "openFile", "someOperation"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/forInModule.ts
-Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/forLoopEndingMultilineComments.ts
 Bindings mismatch:
@@ -6126,14 +5414,6 @@ rebuilt        : SymbolId(31): Span { start: 1080, end: 1089 }
 Symbol redeclarations mismatch for "overload1":
 after transform: SymbolId(31): [Span { start: 1000, end: 1009 }, Span { start: 1040, end: 1049 }, Span { start: 1080, end: 1089 }]
 rebuilt        : SymbolId(31): []
-Symbol flags mismatch for "m2":
-after transform: SymbolId(38): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(36): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/functionCall5.ts
-Symbol flags mismatch for "m1":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/functionDeclarationWithResolutionOfTypeOfSameName01.ts
 Bindings mismatch:
@@ -6156,26 +5436,14 @@ rebuilt        : ScopeId(1): ["Foo", "_Midori"]
 Bindings mismatch:
 after transform: ScopeId(2): ["Foo"]
 rebuilt        : ScopeId(2): []
-Symbol flags mismatch for "Midori":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol scope ID mismatch for "Foo":
 after transform: SymbolId(1): ScopeId(2)
 rebuilt        : SymbolId(2): ScopeId(1)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/functionMergedWithModule.ts
-Symbol flags mismatch for "foo":
-after transform: SymbolId(0): SymbolFlags(Function | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(Function)
 Symbol redeclarations mismatch for "foo":
 after transform: SymbolId(0): [Span { start: 9, end: 12 }, Span { start: 59, end: 62 }, Span { start: 114, end: 117 }]
 rebuilt        : SymbolId(0): []
-Symbol flags mismatch for "Bar":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "Baz":
-after transform: SymbolId(5): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/functionOverloads10.ts
 Symbol span mismatch for "foo":
@@ -6394,11 +5662,6 @@ Bindings mismatch:
 after transform: ScopeId(0): ["foo", "test1", "test2"]
 rebuilt        : ScopeId(0): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/functionTypeArgumentArrayAssignment.ts
-Symbol flags mismatch for "test":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/funduleExportedClassIsUsedBeforeDeclaration.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["B"]
@@ -6412,9 +5675,6 @@ rebuilt        : ["B"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/funduleOfFunctionWithoutReturnTypeAnnotation.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "fn":
-after transform: SymbolId(0): SymbolFlags(Function | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(Function)
 Symbol redeclarations mismatch for "fn":
 after transform: SymbolId(0): [Span { start: 9, end: 11 }, Span { start: 45, end: 47 }]
 rebuilt        : SymbolId(0): []
@@ -6530,35 +5790,11 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericClassImple
 Bindings mismatch:
 after transform: ScopeId(0): ["bar", "foo"]
 rebuilt        : ScopeId(0): ["bar"]
-Symbol flags mismatch for "bar":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericClassPropertyInheritanceSpecialization.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["Portal", "PortalFx", "ViewModel", "_defineProperty", "ko"]
 rebuilt        : ScopeId(0): ["Portal", "PortalFx", "ViewModel", "_defineProperty"]
-Symbol flags mismatch for "Portal":
-after transform: SymbolId(32): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "Controls":
-after transform: SymbolId(33): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "Validators":
-after transform: SymbolId(34): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "PortalFx":
-after transform: SymbolId(39): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "ViewModels":
-after transform: SymbolId(40): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "Controls":
-after transform: SymbolId(41): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "Validators":
-after transform: SymbolId(42): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
 Reference symbol mismatch for "ko":
 after transform: SymbolId(30) "ko"
 rebuilt        : <None>
@@ -6566,38 +5802,15 @@ Unresolved references mismatch:
 after transform: ["require"]
 rebuilt        : ["ko", "require"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericClassesInModule.ts
-Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericConstraintOnExtendedBuiltinTypes.ts
-Symbol flags mismatch for "EndGate":
-after transform: SymbolId(0): SymbolFlags(NamespaceModule | ValueModule | Ambient)
-rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "EndGate":
 after transform: SymbolId(0): [Span { start: 18, end: 25 }, Span { start: 152, end: 159 }, Span { start: 344, end: 351 }]
 rebuilt        : SymbolId(1): []
-Symbol flags mismatch for "Tweening":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "Tweening":
-after transform: SymbolId(7): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericConstraintOnExtendedBuiltinTypes2.ts
-Symbol flags mismatch for "EndGate":
-after transform: SymbolId(0): SymbolFlags(NamespaceModule | ValueModule)
-rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "EndGate":
 after transform: SymbolId(0): [Span { start: 10, end: 17 }, Span { start: 144, end: 151 }, Span { start: 335, end: 342 }]
 rebuilt        : SymbolId(1): []
-Symbol flags mismatch for "Tweening":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "Tweening":
-after transform: SymbolId(7): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericFunctionInference2.ts
 Bindings mismatch:
@@ -6752,9 +5965,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/getAccessorWithIm
 Bindings mismatch:
 after transform: ScopeId(0): ["MyModule", "_"]
 rebuilt        : ScopeId(0): ["MyModule"]
-Symbol flags mismatch for "MyModule":
-after transform: SymbolId(17): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/getParameterNameAtPosition.ts
 Bindings mismatch:
@@ -6769,11 +5979,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["cases", "fn"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/global.ts
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/globalIsContextualKeyword.ts
 Bindings mismatch:
@@ -6849,29 +6054,12 @@ Unresolved references mismatch:
 after transform: ["Promise", "require"]
 rebuilt        : ["Promise", "f1", "f2", "f3", "f4", "f5", "f6", "require"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/importAliasAnExternalModuleInsideAnInternalModule.ts
-Symbol flags mismatch for "m":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/importAliasWithDottedName.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "N":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "A":
-after transform: SymbolId(4): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/importAndVariableDeclarationConflict2.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "m":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/importDeclWithExportModifierInAmbientContext.ts
 Unresolved references mismatch:
@@ -6905,24 +6093,15 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C"]
 rebuilt        : ScopeId(0): ["A", "C"]
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol reference IDs mismatch for "A":
 after transform: SymbolId(0): [ReferenceId(1), ReferenceId(2), ReferenceId(8), ReferenceId(9)]
 rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(7)]
-Symbol flags mismatch for "C":
-after transform: SymbolId(7): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/importOnAliasedIdentifiers.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Bindings mismatch:
 after transform: ScopeId(1): ["_A"]
 rebuilt        : ScopeId(1): ["X", "_A"]
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol reference IDs mismatch for "A":
 after transform: SymbolId(0): [ReferenceId(1), ReferenceId(2), ReferenceId(5), ReferenceId(6)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
@@ -6935,9 +6114,6 @@ rebuilt        : SymbolId(2): Span { start: 66, end: 67 }
 Symbol redeclarations mismatch for "X":
 after transform: SymbolId(1): [Span { start: 35, end: 36 }, Span { start: 66, end: 67 }]
 rebuilt        : SymbolId(2): []
-Symbol flags mismatch for "B":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/inKeywordNarrowingWithNoUncheckedIndexedAccess.ts
 Bindings mismatch:
@@ -6992,9 +6168,6 @@ after transform: ["Array", "Symbol", "require", "window"]
 rebuilt        : ["Array", "Symbol", "error", "isAOrB", "require", "window", "x"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/indexIntoEnum.ts
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "E":
 after transform: SymbolId(1): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
@@ -7427,14 +6600,6 @@ Symbol redeclarations mismatch for "from":
 after transform: SymbolId(8): [Span { start: 149, end: 153 }, Span { start: 189, end: 193 }, Span { start: 244, end: 248 }]
 rebuilt        : SymbolId(0): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/inheritanceOfGenericConstructorMethod2.ts
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "N":
-after transform: SymbolId(4): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/inheritedConstructorPropertyContextualType.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["Assignment", "Base"]
@@ -7451,32 +6616,16 @@ Bindings mismatch:
 after transform: ScopeId(0): ["E"]
 rebuilt        : ScopeId(0): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/innerBoundLambdaEmit.ts
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/innerExtern.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["B", "BB", "_A"]
 rebuilt        : ScopeId(1): ["B", "_A"]
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "B":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 Reference symbol mismatch for "BB":
 after transform: SymbolId(1) "BB"
 rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["require"]
 rebuilt        : ["BB", "require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/innerFunc.ts
-Symbol flags mismatch for "M":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/innerOverloads.ts
 Symbol span mismatch for "inner":
@@ -7513,9 +6662,6 @@ rebuilt        : ScopeId(0): ["Interesting", "N1", "NON_VOID_ACTION", "VOID_ACTI
 Bindings mismatch:
 after transform: ScopeId(33): ["Component", "InferFunctionTypes", "_N", "createElement", "createElement2"]
 rebuilt        : ScopeId(8): ["InferFunctionTypes", "_N"]
-Symbol flags mismatch for "N1":
-after transform: SymbolId(62): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
 Reference symbol mismatch for "handlers":
 after transform: SymbolId(6) "handlers"
 rebuilt        : <None>
@@ -7620,166 +6766,62 @@ rebuilt        : ScopeId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasClass.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "a":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "c":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasClassInsideLocalModuleWithExport.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "x":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m2":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m3":
-after transform: SymbolId(4): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasClassInsideLocalModuleWithoutExport.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "x":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m2":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m3":
-after transform: SymbolId(4): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasClassInsideTopLevelModuleWithExport.ts
-Symbol flags mismatch for "x":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasClassInsideTopLevelModuleWithoutExport.ts
-Symbol flags mismatch for "x":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasEnum.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Bindings mismatch:
 after transform: ScopeId(2): ["Friday", "Saturday", "Sunday", "weekend"]
 rebuilt        : ScopeId(2): ["weekend"]
-Symbol flags mismatch for "a":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "weekend":
 after transform: SymbolId(1): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "c":
-after transform: SymbolId(5): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasEnumInsideLocalModuleWithExport.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Bindings mismatch:
 after transform: ScopeId(2): ["Friday", "Saturday", "Sunday", "weekend"]
 rebuilt        : ScopeId(2): ["weekend"]
-Symbol flags mismatch for "a":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "weekend":
 after transform: SymbolId(1): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "c":
-after transform: SymbolId(5): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasEnumInsideLocalModuleWithoutExport.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Bindings mismatch:
 after transform: ScopeId(2): ["Friday", "Saturday", "Sunday", "weekend"]
 rebuilt        : ScopeId(2): ["weekend"]
-Symbol flags mismatch for "a":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "weekend":
 after transform: SymbolId(1): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "c":
-after transform: SymbolId(5): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasFunction.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "a":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "c":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasFunctionInsideLocalModuleWithExport.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "a":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "c":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasFunctionInsideLocalModuleWithoutExport.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "a":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "c":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasFunctionInsideTopLevelModuleWithoutExport.ts
-Symbol flags mismatch for "a":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasInitializedModule.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "a":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "b":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "c":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasInitializedModuleInsideLocalModuleWithoutExport.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "a":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "b":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "c":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasInitializedModuleInsideTopLevelModuleWithExport.ts
-Symbol flags mismatch for "a":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "b":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasInterface.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Bindings mismatch:
 after transform: ScopeId(0): ["a", "c"]
 rebuilt        : ScopeId(0): ["c"]
-Symbol flags mismatch for "c":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Unresolved references mismatch:
 after transform: ["a"]
 rebuilt        : []
@@ -7794,9 +6836,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Bindings mismatch:
 after transform: ScopeId(0): ["a", "c"]
 rebuilt        : ScopeId(0): ["c"]
-Symbol flags mismatch for "c":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Unresolved references mismatch:
 after transform: ["a"]
 rebuilt        : []
@@ -7806,18 +6845,12 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Bindings mismatch:
 after transform: ScopeId(0): ["a", "c"]
 rebuilt        : ScopeId(0): ["c"]
-Symbol flags mismatch for "c":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasUninitializedModuleInsideLocalModuleWithoutExport.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Bindings mismatch:
 after transform: ScopeId(0): ["a", "c"]
 rebuilt        : ScopeId(0): ["c"]
-Symbol flags mismatch for "c":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Unresolved references mismatch:
 after transform: ["a"]
 rebuilt        : []
@@ -7830,33 +6863,15 @@ rebuilt        : ScopeId(0): ["x"]
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasVar.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "a":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "c":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasVarInsideTopLevelModuleWithoutExport.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "a":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasWithDottedNameEmit.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "a":
-after transform: SymbolId(0): SymbolFlags(NamespaceModule | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "a":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 50, end: 51 }]
 rebuilt        : SymbolId(0): []
-Symbol flags mismatch for "b":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "c":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 Unresolved references mismatch:
 after transform: ["b"]
 rebuilt        : []
@@ -7865,9 +6880,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalImportUnI
 Bindings mismatch:
 after transform: ScopeId(0): ["A", "B"]
 rebuilt        : ScopeId(0): ["B"]
-Symbol flags mismatch for "B":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol reference IDs mismatch for "A":
 after transform: SymbolId(3): [ReferenceId(0)]
 rebuilt        : SymbolId(2): []
@@ -7904,9 +6916,6 @@ rebuilt        : ScopeId(5): ["B"]
 Bindings mismatch:
 after transform: ScopeId(29): ["C", "c1", "c2", "c210", "c211"]
 rebuilt        : ScopeId(6): ["C"]
-Symbol flags mismatch for "enums":
-after transform: SymbolId(27): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "A":
 after transform: SymbolId(28): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
@@ -8117,17 +7126,11 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsxEmitWithAttrib
 Bindings mismatch:
 after transform: ScopeId(0): ["Element", "JSX", "createElement", "toCamelCase"]
 rebuilt        : ScopeId(0): ["Element", "createElement", "toCamelCase"]
-Symbol flags mismatch for "Element":
-after transform: SymbolId(5): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryIdentifier.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["Element", "JSX", "createElement", "toCamelCase"]
 rebuilt        : ScopeId(0): ["Element", "createElement", "toCamelCase"]
-Symbol flags mismatch for "Element":
-after transform: SymbolId(5): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryIdentifierAsParameter.ts
 Bindings mismatch:
@@ -8138,9 +7141,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryQualifi
 Bindings mismatch:
 after transform: ScopeId(0): ["Element", "JSX", "createElement", "toCamelCase"]
 rebuilt        : ScopeId(0): ["Element", "createElement", "toCamelCase"]
-Symbol flags mismatch for "Element":
-after transform: SymbolId(5): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsxFunctionTypeChildren.tsx
 Bindings mismatch:
@@ -8236,14 +7236,6 @@ rebuilt        : ScopeId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/letDeclarations2.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/letKeepNamesOfTopLevelItems.ts
-Symbol flags mismatch for "A":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/literalWideningWithCompoundLikeAssignments.ts
 Bindings mismatch:
@@ -8309,15 +7301,9 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/localImportNameVs
 Bindings mismatch:
 after transform: ScopeId(2): ["DOWN", "Key", "LEFT", "RIGHT", "UP"]
 rebuilt        : ScopeId(2): ["Key"]
-Symbol flags mismatch for "Keyboard":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "Key":
 after transform: SymbolId(1): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "App":
-after transform: SymbolId(6): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/mappedToToIndexSignatureInference.ts
 Bindings mismatch:
@@ -8478,24 +7464,15 @@ rebuilt        : ["p012"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/mergedDeclarations1.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "point":
-after transform: SymbolId(1): SymbolFlags(Function | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(Function)
 Symbol redeclarations mismatch for "point":
 after transform: SymbolId(1): [Span { start: 59, end: 64 }, Span { start: 135, end: 140 }]
 rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/mergedDeclarations4.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 101, end: 102 }]
 rebuilt        : SymbolId(0): []
-Symbol flags mismatch for "f":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/mergedEnumDeclarationCodeGen.ts
 Bindings mismatch:
@@ -8515,111 +7492,39 @@ after transform: ["a"]
 rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationCodeGen.ts
-Symbol flags mismatch for "X":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "X":
 after transform: SymbolId(0): [Span { start: 17, end: 18 }, Span { start: 172, end: 173 }]
 rebuilt        : SymbolId(0): []
-Symbol flags mismatch for "Y":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "Y":
-after transform: SymbolId(4): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationCodeGen2.ts
-Symbol flags mismatch for "my":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "my":
 after transform: SymbolId(0): [Span { start: 10, end: 12 }, Span { start: 66, end: 68 }]
 rebuilt        : SymbolId(0): []
-Symbol flags mismatch for "data":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "foo":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "data":
-after transform: SymbolId(4): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationCodeGen3.ts
-Symbol flags mismatch for "my":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "my":
 after transform: SymbolId(0): [Span { start: 10, end: 12 }, Span { start: 62, end: 64 }]
 rebuilt        : SymbolId(0): []
-Symbol flags mismatch for "data":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "data":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "foo":
-after transform: SymbolId(4): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationCodeGen4.ts
-Symbol flags mismatch for "superContain":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "contain":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "my":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "my":
 after transform: SymbolId(2): [Span { start: 81, end: 83 }, Span { start: 217, end: 219 }]
 rebuilt        : SymbolId(4): []
-Symbol flags mismatch for "buz":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "data":
-after transform: SymbolId(4): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "buz":
-after transform: SymbolId(6): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "data":
-after transform: SymbolId(7): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationCodeGen5.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 94, end: 95 }]
 rebuilt        : SymbolId(0): []
-Symbol flags mismatch for "buz":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "plop":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "buz":
-after transform: SymbolId(5): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "plop":
-after transform: SymbolId(6): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "plop":
 after transform: SymbolId(10): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationWithSharedExportedVar.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 56, end: 57 }]
 rebuilt        : SymbolId(0): []
@@ -8716,9 +7621,6 @@ rebuilt        : ScopeId(6): ["_D"]
 Bindings mismatch:
 after transform: ScopeId(15): ["My", "_E"]
 rebuilt        : ScopeId(7): ["_E"]
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "My":
 after transform: SymbolId(1): SymbolFlags(Function | ValueModule | Ambient)
 rebuilt        : SymbolId(2): SymbolFlags(Function)
@@ -8728,9 +7630,6 @@ rebuilt        : SymbolId(2): Span { start: 90, end: 92 }
 Symbol redeclarations mismatch for "My":
 after transform: SymbolId(1): [Span { start: 36, end: 38 }, Span { start: 90, end: 92 }]
 rebuilt        : SymbolId(2): []
-Symbol flags mismatch for "B":
-after transform: SymbolId(4): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "My":
 after transform: SymbolId(5): SymbolFlags(Function | ValueModule | Ambient)
 rebuilt        : SymbolId(6): SymbolFlags(Function)
@@ -8740,15 +7639,6 @@ rebuilt        : SymbolId(6): Span { start: 230, end: 232 }
 Symbol redeclarations mismatch for "My":
 after transform: SymbolId(5): [Span { start: 147, end: 149 }, Span { start: 201, end: 203 }, Span { start: 230, end: 232 }]
 rebuilt        : SymbolId(6): []
-Symbol flags mismatch for "C":
-after transform: SymbolId(9): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "D":
-after transform: SymbolId(13): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "E":
-after transform: SymbolId(18): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/modFunctionCrash.ts
 Bindings mismatch:
@@ -8795,30 +7685,12 @@ after transform: ["Array", "Map", "Math", "Promise", "Proxy", "Reflect", "RegExp
 rebuilt        : ["Array", "Map", "Math", "Promise", "Proxy", "Reflect", "RegExp", "Symbol", "arguments", "console", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleAliasInterface.ts
-Symbol flags mismatch for "_modes":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol reference IDs mismatch for "_modes":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(16), ReferenceId(17)]
 rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3)]
-Symbol flags mismatch for "editor":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "editor2":
-after transform: SymbolId(11): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "Foo":
-after transform: SymbolId(16): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "A1":
-after transform: SymbolId(21): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(22): SymbolFlags(BlockScopedVariable)
 Symbol reference IDs mismatch for "A1":
 after transform: SymbolId(21): [ReferenceId(11), ReferenceId(28), ReferenceId(29)]
 rebuilt        : SymbolId(22): [ReferenceId(14), ReferenceId(15)]
-Symbol flags mismatch for "B1":
-after transform: SymbolId(24): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(25): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleAndInterfaceSharingName4.ts
 Bindings mismatch:
@@ -8857,9 +7729,6 @@ rebuilt        : ScopeId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleCodeGenTest3.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "Baz":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleCodeGenTest5.ts
 Bindings mismatch:
@@ -8877,51 +7746,22 @@ rebuilt        : SymbolId(10): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleCodegenTest4.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "Baz":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleIdentifiers.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleMemberWithoutTypeAnnotation1.ts
-Symbol flags mismatch for "TypeScript":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "TypeScript":
 after transform: SymbolId(0): [Span { start: 10, end: 20 }, Span { start: 152, end: 162 }, Span { start: 544, end: 554 }, Span { start: 891, end: 901 }]
 rebuilt        : SymbolId(0): []
-Symbol flags mismatch for "Parser":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "Syntax":
-after transform: SymbolId(18): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(21): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleMemberWithoutTypeAnnotation2.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "TypeScript":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "CompilerDiagnostics":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleMerge.ts
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "A":
 after transform: SymbolId(0): [Span { start: 104, end: 105 }, Span { start: 233, end: 234 }]
 rebuilt        : SymbolId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleNoEmit.ts
-Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleOuterQualification.ts
 Bindings mismatch:
@@ -8983,58 +7823,10 @@ Symbol flags mismatch for "Animals":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleScopingBug.ts
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "X":
-after transform: SymbolId(6): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleSharesNameWithImportDeclarationInsideIt.ts
-Symbol flags mismatch for "Z":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "M":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "A":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "M":
-after transform: SymbolId(4): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleSharesNameWithImportDeclarationInsideIt2.ts
-Symbol flags mismatch for "Z":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "M":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "A":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "M":
-after transform: SymbolId(4): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleSharesNameWithImportDeclarationInsideIt4.ts
 Bindings mismatch:
 after transform: ScopeId(5): ["_M2", "bar"]
 rebuilt        : ScopeId(5): ["M", "_M2", "bar"]
-Symbol flags mismatch for "Z":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "M":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "A":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "M":
-after transform: SymbolId(4): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "M":
 after transform: SymbolId(5): SymbolFlags(FunctionScopedVariable | Interface)
 rebuilt        : SymbolId(9): SymbolFlags(FunctionScopedVariable)
@@ -9046,37 +7838,19 @@ after transform: SymbolId(5): [Span { start: 101, end: 102 }, Span { start: 118,
 rebuilt        : SymbolId(9): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleSharesNameWithImportDeclarationInsideIt6.ts
-Symbol flags mismatch for "Z":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol reference IDs mismatch for "Z":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(7), ReferenceId(8)]
 rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(7)]
-Symbol flags mismatch for "M":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "A":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "M":
-after transform: SymbolId(4): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleUnassignedVariable.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "Bar":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleVariables.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Bindings mismatch:
 after transform: ScopeId(0): ["M", "console", "x"]
 rebuilt        : ScopeId(0): ["M", "x"]
-Symbol flags mismatch for "M":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(2): [Span { start: 49, end: 50 }, Span { start: 114, end: 115 }, Span { start: 157, end: 158 }]
 rebuilt        : SymbolId(1): []
@@ -9103,44 +7877,21 @@ rebuilt        : ScopeId(5): ["B", "C", "E", "InnerMod", "_M", "someModuleFuncti
 Bindings mismatch:
 after transform: ScopeId(8): ["A", "B", "C", "E"]
 rebuilt        : ScopeId(8): ["E"]
-Symbol flags mismatch for "OuterMod":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "OuterInnerMod":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "M":
-after transform: SymbolId(5): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(5): [Span { start: 243, end: 244 }, Span { start: 1079, end: 1080 }]
 rebuilt        : SymbolId(8): []
-Symbol flags mismatch for "InnerMod":
-after transform: SymbolId(6): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "E":
 after transform: SymbolId(8): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(13): SymbolFlags(BlockScopedVariable)
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleWithTryStatement1.ts
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/multiModuleClodule1.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "C":
-after transform: SymbolId(0): SymbolFlags(Class | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(Class)
 Symbol redeclarations mismatch for "C":
 after transform: SymbolId(0): [Span { start: 6, end: 7 }, Span { start: 103, end: 104 }, Span { start: 156, end: 157 }]
 rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/multiModuleFundule1.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "C":
-after transform: SymbolId(0): SymbolFlags(Function | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(Function)
 Symbol redeclarations mismatch for "C":
 after transform: SymbolId(0): [Span { start: 9, end: 10 }, Span { start: 37, end: 38 }, Span { start: 75, end: 76 }]
 rebuilt        : SymbolId(0): []
@@ -9167,30 +7918,14 @@ after transform: []
 rebuilt        : ["Moon"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/nameCollisionWithBlockScopedVariable1.ts
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 49, end: 50 }]
 rebuilt        : SymbolId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/namedFunctionExpressionInModule.ts
-Symbol flags mismatch for "Variables":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/namespaces1.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["X", "x", "x2"]
 rebuilt        : ScopeId(0): ["x", "x2"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/namespaces2.ts
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "B":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/namespacesDeclaration1.ts
 Bindings mismatch:
@@ -9582,19 +8317,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["call", "wrap"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/nestedModulePrivateAccess.ts
-Symbol flags mismatch for "a":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "b":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/nestedSelf.ts
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/nestedTypeVariableInfersLiteral.ts
 Bindings mismatch:
@@ -10129,16 +8851,6 @@ Symbol redeclarations mismatch for "f":
 after transform: SymbolId(7): [Span { start: 123, end: 124 }, Span { start: 145, end: 146 }, Span { start: 172, end: 173 }]
 rebuilt        : SymbolId(7): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/overloadResolutionOverNonCTLambdas.ts
-Symbol flags mismatch for "Bugs":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/overloadResolutionOverNonCTObjectLit.ts
-Symbol flags mismatch for "Bugs":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/overloadReturnTypes.ts
 Symbol span mismatch for "attr":
 after transform: SymbolId(1): Span { start: 28, end: 32 }
@@ -10283,11 +8995,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["getInterfaceFromString"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyCannotNameVarTypeDeclFile.ts
-Symbol flags mismatch for "SpecializedWidget":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyCheckExternalModuleExportAssignmentOfGenericClass.ts
 Reference symbol mismatch for "Bar":
 after transform: SymbolId(1) "Bar"
@@ -10302,53 +9009,10 @@ rebuilt        : ["Bar", "module"]
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyCheckTypeOfInvisibleModuleError.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "Outer":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "Inner":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyCheckTypeOfInvisibleModuleNoError.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "Outer":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "Inner":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyClass.ts
-Symbol flags mismatch for "m1":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m2":
-after transform: SymbolId(17): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyClassImplementsClauseDeclFile.ts
-Symbol flags mismatch for "publicModule":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "privateModule":
-after transform: SymbolId(10): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyFunc.ts
-Symbol flags mismatch for "m1":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyFunctionCannotNameParameterTypeDeclFile.ts
-Symbol flags mismatch for "SpecializedWidget":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyFunctionCannotNameReturnTypeDeclFile.ts
-Symbol flags mismatch for "SpecializedWidget":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyFunctionParameterDeclFile.ts
 Bindings mismatch:
@@ -10360,17 +9024,6 @@ rebuilt        : ScopeId(41): ["_publicModule", "privateClass", "privateClassWit
 Bindings mismatch:
 after transform: ScopeId(142): ["_privateModule", "privateAmbientFunctionWithPrivateModuleParameterTypes", "privateAmbientFunctionWithPrivateParmeterTypes", "privateAmbientFunctionWithPublicParmeterTypes", "privateClass", "privateClassWithPrivateModuleParameterTypes", "privateClassWithWithPrivateParmeterTypes", "privateClassWithWithPublicParmeterTypes", "privateFunctionWithPrivateModuleParameterTypes", "privateFunctionWithPrivateParmeterTypes", "privateFunctionWithPublicParmeterTypes", "publicAmbientFunctionWithPrivateModuleParameterTypes", "publicAmbientFunctionWithPrivateParmeterTypes", "publicAmbientFunctionWithPublicParmeterTypes", "publicClass", "publicClassWithPrivateModuleParameterTypes", "publicClassWithWithPrivateParmeterTypes", "publicClassWithWithPublicParmeterTypes", "publicFunctionWithPrivateModuleParameterTypes", "publicFunctionWithPrivateParmeterTypes", "publicFunctionWithPublicParmeterTypes"]
 rebuilt        : ScopeId(82): ["_privateModule", "privateClass", "privateClassWithPrivateModuleParameterTypes", "privateClassWithWithPrivateParmeterTypes", "privateClassWithWithPublicParmeterTypes", "privateFunctionWithPrivateModuleParameterTypes", "privateFunctionWithPrivateParmeterTypes", "privateFunctionWithPublicParmeterTypes", "publicClass", "publicClassWithPrivateModuleParameterTypes", "publicClassWithWithPrivateParmeterTypes", "publicClassWithWithPublicParmeterTypes", "publicFunctionWithPrivateModuleParameterTypes", "publicFunctionWithPrivateParmeterTypes", "publicFunctionWithPublicParmeterTypes"]
-Symbol flags mismatch for "publicModule":
-after transform: SymbolId(94): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(58): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "privateModule":
-after transform: SymbolId(189): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(118): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyGloClass.ts
-Symbol flags mismatch for "m1":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyGloImport.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -10387,35 +9040,14 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "m1":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m1_M1_public":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m1_M2_private":
-after transform: SymbolId(6): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "glo_M1_public":
-after transform: SymbolId(31): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(34): SymbolFlags(BlockScopedVariable)
 Symbol reference IDs mismatch for "glo_M1_public":
 after transform: SymbolId(31): [ReferenceId(31), ReferenceId(44), ReferenceId(45), ReferenceId(81), ReferenceId(82)]
 rebuilt        : SymbolId(34): [ReferenceId(61), ReferenceId(62)]
-Symbol flags mismatch for "m2":
-after transform: SymbolId(59): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(40): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m4":
-after transform: SymbolId(60): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(42): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyGloInterface.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["C5_public", "m1", "m3"]
 rebuilt        : ScopeId(0): ["C5_public", "m1"]
-Symbol flags mismatch for "m1":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyImport.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -10446,53 +9078,14 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "m1":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m1_M1_public":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m1_M2_private":
-after transform: SymbolId(6): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m2":
-after transform: SymbolId(31): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(34): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "m2":
 after transform: SymbolId(31): [Span { start: 3194, end: 3196 }, Span { start: 12472, end: 12474 }]
 rebuilt        : SymbolId(34): []
-Symbol flags mismatch for "m2_M1_public":
-after transform: SymbolId(32): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(36): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m2_M2_private":
-after transform: SymbolId(37): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(42): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "glo_M1_public":
-after transform: SymbolId(62): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(68): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "glo_M3_private":
-after transform: SymbolId(67): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(74): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m4":
-after transform: SymbolId(92): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(101): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m3":
-after transform: SymbolId(94): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(104): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m4":
-after transform: SymbolId(95): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(106): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyInterface.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["C5_public", "C6_private", "m1", "m2", "m3", "m4"]
 rebuilt        : ScopeId(0): ["C5_public", "C6_private", "m1", "m2"]
-Symbol flags mismatch for "m1":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m2":
-after transform: SymbolId(21): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyInterfaceExtendsClauseDeclFile.ts
 Bindings mismatch:
@@ -10542,54 +9135,12 @@ rebuilt        : ScopeId(7): ["_m_public", "c_public", "e_public", "f_public", "
 Bindings mismatch:
 after transform: ScopeId(12): ["Grumpy", "Happy", "e_public"]
 rebuilt        : ScopeId(9): ["e_public"]
-Symbol flags mismatch for "m_private":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "e_private":
 after transform: SymbolId(2): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "mi_private":
-after transform: SymbolId(8): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m_public":
-after transform: SymbolId(12): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "e_public":
 after transform: SymbolId(14): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(13): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "mi_public":
-after transform: SymbolId(20): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(17): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "import_public":
-after transform: SymbolId(24): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "import_private":
-after transform: SymbolId(67): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(64): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyTypeParameterOfFunctionDeclFile.ts
-Symbol flags mismatch for "publicModule":
-after transform: SymbolId(86): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(18): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "privateModule":
-after transform: SymbolId(173): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(38): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyTypeParametersOfClassDeclFile.ts
-Symbol flags mismatch for "publicModule":
-after transform: SymbolId(26): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(18): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "privateModule":
-after transform: SymbolId(53): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(38): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyTypeParametersOfInterfaceDeclFile.ts
-Symbol flags mismatch for "publicModule":
-after transform: SymbolId(28): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "privateModule":
-after transform: SymbolId(57): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/promiseType.ts
 Bindings mismatch:
@@ -11558,9 +10109,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Bindings mismatch:
 after transform: ScopeId(0): ["Alpha", "Beta", "x"]
 rebuilt        : ScopeId(0): ["Alpha", "x"]
-Symbol flags mismatch for "Alpha":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol reference IDs mismatch for "Alpha":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(4)]
 rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(2), ReferenceId(3)]
@@ -11643,11 +10191,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["Tag"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/reboundBaseClassSymbol.ts
-Symbol flags mismatch for "Foo":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/recursiveArrayNotCircular.ts
 Bindings mismatch:
 after transform: ScopeId(3): ["ActionType", "Bar", "Batch", "Baz", "Foo"]
@@ -11681,19 +10224,8 @@ Unresolved references mismatch:
 after transform: ["undefined"]
 rebuilt        : ["Base", "p", "undefined"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/recursiveClassInstantiationsWithDefaultConstructors.ts
-Symbol flags mismatch for "TypeScript2":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/recursiveCloduleReference.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "C":
-after transform: SymbolId(1): SymbolFlags(Class | ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(Class)
 Symbol redeclarations mismatch for "C":
 after transform: SymbolId(1): [Span { start: 29, end: 30 }, Span { start: 56, end: 57 }]
 rebuilt        : SymbolId(2): []
@@ -11730,9 +10262,6 @@ after transform: []
 rebuilt        : ["a", "b", "c"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/recursiveMods.ts
-Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(0): [Span { start: 17, end: 20 }, Span { start: 62, end: 65 }]
 rebuilt        : SymbolId(0): []
@@ -11771,20 +10300,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["opt1", "opt2", "opt3"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/recursivelySpecializedConstructorDeclaration.ts
-Symbol flags mismatch for "MsPortal":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "Controls":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "Base":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "ItemList":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/reducibleIndexedAccessTypes.ts
 Bindings mismatch:
@@ -12006,14 +10521,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["sepsis", "unwrap"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/returnTypeParameterWithModules.ts
-Symbol flags mismatch for "M1":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "M2":
-after transform: SymbolId(6): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/reuseInnerModuleMember.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["M"]
@@ -12206,11 +10713,6 @@ Bindings mismatch:
 after transform: ScopeId(0): ["f", "g", "h"]
 rebuilt        : ScopeId(0): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/separate1-2.ts
-Symbol flags mismatch for "X":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/shebangBeforeReferences.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["use", "x"]
@@ -12260,24 +10762,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["x"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/sourceMap-FileWithComments.ts
-Symbol flags mismatch for "Shapes":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/sourceMapForFunctionInInternalModuleWithCommentPrecedingStatement01.ts
-Symbol flags mismatch for "Q":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationClasses.ts
-Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "Bar":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringForObjectBindingPattern.ts
 Bindings mismatch:
@@ -12648,27 +11132,10 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["console"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationImport.ts
-Symbol flags mismatch for "m":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationModule.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "m2":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m3":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m4":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/sourcemapValidationDuplicateNames.ts
-Symbol flags mismatch for "m1":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "m1":
 after transform: SymbolId(0): [Span { start: 10, end: 12 }, Span { start: 70, end: 72 }]
 rebuilt        : SymbolId(0): []
@@ -12677,11 +11144,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/specedNoStackBlow
 Bindings mismatch:
 after transform: ScopeId(0): ["spected"]
 rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/specializationOfExportedClass.ts
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/specializedOverloadWithRestParameters.ts
 Symbol span mismatch for "f":
@@ -13092,9 +11554,6 @@ rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/stringLiteralObjectLiteralDeclaration1.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "m1":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/stripMembersOptionality.ts
 Bindings mismatch:
@@ -13110,16 +11569,8 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["someVal", "someVal2"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/structural1.ts
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/structuralTypeInDeclareFileForModule.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/substitutionTypesInIndexedAccessTypes.ts
 Bindings mismatch:
@@ -13151,11 +11602,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["isBar", "isNode"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/superAccessInFatArrow1.ts
-Symbol flags mismatch for "test":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatDerivesFromGenericType1.ts
 Bindings mismatch:
@@ -13260,11 +11706,6 @@ Unresolved reference IDs mismatch for "String":
 after transform: [ReferenceId(2), ReferenceId(3)]
 rebuilt        : [ReferenceId(4)]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/testContainerList.ts
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/testTypings.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["sort"]
@@ -13281,16 +11722,8 @@ Unresolved references mismatch:
 after transform: ["require"]
 rebuilt        : ["Component", "require"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/this_inside-object-literal-getters-and-setters.ts
-Symbol flags mismatch for "ObjectLiteral":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/topLevel.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "M":
-after transform: SymbolId(7): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/trackedSymbolsNoCrash.ts
 Bindings mismatch:
@@ -13613,16 +12046,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["aIndex", "bIndex", "cIndex"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty7.ts
-Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeGuardOnContainerTypeNoHang.ts
-Symbol flags mismatch for "TypeGuards":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeInferenceCacheInvalidation.ts
 Bindings mismatch:
@@ -14027,9 +12450,6 @@ after transform: []
 rebuilt        : ["View", "_"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/unexportedInstanceClassVariables.ts
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 67, end: 68 }]
 rebuilt        : SymbolId(0): []
@@ -14168,20 +12588,9 @@ rebuilt        : ["f"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/unusedClassesinNamespace3.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "Validation":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/unusedInterfaceinNamespace4.ts
-Symbol flags mismatch for "Validation":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/unusedInterfaceinNamespace5.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "Validation":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/unusedLocalProperty.ts
 Bindings mismatch:
@@ -14193,11 +12602,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["console"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsAndParametersDeferred.ts
-Symbol flags mismatch for "N":
-after transform: SymbolId(29): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(29): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsAndParametersOverloadSignatures.ts
 Symbol span mismatch for "func":
@@ -14232,12 +12636,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Bindings mismatch:
 after transform: ScopeId(1): ["B", "Point", "_A", "x"]
 rebuilt        : ScopeId(1): ["Point", "_A", "x"]
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "C":
-after transform: SymbolId(7): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/vardecl.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -14251,9 +12649,6 @@ rebuilt        : ScopeId(0): ["a22", "anotherVar", "arrayVar", "b", "b22", "c", 
 Bindings mismatch:
 after transform: ScopeId(8): ["C", "C2", "_m", "a", "a2", "b", "b2", "b22", "b222", "b23", "b2E", "d1", "d1E", "d2", "d2E", "m", "m1", "m3", "mE", "v1", "v1E"]
 rebuilt        : ScopeId(1): ["C", "C2", "_m", "a", "a2", "b", "b2", "b22", "b222", "b23", "b2E", "m", "m1", "m3", "mE"]
-Symbol flags mismatch for "m2":
-after transform: SymbolId(22): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/varianceCantBeStrictWhileStructureIsnt.ts
 Bindings mismatch:
@@ -14324,9 +12719,6 @@ rebuilt        : ["source"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/visSyntax.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/voidUndefinedReduction.ts
 Bindings mismatch:
@@ -14438,12 +12830,6 @@ rebuilt        : ScopeId(1): ["_M"]
 Bindings mismatch:
 after transform: ScopeId(6): ["C", "E", "M", "_M2", "f", "x"]
 rebuilt        : ScopeId(2): ["_M2"]
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "M2":
-after transform: SymbolId(6): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncUnParenthesizedArrowFunction_es2017.ts
 Bindings mismatch:
@@ -14463,9 +12849,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es2017/a
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "M", "_asyncToGenerator", "_f", "_f2", "_f3", "_f5", "f0", "f1", "f10", "f11", "f12", "f13", "f14", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "mp", "o", "p"]
 rebuilt        : ScopeId(0): ["C", "M", "_asyncToGenerator", "_f", "_f2", "_f3", "_f5", "f0", "f1", "f10", "f11", "f12", "f13", "f14", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "o"]
-Symbol flags mismatch for "M":
-after transform: SymbolId(19): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(33): SymbolFlags(BlockScopedVariable)
 Reference symbol mismatch for "p":
 after transform: SymbolId(2) "p"
 rebuilt        : <None>
@@ -14824,9 +13207,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyn
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "M", "_asyncToGenerator", "_f", "_f2", "_f3", "_f5", "f0", "f1", "f10", "f11", "f12", "f13", "f14", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "mp", "o", "p"]
 rebuilt        : ScopeId(0): ["C", "M", "_asyncToGenerator", "_f", "_f2", "_f3", "_f5", "f0", "f1", "f10", "f11", "f12", "f13", "f14", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "o"]
-Symbol flags mismatch for "M":
-after transform: SymbolId(19): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(33): SymbolFlags(BlockScopedVariable)
 Reference symbol mismatch for "p":
 after transform: SymbolId(2) "p"
 rebuilt        : <None>
@@ -15179,11 +13559,6 @@ Unresolved references mismatch:
 after transform: ["arguments", "require"]
 rebuilt        : ["a", "arguments", "b", "c", "d", "e", "require"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/classExpression.ts
-Symbol flags mismatch for "M":
-after transform: SymbolId(4): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classWithStaticFieldInParameterBindingPattern.3.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "_defineProperty", "x"]
@@ -15217,11 +13592,6 @@ rebuilt        : SymbolId(1): ScopeId(0)
 Symbol scope ID mismatch for "_Class2":
 after transform: SymbolId(9): ScopeId(4)
 rebuilt        : SymbolId(2): ScopeId(0)
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/classTypes/genericSetterInClassType.ts
-Symbol flags mismatch for "Generic":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/thisAndSuperInStaticMembers1.ts
 Bindings mismatch:
@@ -16396,9 +14766,6 @@ rebuilt        : ScopeId(18): ["Color"]
 Bindings mismatch:
 after transform: ScopeId(21): ["Color", "Yellow"]
 rebuilt        : ScopeId(21): ["Color"]
-Symbol flags mismatch for "M1":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "EImpl1":
 after transform: SymbolId(1): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
@@ -16411,51 +14778,30 @@ rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "EConst1":
 after transform: SymbolId(8): [Span { start: 293, end: 300 }, Span { start: 354, end: 361 }]
 rebuilt        : SymbolId(5): []
-Symbol flags mismatch for "M2":
-after transform: SymbolId(16): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "EComp2":
 after transform: SymbolId(17): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "EComp2":
 after transform: SymbolId(17): [Span { start: 597, end: 603 }, Span { start: 690, end: 696 }]
 rebuilt        : SymbolId(11): []
-Symbol flags mismatch for "M3":
-after transform: SymbolId(25): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(15): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "EInit":
 after transform: SymbolId(26): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(17): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "EInit":
 after transform: SymbolId(26): [Span { start: 973, end: 978 }, Span { start: 1018, end: 1023 }]
 rebuilt        : SymbolId(17): []
-Symbol flags mismatch for "M4":
-after transform: SymbolId(32): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "Color":
 after transform: SymbolId(33): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(22): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "M5":
-after transform: SymbolId(37): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(24): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "Color":
 after transform: SymbolId(38): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(26): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "M6":
-after transform: SymbolId(42): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(28): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "M6":
 after transform: SymbolId(42): [Span { start: 1236, end: 1238 }, Span { start: 1298, end: 1300 }]
 rebuilt        : SymbolId(28): []
-Symbol flags mismatch for "A":
-after transform: SymbolId(43): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(30): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "Color":
 after transform: SymbolId(44): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(32): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "A":
-after transform: SymbolId(48): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(35): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "Color":
 after transform: SymbolId(49): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(37): SymbolFlags(BlockScopedVariable)
@@ -16777,34 +15123,13 @@ Unresolved reference IDs mismatch for "Symbol":
 after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(6), ReferenceId(8)]
 rebuilt        : [ReferenceId(0), ReferenceId(4), ReferenceId(6)]
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty48.ts
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty49.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty50.ts
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty51.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["C", "Symbol", "_M"]
 rebuilt        : ScopeId(1): ["C", "_M"]
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty56.ts
-Symbol flags mismatch for "M":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty60.ts
 Bindings mismatch:
@@ -17114,9 +15439,6 @@ rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch for "D":
 after transform: SymbolId(8): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(5): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "M":
-after transform: SymbolId(12): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports1.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -17135,9 +15457,6 @@ rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch for "D":
 after transform: SymbolId(8): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(5): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "M":
-after transform: SymbolId(12): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports3-es6.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -17156,9 +15475,6 @@ rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "D":
 after transform: SymbolId(8): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "M":
-after transform: SymbolId(12): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports3.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -17177,24 +15493,15 @@ rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "D":
 after transform: SymbolId(8): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "M":
-after transform: SymbolId(12): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesWithModule.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "m":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "m":
 after transform: SymbolId(0): [Span { start: 28, end: 29 }, Span { start: 63, end: 64 }]
 rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesWithModuleES6.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "m":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "m":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 45, end: 46 }]
 rebuilt        : SymbolId(0): []
@@ -17247,15 +15554,7 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["f", "g", "obj"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorInAmbientContext6.ts
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorOverloads5.ts
-Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "f":
 after transform: SymbolId(1): Span { start: 27, end: 28 }
 rebuilt        : SymbolId(2): Span { start: 112, end: 113 }
@@ -18564,9 +16863,6 @@ rebuilt        : ScopeId(5): ["E"]
 Symbol flags mismatch for "E":
 after transform: SymbolId(2): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "M":
-after transform: SymbolId(6): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnOptionalProperty.ts
 Bindings mismatch:
@@ -19332,18 +17628,6 @@ rebuilt        : ["g", "o"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/identifiers/scopeResolutionIdentifiers.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "M1":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "M2":
-after transform: SymbolId(4): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "M3":
-after transform: SymbolId(12): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(15): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "M4":
-after transform: SymbolId(14): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(18): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/newOperator/newOperatorConformance.ts
 Bindings mismatch:
@@ -20875,21 +19159,6 @@ rebuilt        : ScopeId(10): []
 Symbol scope ID mismatch for "foo":
 after transform: SymbolId(19): ScopeId(10)
 rebuilt        : SymbolId(19): ScopeId(9)
-Symbol flags mismatch for "m":
-after transform: SymbolId(21): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(21): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m2":
-after transform: SymbolId(23): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(24): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m1":
-after transform: SymbolId(26): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(28): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m2":
-after transform: SymbolId(28): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(31): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m3":
-after transform: SymbolId(29): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(33): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_propertyValueConformance1.ts
 Bindings mismatch:
@@ -20929,21 +19198,12 @@ rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherType.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "M":
-after transform: SymbolId(5): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherType.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "M":
-after transform: SymbolId(5): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/voidOperator/voidOperatorWithBooleanType.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "M":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/voidOperator/voidOperatorWithEnumType.ts
 Bindings mismatch:
@@ -20958,20 +19218,9 @@ rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/voidOperator/voidOperatorWithNumberType.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "M":
-after transform: SymbolId(4): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/voidOperator/voidOperatorWithStringType.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "M":
-after transform: SymbolId(4): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/asiPreventsParsingAsAmbientExternalModule02.ts
-Symbol flags mismatch for "container":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/commonJSImportNotAsPrimaryExpression.ts
 Bindings mismatch:
@@ -20987,15 +19236,9 @@ rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentMergedModule.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(0): [Span { start: 10, end: 13 }, Span { start: 87, end: 90 }]
 rebuilt        : SymbolId(0): []
-Symbol flags mismatch for "Test":
-after transform: SymbolId(5): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportDeclaredModule.ts
 Bindings mismatch:
@@ -21015,9 +19258,6 @@ rebuilt        : ScopeId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/nameWithRelativePaths.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "M2":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/topLevelAwait.2.ts
 Bindings mismatch:
@@ -21036,11 +19276,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModule
 Bindings mismatch:
 after transform: ScopeId(0): ["A", "a"]
 rebuilt        : ScopeId(0): ["A"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/nestedNamespace.ts
-Symbol flags mismatch for "types":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeValueMerge1.ts
 Bindings mismatch:
@@ -21082,9 +19317,6 @@ after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/verbatimModuleSyntaxRestrictionsESM.ts
-Symbol flags mismatch for "ns":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "A":
 after transform: SymbolId(1): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
@@ -21107,20 +19339,17 @@ rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/generators/generatorYieldContextualType.ts
 Bindings mismatch:
-after transform: ScopeId(0): ["Directive", "_wrapAsyncGenerator", "canPickStepContinue", "createPickStep", "f1", "f2", "showStep"]
+after transform: ScopeId(0): ["Directive", "StepResult", "_wrapAsyncGenerator", "canPickStepContinue", "createPickStep", "f1", "f2", "showStep"]
 rebuilt        : ScopeId(0): ["Directive", "StepResult", "_wrapAsyncGenerator", "canPickStepContinue", "createPickStep", "showStep"]
 Bindings mismatch:
 after transform: ScopeId(7): ["Back", "Cancel", "Directive", "LoadMore", "Noop"]
 rebuilt        : ScopeId(3): ["Directive"]
 Symbol flags mismatch for "Directive":
-after transform: SymbolId(12): SymbolFlags(RegularEnum | ValueModule)
+after transform: SymbolId(12): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
 Symbol redeclarations mismatch for "Directive":
 after transform: SymbolId(12): [Span { start: 318, end: 327 }, Span { start: 381, end: 390 }]
 rebuilt        : SymbolId(3): []
-Symbol flags mismatch for "StepResult":
-after transform: SymbolId(28): SymbolFlags(TypeAlias | ValueModule)
-rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "StepResult":
 after transform: SymbolId(28): [Span { start: 1257, end: 1267 }, Span { start: 1321, end: 1331 }]
 rebuilt        : SymbolId(8): []
@@ -21223,41 +19452,18 @@ Unresolved references mismatch:
 after transform: ["require"]
 rebuilt        : ["Constructor", "require"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/AmbientModuleAndNonAmbientClassWithSameNameAndCommonRoot.ts
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithStaticFunctionAndNonExportedFunctionThatShareAName.ts
-Symbol flags mismatch for "Point":
-after transform: SymbolId(0): SymbolFlags(Class | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(Class)
 Symbol redeclarations mismatch for "Point":
 after transform: SymbolId(0): [Span { start: 6, end: 11 }, Span { start: 138, end: 143 }]
 rebuilt        : SymbolId(0): []
-Symbol flags mismatch for "A":
-after transform: SymbolId(4): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "Point":
-after transform: SymbolId(5): SymbolFlags(Class | ValueModule)
-rebuilt        : SymbolId(7): SymbolFlags(Class)
 Symbol redeclarations mismatch for "Point":
 after transform: SymbolId(5): [Span { start: 253, end: 258 }, Span { start: 408, end: 413 }]
 rebuilt        : SymbolId(7): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithStaticVariableAndNonExportedVarThatShareAName.ts
-Symbol flags mismatch for "Point":
-after transform: SymbolId(0): SymbolFlags(Class | ValueModule)
-rebuilt        : SymbolId(1): SymbolFlags(Class)
 Symbol redeclarations mismatch for "Point":
 after transform: SymbolId(0): [Span { start: 6, end: 11 }, Span { start: 127, end: 132 }]
 rebuilt        : SymbolId(1): []
-Symbol flags mismatch for "A":
-after transform: SymbolId(4): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "Point":
-after transform: SymbolId(5): SymbolFlags(Class | ValueModule)
-rebuilt        : SymbolId(8): SymbolFlags(Class)
 Symbol redeclarations mismatch for "Point":
 after transform: SymbolId(5): [Span { start: 227, end: 232 }, Span { start: 371, end: 376 }]
 rebuilt        : SymbolId(8): []
@@ -21267,24 +19473,19 @@ Bindings mismatch:
 after transform: ScopeId(1): ["Blue", "Red", "enumdule"]
 rebuilt        : ScopeId(1): ["enumdule"]
 Symbol flags mismatch for "enumdule":
-after transform: SymbolId(0): SymbolFlags(RegularEnum | ValueModule)
+after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol redeclarations mismatch for "enumdule":
 after transform: SymbolId(0): [Span { start: 5, end: 13 }, Span { start: 43, end: 51 }]
 rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/FunctionAndModuleWithSameNameAndDifferentCommonRoot.ts
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ModuleAndEnumWithSameNameAndCommonRoot.ts
 Bindings mismatch:
 after transform: ScopeId(4): ["Blue", "Red", "enumdule"]
 rebuilt        : ScopeId(4): ["enumdule"]
-Symbol flags mismatch for "enumdule":
-after transform: SymbolId(0): SymbolFlags(RegularEnum | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "enumdule":
 after transform: SymbolId(0): [Span { start: 10, end: 18 }, Span { start: 121, end: 129 }]
 rebuilt        : SymbolId(0): []
@@ -21296,12 +19497,6 @@ rebuilt        : ScopeId(0): ["l", "p"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesThatMergeEachWithExportedAndNonExportedLocalVarsOfTheSameName.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "Utils":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesThatMergeEachWithExportedInterfacesOfTheSameName.ts
 Bindings mismatch:
@@ -21309,56 +19504,23 @@ after transform: ScopeId(0): ["A", "X", "l", "p"]
 rebuilt        : ScopeId(0): ["l", "p"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesWithTheSameNameAndDifferentCommonRoot.ts
-Symbol flags mismatch for "Root":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "A":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "Utils":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
+Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesWithTheSameNameAndSameCommonRoot.ts
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "Utils":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/codeGeneration/importStatements.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "D", "E"]
 rebuilt        : ScopeId(0): ["A", "C", "D", "E"]
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol reference IDs mismatch for "A":
 after transform: SymbolId(0): [ReferenceId(1), ReferenceId(2), ReferenceId(5), ReferenceId(7), ReferenceId(14), ReferenceId(15)]
 rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(7), ReferenceId(10), ReferenceId(14)]
-Symbol flags mismatch for "C":
-after transform: SymbolId(7): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "D":
-after transform: SymbolId(11): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "E":
-after transform: SymbolId(14): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportClassWhichExtendsInterfaceWithInaccessibleType.ts
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportInterfaceWithAccessibleTypesInTypeParameterConstraintsClassHeritageListMemberTypeAnnotations.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportInterfaceWithInaccessibleTypeInIndexerTypeAnnotations.ts
 Bindings mismatch:
@@ -21368,38 +19530,20 @@ rebuilt        : ScopeId(0): []
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportInterfaceWithInaccessibleTypeInTypeParameterConstraint.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportModuleWithAccessibleTypesOnItsExportedMembers.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "B":
-after transform: SymbolId(4): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportObjectLiteralAndObjectTypeLiteralWithAccessibleTypesInMemberTypeAnnotations.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportVariableWithAccessibleTypeInTypeAnnotation.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportVariableWithInaccessibleTypeInTypeAnnotation.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/importDeclarations/exportImportAlias.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -21407,71 +19551,24 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Bindings mismatch:
 after transform: ScopeId(1): ["B", "Point", "_A", "x"]
 rebuilt        : ScopeId(1): ["Point", "_A", "x"]
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "C":
-after transform: SymbolId(7): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "X":
-after transform: SymbolId(12): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "Y":
-after transform: SymbolId(13): SymbolFlags(Function | ValueModule)
-rebuilt        : SymbolId(14): SymbolFlags(Function)
 Symbol redeclarations mismatch for "Y":
 after transform: SymbolId(13): [Span { start: 463, end: 464 }, Span { start: 516, end: 517 }]
 rebuilt        : SymbolId(14): []
-Symbol flags mismatch for "Z":
-after transform: SymbolId(17): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(19): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "K":
-after transform: SymbolId(21): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(24): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "L":
-after transform: SymbolId(22): SymbolFlags(Class | ValueModule)
-rebuilt        : SymbolId(26): SymbolFlags(Class)
 Symbol redeclarations mismatch for "L":
 after transform: SymbolId(22): [Span { start: 824, end: 825 }, Span { start: 901, end: 902 }]
 rebuilt        : SymbolId(26): []
-Symbol flags mismatch for "M":
-after transform: SymbolId(26): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(30): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/asiPreventsParsingAsNamespace03.ts
-Symbol flags mismatch for "container":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/asiPreventsParsingAsNamespace05.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "a":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "b":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/nestedModules.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(NamespaceModule | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "A":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 104, end: 105 }]
 rebuilt        : SymbolId(0): []
-Symbol flags mismatch for "B":
-after transform: SymbolId(4): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "M2":
-after transform: SymbolId(6): SymbolFlags(NamespaceModule | ValueModule)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "M2":
 after transform: SymbolId(6): [Span { start: 238, end: 240 }, Span { start: 323, end: 325 }]
 rebuilt        : SymbolId(5): []
-Symbol flags mismatch for "X":
-after transform: SymbolId(9): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/reExportAliasMakesInstantiated.ts
 Bindings mismatch:
@@ -22099,11 +20196,6 @@ Symbol flags mismatch for "CodeGenTarget":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/everyTypeWithInitializer.ts
-Symbol flags mismatch for "M":
-after transform: SymbolId(6): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsNamedEvaluationDecoratorsAndClassFields.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["C1", "C2", "C3", "C4", "_Class", "_Class2", "_defineProperty", "_usingCtx", "_usingCtx2", "dec"]
@@ -22117,11 +20209,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["Symbol"]
 rebuilt        : ["Symbol", "dec"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/statements/throwStatements/throwStatements.ts
-Symbol flags mismatch for "M":
-after transform: SymbolId(6): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/conditional/inferTypes2.ts
 Bindings mismatch:
@@ -22927,23 +21014,14 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Bindings mismatch:
 after transform: ScopeId(32): ["A", "e1"]
 rebuilt        : ScopeId(31): ["e1"]
-Symbol flags mismatch for "M":
-after transform: SymbolId(35): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(34): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "m1":
-after transform: SymbolId(44): SymbolFlags(Function | ValueModule)
-rebuilt        : SymbolId(43): SymbolFlags(Function)
 Symbol redeclarations mismatch for "m1":
 after transform: SymbolId(44): [Span { start: 1248, end: 1250 }, Span { start: 1277, end: 1279 }]
 rebuilt        : SymbolId(43): []
-Symbol flags mismatch for "c1":
-after transform: SymbolId(48): SymbolFlags(Class | ValueModule)
-rebuilt        : SymbolId(48): SymbolFlags(Class)
 Symbol redeclarations mismatch for "c1":
 after transform: SymbolId(48): [Span { start: 1364, end: 1366 }, Span { start: 1421, end: 1423 }]
 rebuilt        : SymbolId(48): []
 Symbol flags mismatch for "e1":
-after transform: SymbolId(53): SymbolFlags(RegularEnum | ValueModule)
+after transform: SymbolId(53): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(54): SymbolFlags(FunctionScopedVariable)
 Symbol redeclarations mismatch for "e1":
 after transform: SymbolId(53): [Span { start: 1511, end: 1513 }, Span { start: 1530, end: 1532 }]
@@ -23388,12 +21466,6 @@ rebuilt        : SymbolId(0): Span { start: 515, end: 532 }
 Symbol redeclarations mismatch for "getFalsyPrimitive":
 after transform: SymbolId(1): [Span { start: 64, end: 81 }, Span { start: 113, end: 130 }, Span { start: 162, end: 179 }, Span { start: 213, end: 230 }, Span { start: 284, end: 301 }, Span { start: 355, end: 372 }, Span { start: 424, end: 441 }, Span { start: 515, end: 532 }]
 rebuilt        : SymbolId(0): []
-Symbol flags mismatch for "Consts1":
-after transform: SymbolId(10): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "Consts2":
-after transform: SymbolId(21): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloads02.ts
 Symbol span mismatch for "getFalsyPrimitive":
@@ -23402,12 +21474,6 @@ rebuilt        : SymbolId(0): Span { start: 460, end: 477 }
 Symbol redeclarations mismatch for "getFalsyPrimitive":
 after transform: SymbolId(0): [Span { start: 9, end: 26 }, Span { start: 58, end: 75 }, Span { start: 107, end: 124 }, Span { start: 158, end: 175 }, Span { start: 229, end: 246 }, Span { start: 300, end: 317 }, Span { start: 369, end: 386 }, Span { start: 460, end: 477 }]
 rebuilt        : SymbolId(0): []
-Symbol flags mismatch for "Consts1":
-after transform: SymbolId(9): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "Consts2":
-after transform: SymbolId(20): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloads04.ts
 Bindings mismatch:
@@ -23757,11 +21823,6 @@ Unresolved references mismatch:
 after transform: ["undefined"]
 rebuilt        : ["foo", "undefined"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/asiPreventsParsingAsTypeAlias02.ts
-Symbol flags mismatch for "container":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/builtinIteratorReturn.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["array", "i0", "i1", "i10", "i11", "i12", "i13", "i14", "i15", "i16", "i17", "i2", "i3", "i4", "i5", "i6", "i7", "i8", "i9", "map", "set"]
@@ -23985,15 +22046,9 @@ rebuilt        : ScopeId(5): ["E"]
 Symbol flags mismatch for "E":
 after transform: SymbolId(49): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(5): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "f":
-after transform: SymbolId(54): SymbolFlags(Function | ValueModule)
-rebuilt        : SymbolId(7): SymbolFlags(Function)
 Symbol redeclarations mismatch for "f":
 after transform: SymbolId(54): [Span { start: 1850, end: 1851 }, Span { start: 1868, end: 1869 }]
 rebuilt        : SymbolId(7): []
-Symbol flags mismatch for "CC":
-after transform: SymbolId(59): SymbolFlags(Class | ValueModule)
-rebuilt        : SymbolId(10): SymbolFlags(Class)
 Symbol redeclarations mismatch for "CC":
 after transform: SymbolId(59): [Span { start: 2014, end: 2016 }, Span { start: 2043, end: 2045 }]
 rebuilt        : SymbolId(10): []
@@ -24061,26 +22116,12 @@ rebuilt        : ScopeId(5): ["E"]
 Symbol flags mismatch for "E":
 after transform: SymbolId(19): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "f":
-after transform: SymbolId(22): SymbolFlags(Function | ValueModule)
-rebuilt        : SymbolId(5): SymbolFlags(Function)
 Symbol redeclarations mismatch for "f":
 after transform: SymbolId(22): [Span { start: 1018, end: 1019 }, Span { start: 1036, end: 1037 }]
 rebuilt        : SymbolId(5): []
-Symbol flags mismatch for "c":
-after transform: SymbolId(25): SymbolFlags(Class | ValueModule)
-rebuilt        : SymbolId(8): SymbolFlags(Class)
 Symbol redeclarations mismatch for "c":
 after transform: SymbolId(25): [Span { start: 1133, end: 1134 }, Span { start: 1161, end: 1162 }]
 rebuilt        : SymbolId(8): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembers.ts
-Symbol flags mismatch for "SimpleTypes":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "ObjectTypes":
-after transform: SymbolId(13): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(13): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/intersectionIncludingPropFromGlobalAugmentation.ts
 Bindings mismatch:
@@ -24102,15 +22143,9 @@ after transform: SymbolId(4): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/bestCommonType/heterogeneousArrayLiterals.ts
-Symbol flags mismatch for "Derived":
-after transform: SymbolId(15): SymbolFlags(Class | ValueModule)
-rebuilt        : SymbolId(16): SymbolFlags(Class)
 Symbol redeclarations mismatch for "Derived":
 after transform: SymbolId(15): [Span { start: 689, end: 696 }, Span { start: 845, end: 852 }]
 rebuilt        : SymbolId(16): []
-Symbol flags mismatch for "WithContextualType":
-after transform: SymbolId(30): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(34): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/independentPropertyVariance.ts
 Bindings mismatch:
@@ -24181,15 +22216,9 @@ rebuilt        : ScopeId(9): ["E"]
 Symbol flags mismatch for "E":
 after transform: SymbolId(26): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(23): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "f":
-after transform: SymbolId(30): SymbolFlags(Function | ValueModule)
-rebuilt        : SymbolId(27): SymbolFlags(Function)
 Symbol redeclarations mismatch for "f":
 after transform: SymbolId(30): [Span { start: 1216, end: 1217 }, Span { start: 1234, end: 1235 }]
 rebuilt        : SymbolId(27): []
-Symbol flags mismatch for "c":
-after transform: SymbolId(34): SymbolFlags(Class | ValueModule)
-rebuilt        : SymbolId(32): SymbolFlags(Class)
 Symbol redeclarations mismatch for "c":
 after transform: SymbolId(34): [Span { start: 1345, end: 1346 }, Span { start: 1373, end: 1374 }]
 rebuilt        : SymbolId(32): []
@@ -24203,15 +22232,9 @@ rebuilt        : ScopeId(5): ["E"]
 Symbol flags mismatch for "E":
 after transform: SymbolId(19): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "f":
-after transform: SymbolId(22): SymbolFlags(Function | ValueModule)
-rebuilt        : SymbolId(5): SymbolFlags(Function)
 Symbol redeclarations mismatch for "f":
 after transform: SymbolId(22): [Span { start: 951, end: 952 }, Span { start: 969, end: 970 }]
 rebuilt        : SymbolId(5): []
-Symbol flags mismatch for "c":
-after transform: SymbolId(25): SymbolFlags(Class | ValueModule)
-rebuilt        : SymbolId(8): SymbolFlags(Class)
 Symbol redeclarations mismatch for "c":
 after transform: SymbolId(25): [Span { start: 1066, end: 1067 }, Span { start: 1094, end: 1095 }]
 rebuilt        : SymbolId(8): []
@@ -24220,9 +22243,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRela
 Bindings mismatch:
 after transform: ScopeId(1): ["_CallSignature", "foo1", "foo2", "r", "r2", "r3", "r4"]
 rebuilt        : ScopeId(1): ["_CallSignature", "r", "r2", "r3", "r4"]
-Symbol flags mismatch for "CallSignature":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Reference symbol mismatch for "foo1":
 after transform: SymbolId(1) "foo1"
 rebuilt        : <None>
@@ -28734,14 +26754,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["foo"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithOverloadedFunctionTypedArguments.ts
-Symbol flags mismatch for "NonGenericParameter":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "GenericParameter":
-after transform: SymbolId(12): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericContextualTypes1.ts
 Bindings mismatch:

--- a/tasks/track_memory_allocations/allocs_transformer.snap
+++ b/tasks/track_memory_allocations/allocs_transformer.snap
@@ -1,6 +1,6 @@
 File                       | File size      || Sys allocs     | Sys reallocs   || Arena allocs   | Arena reallocs 
 ---------------------------------------------------------------------------------------------------------------------------
-checker.ts                 | 2.92 MB        ||             18 |              0 ||           1959 |              5
+checker.ts                 | 2.92 MB        ||             19 |              0 ||           1959 |              5
 
 App.tsx                    | 415.34 kB      ||             23 |              2 ||            618 |             17
 
@@ -12,5 +12,5 @@ antd.js                    | 6.69 MB        ||             13 |              0 |
 
 binder.ts                  | 193.08 kB      ||             15 |              0 ||            154 |              0
 
-kitchen-sink.tsx           | 732.90 kB      ||            182 |              3 ||           6132 |            280
+kitchen-sink.tsx           | 732.90 kB      ||            183 |              3 ||           6132 |            280
 

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 1fb0b771
 
-Passed: 742/1165
+Passed: 747/1165
 
 # All Passed:
 * babel-plugin-transform-logical-assignment-operators
@@ -1070,7 +1070,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-typescript (90/157)
+# babel-plugin-transform-typescript (95/157)
 * class/accessor-allowDeclareFields-false/input.ts
 
   x TS(18010): An accessibility modifier cannot be used with a private
@@ -1440,9 +1440,6 @@ after transform: ["console"]
 rebuilt        : ["LongNameModule", "console"]
 
 * namespace/clobber-class/input.ts
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(Class | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(Class)
 Symbol redeclarations mismatch for "A":
 after transform: SymbolId(0): [Span { start: 6, end: 7 }, Span { start: 22, end: 23 }]
 rebuilt        : SymbolId(0): []
@@ -1452,139 +1449,21 @@ Bindings mismatch:
 after transform: ScopeId(1): ["A", "C"]
 rebuilt        : ScopeId(1): ["A"]
 Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(RegularEnum | ValueModule)
+after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol redeclarations mismatch for "A":
 after transform: SymbolId(0): [Span { start: 5, end: 6 }, Span { start: 30, end: 31 }]
 rebuilt        : SymbolId(0): []
 
 * namespace/clobber-export/input.ts
-Symbol flags mismatch for "N":
-after transform: SymbolId(0): SymbolFlags(Class | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(Class)
 Symbol redeclarations mismatch for "N":
 after transform: SymbolId(0): [Span { start: 13, end: 14 }, Span { start: 35, end: 36 }]
 rebuilt        : SymbolId(0): []
-
-* namespace/contentious-names/input.ts
-Symbol flags mismatch for "N":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "N":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "constructor":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "length":
-after transform: SymbolId(5): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "concat":
-after transform: SymbolId(7): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "copyWithin":
-after transform: SymbolId(9): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "fill":
-after transform: SymbolId(11): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(17): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "find":
-after transform: SymbolId(13): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "findIndex":
-after transform: SymbolId(15): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(23): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "lastIndexOf":
-after transform: SymbolId(17): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(26): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "pop":
-after transform: SymbolId(19): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(29): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "push":
-after transform: SymbolId(21): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(32): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "reverse":
-after transform: SymbolId(23): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(35): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "shift":
-after transform: SymbolId(25): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(38): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "unshift":
-after transform: SymbolId(27): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(41): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "slice":
-after transform: SymbolId(29): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(44): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "sort":
-after transform: SymbolId(31): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(47): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "splice":
-after transform: SymbolId(33): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(50): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "includes":
-after transform: SymbolId(35): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(53): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "indexOf":
-after transform: SymbolId(37): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(56): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "join":
-after transform: SymbolId(39): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(59): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "keys":
-after transform: SymbolId(41): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(62): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "entries":
-after transform: SymbolId(43): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(65): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "values":
-after transform: SymbolId(45): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(68): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "forEach":
-after transform: SymbolId(47): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(71): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "filter":
-after transform: SymbolId(49): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(74): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "map":
-after transform: SymbolId(51): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(77): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "every":
-after transform: SymbolId(53): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(80): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "some":
-after transform: SymbolId(55): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(83): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "reduce":
-after transform: SymbolId(57): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(86): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "reduceRight":
-after transform: SymbolId(59): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(89): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "toLocaleString":
-after transform: SymbolId(61): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(92): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "toString":
-after transform: SymbolId(63): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(95): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "flat":
-after transform: SymbolId(65): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(98): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "flatMap":
-after transform: SymbolId(67): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(101): SymbolFlags(BlockScopedVariable)
 
 * namespace/declare/input.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["B", "C", "_N", "e", "f", "v"]
 rebuilt        : ScopeId(1): ["_N"]
-Symbol flags mismatch for "N":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
-* namespace/declare-global-nested-namespace/input.ts
-Symbol flags mismatch for "X":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 * namespace/empty-removed/input.ts
 Bindings mismatch:
@@ -1596,47 +1475,12 @@ rebuilt        : ScopeId(3): ["_WithTypes", "d"]
 Bindings mismatch:
 after transform: ScopeId(12): ["D", "_d"]
 rebuilt        : ScopeId(4): ["_d"]
-Symbol flags mismatch for "a":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol reference IDs mismatch for "a":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(4), ReferenceId(5)]
 rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3)]
-Symbol flags mismatch for "c":
-after transform: SymbolId(2): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "WithTypes":
-after transform: SymbolId(6): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "d":
-after transform: SymbolId(13): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "WithValues":
-after transform: SymbolId(15): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "a":
-after transform: SymbolId(16): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "b":
-after transform: SymbolId(18): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "B":
 after transform: SymbolId(19): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "c":
-after transform: SymbolId(20): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(18): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "d":
-after transform: SymbolId(22): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(21): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "e":
-after transform: SymbolId(24): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(24): SymbolFlags(BlockScopedVariable)
-
-* namespace/export/input.ts
-Symbol flags mismatch for "N":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 * namespace/export-type-only/input.ts
 Bindings mismatch:
@@ -1644,9 +1488,6 @@ after transform: ScopeId(0): ["Platform"]
 rebuilt        : ScopeId(0): []
 
 * namespace/multiple/input.ts
-Symbol flags mismatch for "N":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "N":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 33, end: 34 }]
 rebuilt        : SymbolId(0): []
@@ -1682,39 +1523,21 @@ rebuilt        : ScopeId(9): ["H"]
 Bindings mismatch:
 after transform: ScopeId(13): ["L", "M"]
 rebuilt        : ScopeId(13): ["L"]
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(Class | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(Class)
 Symbol redeclarations mismatch for "A":
 after transform: SymbolId(0): [Span { start: 6, end: 7 }, Span { start: 22, end: 23 }]
 rebuilt        : SymbolId(0): []
-Symbol flags mismatch for "C":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "M":
-after transform: SymbolId(4): SymbolFlags(Function | ValueModule)
-rebuilt        : SymbolId(6): SymbolFlags(Function)
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(4): [Span { start: 110, end: 111 }, Span { start: 129, end: 130 }]
 rebuilt        : SymbolId(6): []
-Symbol flags mismatch for "D":
-after transform: SymbolId(6): SymbolFlags(Function | ValueModule)
-rebuilt        : SymbolId(9): SymbolFlags(Function)
 Symbol redeclarations mismatch for "D":
 after transform: SymbolId(6): [Span { start: 181, end: 182 }, Span { start: 207, end: 208 }]
 rebuilt        : SymbolId(9): []
 Symbol flags mismatch for "H":
 after transform: SymbolId(8): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "F":
-after transform: SymbolId(12): SymbolFlags(Class | ValueModule)
-rebuilt        : SymbolId(14): SymbolFlags(Class)
 Symbol redeclarations mismatch for "F":
 after transform: SymbolId(12): [Span { start: 308, end: 309 }, Span { start: 325, end: 326 }]
 rebuilt        : SymbolId(14): []
-Symbol flags mismatch for "G":
-after transform: SymbolId(14): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(17): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "L":
 after transform: SymbolId(16): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
@@ -1726,54 +1549,17 @@ rebuilt        : ScopeId(1): ["G", "_A"]
 Bindings mismatch:
 after transform: ScopeId(4): ["G", "H"]
 rebuilt        : ScopeId(2): ["G"]
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "G":
 after transform: SymbolId(3): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
-* namespace/nested-shorthand/input.ts
-Symbol flags mismatch for "X":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "Y":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "proj":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "data":
-after transform: SymbolId(4): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "util":
-after transform: SymbolId(5): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "api":
-after transform: SymbolId(6): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
-
 * namespace/same-name/input.ts
-Symbol flags mismatch for "N":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "_N7":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "N":
-after transform: SymbolId(3): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "N":
 after transform: SymbolId(3): [Span { start: 59, end: 60 }, Span { start: 115, end: 116 }, Span { start: 166, end: 167 }]
 rebuilt        : SymbolId(5): []
 Symbol flags mismatch for "_N":
 after transform: SymbolId(6): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
-
-* namespace/undeclared/input.ts
-Symbol flags mismatch for "N":
-after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 * optimize-const-enums/custom-values-exported/input.ts
 x Output mismatch

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 1fb0b771
 
-Passed: 254/398
+Passed: 256/398
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -48,7 +48,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-typescript (26/60)
+# babel-plugin-transform-typescript (28/60)
 * allow-declare-fields-false/input.ts
 Unresolved references mismatch:
 after transform: ["dce"]
@@ -251,9 +251,6 @@ rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
 Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "Foo", "Func", "Im", "Name", "Ok"]
 rebuilt        : ScopeId(0): ["Bar", "Foo", "Func", "Im", "Name", "Ok", "T"]
-Symbol flags mismatch for "Name":
-after transform: SymbolId(7): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "T":
 after transform: SymbolId(9): SymbolFlags(Function | TypeAlias)
 rebuilt        : SymbolId(8): SymbolFlags(Function)
@@ -264,73 +261,36 @@ Symbol redeclarations mismatch for "T":
 after transform: SymbolId(9): [Span { start: 205, end: 206 }, Span { start: 226, end: 227 }]
 rebuilt        : SymbolId(8): []
 
-* namespace/export-import-=/input.ts
-Symbol flags mismatch for "N1":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-
 * namespace/import-=/input.ts
 Symbol reference IDs mismatch for "A":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
 rebuilt        : SymbolId(0): [ReferenceId(2)]
-Symbol flags mismatch for "N1":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "N2":
-after transform: SymbolId(4): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
-
-* namespace/preserve-import-=/input.ts
-Symbol flags mismatch for "N1":
-after transform: SymbolId(1): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "N2":
-after transform: SymbolId(4): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 
 * namespace/redeclaration-with-enum/input.ts
 Bindings mismatch:
 after transform: ScopeId(2): ["x", "y"]
 rebuilt        : ScopeId(2): ["x"]
-Symbol flags mismatch for "x":
-after transform: SymbolId(0): SymbolFlags(RegularEnum | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "x":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 39, end: 40 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "y":
-after transform: SymbolId(2): SymbolFlags(RegularEnum | ValueModule)
+after transform: SymbolId(2): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
 Symbol redeclarations mismatch for "y":
 after transform: SymbolId(2): [Span { start: 59, end: 60 }, Span { start: 83, end: 84 }]
 rebuilt        : SymbolId(3): []
 
 * namespace/redeclaration-with-interface/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): []
-rebuilt        : ScopeId(0): ["Foo"]
-Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(Interface | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(0): [Span { start: 17, end: 20 }, Span { start: 41, end: 44 }]
 rebuilt        : SymbolId(0): []
 
 * namespace/redeclaration-with-type-alias/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): []
-rebuilt        : ScopeId(0): ["Foo"]
-Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(TypeAlias | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(0): [Span { start: 12, end: 15 }, Span { start: 39, end: 42 }, Span { start: 87, end: 90 }]
 rebuilt        : SymbolId(0): []
 
 * namespace/redeclaration-with-type-only-namespace/input.ts
-Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(NamespaceModule | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(0): [Span { start: 17, end: 20 }, Span { start: 62, end: 65 }]
 rebuilt        : SymbolId(0): []


### PR DESCRIPTION
## Summary

Synchronize semantic symbol flags with the JavaScript emitted when lowering TypeScript namespaces.

- Mark generated namespace `let` bindings as block-scoped variables.
- Remove namespace module flags when a namespace merges with another runtime declaration.
- Defer flag updates until all namespace declarations are classified, avoiding order-dependent behavior for merged namespaces.
- Update semantic and transformer conformance snapshots.

