### PR TITLE
perf(diagnostics): make miette's graphical renderer opt-in via a `fancy` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,9 +222,7 @@ language-tags = "0.3.2" # Language tag parsing
 lazy-regex = "3.6.0" # Lazy regex compilation
 markdown = "1.0.0" # Markdown parsing
 memchr = "2.8.2" # Fast byte searching
-miette = { package = "oxc-miette", version = "3.0.0", features = [
-  "fancy-no-syscall",
-] } # Error reporting
+miette = { package = "oxc-miette", version = "3.0.0" } # Error reporting; graphical renderer is opt-in via `oxc_diagnostics/fancy`
 mimalloc-safe = "0.1.64" # Fast allocator
 nodejs-built-in-modules = "1.0.0" # Node.js built-in modules
 nonmax = "0.5.5" # Non-maximum numbers

--- a/apps/oxfmt/Cargo.toml
+++ b/apps/oxfmt/Cargo.toml
@@ -30,14 +30,14 @@ doctest = false
 oxc_allocator = { workspace = true, features = ["pool"] }
 oxc_ast = { workspace = true, features = ["disable_old_builder"] }
 oxc_config = { workspace = true }
-oxc_diagnostics = { workspace = true }
+oxc_diagnostics = { workspace = true, features = ["fancy"] }
 oxc_formatter = { workspace = true }
 oxc_formatter_core = { workspace = true }
 oxc_formatter_css = { workspace = true }
 oxc_formatter_graphql = { workspace = true }
 oxc_formatter_json = { workspace = true }
 oxc_language_server = { workspace = true }
-oxc_napi = { workspace = true }
+oxc_napi = { workspace = true, features = ["fancy"] }
 oxc_span = { workspace = true }
 
 bpaf = { workspace = true, features = ["autocomplete", "bright-color", "derive"] }
@@ -46,7 +46,7 @@ editorconfig-parser = { workspace = true }
 fast-glob = { workspace = true }
 ignore = { workspace = true, features = ["simd-accel"] }
 json-strip-comments = { workspace = true }
-miette = { workspace = true }
+miette = { workspace = true, features = ["fancy-no-syscall"] }
 phf = { workspace = true, features = ["macros"] }
 rayon = { workspace = true }
 rustc-hash = { workspace = true }

--- a/apps/oxlint/Cargo.toml
+++ b/apps/oxlint/Cargo.toml
@@ -31,11 +31,11 @@ oxc_allocator = { workspace = true, features = ["fixed_size"] }
 oxc_ast = { workspace = true, features = ["disable_old_builder"] }
 oxc_ast_visit = { workspace = true, features = ["serialize"] }
 oxc_config = { workspace = true }
-oxc_diagnostics = { workspace = true }
+oxc_diagnostics = { workspace = true, features = ["fancy"] }
 oxc_estree_tokens = { workspace = true }
 oxc_language_server = { workspace = true }
 oxc_linter = { workspace = true }
-oxc_napi = { workspace = true }
+oxc_napi = { workspace = true, features = ["fancy"] }
 oxc_parser = { workspace = true }
 oxc_semantic = { workspace = true }
 oxc_span = { workspace = true }
@@ -44,7 +44,7 @@ oxc_str = { workspace = true }
 bpaf = { workspace = true, features = ["autocomplete", "bright-color", "derive"] }
 cow-utils = { workspace = true }
 ignore = { workspace = true, features = ["simd-accel"] }
-miette = { workspace = true }
+miette = { workspace = true, features = ["fancy-no-syscall"] }
 napi = { workspace = true, features = ["async"], optional = true }
 tracing = { workspace = true }
 napi-derive = { workspace = true, optional = true }

--- a/crates/oxc/Cargo.toml
+++ b/crates/oxc/Cargo.toml
@@ -49,6 +49,10 @@ oxc_transformer_plugins = { workspace = true, optional = true }
 # cause it to be activated for `oxc_ast` for the user too.
 oxc_ast = { workspace = true, features = ["disable_old_builder"] }
 
+# The `compiler` example renders diagnostics through miette's default hook; enable
+# the graphical renderer for examples/tests only without leaking it downstream.
+oxc_diagnostics = { workspace = true, features = ["fancy"] }
+
 [features]
 default = ["regular_expression"]
 
@@ -71,6 +75,9 @@ minifier = ["oxc_mangler", "oxc_minifier"]
 codegen = ["oxc_codegen", "oxc_codegen/sourcemap"]
 mangler = ["oxc_mangler"]
 cfg = ["oxc_cfg", "oxc_semantic/cfg"]
