### PR TITLE
fix(transformer): declare temp for renamed anonymous class

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/class.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class.rs
@@ -452,8 +452,11 @@ impl<'a> ClassProperties<'a> {
         if let Some(temp_binding) = &class_details.bindings.temp {
             // Binding for class name is required
             if let Some(ident) = &class.id {
-                // Insert `var _Class` statement, if it wasn't already in entry phase
-                if !class_details.bindings.temp_var_is_created {
+                // For an anonymous class, `temp_var_is_created` assumes the class itself will bind
+                // the temp. If another transform changed the class ID, declare the temp separately.
+                if !class_details.bindings.temp_var_is_created
+                    || ident.symbol_id() != temp_binding.symbol_id
+                {
                     ctx.state.var_declarations.insert_var(temp_binding, &ctx.ast);
                 }
 

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 1fb0b771
 
-Passed: 245/397
+Passed: 246/398
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -504,7 +504,7 @@ x Output mismatch
 x Output mismatch
 
 
-# legacy-decorators (11/105)
+# legacy-decorators (12/106)
 * oxc/accessor/input.ts
 x Output mismatch
 

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/class-without-name-with-decorated-static-element/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/class-without-name-with-decorated-static-element/input.ts
@@ -1,0 +1,6 @@
+import { dec } from "dec";
+
+export default class {
+  @dec
+  static foo = 0;
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/class-without-name-with-decorated-static-element/options.json
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/class-without-name-with-decorated-static-element/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "transform-legacy-decorator",
+    "transform-class-properties"
+  ]
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/class-without-name-with-decorated-static-element/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/class-without-name-with-decorated-static-element/output.js
@@ -1,0 +1,6 @@
+import { dec } from "dec";
+var _Class;
+export default class _default {}
+_Class = _default;
+babelHelpers.defineProperty(_Class, "foo", 0);
+babelHelpers.decorate([dec], _default, "foo", void 0);


### PR DESCRIPTION
## Summary

- declare the class-properties temp when another transform names an anonymous class
- prevent static-field initialization from referencing an undeclared temp
- add legacy-decorator/class-properties conformance coverage

## Transformation

```mermaid
flowchart LR
    A["Anonymous class"] --> B["Class properties reserves _Class"]
    B --> C["Decorator names class _default"]
    C --> D["Declare var _Class"]
    D --> E["_Class = _default"]
    E --> F["Initialize static fields"]
```

```ts
export default class {
  @dec
  static foo = 0;
}
```

```js
var _Class;
export default class _default {}
_Class = _default;
babelHelpers.defineProperty(_Class, "foo", 0);
```