### PR TITLE
fix(transformer): reparent scopes in moved decorator expressions

### DIFF
--- a/crates/oxc_transformer/src/decorator/legacy/mod.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/mod.rs
@@ -1420,6 +1420,14 @@ impl<'a> LegacyDecorator<'a> {
         descriptor: Expression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Statement<'a> {
+        // Member decorators are evaluated outside the class body. Their expressions may contain
+        // functions (e.g. `@((target, context) => {})`), so move those scopes along with the
+        // decorator expression when it is emitted after the class.
+        if let Some(parent_scope_id) = ctx.scoping().scope_parent_id(ctx.current_scope_id()) {
+            let mut visitor = ReparentDecoratorScopes { parent_scope_id, ctx };
+            visitor.visit_expression(&decorations);
+        }
+
         let arguments = ArenaVec::from_array_in(
             [
                 Argument::from(decorations),
@@ -1544,5 +1552,46 @@ impl<'a> ClassReferenceChanger<'a, '_> {
         });
 
         binding.create_read_reference(self.ctx)
+    }
+}
+
+/// Reparent the first scope introduced by a decorator expression when the expression is moved out
+/// of a class body.
+struct ReparentDecoratorScopes<'a, 'ctx> {
+    parent_scope_id: ScopeId,
+    ctx: &'ctx mut TraverseCtx<'a>,
+}
+
+impl Visit<'_> for ReparentDecoratorScopes<'_, '_> {
+    fn visit_function(&mut self, func: &Function<'_>, _flags: ScopeFlags) {
+        self.reparent(
+            func.scope_id(),
+            func.body.as_ref().is_some_and(|body| body.has_use_strict_directive()),
+        );
+    }
+
+    fn visit_arrow_function_expression(&mut self, func: &ArrowFunctionExpression<'_>) {
+        self.reparent(func.scope_id(), func.body.has_use_strict_directive());
+    }
+
+    fn visit_class(&mut self, class: &Class<'_>) {
+        // Decorators are evaluated outside the class scope, so scopes in them are also direct
+        // children of the scope containing this class expression.
+        self.visit_decorators(&class.decorators);
+        self.reparent(class.scope_id(), true);
+    }
+}
+
+impl ReparentDecoratorScopes<'_, '_> {
+    fn reparent(&mut self, scope_id: ScopeId, has_use_strict_directive: bool) {
+        let parent_is_strict =
+            self.ctx.scoping().scope_flags(self.parent_scope_id).is_strict_mode();
+        self.ctx.scoping_mut().change_scope_parent_id(scope_id, Some(self.parent_scope_id));
+        let flags = self.ctx.scoping_mut().scope_flags_mut(scope_id);
+        if has_use_strict_directive || parent_is_strict {
+            flags.insert(ScopeFlags::StrictMode);
+        } else {
+            flags.remove(ScopeFlags::StrictMode);
+        }
     }
 }

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -7,12 +7,6 @@ after transform: ScopeId(0): ["private"]
 rebuilt        : ScopeId(0): []
 
 semantic Error: tasks/coverage/misc/pass/oxc-11593.ts
-Scope parent mismatch:
-after transform: ScopeId(2): Some(ScopeId(1))
-rebuilt        : ScopeId(5): Some(ScopeId(0))
-Scope parent mismatch:
-after transform: ScopeId(4): Some(ScopeId(1))
-rebuilt        : ScopeId(7): Some(ScopeId(0))
 Unresolved reference IDs mismatch for "String":
 after transform: [ReferenceId(11), ReferenceId(12)]
 rebuilt        : [ReferenceId(18)]
@@ -66,15 +60,6 @@ rebuilt        : ScopeId(435): ScopeFlags(Function | Arrow)
 Scope parent mismatch:
 after transform: ScopeId(339): Some(ScopeId(338))
 rebuilt        : ScopeId(435): Some(ScopeId(354))
