### PR TITLE
fix(transformer): correct symbol flags for lowered enums

### DIFF
--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -12,7 +12,7 @@ use oxc_syntax::{
     number::NumberBase,
     operator::{AssignmentOperator, BinaryOperator, LogicalOperator, UnaryOperator},
     reference::{ReferenceFlags, ReferenceId},
-    symbol::SymbolFlags,
+    symbol::{SymbolFlags, SymbolId},
 };
 use oxc_traverse::{BoundIdentifier, Traverse};
 
@@ -21,11 +21,30 @@ use crate::{context::TraverseCtx, state::TransformState};
 pub struct TypeScriptEnum {
     optimize_const_enums: bool,
     optimize_enums: bool,
+    pending_symbol_flags: Vec<(SymbolId, SymbolFlags)>,
 }
 
 impl TypeScriptEnum {
     pub fn new(optimize_const_enums: bool, optimize_enums: bool) -> Self {
-        Self { optimize_const_enums, optimize_enums }
+        Self { optimize_const_enums, optimize_enums, pending_symbol_flags: Vec::new() }
+    }
+
+    fn pending_symbol_flags_mut(
+        &mut self,
+        symbol_id: SymbolId,
+        initial_flags: SymbolFlags,
+    ) -> &mut SymbolFlags {
+        if let Some(index) = self.pending_symbol_flags.iter().position(|&(id, _)| id == symbol_id) {
+            return &mut self.pending_symbol_flags[index].1;
+        }
+        self.pending_symbol_flags.push((symbol_id, initial_flags));
+        &mut self.pending_symbol_flags.last_mut().unwrap().1
+    }
+
+    pub fn exit_program(&mut self, ctx: &mut TraverseCtx<'_>) {
+        for (symbol_id, flags) in self.pending_symbol_flags.drain(..) {
+            *ctx.scoping_mut().symbol_flags_mut(symbol_id) = flags;
+        }
     }
 }
 
@@ -38,14 +57,14 @@ impl<'a> Traverse<'a, TransformState<'a>> for TypeScriptEnum {
                 if self.may_remove_enum(decl, ctx) {
                     return;
                 }
-                if let Some(new_stmt) = Self::transform_ts_enum(decl, None, ctx) {
+                if let Some(new_stmt) = self.transform_ts_enum(decl, None, ctx) {
                     *stmt = new_stmt;
                 }
             }
             Statement::ExportNamedDeclaration(export_decl) => {
                 let span = export_decl.span;
                 if let Some(Declaration::TSEnumDeclaration(decl)) = &mut export_decl.declaration
-                    && let Some(new_stmt) = Self::transform_ts_enum(decl, Some(span), ctx)
+                    && let Some(new_stmt) = self.transform_ts_enum(decl, Some(span), ctx)
                 {
                     *stmt = new_stmt;
                 }
@@ -74,7 +93,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for TypeScriptEnum {
                 continue;
             }
             // Not removable after all (still has value references) — transform now.
-            if let Some(new_stmt) = Self::transform_ts_enum(decl, None, ctx) {
+            if let Some(new_stmt) = self.transform_ts_enum(decl, None, ctx) {
                 *stmt = new_stmt;
             }
         }
@@ -156,6 +175,7 @@ impl<'a> TypeScriptEnum {
     /// })(Foo || {});
     /// ```
     fn transform_ts_enum(
+        &mut self,
         decl: &mut TSEnumDeclaration<'a>,
         export_span: Option<Span>,
         ctx: &mut TraverseCtx<'a>,
@@ -277,6 +297,9 @@ impl<'a> TypeScriptEnum {
         );
 
         if is_already_declared {
+            let initial_flags = ctx.scoping().symbol_flags(enum_symbol_id);
+            let flags = self.pending_symbol_flags_mut(enum_symbol_id, initial_flags);
+            *flags -= SymbolFlags::Enum;
             let op = AssignmentOperator::Assign;
             let left = ctx.create_bound_ident_reference(
                 decl.id.span,
@@ -289,11 +312,12 @@ impl<'a> TypeScriptEnum {
             return Some(Statement::new_expression_statement(span, expr, ctx));
         }
 
-        let kind = if is_export || is_not_top_scope {
-            VariableDeclarationKind::Let
+        let (kind, flags) = if is_export || is_not_top_scope {
+            (VariableDeclarationKind::Let, SymbolFlags::BlockScopedVariable)
         } else {
-            VariableDeclarationKind::Var
+            (VariableDeclarationKind::Var, SymbolFlags::FunctionScopedVariable)
         };
+        *self.pending_symbol_flags_mut(enum_symbol_id, flags) = flags;
         let decls = {
             let binding = BindingPattern::new_binding_identifier_with_symbol_id(
                 decl.id.span,

--- a/crates/oxc_transformer/src/typescript/mod.rs
+++ b/crates/oxc_transformer/src/typescript/mod.rs
@@ -88,6 +88,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for TypeScript<'a> {
     fn exit_program(&mut self, program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
         self.annotations.exit_program(program, ctx);
         self.module.exit_program(program, ctx);
+        self.r#enum.exit_program(ctx);
         ctx.scoping.delete_typescript_bindings();
     }
 

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -2,7 +2,7 @@ commit: 1fb0b771
 
 semantic_babel Summary:
 AST Parsed     : 2236/2236 (100.00%)
-Positive Passed: 2131/2236 (95.30%)
+Positive Passed: 2139/2236 (95.66%)
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/decorators/decorators-after-export/input.js
 Symbol flags mismatch for "_default":
 after transform: SymbolId(3): SymbolFlags(Class)
@@ -17,9 +17,6 @@ semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/comment
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "E"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/class-private-properties/await-in-private-property-in-params-of-async-arrow/input.js
 Bindings mismatch:
@@ -67,9 +64,6 @@ semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "a", "r"]
 rebuilt        : ScopeId(1): ["A"]
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/typescript/loc-index-property/input.js
 Bindings mismatch:
@@ -199,11 +193,6 @@ Bindings mismatch:
 after transform: ScopeId(0): ["x"]
 rebuilt        : ScopeId(0): []
 
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/const/input.ts
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/declare/input.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["E"]
@@ -219,24 +208,6 @@ Bindings mismatch:
 after transform: ScopeId(0): ["E"]
 rebuilt        : ScopeId(0): []
 
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/enum-as-or-satisfies-brackets/input.ts
-Symbol flags mismatch for "as":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "satisfies":
-after transform: SymbolId(1): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/export/input.ts
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/export-const/input.ts
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/export-declare-const/input.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["E"]
@@ -246,41 +217,26 @@ semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescr
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "E"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/members-reserved-words/input.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["E", "const", "default"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/members-strings/input.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["E", "bar", "foo"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/members-trailing-comma/input.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "E"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/members-trailing-comma-with-initializer/input.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "E"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/export/declare/input.ts
 Bindings mismatch:
@@ -306,9 +262,6 @@ semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescr
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "D", "E", "a", "b"]
 rebuilt        : ScopeId(0): ["C", "D", "a", "b"]
-Symbol flags mismatch for "D":
-after transform: SymbolId(3): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/function/declare/input.ts
 Bindings mismatch:
@@ -394,11 +347,6 @@ Bindings mismatch:
 after transform: ScopeId(0): ["as", "satisfies"]
 rebuilt        : ScopeId(0): []
 
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/is-default-export/input.ts
-Symbol flags mismatch for "E":
-after transform: SymbolId(1): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/callable-class/input.ts
 Symbol flags mismatch for "C":
 after transform: SymbolId(0): SymbolFlags(Class | Function | Ambient)
@@ -415,11 +363,6 @@ Bindings mismatch:
 after transform: ScopeId(0): ["C"]
 rebuilt        : ScopeId(0): []
 
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/enum-block-scoped/input.ts
-Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/export-declare-function-after/input.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["foo"]
@@ -429,16 +372,6 @@ semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescr
 Bindings mismatch:
 after transform: ScopeId(0): ["foo"]
 rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/export-enum-after/input.ts
-Symbol flags mismatch for "Test":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/export-enum-before/input.ts
-Symbol flags mismatch for "Test":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/export-namespace/input.ts
 Bindings mismatch:
@@ -495,17 +428,11 @@ after transform: SymbolId(0): [Span { start: 6, end: 7 }, Span { start: 19, end:
 rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-constenum-constenum/input.ts
-Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(0): [Span { start: 11, end: 14 }, Span { start: 29, end: 32 }]
 rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-enum-enum/input.ts
-Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(0): [Span { start: 5, end: 8 }, Span { start: 17, end: 20 }]
 rebuilt        : SymbolId(0): []

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -1,6 +1,6 @@
 semantic_misc Summary:
 AST Parsed     : 70/70 (100.00%)
-Positive Passed: 64/70 (91.43%)
+Positive Passed: 65/70 (92.86%)
 semantic Error: tasks/coverage/misc/pass/declare-let-private.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["private"]
@@ -115,33 +115,4 @@ rebuilt        : ScopeId(7): ["G"]
 Bindings mismatch:
 after transform: ScopeId(8): ["H", "baz"]
 rebuilt        : ScopeId(8): ["H"]
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "B":
-after transform: SymbolId(2): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "C":
-after transform: SymbolId(4): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "D":
-after transform: SymbolId(6): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "E":
-after transform: SymbolId(8): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "F":
-after transform: SymbolId(10): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(10): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "G":
-after transform: SymbolId(12): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(12): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "H":
-after transform: SymbolId(14): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(14): SymbolFlags(FunctionScopedVariable)
-
-semantic Error: tasks/coverage/misc/pass/oxc-8193.ts
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -2,7 +2,7 @@ commit: 7964e22f
 
 semantic_typescript Summary:
 AST Parsed     : 4720/4720 (100.00%)
-Positive Passed: 3349/4720 (70.95%)
+Positive Passed: 3353/4720 (71.04%)
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/APISample_Watch.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["console", "formatHost", "os", "process", "reportDiagnostic", "reportWatchStatusChanged", "ts", "watchMain"]
@@ -206,9 +206,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/ambientConstLiter
 Bindings mismatch:
 after transform: ScopeId(2): ["A", "B", "C", "E", "non identifier"]
 rebuilt        : ScopeId(2): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(3): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/ambientEnumElementInitializer1.ts
 Bindings mismatch:
@@ -442,9 +439,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatF
 Bindings mismatch:
 after transform: ScopeId(1): ["One", "TokenType", "Two"]
 rebuilt        : ScopeId(1): ["TokenType"]
-Symbol flags mismatch for "TokenType":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability1.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -484,9 +478,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/assignmentNonObje
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "C", "E"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionContextuallyTypedReturns.ts
 Bindings mismatch:
@@ -672,9 +663,6 @@ rebuilt        : ScopeId(1): ["Foo"]
 Bindings mismatch:
 after transform: ScopeId(2): ["Foo", "b"]
 rebuilt        : ScopeId(2): ["Foo"]
-Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(0): [Span { start: 5, end: 8 }, Span { start: 29, end: 32 }]
 rebuilt        : SymbolId(0): []
@@ -1345,12 +1333,6 @@ rebuilt        : ScopeId(6): ["SyntaxKind"]
 Bindings mismatch:
 after transform: ScopeId(36): ["ClassExpression", "ClassStatement", "SyntaxKind1"]
 rebuilt        : ScopeId(9): ["SyntaxKind1"]
-Symbol flags mismatch for "SyntaxKind":
-after transform: SymbolId(36): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(10): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "SyntaxKind1":
-after transform: SymbolId(74): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(17): SymbolFlags(FunctionScopedVariable)
 Reference symbol mismatch for "cast":
 after transform: SymbolId(3) "cast"
 rebuilt        : <None>
@@ -1434,9 +1416,6 @@ rebuilt        : ScopeId(0): ["SyntaxKind", "foo"]
 Bindings mismatch:
 after transform: ScopeId(32): ["AssertClause", "Decorator", "ImportClause", "ImportDeclaration", "Modifier", "SyntaxKind"]
 rebuilt        : ScopeId(1): ["SyntaxKind"]
-Symbol flags mismatch for "SyntaxKind":
-after transform: SymbolId(49): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Reference symbol mismatch for "buildOverload":
 after transform: SymbolId(47) "buildOverload"
 rebuilt        : <None>
@@ -1511,9 +1490,6 @@ rebuilt        : ScopeId(0): ["SyntaxKind", "foo"]
 Bindings mismatch:
 after transform: ScopeId(1): ["Decorator", "Modifier", "SyntaxKind"]
 rebuilt        : ScopeId(1): ["SyntaxKind"]
-Symbol flags mismatch for "SyntaxKind":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Reference symbol mismatch for "every":
 after transform: SymbolId(10) "every"
 rebuilt        : <None>
@@ -1582,9 +1558,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenE
 Bindings mismatch:
 after transform: ScopeId(1): ["Color", "Thing"]
 rebuilt        : ScopeId(1): ["Color"]
-Symbol flags mismatch for "Color":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithAccessorChildren.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -1602,9 +1575,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenM
 Bindings mismatch:
 after transform: ScopeId(2): ["e", "m1", "m2"]
 rebuilt        : ScopeId(2): ["e"]
-Symbol flags mismatch for "e":
-after transform: SymbolId(1): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithFunctionChildren.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -1757,9 +1727,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpr
 Bindings mismatch:
 after transform: ScopeId(1): ["_this", "_thisVal1", "_thisVal2"]
 rebuilt        : ScopeId(1): ["_this"]
-Symbol flags mismatch for "_this":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndLocalVarInLambda.ts
 Bindings mismatch:
@@ -1876,9 +1843,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/commentOnExportEn
 Bindings mismatch:
 after transform: ScopeId(1): ["Color", "b", "g", "r"]
 rebuilt        : ScopeId(1): ["Color"]
-Symbol flags mismatch for "Color":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/commentOnSignature1.ts
 Symbol span mismatch for "foo":
@@ -1908,9 +1872,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/comparableRelatio
 Bindings mismatch:
 after transform: ScopeId(1): ["AutomationMode", "LOCATION", "NONE", "SYSTEM", "TIME"]
 rebuilt        : ScopeId(1): ["AutomationMode"]
-Symbol flags mismatch for "AutomationMode":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/complexNarrowingWithAny.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -1933,9 +1894,6 @@ Missing ReferenceId: "Foo"
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "C", "F", "Foo", "G", "H", "I", "J"]
 rebuilt        : ScopeId(1): ["Foo"]
-Symbol flags mismatch for "Foo":
-after transform: SymbolId(1): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "Foo":
 after transform: SymbolId(10): [ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(24)]
 rebuilt        : SymbolId(2): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(9), ReferenceId(11), ReferenceId(12), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(24)]
@@ -1949,9 +1907,6 @@ Missing ReferenceId: "Foo"
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "C", "D", "E1", "E2", "F", "Foo", "G", "H", "I", "J"]
 rebuilt        : ScopeId(1): ["Foo"]
-Symbol flags mismatch for "Foo":
-after transform: SymbolId(2): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "Foo":
 after transform: SymbolId(14): [ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(32), ReferenceId(33)]
 rebuilt        : SymbolId(3): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(14), ReferenceId(15), ReferenceId(17), ReferenceId(18), ReferenceId(20), ReferenceId(21), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(30), ReferenceId(31), ReferenceId(32), ReferenceId(33)]
@@ -1966,12 +1921,6 @@ rebuilt        : ScopeId(1): ["E"]
 Bindings mismatch:
 after transform: ScopeId(9): ["A", "B", "C", "MyEnum"]
 rebuilt        : ScopeId(8): ["MyEnum"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(2): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "MyEnum":
-after transform: SymbolId(52): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(43): SymbolFlags(FunctionScopedVariable)
 Reference symbol mismatch for "computed":
 after transform: SymbolId(0) "computed"
 rebuilt        : <None>
@@ -2004,9 +1953,6 @@ rebuilt        : ScopeId(0): ["Props", "k"]
 Bindings mismatch:
 after transform: ScopeId(1): ["Props", "k"]
 rebuilt        : ScopeId(1): ["Props"]
-Symbol flags mismatch for "Props":
-after transform: SymbolId(1): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
 Reference symbol mismatch for "foo":
 after transform: SymbolId(6) "foo"
 rebuilt        : <None>
@@ -2097,36 +2043,21 @@ rebuilt        : ScopeId(1): ["E"]
 Bindings mismatch:
 after transform: ScopeId(2): ["A", "B", "C", "E2"]
 rebuilt        : ScopeId(2): ["E2"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "E2":
-after transform: SymbolId(4): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/constEnumNamespaceReferenceCausesNoImport.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["ConstFooEnum", "Here", "Some", "Values"]
 rebuilt        : ScopeId(1): ["ConstFooEnum"]
-Symbol flags mismatch for "ConstFooEnum":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/constEnumNamespaceReferenceCausesNoImport2.ts
 Bindings mismatch:
 after transform: ScopeId(2): ["ConstFooEnum", "Here", "Some", "Values"]
 rebuilt        : ScopeId(2): ["ConstFooEnum"]
-Symbol flags mismatch for "ConstFooEnum":
-after transform: SymbolId(1): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/constEnumNoEmitReexport.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["Bar", "Foo", "MyConstEnum"]
 rebuilt        : ScopeId(1): ["MyConstEnum"]
-Symbol flags mismatch for "MyConstEnum":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/constEnumOnlyModuleMerging.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -2136,57 +2067,36 @@ rebuilt        : ScopeId(3): ["A"]
 Symbol redeclarations mismatch for "Outer":
 after transform: SymbolId(0): [Span { start: 10, end: 15 }, Span { start: 53, end: 58 }]
 rebuilt        : SymbolId(0): []
-Symbol flags mismatch for "A":
-after transform: SymbolId(2): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/constEnumPreserveEmitNamedExport1.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "Foo"]
 rebuilt        : ScopeId(1): ["A"]
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/constEnumPreserveEmitNamedExport2.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "Foo"]
 rebuilt        : ScopeId(1): ["A"]
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/constEnumPreserveEmitReexport.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["Bar", "Foo", "MyConstEnum"]
 rebuilt        : ScopeId(1): ["MyConstEnum"]
-Symbol flags mismatch for "MyConstEnum":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/constEnumSyntheticNodesComments.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "C", "D", "En"]
 rebuilt        : ScopeId(1): ["En"]
-Symbol flags mismatch for "En":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/constEnumToStringNoComments.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "C", "Foo", "X", "Y", "Z"]
 rebuilt        : ScopeId(1): ["Foo"]
-Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/constEnumToStringWithComments.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "C", "Foo", "X", "Y", "Z"]
 rebuilt        : ScopeId(1): ["Foo"]
-Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/constructorOverloads5.ts
 Bindings mismatch:
@@ -2977,9 +2887,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowBreakC
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "User"]
 rebuilt        : ScopeId(1): ["User"]
-Symbol flags mismatch for "User":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowCommaExpressionAssertionWithinTernary.ts
 Bindings mismatch:
@@ -3109,9 +3016,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowManyCo
 Bindings mismatch:
 after transform: ScopeId(1): ["Choice", "One", "Two"]
 rebuilt        : ScopeId(1): ["Choice"]
-Symbol flags mismatch for "Choice":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowPropertyDeclarations.ts
 Bindings mismatch:
@@ -3165,9 +3069,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileEnumUsedA
 Bindings mismatch:
 after transform: ScopeId(1): ["a", "b", "c", "e"]
 rebuilt        : ScopeId(1): ["e"]
-Symbol flags mismatch for "e":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileEnums.ts
 Bindings mismatch:
@@ -3185,21 +3086,6 @@ rebuilt        : ScopeId(4): ["e4"]
 Bindings mismatch:
 after transform: ScopeId(5): ["Friday", "Saturday", "Sunday", "Weekend days", "e5"]
 rebuilt        : ScopeId(5): ["e5"]
-Symbol flags mismatch for "e1":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "e2":
-after transform: SymbolId(4): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "e3":
-after transform: SymbolId(8): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "e4":
-after transform: SymbolId(12): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "e5":
-after transform: SymbolId(18): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileExportAssignmentImportInternalModule.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -3265,9 +3151,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileTypeofEnu
 Bindings mismatch:
 after transform: ScopeId(1): ["days", "friday", "monday", "saturday", "sunday", "thursday", "tuesday", "wednesday"]
 rebuilt        : ScopeId(1): ["days"]
-Symbol flags mismatch for "days":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileTypeofFunction.ts
 Symbol span mismatch for "f":
@@ -3287,9 +3170,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileTypeofInA
 Bindings mismatch:
 after transform: ScopeId(3): ["e", "holiday", "weekday", "weekend"]
 rebuilt        : ScopeId(3): ["e"]
-Symbol flags mismatch for "e":
-after transform: SymbolId(2): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileTypeofModule.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -3348,9 +3228,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitCo
 Bindings mismatch:
 after transform: ScopeId(1): ["EnumExample", "TEST"]
 rebuilt        : ScopeId(1): ["EnumExample"]
-Symbol flags mismatch for "EnumExample":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedNameWithQuestionToken.ts
 Bindings mismatch:
@@ -3378,9 +3255,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitCo
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "Enum"]
 rebuilt        : ScopeId(1): ["Enum"]
-Symbol flags mismatch for "Enum":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringArrayPattern3.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -3420,9 +3294,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitEn
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "E"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitEnumReferenceViaImportEquals.ts
 Bindings mismatch:
@@ -3614,9 +3485,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol redeclarations mismatch for "X":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 160, end: 161 }]
 rebuilt        : SymbolId(0): []
-Symbol flags mismatch for "E":
-after transform: SymbolId(7): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNameConflicts3.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -3632,9 +3500,6 @@ rebuilt        : SymbolId(0): []
 Symbol redeclarations mismatch for "D":
 after transform: SymbolId(1): [Span { start: 35, end: 36 }, Span { start: 62, end: 63 }]
 rebuilt        : SymbolId(2): []
-Symbol flags mismatch for "D":
-after transform: SymbolId(10): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNameConflictsWithAlias.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -3654,9 +3519,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNo
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "C", "Test"]
 rebuilt        : ScopeId(1): ["Test"]
-Symbol flags mismatch for "Test":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitOfFuncspace.ts
 Symbol flags mismatch for "ExpandoMerge":
@@ -3690,17 +3552,11 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitSp
 Bindings mismatch:
 after transform: ScopeId(1): ["0-17", "18-22", "23-27", "28-34", "35-44", "45-59", "60-150", "AgeGroups"]
 rebuilt        : ScopeId(1): ["AgeGroups"]
-Symbol flags mismatch for "AgeGroups":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitStringEnumUsedInNonlocalSpread.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["Test1", "Test2", "TestEnum"]
 rebuilt        : ScopeId(1): ["TestEnum"]
-Symbol flags mismatch for "TestEnum":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationImportTypeAliasInferredAndEmittable.ts
 Bindings mismatch:
@@ -4173,12 +4029,6 @@ rebuilt        : ScopeId(17): ["Types"]
 Bindings mismatch:
 after transform: ScopeId(44): ["BarEnum", "bar1", "bar2"]
 rebuilt        : ScopeId(28): ["BarEnum"]
-Symbol flags mismatch for "Types":
-after transform: SymbolId(20): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(16): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "BarEnum":
-after transform: SymbolId(46): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(28): SymbolFlags(FunctionScopedVariable)
 Reference symbol mismatch for "never":
 after transform: SymbolId(44) "never"
 rebuilt        : <None>
@@ -4247,9 +4097,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/discriminantsAndP
 Bindings mismatch:
 after transform: ScopeId(15): ["Disjunction", "EnumTypeNode", "Pattern"]
 rebuilt        : ScopeId(13): ["EnumTypeNode"]
-Symbol flags mismatch for "EnumTypeNode":
-after transform: SymbolId(10): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/discriminateWithDivergentAccessors1.ts
 Bindings mismatch:
@@ -4311,9 +4158,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/discriminatedUnio
 Bindings mismatch:
 after transform: ScopeId(4): ["Avatar", "ListItemVariant", "OneLine"]
 rebuilt        : ScopeId(2): ["ListItemVariant"]
-Symbol flags mismatch for "ListItemVariant":
-after transform: SymbolId(7): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/discriminatingUnionWithUnionPropertyAgainstUndefinedWithoutStrictNullChecks.ts
 Bindings mismatch:
@@ -4376,9 +4220,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/doubleUnderscoreE
 Bindings mismatch:
 after transform: ScopeId(1): ["(Anonymous class)", "(Anonymous function)", "Foo", "__a", "__call"]
 rebuilt        : ScopeId(1): ["Foo"]
-Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(0): [Span { start: 5, end: 8 }, Span { start: 117, end: 120 }]
 rebuilt        : SymbolId(0): []
@@ -4574,11 +4415,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["a"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/emptyEnum.ts
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/emptyOptionalBindingPatternInDeclarationSignature.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["C1", "fn1", "fn2", "fn3", "fn4", "val1", "val2"]
@@ -4593,20 +4429,11 @@ rebuilt        : ScopeId(2): ["MyEnum"]
 Bindings mismatch:
 after transform: ScopeId(4): ["FOO", "MyEnum"]
 rebuilt        : ScopeId(4): ["MyEnum"]
-Symbol flags mismatch for "MyEnum":
-after transform: SymbolId(1): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "MyEnum":
-after transform: SymbolId(5): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumCodeGenNewLines1.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["b", "c", "d", "foo"]
 rebuilt        : ScopeId(1): ["foo"]
-Symbol flags mismatch for "foo":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumDecl1.ts
 Bindings mismatch:
@@ -4617,25 +4444,16 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumDeclarationEm
 Bindings mismatch:
 after transform: ScopeId(1): ["Enum", "Value1", "Value2"]
 rebuilt        : ScopeId(1): ["Enum"]
-Symbol flags mismatch for "Enum":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumFromExternalModule.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["Mode", "Open"]
 rebuilt        : ScopeId(1): ["Mode"]
-Symbol flags mismatch for "Mode":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumIndexer.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["MyEnumType", "bar", "foo"]
 rebuilt        : ScopeId(1): ["MyEnumType"]
-Symbol flags mismatch for "MyEnumType":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumInitializersWithExponents.ts
 Bindings mismatch:
@@ -4646,9 +4464,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumKeysQuotedAsO
 Bindings mismatch:
 after transform: ScopeId(1): ["LEFT_BUTTON", "MIDDLE_BUTTON", "MouseButton", "NO_BUTTON", "RIGHT_BUTTON", "XBUTTON1_BUTTON", "XBUTTON2_BUTTON"]
 rebuilt        : ScopeId(1): ["MouseButton"]
-Symbol flags mismatch for "MouseButton":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumLiteralUnionNotWidened.ts
 Bindings mismatch:
@@ -4657,36 +4472,21 @@ rebuilt        : ScopeId(1): ["A"]
 Bindings mismatch:
 after transform: ScopeId(2): ["B", "bar", "foo"]
 rebuilt        : ScopeId(2): ["B"]
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "B":
-after transform: SymbolId(3): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumLiteralsSubtypeReduction.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["E", "E0", "E1", "E10", "E100", "E1000", "E1001", "E1002", "E1003", "E1004", "E1005", "E1006", "E1007", "E1008", "E1009", "E101", "E1010", "E1011", "E1012", "E1013", "E1014", "E1015", "E1016", "E1017", "E1018", "E1019", "E102", "E1020", "E1021", "E1022", "E1023", "E103", "E104", "E105", "E106", "E107", "E108", "E109", "E11", "E110", "E111", "E112", "E113", "E114", "E115", "E116", "E117", "E118", "E119", "E12", "E120", "E121", "E122", "E123", "E124", "E125", "E126", "E127", "E128", "E129", "E13", "E130", "E131", "E132", "E133", "E134", "E135", "E136", "E137", "E138", "E139", "E14", "E140", "E141", "E142", "E143", "E144", "E145", "E146", "E147", "E148", "E149", "E15", "E150", "E151", "E152", "E153", "E154", "E155", "E156", "E157", "E158", "E159", "E16", "E160", "E161", "E162", "E163", "E164", "E165", "E166", "E167", "E168", "E169", "E17", "E170", "E171", "E172", "E173", "E174", "E175", "E176", "E177", "E178", "E179", "E18", "E180", "E181", "E182", "E183", "E184", "E185", "E186", "E187", "E188", "E189", "E19", "E190", "E191", "E192", "E193", "E194", "E195", "E196", "E197", "E198", "E199", "E2", "E20", "E200", "E201", "E202", "E203", "E204", "E205", "E206", "E207", "E208", "E209", "E21", "E210", "E211", "E212", "E213", "E214", "E215", "E216", "E217", "E218", "E219", "E22", "E220", "E221", "E222", "E223", "E224", "E225", "E226", "E227", "E228", "E229", "E23", "E230", "E231", "E232", "E233", "E234", "E235", "E236", "E237", "E238", "E239", "E24", "E240", "E241", "E242", "E243", "E244", "E245", "E246", "E247", "E248", "E249", "E25", "E250", "E251", "E252", "E253", "E254", "E255", "E256", "E257", "E258", "E259", "E26", "E260", "E261", "E262", "E263", "E264", "E265", "E266", "E267", "E268", "E269", "E27", "E270", "E271", "E272", "E273", "E274", "E275", "E276", "E277", "E278", "E279", "E28", "E280", "E281", "E282", "E283", "E284", "E285", "E286", "E287", "E288", "E289", "E29", "E290", "E291", "E292", "E293", "E294", "E295", "E296", "E297", "E298", "E299", "E3", "E30", "E300", "E301", "E302", "E303", "E304", "E305", "E306", "E307", "E308", "E309", "E31", "E310", "E311", "E312", "E313", "E314", "E315", "E316", "E317", "E318", "E319", "E32", "E320", "E321", "E322", "E323", "E324", "E325", "E326", "E327", "E328", "E329", "E33", "E330", "E331", "E332", "E333", "E334", "E335", "E336", "E337", "E338", "E339", "E34", "E340", "E341", "E342", "E343", "E344", "E345", "E346", "E347", "E348", "E349", "E35", "E350", "E351", "E352", "E353", "E354", "E355", "E356", "E357", "E358", "E359", "E36", "E360", "E361", "E362", "E363", "E364", "E365", "E366", "E367", "E368", "E369", "E37", "E370", "E371", "E372", "E373", "E374", "E375", "E376", "E377", "E378", "E379", "E38", "E380", "E381", "E382", "E383", "E384", "E385", "E386", "E387", "E388", "E389", "E39", "E390", "E391", "E392", "E393", "E394", "E395", "E396", "E397", "E398", "E399", "E4", "E40", "E400", "E401", "E402", "E403", "E404", "E405", "E406", "E407", "E408", "E409", "E41", "E410", "E411", "E412", "E413", "E414", "E415", "E416", "E417", "E418", "E419", "E42", "E420", "E421", "E422", "E423", "E424", "E425", "E426", "E427", "E428", "E429", "E43", "E430", "E431", "E432", "E433", "E434", "E435", "E436", "E437", "E438", "E439", "E44", "E440", "E441", "E442", "E443", "E444", "E445", "E446", "E447", "E448", "E449", "E45", "E450", "E451", "E452", "E453", "E454", "E455", "E456", "E457", "E458", "E459", "E46", "E460", "E461", "E462", "E463", "E464", "E465", "E466", "E467", "E468", "E469", "E47", "E470", "E471", "E472", "E473", "E474", "E475", "E476", "E477", "E478", "E479", "E48", "E480", "E481", "E482", "E483", "E484", "E485", "E486", "E487", "E488", "E489", "E49", "E490", "E491", "E492", "E493", "E494", "E495", "E496", "E497", "E498", "E499", "E5", "E50", "E500", "E501", "E502", "E503", "E504", "E505", "E506", "E507", "E508", "E509", "E51", "E510", "E511", "E512", "E513", "E514", "E515", "E516", "E517", "E518", "E519", "E52", "E520", "E521", "E522", "E523", "E524", "E525", "E526", "E527", "E528", "E529", "E53", "E530", "E531", "E532", "E533", "E534", "E535", "E536", "E537", "E538", "E539", "E54", "E540", "E541", "E542", "E543", "E544", "E545", "E546", "E547", "E548", "E549", "E55", "E550", "E551", "E552", "E553", "E554", "E555", "E556", "E557", "E558", "E559", "E56", "E560", "E561", "E562", "E563", "E564", "E565", "E566", "E567", "E568", "E569", "E57", "E570", "E571", "E572", "E573", "E574", "E575", "E576", "E577", "E578", "E579", "E58", "E580", "E581", "E582", "E583", "E584", "E585", "E586", "E587", "E588", "E589", "E59", "E590", "E591", "E592", "E593", "E594", "E595", "E596", "E597", "E598", "E599", "E6", "E60", "E600", "E601", "E602", "E603", "E604", "E605", "E606", "E607", "E608", "E609", "E61", "E610", "E611", "E612", "E613", "E614", "E615", "E616", "E617", "E618", "E619", "E62", "E620", "E621", "E622", "E623", "E624", "E625", "E626", "E627", "E628", "E629", "E63", "E630", "E631", "E632", "E633", "E634", "E635", "E636", "E637", "E638", "E639", "E64", "E640", "E641", "E642", "E643", "E644", "E645", "E646", "E647", "E648", "E649", "E65", "E650", "E651", "E652", "E653", "E654", "E655", "E656", "E657", "E658", "E659", "E66", "E660", "E661", "E662", "E663", "E664", "E665", "E666", "E667", "E668", "E669", "E67", "E670", "E671", "E672", "E673", "E674", "E675", "E676", "E677", "E678", "E679", "E68", "E680", "E681", "E682", "E683", "E684", "E685", "E686", "E687", "E688", "E689", "E69", "E690", "E691", "E692", "E693", "E694", "E695", "E696", "E697", "E698", "E699", "E7", "E70", "E700", "E701", "E702", "E703", "E704", "E705", "E706", "E707", "E708", "E709", "E71", "E710", "E711", "E712", "E713", "E714", "E715", "E716", "E717", "E718", "E719", "E72", "E720", "E721", "E722", "E723", "E724", "E725", "E726", "E727", "E728", "E729", "E73", "E730", "E731", "E732", "E733", "E734", "E735", "E736", "E737", "E738", "E739", "E74", "E740", "E741", "E742", "E743", "E744", "E745", "E746", "E747", "E748", "E749", "E75", "E750", "E751", "E752", "E753", "E754", "E755", "E756", "E757", "E758", "E759", "E76", "E760", "E761", "E762", "E763", "E764", "E765", "E766", "E767", "E768", "E769", "E77", "E770", "E771", "E772", "E773", "E774", "E775", "E776", "E777", "E778", "E779", "E78", "E780", "E781", "E782", "E783", "E784", "E785", "E786", "E787", "E788", "E789", "E79", "E790", "E791", "E792", "E793", "E794", "E795", "E796", "E797", "E798", "E799", "E8", "E80", "E800", "E801", "E802", "E803", "E804", "E805", "E806", "E807", "E808", "E809", "E81", "E810", "E811", "E812", "E813", "E814", "E815", "E816", "E817", "E818", "E819", "E82", "E820", "E821", "E822", "E823", "E824", "E825", "E826", "E827", "E828", "E829", "E83", "E830", "E831", "E832", "E833", "E834", "E835", "E836", "E837", "E838", "E839", "E84", "E840", "E841", "E842", "E843", "E844", "E845", "E846", "E847", "E848", "E849", "E85", "E850", "E851", "E852", "E853", "E854", "E855", "E856", "E857", "E858", "E859", "E86", "E860", "E861", "E862", "E863", "E864", "E865", "E866", "E867", "E868", "E869", "E87", "E870", "E871", "E872", "E873", "E874", "E875", "E876", "E877", "E878", "E879", "E88", "E880", "E881", "E882", "E883", "E884", "E885", "E886", "E887", "E888", "E889", "E89", "E890", "E891", "E892", "E893", "E894", "E895", "E896", "E897", "E898", "E899", "E9", "E90", "E900", "E901", "E902", "E903", "E904", "E905", "E906", "E907", "E908", "E909", "E91", "E910", "E911", "E912", "E913", "E914", "E915", "E916", "E917", "E918", "E919", "E92", "E920", "E921", "E922", "E923", "E924", "E925", "E926", "E927", "E928", "E929", "E93", "E930", "E931", "E932", "E933", "E934", "E935", "E936", "E937", "E938", "E939", "E94", "E940", "E941", "E942", "E943", "E944", "E945", "E946", "E947", "E948", "E949", "E95", "E950", "E951", "E952", "E953", "E954", "E955", "E956", "E957", "E958", "E959", "E96", "E960", "E961", "E962", "E963", "E964", "E965", "E966", "E967", "E968", "E969", "E97", "E970", "E971", "E972", "E973", "E974", "E975", "E976", "E977", "E978", "E979", "E98", "E980", "E981", "E982", "E983", "E984", "E985", "E986", "E987", "E988", "E989", "E99", "E990", "E991", "E992", "E993", "E994", "E995", "E996", "E997", "E998", "E999"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumMapBackIntoItself.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["Large", "Medium", "Small", "TShirtSize"]
 rebuilt        : ScopeId(1): ["TShirtSize"]
-Symbol flags mismatch for "TShirtSize":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumMemberNameNonIdentifier.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["123startsWithNumber", "E", "has space", "hyphen-member", "regular", "Ϳ"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumMemberReduction.ts
 Bindings mismatch:
@@ -4698,95 +4498,56 @@ rebuilt        : ScopeId(2): ["MyStringEnum"]
 Bindings mismatch:
 after transform: ScopeId(3): ["A", "B", "C", "MyStringEnumWithEmpty"]
 rebuilt        : ScopeId(3): ["MyStringEnumWithEmpty"]
-Symbol flags mismatch for "MyEnum":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "MyStringEnum":
-after transform: SymbolId(4): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "MyStringEnumWithEmpty":
-after transform: SymbolId(8): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumNegativeLiteral1.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["E", "a", "b", "c"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumNumbering1.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "C", "D", "E", "Test"]
 rebuilt        : ScopeId(1): ["Test"]
-Symbol flags mismatch for "Test":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumOperations.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["Enum", "None"]
 rebuilt        : ScopeId(1): ["Enum"]
-Symbol flags mismatch for "Enum":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumWithInfinityProperty.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "Infinity"]
 rebuilt        : ScopeId(1): ["A"]
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumWithNaNProperty.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "NaN"]
 rebuilt        : ScopeId(1): ["A"]
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumWithNegativeInfinityProperty.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["-Infinity", "A"]
 rebuilt        : ScopeId(1): ["A"]
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumWithQuotedElementName1.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["E", "fo\"o"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumWithQuotedElementName2.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["E", "fo'o"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumWithUnicodeEscape1.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["E", "gold ✰"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumWithoutInitializerAfterComputedMember.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["E", "a", "b", "c"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumsWithMultipleDeclarations3.ts
 Bindings mismatch:
@@ -4888,24 +4649,6 @@ rebuilt        : ScopeId(7): ["e5"]
 Bindings mismatch:
 after transform: ScopeId(8): ["e6", "x", "y", "z"]
 rebuilt        : ScopeId(8): ["e6"]
-Symbol flags mismatch for "e1":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "e2":
-after transform: SymbolId(4): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "e3":
-after transform: SymbolId(11): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "e4":
-after transform: SymbolId(15): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "e5":
-after transform: SymbolId(24): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(18): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "e6":
-after transform: SymbolId(28): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ModuleConstEnumDeclaration2.ts
 Bindings mismatch:
@@ -4926,24 +4669,6 @@ rebuilt        : ScopeId(7): ["e5"]
 Bindings mismatch:
 after transform: ScopeId(8): ["e6", "x", "y", "z"]
 rebuilt        : ScopeId(8): ["e6"]
-Symbol flags mismatch for "e1":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "e2":
-after transform: SymbolId(4): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "e3":
-after transform: SymbolId(11): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "e4":
-after transform: SymbolId(15): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "e5":
-after transform: SymbolId(24): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(18): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "e6":
-after transform: SymbolId(28): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ModuleEnumDeclaration.ts
 Bindings mismatch:
@@ -4964,24 +4689,6 @@ rebuilt        : ScopeId(7): ["e5"]
 Bindings mismatch:
 after transform: ScopeId(8): ["e6", "x", "y", "z"]
 rebuilt        : ScopeId(8): ["e6"]
-Symbol flags mismatch for "e1":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "e2":
-after transform: SymbolId(4): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "e3":
-after transform: SymbolId(11): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "e4":
-after transform: SymbolId(15): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "e5":
-after transform: SymbolId(24): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(18): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "e6":
-after transform: SymbolId(28): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ModuleInternalImport.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -5053,9 +4760,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentE
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "C", "E"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/exportDeclarationsInAmbientNamespaces.ts
 Bindings mismatch:
@@ -5198,17 +4902,11 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/fakeInfinity2.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "Foo"]
 rebuilt        : ScopeId(1): ["Foo"]
-Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/fakeInfinity3.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "Foo"]
 rebuilt        : ScopeId(1): ["Foo"]
-Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/fallFromLastCase1.ts
 Bindings mismatch:
@@ -6070,9 +5768,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/importElisionEnum
 Bindings mismatch:
 after transform: ScopeId(1): ["MyEnum", "a", "b", "c", "d"]
 rebuilt        : ScopeId(1): ["MyEnum"]
-Symbol flags mismatch for "MyEnum":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/importElisionExportNonExportAndDefault.ts
 Bindings mismatch:
@@ -6166,11 +5861,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["Array", "Symbol", "require", "window"]
 rebuilt        : ["Array", "Symbol", "error", "isAOrB", "require", "window", "x"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/indexIntoEnum.ts
-Symbol flags mismatch for "E":
-after transform: SymbolId(1): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/indexedAccessAndNullableNarrowing.ts
 Bindings mismatch:
@@ -6778,27 +6468,18 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Bindings mismatch:
 after transform: ScopeId(2): ["Friday", "Saturday", "Sunday", "weekend"]
 rebuilt        : ScopeId(2): ["weekend"]
-Symbol flags mismatch for "weekend":
-after transform: SymbolId(1): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasEnumInsideLocalModuleWithExport.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Bindings mismatch:
 after transform: ScopeId(2): ["Friday", "Saturday", "Sunday", "weekend"]
 rebuilt        : ScopeId(2): ["weekend"]
-Symbol flags mismatch for "weekend":
-after transform: SymbolId(1): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasEnumInsideLocalModuleWithoutExport.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Bindings mismatch:
 after transform: ScopeId(2): ["Friday", "Saturday", "Sunday", "weekend"]
 rebuilt        : ScopeId(2): ["weekend"]
-Symbol flags mismatch for "weekend":
-after transform: SymbolId(1): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasFunction.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -6916,15 +6597,6 @@ rebuilt        : ScopeId(5): ["B"]
 Bindings mismatch:
 after transform: ScopeId(29): ["C", "c1", "c2", "c210", "c211"]
 rebuilt        : ScopeId(6): ["C"]
-Symbol flags mismatch for "A":
-after transform: SymbolId(28): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "B":
-after transform: SymbolId(35): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "C":
-after transform: SymbolId(40): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/intersectionWithConstructSignaturePrototypeResult.ts
 Bindings mismatch:
@@ -7004,25 +6676,16 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesIm
 Bindings mismatch:
 after transform: ScopeId(1): ["BAR", "Foo"]
 rebuilt        : ScopeId(1): ["Foo"]
-Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesImportConstEnumTypeOnly.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["Bar", "Foo"]
 rebuilt        : ScopeId(1): ["Foo"]
-Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesNonAmbientConstEnum.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["E", "X"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesPlainFile-ES6.ts
 Bindings mismatch:
@@ -7075,9 +6738,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsdocAccessEnumTy
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "E"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsxCallbackWithDestructuring.tsx
 Reference symbol mismatch for "Component":
@@ -7301,9 +6961,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/localImportNameVs
 Bindings mismatch:
 after transform: ScopeId(2): ["DOWN", "Key", "LEFT", "RIGHT", "UP"]
 rebuilt        : ScopeId(2): ["Key"]
-Symbol flags mismatch for "Key":
-after transform: SymbolId(1): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/mappedToToIndexSignatureInference.ts
 Bindings mismatch:
@@ -7312,9 +6969,6 @@ rebuilt        : ScopeId(0): ["E", "x"]
 Bindings mismatch:
 after transform: ScopeId(4): ["A", "B", "E"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(10): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Reference symbol mismatch for "fn":
 after transform: SymbolId(0) "fn"
 rebuilt        : <None>
@@ -7481,9 +7135,6 @@ rebuilt        : ScopeId(1): ["E"]
 Bindings mismatch:
 after transform: ScopeId(2): ["E", "c"]
 rebuilt        : ScopeId(2): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol redeclarations mismatch for "E":
 after transform: SymbolId(0): [Span { start: 5, end: 6 }, Span { start: 33, end: 34 }]
 rebuilt        : SymbolId(0): []
@@ -7519,9 +7170,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 94, end: 95 }]
 rebuilt        : SymbolId(0): []
-Symbol flags mismatch for "plop":
-after transform: SymbolId(10): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationWithSharedExportedVar.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -7533,9 +7181,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/metadataOfUnion.t
 Bindings mismatch:
 after transform: ScopeId(4): ["A", "B", "C", "D", "E"]
 rebuilt        : ScopeId(5): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(5): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
 Unresolved references mismatch:
 after transform: ["Boolean", "Number", "Object", "String", "require"]
 rebuilt        : ["Boolean", "Number", "Object", "require"]
@@ -7568,12 +7213,6 @@ rebuilt        : ScopeId(1): ["E"]
 Bindings mismatch:
 after transform: ScopeId(6): ["C1", "E2", "N1", "S1"]
 rebuilt        : ScopeId(5): ["E2"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "E2":
-after transform: SymbolId(9): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
 Reference symbol mismatch for "someNumber":
 after transform: SymbolId(5) "someNumber"
 rebuilt        : <None>
@@ -7737,12 +7376,6 @@ rebuilt        : ScopeId(9): ["E1"]
 Bindings mismatch:
 after transform: ScopeId(8): ["B", "E2"]
 rebuilt        : ScopeId(10): ["E2"]
-Symbol flags mismatch for "E1":
-after transform: SymbolId(6): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "E2":
-after transform: SymbolId(9): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(10): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleCodegenTest4.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -7819,9 +7452,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleSameValueDu
 Bindings mismatch:
 after transform: ScopeId(1): ["Animals", "Cat", "Dog"]
 rebuilt        : ScopeId(1): ["Animals"]
-Symbol flags mismatch for "Animals":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleSharesNameWithImportDeclarationInsideIt4.ts
 Bindings mismatch:
@@ -7880,9 +7510,6 @@ rebuilt        : ScopeId(8): ["E"]
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(5): [Span { start: 243, end: 244 }, Span { start: 1079, end: 1080 }]
 rebuilt        : SymbolId(8): []
-Symbol flags mismatch for "E":
-after transform: SymbolId(8): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(13): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/multiModuleClodule1.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -8360,9 +7987,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/neverAsDiscrimina
 Bindings mismatch:
 after transform: ScopeId(14): ["DISPATCH", "GatewayOpcode", "HEARTBEAT", "HEARTBEAT_ACK", "HELLO", "IDENTIFY", "INVALID_SESSION", "PRESENCE_UPDATE", "RECONNECT", "REQUEST_GUILD_MEMBERS", "RESUME", "VOICE_STATE_UPDATE"]
 rebuilt        : ScopeId(5): ["GatewayOpcode"]
-Symbol flags mismatch for "GatewayOpcode":
-after transform: SymbolId(14): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/noCircularDefinitionOnExportOfPrivateInMergedNamespace.ts
 Symbol reference IDs mismatch for "cat":
@@ -8457,15 +8081,6 @@ rebuilt        : ScopeId(2): ["A"]
 Bindings mismatch:
 after transform: ScopeId(3): ["B", "x", "y", "z"]
 rebuilt        : ScopeId(3): ["B"]
-Symbol flags mismatch for "Meat":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "A":
-after transform: SymbolId(12): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(11): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "B":
-after transform: SymbolId(16): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(13): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/nodeModuleReexportFromDottedPath.ts
 Bindings mismatch:
@@ -8608,15 +8223,6 @@ rebuilt        : ScopeId(2): ["N1"]
 Bindings mismatch:
 after transform: ScopeId(9): ["C", "D", "N2"]
 rebuilt        : ScopeId(3): ["N2"]
-Symbol flags mismatch for "E1":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "N1":
-after transform: SymbolId(17): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "N2":
-after transform: SymbolId(20): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
 Reference symbol mismatch for "E2":
 after transform: SymbolId(4) "E2"
 rebuilt        : <None>
@@ -8707,12 +8313,6 @@ rebuilt        : ScopeId(1): ["Strs"]
 Bindings mismatch:
 after transform: ScopeId(4): ["A", "B", "Nums"]
 rebuilt        : ScopeId(2): ["Nums"]
-Symbol flags mismatch for "Strs":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "Nums":
-after transform: SymbolId(12): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(9): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/objectRestBindingContextualInference.ts
 Bindings mismatch:
@@ -8783,12 +8383,6 @@ after transform: []
 rebuilt        : ["a"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/overload2.ts
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "B":
-after transform: SymbolId(1): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
 Symbol span mismatch for "foo":
 after transform: SymbolId(2): Span { start: 36, end: 39 }
 rebuilt        : SymbolId(4): Span { start: 92, end: 95 }
@@ -8904,9 +8498,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/parseEntityNameWi
 Bindings mismatch:
 after transform: ScopeId(1): ["Bool", "false"]
 rebuilt        : ScopeId(1): ["Bool"]
-Symbol flags mismatch for "Bool":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/parseGenericArrowRatherThanLeftShift.ts
 Bindings mismatch:
@@ -8975,9 +8566,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/preserveConstEnum
 Bindings mismatch:
 after transform: ScopeId(1): ["E", "Value", "Value2"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/primitiveTypeAsmoduleName.ts
 Bindings mismatch:
@@ -9135,12 +8723,6 @@ rebuilt        : ScopeId(7): ["_m_public", "c_public", "e_public", "f_public", "
 Bindings mismatch:
 after transform: ScopeId(12): ["Grumpy", "Happy", "e_public"]
 rebuilt        : ScopeId(9): ["e_public"]
-Symbol flags mismatch for "e_private":
-after transform: SymbolId(2): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "e_public":
-after transform: SymbolId(14): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(13): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/promiseType.ts
 Bindings mismatch:
@@ -10195,9 +9777,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/recursiveArrayNot
 Bindings mismatch:
 after transform: ScopeId(3): ["ActionType", "Bar", "Batch", "Baz", "Foo"]
 rebuilt        : ScopeId(1): ["ActionType"]
-Symbol flags mismatch for "ActionType":
-after transform: SymbolId(3): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/recursiveBaseConstructorCreation2.ts
 Bindings mismatch:
@@ -10305,9 +9884,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/reducibleIndexedA
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "C", "Type"]
 rebuilt        : ScopeId(1): ["Type"]
-Symbol flags mismatch for "Type":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/reexportNameAliasedAndHoisted.ts
 Bindings mismatch:
@@ -11376,9 +10952,6 @@ rebuilt        : ScopeId(0): ["Color", "Message", "_defineProperty", "checkType"
 Bindings mismatch:
 after transform: ScopeId(5): ["Blue", "Color", "Green", "Red"]
 rebuilt        : ScopeId(6): ["Color"]
-Symbol flags mismatch for "Color":
-after transform: SymbolId(9): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(10): SymbolFlags(FunctionScopedVariable)
 Reference symbol mismatch for "person":
 after transform: SymbolId(18) "person"
 rebuilt        : <None>
@@ -11548,9 +11121,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/strictModeEnumMem
 Bindings mismatch:
 after transform: ScopeId(1): ["E", "static"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/stringLiteralObjectLiteralDeclaration1.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -11729,9 +11299,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/trackedSymbolsNoC
 Bindings mismatch:
 after transform: ScopeId(1): ["Node0", "Node1", "Node10", "Node11", "Node12", "Node13", "Node14", "Node15", "Node16", "Node17", "Node18", "Node19", "Node2", "Node20", "Node21", "Node22", "Node23", "Node24", "Node25", "Node26", "Node27", "Node28", "Node29", "Node3", "Node30", "Node31", "Node32", "Node33", "Node34", "Node35", "Node36", "Node37", "Node38", "Node39", "Node4", "Node40", "Node41", "Node42", "Node43", "Node44", "Node45", "Node46", "Node47", "Node48", "Node49", "Node5", "Node50", "Node51", "Node52", "Node53", "Node54", "Node55", "Node56", "Node57", "Node58", "Node59", "Node6", "Node60", "Node61", "Node62", "Node63", "Node64", "Node65", "Node66", "Node67", "Node68", "Node69", "Node7", "Node70", "Node71", "Node72", "Node73", "Node74", "Node75", "Node76", "Node77", "Node78", "Node79", "Node8", "Node80", "Node81", "Node82", "Node83", "Node84", "Node85", "Node86", "Node87", "Node88", "Node89", "Node9", "Node90", "Node91", "Node92", "Node93", "Node94", "Node95", "Node96", "Node97", "Node98", "Node99", "SyntaxKind"]
 rebuilt        : ScopeId(1): ["SyntaxKind"]
-Symbol flags mismatch for "SyntaxKind":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/transformsElideNullUndefinedType.ts
 Bindings mismatch:
@@ -11781,9 +11348,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/tsxDefaultImports
 Bindings mismatch:
 after transform: ScopeId(1): ["SomeEnum", "one"]
 rebuilt        : ScopeId(1): ["SomeEnum"]
-Symbol flags mismatch for "SomeEnum":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/tsxDiscriminantPropertyInference.tsx
 Bindings mismatch:
@@ -11985,9 +11549,6 @@ rebuilt        : ScopeId(0): ["E"]
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "E"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Reference symbol mismatch for "m":
 after transform: SymbolId(3) "m"
 rebuilt        : <None>
@@ -12005,9 +11566,6 @@ rebuilt        : ScopeId(0): ["E"]
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "E"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Reference symbol mismatch for "m":
 after transform: SymbolId(3) "m"
 rebuilt        : <None>
@@ -12267,9 +11825,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/unaryPlus.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["E", "some", "thing"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(2): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/uncalledFunctionChecksInConditionalPerf.ts
 Bindings mismatch:
@@ -12422,9 +11977,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/underscoreEscaped
 Bindings mismatch:
 after transform: ScopeId(1): ["E", "__foo", "bar"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "E":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(6)]
 rebuilt        : SymbolId(0): [ReferenceId(5)]
@@ -12508,9 +12060,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/unionOfEnumInfere
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "C", "Enum"]
 rebuilt        : ScopeId(1): ["Enum"]
-Symbol flags mismatch for "Enum":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/unionReductionMutualSubtypes.ts
 Bindings mismatch:
@@ -13843,25 +13392,16 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/constEnums/con
 Bindings mismatch:
 after transform: ScopeId(1): ["E", "a", "b", "c", "d", "e", "f", "g", "h"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnum3.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["TestType", "bar", "foo"]
 rebuilt        : ScopeId(1): ["TestType"]
-Symbol flags mismatch for "TestType":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnumPropertyAccess3.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "C", "D", "E"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/controlFlow/constLocalsInFunctionExpressions.ts
 Bindings mismatch:
@@ -14530,33 +14070,6 @@ rebuilt        : ScopeId(8): ["E8"]
 Bindings mismatch:
 after transform: ScopeId(9): ["A", "B", "E9"]
 rebuilt        : ScopeId(9): ["E9"]
-Symbol flags mismatch for "E1":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "E2":
-after transform: SymbolId(7): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(5): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "E3":
-after transform: SymbolId(11): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(7): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "E4":
-after transform: SymbolId(15): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(9): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "E5":
-after transform: SymbolId(19): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(11): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "E6":
-after transform: SymbolId(23): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(13): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "E7":
-after transform: SymbolId(27): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(15): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "E8":
-after transform: SymbolId(29): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(17): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "E9":
-after transform: SymbolId(31): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(19): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/enums/enumClassification.ts
 Missing ReferenceId: "E20"
@@ -14593,42 +14106,6 @@ rebuilt        : ScopeId(11): ["E12"]
 Bindings mismatch:
 after transform: ScopeId(12): ["A", "B", "C", "D", "E20"]
 rebuilt        : ScopeId(12): ["E20"]
-Symbol flags mismatch for "E01":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "E02":
-after transform: SymbolId(2): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "E03":
-after transform: SymbolId(4): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "E04":
-after transform: SymbolId(6): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "E05":
-after transform: SymbolId(10): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "E06":
-after transform: SymbolId(14): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(10): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "E07":
-after transform: SymbolId(18): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(12): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "E08":
-after transform: SymbolId(25): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(14): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "E10":
-after transform: SymbolId(31): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(16): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "E11":
-after transform: SymbolId(32): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(18): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "E12":
-after transform: SymbolId(36): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(20): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "E20":
-after transform: SymbolId(40): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(22): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "E20":
 after transform: SymbolId(56): [ReferenceId(77), ReferenceId(78), ReferenceId(79), ReferenceId(80), ReferenceId(81), ReferenceId(82), ReferenceId(83), ReferenceId(84)]
 rebuilt        : SymbolId(23): [ReferenceId(72), ReferenceId(73), ReferenceId(74), ReferenceId(75), ReferenceId(76), ReferenceId(77), ReferenceId(78), ReferenceId(79), ReferenceId(81)]
@@ -14652,21 +14129,6 @@ rebuilt        : ScopeId(4): ["T4"]
 Bindings mismatch:
 after transform: ScopeId(5): ["T5", "a"]
 rebuilt        : ScopeId(5): ["T5"]
-Symbol flags mismatch for "T1":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "T2":
-after transform: SymbolId(4): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "T3":
-after transform: SymbolId(7): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "T4":
-after transform: SymbolId(10): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "T5":
-after transform: SymbolId(12): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/enums/enumConstantMemberWithTemplateLiteralsEmitDeclaration.ts
 Bindings mismatch:
@@ -14690,24 +14152,6 @@ rebuilt        : ScopeId(5): ["T5"]
 Bindings mismatch:
 after transform: ScopeId(6): ["T6", "a", "b"]
 rebuilt        : ScopeId(6): ["T6"]
-Symbol flags mismatch for "T1":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "T2":
-after transform: SymbolId(2): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "T3":
-after transform: SymbolId(6): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "T4":
-after transform: SymbolId(8): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "T5":
-after transform: SymbolId(14): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "T6":
-after transform: SymbolId(19): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(10): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/enums/enumExportMergingES6.ts
 Bindings mismatch:
@@ -14719,9 +14163,6 @@ rebuilt        : ScopeId(2): ["Animals"]
 Bindings mismatch:
 after transform: ScopeId(3): ["Animals", "CatDog"]
 rebuilt        : ScopeId(3): ["Animals"]
-Symbol flags mismatch for "Animals":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "Animals":
 after transform: SymbolId(0): [Span { start: 12, end: 19 }, Span { start: 45, end: 52 }, Span { start: 78, end: 85 }]
 rebuilt        : SymbolId(0): []
@@ -14766,45 +14207,21 @@ rebuilt        : ScopeId(18): ["Color"]
 Bindings mismatch:
 after transform: ScopeId(21): ["Color", "Yellow"]
 rebuilt        : ScopeId(21): ["Color"]
-Symbol flags mismatch for "EImpl1":
-after transform: SymbolId(1): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "EImpl1":
 after transform: SymbolId(1): [Span { start: 200, end: 206 }, Span { start: 241, end: 247 }]
 rebuilt        : SymbolId(2): []
-Symbol flags mismatch for "EConst1":
-after transform: SymbolId(8): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "EConst1":
 after transform: SymbolId(8): [Span { start: 293, end: 300 }, Span { start: 354, end: 361 }]
 rebuilt        : SymbolId(5): []
-Symbol flags mismatch for "EComp2":
-after transform: SymbolId(17): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "EComp2":
 after transform: SymbolId(17): [Span { start: 597, end: 603 }, Span { start: 690, end: 696 }]
 rebuilt        : SymbolId(11): []
-Symbol flags mismatch for "EInit":
-after transform: SymbolId(26): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(17): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "EInit":
 after transform: SymbolId(26): [Span { start: 973, end: 978 }, Span { start: 1018, end: 1023 }]
 rebuilt        : SymbolId(17): []
-Symbol flags mismatch for "Color":
-after transform: SymbolId(33): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(22): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "Color":
-after transform: SymbolId(38): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(26): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "M6":
 after transform: SymbolId(42): [Span { start: 1236, end: 1238 }, Span { start: 1298, end: 1300 }]
 rebuilt        : SymbolId(28): []
-Symbol flags mismatch for "Color":
-after transform: SymbolId(44): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(32): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "Color":
-after transform: SymbolId(49): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(37): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es2019/globalThisTypeIndexAccess.ts
 Bindings mismatch:
@@ -15154,20 +14571,11 @@ rebuilt        : ScopeId(1): ["E1"]
 Bindings mismatch:
 after transform: ScopeId(2): ["E2", "x"]
 rebuilt        : ScopeId(2): ["E2"]
-Symbol flags mismatch for "E1":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "E2":
-after transform: SymbolId(2): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames7_ES6.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["E", "member"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType6_ES6.ts
 Bindings mismatch:
@@ -15433,12 +14841,6 @@ rebuilt        : ScopeId(3): ["E"]
 Bindings mismatch:
 after transform: ScopeId(5): ["A", "B", "C", "D"]
 rebuilt        : ScopeId(4): ["D"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(4): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "D":
-after transform: SymbolId(8): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(5): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports1.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -15451,12 +14853,6 @@ rebuilt        : ScopeId(3): ["E"]
 Bindings mismatch:
 after transform: ScopeId(5): ["A", "B", "C", "D"]
 rebuilt        : ScopeId(4): ["D"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(4): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "D":
-after transform: SymbolId(8): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(5): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports3-es6.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -15469,12 +14865,6 @@ rebuilt        : ScopeId(3): ["E"]
 Bindings mismatch:
 after transform: ScopeId(5): ["A", "B", "C", "D"]
 rebuilt        : ScopeId(4): ["D"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(4): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "D":
-after transform: SymbolId(8): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports3.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -15487,12 +14877,6 @@ rebuilt        : ScopeId(3): ["E"]
 Bindings mismatch:
 after transform: ScopeId(5): ["A", "B", "C", "D"]
 rebuilt        : ScopeId(4): ["D"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(4): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "D":
-after transform: SymbolId(8): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesWithModule.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -16783,12 +16167,6 @@ rebuilt        : ScopeId(1): ["AppType"]
 Bindings mismatch:
 after transform: ScopeId(2): ["AppStyle", "MiniApp", "PivotTable", "Standard", "Tree", "TreeEntity"]
 rebuilt        : ScopeId(2): ["AppStyle"]
-Symbol flags mismatch for "AppType":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "AppStyle":
-after transform: SymbolId(10): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Reference symbol mismatch for "foo":
 after transform: SymbolId(17) "foo"
 rebuilt        : <None>
@@ -16860,9 +16238,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Bindings mismatch:
 after transform: ScopeId(4): ["E", "a", "b", "c"]
 rebuilt        : ScopeId(5): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(2): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnOptionalProperty.ts
 Bindings mismatch:
@@ -17555,9 +16930,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/co
 Bindings mismatch:
 after transform: ScopeId(1): ["E", "blue", "red"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/functionExpressionContextualTyping3.ts
 Bindings mismatch:
@@ -17585,9 +16957,6 @@ rebuilt        : ScopeId(0): ["E", "snb"]
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "C", "E"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Reference symbol mismatch for "item":
 after transform: SymbolId(5) "item"
 rebuilt        : <None>
@@ -18994,17 +18363,11 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/ty
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "Foo"]
 rebuilt        : ScopeId(1): ["Foo"]
-Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/TypeGuardWithEnumUnion.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["B", "Color", "G", "R"]
 rebuilt        : ScopeId(1): ["Color"]
-Symbol flags mismatch for "Color":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardFunction.ts
 Bindings mismatch:
@@ -19192,9 +18555,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/un
 Bindings mismatch:
 after transform: ScopeId(1): ["", "A", "B", "ENUM1"]
 rebuilt        : ScopeId(1): ["ENUM1"]
-Symbol flags mismatch for "ENUM1":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherType.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -19209,12 +18569,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/un
 Bindings mismatch:
 after transform: ScopeId(2): ["", "A", "B", "ENUM1"]
 rebuilt        : ScopeId(2): ["ENUM1"]
-Symbol flags mismatch for "ENUM":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "ENUM1":
-after transform: SymbolId(1): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/voidOperator/voidOperatorWithNumberType.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -19229,9 +18583,6 @@ rebuilt        : ScopeId(0): ["C1", "E1", "_defineProperty"]
 Bindings mismatch:
 after transform: ScopeId(5): ["A", "B", "C", "E1"]
 rebuilt        : ScopeId(3): ["E1"]
-Symbol flags mismatch for "E1":
-after transform: SymbolId(4): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentMergedModule.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -19304,22 +18655,11 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModule
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "E"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/verbatimModuleSyntaxConstEnumUsage.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["Foo", "a", "b", "c"]
 rebuilt        : ScopeId(1): ["Foo"]
-Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/verbatimModuleSyntaxRestrictionsESM.ts
-Symbol flags mismatch for "A":
-after transform: SymbolId(1): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/functions/functionOverloadCompatibilityWithVoid02.ts
 Symbol span mismatch for "f":
@@ -19344,9 +18684,6 @@ rebuilt        : ScopeId(0): ["Directive", "StepResult", "_wrapAsyncGenerator", 
 Bindings mismatch:
 after transform: ScopeId(7): ["Back", "Cancel", "Directive", "LoadMore", "Noop"]
 rebuilt        : ScopeId(3): ["Directive"]
-Symbol flags mismatch for "Directive":
-after transform: SymbolId(12): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
 Symbol redeclarations mismatch for "Directive":
 after transform: SymbolId(12): [Span { start: 318, end: 327 }, Span { start: 381, end: 390 }]
 rebuilt        : SymbolId(3): []
@@ -19472,9 +18809,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModule
 Bindings mismatch:
 after transform: ScopeId(1): ["Blue", "Red", "enumdule"]
 rebuilt        : ScopeId(1): ["enumdule"]
-Symbol flags mismatch for "enumdule":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol redeclarations mismatch for "enumdule":
 after transform: SymbolId(0): [Span { start: 5, end: 13 }, Span { start: 43, end: 51 }]
 rebuilt        : SymbolId(0): []
@@ -19588,9 +18922,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocLin
 Bindings mismatch:
 after transform: ScopeId(1): ["Enum", "EnumValue"]
 rebuilt        : ScopeId(1): ["Enum"]
-Symbol flags mismatch for "Enum":
-after transform: SymbolId(1): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/seeTag1.ts
 Bindings mismatch:
@@ -19999,38 +19330,21 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascr
 Bindings mismatch:
 after transform: ScopeId(1): ["IsIndexer", "IsNumberIndexer", "IsStringIndexer", "None", "SignatureFlags"]
 rebuilt        : ScopeId(1): ["SignatureFlags"]
-Symbol flags mismatch for "SignatureFlags":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum2.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["IsIndexer", "IsNumberIndexer", "IsStringIndexer", "None", "SignatureFlags"]
 rebuilt        : ScopeId(1): ["SignatureFlags"]
-Symbol flags mismatch for "SignatureFlags":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum3.ts
-Symbol flags mismatch for "SignatureFlags":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum6.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "C", "E"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnumDeclaration1.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["Bar", "E", "Foo"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnumDeclaration3.ts
 Bindings mismatch:
@@ -20041,33 +19355,21 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascr
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "C", "D", "E"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnumDeclaration6.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "C", "D", "E"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserInterfaceKeywordInEnum.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["Bar", "interface"]
 rebuilt        : ScopeId(1): ["Bar"]
-Symbol flags mismatch for "Bar":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserInterfaceKeywordInEnum1.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["Bar", "interface"]
 rebuilt        : ScopeId(1): ["Bar"]
-Symbol flags mismatch for "Bar":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration5.ts
 Symbol span mismatch for "foo":
@@ -20192,9 +19494,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmasc
 Bindings mismatch:
 after transform: ScopeId(1): ["CodeGenTarget", "ES3", "ES5"]
 rebuilt        : ScopeId(1): ["CodeGenTarget"]
-Symbol flags mismatch for "CodeGenTarget":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsNamedEvaluationDecoratorsAndClassFields.ts
 Bindings mismatch:
@@ -20345,9 +19644,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/intersec
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "C", "D", "E", "F"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionTypeInference2.ts
 Bindings mismatch:
@@ -20450,9 +19746,6 @@ rebuilt        : ScopeId(0): ["Choice", "assertNever", "f1", "f10", "f11", "f12"
 Bindings mismatch:
 after transform: ScopeId(1): ["Choice", "No", "Unknown", "Yes"]
 rebuilt        : ScopeId(1): ["Choice"]
-Symbol flags mismatch for "Choice":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Reference symbol mismatch for "g":
 after transform: SymbolId(21) "g"
 rebuilt        : <None>
@@ -20479,9 +19772,6 @@ rebuilt        : ScopeId(0): ["Choice", "assertNever", "f1", "f10", "f11", "f12"
 Bindings mismatch:
 after transform: ScopeId(1): ["Choice", "No", "Unknown", "Yes"]
 rebuilt        : ScopeId(1): ["Choice"]
-Symbol flags mismatch for "Choice":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Reference symbol mismatch for "g":
 after transform: SymbolId(21) "g"
 rebuilt        : <None>
@@ -20517,9 +19807,6 @@ rebuilt        : SymbolId(62): Span { start: 2256, end: 2263 }
 Symbol redeclarations mismatch for "FAILURE":
 after transform: SymbolId(65): [Span { start: 2229, end: 2236 }, Span { start: 2256, end: 2263 }]
 rebuilt        : SymbolId(62): []
-Symbol flags mismatch for "E":
-after transform: SymbolId(105): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(87): SymbolFlags(FunctionScopedVariable)
 Reference symbol mismatch for "widening":
 after transform: SymbolId(51) "widening"
 rebuilt        : <None>
@@ -20552,9 +19839,6 @@ rebuilt        : ScopeId(0): ["C1", "C2", "E", "_defineProperty", "a", "aa", "ap
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "C", "E"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
 Reference symbol mismatch for "g1":
 after transform: SymbolId(98) "g1"
 rebuilt        : <None>
@@ -20694,9 +19978,6 @@ rebuilt        : ScopeId(0): ["Choice", "assertNever", "f1", "f10", "f11", "f12"
 Bindings mismatch:
 after transform: ScopeId(1): ["Choice", "No", "Unknown", "Yes"]
 rebuilt        : ScopeId(1): ["Choice"]
-Symbol flags mismatch for "Choice":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Reference symbol mismatch for "g":
 after transform: SymbolId(18) "g"
 rebuilt        : <None>
@@ -20723,9 +20004,6 @@ rebuilt        : ScopeId(0): ["Choice", "assertNever", "f1", "f10", "f11", "f12"
 Bindings mismatch:
 after transform: ScopeId(1): ["Choice", "No", "Unknown", "Yes"]
 rebuilt        : ScopeId(1): ["Choice"]
-Symbol flags mismatch for "Choice":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Reference symbol mismatch for "g":
 after transform: SymbolId(18) "g"
 rebuilt        : <None>
@@ -20771,9 +20049,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/
 Bindings mismatch:
 after transform: ScopeId(1): ["E", "a", "b"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/mapped/isomorphicMappedTypeInference.ts
 Bindings mismatch:
@@ -20820,12 +20095,6 @@ rebuilt        : ScopeId(1): ["TerrestrialAnimalTypes"]
 Bindings mismatch:
 after transform: ScopeId(2): ["AlienAnimalTypes", "CAT"]
 rebuilt        : ScopeId(2): ["AlienAnimalTypes"]
-Symbol flags mismatch for "TerrestrialAnimalTypes":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "AlienAnimalTypes":
-after transform: SymbolId(3): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypes1.ts
 Bindings mismatch:
@@ -21020,9 +20289,6 @@ rebuilt        : SymbolId(43): []
 Symbol redeclarations mismatch for "c1":
 after transform: SymbolId(48): [Span { start: 1364, end: 1366 }, Span { start: 1421, end: 1423 }]
 rebuilt        : SymbolId(48): []
-Symbol flags mismatch for "e1":
-after transform: SymbolId(53): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(54): SymbolFlags(FunctionScopedVariable)
 Symbol redeclarations mismatch for "e1":
 after transform: SymbolId(53): [Span { start: 1511, end: 1513 }, Span { start: 1530, end: 1532 }]
 rebuilt        : SymbolId(54): []
@@ -21058,17 +20324,11 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/objectTy
 Bindings mismatch:
 after transform: ScopeId(3): ["E", "abstract", "as", "boolean", "break", "byte", "case", "catch", "char", "class", "const", "continue", "debugger", "default", "delete", "do", "double", "else", "enum", "export", "extends", "false", "final", "finally", "float", "for", "function", "goto", "if", "implements", "import", "in", "instanceof", "int", "interface", "is", "long", "namespace", "native", "new", "null", "package", "private", "protected", "public", "return", "short", "static", "super", "switch", "synchronized", "this", "throw", "throws", "transient", "true", "try", "typeof", "use", "var", "void", "volatile", "while", "with"]
 rebuilt        : ScopeId(3): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(11): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(11): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/primitives/number/validNumberAssignments.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "E"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(4): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/primitives/stringLiteral/stringLiteralType.ts
 Symbol span mismatch for "f":
@@ -21897,9 +21157,6 @@ rebuilt        : ScopeId(0): ["E", "FileRouter", "UploadThingServerHelper", "_as
 Bindings mismatch:
 after transform: ScopeId(1): ["E", "Val", "Val2"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
 Reference symbol mismatch for "test1":
 after transform: SymbolId(3) "test1"
 rebuilt        : <None>
@@ -22043,9 +21300,6 @@ rebuilt        : ScopeId(0): ["A", "A2", "CC", "E", "_defineProperty", "a", "f",
 Bindings mismatch:
 after transform: ScopeId(33): ["A", "E"]
 rebuilt        : ScopeId(5): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(49): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(5): SymbolFlags(FunctionScopedVariable)
 Symbol redeclarations mismatch for "f":
 after transform: SymbolId(54): [Span { start: 1850, end: 1851 }, Span { start: 1868, end: 1869 }]
 rebuilt        : SymbolId(7): []
@@ -22113,9 +21367,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Bindings mismatch:
 after transform: ScopeId(18): ["A", "E"]
 rebuilt        : ScopeId(5): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(19): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
 Symbol redeclarations mismatch for "f":
 after transform: SymbolId(22): [Span { start: 1018, end: 1019 }, Span { start: 1036, end: 1037 }]
 rebuilt        : SymbolId(5): []
@@ -22138,9 +21389,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRela
 Bindings mismatch:
 after transform: ScopeId(3): ["A", "E"]
 rebuilt        : ScopeId(3): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(4): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/bestCommonType/heterogeneousArrayLiterals.ts
 Symbol redeclarations mismatch for "Derived":
@@ -22213,9 +21461,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Bindings mismatch:
 after transform: ScopeId(8): ["A", "E"]
 rebuilt        : ScopeId(9): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(26): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(23): SymbolFlags(FunctionScopedVariable)
 Symbol redeclarations mismatch for "f":
 after transform: SymbolId(30): [Span { start: 1216, end: 1217 }, Span { start: 1234, end: 1235 }]
 rebuilt        : SymbolId(27): []
@@ -22229,9 +21474,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Bindings mismatch:
 after transform: ScopeId(18): ["A", "E"]
 rebuilt        : ScopeId(5): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(19): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
 Symbol redeclarations mismatch for "f":
 after transform: SymbolId(22): [Span { start: 951, end: 952 }, Span { start: 969, end: 970 }]
 rebuilt        : SymbolId(5): []
@@ -22449,9 +21691,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRela
 Bindings mismatch:
 after transform: ScopeId(5): ["A", "E"]
 rebuilt        : ScopeId(7): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(6): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(5): SymbolFlags(FunctionScopedVariable)
 Symbol span mismatch for "foo5":
 after transform: SymbolId(9): Span { start: 234, end: 238 }
 rebuilt        : SymbolId(8): Span { start: 282, end: 286 }
@@ -26685,9 +25924,6 @@ rebuilt        : SymbolId(8): Span { start: 482, end: 486 }
 Symbol redeclarations mismatch for "foo5":
 after transform: SymbolId(16): [Span { start: 410, end: 414 }, Span { start: 433, end: 437 }, Span { start: 456, end: 460 }, Span { start: 482, end: 486 }]
 rebuilt        : SymbolId(8): []
-Symbol flags mismatch for "E":
-after transform: SymbolId(21): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(10): SymbolFlags(FunctionScopedVariable)
 Symbol span mismatch for "foo6":
 after transform: SymbolId(23): Span { start: 522, end: 526 }
 rebuilt        : SymbolId(12): Span { start: 564, end: 568 }
@@ -27003,9 +26239,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/union/di
 Bindings mismatch:
 after transform: ScopeId(1): ["AnimalType", "cat", "dog"]
 rebuilt        : ScopeId(1): ["AnimalType"]
-Symbol flags mismatch for "AnimalType":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeCallSignatures7.ts
 Bindings mismatch:

--- a/tasks/track_memory_allocations/allocs_transformer.snap
+++ b/tasks/track_memory_allocations/allocs_transformer.snap
@@ -1,6 +1,6 @@
 File                       | File size      || Sys allocs     | Sys reallocs   || Arena allocs   | Arena reallocs 
 ---------------------------------------------------------------------------------------------------------------------------
-checker.ts                 | 2.92 MB        ||             19 |              0 ||           1959 |              5
+checker.ts                 | 2.92 MB        ||             20 |              3 ||           1959 |              5
 
 App.tsx                    | 415.34 kB      ||             23 |              2 ||            618 |             17
 
@@ -10,7 +10,7 @@ pdf.mjs                    | 567.30 kB      ||             13 |              0 |
 
 antd.js                    | 6.69 MB        ||             13 |              0 ||              2 |              0
 
-binder.ts                  | 193.08 kB      ||             15 |              0 ||            154 |              0
+binder.ts                  | 193.08 kB      ||             16 |              0 ||            154 |              0
 
-kitchen-sink.tsx           | 732.90 kB      ||            183 |              3 ||           6132 |            280
+kitchen-sink.tsx           | 732.90 kB      ||            184 |              3 ||           6132 |            280
 

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 1fb0b771
 
-Passed: 747/1165
+Passed: 750/1165
 
 # All Passed:
 * babel-plugin-transform-logical-assignment-operators
@@ -1070,7 +1070,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-typescript (95/157)
+# babel-plugin-transform-typescript (98/157)
 * class/accessor-allowDeclareFields-false/input.ts
 
   x TS(18010): An accessibility modifier cannot be used with a private
@@ -1163,22 +1163,11 @@ rebuilt        : ScopeId(0): []
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "E"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-
-* enum/const/input.ts
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 * enum/constant-folding/input.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["E", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 * enum/enum-merging-inner-references/input.ts
 Bindings mismatch:
@@ -1187,9 +1176,6 @@ rebuilt        : ScopeId(1): ["Animals"]
 Bindings mismatch:
 after transform: ScopeId(2): ["Animals", "CatDog"]
 rebuilt        : ScopeId(2): ["Animals"]
-Symbol flags mismatch for "Animals":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol redeclarations mismatch for "Animals":
 after transform: SymbolId(0): [Span { start: 5, end: 12 }, Span { start: 41, end: 48 }]
 rebuilt        : SymbolId(0): []
@@ -1213,9 +1199,6 @@ rebuilt        : SymbolId(0): []
 Symbol reference IDs mismatch for "Dog":
 after transform: SymbolId(1): [ReferenceId(1)]
 rebuilt        : SymbolId(1): []
-Symbol flags mismatch for "Animals":
-after transform: SymbolId(2): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
 Symbol redeclarations mismatch for "Animals":
 after transform: SymbolId(2): [Span { start: 38, end: 45 }, Span { start: 65, end: 72 }, Span { start: 92, end: 99 }]
 rebuilt        : SymbolId(2): []
@@ -1227,9 +1210,6 @@ rebuilt        : ScopeId(1): ["E"]
 Bindings mismatch:
 after transform: ScopeId(2): ["B", "E"]
 rebuilt        : ScopeId(2): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "E":
 after transform: SymbolId(0): [Span { start: 12, end: 13 }, Span { start: 40, end: 41 }]
 rebuilt        : SymbolId(0): []
@@ -1238,17 +1218,11 @@ rebuilt        : SymbolId(0): []
 Bindings mismatch:
 after transform: ScopeId(1): ["E", "x", "y"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 * enum/inner-references/input.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["E", "a", "b"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 * enum/mix-references/input.ts
 x Output mismatch
@@ -1259,9 +1233,6 @@ Missing ReferenceId: "Foo"
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "C", "D", "Foo"]
 rebuilt        : ScopeId(1): ["Foo"]
-Symbol flags mismatch for "Foo":
-after transform: SymbolId(1): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "Foo":
 after transform: SymbolId(7): [ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12)]
 rebuilt        : SymbolId(2): [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(12)]
@@ -1270,9 +1241,6 @@ rebuilt        : SymbolId(2): [ReferenceId(0), ReferenceId(1), ReferenceId(3), R
 Bindings mismatch:
 after transform: ScopeId(1): ["E", "a", "b"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 * enum/non-scoped/input.ts
 Bindings mismatch:
@@ -1281,9 +1249,6 @@ rebuilt        : ScopeId(1): ["E"]
 Bindings mismatch:
 after transform: ScopeId(2): ["E", "z"]
 rebuilt        : ScopeId(2): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol redeclarations mismatch for "E":
 after transform: SymbolId(0): [Span { start: 5, end: 6 }, Span { start: 40, end: 41 }]
 rebuilt        : SymbolId(0): []
@@ -1295,47 +1260,27 @@ rebuilt        : ScopeId(1): ["socketType"]
 Bindings mismatch:
 after transform: ScopeId(2): ["IPC", "SERVER", "SOCKET", "UV_READABLE", "UV_WRITABLE", "constants"]
 rebuilt        : ScopeId(2): ["constants"]
-Symbol flags mismatch for "socketType":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "socketType":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(10)]
 rebuilt        : SymbolId(0): [ReferenceId(7)]
-Symbol flags mismatch for "constants":
-after transform: SymbolId(4): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
 
 * enum/reverse-mappings-syntactically-determinable/input.ts
 x Output mismatch
-
-* enum/scoped/input.ts
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 * enum/string-value/input.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "A2", "B", "B2", "E"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 * enum/string-value-template/input.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "E"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 * enum/string-values-computed/input.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "E"]
 rebuilt        : ScopeId(1): ["E"]
-Symbol flags mismatch for "E":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 * enum/ts5.0-const-foldable/input.ts
 x Output mismatch
@@ -1375,20 +1320,9 @@ rebuilt        : ScopeId(2): ["BB"]
 Bindings mismatch:
 after transform: ScopeId(12): ["BB", "L"]
 rebuilt        : ScopeId(3): ["BB"]
-Symbol flags mismatch for "BB":
-after transform: SymbolId(10): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
 Symbol redeclarations mismatch for "BB":
 after transform: SymbolId(10): [Span { start: 445, end: 447 }, Span { start: 461, end: 463 }]
 rebuilt        : SymbolId(1): []
-Symbol flags mismatch for "BB2":
-after transform: SymbolId(15): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
-
-* exports/export-const-enums/input.ts
-Symbol flags mismatch for "None":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 * exports/interface/input.ts
 x Output mismatch
@@ -1413,17 +1347,11 @@ rebuilt        : SymbolId(0): []
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "Enum"]
 rebuilt        : ScopeId(1): ["Enum"]
-Symbol flags mismatch for "Enum":
-after transform: SymbolId(1): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 * imports/enum-value/input.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["Enum", "id"]
 rebuilt        : ScopeId(1): ["Enum"]
-Symbol flags mismatch for "Enum":
-after transform: SymbolId(1): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
 
 * imports/type-only-export-specifier-2/input.ts
 x Output mismatch
@@ -1448,9 +1376,6 @@ rebuilt        : SymbolId(0): []
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "C"]
 rebuilt        : ScopeId(1): ["A"]
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol redeclarations mismatch for "A":
 after transform: SymbolId(0): [Span { start: 5, end: 6 }, Span { start: 30, end: 31 }]
 rebuilt        : SymbolId(0): []
@@ -1478,9 +1403,6 @@ rebuilt        : ScopeId(4): ["_d"]
 Symbol reference IDs mismatch for "a":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(4), ReferenceId(5)]
 rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3)]
-Symbol flags mismatch for "B":
-after transform: SymbolId(19): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
 
 * namespace/export-type-only/input.ts
 Bindings mismatch:
@@ -1532,15 +1454,9 @@ rebuilt        : SymbolId(6): []
 Symbol redeclarations mismatch for "D":
 after transform: SymbolId(6): [Span { start: 181, end: 182 }, Span { start: 207, end: 208 }]
 rebuilt        : SymbolId(9): []
-Symbol flags mismatch for "H":
-after transform: SymbolId(8): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "F":
 after transform: SymbolId(12): [Span { start: 308, end: 309 }, Span { start: 325, end: 326 }]
 rebuilt        : SymbolId(14): []
-Symbol flags mismatch for "L":
-after transform: SymbolId(16): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
 
 * namespace/nested-namespace/input.ts
 Bindings mismatch:
@@ -1549,17 +1465,11 @@ rebuilt        : ScopeId(1): ["G", "_A"]
 Bindings mismatch:
 after transform: ScopeId(4): ["G", "H"]
 rebuilt        : ScopeId(2): ["G"]
-Symbol flags mismatch for "G":
-after transform: SymbolId(3): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
 * namespace/same-name/input.ts
 Symbol redeclarations mismatch for "N":
 after transform: SymbolId(3): [Span { start: 59, end: 60 }, Span { start: 115, end: 116 }, Span { start: 166, end: 167 }]
 rebuilt        : SymbolId(5): []
-Symbol flags mismatch for "_N":
-after transform: SymbolId(6): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
 
 * optimize-const-enums/custom-values-exported/input.ts
 x Output mismatch
@@ -1585,9 +1495,6 @@ x Output mismatch
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "x", "y"]
 rebuilt        : ScopeId(1): ["A"]
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 * optimize-const-enums/merged/input.ts
 Bindings mismatch:
@@ -1596,9 +1503,6 @@ rebuilt        : ScopeId(1): ["A"]
 Bindings mismatch:
 after transform: ScopeId(2): ["A", "z"]
 rebuilt        : ScopeId(2): ["A"]
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol redeclarations mismatch for "A":
 after transform: SymbolId(0): [Span { start: 11, end: 12 }, Span { start: 36, end: 37 }]
 rebuilt        : SymbolId(0): []

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -67,18 +67,6 @@ rebuilt        : ScopeId(3): ["C"]
 Bindings mismatch:
 after transform: ScopeId(4): ["D", "a", "b", "c"]
 rebuilt        : ScopeId(4): ["D"]
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "B":
-after transform: SymbolId(6): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "C":
-after transform: SymbolId(12): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "D":
-after transform: SymbolId(16): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
 Unresolved references mismatch:
 after transform: ["Infinity", "NaN"]
 rebuilt        : ["Infinity"]
@@ -90,17 +78,11 @@ rebuilt        : [ReferenceId(2), ReferenceId(5), ReferenceId(8), ReferenceId(12
 Bindings mismatch:
 after transform: ScopeId(1): ["Phase", "one", "two"]
 rebuilt        : ScopeId(1): ["Phase"]
-Symbol flags mismatch for "Phase":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 * const-enum-value-ref-kept/input.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["Phase", "one", "two"]
 rebuilt        : ScopeId(1): ["Phase"]
-Symbol flags mismatch for "Phase":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 * declare-and-definite-with-initializer/input.ts
 
@@ -151,27 +133,15 @@ rebuilt        : ScopeId(6): ["NestInner"]
 Symbol reference IDs mismatch for "x":
 after transform: SymbolId(0): [ReferenceId(2), ReferenceId(4)]
 rebuilt        : SymbolId(0): [ReferenceId(7)]
-Symbol flags mismatch for "Foo":
-after transform: SymbolId(1): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "Foo":
 after transform: SymbolId(14): [ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14)]
 rebuilt        : SymbolId(2): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(8)]
-Symbol flags mismatch for "Merge":
-after transform: SymbolId(5): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
 Symbol redeclarations mismatch for "Merge":
 after transform: SymbolId(5): [Span { start: 70, end: 75 }, Span { start: 103, end: 108 }]
 rebuilt        : SymbolId(3): []
 Symbol reference IDs mismatch for "Merge":
 after transform: SymbolId(16): [ReferenceId(20), ReferenceId(21), ReferenceId(22)]
 rebuilt        : SymbolId(5): [ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19)]
-Symbol flags mismatch for "NestOuter":
-after transform: SymbolId(8): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "NestInner":
-after transform: SymbolId(11): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
 Symbol reference IDs mismatch for "NestInner":
 after transform: SymbolId(18): [ReferenceId(31), ReferenceId(32), ReferenceId(33), ReferenceId(34), ReferenceId(35)]
 rebuilt        : SymbolId(9): [ReferenceId(25), ReferenceId(26), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31)]
@@ -180,9 +150,6 @@ rebuilt        : SymbolId(9): [ReferenceId(25), ReferenceId(26), ReferenceId(28)
 Bindings mismatch:
 after transform: ScopeId(2): ["Color", "Green", "Primary", "Red"]
 rebuilt        : ScopeId(1): ["Color"]
-Symbol flags mismatch for "Color":
-after transform: SymbolId(4): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "Color":
 after transform: SymbolId(4): [ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(12)]
 rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(7), ReferenceId(8)]
@@ -197,21 +164,12 @@ rebuilt        : ScopeId(2): ["Animal"]
 Bindings mismatch:
 after transform: ScopeId(3): ["AnimalSize", "LARGE_DOG", "SMALL_CAT"]
 rebuilt        : ScopeId(3): ["AnimalSize"]
-Symbol flags mismatch for "Size":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "Size":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(7)]
 rebuilt        : SymbolId(0): [ReferenceId(3)]
-Symbol flags mismatch for "Animal":
-after transform: SymbolId(3): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "Animal":
 after transform: SymbolId(3): [ReferenceId(1), ReferenceId(3), ReferenceId(11)]
 rebuilt        : SymbolId(2): [ReferenceId(7)]
-Symbol flags mismatch for "AnimalSize":
-after transform: SymbolId(6): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
 
 * enum-template-literal-number/input.ts
 Bindings mismatch:
@@ -220,15 +178,9 @@ rebuilt        : ScopeId(1): ["NumberEnum"]
 Bindings mismatch:
 after transform: ScopeId(2): ["COMPUTED_1", "COMPUTED_2", "ComputedEnum"]
 rebuilt        : ScopeId(2): ["ComputedEnum"]
-Symbol flags mismatch for "NumberEnum":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "NumberEnum":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(13)]
 rebuilt        : SymbolId(0): [ReferenceId(9)]
-Symbol flags mismatch for "ComputedEnum":
-after transform: SymbolId(5): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
 
 * enum-template-literal-trailing-quasi/input.ts
 Bindings mismatch:
@@ -237,15 +189,9 @@ rebuilt        : ScopeId(1): ["NumberEnum"]
 Bindings mismatch:
 after transform: ScopeId(2): ["C", "ComputedEnum", "D"]
 rebuilt        : ScopeId(2): ["ComputedEnum"]
-Symbol flags mismatch for "NumberEnum":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "NumberEnum":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(8)]
 rebuilt        : SymbolId(0): [ReferenceId(5)]
-Symbol flags mismatch for "ComputedEnum":
-after transform: SymbolId(3): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
 
 * export-elimination/input.ts
 Bindings mismatch:
@@ -273,9 +219,6 @@ rebuilt        : ScopeId(2): ["x"]
 Symbol redeclarations mismatch for "x":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 39, end: 40 }]
 rebuilt        : SymbolId(0): []
-Symbol flags mismatch for "y":
-after transform: SymbolId(2): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
 Symbol redeclarations mismatch for "y":
 after transform: SymbolId(2): [Span { start: 59, end: 60 }, Span { start: 83, end: 84 }]
 rebuilt        : SymbolId(3): []
@@ -299,17 +242,11 @@ rebuilt        : SymbolId(0): []
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "Mixed"]
 rebuilt        : ScopeId(1): ["Mixed"]
-Symbol flags mismatch for "Mixed":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 * optimize-enums/exported-not-removed/input.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["Direction", "Down", "Up"]
 rebuilt        : ScopeId(1): ["Direction"]
-Symbol flags mismatch for "Direction":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 * optimize-enums/merged-enum/input.ts
 Unresolved references mismatch:
@@ -320,25 +257,16 @@ rebuilt        : []
 Bindings mismatch:
 after transform: ScopeId(1): ["Runtime", "X", "Y"]
 rebuilt        : ScopeId(1): ["Runtime"]
-Symbol flags mismatch for "Runtime":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 * optimize-enums/optional-chain-value-kept/input.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "Foo"]
 rebuilt        : ScopeId(1): ["Foo"]
-Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 * optimize-enums/passed-as-argument-kept/input.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["Active", "Inactive", "Status"]
 rebuilt        : ScopeId(1): ["Status"]
-Symbol flags mismatch for "Status":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 * optimize-enums/re-exported-not-removed/input.ts
 Bindings mismatch:
@@ -347,28 +275,16 @@ rebuilt        : ScopeId(1): ["A"]
 Bindings mismatch:
 after transform: ScopeId(2): ["B", "Y"]
 rebuilt        : ScopeId(2): ["B"]
-Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "B":
-after transform: SymbolId(2): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
 
 * optimize-enums/typeof-kept/input.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["Bar", "X"]
 rebuilt        : ScopeId(1): ["Bar"]
-Symbol flags mismatch for "Bar":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 * optimize-enums/value-usage-kept/input.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "Foo"]
 rebuilt        : ScopeId(1): ["Foo"]
-Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 * redeclarations/input.ts
 Bindings mismatch:
@@ -574,30 +490,6 @@ rebuilt        : ScopeId(8): ["MixedEnum"]
 Bindings mismatch:
 after transform: ScopeId(9): ["ComputedEnum", "computed", "expression"]
 rebuilt        : ScopeId(9): ["ComputedEnum"]
-Symbol flags mismatch for "StringEnum":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "TemplateStringEnum":
-after transform: SymbolId(3): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "NumberEnum":
-after transform: SymbolId(6): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "UnaryEnum":
-after transform: SymbolId(9): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "UnaryOtherEnum":
-after transform: SymbolId(14): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(9): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "AutoIncrementEnum":
-after transform: SymbolId(18): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(11): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "MixedEnum":
-after transform: SymbolId(22): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(13): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch for "ComputedEnum":
-after transform: SymbolId(25): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(15): SymbolFlags(FunctionScopedVariable)
 
 * oxc/metadata/erased-import-no-type-keyword/input.ts
 Bindings mismatch:


### PR DESCRIPTION
## Summary

Synchronize semantic symbol flags with the JavaScript emitted when lowering TypeScript enums.

- Mark top-level lowered enums as function-scoped variables.
- Mark exported and nested lowered enums as block-scoped variables.
- Remove enum flags when lowering a merged enum to an assignment, while preserving flags from the existing runtime declaration.
- Defer updates until program exit so enum inlining and removal can still identify enums during traversal.

This removes over 1,000 stale symbol-flag mismatches from semantic and transform-conformance snapshots.

## Why Pending?

We delay it because `SymbolFlags::RegularEnum`/`ConstEnum` is still analysis input for the rest of traversal.

For example:

```ts
enum E {
  A = 1,
  B = foo(),
}
const x = E.A;
```

`E` is lowered when `enter_statement` visits the enum. Later, `enter_expression` visits `E.A` and checks the symbol flags to recognize and inline the enum member.

If lowering immediately changed `E` to `FunctionScopedVariable`, `E.A` would no longer be recognized as an enum, so the optimization would be skipped.

Thus the flags temporarily serve two roles:

1. During traversal: describe the original TypeScript enum for analysis and inlining.
2. After transformation: describe the emitted JavaScript binding (`var`, `let`, or a merged declaration).

Applying pending flags in `exit_program` updates them only after all enum-aware analysis is finished. It does not strictly need to be “at the end” if we introduced separate original/final flag storage, but with one shared `SymbolFlags` value, deferral is the simplest correct approach.

