### PR TITLE
fix(semantic): mark TS `PropertyDefinition`s computed fields as type references

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -2450,6 +2450,38 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         self.leave_node(kind);
     }
 
+    fn visit_property_definition(&mut self, prop: &PropertyDefinition<'a>) {
+        let kind = AstKind::PropertyDefinition(self.alloc(prop));
+        self.enter_node(kind);
+        self.visit_span(&prop.span);
+        self.visit_decorators(&prop.decorators);
+        if prop.computed
+            && (prop.declare
+                || prop.r#type.is_abstract()
+                || self
+                    .ancestry()
+                    .ancestor_kinds()
+                    .find_map(|kind| match kind {
+                        AstKind::Class(class) => Some(class.declare),
+                        _ => None,
+                    })
+                    .unwrap_or(false))
+        {
+            // class A { declare [prop]: string }
+            //                   ^^^^^ The property can reference value or [`SymbolFlags::TypeImport`] symbol
+            self.current_reference_flags = ReferenceFlags::ValueAsType;
+        }
+        self.visit_property_key(&prop.key);
+        self.current_reference_flags = ReferenceFlags::empty();
+        if let Some(type_annotation) = &prop.type_annotation {
+            self.visit_ts_type_annotation(type_annotation);
+        }
+        if let Some(value) = &prop.value {
+            self.visit_expression(value);
+        }
+        self.leave_node(kind);
+    }
+
     fn visit_import_specifier(&mut self, specifier: &ImportSpecifier<'a>) {
         let kind = AstKind::ImportSpecifier(self.alloc(specifier));
         self.enter_node(kind);

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/declare-computed-class-fields.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/declare-computed-class-fields.snap
@@ -1,0 +1,146 @@
+---
+source: crates/oxc_semantic/tests/main.rs
+input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/declare-computed-class-fields.ts
+---
+[
+  {
+    "children": [
+      {
+        "children": [],
+        "flags": "ScopeFlags(StrictMode)",
+        "id": 1,
+        "node": "Class(Foo)",
+        "symbols": []
+      },
+      {
+        "children": [],
+        "flags": "ScopeFlags(StrictMode)",
+        "id": 2,
+        "node": "Class(AmbientFoo)",
+        "symbols": []
+      },
+      {
+        "children": [],
+        "flags": "ScopeFlags(StrictMode)",
+        "id": 3,
+        "node": "Class(AbstractFoo)",
+        "symbols": []
+      }
+    ],
+    "flags": "ScopeFlags(StrictMode | Top)",
+    "id": 0,
+    "node": "Program",
+    "symbols": [
+      {
+        "flags": "SymbolFlags(TypeImport)",
+        "id": 0,
+        "name": "importedKey",
+        "node": "ImportDefaultSpecifier",
+        "references": [
+          {
+            "flags": "ReferenceFlags(Type)",
+            "id": 1,
+            "name": "importedKey",
+            "node_id": 29,
+            "scope_id": 1
+          },
+          {
+            "flags": "ReferenceFlags(Type)",
+            "id": 4,
+            "name": "importedKey",
+            "node_id": 44,
+            "scope_id": 2
+          },
+          {
+            "flags": "ReferenceFlags(Type)",
+            "id": 6,
+            "name": "importedKey",
+            "node_id": 55,
+            "scope_id": 3
+          }
+        ]
+      },
+      {
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "id": 1,
+        "name": "declaredKey",
+        "node": "VariableDeclarator(declaredKey)",
+        "references": [
+          {
+            "flags": "ReferenceFlags(Type)",
+            "id": 0,
+            "name": "declaredKey",
+            "node_id": 25,
+            "scope_id": 1
+          }
+        ]
+      },
+      {
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "id": 2,
+        "name": "ambientKey",
+        "node": "VariableDeclarator(ambientKey)",
+        "references": [
+          {
+            "flags": "ReferenceFlags(Type)",
+            "id": 3,
+            "name": "ambientKey",
+            "node_id": 40,
+            "scope_id": 2
+          }
+        ]
+      },
+      {
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "id": 3,
+        "name": "abstractKey",
+        "node": "VariableDeclarator(abstractKey)",
+        "references": [
+          {
+            "flags": "ReferenceFlags(Type)",
+            "id": 5,
+            "name": "abstractKey",
+            "node_id": 51,
+            "scope_id": 3
+          }
+        ]
+      },
+      {
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "id": 4,
+        "name": "runtimeKey",
+        "node": "VariableDeclarator(runtimeKey)",
+        "references": [
+          {
+            "flags": "ReferenceFlags(Read)",
+            "id": 2,
+            "name": "runtimeKey",
+            "node_id": 33,
+            "scope_id": 1
+          }
+        ]
+      },
+      {
+        "flags": "SymbolFlags(Class)",
+        "id": 5,
+        "name": "Foo",
+        "node": "Class(Foo)",
+        "references": []
+      },
+      {
+        "flags": "SymbolFlags(Class | Ambient)",
+        "id": 6,
+        "name": "AmbientFoo",
+        "node": "Class(AmbientFoo)",
+        "references": []
+      },
+      {
+        "flags": "SymbolFlags(Class)",
+        "id": 7,
+        "name": "AbstractFoo",
+        "node": "Class(AbstractFoo)",
+        "references": []
+      }
+    ]
+  }
+]

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/declare-computed-class-fields.ts
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/declare-computed-class-fields.ts
@@ -1,0 +1,22 @@
+import type importedKey from "mod";
+
+const declaredKey = "";
+const ambientKey = "";
+const abstractKey = "";
+const runtimeKey = "";
+
+class Foo {
+    declare [declaredKey]: string;
+    declare [importedKey]: string;
+    [runtimeKey]: string;
+}
+
+declare class AmbientFoo {
+    [ambientKey]: string;
+    [importedKey]: string;
+}
+
+abstract class AbstractFoo {
+    abstract [abstractKey]: string;
+    abstract [importedKey]: string;
+}

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -2,7 +2,7 @@ commit: 7964e22f
 
 semantic_typescript Summary:
 AST Parsed     : 4720/4720 (100.00%)
-Positive Passed: 3241/4720 (68.67%)
+Positive Passed: 3242/4720 (68.69%)
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/APISample_Watch.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["console", "formatHost", "os", "process", "reportDiagnostic", "reportWatchStatusChanged", "ts", "watchMain"]
@@ -6288,11 +6288,6 @@ Symbol scope ID mismatch for "_class":
 after transform: SymbolId(8): ScopeId(0)
 rebuilt        : SymbolId(14): ScopeId(3)
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/esNextWeakRefs_IterableWeakMap.ts
-Unresolved reference IDs mismatch for "Symbol":
-after transform: [ReferenceId(8), ReferenceId(74), ReferenceId(88), ReferenceId(91)]
-rebuilt        : [ReferenceId(93), ReferenceId(96)]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionNestedAssigmentsDeclared.ts
 Symbol flags mismatch for "Foo":
 after transform: SymbolId(0): SymbolFlags(Function | ValueModule | Ambient)
@@ -6738,9 +6733,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/forwardRefInTypeD
 Bindings mismatch:
 after transform: ScopeId(0): ["Cls1", "Cls2", "Foo5", "_defineProperty", "foo4", "obj1", "obj2", "s", "s1", "s2", "s3", "s4", "s5"]
 rebuilt        : ScopeId(0): ["Cls2", "_defineProperty", "obj2", "s1", "s2", "s3", "s4", "s5"]
-Symbol reference IDs mismatch for "s5":
-after transform: SymbolId(9): [ReferenceId(4)]
-rebuilt        : SymbolId(5): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/freshLiteralInference.ts
 Bindings mismatch:
@@ -8950,9 +8942,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["Error", "Number", "Symbol", "arguments", "require", "undefined"]
 rebuilt        : ["Error", "Number", "Symbol", "arguments", "map", "require", "set", "undefined"]
-Unresolved reference IDs mismatch for "Symbol":
-after transform: [ReferenceId(10), ReferenceId(19)]
-rebuilt        : [ReferenceId(17)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/jqueryInference.ts
 Bindings mismatch:
@@ -17444,9 +17433,6 @@ rebuilt        : ScopeId(0): ["Foo", "_b", "_decorate", "_decorateMetadata", "b"
 Symbol reference IDs mismatch for "_b":
 after transform: SymbolId(7): [ReferenceId(11), ReferenceId(12)]
 rebuilt        : SymbolId(2): [ReferenceId(13)]
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(3): [ReferenceId(3)]
-rebuilt        : SymbolId(3): []
 Reference symbol mismatch for "decorator":
 after transform: SymbolId(0) "decorator"
 rebuilt        : <None>
@@ -24149,9 +24135,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascr
 Bindings mismatch:
 after transform: ScopeId(0): ["C"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Symbol"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/salsa/inferingFromAny.ts
 Bindings mismatch:

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 1fb0b771
 
-Passed: 246/398
+Passed: 247/398
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -34,7 +34,7 @@ after transform: SymbolId(1) "C"
 rebuilt        : SymbolId(3) "C"
 
 
-# babel-plugin-transform-class-properties (28/33)
+# babel-plugin-transform-class-properties (29/33)
 * private-field-resolve-to-method/input.js
 x Output mismatch
 
@@ -46,11 +46,6 @@ x Output mismatch
 
 * static-super-tagged-template/input.js
 x Output mismatch
-
-* typescript/declare-computed-keys/input.ts
-Symbol reference IDs mismatch for "KEY1":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2)]
-rebuilt        : SymbolId(1): []
 
 
 # babel-plugin-transform-typescript (26/60)


### PR DESCRIPTION
## Summary

- resolve computed declare class-field keys through ValueAsType so their final references are Type
- allow declared keys to resolve type-only import bindings while preserving Read for ordinary runtime class fields
- add a red/green semantic snapshot and update conformance snapshots, yielding one additional TypeScript semantic pass and one additional transform-conformance pass