-Scope parent mismatch:
-after transform: ScopeId(359): Some(ScopeId(358))
-rebuilt        : ScopeId(467): Some(ScopeId(455))
-Scope parent mismatch:
-after transform: ScopeId(376): Some(ScopeId(375))
-rebuilt        : ScopeId(482): Some(ScopeId(470))
-Scope parent mismatch:
-after transform: ScopeId(392): Some(ScopeId(391))
-rebuilt        : ScopeId(496): Some(ScopeId(484))
 Symbol reference IDs mismatch for "_decorateMetadata":
 after transform: SymbolId(200): [ReferenceId(167), ReferenceId(171), ReferenceId(175), ReferenceId(176), ReferenceId(186), ReferenceId(187), ReferenceId(193), ReferenceId(194), ReferenceId(195), ReferenceId(199), ReferenceId(200), ReferenceId(201), ReferenceId(227), ReferenceId(229), ReferenceId(230), ReferenceId(236), ReferenceId(237), ReferenceId(238), ReferenceId(266), ReferenceId(268), ReferenceId(269), ReferenceId(275), ReferenceId(276), ReferenceId(277), ReferenceId(305), ReferenceId(307), ReferenceId(308), ReferenceId(314), ReferenceId(315), ReferenceId(316), ReferenceId(344), ReferenceId(346), ReferenceId(347), ReferenceId(353), ReferenceId(354), ReferenceId(355), ReferenceId(383), ReferenceId(387), ReferenceId(388), ReferenceId(396), ReferenceId(397), ReferenceId(398), ReferenceId(426), ReferenceId(428), ReferenceId(429), ReferenceId(435), ReferenceId(436), ReferenceId(437), ReferenceId(465), ReferenceId(469), ReferenceId(470), ReferenceId(478), ReferenceId(479), ReferenceId(480), ReferenceId(508), ReferenceId(510), ReferenceId(511), ReferenceId(517), ReferenceId(518), ReferenceId(519), ReferenceId(547), ReferenceId(551), ReferenceId(552), ReferenceId(560), ReferenceId(561), ReferenceId(562), ReferenceId(590), ReferenceId(592), ReferenceId(593), ReferenceId(599), ReferenceId(600), ReferenceId(601), ReferenceId(629), ReferenceId(633), ReferenceId(634), ReferenceId(642), ReferenceId(643), ReferenceId(644), ReferenceId(672), ReferenceId(674), ReferenceId(675), ReferenceId(681), ReferenceId(682), ReferenceId(683), ReferenceId(840), ReferenceId(844), ReferenceId(845), ReferenceId(853), ReferenceId(854), ReferenceId(855), ReferenceId(877), ReferenceId(881), ReferenceId(882), ReferenceId(892), ReferenceId(896), ReferenceId(897), ReferenceId(903), ReferenceId(904), ReferenceId(905), ReferenceId(909), ReferenceId(910), ReferenceId(911), ReferenceId(917), ReferenceId(918), ReferenceId(919), ReferenceId(921), ReferenceId(922), ReferenceId(923), ReferenceId(925), ReferenceId(926), ReferenceId(927), ReferenceId(931), ReferenceId(932), ReferenceId(933), ReferenceId(935), ReferenceId(936), ReferenceId(937), ReferenceId(939), ReferenceId(940), ReferenceId(941), ReferenceId(945), ReferenceId(946), ReferenceId(947), ReferenceId(949), ReferenceId(950), ReferenceId(951), ReferenceId(953), ReferenceId(954), ReferenceId(955)]
 rebuilt        : SymbolId(7): [ReferenceId(168), ReferenceId(172), ReferenceId(176), ReferenceId(178), ReferenceId(181), ReferenceId(183), ReferenceId(186), ReferenceId(188), ReferenceId(189), ReferenceId(192), ReferenceId(194), ReferenceId(195), ReferenceId(290), ReferenceId(294), ReferenceId(296), ReferenceId(299), ReferenceId(301), ReferenceId(302), ReferenceId(363), ReferenceId(367), ReferenceId(369), ReferenceId(372), ReferenceId(374), ReferenceId(375), ReferenceId(436), ReferenceId(440), ReferenceId(442), ReferenceId(445), ReferenceId(447), ReferenceId(448), ReferenceId(624), ReferenceId(631), ReferenceId(633), ReferenceId(639), ReferenceId(641), ReferenceId(642), ReferenceId(776), ReferenceId(780), ReferenceId(782), ReferenceId(785), ReferenceId(787), ReferenceId(788), ReferenceId(809), ReferenceId(813), ReferenceId(815), ReferenceId(818), ReferenceId(822), ReferenceId(824), ReferenceId(827), ReferenceId(829), ReferenceId(830), ReferenceId(833), ReferenceId(835), ReferenceId(836), ReferenceId(840), ReferenceId(842), ReferenceId(843), ReferenceId(846), ReferenceId(848), ReferenceId(849), ReferenceId(853), ReferenceId(855), ReferenceId(856)]

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -2,7 +2,7 @@ commit: 7964e22f
 
 semantic_typescript Summary:
 AST Parsed     : 4720/4720 (100.00%)
