### PR TITLE
fix(formatter): keep comments inside surviving parens and suppressed statement terminators

### DIFF
--- a/crates/oxc_formatter/AGENTS.md
+++ b/crates/oxc_formatter/AGENTS.md
@@ -90,9 +90,29 @@ The `;` rule applies to statement _terminators_ only, never to member _separator
   we follow Prettier for now. If Prettier extends the rule to them, follow;
   each is a small mechanical `FormatContentWithSemicolon` adoption
 
-When the content's source parentheses survive in the output (return/throw arguments),
+When the content's source parentheses survive in the output
+(return/throw arguments, sequence/assignment in the prettier#19263 positions),
 comments inside them belong to the content and stay there;
 only comments after the closing paren may move behind the terminator (see `Comments::end_including_source_parens`).
+
+The "which positions keep their parens" table is intentionally encoded twice:
+
+- `keeps_trailing_comment_inside_parens` (statement side, walks down the rightmost expression)
+- and `write_trailing_comments_inside_parens` (expression side, matches on the parent) in `print/semicolon.rs`
+
+The statement side promises not to hide/move the comment; the expression side actually prints it.
+Change them together: if they drift, the comment silently lands elsewhere (no assert catches it),
+so pin every position change in a fixture.
+
+The move-behind-the-terminator policy has four deliberate variants.
+When extending to a new node, pick by measuring Prettier, not by analogy:
+
+| Site                                                        | Source `;` required?      | Own-line comment before `;`              |
+| ----------------------------------------------------------- | ------------------------- | ---------------------------------------- |
+| Statements (`FormatContentWithSemicolon`)                   | yes (ASI: no move)        | deferred to the next node's leading pass |
+| return/throw (`ReturnAndThrowStatement`)                    | no (moves even under ASI) | printed as dangling                      |
+| Class property/accessor (`FormatClassElementWithSemicolon`) | yes                       | cancels the move (stays own-line)        |
+| Bodyless methods (`MethodDefinition`)                       | yes                       | cancels the move                         |
 
 Never let it cross:
 

--- a/crates/oxc_formatter/src/ast_nodes/generated/format.rs
+++ b/crates/oxc_formatter/src/ast_nodes/generated/format.rs
@@ -2027,7 +2027,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, DoWhileStatement<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            self.write_suppressed(f);
         } else {
             self.write(f);
         }
@@ -2154,7 +2154,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ContinueStatement<'a>> 
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            self.write_suppressed(f);
         } else {
             self.write(f);
         }
@@ -2167,7 +2167,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BreakStatement<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            self.write_suppressed(f);
         } else {
             self.write(f);
         }

--- a/crates/oxc_formatter/src/formatter/comments.rs
+++ b/crates/oxc_formatter/src/formatter/comments.rs
@@ -248,9 +248,42 @@ impl<'a> Comments<'a> {
         comments
     }
 
+    /// Comments sitting between `pos` and a closing source paren:
+    /// the run of comments after `pos` separated only by whitespace,
+    /// whose next non-whitespace character is `)`.
+    /// `None` when there is no such comment or another token intervenes.
+    ///
+    /// Lexical byte scan: the range starting at `pos` must contain only trivia and punctuation.
+    /// (e.g. an expression end up to the statement end)
+    /// A range containing a string literal would false-match a `)` inside it.
+    pub(crate) fn comments_before_closing_paren(&self, pos: u32) -> Option<&'a [Comment]> {
+        let comments = self.comments_after(pos);
+
+        let mut pos = pos;
+        let mut count = 0;
+        for comment in comments {
+            if comment.span.start < pos
+                || !self
+                    .source_text
+                    .all_bytes_match(pos, comment.span.start, |b| b.is_ascii_whitespace())
+            {
+                break;
+            }
+            count += 1;
+            pos = comment.span.end;
+        }
+
+        (count > 0 && self.source_text.next_non_whitespace_byte_is(pos, b')'))
+            .then(|| &comments[..count])
+    }
+
     /// Whether the source has a `;` between the given positions,
     /// ignoring `;` bytes inside comments (e.g. `foo /* ; */`).
     /// `false` when the source relies on ASI.
