### PR TITLE
refactor(react_compiler): simplify compile_program signature and tidy imports

### DIFF
--- a/crates/oxc_react_compiler/src/lib.rs
+++ b/crates/oxc_react_compiler/src/lib.rs
@@ -20,8 +20,7 @@ mod react_compiler_validation;
 use crate::react_compiler::entrypoint::compile_result::CompileResult;
 use crate::react_compiler::entrypoint::imports::get_react_compiler_runtime_module;
 use crate::react_compiler::entrypoint::program::compile_program;
-use prefilter::has_react_like_functions;
-use scope::ScopeResolver;
+use prefilter::{has_memo_cache_function_import, has_react_like_functions};
 
 // Re-exported so integrations needn't depend on the upstream `react_compiler` crates.
 pub use crate::options::{
@@ -85,6 +84,24 @@ pub fn transform<'a>(
     TransformResult { program, changed, diagnostics }
 }
 
+/// Lint a pre-parsed program — like [`transform`] but read-only: it collects
+/// diagnostics without rewriting the program.
+///
+/// The borrowed `semantic` must have been built from `program` with
+/// `SemanticBuilder::with_build_nodes(true)`.
+pub fn lint<'a>(
+    program: &Program<'a>,
+    semantic: &Semantic<'_>,
+    allocator: &'a Allocator,
+    options: PluginOptions,
+) -> LintResult {
+    let mut options = options;
+    options.no_emit = true;
+
+    let (_program, diagnostics) = compile(program, semantic, allocator, options);
+    LintResult { diagnostics }
+}
+
 /// Shared compile pipeline behind [`transform`] and [`lint`]. Borrows `program`
 /// (so `lint` can stay read-only) and returns the compiled OXC program — `None`
 /// when nothing was compiled — together with diagnostics and logger events.
@@ -107,12 +124,7 @@ fn compile<'a>(
         return (None, Diagnostics::default());
     }
 
-    // The codegen back-end builds oxc nodes directly via this `AstBuilder`, and the
-    // compiled program is spliced/returned as an arena-allocated `Program<'a>`.
-    let ast_builder = oxc_ast::builder::AstBuilder::new(allocator);
-    let scope = ScopeResolver::new(semantic, program);
-    // Function discovery and lowering both walk the oxc `Program` directly.
-    let result = compile_program(&ast_builder, program, &scope, options);
+    let result = compile_program(allocator, semantic, program, options);
 
     let (program_ast, diagnostics) = match result {
         CompileResult::Success { ast, diagnostics, .. } => (ast, diagnostics),
@@ -126,36 +138,6 @@ fn compile<'a>(
     });
 
     (compiled, diagnostics)
-}
-
-fn has_memo_cache_function_import(program: &Program<'_>, module_name: &str) -> bool {
-    for stmt in &program.body {
-        if let oxc_ast::ast::Statement::ImportDeclaration(import) = stmt
-            && import.source.value == module_name
-            && import.import_kind.is_value()
-            && let Some(specifiers) = &import.specifiers
-        {
-            for specifier in specifiers {
-                if let oxc_ast::ast::ImportDeclarationSpecifier::ImportSpecifier(data) = specifier
-                    && data.import_kind.is_value()
-                {
-                    let imported_name = match &data.imported {
-                        oxc_ast::ast::ModuleExportName::IdentifierName(id) => {
-                            Some(id.name.as_str())
-                        }
-                        oxc_ast::ast::ModuleExportName::IdentifierReference(id) => {
-                            Some(id.name.as_str())
-                        }
-                        oxc_ast::ast::ModuleExportName::StringLiteral(s) => Some(s.value.as_str()),
-                    };
-                    if imported_name == Some("c") {
-                        return true;
-                    }
-                }
-            }
-        }
-    }
-    false
 }
 
 /// Carry over the comments attached to top-level statements of the compiled
@@ -190,22 +172,4 @@ fn preserve_comments<'a>(
     // Codegen reads comment content from `source_text` via span offsets, so the
     // compiled program must point at the same source as the original.
     compiled.source_text = source.source_text;
-}
-
-/// Lint a pre-parsed program — like [`transform`] but read-only: it collects
-/// diagnostics without rewriting the program.
-///
-/// The borrowed `semantic` must have been built from `program` with
-/// `SemanticBuilder::with_build_nodes(true)`.
-pub fn lint<'a>(
-    program: &Program<'a>,
-    semantic: &Semantic<'_>,
-    allocator: &'a Allocator,
-    options: PluginOptions,
-) -> LintResult {
-    let mut options = options;
-    options.no_emit = true;
-
-    let (_program, diagnostics) = compile(program, semantic, allocator, options);
-    LintResult { diagnostics }
 }

--- a/crates/oxc_react_compiler/src/prefilter.rs
+++ b/crates/oxc_react_compiler/src/prefilter.rs
@@ -5,7 +5,8 @@
 
 use oxc_ast::ast::{
     ArrowFunctionExpression, AssignmentExpression, AssignmentTarget, BindingPattern,
-    CallExpression, Class, Expression, Function, Program, VariableDeclarator,
+    CallExpression, Class, Expression, Function, ImportDeclarationSpecifier, ModuleExportName,
+    Program, Statement, VariableDeclarator,
 };
 use oxc_ast_visit::{Visit, walk};
 use oxc_semantic::ScopeFlags;