-Positive Passed: 3235/4720 (68.54%)
+Positive Passed: 3236/4720 (68.56%)
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/APISample_Watch.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["console", "formatHost", "os", "process", "reportDiagnostic", "reportWatchStatusChanged", "ts", "watchMain"]
@@ -16950,20 +16950,6 @@ Unresolved references mismatch:
 after transform: ["require"]
 rebuilt        : ["Mup", "require"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticAutoAccessorsWithDecorators.ts
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(7): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(2): Some(ScopeId(1))
-rebuilt        : ScopeId(7): Some(ScopeId(0))
-Scope flags mismatch:
-after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(8): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(3): Some(ScopeId(1))
-rebuilt        : ScopeId(8): Some(ScopeId(0))
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnum1.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["E", "a", "b", "c", "d", "e", "f", "g", "h"]
@@ -17379,18 +17365,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/decorators/cla
 Bindings mismatch:
 after transform: ScopeId(0): ["C1", "C2", "_classPrivateFieldGet", "_classPrivateFieldInitSpec", "_decorate", "_decorateMetadata", "_decorateParam", "_x", "_x2", "decorator"]
 rebuilt        : ScopeId(0): ["C1", "C2", "_classPrivateFieldGet", "_classPrivateFieldInitSpec", "_decorate", "_decorateMetadata", "_decorateParam", "_x", "_x2"]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(4): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(2): Some(ScopeId(1))
-rebuilt        : ScopeId(4): Some(ScopeId(0))
-Scope flags mismatch:
-after transform: ScopeId(6): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(8): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(6): Some(ScopeId(4))
-rebuilt        : ScopeId(8): Some(ScopeId(0))
 Reference symbol mismatch for "decorator":
 after transform: SymbolId(0) "decorator"
 rebuilt        : <None>
@@ -17466,66 +17440,6 @@ after transform: ["Number", "Symbol", "require"]
 rebuilt        : ["Number", "Symbol", "decorator", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/decorators/legacyDecorators-contextualTypes.ts
-Scope flags mismatch:
-after transform: ScopeId(5): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(15): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(5): Some(ScopeId(2))
-rebuilt        : ScopeId(15): Some(ScopeId(0))
-Scope flags mismatch:
-after transform: ScopeId(7): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(16): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(7): Some(ScopeId(2))
-rebuilt        : ScopeId(16): Some(ScopeId(0))
-Scope flags mismatch:
-after transform: ScopeId(10): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(17): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(10): Some(ScopeId(2))
-rebuilt        : ScopeId(17): Some(ScopeId(0))
-Scope flags mismatch:
-after transform: ScopeId(11): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(18): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(11): Some(ScopeId(2))
-rebuilt        : ScopeId(18): Some(ScopeId(0))
-Scope flags mismatch:
-after transform: ScopeId(12): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(19): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(12): Some(ScopeId(2))
-rebuilt        : ScopeId(19): Some(ScopeId(0))
-Scope flags mismatch:
-after transform: ScopeId(14): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(20): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(14): Some(ScopeId(2))
-rebuilt        : ScopeId(20): Some(ScopeId(0))
-Scope flags mismatch:
-after transform: ScopeId(17): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(21): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(17): Some(ScopeId(2))
-rebuilt        : ScopeId(21): Some(ScopeId(0))
-Scope flags mismatch:
-after transform: ScopeId(18): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(22): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(18): Some(ScopeId(2))
-rebuilt        : ScopeId(22): Some(ScopeId(0))
-Scope flags mismatch:
-after transform: ScopeId(20): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(23): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(20): Some(ScopeId(2))
-rebuilt        : ScopeId(23): Some(ScopeId(0))
-Scope flags mismatch:
-after transform: ScopeId(22): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(24): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(22): Some(ScopeId(2))
-rebuilt        : ScopeId(24): Some(ScopeId(0))
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Arrow)
 rebuilt        : ScopeId(26): ScopeFlags(Function | Arrow)
@@ -19392,12 +19306,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/c
 Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "_a", "_classPrivateFieldGet", "_classPrivateFieldInitSpec", "_decorate", "_decorateMetadata", "_defineProperty", "_f", "_f2", "dec", "f"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "_a", "_classPrivateFieldGet", "_classPrivateFieldInitSpec", "_decorate", "_decorateMetadata", "_defineProperty", "_f", "_f2"]