+# Graphical diagnostic rendering (`GraphicalReportHandler`); off by default to
+# keep miette's renderer out of downstream binaries.
+fancy = ["oxc_diagnostics/fancy"]
 isolated_declarations = ["oxc_isolated_declarations"]
 ast_visit = ["oxc_ast_visit"]
 regular_expression = ["oxc_regular_expression", "oxc_parser/regular_expression"]

--- a/crates/oxc_diagnostics/Cargo.toml
+++ b/crates/oxc_diagnostics/Cargo.toml
@@ -21,5 +21,12 @@ cow-utils = { workspace = true }
 miette = { workspace = true }
 percent-encoding = { workspace = true }
 
+[features]
+# Enable miette's graphical report renderer and re-export `GraphicalReportHandler`
+# / `GraphicalTheme`. Off by default: the renderer (plus textwrap/owo-colors) is
+# only needed by CLIs that print codeframes to a terminal, and it otherwise ends
+# up linked into every downstream binary that formats a `miette::Report`.
+fancy = ["miette/fancy-no-syscall"]
+
 [lib]
 doctest = false

--- a/crates/oxc_diagnostics/src/lib.rs
+++ b/crates/oxc_diagnostics/src/lib.rs
@@ -64,7 +64,9 @@ pub type Severity = miette::Severity;
 pub type Result<T> = std::result::Result<T, OxcDiagnostic>;
 
 use miette::{Diagnostic, SourceCode};
-pub use miette::{GraphicalReportHandler, GraphicalTheme, LabeledSpan, Labels, NamedSource};
+#[cfg(feature = "fancy")]
+pub use miette::{GraphicalReportHandler, GraphicalTheme};
+pub use miette::{LabeledSpan, Labels, NamedSource};
 
 /// A collection of [`OxcDiagnostic`]s.
 ///

--- a/crates/oxc_isolated_declarations/Cargo.toml
+++ b/crates/oxc_isolated_declarations/Cargo.toml
@@ -38,6 +38,10 @@ insta = { workspace = true, features = ["glob"] }
 oxc_codegen = { workspace = true, features = ["sourcemap"] }
 oxc_parser = { workspace = true }
 
+# Snapshot tests render diagnostics through miette's default hook; enable the
+# graphical renderer for tests only so downstream consumers don't link it.
+oxc_diagnostics = { workspace = true, features = ["fancy"] }
+
 # Catch usage of old `AstBuilder` APIs in tests, without affecting downstream consumers.
 # If we enabled `disable_old_builder` feature in main dependency, feature unification would
 # cause it to be activated for `oxc_ast` for the user too.

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -86,3 +86,7 @@ markdown = { workspace = true }
 # If we enabled `disable_old_builder` feature in main dependency, feature unification would
 # cause it to be activated for `oxc_ast` for the user too.
 oxc_ast = { workspace = true, features = ["disable_old_builder"] }
+
+# The tester renders diagnostics with `GraphicalReportHandler`; enable the renderer
+# for tests only so downstream consumers don't link it.
+oxc_diagnostics = { workspace = true, features = ["fancy"] }

--- a/crates/oxc_napi/Cargo.toml
+++ b/crates/oxc_napi/Cargo.toml
@@ -40,5 +40,11 @@ oxc_ast = { workspace = true, features = ["disable_old_builder"] }
 [build-dependencies]
 napi-build = { workspace = true }
 
+[features]
+# Render pretty codeframes in `OxcError` via miette's graphical renderer.
+# Off by default so library consumers (e.g. bundlers embedding these bindings)
+# don't link the renderer; without it `codeframe` is `None`.
+fancy = ["oxc_diagnostics/fancy"]
+
 [package.metadata.cargo-shear]
 ignored = ["napi"]

--- a/crates/oxc_napi/src/error.rs
+++ b/crates/oxc_napi/src/error.rs
@@ -37,6 +37,9 @@ impl OxcError {
         diagnostics.into_iter().map(|e| Self::from_diagnostic(&source, e)).collect()
     }
 
+    /// Rendering the codeframe requires miette's graphical renderer, which is
+    /// only linked when the `fancy` feature is enabled.
+    #[cfg(feature = "fancy")]
     pub fn from_diagnostic(
         named_source: &Arc<NamedSource<String>>,
         diagnostic: OxcDiagnostic,
@@ -44,6 +47,18 @@ impl OxcError {
         let mut error = Self::from(&diagnostic);
         let codeframe = diagnostic.with_source_code(Arc::clone(named_source));
         error.codeframe = Some(format!("{codeframe:?}"));
+        error
+    }
+
+    /// Without the `fancy` feature the graphical renderer is not linked and
+    /// `codeframe` stays `None`.
+    #[cfg(not(feature = "fancy"))]
+    pub fn from_diagnostic(
+        _named_source: &Arc<NamedSource<String>>,
+        diagnostic: OxcDiagnostic,
+    ) -> Self {
+        let error = Self::from(&diagnostic);
+        drop(diagnostic);
         error
     }
 }