+    ///
+    /// Lexical byte scan: the range must contain only trivia and punctuation.
+    /// (e.g. a content end up to the statement end)
+    /// A range containing a string literal would false-match a `;` inside it.
     pub(crate) fn has_semicolon_in_range(&self, start: u32, end: u32) -> bool {
         let mut pos = start;
         for comment in self.comments_in_range(start, end) {
@@ -272,6 +305,10 @@ impl<'a> Comments<'a> {
     ///
     /// Comments before this position sit inside the parentheses and belong to the content;
     /// only comments after it may move behind the semicolon.
+    ///
+    /// Lexical byte scan: the range must contain only trivia and punctuation.
+    /// (e.g. a content end up to the statement end)
+    /// A range containing a string literal would false-match a `)` inside it.
     pub(crate) fn end_including_source_parens(&self, content_end: u32, node_end: u32) -> u32 {
         #[expect(clippy::cast_possible_truncation)] // Offsets fit in `u32`, source length does
         let position_after_last_close_paren = |from: u32, to: u32| {

--- a/crates/oxc_formatter/src/print/class.rs
+++ b/crates/oxc_formatter/src/print/class.rs
@@ -636,6 +636,9 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatClassElementWithSemicolon<'a,
                     unreachable!("Only `PropertyDefinition` and `AccessorProperty` can reach here");
                 }
             };
+            // A definite/optional marker may sit between `content_end` and the `;`
+            // (`z? /* e */;` -> `content_end` is after `z`);
+            // the comment still ends up behind the semicolon like Prettier.
             let content_end = value_end.or(type_annotation_end).unwrap_or(key_end);
             // An own-line comment before the semicolon stays attached to the value
             // (`x = 1 \n /* own */;` keeps the comment on its own line like Prettier),

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -89,7 +89,10 @@ use self::{
     object_pattern_like::ObjectPatternLike,
     program::FormatStatementsWithImports,
     return_or_throw_statement::FormatAdjacentArgument,
-    semicolon::{FormatContentWithSemicolon, OptionalSemicolon},
+    semicolon::{
+        FormatContentWithSemicolon, OptionalSemicolon, keeps_trailing_comment_inside_parens,
+        write_trailing_comments_inside_parens,
+    },
     type_parameters::{FormatTSTypeParameters, FormatTSTypeParametersOptions},
 };
 
@@ -97,6 +100,16 @@ pub trait FormatWrite<'ast, T = ()> {
     fn write(&self, f: &mut JsFormatter<'_, 'ast>);
     fn write_with_options(&self, _options: T, _f: &mut JsFormatter<'_, 'ast>) {
         unreachable!("Please implement it first.");
+    }
+    /// Formats the node when it is suppressed (`oxfmt-ignore` / `prettier-ignore`).
+    /// Only called for statements whose ignored range must exclude the trailing semicolon,
+    /// so the formatter prints its own terminator, like Prettier;
+    /// every other node prints its whole span verbatim in the generated `fmt`.
+    fn write_suppressed(&self, _f: &mut JsFormatter<'_, 'ast>) {
+        unreachable!(
+            "Implement `write_suppressed` for every node listed in \
+             `AST_NODE_WITH_CUSTOM_SUPPRESSED_FORMATTING` (tasks/ast_tools)."
+        );
     }
 }
 
@@ -310,6 +323,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ConditionalExpression<'a>> {
 impl<'a> FormatWrite<'a> for AstNode<'a, AssignmentExpression<'a>> {
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         AssignmentLike::AssignmentExpression(self).fmt(f);
+        write_trailing_comments_inside_parens(f, self.parent(), self.span().end, false);
     }
 }
 
@@ -600,14 +614,41 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ExpressionStatement<'a>> {
         }
 
         let expression = self.expression();
-        write!(
-            f,
-            FormatContentWithSemicolon::new(expression, expression.span().end, self.span().end)
-        );
+        // A trailing comment right before the closing paren of the rightmost
+        // sequence/assignment stays inside the parentheses;
+        // extend the content past the closing paren so the comment is not moved behind the semicolon
+        // (the sub-expression prints it, see `keeps_trailing_comment_inside_parens`).
+        let expression_end = expression.span().end;
+        let content_end = if keeps_trailing_comment_inside_parens(expression.as_ref(), false) {
+            f.comments().end_including_source_parens(expression_end, self.span().end)
+        } else {
+            expression_end
+        };
+        write!(f, FormatContentWithSemicolon::new(expression, content_end, self.span().end));
     }
 }
 