-Scope flags mismatch:
-after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(7): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(4): Some(ScopeId(3))
-rebuilt        : ScopeId(7): Some(ScopeId(0))
 Symbol span mismatch for "A":
 after transform: SymbolId(2): Span { start: 119, end: 120 }
 rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
@@ -20144,126 +20052,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/e
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "_C_brand", "_b_accessor_storage", "_b_accessor_storage2", "_c", "_classPrivateFieldGet", "_classPrivateFieldInitSpec", "_classPrivateFieldSet", "_classPrivateMethodInitSpec", "_decorate", "_decorateMetadata", "_defineProperty", "_f", "_g", "_get_a", "_get_b", "_get_x", "_get_y", "_set_a", "_set_b", "_set_x", "_set_y", "_y_accessor_storage", "_y_accessor_storage2", "_z"]
 rebuilt        : ScopeId(0): ["C", "_C_brand", "_b_accessor_storage2", "_c", "_classPrivateFieldGet", "_classPrivateFieldInitSpec", "_classPrivateFieldSet", "_classPrivateMethodInitSpec", "_decorate", "_decorateMetadata", "_defineProperty", "_f", "_g", "_get_a", "_get_b", "_get_x", "_get_y", "_set_a", "_set_b", "_set_x", "_set_y", "_y_accessor_storage2", "_z"]
