### PR TITLE
fix(linter/import/unambiguous): skip explicit CommonJS files

### DIFF
--- a/crates/oxc_linter/src/rules/import/unambiguous.rs
+++ b/crates/oxc_linter/src/rules/import/unambiguous.rs
@@ -52,6 +52,10 @@ declare_oxc_lint!(
 /// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/unambiguous.md>
 impl Rule for Unambiguous {
     fn run_once(&self, ctx: &LintContext<'_>) {
+        // Explicit CommonJS files (`.cjs`, `.cts`) cannot be mistakenly parsed as scripts.
+        if ctx.source_type().is_commonjs() {
+            return;
+        }
         if !ctx.module_record().has_module_syntax {
             ctx.diagnostic(unambiguous_diagnostic(Span::default()));
         }
@@ -83,4 +87,17 @@ fn test() {
         .change_rule_path("index.ts")
         .with_import_plugin(true)
         .test_and_snapshot();
+
+    // Explicit CommonJS files (`.cjs`, `.cts`) cannot be mistakenly parsed as scripts
+    let pass = vec![r#"const x = require("y");"#, r"function x() {}"];
+
+    Tester::new(Unambiguous::NAME, Unambiguous::PLUGIN, pass.clone(), vec![])
+        .change_rule_path("index.cjs")
+        .with_import_plugin(true)
+        .test();
+
+    Tester::new(Unambiguous::NAME, Unambiguous::PLUGIN, pass, vec![])
+        .change_rule_path("index.cts")
+        .with_import_plugin(true)
+        .test();
 }


### PR DESCRIPTION
### AI usage disclosure

I used Claude Code to help trace the root cause and draft the fix and tests. I have reviewed, understood, and verified everything below myself (including running the released `oxlint` binary and a locally built one against the reproduction).

### Summary

Closes #19907 (the `import/unambiguous` half — see scope note below).

`import/unambiguous` reports **every** `.cjs`/`.cts` file:

```
⚠ eslint-plugin-import(unambiguous): This module could be mistakenly parsed as script instead of module
 ╭─[.ncurc.cjs:1:1]
1 │ const { defineConfig } = require("npm-check-updates");
```

An explicit CommonJS file can never be "mistakenly parsed as script instead of module" — its parse goal is unambiguous by extension — so the warning is noise, and the suggested fix (add an `import`/`export` statement) would actually break the file.

### Root cause

`run_once` only checks `ctx.module_record().has_module_syntax`. Since #18089, `.cjs`/`.cts` files parse with `ModuleKind::CommonJS`; they contain no ESM syntax by definition, so the rule fires on all of them unconditionally.

Upstream `eslint-plugin-import` makes this rule a no-op for non-`module` source types ([`unambiguous.js`](https://github.com/import-js/eslint-plugin-import/blob/main/src/rules/unambiguous.js): `if (sourceType(context) !== 'module') return {};`).

### The fix

Early-return when `ctx.source_type().is_commonjs()` (same pattern as `no_implicit_globals`).

Note: gating on `!is_module()` instead would break the rule entirely — `.js`/`.ts` files parse with `ModuleKind::Unambiguous`, which resolves to `Script` exactly when the file has no ESM syntax, i.e. precisely the case this rule exists to flag. Only the explicit-CommonJS kind must be skipped.

### Testing

Added `.cjs`/`.cts` pass cases. Before the fix they fail:

```
⚠ import(unambiguous): This module could be mistakenly parsed as script instead of module
 ╭─[index.cjs:1:1]
1 │ function x() {}
test rules::import::unambiguous::test ... FAILED
```

After the fix:

```
test rules::import::unambiguous::test ... ok
```

Full `cargo test -p oxc_linter` suite passes (1168 tests, 0 failed). Also verified end-to-end with a locally built `oxlint` on the issue's reproduction: the `.cjs` file reports 0 warnings, while a plain `.js` file without ESM syntax still reports (rule's core behavior unchanged).

### Scope note

The issue also questions `import/no-commonjs` firing in `.cjs` files. That matches upstream behavior — the rule is purely syntactic and fires in `.cjs` under `eslint-plugin-import` too — so it is intentionally not changed here.