@@ -15,6 +16,34 @@ pub fn has_react_like_functions(program: &Program) -> bool {
     let mut visitor = ReactLikeVisitor { found: false, current_name: None };
     visitor.visit_program(program);
     visitor.found
+}
+
+/// Whether the program already imports the `c` memo-cache helper from `module_name`
+/// — i.e. the file has already been compiled and must be skipped.
+pub fn has_memo_cache_function_import(program: &Program, module_name: &str) -> bool {
+    for stmt in &program.body {
+        if let Statement::ImportDeclaration(import) = stmt
+            && import.source.value == module_name
+            && import.import_kind.is_value()
+            && let Some(specifiers) = &import.specifiers
+        {
+            for specifier in specifiers {
+                if let ImportDeclarationSpecifier::ImportSpecifier(data) = specifier
+                    && data.import_kind.is_value()
+                {
+                    let imported_name = match &data.imported {
+                        ModuleExportName::IdentifierName(id) => Some(id.name.as_str()),
+                        ModuleExportName::IdentifierReference(id) => Some(id.name.as_str()),
+                        ModuleExportName::StringLiteral(s) => Some(s.value.as_str()),
+                    };
+                    if imported_name == Some("c") {
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+    false
 }
 
 use crate::react_compiler_hir::environment::is_react_like_name;

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -16,8 +16,9 @@
 
 use cow_utils::CowUtils;
 use oxc_ast::ast as oxc;
+use oxc_ast::builder::AstBuilder;
 use oxc_diagnostics::OxcDiagnostic;
-use oxc_span::Span;
+use oxc_span::{SPAN, Span};
 use rustc_hash::FxHashMap;
 
 use crate::react_compiler_diagnostics::CompilerError;
@@ -28,7 +29,8 @@ use crate::react_compiler_hir::ReactFunctionType;
 use crate::react_compiler_hir::environment_config::EnvironmentConfig;
 use crate::react_compiler_lowering::FunctionNode;
 use crate::scope::ScopeResolver;
-use oxc_allocator::GetAllocator;
+use oxc_allocator::{Allocator, ArenaBox, ArenaVec, CloneIn, GetAllocator};
+use oxc_semantic::Semantic;
 use oxc_syntax::scope::ScopeId;
 
 use super::compile_result::CodegenFunction;
@@ -64,11 +66,9 @@ const OPT_OUT_DIRECTIVES: &[&str] = &["use no forget", "use no memo"];
 /// A function found in the program that should be compiled.
 ///
 /// `'a` is the arena lifetime of the discovered oxc function node.
-#[allow(dead_code)]
 struct CompileSource<'a> {
     kind: CompileSourceKind,
     original_kind: OriginalFnKind,
-    fn_name: Option<String>,
     /// Byte span of the discovered function, used as the fallback labeled span in
     /// compile-error diagnostics.
     fn_ast_loc: Option<Span>,
@@ -85,8 +85,6 @@ struct CompileSource<'a> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum CompileSourceKind {
     Original,
-    #[allow(dead_code)]
-    Outlined,
 }
 
 // -----------------------------------------------------------------------
@@ -129,7 +127,6 @@ fn find_directive_disabling_memoization<'a>(
 
 /// Result of a dynamic gating directive parse.
 struct DynamicGatingResult<'a> {
-    #[allow(dead_code)]
     directive: &'a str,
     gating: GatingConfig,
 }
@@ -339,23 +336,6 @@ fn expr_contains_optional(expr: &oxc::Expression) -> bool {
 /// chain flattening exactly.
 fn is_regular_call(call: &oxc::CallExpression) -> bool {
     !call.optional && !expr_contains_optional(&call.callee)
-}
-
-/// Check if an expression is a React API call (e.g., `forwardRef` or `React.forwardRef`).
-#[allow(dead_code)]
-fn is_react_api(expr: &oxc::Expression, function_name: &str) -> bool {
-    match expr {
-        oxc::Expression::Identifier(id) => id.name == function_name,
-        oxc::Expression::StaticMemberExpression(member) => {
-            if let oxc::Expression::Identifier(obj) = &member.object {
-                if obj.name == "React" {
-                    return member.property.name == function_name;
-                }
-            }
-            false
-        }
-        _ => false,
-    }
 }
 
 /// Get the inferred function name from a function's context.
@@ -1180,7 +1160,7 @@ fn handle_error<'a>(
 /// Returns `CodegenFunction` on success or `CompilerError` on failure.
 /// Debug log entries are accumulated on `context.debug_logs`.
 fn try_compile_function<'a>(
-    ast: &oxc_ast::builder::AstBuilder<'a>,
+    ast: &AstBuilder<'a>,
     source: &CompileSource,
     scope: &ScopeResolver<'_, '_>,
     output_mode: CompilerOutputMode,
@@ -1222,7 +1202,7 @@ fn try_compile_function<'a>(
 /// or `Err(CompileResult)` if a fatal error should short-circuit the program.
 #[allow(clippy::result_large_err)]
 fn process_fn<'a>(
-    ast: &oxc_ast::builder::AstBuilder<'a>,
+    ast: &AstBuilder<'a>,
     source: &CompileSource,
     scope: &ScopeResolver<'_, '_>,
     output_mode: CompilerOutputMode,
@@ -1378,7 +1358,6 @@ fn try_make_compile_source<'a>(
     Some(CompileSource {
         kind: CompileSourceKind::Original,
         original_kind,
-        fn_name: name,
         // The function source location flows into compile-error diagnostics as the
         // fallback labeled span (offset/length). Only the byte `index` is
         // load-bearing; line/column/filename never reach the example's output.
@@ -1974,7 +1953,7 @@ impl<'a, 'ast> DiscoveryWalker<'a, 'ast> {
         self.walk_jsx_children(&node.children);
     }
 
-    fn walk_jsx_children(&mut self, children: &'ast oxc_allocator::Vec<'ast, oxc::JSXChild<'ast>>) {
+    fn walk_jsx_children(&mut self, children: &'ast ArenaVec<'ast, oxc::JSXChild<'ast>>) {
         for child in children {
             match child {
                 oxc::JSXChild::Element(el) => self.walk_jsx_element(el),
@@ -2006,11 +1985,8 @@ fn find_functions_to_compile<'ast>(
 }
 
 struct CompiledFunction<'a, 'p, 's> {
-    #[allow(dead_code)]
     kind: CompileSourceKind,
-    #[allow(dead_code)]
     source: &'s CompileSource<'p>,
-    #[allow(dead_code)]
     codegen_fn: CodegenFunction<'a>,
 }
 
@@ -2046,10 +2022,9 @@ struct OxcReplacement<'a> {
 /// types carry through. The compiled params (from codegen) never carry types.
 fn copy_param_ts_metadata<'a>(
     allocator: &'a oxc_allocator::Allocator,
-    new_params: &mut oxc_ast::ast::FormalParameters<'a>,
-    source_params: &oxc_ast::ast::FormalParameters<'a>,
+    new_params: &mut oxc::FormalParameters<'a>,
+    source_params: &oxc::FormalParameters<'a>,
 ) {
-    use oxc_allocator::CloneIn;
     for (param, source) in new_params.items.iter_mut().zip(source_params.items.iter()) {
         param.decorators = source.decorators.clone_in(allocator);
         param.type_annotation = source.type_annotation.clone_in(allocator);
@@ -2067,23 +2042,21 @@ fn copy_param_ts_metadata<'a>(
 /// Build an oxc `Function` from a compiled codegen function. `r#type` selects
 /// declaration vs expression. Mirrors the Babel `ReplaceFnVisitor` field copy.
 fn ox_build_function<'a>(
-    ast: &oxc_ast::builder::AstBuilder<'a>,
+    ast: &AstBuilder<'a>,
     codegen: &CodegenFunction<'a>,
-    fn_type: oxc_ast::ast::FunctionType,
-) -> oxc_allocator::Box<'a, oxc_ast::ast::Function<'a>> {
-    use oxc_allocator::CloneIn;
-    use oxc_span::SPAN;
-    oxc_ast::ast::Function::boxed(
+    fn_type: oxc::FunctionType,
+) -> ArenaBox<'a, oxc::Function<'a>> {
+    oxc::Function::boxed(
         SPAN,
         fn_type,
         codegen.id.clone_in(ast.allocator()),
         codegen.generator,
         codegen.is_async,
         false,
-        None::<oxc_allocator::Box<oxc_ast::ast::TSTypeParameterDeclaration>>,
-        None::<oxc_allocator::Box<oxc_ast::ast::TSThisParameter>>,
+        None::<ArenaBox<oxc::TSTypeParameterDeclaration>>,
+        None::<ArenaBox<oxc::TSThisParameter>>,
         codegen.params.clone_in(ast.allocator()),
-        None::<oxc_allocator::Box<oxc_ast::ast::TSTypeAnnotation>>,
+        None::<ArenaBox<oxc::TSTypeAnnotation>>,
         Some(codegen.body.clone_in(ast.allocator())),
         ast,
     )
@@ -2092,31 +2065,27 @@ fn ox_build_function<'a>(
 /// Build the compiled replacement as an `Expression`, matching the original node
 /// kind (arrow vs function expression). Mirrors `build_compiled_expression_matching_kind`.
 fn ox_build_compiled_expression<'a>(
-    ast: &oxc_ast::builder::AstBuilder<'a>,
+    ast: &AstBuilder<'a>,
     codegen: &CodegenFunction<'a>,
     original_kind: OriginalFnKind,
-) -> oxc_ast::ast::Expression<'a> {
-    use oxc_allocator::CloneIn;
-    use oxc_span::SPAN;
+) -> oxc::Expression<'a> {
     match original_kind {
         OriginalFnKind::ArrowFunctionExpression => {
-            oxc_ast::ast::Expression::ArrowFunctionExpression(
-                oxc_ast::ast::ArrowFunctionExpression::boxed(
-                    SPAN,
-                    false,
-                    codegen.is_async,
-                    None::<oxc_allocator::Box<oxc_ast::ast::TSTypeParameterDeclaration>>,
-                    codegen.params.clone_in(ast.allocator()),
-                    None::<oxc_allocator::Box<oxc_ast::ast::TSTypeAnnotation>>,
-                    codegen.body.clone_in(ast.allocator()),
-                    ast,
-                ),
-            )
+            oxc::Expression::ArrowFunctionExpression(oxc::ArrowFunctionExpression::boxed(
+                SPAN,
+                false,
+                codegen.is_async,
+                None::<ArenaBox<oxc::TSTypeParameterDeclaration>>,
+                codegen.params.clone_in(ast.allocator()),
+                None::<ArenaBox<oxc::TSTypeAnnotation>>,
+                codegen.body.clone_in(ast.allocator()),
+                ast,
+            ))
         }
-        _ => oxc_ast::ast::Expression::FunctionExpression(ox_build_function(
+        _ => oxc::Expression::FunctionExpression(ox_build_function(
             ast,
             codegen,
-            oxc_ast::ast::FunctionType::FunctionExpression,
+            oxc::FunctionType::FunctionExpression,
         )),
     }
 }
@@ -2124,7 +2093,7 @@ fn ox_build_compiled_expression<'a>(
 /// Visitor that replaces a compiled function in the oxc AST by matching `span.start`.
 /// Mirrors the Babel `ReplaceFnVisitor`.
 struct OxcReplaceFnVisitor<'a, 'b> {
-    ast: &'b oxc_ast::builder::AstBuilder<'a>,
+    ast: &'b AstBuilder<'a>,
     node_id: u32,
     codegen: &'b CodegenFunction<'a>,
     done: bool,
@@ -2133,14 +2102,13 @@ struct OxcReplaceFnVisitor<'a, 'b> {
 impl<'a, 'b> oxc_ast_visit::VisitMut<'a> for OxcReplaceFnVisitor<'a, 'b> {
     fn visit_function(
         &mut self,
-        func: &mut oxc_ast::ast::Function<'a>,
+        func: &mut oxc::Function<'a>,
         flags: oxc_syntax::scope::ScopeFlags,
     ) {
         if self.done {
             return;
         }
         if func.span.start == self.node_id {
-            use oxc_allocator::CloneIn;
             // When the compiled function does not initialize a memo cache, the body is
             // left essentially intact, so the original TS signature (type parameters,
             // `this` parameter, return type, and per-parameter type annotations) is
@@ -2166,15 +2134,11 @@ impl<'a, 'b> oxc_ast_visit::VisitMut<'a> for OxcReplaceFnVisitor<'a, 'b> {
         oxc_ast_visit::walk_mut::walk_function(self, func, flags);
     }
 
-    fn visit_arrow_function_expression(
-        &mut self,
-        arrow: &mut oxc_ast::ast::ArrowFunctionExpression<'a>,
-    ) {
+    fn visit_arrow_function_expression(&mut self, arrow: &mut oxc::ArrowFunctionExpression<'a>) {
         if self.done {
             return;
         }
         if arrow.span.start == self.node_id {
-            use oxc_allocator::CloneIn;
             let keep_types = self.codegen.memo_slots_used == 0;
             let mut params = self.codegen.params.clone_in(self.ast.allocator());
             if keep_types {
@@ -2197,9 +2161,9 @@ impl<'a, 'b> oxc_ast_visit::VisitMut<'a> for OxcReplaceFnVisitor<'a, 'b> {
 /// Visitor that replaces a function (matched by `span.start`) with a gated
 /// conditional expression. Mirrors the Babel `ReplaceWithGatedVisitor`.
 struct OxcReplaceWithGatedVisitor<'a, 'b> {
-    ast: &'b oxc_ast::builder::AstBuilder<'a>,
+    ast: &'b AstBuilder<'a>,
     node_id: u32,
-    gating_expression: &'b oxc_ast::ast::Expression<'a>,
+    gating_expression: &'b oxc::Expression<'a>,
     /// Pending `export default Name;` to insert after a named export-default fn.
     export_default_name: Option<String>,
     done: bool,
@@ -2207,26 +2171,20 @@ struct OxcReplaceWithGatedVisitor<'a, 'b> {
 
 impl<'a, 'b> OxcReplaceWithGatedVisitor<'a, 'b> {
     /// Build `const <name> = <gating_expression>;`
-    fn build_const_decl(&self, name: &str) -> oxc_ast::ast::Statement<'a> {
-        use oxc_allocator::CloneIn;
-        use oxc_span::SPAN;
-        let declarator = oxc_ast::ast::VariableDeclarator::new(
+    fn build_const_decl(&self, name: &str) -> oxc::Statement<'a> {
+        let declarator = oxc::VariableDeclarator::new(
             SPAN,
-            oxc_ast::ast::VariableDeclarationKind::Const,
-            oxc_ast::ast::BindingPattern::new_binding_identifier(
-                SPAN,
-                ox_atom(self.ast, name),
-                self.ast,
-            ),
-            None::<oxc_allocator::Box<oxc_ast::ast::TSTypeAnnotation>>,
+            oxc::VariableDeclarationKind::Const,
+            oxc::BindingPattern::new_binding_identifier(SPAN, ox_atom(self.ast, name), self.ast),
+            None::<ArenaBox<oxc::TSTypeAnnotation>>,
             Some(self.gating_expression.clone_in(self.ast.allocator())),
             false,
             self.ast,
         );
-        oxc_ast::ast::Statement::VariableDeclaration(oxc_ast::ast::VariableDeclaration::boxed(
+        oxc::Statement::VariableDeclaration(oxc::VariableDeclaration::boxed(
             SPAN,
-            oxc_ast::ast::VariableDeclarationKind::Const,
-            oxc_allocator::ArenaVec::from_value_in(declarator, self.ast),
+            oxc::VariableDeclarationKind::Const,
+            ArenaVec::from_value_in(declarator, self.ast),
             false,
             self.ast,
         ))
@@ -2234,11 +2192,7 @@ impl<'a, 'b> OxcReplaceWithGatedVisitor<'a, 'b> {
 }
 
 impl<'a, 'b> oxc_ast_visit::VisitMut<'a> for OxcReplaceWithGatedVisitor<'a, 'b> {
-    fn visit_statements(
-        &mut self,
-        stmts: &mut oxc_allocator::Vec<'a, oxc_ast::ast::Statement<'a>>,
-    ) {
-        use oxc_ast::ast::Statement;
+    fn visit_statements(&mut self, stmts: &mut ArenaVec<'a, oxc::Statement<'a>>) {
         let mut i = 0;
         while i < stmts.len() {
             if self.done {
@@ -2246,11 +2200,11 @@ impl<'a, 'b> oxc_ast_visit::VisitMut<'a> for OxcReplaceWithGatedVisitor<'a, 'b> 
             }
             // FunctionDeclaration → `const Foo = gating() ? ... : ...;`
             let replace_name: Option<Option<String>> = match &stmts[i] {
-                Statement::FunctionDeclaration(f) if f.span.start == self.node_id => {
+                oxc::Statement::FunctionDeclaration(f) if f.span.start == self.node_id => {
                     Some(f.id.as_ref().map(|id| id.name.to_string()))
                 }
-                Statement::ExportNamedDeclaration(e) => match &e.declaration {
-                    Some(oxc_ast::ast::Declaration::FunctionDeclaration(f))
+                oxc::Statement::ExportNamedDeclaration(e) => match &e.declaration {
+                    Some(oxc::Declaration::FunctionDeclaration(f))
                         if f.span.start == self.node_id =>
                     {
                         Some(f.id.as_ref().map(|id| id.name.to_string()))
@@ -2261,27 +2215,25 @@ impl<'a, 'b> oxc_ast_visit::VisitMut<'a> for OxcReplaceWithGatedVisitor<'a, 'b> 
             };
             if let Some(name) = replace_name {
                 let name = name.as_deref().unwrap_or("anonymous");
-                let is_export = matches!(stmts[i], Statement::ExportNamedDeclaration(_));
+                let is_export = matches!(stmts[i], oxc::Statement::ExportNamedDeclaration(_));
                 let const_decl = self.build_const_decl(name);
                 if is_export {
-                    use oxc_span::SPAN;
                     let decl = match const_decl {
-                        Statement::VariableDeclaration(d) => {
-                            oxc_ast::ast::Declaration::VariableDeclaration(d)
+                        oxc::Statement::VariableDeclaration(d) => {
+                            oxc::Declaration::VariableDeclaration(d)
                         }
                         _ => unreachable!(),
                     };
-                    stmts[i] = oxc_ast::ast::Statement::ExportNamedDeclaration(
-                        oxc_ast::ast::ExportNamedDeclaration::boxed(
+                    stmts[i] =
+                        oxc::Statement::ExportNamedDeclaration(oxc::ExportNamedDeclaration::boxed(
                             SPAN,
                             Some(decl),
-                            oxc_allocator::ArenaVec::new_in(self.ast),
+                            ArenaVec::new_in(self.ast),
                             None,
-                            oxc_ast::ast::ImportOrExportKind::Value,
-                            None::<oxc_allocator::Box<oxc_ast::ast::WithClause>>,
+                            oxc::ImportOrExportKind::Value,
+                            None::<ArenaBox<oxc::WithClause>>,
                             self.ast,
-                        ),
-                    );
+                        ));
                 } else {
                     stmts[i] = const_decl;
                 }
@@ -2289,21 +2241,17 @@ impl<'a, 'b> oxc_ast_visit::VisitMut<'a> for OxcReplaceWithGatedVisitor<'a, 'b> 
                 break;
             }
             // ExportDefaultDeclaration with FunctionDeclaration
-            if let Statement::ExportDefaultDeclaration(e) = &stmts[i] {
-                if let oxc_ast::ast::ExportDefaultDeclarationKind::FunctionDeclaration(f) =
-                    &e.declaration
-                {
+            if let oxc::Statement::ExportDefaultDeclaration(e) = &stmts[i] {
+                if let oxc::ExportDefaultDeclarationKind::FunctionDeclaration(f) = &e.declaration {
                     if f.span.start == self.node_id {
                         if let Some(id) = f.id.as_ref().map(|id| id.name.to_string()) {
                             stmts[i] = self.build_const_decl(&id);
                             self.export_default_name = Some(id);
                         } else {
-                            use oxc_allocator::CloneIn;
-                            use oxc_span::SPAN;
-                            stmts[i] = oxc_ast::ast::Statement::ExportDefaultDeclaration(
-                                oxc_ast::ast::ExportDefaultDeclaration::boxed(
+                            stmts[i] = oxc::Statement::ExportDefaultDeclaration(
+                                oxc::ExportDefaultDeclaration::boxed(
                                     SPAN,
-                                    oxc_ast::ast::ExportDefaultDeclarationKind::from(
+                                    oxc::ExportDefaultDeclarationKind::from(
                                         self.gating_expression.clone_in(self.ast.allocator()),
                                     ),
                                     self.ast,
@@ -2321,21 +2269,18 @@ impl<'a, 'b> oxc_ast_visit::VisitMut<'a> for OxcReplaceWithGatedVisitor<'a, 'b> 
 
         // Insert `export default Name;` right after the replaced declaration.
         if let Some(name) = self.export_default_name.take() {
-            use oxc_span::SPAN;
-            let ident =
-                oxc_ast::ast::Expression::new_identifier(SPAN, ox_atom(self.ast, &name), self.ast);
-            let export = oxc_ast::ast::Statement::ExportDefaultDeclaration(
-                oxc_ast::ast::ExportDefaultDeclaration::boxed(
+            let ident = oxc::Expression::new_identifier(SPAN, ox_atom(self.ast, &name), self.ast);
+            let export =
+                oxc::Statement::ExportDefaultDeclaration(oxc::ExportDefaultDeclaration::boxed(
                     SPAN,
-                    oxc_ast::ast::ExportDefaultDeclarationKind::from(ident),
+                    oxc::ExportDefaultDeclarationKind::from(ident),
                     self.ast,
-                ),
-            );
+                ));
             // Find the const decl we just inserted (it has name `name`); insert after.
             let pos = stmts.iter().position(|s| {
-                matches!(s, oxc_ast::ast::Statement::VariableDeclaration(d)
+                matches!(s, oxc::Statement::VariableDeclaration(d)
                     if d.declarations.first().is_some_and(|decl| matches!(&decl.id,
-                        oxc_ast::ast::BindingPattern::BindingIdentifier(b) if b.name.as_str() == name)))
+                        oxc::BindingPattern::BindingIdentifier(b) if b.name.as_str() == name)))
             });
             if let Some(pos) = pos {
                 stmts.insert(pos + 1, export);
@@ -2345,17 +2290,16 @@ impl<'a, 'b> oxc_ast_visit::VisitMut<'a> for OxcReplaceWithGatedVisitor<'a, 'b> 
         }
     }
 
-    fn visit_expression(&mut self, expr: &mut oxc_ast::ast::Expression<'a>) {
+    fn visit_expression(&mut self, expr: &mut oxc::Expression<'a>) {
         if self.done {
             return;
         }
         let matched = match expr {
-            oxc_ast::ast::Expression::FunctionExpression(f) => f.span.start == self.node_id,
-            oxc_ast::ast::Expression::ArrowFunctionExpression(f) => f.span.start == self.node_id,
+            oxc::Expression::FunctionExpression(f) => f.span.start == self.node_id,
+            oxc::Expression::ArrowFunctionExpression(f) => f.span.start == self.node_id,
             _ => false,
         };
         if matched {
-            use oxc_allocator::CloneIn;
             *expr = self.gating_expression.clone_in(self.ast.allocator());
             self.done = true;
             return;
@@ -2367,13 +2311,13 @@ impl<'a, 'b> oxc_ast_visit::VisitMut<'a> for OxcReplaceWithGatedVisitor<'a, 'b> 
 /// Visitor that renames every identifier reference matching `old_name` to `new_name`.
 /// Mirrors the Babel `RenameIdentifierVisitor` (used to rename `useMemoCache`).
 struct OxcRenameIdentifierVisitor<'a, 'b> {
-    ast: &'b oxc_ast::builder::AstBuilder<'a>,
+    ast: &'b AstBuilder<'a>,
     old_name: &'b str,
     new_name: &'b str,
 }
 
 impl<'a, 'b> oxc_ast_visit::VisitMut<'a> for OxcRenameIdentifierVisitor<'a, 'b> {
-    fn visit_identifier_reference(&mut self, ident: &mut oxc_ast::ast::IdentifierReference<'a>) {
+    fn visit_identifier_reference(&mut self, ident: &mut oxc::IdentifierReference<'a>) {
         if ident.name == self.old_name {
             ident.name = ox_atom(self.ast, self.new_name).into();
         }
@@ -2382,21 +2326,17 @@ impl<'a, 'b> oxc_ast_visit::VisitMut<'a> for OxcRenameIdentifierVisitor<'a, 'b> 
 
 /// Allocate a `&'a str` in the arena (satisfies the builders' `Into<Ident>` /
 /// `IntoIn` slots; convert to `Atom` via `.into()` where a bare `Atom` is needed).
-fn ox_atom<'a>(ast: &oxc_ast::builder::AstBuilder<'a>, s: &str) -> &'a str {
+fn ox_atom<'a>(ast: &AstBuilder<'a>, s: &str) -> &'a str {
     oxc_allocator::StringBuilder::from_str_in(s, ast.allocator()).into_str()
 }
 
 /// Build `<callee_name>()` as an oxc call expression.
-fn ox_gating_call<'a>(
-    ast: &oxc_ast::builder::AstBuilder<'a>,
-    callee_name: &str,
-) -> oxc_ast::ast::Expression<'a> {
-    use oxc_span::SPAN;
-    oxc_ast::ast::Expression::new_call_expression(
+fn ox_gating_call<'a>(ast: &AstBuilder<'a>, callee_name: &str) -> oxc::Expression<'a> {
+    oxc::Expression::new_call_expression(
         SPAN,
-        oxc_ast::ast::Expression::new_identifier(SPAN, ox_atom(ast, callee_name), ast),
-        None::<oxc_allocator::Box<oxc_ast::ast::TSTypeParameterInstantiation>>,
-        oxc_allocator::ArenaVec::new_in(ast),
+        oxc::Expression::new_identifier(SPAN, ox_atom(ast, callee_name), ast),
+        None::<ArenaBox<oxc::TSTypeParameterInstantiation>>,
+        ArenaVec::new_in(ast),
         false,
         ast,
     )
@@ -2405,8 +2345,8 @@ fn ox_gating_call<'a>(
 /// Apply the conditional gating pattern to the oxc program. Mirrors
 /// `apply_gated_function_conditional`.
 fn ox_apply_gated_conditional<'a>(
-    ast: &oxc_ast::builder::AstBuilder<'a>,
-    program: &mut oxc_ast::ast::Program<'a>,
+    ast: &AstBuilder<'a>,
+    program: &mut oxc::Program<'a>,
     replacement: &OxcReplacement<'a>,
     gating_config: &GatingConfig,
     context: &mut ProgramContext,
@@ -2434,8 +2374,7 @@ fn ox_apply_gated_conditional<'a>(
         ox_build_compiled_expression(ast, &replacement.codegen_fn, replacement.original_kind);
 
     // gating() ? compiled : original
-    use oxc_span::SPAN;
-    let gating_expression = oxc_ast::ast::Expression::new_conditional_expression(
+    let gating_expression = oxc::Expression::new_conditional_expression(
         SPAN,
         ox_gating_call(ast, &gating_import.name),
         compiled_expr,
@@ -2456,59 +2395,53 @@ fn ox_apply_gated_conditional<'a>(
 /// Clone the original function at `node_id` as an `Expression` (FunctionDeclaration
 /// becomes a FunctionExpression). Mirrors `clone_original_fn_as_expression`.
 fn ox_clone_original_fn_as_expression<'a>(
-    ast: &oxc_ast::builder::AstBuilder<'a>,
-    program: &oxc_ast::ast::Program<'a>,
+    ast: &AstBuilder<'a>,
+    program: &oxc::Program<'a>,
     node_id: u32,
-) -> Option<oxc_ast::ast::Expression<'a>> {
-    use oxc_allocator::CloneIn;
-
+) -> Option<oxc::Expression<'a>> {
     struct Finder<'a, 'b> {
-        ast: &'b oxc_ast::builder::AstBuilder<'a>,
+        ast: &'b AstBuilder<'a>,
         node_id: u32,
-        found: Option<oxc_ast::ast::Expression<'a>>,
+        found: Option<oxc::Expression<'a>>,
     }
     impl<'a, 'b> oxc_ast_visit::Visit<'a> for Finder<'a, 'b> {
         fn visit_function(
             &mut self,
-            func: &oxc_ast::ast::Function<'a>,
+            func: &oxc::Function<'a>,
             flags: oxc_syntax::scope::ScopeFlags,
         ) {
             if self.found.is_some() {
                 return;
             }
             if func.span.start == self.node_id {
-                use oxc_allocator::CloneIn;
-                use oxc_span::SPAN;
-                let f = oxc_ast::ast::Function::boxed(
+                let f = oxc::Function::boxed(
                     SPAN,
-                    oxc_ast::ast::FunctionType::FunctionExpression,
+                    oxc::FunctionType::FunctionExpression,
                     func.id.clone_in(self.ast.allocator()),
                     func.generator,
                     func.r#async,
                     false,
-                    None::<oxc_allocator::Box<oxc_ast::ast::TSTypeParameterDeclaration>>,
-                    None::<oxc_allocator::Box<oxc_ast::ast::TSThisParameter>>,
+                    None::<ArenaBox<oxc::TSTypeParameterDeclaration>>,
+                    None::<ArenaBox<oxc::TSThisParameter>>,
                     func.params.clone_in(self.ast.allocator()),
-                    None::<oxc_allocator::Box<oxc_ast::ast::TSTypeAnnotation>>,
+                    None::<ArenaBox<oxc::TSTypeAnnotation>>,
                     func.body.clone_in(self.ast.allocator()),
                     self.ast,
                 );
-                self.found = Some(oxc_ast::ast::Expression::FunctionExpression(f));
+                self.found = Some(oxc::Expression::FunctionExpression(f));
                 return;
             }
             oxc_ast_visit::walk::walk_function(self, func, flags);
         }
-        fn visit_arrow_function_expression(
-            &mut self,
-            arrow: &oxc_ast::ast::ArrowFunctionExpression<'a>,
-        ) {
+        fn visit_arrow_function_expression(&mut self, arrow: &oxc::ArrowFunctionExpression<'a>) {
             if self.found.is_some() {
                 return;
             }
             if arrow.span.start == self.node_id {
-                self.found = Some(oxc_ast::ast::Expression::ArrowFunctionExpression(
-                    oxc_allocator::ArenaBox::new_in(arrow.clone_in(self.ast.allocator()), self.ast),
-                ));
+                self.found = Some(oxc::Expression::ArrowFunctionExpression(ArenaBox::new_in(
+                    arrow.clone_in(self.ast.allocator()),
+                    self.ast,
+                )));
                 return;
             }
             oxc_ast_visit::walk::walk_arrow_function_expression(self, arrow);
@@ -2522,14 +2455,12 @@ fn ox_clone_original_fn_as_expression<'a>(
 /// Splice every compiled oxc function into a clone of the original oxc program and
 /// add the required imports. Returns the final memoized program.
 fn ox_splice_program<'a>(
-    ast: &oxc_ast::builder::AstBuilder<'a>,
-    oxc_program: &oxc_ast::ast::Program<'a>,
+    ast: &AstBuilder<'a>,
+    program: &oxc::Program<'a>,
     replacements: &[OxcReplacement<'a>],
     context: &mut ProgramContext,
-) -> oxc_ast::ast::Program<'a> {
-    use oxc_allocator::CloneIn;
-
-    let mut program = oxc_program.clone_in(ast.allocator());
+) -> oxc::Program<'a> {
+    let mut program = program.clone_in(ast.allocator());
 
     // Outlined function declarations are placed differently depending on the
     // original function's syntactic kind, mirroring `insertNewOutlinedFunctionNode`
@@ -2539,18 +2470,15 @@ fn ox_splice_program<'a>(
     //   - (Arrow)FunctionExpression originals: appended at the end of the program
     //     body (Babel `pushContainer('body', ...)`), since inserting as a sibling
     //     would corrupt the parent expression.
-    let mut appended_outlined_decls: Vec<oxc_ast::ast::Statement<'a>> = Vec::new();
+    let mut appended_outlined_decls: Vec<oxc::Statement<'a>> = Vec::new();
 
     for replacement in replacements {
-        let mut sibling_outlined_decls: Vec<oxc_ast::ast::Statement<'a>> = Vec::new();
+        let mut sibling_outlined_decls: Vec<oxc::Statement<'a>> = Vec::new();
         let insert_as_sibling = replacement.original_kind == OriginalFnKind::FunctionDeclaration;
         for outlined in &replacement.codegen_fn.outlined {
-            let func = ox_build_function(
-                ast,
-                &outlined.func,
-                oxc_ast::ast::FunctionType::FunctionDeclaration,
-            );
-            let stmt = oxc_ast::ast::Statement::FunctionDeclaration(func);
+            let func =
+                ox_build_function(ast, &outlined.func, oxc::FunctionType::FunctionDeclaration);
+            let stmt = oxc::Statement::FunctionDeclaration(func);
             if insert_as_sibling {
                 sibling_outlined_decls.push(stmt);
             } else {
@@ -2599,20 +2527,18 @@ fn ox_splice_program<'a>(
 /// `originalFn.insertAfter(...)` for `FunctionDeclaration` originals. The statement
 /// may be a bare `FunctionDeclaration` or one wrapped in an `export`.
 fn ox_insert_outlined_after<'a>(
-    program: &mut oxc_ast::ast::Program<'a>,
+    program: &mut oxc::Program<'a>,
     node_id: u32,
-    outlined_decls: Vec<oxc_ast::ast::Statement<'a>>,
+    outlined_decls: Vec<oxc::Statement<'a>>,
 ) {
-    use oxc_ast::ast::{Declaration, ExportDefaultDeclarationKind, Statement};
-
-    let matches = |stmt: &Statement<'a>| -> bool {
+    let matches = |stmt: &oxc::Statement<'a>| -> bool {
         match stmt {
-            Statement::FunctionDeclaration(f) => f.span.start == node_id,
-            Statement::ExportNamedDeclaration(e) => {
-                matches!(&e.declaration, Some(Declaration::FunctionDeclaration(f)) if f.span.start == node_id)
+            oxc::Statement::FunctionDeclaration(f) => f.span.start == node_id,
+            oxc::Statement::ExportNamedDeclaration(e) => {
+                matches!(&e.declaration, Some(oxc::Declaration::FunctionDeclaration(f)) if f.span.start == node_id)
             }
-            Statement::ExportDefaultDeclaration(e) => {
-                matches!(&e.declaration, ExportDefaultDeclarationKind::FunctionDeclaration(f) if f.span.start == node_id)
+            oxc::Statement::ExportDefaultDeclaration(e) => {
+                matches!(&e.declaration, oxc::ExportDefaultDeclarationKind::FunctionDeclaration(f) if f.span.start == node_id)
             }
             _ => false,
         }
@@ -2640,11 +2566,10 @@ fn ox_insert_outlined_after<'a>(
 /// in imports.rs but builds oxc nodes. Handles ESM imports, CommonJS require, and
 /// merging into an existing non-namespaced import of the same module.
 fn ox_add_imports_to_program<'a>(
-    ast: &oxc_ast::builder::AstBuilder<'a>,
-    program: &mut oxc_ast::ast::Program<'a>,
+    ast: &AstBuilder<'a>,
+    program: &mut oxc::Program<'a>,
     context: &ProgramContext,
 ) {
-    use oxc_span::SPAN;
     if !context.has_pending_imports() {
         return;
     }
@@ -2653,7 +2578,7 @@ fn ox_add_imports_to_program<'a>(
     // Existing non-namespaced value imports, by module name.
     let mut existing_import_indices: FxHashMap<String, usize> = FxHashMap::default();
     for (idx, stmt) in program.body.iter().enumerate() {
-        if let oxc_ast::ast::Statement::ImportDeclaration(import) = stmt {
+        if let oxc::Statement::ImportDeclaration(import) = stmt {
             if ox_is_non_namespaced_import(import) {
                 existing_import_indices.entry(import.source.value.to_string()).or_insert(idx);
             }
@@ -2665,7 +2590,7 @@ fn ox_add_imports_to_program<'a>(
 
     let is_module = matches!(program.source_type.module_kind(), oxc_span::ModuleKind::Module);
 
-    let mut new_stmts: Vec<oxc_ast::ast::Statement<'a>> = Vec::new();
+    let mut new_stmts: Vec<oxc::Statement<'a>> = Vec::new();
 
     for (module_name, imports_map) in sorted_modules {
         let mut sorted_imports: Vec<_> = imports_map.values().collect();
@@ -2673,59 +2598,57 @@ fn ox_add_imports_to_program<'a>(
 
         if let Some(&idx) = existing_import_indices.get(module_name) {
             // Merge into the existing import declaration.
-            if let oxc_ast::ast::Statement::ImportDeclaration(import) = &mut program.body[idx] {
-                let specifiers =
-                    import.specifiers.get_or_insert_with(|| oxc_allocator::ArenaVec::new_in(ast));
+            if let oxc::Statement::ImportDeclaration(import) = &mut program.body[idx] {
+                let specifiers = import.specifiers.get_or_insert_with(|| ArenaVec::new_in(ast));
                 for spec in &sorted_imports {
                     specifiers.push(ox_make_import_specifier(ast, spec));
                 }
             }
         } else if is_module {
             // ESM: import { imported as local, ... } from 'module'
-            let mut specifiers = oxc_allocator::ArenaVec::new_in(ast);
+            let mut specifiers = ArenaVec::new_in(ast);
             for spec in &sorted_imports {
                 specifiers.push(ox_make_import_specifier(ast, spec));
             }
-            let source =
-                oxc_ast::ast::StringLiteral::new(SPAN, ox_atom(ast, module_name), None, ast);
-            let import = oxc_ast::ast::ImportDeclaration::boxed(
+            let source = oxc::StringLiteral::new(SPAN, ox_atom(ast, module_name), None, ast);
+            let import = oxc::ImportDeclaration::boxed(
                 SPAN,
                 Some(specifiers),
                 source,
                 None,
-                None::<oxc_allocator::Box<oxc_ast::ast::WithClause>>,
-                oxc_ast::ast::ImportOrExportKind::Value,
+                None::<ArenaBox<oxc::WithClause>>,
+                oxc::ImportOrExportKind::Value,
                 ast,
             );
-            new_stmts.push(oxc_ast::ast::Statement::ImportDeclaration(import));
+            new_stmts.push(oxc::Statement::ImportDeclaration(import));
         } else {
             // CommonJS: const { imported: local, ... } = require('module')
-            let mut props = oxc_allocator::ArenaVec::new_in(ast);
+            let mut props = ArenaVec::new_in(ast);
             for spec in &sorted_imports {
-                let key = oxc_ast::ast::PropertyKey::new_static_identifier(
+                let key = oxc::PropertyKey::new_static_identifier(
                     SPAN,
                     ox_atom(ast, &spec.imported),
                     ast,
                 );
-                let value = oxc_ast::ast::BindingPattern::new_binding_identifier(
+                let value = oxc::BindingPattern::new_binding_identifier(
                     SPAN,
                     ox_atom(ast, &spec.name),
                     ast,
                 );
-                props.push(oxc_ast::ast::BindingProperty::new(SPAN, key, value, false, false, ast));
+                props.push(oxc::BindingProperty::new(SPAN, key, value, false, false, ast));
             }
-            let object_pattern = oxc_ast::ast::BindingPattern::new_object_pattern(
+            let object_pattern = oxc::BindingPattern::new_object_pattern(
                 SPAN,
                 props,
-                None::<oxc_allocator::Box<oxc_ast::ast::BindingRestElement>>,
+                None::<ArenaBox<oxc::BindingRestElement>>,
                 ast,
             );
-            let require_call = oxc_ast::ast::Expression::new_call_expression(
+            let require_call = oxc::Expression::new_call_expression(
                 SPAN,
-                oxc_ast::ast::Expression::new_identifier(SPAN, "require", ast),
-                None::<oxc_allocator::Box<oxc_ast::ast::TSTypeParameterInstantiation>>,
-                oxc_allocator::ArenaVec::from_value_in(
-                    oxc_ast::ast::Argument::from(oxc_ast::ast::Expression::new_string_literal(
+                oxc::Expression::new_identifier(SPAN, "require", ast),
+                None::<ArenaBox<oxc::TSTypeParameterInstantiation>>,
+                ArenaVec::from_value_in(
+                    oxc::Argument::from(oxc::Expression::new_string_literal(
                         SPAN,
                         ox_atom(ast, module_name),
                         None,
@@ -2736,28 +2659,28 @@ fn ox_add_imports_to_program<'a>(
                 false,
                 ast,
             );
-            let declarator = oxc_ast::ast::VariableDeclarator::new(
+            let declarator = oxc::VariableDeclarator::new(
                 SPAN,
-                oxc_ast::ast::VariableDeclarationKind::Const,
+                oxc::VariableDeclarationKind::Const,
                 object_pattern,
-                None::<oxc_allocator::Box<oxc_ast::ast::TSTypeAnnotation>>,
+                None::<ArenaBox<oxc::TSTypeAnnotation>>,
                 Some(require_call),
                 false,
                 ast,
             );
-            let decl = oxc_ast::ast::VariableDeclaration::boxed(
+            let decl = oxc::VariableDeclaration::boxed(
                 SPAN,
-                oxc_ast::ast::VariableDeclarationKind::Const,
-                oxc_allocator::ArenaVec::from_value_in(declarator, ast),
+                oxc::VariableDeclarationKind::Const,
+                ArenaVec::from_value_in(declarator, ast),
                 false,
                 ast,
             );
-            new_stmts.push(oxc_ast::ast::Statement::VariableDeclaration(decl));
+            new_stmts.push(oxc::Statement::VariableDeclaration(decl));
         }
     }
 
     if !new_stmts.is_empty() {
-        let old_body = std::mem::replace(&mut program.body, oxc_allocator::ArenaVec::new_in(ast));
+        let old_body = std::mem::replace(&mut program.body, ArenaVec::new_in(ast));
         program.body.extend(new_stmts);
         program.body.extend(old_body);
     }
@@ -2765,42 +2688,43 @@ fn ox_add_imports_to_program<'a>(
 
 /// Build an oxc named import specifier `imported as local`. Mirrors `make_import_specifier`.
 fn ox_make_import_specifier<'a>(
-    ast: &oxc_ast::builder::AstBuilder<'a>,
+    ast: &AstBuilder<'a>,
     spec: &super::imports::NonLocalImportSpecifier,
-) -> oxc_ast::ast::ImportDeclarationSpecifier<'a> {
-    use oxc_span::SPAN;
-    let imported = oxc_ast::ast::ModuleExportName::IdentifierName(
-        oxc_ast::ast::IdentifierName::new(SPAN, ox_atom(ast, &spec.imported), ast),
-    );
-    let local = oxc_ast::ast::BindingIdentifier::new(SPAN, ox_atom(ast, &spec.name), ast);
-    oxc_ast::ast::ImportDeclarationSpecifier::ImportSpecifier(oxc_ast::ast::ImportSpecifier::boxed(
+) -> oxc::ImportDeclarationSpecifier<'a> {
+    let imported = oxc::ModuleExportName::IdentifierName(oxc::IdentifierName::new(
+        SPAN,
+        ox_atom(ast, &spec.imported),
+        ast,
+    ));
+    let local = oxc::BindingIdentifier::new(SPAN, ox_atom(ast, &spec.name), ast);
+    oxc::ImportDeclarationSpecifier::ImportSpecifier(oxc::ImportSpecifier::boxed(
         SPAN,
         imported,
         local,
-        oxc_ast::ast::ImportOrExportKind::Value,
+        oxc::ImportOrExportKind::Value,
         ast,
     ))
 }
 
 /// Whether an import declaration is a non-namespaced value import. Mirrors
 /// `is_non_namespaced_import`.
-fn ox_is_non_namespaced_import(import: &oxc_ast::ast::ImportDeclaration) -> bool {
-    if !matches!(import.import_kind, oxc_ast::ast::ImportOrExportKind::Value) {
+fn ox_is_non_namespaced_import(import: &oxc::ImportDeclaration) -> bool {
+    if !matches!(import.import_kind, oxc::ImportOrExportKind::Value) {
         return false;
     }
     match &import.specifiers {
         None => true,
         Some(specifiers) => specifiers
             .iter()
-            .all(|s| matches!(s, oxc_ast::ast::ImportDeclarationSpecifier::ImportSpecifier(_))),
+            .all(|s| matches!(s, oxc::ImportDeclarationSpecifier::ImportSpecifier(_))),
     }
 }
 
 /// Main entry point for the React Compiler.
 ///
-/// Receives a full program AST, scope information (unused for now), and resolved options.
-/// Returns a CompileResult indicating whether the AST was modified,
-/// along with any logger events.
+/// Receives the arena allocator, semantic model, the full program AST, and
+/// resolved options. Returns a CompileResult indicating whether the AST was
+/// modified, along with any logger events.
 ///
 /// This function implements the logic from the TS entrypoint (Program.ts):
 /// - validateRestrictedImports: check for blocklisted imports
@@ -2809,11 +2733,16 @@ fn ox_is_non_namespaced_import(import: &oxc_ast::ast::ImportDeclaration) -> bool
 /// - processFn: per-function compilation with directive and suppression handling
 /// - applyCompiledFunctions: replace original functions with compiled versions
 pub fn compile_program<'a, 'p>(
-    ast: &oxc_ast::builder::AstBuilder<'a>,
-    oxc_program: &'p oxc_ast::ast::Program<'a>,
-    scope: &ScopeResolver<'_, '_>,
+    allocator: &'a Allocator,
+    semantic: &Semantic<'_>,
+    program: &'p oxc::Program<'a>,
     options: PluginOptions,
 ) -> CompileResult<'a> {
+    // The codegen back-end builds oxc nodes directly via this `AstBuilder`; `scope`
+    // is a read-through view over `Semantic` for binding/reference lookups.
+    let ast = AstBuilder::new(allocator);
+    let scope = ScopeResolver::new(semantic, program);
+
     // Compute output mode once, up front
     let output_mode = CompilerOutputMode::from_opts(&options);
 
@@ -2831,15 +2760,15 @@ pub fn compile_program<'a, 'p>(
 
     // Find program-level suppressions from comments
     let suppressions = find_program_suppressions(
-        &oxc_program.comments,
-        oxc_program.source_text,
+        &program.comments,
+        program.source_text,
         eslint_rules.as_deref(),
         options.flow_suppressions,
     );
 
     // Check for module-scope opt-out directive
     let module_directives: Vec<String> =
-        oxc_program.directives.iter().map(|d| d.expression.value.to_string()).collect();
+        program.directives.iter().map(|d| d.expression.value.to_string()).collect();
     let has_module_scope_opt_out =
         find_directive_disabling_memoization(&module_directives, &options).is_some();
 
@@ -2847,11 +2776,11 @@ pub fn compile_program<'a, 'p>(
     let mut context = ProgramContext::new(options.clone(), suppressions, has_module_scope_opt_out);
 
     // Initialize known referenced names from scope bindings for UID collision detection
-    context.init_from_scope(scope);
+    context.init_from_scope(&scope);
 
     // Validate restricted imports (needs context for handle_error)
     if let Some(err) =
-        validate_restricted_imports(oxc_program, &options.environment.validate_blocklisted_imports)
+        validate_restricted_imports(program, &options.environment.validate_blocklisted_imports)
     {
         if let Some(result) = handle_error(&err, None, &mut context) {
             return result;
@@ -2893,7 +2822,7 @@ pub fn compile_program<'a, 'p>(
     context.hook_guard_name = hook_guard_name;
 
     // Find all functions to compile
-    let queue = find_functions_to_compile(oxc_program, &options, &mut context);
+    let queue = find_functions_to_compile(program, &options, &mut context);
 
     // Clone env_config once for all function compilations (avoids per-function clone
     // while satisfying the borrow checker — compile_fn needs &mut context + &env_config)
@@ -2904,13 +2833,13 @@ pub fn compile_program<'a, 'p>(
 
     for source in &queue {
         match process_fn(
-            ast,
+            &ast,
             source,
-            scope,
+            &scope,
             output_mode,
             &env_config,
             &mut context,
-            oxc_program.source_text,
+            program.source_text,
         ) {
             Ok(Some(codegen_fn)) => {
                 compiled_fns.push(CompiledFunction { kind: source.kind, source, codegen_fn });
@@ -2978,7 +2907,7 @@ pub fn compile_program<'a, 'p>(
     // Build the memoized oxc program: splice each compiled oxc function in for its
     // original (matched by `span.start == fn_node_id`), apply gating, insert outlined
     // functions, and add the memo-cache / gating imports.
-    let compiled_program = ox_splice_program(ast, oxc_program, &replacements, &mut context);
+    let compiled_program = ox_splice_program(&ast, program, &replacements, &mut context);
 
     CompileResult::Success { ast: Some(compiled_program), diagnostics: context.diagnostics }
 }


### PR DESCRIPTION
Pure refactor of the react compiler entrypoint; no behavior change (verified against the fixture snapshot corpus and the integration tests).

- `compile_program` now takes `allocator`/`semantic` and builds the `AstBuilder` and `ScopeResolver` itself, instead of receiving pre-built ones from `compile`. Its `oxc_program` parameter is renamed to `program`.
- Fully-qualified paths and function-local `use` statements are hoisted to top-level imports. `oxc_allocator::Box`/`Vec` become the non-colliding `ArenaBox`/`ArenaVec` aliases; the `oxc::`-alias AST types are used consistently rather than imported bare.
- Dead code and stale `#[allow(dead_code)]` attributes are removed — the unused `is_react_api` fn, the never-constructed `CompileSourceKind::Outlined` variant, and the write-only `CompileSource::fn_name` field.
- `has_memo_cache_function_import` moves into `prefilter`, next to `has_react_like_functions` (both are "should we skip this file?" checks).
- `lint` moves directly below `transform` so the two public entry points sit together.