-Scope flags mismatch:
-after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(23): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(3): Some(ScopeId(2))
-rebuilt        : ScopeId(23): Some(ScopeId(0))
-Scope flags mismatch:
-after transform: ScopeId(5): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(24): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(5): Some(ScopeId(2))
-rebuilt        : ScopeId(24): Some(ScopeId(0))
-Scope flags mismatch:
-after transform: ScopeId(7): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(25): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(7): Some(ScopeId(2))
-rebuilt        : ScopeId(25): Some(ScopeId(0))
-Scope flags mismatch:
-after transform: ScopeId(9): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(26): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(9): Some(ScopeId(2))
-rebuilt        : ScopeId(26): Some(ScopeId(0))
-Scope flags mismatch:
-after transform: ScopeId(11): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(27): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(11): Some(ScopeId(2))
-rebuilt        : ScopeId(27): Some(ScopeId(0))
-Scope flags mismatch:
-after transform: ScopeId(13): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(28): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(13): Some(ScopeId(2))
-rebuilt        : ScopeId(28): Some(ScopeId(0))
-Scope flags mismatch:
-after transform: ScopeId(15): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(29): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(15): Some(ScopeId(2))
-rebuilt        : ScopeId(29): Some(ScopeId(0))
-Scope flags mismatch:
-after transform: ScopeId(16): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(30): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(16): Some(ScopeId(2))
-rebuilt        : ScopeId(30): Some(ScopeId(0))
-Scope flags mismatch:
-after transform: ScopeId(17): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(31): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(17): Some(ScopeId(2))
-rebuilt        : ScopeId(31): Some(ScopeId(0))
-Scope flags mismatch:
-after transform: ScopeId(18): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(32): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(18): Some(ScopeId(2))
-rebuilt        : ScopeId(32): Some(ScopeId(0))
-Scope flags mismatch:
-after transform: ScopeId(19): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(33): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(19): Some(ScopeId(2))
-rebuilt        : ScopeId(33): Some(ScopeId(0))
-Scope flags mismatch:
-after transform: ScopeId(21): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(34): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(21): Some(ScopeId(2))
-rebuilt        : ScopeId(34): Some(ScopeId(0))
-Scope flags mismatch:
-after transform: ScopeId(23): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(35): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(23): Some(ScopeId(2))
-rebuilt        : ScopeId(35): Some(ScopeId(0))
-Scope flags mismatch:
-after transform: ScopeId(25): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(36): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(25): Some(ScopeId(2))
-rebuilt        : ScopeId(36): Some(ScopeId(0))
-Scope flags mismatch:
-after transform: ScopeId(27): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(37): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(27): Some(ScopeId(2))
-rebuilt        : ScopeId(37): Some(ScopeId(0))
-Scope flags mismatch:
-after transform: ScopeId(29): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(38): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(29): Some(ScopeId(2))
-rebuilt        : ScopeId(38): Some(ScopeId(0))
-Scope flags mismatch:
-after transform: ScopeId(31): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(39): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(31): Some(ScopeId(2))
-rebuilt        : ScopeId(39): Some(ScopeId(0))
-Scope flags mismatch:
-after transform: ScopeId(32): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(40): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(32): Some(ScopeId(2))
-rebuilt        : ScopeId(40): Some(ScopeId(0))
-Scope flags mismatch:
-after transform: ScopeId(33): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(41): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(33): Some(ScopeId(2))
-rebuilt        : ScopeId(41): Some(ScopeId(0))
-Scope flags mismatch:
-after transform: ScopeId(34): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(42): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(34): Some(ScopeId(2))
-rebuilt        : ScopeId(42): Some(ScopeId(0))
 Symbol span mismatch for "C":
 after transform: SymbolId(0): Span { start: 23, end: 24 }
 rebuilt        : SymbolId(10): Span { start: 0, end: 0 }

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 1fb0b771
 
-Passed: 244/397
+Passed: 245/397
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -504,7 +504,7 @@ x Output mismatch
 x Output mismatch
 
 
-# legacy-decorators (10/105)
+# legacy-decorators (11/105)
 * oxc/accessor/input.ts
 x Output mismatch
 
@@ -1256,14 +1256,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["babelHelpers"]
 rebuilt        : ["Something", "babelHelpers"]
-
-* typescript/decoratorChecksFunctionBodies/input.ts
-Scope flags mismatch:
-after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(4): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(3): Some(ScopeId(2))
-rebuilt        : ScopeId(4): Some(ScopeId(0))
 
 * typescript/decoratorOnClass1/input.ts
 Bindings mismatch:


### PR DESCRIPTION
## Summary

Legacy decorator expressions are evaluated inside the class during parsing, but the transformer emits member decorator calls after the class.

```text
Input AST scopes                    Transformed output

Program                             Program
└─ Class (strict)                   ├─ Class
   └─ decorator arrow (strict)      └─ _decorate([() => {}], ...)
```

Previously, the moved arrow retained its original class scope parent:

```text
Incorrect                           Correct

Program                             Program
└─ Class                            ├─ Class
   └─ Arrow                         └─ Arrow
      parent: Class                    parent: Program
      strict: true                     strict: false
```

This caused the transformer’s semantic data to disagree with semantics rebuilt from the transformed AST.

## Changes

- Reparent scopes introduced by member decorator expressions to the class’s enclosing scope.
- Recalculate inherited strict-mode flags after moving those scopes.
- Treat class expressions as scope boundaries, keeping their methods parented to the class.
- Update semantic and transform-conformance snapshots.

```text
Decorator expression traversal

expression
├─ function/arrow ── reparent scope
├─ class ─────────── reparent class scope
│  └─ methods ────── remain inside class scope
└─ other expression nodes ── continue searching
```