+/// Prints a suppressed statement whose ignored range excludes the trailing semicolon:
+/// the source from `start` up to `content_end` verbatim,
+/// then the formatter's own terminator, like Prettier (prettier#18678).
+/// Comments between `content_end` and the end of the statement are left
+/// for the next node's leading-comments pass.
+fn write_suppressed_statement_with_semicolon(
+    start: u32,
+    content_end: u32,
+    f: &mut JsFormatter<'_, '_>,
+) {
+    write!(f, [FormatSuppressedNode(Span::new(start, content_end)), OptionalSemicolon]);
+}
+
 impl<'a> FormatWrite<'a> for AstNode<'a, DoWhileStatement<'a>> {
+    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
+        // The ignored range ends at the closing paren
+        let rparen_end =
+            f.comments().end_including_source_parens(self.test().span().end, self.span().end);
+        write_suppressed_statement_with_semicolon(self.span().start, rparen_end, f);
+    }
+
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         let body = self.body();
         write!(f, group(&format_args!("do", FormatStatementBody::new(body))));
@@ -881,6 +922,16 @@ impl<'a> FormatWrite<'a> for AstNode<'a, IfStatement<'a>> {
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ContinueStatement<'a>> {
+    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
+        #[expect(clippy::cast_possible_truncation)]
+        const CONTINUE_KEYWORD_LEN: u32 = "continue".len() as u32;
+
+        // The ignored range ends at the label (or the keyword)
+        let content_end =
+            self.label().map_or_else(|| self.span().start + CONTINUE_KEYWORD_LEN, |l| l.span().end);
+        write_suppressed_statement_with_semicolon(self.span().start, content_end, f);
+    }
+
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         if let Some(label) = self.label() {
             let content = format_with(|f| write!(f, ["continue", space(), label]));
@@ -892,6 +943,16 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ContinueStatement<'a>> {
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, BreakStatement<'a>> {
+    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
+        #[expect(clippy::cast_possible_truncation)]
+        const BREAK_KEYWORD_LEN: u32 = "break".len() as u32;
+
+        // The ignored range ends at the label (or the keyword)
+        let content_end =
+            self.label().map_or_else(|| self.span().start + BREAK_KEYWORD_LEN, |l| l.span().end);
+        write_suppressed_statement_with_semicolon(self.span().start, content_end, f);
+    }
+
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         if let Some(label) = self.label() {
             let content = format_with(|f| write!(f, ["break", space(), label]));

--- a/crates/oxc_formatter/src/print/semicolon.rs
+++ b/crates/oxc_formatter/src/print/semicolon.rs
@@ -1,6 +1,7 @@
-use oxc_ast::ast::Comment;
+use oxc_ast::ast::{Comment, Expression};
 
 use crate::{
+    ast_nodes::AstNodes,
     formatter::{Buffer, Format, JsFormatContext, JsFormatter, trivia::FormatTrailingComments},
     options::Semicolons,
     utils::format_node_without_trailing_comments::format_content_without_comments_after,
@@ -47,6 +48,59 @@ pub fn trailing_comments_to_move_behind_semicolon<'a>(
         return None;
     }
     Some(trailing_comments)
+}
+
+/// Whether a trailing comment sitting right before the closing source paren of
+/// the rightmost sub-expression stays inside the re-printed parentheses,
+/// instead of moving behind the semicolon.
+///
+/// Mirrors Prettier's `handleParenthesizedExpressionTrailingComment` (prettier#19263):
+/// a parenthesized sequence/assignment keeps the comment when it is a variable declarator initializer,
+/// a `return` argument, an arrow expression body, or an assignment's right-hand side.
+/// Positions where the parentheses survive in the output. (Notably not `throw` and not a plain expression statement.)
+/// The sequence/assignment itself prints the comment before its closing paren.
+///
+/// `gated` is `true` when `expr` itself sits in one of those positions.
+pub fn keeps_trailing_comment_inside_parens(expr: &Expression<'_>, gated: bool) -> bool {
+    match expr {
+        Expression::SequenceExpression(_) => gated,
+        Expression::AssignmentExpression(assignment) => {
+            gated
+                || match &assignment.right {
+                    Expression::SequenceExpression(_) => true,
+                    right => keeps_trailing_comment_inside_parens(right, false),
+                }
+        }
+        Expression::ArrowFunctionExpression(arrow) if arrow.expression => arrow
+            .get_expression()
+            .is_some_and(|body| keeps_trailing_comment_inside_parens(body, true)),
+        _ => false,
+    }
+}
+
+/// The printing half of [`keeps_trailing_comment_inside_parens`]:
+/// sequence/assignment call this at the end of their `write` to print the comments
+/// sitting right before their closing source paren inside the parentheses.
+///
+/// `is_sequence` distinguishes the one asymmetric position:
+/// only a sequence keeps its parens as an assignment's right-hand side.
+pub fn write_trailing_comments_inside_parens<'a>(
+    f: &mut JsFormatter<'_, 'a>,
+    parent: &AstNodes<'a>,
+    node_end: u32,
+    is_sequence: bool,
+) {
+    let parens_survive = match parent {
+        AstNodes::VariableDeclarator(_) | AstNodes::ReturnStatement(_) => true,
+        AstNodes::AssignmentExpression(_) => is_sequence,
+        AstNodes::ExpressionStatement(statement) => statement.is_arrow_function_body(),
+        _ => false,
+    };
+    if parens_survive
+        && let Some(comments) = f.context().comments().comments_before_closing_paren(node_end)
+    {
+        write!(f, FormatTrailingComments::Comments(comments));
+    }
 }
 
 /// Formats `content` followed by an `OptionalSemicolon`,

