### PR TITLE
refactor(react_compiler): de-monomorphize block completion and operand iterators

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler_hir/visitors.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/visitors.rs
@@ -868,7 +868,7 @@ pub fn each_terminal_operand_ids(terminal: &Terminal) -> Vec<IdentifierId> {
 /// Does NOT handle FunctionExpression/ObjectMethod context — callers handle those separately.
 pub fn for_each_instruction_value_operand_mut(
     value: &mut InstructionValue,
-    f: &mut impl FnMut(&mut Place),
+    f: &mut dyn FnMut(&mut Place),
 ) {
     match value {
         InstructionValue::BinaryExpression { left, right, .. } => {
@@ -1025,7 +1025,7 @@ pub fn for_each_instruction_value_operand_mut(
 }
 
 /// In-place mutation of call arguments.
-pub fn for_each_call_argument_mut(args: &mut [PlaceOrSpread], f: &mut impl FnMut(&mut Place)) {
+pub fn for_each_call_argument_mut(args: &mut [PlaceOrSpread], f: &mut dyn FnMut(&mut Place)) {
     for arg in args.iter_mut() {
         match arg {
             PlaceOrSpread::Place(place) => f(place),
@@ -1039,7 +1039,7 @@ pub fn for_each_call_argument_mut(args: &mut [PlaceOrSpread], f: &mut impl FnMut
 /// top-level lvalue — use `for_each_instruction_lvalue_mut` for that.
 pub fn for_each_instruction_value_lvalue_mut(
     value: &mut InstructionValue,
-    f: &mut impl FnMut(&mut Place),
+    f: &mut dyn FnMut(&mut Place),
 ) {
     match value {
         InstructionValue::DeclareContext { lvalue, .. }
@@ -1061,7 +1061,7 @@ pub fn for_each_instruction_value_lvalue_mut(
 
 /// In-place mutation of the instruction's lvalue and value's lvalues.
 /// Matches the same variants as TS `mapInstructionLValues` (skips DeclareContext/StoreContext).
-pub fn for_each_instruction_lvalue_mut(instr: &mut Instruction, f: &mut impl FnMut(&mut Place)) {
+pub fn for_each_instruction_lvalue_mut(instr: &mut Instruction, f: &mut dyn FnMut(&mut Place)) {
     match &mut instr.value {
         InstructionValue::DeclareLocal { lvalue, .. }
         | InstructionValue::StoreLocal { lvalue, .. } => {
@@ -1080,7 +1080,7 @@ pub fn for_each_instruction_lvalue_mut(instr: &mut Instruction, f: &mut impl FnM
 }
 
 /// In-place mutation of pattern operands.
-pub fn for_each_pattern_operand_mut(pattern: &mut Pattern, f: &mut impl FnMut(&mut Place)) {
+pub fn for_each_pattern_operand_mut(pattern: &mut Pattern, f: &mut dyn FnMut(&mut Place)) {
     match pattern {
         Pattern::Array(arr) => {
             for item in arr.items.iter_mut() {
@@ -1103,7 +1103,7 @@ pub fn for_each_pattern_operand_mut(pattern: &mut Pattern, f: &mut impl FnMut(&m
 }
 
 /// In-place mutation of terminal operand places.
-pub fn for_each_terminal_operand_mut(terminal: &mut Terminal, f: &mut impl FnMut(&mut Place)) {
+pub fn for_each_terminal_operand_mut(terminal: &mut Terminal, f: &mut dyn FnMut(&mut Place)) {
     match terminal {
         Terminal::If { test, .. } | Terminal::Branch { test, .. } => {
             f(test);

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/hir_builder.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/hir_builder.rs
@@ -345,6 +345,25 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
         }
     }
 
+    /// Insert `wip` into `completed` as a finished block terminated by `terminal`.
+    ///
+    /// Kept non-generic (and out-of-line) so the block-completion machinery compiles
+    /// once instead of being duplicated into every generic `try_enter*` instantiation.
+    #[inline(never)]
+    fn complete_block(&mut self, wip: WipBlock, terminal: Terminal) {
+        self.completed.insert(
+            wip.id,
+            BasicBlock {
+                kind: wip.kind,
+                id: wip.id,
+                instructions: wip.instructions,
+                terminal,
+                preds: FxIndexSet::default(),
+                phis: Vec::new(),
+            },
+        );
+    }
+
     /// Terminate the current block with the given terminal and start a new block.
     ///
     /// If `next_block_kind` is `Some`, a new current block is created with that kind.
@@ -358,17 +377,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
             std::mem::replace(&mut self.current, new_block(BlockId(u32::MAX), BlockKind::Block));
         let block_id = wip.id;
 
-        self.completed.insert(
-            block_id,
-            BasicBlock {
-                kind: wip.kind,
-                id: block_id,
-                instructions: wip.instructions,
-                terminal,
-                preds: FxIndexSet::default(),
-                phis: Vec::new(),
-            },
-        );
+        self.complete_block(wip, terminal);
 
         if let Some(kind) = next_block_kind {
             let next_id = self.env.next_block_id();
@@ -381,18 +390,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
     /// a previously reserved block as the new current block.
     pub fn terminate_with_continuation(&mut self, terminal: Terminal, continuation: WipBlock) {
         let wip = std::mem::replace(&mut self.current, continuation);
-        let block_id = wip.id;
-        self.completed.insert(
-            block_id,
-            BasicBlock {
-                kind: wip.kind,
-                id: block_id,
-                instructions: wip.instructions,
-                terminal,
-                preds: FxIndexSet::default(),
-                phis: Vec::new(),
-            },
-        );
+        self.complete_block(wip, terminal);
     }
 
     /// Reserve a new block so it can be referenced before construction.
@@ -412,17 +410,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
         let prev = std::mem::replace(&mut self.current, wip);
         let terminal = f(self)?;
         let completed_wip = std::mem::replace(&mut self.current, prev);
-        self.completed.insert(
-            completed_wip.id,
-            BasicBlock {
-                kind: completed_wip.kind,
-                id: completed_wip.id,
-                instructions: completed_wip.instructions,
-                terminal,
-                preds: FxIndexSet::default(),
-                phis: Vec::new(),
-            },
-        );
+        self.complete_block(completed_wip, terminal);
         Ok(())
     }
 


### PR DESCRIPTION
## What

Two monomorphization cuts in `oxc_react_compiler` that shrink generated code with **no behavior change**.

**1. Extract a non-generic `HirBuilder::complete_block`.** `try_enter_reserved` is generic over its closure and was instantiated 28×; the heavy, non-generic tail (constructing a `BasicBlock` + `FxIndexMap` insert) was inlined into every copy. Moving it into one `#[inline(never)]` helper compiles it once, and dedups the identical block copy-pasted in `terminate` and `terminate_with_continuation`.

**2. Erase the `for_each_*_mut` closures.** The six operand/lvalue iterators in `react_compiler_hir::visitors` took `&mut impl FnMut(&mut Place)`, so each walker body was monomorphized per distinct caller closure. Switching to `&mut dyn FnMut(&mut Place)` compiles each body once. Callers are unchanged (auto-coercion).

Both are "different-body" copies that fat-LTO cannot fold, so the savings are real in the shipped binary.

## Size impact

Measured on a fat-LTO build (`opt-level=3`, `lto="fat"`, `codegen-units=1`) of the `react_compiler` example, before vs after on an identical base (diff-only):

| `.text` section | bytes |
| --- | ---: |
| before | 2,867,912 |
| after | 2,845,812 |
| **reduction** | **−22,100 (~21.6 KiB, ~1.6% of the crate's code)** |

(`cargo llvm-lines` reports −5,368 pre-opt IR lines; LTO inlining multiplies the win across call sites, hence the larger real figure.)

## Correctness

`cargo test -p oxc_react_compiler` — the 1806-fixture snapshot corpus and 15 transform integration tests pass **byte-identically**; `cargo clippy` clean.

## Note on change 2

The `for_each_*_mut` iterators run on the per-instruction operand path, so change 2 swaps an inlinable direct closure call for a `dyn FnMut` indirect call. Correctness is verified but throughput is **not** benchmarked. If CI benchmarks flag a regression it can be dropped independently — change 1 is zero-risk (cold, once-per-block) and carries the rest of the win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
