### PR TITLE
ci(lint): run release-mode clippy on main only, without --all-targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -490,7 +490,14 @@ jobs:
             pnpm
       - run: rustup component add clippy
       - run: cargo lint -- -D warnings
-      - run: cargo lint --profile dev-no-debug-assertions -- -D warnings
+      # Catch lints which only fire with `debug_assertions` off (i.e. release mode),
+      # e.g. code becoming unused when a `#[cfg(debug_assertions)]` block vanishes.
+      # Main-only and without `--all-targets`: these failures are rare and a post-merge
+      # failure pinpoints the culprit commit, so not worth doubling clippy time on every PR.
+      # `--all-targets` is omitted because test/bench code is never built in release mode
+      # with `-D warnings`.
+      - if: ${{ github.ref_name == 'main' }}
+        run: cargo clippy --all-features --profile dev-no-debug-assertions -- -D warnings
       - run: pnpm --filter oxlint-app build-js
       - run: pnpm --filter oxfmt-app build-js
       - run: node --run lint


### PR DESCRIPTION
The Lint job is one of the two slowest jobs on PR CI (median 3m29s, p90 4m48s over the last 31 runs), and the `dev-no-debug-assertions` clippy pass accounts for roughly half of its clippy time — every core-crate commit re-checks ~60 crates twice, once per profile.

That pass exists to catch lints which only fire with `debug_assertions` off (e.g. #8539, the motivation for adding it in #8541). This failure class is rare (~4 occurrences in the project's history) and a post-merge failure on main pinpoints the culprit commit, so run it on `main` pushes only — the same trade already made for the mac/windows/32-bit/big-endian test jobs.

Also drop `--all-targets` from this pass (calling `cargo clippy` directly, since the `cargo lint` alias bakes it in): test/bench code is never built in release mode with `-D warnings`, and skipping it avoids re-checking `oxc_linter`'s inline rule tests a second time. The `#[cfg(debug_assertions)]` sites in the workspace are almost entirely in lib code.

Expected PR lint job time: ~3m30s → ~1m45s median.

🤖 Generated with [Claude Code](https://claude.com/claude-code)