--- a/crates/oxc_formatter/src/print/sequence_expression.rs
+++ b/crates/oxc_formatter/src/print/sequence_expression.rs
@@ -3,6 +3,7 @@ use oxc_ast::ast::*;
 use crate::{
     ast_nodes::{AstNode, AstNodes},
     formatter::{Format, JsFormatter, prelude::*},
+    print::semicolon::write_trailing_comments_inside_parens,
     write,
 };
 
@@ -42,6 +43,10 @@ impl<'a> FormatWrite<'a> for AstNode<'a, SequenceExpression<'a>> {
             } else {
                 rest.fmt(f);
             }
+
+            // Print the comments before the closing paren inside the group,
+            // so they stay on the last expression's line.
+            write_trailing_comments_inside_parens(f, self.parent(), self.span.end, true);
         });
 
         // For arrow bodies, own the `soft_block_indent` so the break decision is made

--- a/crates/oxc_formatter/src/print/variable_declaration.rs
+++ b/crates/oxc_formatter/src/print/variable_declaration.rs
@@ -2,7 +2,7 @@ use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 
-use crate::print::semicolon::FormatContentWithSemicolon;
+use crate::print::semicolon::{FormatContentWithSemicolon, keeps_trailing_comment_inside_parens};
 use crate::utils::assignment_like::AssignmentLike;
 use crate::{
     ast_nodes::{AstNode, AstNodes},
@@ -24,6 +24,8 @@ impl<'a> FormatWrite<'a> for AstNode<'a, VariableDeclaration<'a>> {
             }
             AstNodes::ForInStatement(stmt) => stmt.left().span() != self.span(),
             AstNodes::ForOfStatement(stmt) => stmt.left().span() != self.span(),
+            // Everywhere else the declaration terminates itself, including `export const ...`,
+            // whose `ExportNamedDeclaration` prints no semicolon of its own (see its `FormatWrite` implementation).
             _ => true,
         };
 
