### PR TITLE
fix(transformer): scope anonymous decorated class bindings correctly

### DIFF
--- a/crates/oxc_transformer/src/decorator/legacy/mod.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/mod.rs
@@ -594,7 +594,9 @@ impl<'a> LegacyDecorator<'a> {
             if let Some(ident) = class.id() {
                 BoundIdentifier::from_binding_ident(ident)
             } else {
-                ctx.generate_uid_in_current_scope("default", SymbolFlags::Class)
+                let class_scope_id = class.scope_id().get().unwrap();
+                let outer_scope_id = ctx.scoping().scope_parent_id(class_scope_id).unwrap();
+                ctx.generate_uid("default", outer_scope_id, SymbolFlags::Class)
             }
         });
 

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -18455,14 +18455,8 @@ rebuilt        : SymbolId(0): [ReferenceId(0)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/accessor/decoratorOnClassAccessor1.es6.ts
 Bindings mismatch:
-after transform: ScopeId(0): ["_decorate", "_decorateMetadata", "dec"]
+after transform: ScopeId(0): ["_decorate", "_decorateMetadata", "_default", "dec"]
 rebuilt        : ScopeId(0): ["_decorate", "_decorateMetadata", "_default"]
-Bindings mismatch:
-after transform: ScopeId(2): ["_default"]
-rebuilt        : ScopeId(1): []
-Symbol scope ID mismatch for "_default":
-after transform: SymbolId(6): ScopeId(2)
-rebuilt        : SymbolId(2): ScopeId(0)
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -18623,14 +18617,8 @@ rebuilt        : ["_Class", "dec"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/method/decoratorOnClassMethod1.es6.ts
 Bindings mismatch:
-after transform: ScopeId(0): ["_decorate", "_decorateMetadata", "dec"]
+after transform: ScopeId(0): ["_decorate", "_decorateMetadata", "_default", "dec"]
 rebuilt        : ScopeId(0): ["_decorate", "_decorateMetadata", "_default"]
-Bindings mismatch:
-after transform: ScopeId(2): ["_default"]
-rebuilt        : ScopeId(1): []
-Symbol scope ID mismatch for "_default":
-after transform: SymbolId(6): ScopeId(2)
-rebuilt        : SymbolId(2): ScopeId(0)
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -18640,14 +18628,8 @@ rebuilt        : ["Function", "dec"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/method/parameter/decoratorOnClassMethodParameter1.es6.ts
 Bindings mismatch:
-after transform: ScopeId(0): ["_decorate", "_decorateMetadata", "_decorateParam", "dec"]
+after transform: ScopeId(0): ["_decorate", "_decorateMetadata", "_decorateParam", "_default", "dec"]
 rebuilt        : ScopeId(0): ["_decorate", "_decorateMetadata", "_decorateParam", "_default"]
-Bindings mismatch:
-after transform: ScopeId(2): ["_default"]
-rebuilt        : ScopeId(1): []
-Symbol scope ID mismatch for "_default":
-after transform: SymbolId(7): ScopeId(2)
-rebuilt        : SymbolId(3): ScopeId(0)
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -18657,14 +18639,8 @@ rebuilt        : ["Function", "Number", "dec"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/property/decoratorOnClassProperty1.es6.ts
 Bindings mismatch:
-after transform: ScopeId(0): ["_decorate", "_decorateMetadata", "_defineProperty", "dec"]
+after transform: ScopeId(0): ["_decorate", "_decorateMetadata", "_default", "_defineProperty", "dec"]
 rebuilt        : ScopeId(0): ["_decorate", "_decorateMetadata", "_default", "_defineProperty"]
-Bindings mismatch:
-after transform: ScopeId(2): ["_default"]
-rebuilt        : ScopeId(1): []
-Symbol scope ID mismatch for "_default":
-after transform: SymbolId(5): ScopeId(2)
-rebuilt        : SymbolId(3): ScopeId(0)
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 1fb0b771
 
-Passed: 244/397
+Passed: 245/397
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -504,7 +504,7 @@ x Output mismatch
 x Output mismatch
 
 
-# legacy-decorators (10/105)
+# legacy-decorators (11/105)
 * oxc/accessor/input.ts
 x Output mismatch
 
@@ -555,29 +555,9 @@ after transform: ["WeakMap", "babelHelpers"]
 rebuilt        : ["WeakMap", "a", "babelHelpers", "dec"]
 
 * oxc/class-without-name-with-decorated_class/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["dec"]
-rebuilt        : ScopeId(0): ["_default", "dec"]
-Bindings mismatch:
-after transform: ScopeId(1): ["_default"]
-rebuilt        : ScopeId(1): []
 Symbol flags mismatch for "_default":
 after transform: SymbolId(1): SymbolFlags(Class)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol scope ID mismatch for "_default":
-after transform: SymbolId(1): ScopeId(1)
-rebuilt        : SymbolId(1): ScopeId(0)
-
-* oxc/class-without-name-with-decorated_element/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["dec"]
-rebuilt        : ScopeId(0): ["_default", "dec"]
-Bindings mismatch:
-after transform: ScopeId(1): ["_default"]
-rebuilt        : ScopeId(1): []
-Symbol scope ID mismatch for "_default":
-after transform: SymbolId(1): ScopeId(1)
-rebuilt        : SymbolId(1): ScopeId(0)
 
 * oxc/metadata/abstract-class/input.ts
 Symbol span mismatch for "AbstractClass":


### PR DESCRIPTION
## Summary

Generate bindings for anonymous decorated classes in the class’s enclosing scope.

## Problem

When an anonymous class element has a decorator, the transformer creates a
temporary `_default` binding while traversing the class body.

Previously, the binding was registered in the current class scope even though
the transformed declaration is emitted outside that class.

```text
Semantic data before fix          Transformed AST

Program                           Program
└─ Class scope                    └─ class/variable _default
   └─ binding: _default               ↑ emitted here
       ↑ recorded here
```

This caused the retained semantic data to disagree with semantics rebuilt from
the transformed AST:

```text
after transform: _default → class scope
rebuilt:         _default → enclosing scope
```

## Solution

Derive the class’s enclosing scope from its semantic scope and generate the
temporary binding there.

```text
Class scope
    │
    └── parent scope ── generate `_default` binding here
                            │
                            └── matches emitted declaration
```

This corrects binding ownership for anonymous default-export classes with
decorated members.