### PR TITLE
fix(semantic): mark computed method keys in `TSMethodSignature`s as type references

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -2424,6 +2424,32 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         self.leave_node(kind);
     }
 
+    fn visit_ts_method_signature(&mut self, sig: &TSMethodSignature<'a>) {
+        let kind = AstKind::TSMethodSignature(self.alloc(sig));
+        self.enter_node(kind);
+        self.enter_scope(ScopeFlags::empty(), &sig.scope_id);
+        self.visit_span(&sig.span);
+        if sig.computed {
+            // interface A { [prop](): string }
+            //                ^^^^ The property can reference value or [`SymbolFlags::TypeImport`] symbol
+            self.current_reference_flags = ReferenceFlags::ValueAsType;
+        }
+        self.visit_property_key(&sig.key);
+        self.current_reference_flags = ReferenceFlags::empty();
+        if let Some(type_parameters) = &sig.type_parameters {
+            self.visit_ts_type_parameter_declaration(type_parameters);
+        }
+        if let Some(this_param) = &sig.this_param {
+            self.visit_ts_this_parameter(this_param);
+        }
+        self.visit_formal_parameters(&sig.params);
+        if let Some(return_type) = &sig.return_type {
+            self.visit_ts_type_annotation(return_type);
+        }
+        self.leave_scope();
+        self.leave_node(kind);
+    }
+
     fn visit_import_specifier(&mut self, specifier: &ImportSpecifier<'a>) {
         let kind = AstKind::ImportSpecifier(self.alloc(specifier));
         self.enter_node(kind);

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/interfaces/computed-method-signatures.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/interfaces/computed-method-signatures.snap
@@ -1,0 +1,117 @@
+---
+source: crates/oxc_semantic/tests/main.rs
+input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/interfaces/computed-method-signatures.ts
+---
+[
+  {
+    "children": [
+      {
+        "children": [
+          {
+            "children": [],
+            "flags": "ScopeFlags(StrictMode)",
+            "id": 2,
+            "node": "TSMethodSignature",
+            "symbols": []
+          },
+          {
+            "children": [],
+            "flags": "ScopeFlags(StrictMode)",
+            "id": 3,
+            "node": "TSMethodSignature",
+            "symbols": [
+              {
+                "flags": "SymbolFlags(FunctionScopedVariable)",
+                "id": 3,
+                "name": "value",
+                "node": "FormalParameter(value)",
+                "references": []
+              }
+            ]
+          },
+          {
+            "children": [],
+            "flags": "ScopeFlags(StrictMode)",
+            "id": 4,
+            "node": "TSMethodSignature",
+            "symbols": []
+          }
+        ],
+        "flags": "ScopeFlags(StrictMode)",
+        "id": 1,
+        "node": "TSInterfaceDeclaration",
+        "symbols": []
+      },
+      {
+        "children": [],
+        "flags": "ScopeFlags(StrictMode)",
+        "id": 5,
+        "node": "TSTypeAliasDeclaration",
+        "symbols": []
+      }
+    ],
+    "flags": "ScopeFlags(StrictMode | Top)",
+    "id": 0,
+    "node": "Program",
+    "symbols": [
+      {
+        "flags": "SymbolFlags(TypeImport)",
+        "id": 0,
+        "name": "importedKey",
+        "node": "ImportDefaultSpecifier",
+        "references": [
+          {
+            "flags": "ReferenceFlags(Type)",
+            "id": 5,
+            "name": "importedKey",
+            "node_id": 32,
+            "scope_id": 4
+          }
+        ]
+      },
+      {
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "id": 1,
+        "name": "valueKey",
+        "node": "VariableDeclarator(valueKey)",
+        "references": [
+          {
+            "flags": "ReferenceFlags(Type)",
+            "id": 1,
+            "name": "valueKey",
+            "node_id": 14,
+            "scope_id": 2
+          },
+          {
+            "flags": "ReferenceFlags(Type)",
+            "id": 3,
+            "name": "valueKey",
+            "node_id": 22,
+            "scope_id": 3
+          },
+          {
+            "flags": "ReferenceFlags(Type)",
+            "id": 6,
+            "name": "valueKey",
+            "node_id": 39,
+            "scope_id": 5
+          }
+        ]
+      },
+      {
+        "flags": "SymbolFlags(Interface)",
+        "id": 2,
+        "name": "Foo",
+        "node": "TSInterfaceDeclaration",
+        "references": []
+      },
+      {
+        "flags": "SymbolFlags(TypeAlias)",
+        "id": 4,
+        "name": "T",
+        "node": "TSTypeAliasDeclaration",
+        "references": []
+      }
+    ]
+  }
+]

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/interfaces/computed-method-signatures.ts
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/interfaces/computed-method-signatures.ts
@@ -1,0 +1,11 @@
+import type importedKey from "mod";
+
+const valueKey = Symbol();
+
+interface Foo {
+    get [valueKey](): Set<string>;
+    set [valueKey](value: Set<string>);
+    [importedKey](): string;
+}
+
+type T = typeof valueKey;

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method-computed-name.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method-computed-name.snap
@@ -47,7 +47,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flags": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "x",
             "node_id": 13,

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method-computed-name2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method-computed-name2.snap
@@ -47,7 +47,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSEnumDeclaration(Foo)",
         "references": [
           {
-            "flags": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "Foo",
             "node_id": 11,

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -2,7 +2,7 @@ commit: 1fb0b771
 
 semantic_babel Summary:
 AST Parsed     : 2236/2236 (100.00%)
-Positive Passed: 2127/2236 (95.13%)
+Positive Passed: 2128/2236 (95.17%)
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/decorators/decorators-after-export/input.js
 Symbol span mismatch for "C":
 after transform: SymbolId(0): Span { start: 65, end: 66 }
@@ -360,11 +360,6 @@ semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescr
 Bindings mismatch:
 after transform: ScopeId(0): ["B", "b"]
 rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/method-computed/input.ts
-Unresolved references mismatch:
-after transform: ["Symbol"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/body/input.ts
 Symbol flags mismatch for "N":

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -2,7 +2,7 @@ commit: 7964e22f
 
 semantic_typescript Summary:
 AST Parsed     : 4720/4720 (100.00%)
-Positive Passed: 3235/4720 (68.54%)
+Positive Passed: 3241/4720 (68.67%)
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/APISample_Watch.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["console", "formatHost", "os", "process", "reportDiagnostic", "reportWatchStatusChanged", "ts", "watchMain"]
@@ -703,7 +703,7 @@ Reference symbol mismatch for "g":
 after transform: SymbolId(10) "g"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Symbol", "arguments", "require"]
+after transform: ["arguments", "require"]
 rebuilt        : ["arguments", "authorPromise", "g", "mapper", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals3.ts
@@ -2580,9 +2580,6 @@ rebuilt        : ScopeId(0): ["Props", "k"]
 Bindings mismatch:
 after transform: ScopeId(1): ["Props", "k"]
 rebuilt        : ScopeId(1): ["Props"]
-Symbol reference IDs mismatch for "k":
-after transform: SymbolId(0): [ReferenceId(3), ReferenceId(5), ReferenceId(13)]
-rebuilt        : SymbolId(0): [ReferenceId(9)]
 Symbol flags mismatch for "Props":
 after transform: SymbolId(1): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
@@ -3709,11 +3706,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["Promise", "Set", "require"]
 rebuilt        : ["Promise", "Set", "ctor", "require", "x"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowInstanceofWithSymbolHasInstance.ts
-Unresolved reference IDs mismatch for "Symbol":
-after transform: [ReferenceId(0), ReferenceId(2), ReferenceId(40), ReferenceId(45)]
-rebuilt        : [ReferenceId(30), ReferenceId(34)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowManyConsecutiveConditionsNoTimeout.ts
 Bindings mismatch:
@@ -7121,7 +7113,7 @@ Reference symbol mismatch for "offer":
 after transform: SymbolId(5) "offer"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Symbol"]
+after transform: []
 rebuilt        : ["fn", "offer"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericCallAtYieldExpressionInGenericCall3.ts
@@ -7141,7 +7133,7 @@ Reference symbol mismatch for "gen":
 after transform: SymbolId(20) "gen"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Symbol"]
+after transform: []
 rebuilt        : ["gen", "runPromise", "traverse"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericCallInferenceConditionalType1.ts
@@ -18246,11 +18238,6 @@ Unresolved reference IDs mismatch for "Symbol":
 after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 rebuilt        : [ReferenceId(0)]
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit5.ts
-Unresolved references mismatch:
-after transform: ["Symbol"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty13.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "_Symbol$iterator", "_defineProperty", "bar", "foo", "i"]
@@ -18307,11 +18294,6 @@ Unresolved references mismatch:
 after transform: ["Symbol", "require"]
 rebuilt        : ["Symbol", "bar", "foo", "require"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty20.ts
-Unresolved reference IDs mismatch for "Symbol":
-after transform: [ReferenceId(1), ReferenceId(3), ReferenceId(5)]
-rebuilt        : [ReferenceId(0), ReferenceId(2)]
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty22.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["foo"]
@@ -18322,9 +18304,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["Symbol"]
 rebuilt        : ["Symbol", "foo"]
-Unresolved reference IDs mismatch for "Symbol":
-after transform: [ReferenceId(0), ReferenceId(9)]
-rebuilt        : [ReferenceId(1)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty40.ts
 Unresolved reference IDs mismatch for "Symbol":
@@ -18384,11 +18363,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/sy
 Bindings mismatch:
 after transform: ScopeId(0): ["mySymbol"]
 rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty8.ts
-Unresolved references mismatch:
-after transform: ["Symbol"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/superCallBeforeThisAccessing1.ts
 Bindings mismatch:
@@ -24163,11 +24137,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["A", "B", "C"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty2.ts
-Unresolved references mismatch:
-after transform: ["Symbol"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty3.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["C"]
@@ -24180,11 +24149,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascr
 Bindings mismatch:
 after transform: ScopeId(0): ["C"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Symbol"]
-rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty8.ts
 Unresolved references mismatch:
 after transform: ["Symbol"]
 rebuilt        : []


### PR DESCRIPTION
## Summary

- resolve computed TypeScript method, getter, and setter keys through ValueAsType so their final references are Type
- allow those keys to resolve value bindings and type-only import bindings consistently with computed property signatures and type queries
- add regression coverage and update semantic conformance snapshots, yielding one additional Babel pass and six additional TypeScript passes

Handled for TSPropertySignature via https://github.com/oxc-project/oxc/commit/d8b9909bd8df193306de7ff6f1204f3ac0963076