--- a/crates/oxc_regular_expression/Cargo.toml
+++ b/crates/oxc_regular_expression/Cargo.toml
@@ -34,5 +34,9 @@ unicode-id-start = { workspace = true }
 [dev-dependencies]
 insta = { workspace = true }
 
+# The diagnostics tests render with `GraphicalReportHandler`; enable the renderer
+# for tests only so downstream consumers don't link it.
+oxc_diagnostics = { workspace = true, features = ["fancy"] }
+
 [package.metadata.cargo-shear]
 ignored-paths = ["src/generated/derive_get_address.rs"]

--- a/crates/oxc_semantic/Cargo.toml
+++ b/crates/oxc_semantic/Cargo.toml
@@ -50,6 +50,10 @@ serde_json = { workspace = true }
 # cause it to be activated for `oxc_ast` for the user too.
 oxc_ast = { workspace = true, features = ["disable_old_builder"] }
 
+# The example and conformance tests render diagnostics with `GraphicalReportHandler`;
+# enable the renderer for tests/examples only so downstream consumers don't link it.
+oxc_diagnostics = { workspace = true, features = ["fancy"] }
+
 [features]
 default = []
 cfg = ["dep:oxc_cfg"]

--- a/napi/minify/Cargo.toml
+++ b/napi/minify/Cargo.toml
@@ -56,5 +56,8 @@ mimalloc-safe = { workspace = true, optional = true, features = [
 napi-build = { workspace = true }
 
 [features]
-default = []
+default = ["fancy"]
 allocator = ["dep:mimalloc-safe"]
+# Pretty codeframes in errors. Downstream embedders (e.g. rolldown) can opt out
+# with `default-features = false` to avoid linking miette's graphical renderer.
+fancy = ["oxc_napi/fancy"]

--- a/napi/parser/Cargo.toml
+++ b/napi/parser/Cargo.toml
@@ -54,8 +54,11 @@ mimalloc-safe = { workspace = true, optional = true, features = [
 napi-build = { workspace = true }
 
 [features]
-default = []
+default = ["fancy"]
 allocator = ["dep:mimalloc-safe"]
+# Pretty codeframes in errors. Downstream embedders (e.g. rolldown) can opt out
+# with `default-features = false` to avoid linking miette's graphical renderer.
+fancy = ["oxc_napi/fancy"]
 tokens = ["dep:oxc_estree_tokens"]
 
 [package.metadata.cargo-shear]

--- a/napi/parser/src/raw_transfer_types.rs
+++ b/napi/parser/src/raw_transfer_types.rs
@@ -13,7 +13,9 @@ use oxc::{
 };
 use oxc_ast_macros::ast;
 use oxc_estree::ESTree;
-use oxc_str::{Str, format_str};
+use oxc_str::Str;
+#[cfg(feature = "fancy")]
+use oxc_str::format_str;
 
 /// The main struct containing all deserializable data in raw transfer.
 #[ast]
@@ -101,8 +103,19 @@ impl<'a> Error<'a> {
         let message = Str::from_in(diagnostic.message.as_ref(), allocator);
         let help_message =
             diagnostic.help.as_ref().map(|help| Str::from_in(help.as_ref(), allocator));
-        let report = diagnostic.with_source_code(Arc::clone(named_source));
-        let codeframe = format_str!(allocator, "{report:?}");
+        // Rendering the codeframe requires miette's graphical renderer, which is
+        // only linked when the `fancy` feature is enabled.
+        #[cfg(feature = "fancy")]
+        let codeframe = {
+            let report = diagnostic.with_source_code(Arc::clone(named_source));
+            format_str!(allocator, "{report:?}")
+        };
+        #[cfg(not(feature = "fancy"))]
+        let codeframe = {
+            let _ = named_source;
+            drop(diagnostic);
+            Str::from_in("", allocator)
+        };
 
         #[expect(clippy::inconsistent_struct_constructor)] // `#[ast]` macro re-orders struct fields
         Self { severity, message, labels, help_message, codeframe }

--- a/napi/playground/Cargo.toml
+++ b/napi/playground/Cargo.toml
@@ -38,7 +38,7 @@ oxc_compat = { workspace = true }
 oxc_formatter = { workspace = true }
 oxc_formatter_core = { workspace = true }
 oxc_linter = { workspace = true }
-oxc_napi = { workspace = true }
+oxc_napi = { workspace = true, features = ["fancy"] }
 oxc_transformer_plugins = { workspace = true }
 
 napi = { workspace = true, features = ["async"] }

--- a/napi/transform/Cargo.toml
+++ b/napi/transform/Cargo.toml
@@ -51,5 +51,8 @@ mimalloc-safe = { workspace = true, optional = true, features = [
 napi-build = { workspace = true }
 
 [features]
-default = []
+default = ["fancy"]
 allocator = ["dep:mimalloc-safe"]
+# Pretty codeframes in errors. Downstream embedders (e.g. rolldown) can opt out
+# with `default-features = false` to avoid linking miette's graphical renderer.
+fancy = ["oxc_napi/fancy"]

--- a/tasks/coverage/Cargo.toml
+++ b/tasks/coverage/Cargo.toml
@@ -23,7 +23,13 @@ doctest = false
 
 [dependencies]
 cow-utils = { workspace = true }
-oxc = { workspace = true, features = ["full", "isolated_declarations", "serialize", "conformance", "fancy"] }
+oxc = { workspace = true, features = [
+  "full",
+  "isolated_declarations",
+  "serialize",
+  "conformance",
+  "fancy",
+] }
 oxc_ast = { workspace = true, features = ["disable_old_builder"] }
 oxc_estree_tokens = { workspace = true }
 oxc_formatter = { workspace = true }

--- a/tasks/coverage/Cargo.toml
+++ b/tasks/coverage/Cargo.toml
@@ -23,7 +23,7 @@ doctest = false
 
 [dependencies]
 cow-utils = { workspace = true }
-oxc = { workspace = true, features = ["full", "isolated_declarations", "serialize", "conformance"] }
+oxc = { workspace = true, features = ["full", "isolated_declarations", "serialize", "conformance", "fancy"] }
 oxc_ast = { workspace = true, features = ["disable_old_builder"] }
 oxc_estree_tokens = { workspace = true }
 oxc_formatter = { workspace = true }


### PR DESCRIPTION
## Why

Every binary that constructs a `miette::Report` links the graphical renderer, even if it never renders a fancy codeframe. Report construction captures the default handler through `HOOK.get_or_init(|| Box::new(get_default_printer))`, and with `fancy-no-syscall` enabled `get_default_printer` statically constructs `MietteHandler::new()` — instantiating both the graphical and narratable handler vtables. LTO cannot strip any of it: the path is reachable from exported functions, the factory is an address-taken function pointer in a global, and vtable methods can't be proven uncalled.

Measured in rolldown's binding (which re-exports `parseSync`/`transform`/`minify`): ~80 KB of renderer code (miette graphical+narratable, textwrap, owo-colors, supports-color) that can never be used, retained via `oxc_napi::OxcError::from_diagnostic`'s `format!("{codeframe:?}")`.

This redoes #23602, which no longer suffices on its own since `oxc_span` also grew an oxc-miette dependency carrying `fancy-no-syscall`.

## What

- Remove `fancy-no-syscall` from the workspace miette dependency.
- `oxc_diagnostics`: new default-off `fancy` feature forwarding `miette/fancy-no-syscall`, gating the `GraphicalReportHandler`/`GraphicalTheme` re-exports.
- `oxc` umbrella: forwards it as `fancy = ["oxc_diagnostics/fancy"]`.
- `oxc_napi`: new `fancy` feature; without it `OxcError.codeframe` is `None` instead of a rendered frame (no more debug-struct dump fallback). Same for napi/parser's raw-transfer errors (empty string).
- **npm packages unchanged**: napi/parser, napi/transform, napi/minify enable `fancy` by default (embedders like rolldown opt out with `default-features = false`). napi/playground enables it directly.
- CLIs keep rendering fancy: oxlint, oxfmt (direct miette dep + `oxc_diagnostics/fancy` + `oxc_napi/fancy`), tasks/coverage (via `oxc/fancy`).
- Crates whose tests/examples render diagnostics (linter tester, semantic conformance, regular_expression tests, isolated_declarations snapshots, oxc's `compiler` example) get fancy through **dev-dependencies only**, so it doesn't leak downstream — same pattern as the existing `disable_old_builder` dev-dep.

## Verification

- `cargo clippy -p oxc_napi -p oxc_parser_napi` with defaults and with `--no-default-features`: clean.
- `cargo check` for transform/minify/playground napi, oxlint, oxfmt, coverage, and `--tests`/`--example` for linter/semantic/regular_expression: clean.
- `cargo test -p oxc_isolated_declarations`: 20 snapshot tests pass unchanged.
- `cargo tree -p oxc_parser_napi --no-default-features -e normal`: textwrap/owo-colors gone; with default features: still present (npm output identical).