### PR TITLE
feat(linter): add unicorn/no-array-from-fill rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1517,6 +1517,7 @@ export interface DummyRuleMap {
   "unicorn/no-array-callback-reference"?: RuleNoConfig;
   "unicorn/no-array-fill-with-reference-type"?: RuleNoConfig;
   "unicorn/no-array-for-each"?: RuleNoConfig;
+  "unicorn/no-array-from-fill"?: RuleNoConfig;
   "unicorn/no-array-method-this-argument"?: RuleNoConfig;
   "unicorn/no-array-reduce"?: RuleNoConfig | [AllowWarnDeny, NoArrayReduce];
   "unicorn/no-array-reverse"?: RuleNoConfig | [AllowWarnDeny, NoArrayReverse];

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -3118,6 +3118,12 @@ impl RuleRunner for crate::rules::unicorn::no_array_for_each::NoArrayForEach {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::unicorn::no_array_from_fill::NoArrayFromFill {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner
     for crate::rules::unicorn::no_array_method_this_argument::NoArrayMethodThisArgument
 {

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -620,6 +620,7 @@ pub use crate::rules::unicorn::no_anonymous_default_export::NoAnonymousDefaultEx
 pub use crate::rules::unicorn::no_array_callback_reference::NoArrayCallbackReference as UnicornNoArrayCallbackReference;
 pub use crate::rules::unicorn::no_array_fill_with_reference_type::NoArrayFillWithReferenceType as UnicornNoArrayFillWithReferenceType;
 pub use crate::rules::unicorn::no_array_for_each::NoArrayForEach as UnicornNoArrayForEach;
+pub use crate::rules::unicorn::no_array_from_fill::NoArrayFromFill as UnicornNoArrayFromFill;
 pub use crate::rules::unicorn::no_array_method_this_argument::NoArrayMethodThisArgument as UnicornNoArrayMethodThisArgument;
 pub use crate::rules::unicorn::no_array_reduce::NoArrayReduce as UnicornNoArrayReduce;
 pub use crate::rules::unicorn::no_array_reverse::NoArrayReverse as UnicornNoArrayReverse;
@@ -1345,6 +1346,7 @@ pub enum RuleEnum {
     UnicornNoArrayCallbackReference(UnicornNoArrayCallbackReference),
     UnicornNoArrayFillWithReferenceType(UnicornNoArrayFillWithReferenceType),
     UnicornNoArrayForEach(UnicornNoArrayForEach),
+    UnicornNoArrayFromFill(UnicornNoArrayFromFill),
     UnicornNoArrayMethodThisArgument(UnicornNoArrayMethodThisArgument),
     UnicornNoArrayReduce(UnicornNoArrayReduce),
     UnicornNoArrayReverse(UnicornNoArrayReverse),
@@ -2254,7 +2256,8 @@ const UNICORN_NO_ARRAY_CALLBACK_REFERENCE_ID: usize =
 const UNICORN_NO_ARRAY_FILL_WITH_REFERENCE_TYPE_ID: usize =
     UNICORN_NO_ARRAY_CALLBACK_REFERENCE_ID + 1usize;
 const UNICORN_NO_ARRAY_FOR_EACH_ID: usize = UNICORN_NO_ARRAY_FILL_WITH_REFERENCE_TYPE_ID + 1usize;
-const UNICORN_NO_ARRAY_METHOD_THIS_ARGUMENT_ID: usize = UNICORN_NO_ARRAY_FOR_EACH_ID + 1usize;
+const UNICORN_NO_ARRAY_FROM_FILL_ID: usize = UNICORN_NO_ARRAY_FOR_EACH_ID + 1usize;
+const UNICORN_NO_ARRAY_METHOD_THIS_ARGUMENT_ID: usize = UNICORN_NO_ARRAY_FROM_FILL_ID + 1usize;
 const UNICORN_NO_ARRAY_REDUCE_ID: usize = UNICORN_NO_ARRAY_METHOD_THIS_ARGUMENT_ID + 1usize;
 const UNICORN_NO_ARRAY_REVERSE_ID: usize = UNICORN_NO_ARRAY_REDUCE_ID + 1usize;
 const UNICORN_NO_ARRAY_SORT_ID: usize = UNICORN_NO_ARRAY_REVERSE_ID + 1usize;
@@ -3234,6 +3237,7 @@ impl RuleEnum {
                 UNICORN_NO_ARRAY_FILL_WITH_REFERENCE_TYPE_ID
             }
             Self::UnicornNoArrayForEach(_) => UNICORN_NO_ARRAY_FOR_EACH_ID,
+            Self::UnicornNoArrayFromFill(_) => UNICORN_NO_ARRAY_FROM_FILL_ID,
             Self::UnicornNoArrayMethodThisArgument(_) => UNICORN_NO_ARRAY_METHOD_THIS_ARGUMENT_ID,
             Self::UnicornNoArrayReduce(_) => UNICORN_NO_ARRAY_REDUCE_ID,
             Self::UnicornNoArrayReverse(_) => UNICORN_NO_ARRAY_REVERSE_ID,
@@ -4206,6 +4210,7 @@ impl RuleEnum {
                 UnicornNoArrayFillWithReferenceType::NAME
             }
             Self::UnicornNoArrayForEach(_) => UnicornNoArrayForEach::NAME,
+            Self::UnicornNoArrayFromFill(_) => UnicornNoArrayFromFill::NAME,
             Self::UnicornNoArrayMethodThisArgument(_) => UnicornNoArrayMethodThisArgument::NAME,
             Self::UnicornNoArrayReduce(_) => UnicornNoArrayReduce::NAME,
             Self::UnicornNoArrayReverse(_) => UnicornNoArrayReverse::NAME,
@@ -5196,6 +5201,7 @@ impl RuleEnum {
                 UnicornNoArrayFillWithReferenceType::CATEGORY
             }
             Self::UnicornNoArrayForEach(_) => UnicornNoArrayForEach::CATEGORY,
+            Self::UnicornNoArrayFromFill(_) => UnicornNoArrayFromFill::CATEGORY,
             Self::UnicornNoArrayMethodThisArgument(_) => UnicornNoArrayMethodThisArgument::CATEGORY,
             Self::UnicornNoArrayReduce(_) => UnicornNoArrayReduce::CATEGORY,
             Self::UnicornNoArrayReverse(_) => UnicornNoArrayReverse::CATEGORY,
@@ -6189,6 +6195,7 @@ impl RuleEnum {
                 UnicornNoArrayFillWithReferenceType::FIX
             }
             Self::UnicornNoArrayForEach(_) => UnicornNoArrayForEach::FIX,
+            Self::UnicornNoArrayFromFill(_) => UnicornNoArrayFromFill::FIX,
             Self::UnicornNoArrayMethodThisArgument(_) => UnicornNoArrayMethodThisArgument::FIX,
             Self::UnicornNoArrayReduce(_) => UnicornNoArrayReduce::FIX,
             Self::UnicornNoArrayReverse(_) => UnicornNoArrayReverse::FIX,
@@ -7282,6 +7289,7 @@ impl RuleEnum {
                 UnicornNoArrayFillWithReferenceType::documentation()
             }
             Self::UnicornNoArrayForEach(_) => UnicornNoArrayForEach::documentation(),
+            Self::UnicornNoArrayFromFill(_) => UnicornNoArrayFromFill::documentation(),
             Self::UnicornNoArrayMethodThisArgument(_) => {
                 UnicornNoArrayMethodThisArgument::documentation()
             }
@@ -9191,6 +9199,8 @@ impl RuleEnum {
             }
             Self::UnicornNoArrayForEach(_) => UnicornNoArrayForEach::config_schema(generator)
                 .or_else(|| UnicornNoArrayForEach::schema(generator)),
+            Self::UnicornNoArrayFromFill(_) => UnicornNoArrayFromFill::config_schema(generator)
+                .or_else(|| UnicornNoArrayFromFill::schema(generator)),
             Self::UnicornNoArrayMethodThisArgument(_) => {
                 UnicornNoArrayMethodThisArgument::config_schema(generator)
                     .or_else(|| UnicornNoArrayMethodThisArgument::schema(generator))
@@ -10739,6 +10749,7 @@ impl RuleEnum {
             Self::UnicornNoArrayCallbackReference(_) => "unicorn",
             Self::UnicornNoArrayFillWithReferenceType(_) => "unicorn",
             Self::UnicornNoArrayForEach(_) => "unicorn",
+            Self::UnicornNoArrayFromFill(_) => "unicorn",
             Self::UnicornNoArrayMethodThisArgument(_) => "unicorn",
             Self::UnicornNoArrayReduce(_) => "unicorn",
             Self::UnicornNoArrayReverse(_) => "unicorn",
@@ -12652,6 +12663,9 @@ impl RuleEnum {
             Self::UnicornNoArrayForEach(_) => {
                 Ok(Self::UnicornNoArrayForEach(UnicornNoArrayForEach::from_configuration(value)?))
             }
+            Self::UnicornNoArrayFromFill(_) => {
+                Ok(Self::UnicornNoArrayFromFill(UnicornNoArrayFromFill::from_configuration(value)?))
+            }
             Self::UnicornNoArrayMethodThisArgument(_) => {
                 Ok(Self::UnicornNoArrayMethodThisArgument(
                     UnicornNoArrayMethodThisArgument::from_configuration(value)?,
@@ -14314,6 +14328,7 @@ impl RuleEnum {
             Self::UnicornNoArrayCallbackReference(rule) => rule.to_configuration(),
             Self::UnicornNoArrayFillWithReferenceType(rule) => rule.to_configuration(),
             Self::UnicornNoArrayForEach(rule) => rule.to_configuration(),
+            Self::UnicornNoArrayFromFill(rule) => rule.to_configuration(),
             Self::UnicornNoArrayMethodThisArgument(rule) => rule.to_configuration(),
             Self::UnicornNoArrayReduce(rule) => rule.to_configuration(),
             Self::UnicornNoArrayReverse(rule) => rule.to_configuration(),
@@ -15165,6 +15180,7 @@ impl RuleEnum {
             Self::UnicornNoArrayCallbackReference(rule) => rule.run(node, ctx),
             Self::UnicornNoArrayFillWithReferenceType(rule) => rule.run(node, ctx),
             Self::UnicornNoArrayForEach(rule) => rule.run(node, ctx),
+            Self::UnicornNoArrayFromFill(rule) => rule.run(node, ctx),
             Self::UnicornNoArrayMethodThisArgument(rule) => rule.run(node, ctx),
             Self::UnicornNoArrayReduce(rule) => rule.run(node, ctx),
             Self::UnicornNoArrayReverse(rule) => rule.run(node, ctx),
@@ -16026,6 +16042,7 @@ impl RuleEnum {
             Self::UnicornNoArrayCallbackReference(rule) => rule.run_once(ctx),
             Self::UnicornNoArrayFillWithReferenceType(rule) => rule.run_once(ctx),
             Self::UnicornNoArrayForEach(rule) => rule.run_once(ctx),
+            Self::UnicornNoArrayFromFill(rule) => rule.run_once(ctx),
             Self::UnicornNoArrayMethodThisArgument(rule) => rule.run_once(ctx),
             Self::UnicornNoArrayReduce(rule) => rule.run_once(ctx),
             Self::UnicornNoArrayReverse(rule) => rule.run_once(ctx),
@@ -16966,6 +16983,7 @@ impl RuleEnum {
                 rule.run_on_jest_node(jest_node, ctx)
             }
             Self::UnicornNoArrayForEach(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::UnicornNoArrayFromFill(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoArrayMethodThisArgument(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoArrayReduce(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoArrayReverse(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -17866,6 +17884,7 @@ impl RuleEnum {
             Self::UnicornNoArrayCallbackReference(rule) => rule.should_run(ctx),
             Self::UnicornNoArrayFillWithReferenceType(rule) => rule.should_run(ctx),
             Self::UnicornNoArrayForEach(rule) => rule.should_run(ctx),
+            Self::UnicornNoArrayFromFill(rule) => rule.should_run(ctx),
             Self::UnicornNoArrayMethodThisArgument(rule) => rule.should_run(ctx),
             Self::UnicornNoArrayReduce(rule) => rule.should_run(ctx),
             Self::UnicornNoArrayReverse(rule) => rule.should_run(ctx),
@@ -18920,6 +18939,7 @@ impl RuleEnum {
                 UnicornNoArrayFillWithReferenceType::IS_TSGOLINT_RULE
             }
             Self::UnicornNoArrayForEach(_) => UnicornNoArrayForEach::IS_TSGOLINT_RULE,
+            Self::UnicornNoArrayFromFill(_) => UnicornNoArrayFromFill::IS_TSGOLINT_RULE,
             Self::UnicornNoArrayMethodThisArgument(_) => {
                 UnicornNoArrayMethodThisArgument::IS_TSGOLINT_RULE
             }
@@ -20050,6 +20070,7 @@ impl RuleEnum {
                 UnicornNoArrayFillWithReferenceType::VERSION
             }
             Self::UnicornNoArrayForEach(_) => UnicornNoArrayForEach::VERSION,
+            Self::UnicornNoArrayFromFill(_) => UnicornNoArrayFromFill::VERSION,
             Self::UnicornNoArrayMethodThisArgument(_) => UnicornNoArrayMethodThisArgument::VERSION,
             Self::UnicornNoArrayReduce(_) => UnicornNoArrayReduce::VERSION,
             Self::UnicornNoArrayReverse(_) => UnicornNoArrayReverse::VERSION,
@@ -21091,6 +21112,7 @@ impl RuleEnum {
                 UnicornNoArrayFillWithReferenceType::HAS_CONFIG
             }
             Self::UnicornNoArrayForEach(_) => UnicornNoArrayForEach::HAS_CONFIG,
+            Self::UnicornNoArrayFromFill(_) => UnicornNoArrayFromFill::HAS_CONFIG,
             Self::UnicornNoArrayMethodThisArgument(_) => {
                 UnicornNoArrayMethodThisArgument::HAS_CONFIG
             }
@@ -22105,6 +22127,7 @@ impl RuleEnum {
                 UnicornNoArrayFillWithReferenceType::INFO
             }
             Self::UnicornNoArrayForEach(_) => UnicornNoArrayForEach::INFO,
+            Self::UnicornNoArrayFromFill(_) => UnicornNoArrayFromFill::INFO,
             Self::UnicornNoArrayMethodThisArgument(_) => UnicornNoArrayMethodThisArgument::INFO,
             Self::UnicornNoArrayReduce(_) => UnicornNoArrayReduce::INFO,
             Self::UnicornNoArrayReverse(_) => UnicornNoArrayReverse::INFO,
@@ -22996,6 +23019,7 @@ impl RuleEnum {
             Self::UnicornNoArrayCallbackReference(rule) => rule.types_info(),
             Self::UnicornNoArrayFillWithReferenceType(rule) => rule.types_info(),
             Self::UnicornNoArrayForEach(rule) => rule.types_info(),
+            Self::UnicornNoArrayFromFill(rule) => rule.types_info(),
             Self::UnicornNoArrayMethodThisArgument(rule) => rule.types_info(),
             Self::UnicornNoArrayReduce(rule) => rule.types_info(),
             Self::UnicornNoArrayReverse(rule) => rule.types_info(),
@@ -23844,6 +23868,7 @@ impl RuleEnum {
             Self::UnicornNoArrayCallbackReference(rule) => rule.run_info(),
             Self::UnicornNoArrayFillWithReferenceType(rule) => rule.run_info(),
             Self::UnicornNoArrayForEach(rule) => rule.run_info(),
+            Self::UnicornNoArrayFromFill(rule) => rule.run_info(),
             Self::UnicornNoArrayMethodThisArgument(rule) => rule.run_info(),
             Self::UnicornNoArrayReduce(rule) => rule.run_info(),
             Self::UnicornNoArrayReverse(rule) => rule.run_info(),
@@ -24790,6 +24815,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
             UnicornNoArrayFillWithReferenceType::default(),
         ),
         RuleEnum::UnicornNoArrayForEach(UnicornNoArrayForEach::default()),
+        RuleEnum::UnicornNoArrayFromFill(UnicornNoArrayFromFill::default()),
         RuleEnum::UnicornNoArrayMethodThisArgument(UnicornNoArrayMethodThisArgument::default()),
         RuleEnum::UnicornNoArrayReduce(UnicornNoArrayReduce::default()),
         RuleEnum::UnicornNoArrayReverse(UnicornNoArrayReverse::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -508,6 +508,7 @@ pub(crate) mod unicorn {
     pub mod no_array_callback_reference;
     pub mod no_array_fill_with_reference_type;
     pub mod no_array_for_each;
+    pub mod no_array_from_fill;
     pub mod no_array_method_this_argument;
     pub mod no_array_reduce;
     pub mod no_array_reverse;

--- a/crates/oxc_linter/src/rules/unicorn/no_array_from_fill.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_from_fill.rs
@@ -1,0 +1,177 @@
+use oxc_ast::{
+    AstKind,
+    ast::{Argument, CallExpression, Expression, ObjectPropertyKind, PropertyKind},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, ast_util::is_method_call, context::LintContext, rule::Rule};
+
+fn no_array_from_fill_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Do not chain `.fill()` after `Array.from({length: …})`.")
+        .with_help("Use the `Array.from(…, mapFunction)` argument to create values directly.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoArrayFromFill;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows `.fill()` chained after `Array.from({length: …})`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Calling `.fill()` after `Array.from({length: …})` is usually redundant, since
+    /// `Array.from(…, mapFunction)` can create each value directly. Additionally,
+    /// filling with an object such as `.fill({})` creates a single object shared by
+    /// every element, which is rarely intended.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// Array.from({length: 3}).fill(0);
+    /// Array.from({length: 3}).fill().map((_, index) => index);
+    /// Array.from({length: 3}).fill({});
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// Array.from({length: 3}, () => 0);
+    /// Array.from({length: 3}, (_, index) => index);
+    /// Array.from({length: 3}, () => ({}));
+    /// ```
+    NoArrayFromFill,
+    unicorn,
+    suspicious,
+    pending,
+    version = "next",
+    short_description = "Disallow `.fill()` after `Array.from({length: …})`.",
+);
+
+impl Rule for NoArrayFromFill {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::CallExpression(call_expr) = node.kind() else {
+            return;
+        };
+
+        // `.fill()` with at most one non-spread argument, no optional chaining
+        if !is_method_call(call_expr, None, Some(&["fill"]), None, Some(1))
+            || call_expr.optional
+            || call_expr.arguments.iter().any(Argument::is_spread)
+        {
+            return;
+        }
+        let Some(member_expr) = call_expr.callee.get_member_expr() else {
+            return;
+        };
+        if member_expr.optional() {
+            return;
+        }
+
+        let Expression::CallExpression(from_call) = member_expr.object().get_inner_expression()
+        else {
+            return;
+        };
+        if !is_array_from_length_call(from_call, ctx) {
+            return;
+        }
+
+        let Some((property_span, _)) = member_expr.static_property_info() else {
+            return;
+        };
+        ctx.diagnostic(no_array_from_fill_diagnostic(property_span));
+    }
+}
+
+/// Matches `Array.from({length: …})` where `Array` is a global reference and the
+/// sole argument is an object literal with a single non-computed `length` property.
+fn is_array_from_length_call(call_expr: &CallExpression, ctx: &LintContext) -> bool {
+    if !is_method_call(call_expr, Some(&["Array"]), Some(&["from"]), Some(1), Some(1))
+        || call_expr.optional
+    {
+        return false;
+    }
+
+    let Some(member_expr) = call_expr.callee.get_member_expr() else {
+        return false;
+    };
+    if member_expr.optional() {
+        return false;
+    }
+    let Expression::Identifier(ident) = member_expr.object().get_inner_expression() else {
+        return false;
+    };
+    if !ctx.is_reference_to_global_variable(ident) {
+        return false;
+    }
+
+    let Some(Expression::ObjectExpression(object)) =
+        call_expr.arguments[0].as_expression().map(Expression::get_inner_expression)
+    else {
+        return false;
+    };
+    if object.properties.len() != 1 {
+        return false;
+    }
+    let ObjectPropertyKind::ObjectProperty(property) = &object.properties[0] else {
+        return false;
+    };
+
+    !property.computed
+        && !property.method
+        && property.kind == PropertyKind::Init
+        && property.key.is_specific_static_name("length")
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "Array.from({length: 3})",
+        "Array.from({length: 3}, (_, index) => index)",
+        "Array.from({length: 3}).map((_, index) => index)",
+        "Array.from(items).fill(0)",
+        r#"Array.from({length: 3, 0: "value"}).fill(0)"#,
+        "Array.from({...length}).fill(0)",
+        r#"Array.from({["length"]: 3}).fill(0)"#,
+        "Array.from({length: 3}).fill(0, 1)",
+        "Array.from({length: 3}).fill(0, 1, 2)",
+        "Array.from({length: 3}).fill(...value)",
+        "Array.from?.({length: 3}).fill(0)",
+        "Array.from({length: 3})?.fill(0)",
+        "Array.from({length: 3}).fill?.(0)",
+        "NotArray.from({length: 3}).fill(0)",
+        "Array.notFrom({length: 3}).fill(0)",
+        "Array.from({length: 3}).slice().fill(0)",
+        "const Array = {from() { return {fill() { return {map() {}}; }}; }}; Array.from({length: 3}).fill().map((_, index) => index)",
+        "function unicorn(Array) { return Array.from({length: 3}).fill(0); }",
+    ];
+
+    let fail = vec![
+        "Array.from({length: 3}).fill(0)",
+        "Array.from({length: 3}).fill()",
+        "Array.from({length}).fill(null)",
+        r#"Array.from({"length": 3}).fill(0)"#,
+        "Array.from({length: 3}).fill({})",
+        "Array.from({length: 3}).fill(0).map((_, index) => index)",
+        "Array.from({length: 3}).fill().map((value, index) => index)",
+        "Array.from({length: 3}).fill(0).flatMap((_, index) => [index])",
+        "Array.from({length: 3}).fill().flatMap(value => [value])",
+        "Array.from({length: 3}).fill(0).filter(Boolean)",
+        "Array.from({length: 3})
+                .fill(0)
+                .map((_, index) => index);",
+        "Array.from(
+                {length: 3}
+            )
+                .fill(0)
+                .map((_, index) => index);",
+    ];
+
+    Tester::new(NoArrayFromFill::NAME, NoArrayFromFill::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/unicorn_no_array_from_fill.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_array_from_fill.snap
@@ -1,0 +1,92 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 490
+---
+
+  ⚠ unicorn(no-array-from-fill): Do not chain `.fill()` after `Array.from({length: …})`.
+   ╭─[no_array_from_fill.tsx:1:25]
+ 1 │ Array.from({length: 3}).fill(0)
+   ·                         ────
+   ╰────
+  help: Use the `Array.from(…, mapFunction)` argument to create values directly.
+
+  ⚠ unicorn(no-array-from-fill): Do not chain `.fill()` after `Array.from({length: …})`.
+   ╭─[no_array_from_fill.tsx:1:25]
+ 1 │ Array.from({length: 3}).fill()
+   ·                         ────
+   ╰────
+  help: Use the `Array.from(…, mapFunction)` argument to create values directly.
+
+  ⚠ unicorn(no-array-from-fill): Do not chain `.fill()` after `Array.from({length: …})`.
+   ╭─[no_array_from_fill.tsx:1:22]
+ 1 │ Array.from({length}).fill(null)
+   ·                      ────
+   ╰────
+  help: Use the `Array.from(…, mapFunction)` argument to create values directly.
+
+  ⚠ unicorn(no-array-from-fill): Do not chain `.fill()` after `Array.from({length: …})`.
+   ╭─[no_array_from_fill.tsx:1:27]
+ 1 │ Array.from({"length": 3}).fill(0)
+   ·                           ────
+   ╰────
+  help: Use the `Array.from(…, mapFunction)` argument to create values directly.
+
+  ⚠ unicorn(no-array-from-fill): Do not chain `.fill()` after `Array.from({length: …})`.
+   ╭─[no_array_from_fill.tsx:1:25]
+ 1 │ Array.from({length: 3}).fill({})
+   ·                         ────
+   ╰────
+  help: Use the `Array.from(…, mapFunction)` argument to create values directly.
+
+  ⚠ unicorn(no-array-from-fill): Do not chain `.fill()` after `Array.from({length: …})`.
+   ╭─[no_array_from_fill.tsx:1:25]
+ 1 │ Array.from({length: 3}).fill(0).map((_, index) => index)
+   ·                         ────
+   ╰────
+  help: Use the `Array.from(…, mapFunction)` argument to create values directly.
+
+  ⚠ unicorn(no-array-from-fill): Do not chain `.fill()` after `Array.from({length: …})`.
+   ╭─[no_array_from_fill.tsx:1:25]
+ 1 │ Array.from({length: 3}).fill().map((value, index) => index)
+   ·                         ────
+   ╰────
+  help: Use the `Array.from(…, mapFunction)` argument to create values directly.
+
+  ⚠ unicorn(no-array-from-fill): Do not chain `.fill()` after `Array.from({length: …})`.
+   ╭─[no_array_from_fill.tsx:1:25]
+ 1 │ Array.from({length: 3}).fill(0).flatMap((_, index) => [index])
+   ·                         ────
+   ╰────
+  help: Use the `Array.from(…, mapFunction)` argument to create values directly.
+
+  ⚠ unicorn(no-array-from-fill): Do not chain `.fill()` after `Array.from({length: …})`.
+   ╭─[no_array_from_fill.tsx:1:25]
+ 1 │ Array.from({length: 3}).fill().flatMap(value => [value])
+   ·                         ────
+   ╰────
+  help: Use the `Array.from(…, mapFunction)` argument to create values directly.
+
+  ⚠ unicorn(no-array-from-fill): Do not chain `.fill()` after `Array.from({length: …})`.
+   ╭─[no_array_from_fill.tsx:1:25]
+ 1 │ Array.from({length: 3}).fill(0).filter(Boolean)
+   ·                         ────
+   ╰────
+  help: Use the `Array.from(…, mapFunction)` argument to create values directly.
+
+  ⚠ unicorn(no-array-from-fill): Do not chain `.fill()` after `Array.from({length: …})`.
+   ╭─[no_array_from_fill.tsx:2:18]
+ 1 │ Array.from({length: 3})
+ 2 │                 .fill(0)
+   ·                  ────
+ 3 │                 .map((_, index) => index);
+   ╰────
+  help: Use the `Array.from(…, mapFunction)` argument to create values directly.
+
+  ⚠ unicorn(no-array-from-fill): Do not chain `.fill()` after `Array.from({length: …})`.
+   ╭─[no_array_from_fill.tsx:4:18]
+ 3 │             )
+ 4 │                 .fill(0)
+   ·                  ────
+ 5 │                 .map((_, index) => index);
+   ╰────
+  help: Use the `Array.from(…, mapFunction)` argument to create values directly.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -8812,6 +8812,9 @@
         "unicorn/no-array-for-each": {
           "$ref": "#/definitions/RuleNoConfig"
         },
+        "unicorn/no-array-from-fill": {
+          "$ref": "#/definitions/RuleNoConfig"
+        },
         "unicorn/no-array-method-this-argument": {
           "$ref": "#/definitions/RuleNoConfig"
         },

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -544,6 +544,7 @@ unicorn/no-anonymous-default-export                        |  13007
 unicorn/no-array-callback-reference                        |  62606
 unicorn/no-array-fill-with-reference-type                  |  62606
 unicorn/no-array-for-each                                  |  62606
+unicorn/no-array-from-fill                                 |  62606
 unicorn/no-array-method-this-argument                      |  62606
 unicorn/no-array-reduce                                    |  62606
 unicorn/no-array-reverse                                   |  62606


### PR DESCRIPTION
## Changes

- Added [`unicorn/no-array-from-fill`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-array-from-fill.md) rule.

## Notes

- I [pitched](https://github.com/sindresorhus/eslint-plugin-unicorn/issues/2943) this rule upstream in the unicorn repo.
- Since I don't have direct Rust experience, I had Claude Fable prepare this PR.