### PR TITLE
fix(transformer): preserve decorated class read bindings

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/class.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class.rs
@@ -463,8 +463,18 @@ impl<'a> ClassProperties<'a> {
                 // Insert `_Class = Class` after class.
                 // TODO(improve-on-babel): Could just insert `var _Class = Class;` after class,
                 // rather than separate `var _Class` declaration.
-                let class_name =
-                    BoundIdentifier::from_binding_ident(ident).create_read_expression(ctx);
+                let class_name_binding = class_details
+                    .bindings
+                    .name
+                    .as_ref()
+                    .expect("class declaration with a temp always has a name binding");
+                // Preserve a later name assigned to an anonymous class. Named classes use the
+                // outer binding captured on entry, rather than a rewritten inner class binding.
+                let class_name = if class_name_binding.symbol_id == temp_binding.symbol_id {
+                    BoundIdentifier::from_binding_ident(ident).create_read_expression(ctx)
+                } else {
+                    class_name_binding.create_read_expression(ctx)
+                };
                 let expr = create_assignment(temp_binding, class_name, SPAN, ctx);
                 let stmt = Statement::new_expression_statement(SPAN, expr, ctx);
                 self.insert_after_stmts.insert(0, stmt);

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -18953,24 +18953,15 @@ rebuilt        : ScopeId(0): ["C", "D", "_D", "_assertClassBrand", "_decorate", 
 Symbol span mismatch for "D":
 after transform: SymbolId(3): Span { start: 137, end: 138 }
 rebuilt        : SymbolId(9): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "D":
-after transform: SymbolId(3): [ReferenceId(21), ReferenceId(23)]
-rebuilt        : SymbolId(9): [ReferenceId(18), ReferenceId(28), ReferenceId(31)]
 Symbol span mismatch for "D":
 after transform: SymbolId(14): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(10): Span { start: 137, end: 138 }
-Symbol reference IDs mismatch for "D":
-after transform: SymbolId(14): [ReferenceId(26)]
-rebuilt        : SymbolId(10): []
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
-Reference symbol mismatch for "D":
-after transform: SymbolId(14) "D"
-rebuilt        : SymbolId(9) "D"
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -18985,21 +18976,12 @@ rebuilt        : ScopeId(0): ["C", "_C", "_decorate", "_superPropGet", "method"]
 Symbol span mismatch for "C":
 after transform: SymbolId(4): Span { start: 125, end: 126 }
 rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(4): [ReferenceId(4), ReferenceId(6)]
-rebuilt        : SymbolId(4): [ReferenceId(4), ReferenceId(25), ReferenceId(28)]
 Symbol span mismatch for "C":
 after transform: SymbolId(5): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(5): Span { start: 125, end: 126 }
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(5): [ReferenceId(25)]
-rebuilt        : SymbolId(5): []
 Reference symbol mismatch for "Base":
 after transform: SymbolId(1) "Base"
 rebuilt        : <None>
-Reference symbol mismatch for "C":
-after transform: SymbolId(5) "C"
-rebuilt        : SymbolId(4) "C"
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -19014,54 +18996,27 @@ rebuilt        : ScopeId(0): ["C1", "C2", "C3", "_C", "_C2", "_C3", "_decorate",
 Symbol span mismatch for "C1":
 after transform: SymbolId(1): Span { start: 97, end: 99 }
 rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "C1":
-after transform: SymbolId(1): [ReferenceId(3), ReferenceId(5)]
-rebuilt        : SymbolId(5): [ReferenceId(3), ReferenceId(7), ReferenceId(10)]
 Symbol span mismatch for "C1":
 after transform: SymbolId(4): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(6): Span { start: 97, end: 99 }
-Symbol reference IDs mismatch for "C1":
-after transform: SymbolId(4): [ReferenceId(9)]
-rebuilt        : SymbolId(6): []
 Symbol span mismatch for "C2":
 after transform: SymbolId(2): Span { start: 239, end: 241 }
 rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "C2":
-after transform: SymbolId(2): [ReferenceId(11), ReferenceId(13)]
-rebuilt        : SymbolId(7): [ReferenceId(12), ReferenceId(16), ReferenceId(19)]
 Symbol span mismatch for "C2":
 after transform: SymbolId(8): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(8): Span { start: 239, end: 241 }
-Symbol reference IDs mismatch for "C2":
-after transform: SymbolId(8): [ReferenceId(17)]
-rebuilt        : SymbolId(8): []
 Symbol span mismatch for "C3":
 after transform: SymbolId(3): Span { start: 389, end: 391 }
 rebuilt        : SymbolId(9): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "C3":
-after transform: SymbolId(3): [ReferenceId(19), ReferenceId(21)]
-rebuilt        : SymbolId(9): [ReferenceId(21), ReferenceId(25), ReferenceId(28)]
 Symbol span mismatch for "C3":
 after transform: SymbolId(10): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(10): Span { start: 389, end: 391 }
-Symbol reference IDs mismatch for "C3":
-after transform: SymbolId(10): [ReferenceId(25)]
-rebuilt        : SymbolId(10): []
-Reference symbol mismatch for "C1":
-after transform: SymbolId(4) "C1"
-rebuilt        : SymbolId(5) "C1"
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
-Reference symbol mismatch for "C2":
-after transform: SymbolId(8) "C2"
-rebuilt        : SymbolId(7) "C2"
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
-Reference symbol mismatch for "C3":
-after transform: SymbolId(10) "C3"
-rebuilt        : SymbolId(9) "C3"
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -19076,21 +19031,12 @@ rebuilt        : ScopeId(0): ["C", "_C", "_decorate", "_super$x", "_super$x10", 
 Symbol span mismatch for "C":
 after transform: SymbolId(3): Span { start: 96, end: 97 }
 rebuilt        : SymbolId(23): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(3): [ReferenceId(11), ReferenceId(13)]
-rebuilt        : SymbolId(23): [ReferenceId(5), ReferenceId(170), ReferenceId(173)]
 Symbol span mismatch for "C":
 after transform: SymbolId(4): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(24): Span { start: 96, end: 97 }
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(4): [ReferenceId(169)]
-rebuilt        : SymbolId(24): []
 Reference symbol mismatch for "Base":
 after transform: SymbolId(1) "Base"
 rebuilt        : <None>
-Reference symbol mismatch for "C":
-after transform: SymbolId(4) "C"
-rebuilt        : SymbolId(23) "C"
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -19105,21 +19051,12 @@ rebuilt        : ScopeId(0): ["C", "_C", "_decorate", "_defineProperty", "_super
 Symbol span mismatch for "C":
 after transform: SymbolId(4): Span { start: 127, end: 128 }
 rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(4): [ReferenceId(4), ReferenceId(6), ReferenceId(10), ReferenceId(15), ReferenceId(20), ReferenceId(25), ReferenceId(30), ReferenceId(35)]
-rebuilt        : SymbolId(5): [ReferenceId(5), ReferenceId(7), ReferenceId(12), ReferenceId(17), ReferenceId(23), ReferenceId(28), ReferenceId(33), ReferenceId(38), ReferenceId(41)]
 Symbol span mismatch for "C":
 after transform: SymbolId(5): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(6): Span { start: 127, end: 128 }
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(5): [ReferenceId(37)]
-rebuilt        : SymbolId(6): []
 Reference symbol mismatch for "Base":
 after transform: SymbolId(1) "Base"
 rebuilt        : <None>
-Reference symbol mismatch for "C":
-after transform: SymbolId(5) "C"
-rebuilt        : SymbolId(5) "C"
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -19134,63 +19071,36 @@ rebuilt        : ScopeId(0): ["C1", "C2", "C3", "_C", "_C2", "_C3", "_decorate",
 Symbol span mismatch for "C1":
 after transform: SymbolId(3): Span { start: 96, end: 98 }
 rebuilt        : SymbolId(26): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "C1":
-after transform: SymbolId(3): [ReferenceId(15), ReferenceId(17), ReferenceId(21), ReferenceId(26), ReferenceId(34), ReferenceId(47), ReferenceId(60), ReferenceId(70), ReferenceId(80), ReferenceId(82), ReferenceId(84)]
-rebuilt        : SymbolId(26): [ReferenceId(6), ReferenceId(8), ReferenceId(13), ReferenceId(18), ReferenceId(26), ReferenceId(39), ReferenceId(52), ReferenceId(62), ReferenceId(72), ReferenceId(74), ReferenceId(75), ReferenceId(78)]
 Symbol span mismatch for "C1":
 after transform: SymbolId(6): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(27): Span { start: 96, end: 98 }
-Symbol reference IDs mismatch for "C1":
-after transform: SymbolId(6): [ReferenceId(86)]
-rebuilt        : SymbolId(27): []
 Symbol span mismatch for "C2":
 after transform: SymbolId(4): Span { start: 389, end: 391 }
 rebuilt        : SymbolId(28): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "C2":
-after transform: SymbolId(4): [ReferenceId(88), ReferenceId(90), ReferenceId(94), ReferenceId(99), ReferenceId(107), ReferenceId(120), ReferenceId(133), ReferenceId(143), ReferenceId(153), ReferenceId(155), ReferenceId(157)]
-rebuilt        : SymbolId(28): [ReferenceId(81), ReferenceId(83), ReferenceId(88), ReferenceId(93), ReferenceId(101), ReferenceId(114), ReferenceId(127), ReferenceId(137), ReferenceId(147), ReferenceId(149), ReferenceId(150), ReferenceId(153)]
 Symbol span mismatch for "C2":
 after transform: SymbolId(18): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(29): Span { start: 389, end: 391 }
-Symbol reference IDs mismatch for "C2":
-after transform: SymbolId(18): [ReferenceId(159)]
-rebuilt        : SymbolId(29): []
 Symbol span mismatch for "C3":
 after transform: SymbolId(5): Span { start: 709, end: 711 }
 rebuilt        : SymbolId(30): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "C3":
-after transform: SymbolId(5): [ReferenceId(161), ReferenceId(163), ReferenceId(167), ReferenceId(172), ReferenceId(181), ReferenceId(195), ReferenceId(209), ReferenceId(220), ReferenceId(231), ReferenceId(233), ReferenceId(235)]
-rebuilt        : SymbolId(30): [ReferenceId(156), ReferenceId(158), ReferenceId(164), ReferenceId(170), ReferenceId(180), ReferenceId(195), ReferenceId(210), ReferenceId(222), ReferenceId(234), ReferenceId(237), ReferenceId(239), ReferenceId(242)]
 Symbol span mismatch for "C3":
 after transform: SymbolId(26): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(31): Span { start: 709, end: 711 }
-Symbol reference IDs mismatch for "C3":
-after transform: SymbolId(26): [ReferenceId(237)]
-rebuilt        : SymbolId(31): []
 Reference symbol mismatch for "Base":
 after transform: SymbolId(1) "Base"
 rebuilt        : <None>
-Reference symbol mismatch for "C1":
-after transform: SymbolId(6) "C1"
-rebuilt        : SymbolId(26) "C1"
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Reference symbol mismatch for "Base":
 after transform: SymbolId(1) "Base"
 rebuilt        : <None>
-Reference symbol mismatch for "C2":
-after transform: SymbolId(18) "C2"
-rebuilt        : SymbolId(28) "C2"
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Reference symbol mismatch for "Base":
 after transform: SymbolId(1) "Base"
 rebuilt        : <None>
-Reference symbol mismatch for "C3":
-after transform: SymbolId(26) "C3"
-rebuilt        : SymbolId(30) "C3"
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -19225,18 +19135,9 @@ rebuilt        : ScopeId(0): ["C", "_C", "_a_accessor_storage", "_decorate", "_d
 Symbol span mismatch for "C":
 after transform: SymbolId(1): Span { start: 34, end: 35 }
 rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(1): [ReferenceId(6), ReferenceId(8), ReferenceId(11)]
-rebuilt        : SymbolId(3): [ReferenceId(6), ReferenceId(9), ReferenceId(12), ReferenceId(15)]
 Symbol span mismatch for "C":
 after transform: SymbolId(4): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(4): Span { start: 34, end: 35 }
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(4): [ReferenceId(14)]
-rebuilt        : SymbolId(4): []
-Reference symbol mismatch for "C":
-after transform: SymbolId(4) "C"
-rebuilt        : SymbolId(3) "C"
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -19594,15 +19495,9 @@ rebuilt        : ScopeId(0): ["C", "D", "_D", "_decorate", "_decorateMetadata", 
 Symbol span mismatch for "D":
 after transform: SymbolId(3): Span { start: 199, end: 200 }
 rebuilt        : SymbolId(13): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "D":
-after transform: SymbolId(3): [ReferenceId(45), ReferenceId(47)]
-rebuilt        : SymbolId(13): [ReferenceId(39), ReferenceId(42), ReferenceId(45)]
 Symbol span mismatch for "D":
 after transform: SymbolId(16): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(14): Span { start: 199, end: 200 }
-Symbol reference IDs mismatch for "D":
-after transform: SymbolId(16): [ReferenceId(50)]
-rebuilt        : SymbolId(14): []
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -19612,9 +19507,6 @@ rebuilt        : <None>
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
-Reference symbol mismatch for "D":
-after transform: SymbolId(16) "D"
-rebuilt        : SymbolId(13) "D"
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -19629,21 +19521,12 @@ rebuilt        : ScopeId(0): ["C", "D", "_D", "_assertClassBrand", "_decorate", 
 Symbol span mismatch for "D":
 after transform: SymbolId(2): Span { start: 76, end: 77 }
 rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "D":
-after transform: SymbolId(2): [ReferenceId(12), ReferenceId(14)]
-rebuilt        : SymbolId(6): [ReferenceId(9), ReferenceId(18), ReferenceId(21)]
 Symbol span mismatch for "D":
 after transform: SymbolId(9): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(7): Span { start: 76, end: 77 }
-Symbol reference IDs mismatch for "D":
-after transform: SymbolId(9): [ReferenceId(17)]
-rebuilt        : SymbolId(7): []
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
-Reference symbol mismatch for "D":
-after transform: SymbolId(9) "D"
-rebuilt        : SymbolId(6) "D"
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -19658,21 +19541,12 @@ rebuilt        : ScopeId(0): ["C", "D", "_D", "_assertClassBrand", "_decorate", 
 Symbol span mismatch for "D":
 after transform: SymbolId(2): Span { start: 85, end: 86 }
 rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "D":
-after transform: SymbolId(2): [ReferenceId(24), ReferenceId(26)]
-rebuilt        : SymbolId(10): [ReferenceId(14), ReferenceId(27), ReferenceId(30)]
 Symbol span mismatch for "D":
 after transform: SymbolId(16): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(11): Span { start: 85, end: 86 }
-Symbol reference IDs mismatch for "D":
-after transform: SymbolId(16): [ReferenceId(29)]
-rebuilt        : SymbolId(11): []
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
-Reference symbol mismatch for "D":
-after transform: SymbolId(16) "D"
-rebuilt        : SymbolId(10) "D"
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>


### PR DESCRIPTION
## Summary

Fix semantic reference tracking when class-properties processes a named class rewritten by legacy decorators.

## Problem

Legacy decorators split a named class into two bindings:

- the outer variable binding;
- the inner class-expression binding.

Class-properties previously created `_Class = Class` using the rewritten `class.id`, which points to the inner binding. Since the assignment executes outside the class body, it must reference the outer binding captured when entering the class.

Originally anonymous classes are different: another transform may assign their final name later, so they must continue using the current `class.id`.

```mermaid
flowchart TD
    A["Create read for `_Class = Class`"] --> B{"Captured class name is the temp binding?"}
    B -- "No" --> C["Named class: read captured outer binding"]
    B -- "Yes" --> D["Originally anonymous class: read current class ID"]
```

## Solution

Use the class binding captured on entry for named declarations, while retaining the current class ID for originally anonymous declarations.

This aligns transformed reference IDs with semantics rebuilt from the generated output without regressing anonymous decorated classes.