@@ -34,15 +36,22 @@ impl<'a> FormatWrite<'a> for AstNode<'a, VariableDeclaration<'a>> {
         let declarations = self.declarations();
         let format_declarations = format_with(|f| {
             if semicolon {
-                let declarations_end =
-                    declarations.as_ref().last().map_or(self.span().end, |d| d.span().end);
+                let last_declarator = declarations.as_ref().last();
+                let declarations_end = last_declarator.map_or(self.span().end, |d| d.span().end);
+                // A trailing comment right before the closing paren of the last initializer stays inside the parentheses;
+                // extend the content past the closing paren so the comment is not moved behind the semicolon
+                // (the initializer prints it, see `keeps_trailing_comment_inside_parens`).
+                let keeps_comment_inside_parens = last_declarator
+                    .and_then(|declarator| declarator.init.as_ref())
+                    .is_some_and(|init| keeps_trailing_comment_inside_parens(init, true));
+                let content_end = if keeps_comment_inside_parens {
+                    f.comments().end_including_source_parens(declarations_end, self.span().end)
+                } else {
+                    declarations_end
+                };
                 write!(
                     f,
-                    FormatContentWithSemicolon::new(
-                        declarations,
-                        declarations_end,
-                        self.span().end
-                    )
+                    FormatContentWithSemicolon::new(declarations, content_end, self.span().end)
                 );
             } else {
                 write!(f, declarations);

--- a/crates/oxc_formatter/tests/fixtures/js/comments/parenthesized-trailing-comment.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/parenthesized-trailing-comment.js
@@ -1,0 +1,34 @@
+// A trailing comment right before the closing source paren stays inside the
+// parentheses when they survive in the output (Prettier >= 3.9):
+// sequence/assignment as a declarator init, return argument, arrow expression
+// body, or an assignment's right-hand side
+const x1 = (a, b, c /* comment */);
+const x2 = (a = c /* comment */);
+assigned = (a, b, c /* comment */);
+nested = other = (a, b /* nested right */);
+fn = () => (a, b, c /* abc */);
+fn2 = () => (a = b /* abc */);
+const g = () => (a, b /* arrow in init */);
+function f() {
+  return (a, b, c /* ret seq */);
+  return (a = c /* ret assign */);
+}
+multilineCase = (someParameter) => (
+  someVeryLongExpressionName,
+  anotherVeryLongExpressionName,
+  yetAnotherVeryLongExpressionName /* abc */
+);
+
+// A plain expression statement, call arguments, and removable parens
+// don't keep the comment inside
+(a, b, c /* stmt */);
+(foo() /* removable */);
+callee((a, b /* call arg */));
+
+// throw does not keep it either (Prettier keeps it between `)` and `;`), and
+// `export default` differs: Prettier prints `(a, b) /* c */;`,
+// we move it behind the semicolon uniformly
+function t() {
+  throw (a = b /* throw assign */);
+}
+export default (a, b /* export default */);

--- a/crates/oxc_formatter/tests/fixtures/js/comments/parenthesized-trailing-comment.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/parenthesized-trailing-comment.js.snap
@@ -1,0 +1,117 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// A trailing comment right before the closing source paren stays inside the
+// parentheses when they survive in the output (Prettier >= 3.9):
+// sequence/assignment as a declarator init, return argument, arrow expression
+// body, or an assignment's right-hand side
+const x1 = (a, b, c /* comment */);
+const x2 = (a = c /* comment */);
+assigned = (a, b, c /* comment */);
+nested = other = (a, b /* nested right */);
+fn = () => (a, b, c /* abc */);
+fn2 = () => (a = b /* abc */);
+const g = () => (a, b /* arrow in init */);
+function f() {
+  return (a, b, c /* ret seq */);
+  return (a = c /* ret assign */);
+}
+multilineCase = (someParameter) => (
+  someVeryLongExpressionName,
+  anotherVeryLongExpressionName,
+  yetAnotherVeryLongExpressionName /* abc */
+);
+
+// A plain expression statement, call arguments, and removable parens
+// don't keep the comment inside
+(a, b, c /* stmt */);
+(foo() /* removable */);
+callee((a, b /* call arg */));
+
+// throw does not keep it either (Prettier keeps it between `)` and `;`), and
+// `export default` differs: Prettier prints `(a, b) /* c */;`,
+// we move it behind the semicolon uniformly
+function t() {
+  throw (a = b /* throw assign */);
+}
+export default (a, b /* export default */);
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// A trailing comment right before the closing source paren stays inside the
+// parentheses when they survive in the output (Prettier >= 3.9):
+// sequence/assignment as a declarator init, return argument, arrow expression
+// body, or an assignment's right-hand side
+const x1 = (a, b, c /* comment */);
+const x2 = (a = c /* comment */);
+assigned = (a, b, c /* comment */);
+nested = other = (a, b /* nested right */);
+fn = () => (a, b, c /* abc */);
+fn2 = () => (a = b /* abc */);
+const g = () => (a, b /* arrow in init */);
+function f() {
+  return (a, b, c /* ret seq */);
+  return (a = c /* ret assign */);
+}
+multilineCase = (someParameter) => (
+  someVeryLongExpressionName,
+  anotherVeryLongExpressionName,
+  yetAnotherVeryLongExpressionName /* abc */
+);
+
+// A plain expression statement, call arguments, and removable parens
+// don't keep the comment inside
+(a, b, c); /* stmt */
+foo(); /* removable */
+callee((a, b) /* call arg */);
+
+// throw does not keep it either (Prettier keeps it between `)` and `;`), and
+// `export default` differs: Prettier prints `(a, b) /* c */;`,
+// we move it behind the semicolon uniformly
+function t() {
+  throw (a = b) /* throw assign */;
+}
+export default (a, b); /* export default */
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// A trailing comment right before the closing source paren stays inside the
+// parentheses when they survive in the output (Prettier >= 3.9):
+// sequence/assignment as a declarator init, return argument, arrow expression
+// body, or an assignment's right-hand side
+const x1 = (a, b, c /* comment */);
+const x2 = (a = c /* comment */);
+assigned = (a, b, c /* comment */);
+nested = other = (a, b /* nested right */);
+fn = () => (a, b, c /* abc */);
+fn2 = () => (a = b /* abc */);
+const g = () => (a, b /* arrow in init */);
+function f() {
+  return (a, b, c /* ret seq */);
+  return (a = c /* ret assign */);
+}
+multilineCase = (someParameter) => (
+  someVeryLongExpressionName,
+  anotherVeryLongExpressionName,
+  yetAnotherVeryLongExpressionName /* abc */
+);
+
+// A plain expression statement, call arguments, and removable parens
+// don't keep the comment inside
+(a, b, c); /* stmt */
+foo(); /* removable */
+callee((a, b) /* call arg */);
+
+// throw does not keep it either (Prettier keeps it between `)` and `;`), and
+// `export default` differs: Prettier prints `(a, b) /* c */;`,
+// we move it behind the semicolon uniformly
+function t() {
+  throw (a = b) /* throw assign */;
+}
+export default (a, b); /* export default */
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-statement.js
+++ b/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-statement.js
@@ -1,0 +1,29 @@
+// A suppressed statement keeps its source text up to the content end;
+// the terminator is printed by the formatter (`;` added or removed per options),
+// and comments between the content and the source `;` lead the next statement.
+
+// prettier-ignore
+do;   while(   1)
+
+;[].sort()
+
+// prettier-ignore
+do  {}   while(   two  );
+
+lbl: for (;;) {
+  // prettier-ignore
+  continue                   lbl
+
+  // breaking comment
+  ;(possibleArray || []).sort()
+}
+
+lbl2: for (;;) {
+  // prettier-ignore
+  break                   lbl2;
+}
+
+lbl3: for (;;) {
+  // prettier-ignore
+  break   lbl3
+}

--- a/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-statement.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-statement.js.snap
@@ -1,0 +1,168 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// A suppressed statement keeps its source text up to the content end;
+// the terminator is printed by the formatter (`;` added or removed per options),
+// and comments between the content and the source `;` lead the next statement.
+
+// prettier-ignore
+do;   while(   1)
+
+;[].sort()
+
+// prettier-ignore
+do  {}   while(   two  );
+
+lbl: for (;;) {
+  // prettier-ignore
+  continue                   lbl
+
+  // breaking comment
+  ;(possibleArray || []).sort()
+}
+
+lbl2: for (;;) {
+  // prettier-ignore
+  break                   lbl2;
+}
+
+lbl3: for (;;) {
+  // prettier-ignore
+  break   lbl3
+}
+
+==================== Output ====================
+------------------------------
+{ printWidth: 80, semi: true }
+------------------------------
+// A suppressed statement keeps its source text up to the content end;
+// the terminator is printed by the formatter (`;` added or removed per options),
+// and comments between the content and the source `;` lead the next statement.
+
+// prettier-ignore
+do;   while(   1);
+
+[].sort();
+
+// prettier-ignore
+do  {}   while(   two  );
+
+lbl: for (;;) {
+  // prettier-ignore
+  continue                   lbl;
+
+  // breaking comment
+  (possibleArray || []).sort();
+}
+
+lbl2: for (;;) {
+  // prettier-ignore
+  break                   lbl2;
+}
+
+lbl3: for (;;) {
+  // prettier-ignore
+  break   lbl3;
+}
+
+-------------------------------
+{ printWidth: 100, semi: true }
+-------------------------------
+// A suppressed statement keeps its source text up to the content end;
+// the terminator is printed by the formatter (`;` added or removed per options),
+// and comments between the content and the source `;` lead the next statement.
+
+// prettier-ignore
+do;   while(   1);
+
+[].sort();
+
+// prettier-ignore
+do  {}   while(   two  );
+
+lbl: for (;;) {
+  // prettier-ignore
+  continue                   lbl;
+
+  // breaking comment
+  (possibleArray || []).sort();
+}
+
+lbl2: for (;;) {
+  // prettier-ignore
+  break                   lbl2;
+}
+
+lbl3: for (;;) {
+  // prettier-ignore
+  break   lbl3;
+}
+
+-------------------------------
+{ printWidth: 80, semi: false }
+-------------------------------
+// A suppressed statement keeps its source text up to the content end;
+// the terminator is printed by the formatter (`;` added or removed per options),
+// and comments between the content and the source `;` lead the next statement.
+
+// prettier-ignore
+do;   while(   1)
+
+;[].sort()
+
+// prettier-ignore
+do  {}   while(   two  )
+
+lbl: for (;;) {
+  // prettier-ignore
+  continue                   lbl
+
+  // breaking comment
+  ;(possibleArray || []).sort()
+}
+
+lbl2: for (;;) {
+  // prettier-ignore
+  break                   lbl2
+}
+
+lbl3: for (;;) {
+  // prettier-ignore
+  break   lbl3
+}
+
+--------------------------------
+{ printWidth: 100, semi: false }
+--------------------------------
+// A suppressed statement keeps its source text up to the content end;
+// the terminator is printed by the formatter (`;` added or removed per options),
+// and comments between the content and the source `;` lead the next statement.
+
+// prettier-ignore
+do;   while(   1)
+
+;[].sort()
+
+// prettier-ignore
+do  {}   while(   two  )
+
+lbl: for (;;) {
+  // prettier-ignore
+  continue                   lbl
+
+  // breaking comment
+  ;(possibleArray || []).sort()
+}
+
+lbl2: for (;;) {
+  // prettier-ignore
+  break                   lbl2
+}
+
+lbl3: for (;;) {
+  // prettier-ignore
+  break   lbl3
+}
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/ts/semi/trailing-comments.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/semi/trailing-comments.ts
@@ -116,6 +116,12 @@ class Cls {
   e = 5;
 }
 
+// A definite/optional marker between the content end and the `;`
+class Markers {
+  x!: number /* m1 */;
+  z? /* m2 */;
+}
+
 // Bodyless method signatures (overloads, abstract, ambient) move the comment
 // behind the semicolon too; an own-line comment stays in place
 class Overloads {

--- a/crates/oxc_formatter/tests/fixtures/ts/semi/trailing-comments.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/semi/trailing-comments.ts.snap
@@ -120,6 +120,12 @@ class Cls {
   e = 5;
 }
 
+// A definite/optional marker between the content end and the `;`
+class Markers {
+  x!: number /* m1 */;
+  z? /* m2 */;
+}
+
 // Bodyless method signatures (overloads, abstract, ambient) move the comment
 // behind the semicolon too; an own-line comment stays in place
 class Overloads {
@@ -266,6 +272,12 @@ class Cls {
   e = 5
 }
 
+// A definite/optional marker between the content end and the `;`
+class Markers {
+  x!: number /* m1 */
+  z? /* m2 */
+}
+
 // Bodyless method signatures (overloads, abstract, ambient) move the comment
 // behind the semicolon too; an own-line comment stays in place
 class Overloads {
@@ -403,6 +415,12 @@ class Cls {
   d = 4 /* keeps */
   /* own line */
   e = 5
+}
+
+// A definite/optional marker between the content end and the `;`
+class Markers {
+  x!: number /* m1 */
+  z? /* m2 */
 }
 
 // Bodyless method signatures (overloads, abstract, ambient) move the comment
@@ -549,6 +567,12 @@ class Cls {
   e = 5;
 }
 
+// A definite/optional marker between the content end and the `;`
+class Markers {
+  x!: number; /* m1 */
+  z?; /* m2 */
+}
+
 // Bodyless method signatures (overloads, abstract, ambient) move the comment
 // behind the semicolon too; an own-line comment stays in place
 class Overloads {
@@ -686,6 +710,12 @@ class Cls {
   d = 4 /* keeps */;
   /* own line */
   e = 5;
+}
+
+// A definite/optional marker between the content end and the `;`
+class Markers {
+  x!: number; /* m1 */
+  z?; /* m2 */
 }
 
 // Bodyless method signatures (overloads, abstract, ambient) move the comment

--- a/tasks/ast_tools/src/generators/formatter/format.rs
+++ b/tasks/ast_tools/src/generators/formatter/format.rs
@@ -36,6 +36,19 @@ const AST_NODE_WITHOUT_PRINTING_COMMENTS_LIST: &[&str] = &[
 const AST_NODE_WITHOUT_PRINTING_LEADING_COMMENTS_LIST: &[&str] =
     &["TSUnionType", "ExpressionStatement"];
 
+// Statements whose suppressed (`oxfmt-ignore`d) range must exclude the trailing semicolon,
+// so the formatter prints its own terminator like Prettier's ignored range.
+// Every node listed here MUST implement `FormatWrite::write_suppressed`
+// (the default implementation panics at runtime).
+//
+// Other semicolon-terminated statements have the same issue in principle,
+// (`ExpressionStatement`, `VariableDeclaration`, ...)
+// but only these three have a confirmed divergence against Prettier 3.9.
+// (return/throw already handle their suppression in their own `write`)
+// Extend the list one statement at a time, verifying each against Prettier first.
+const AST_NODE_WITH_CUSTOM_SUPPRESSED_FORMATTING: &[&str] =
+    &["BreakStatement", "ContinueStatement", "DoWhileStatement"];
+
 const AST_NODE_NEEDS_PARENTHESES: &[&str] = &[
     "TSTypeAssertion",
     "TSInferType",
@@ -174,6 +187,12 @@ fn generate_struct_implementation(
         let write_implementation = if suppressed_check.is_none() {
             write_call
         } else {
+            let suppressed_write =
+                if AST_NODE_WITH_CUSTOM_SUPPRESSED_FORMATTING.contains(&struct_name) {
+                    quote! { self.write_suppressed(f); }
+                } else {
+                    quote! { FormatSuppressedNode(self.span()).fmt(f); }
+                };
             // When `fmt` doesn't print leading/trailing comments itself,
             // the suppressed path still has to print them, or the suppression comment would be lost.
             let suppressed_leading_comments = do_not_print_leading_comment.then(|| {
@@ -189,7 +208,7 @@ fn generate_struct_implementation(
             quote! {
                 if is_suppressed {
                     #suppressed_leading_comments
-                    FormatSuppressedNode(self.span()).fmt(f);
+                    #suppressed_write
                     #suppressed_trailing_comments
                 } else {
                     #write_call

--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,18 +1,15 @@
-js compatibility: 755/808 (93.44%), 23 files skipped
+js compatibility: 760/808 (94.06%), 23 files skipped
 
 # Failed
 
 | Spec path | Failed or Passed | Match ratio |
 | :-------- | :--------------: | :---------: |
 | js/arrows/issue-17421.js | 💥💥 | 90.43% |
-| js/arrows/parenthesized-body/issue-18776.js | 💥 | 85.71% |
-| js/arrows/parenthesized-body/issue-19261.js | 💥 | 77.78% |
 | js/assignment-comments/indentable-block-comment.js | 💥 | 12.50% |
 | js/call/no-argument/no-arguments.js | 💥 | 57.53% |
 | js/chain-expression/member-chain.js | 💥 | 57.14% |
 | js/comments/15661.js | 💥💥 | 43.53% |
 | js/comments/break-continue-statements-2.js | 💥💥 | 87.18% |
-| js/comments/break-continue-statements-3.js | 💥💥 | 95.77% |
 | js/comments/empty-statements.js | 💥💥 | 90.91% |
 | js/comments/if.js | 💥💥 | 97.99% |
 | js/comments/return-statement-2.js | 💥💥 | 77.78% |
@@ -41,7 +38,6 @@ js compatibility: 755/808 (93.44%), 23 files skipped
 | js/logical-expressions/in-unary-expression.js | 💥 | 33.33% |
 | js/new-expression/parentheses.js | 💥 | 33.33% |
 | js/no-semi/debugger-statement.js | 💥💥 | 91.18% |
-| js/no-semi/do-while-statement.js | 💥💥 | 92.50% |
 | js/no-semi/for-in-statement.js | 💥💥 | 63.89% |
 | js/no-semi/for-of-statement.js | 💥💥 | 66.67% |
 | js/no-semi/for-statement.js | 💥💥 | 63.89% |
@@ -50,7 +46,6 @@ js compatibility: 755/808 (93.44%), 23 files skipped
 | js/no-semi/return-statement.js | 💥💥 | 67.65% |
 | js/no-semi/while-statement.js | 💥💥 | 63.89% |
 | js/no-semi/with-statement.js | 💥💥 | 63.89% |
-| js/sequence-expression/parenthesized-trailing-comment.js | 💥 | 88.57% |
 | js/template-literals/expression-break.js | 💥 | 80.00% |
 | js/template-literals/expressions.js | 💥 | 97.64% |
 | js/test-declarations/jest-each.js | 💥💥 | 95.71% |


### PR DESCRIPTION
Fix regression found in this series of PRs.
