### PR TITLE
fix(linter): emit repo-relative paths in github format output

### DIFF
--- a/apps/oxlint/src/output_formatter/github.rs
+++ b/apps/oxlint/src/output_formatter/github.rs
@@ -1,4 +1,8 @@
 use std::borrow::Cow;
+use std::path::{Path, PathBuf};
+
+#[cfg(windows)]
+use cow_utils::CowUtils;
 
 use oxc_diagnostics::{
     Error, Severity,
@@ -6,7 +10,7 @@ use oxc_diagnostics::{
 };
 
 use super::default::get_diagnostic_result_output;
-use crate::output_formatter::InternalFormatter;
+use crate::output_formatter::{InternalFormatter, get_repo_path_prefix};
 
 #[derive(Debug)]
 pub struct GithubOutputFormatter;
@@ -17,13 +21,23 @@ impl InternalFormatter for GithubOutputFormatter {
     }
 
     fn get_diagnostic_reporter(&self) -> Box<dyn DiagnosticReporter> {
-        Box::new(GithubReporter)
+        Box::new(GithubReporter::default())
     }
 }
 
 /// Formats reports using [GitHub Actions
 /// annotations](https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-error-message). Useful for reporting in CI.
-struct GithubReporter;
+struct GithubReporter {
+    /// Path prefix to prepend to CWD-relative paths to make them repo-relative.
+    /// `None` if CWD is the git root or if we're not in a git repository.
+    repo_path_prefix: Option<PathBuf>,
+}
+
+impl GithubReporter {
+    fn default() -> Self {
+        Self { repo_path_prefix: get_repo_path_prefix() }
+    }
+}
 
 impl DiagnosticReporter for GithubReporter {
     fn finish(&mut self, result: &DiagnosticResult) -> Option<String> {
@@ -35,17 +49,34 @@ impl DiagnosticReporter for GithubReporter {
     }
 
     fn render_error(&mut self, error: Error) -> Option<String> {
-        Some(format_github(&error))
+        Some(format_github(&error, self.repo_path_prefix.as_deref()))
     }
 }
 
-fn format_github(diagnostic: &Error) -> String {
+fn format_github(diagnostic: &Error, repo_path_prefix: Option<&Path>) -> String {
     let Info { start, end, filename, message, severity, rule_id } = Info::new(diagnostic);
     let severity = match severity {
         Severity::Error => "error",
         Severity::Warning | miette::Severity::Advice => "warning",
     };
     let title = rule_id.map_or(Cow::Borrowed("oxlint"), Cow::Owned);
+    // GitHub Actions resolves relative annotation paths against the workspace
+    // (repository) root, not the process CWD, so adjust accordingly.
+    let filename = match repo_path_prefix {
+        Some(prefix) if !filename.is_empty() => {
+            // only do the path swap on Windows
+            #[cfg(windows)]
+            {
+                let combined = prefix.join(&filename);
+                combined.to_string_lossy().cow_replace('\\', "/").into_owned()
+            }
+            #[cfg(not(windows))]
+            {
+                prefix.join(&filename).to_string_lossy().to_string()
+            }
+        }
+        _ => filename,
+    };
     let filename = escape_property(&filename);
 
     if filename.is_empty() {
@@ -101,6 +132,7 @@ fn escape_property(value: &str) -> String {
 
 #[cfg(test)]
 mod test {
+    use std::path::Path;
     use std::time::Duration;
 
     use oxc_diagnostics::{
@@ -109,7 +141,7 @@ mod test {
     };
     use oxc_span::Span;
 
-    use super::{GithubOutputFormatter, GithubReporter};
+    use super::{GithubOutputFormatter, GithubReporter, format_github};
     use crate::output_formatter::{InternalFormatter, LintCommandInfo};
 
     #[test]
@@ -147,7 +179,7 @@ mod test {
 
     #[test]
     fn reporter_finish() {
-        let mut reporter = GithubReporter;
+        let mut reporter = GithubReporter { repo_path_prefix: None };
 
         let result = reporter.finish(&DiagnosticResult::default());
 
@@ -156,7 +188,7 @@ mod test {
 
     #[test]
     fn reporter_finish_with_errors() {
-        let mut reporter = GithubReporter;
+        let mut reporter = GithubReporter { repo_path_prefix: None };
 
         let result = reporter.finish(&DiagnosticResult::new(2, 1, false));
 
@@ -165,7 +197,7 @@ mod test {
 
     #[test]
     fn reporter_error() {
-        let mut reporter = GithubReporter;
+        let mut reporter = GithubReporter { repo_path_prefix: None };
         let error = OxcDiagnostic::warn("error message")
             .with_label(Span::new(0, 8))
             .with_source_code(NamedSource::new("file://test.ts", "debugger;"));
@@ -180,8 +212,52 @@ mod test {
     }
 
     #[test]
+    fn format_github_with_prefix() {
+        let error = OxcDiagnostic::warn("error message")
+            .with_label(Span::new(0, 8))
+            .with_source_code(NamedSource::new("example.js", "debugger;"));
+
+        let result = format_github(&error, Some(Path::new("packages/foo")));
+
+        assert_eq!(
+            result,
+            "::warning file=packages/foo/example.js,line=1,endLine=1,col=1,endColumn=9,title=oxlint::error message\n"
+        );
+    }
+
+    #[test]
+    fn format_github_without_prefix() {
+        let error = OxcDiagnostic::warn("error message")
+            .with_label(Span::new(0, 8))
+            .with_source_code(NamedSource::new("example.js", "debugger;"));
+
+        let result = format_github(&error, None);
+
+        assert_eq!(
+            result,
+            "::warning file=example.js,line=1,endLine=1,col=1,endColumn=9,title=oxlint::error message\n"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn format_github_windows_normalization() {
+        let error = OxcDiagnostic::warn("error message")
+            .with_label(Span::new(0, 8))
+            .with_source_code(NamedSource::new("example.js", "debugger;"));
+
+        // Windows-style prefix with backslashes should be normalized to forward slashes
+        let result = format_github(&error, Some(Path::new(r"packages\foo")));
+
+        assert_eq!(
+            result,
+            "::warning file=packages/foo/example.js,line=1,endLine=1,col=1,endColumn=9,title=oxlint::error message\n"
+        );
+    }
+
+    #[test]
     fn reporter_error_without_labels_omits_file_and_location() {
-        let mut reporter = GithubReporter;
+        let mut reporter = GithubReporter { repo_path_prefix: None };
         let error = OxcDiagnostic::warn("warning message")
             .with_error_code("scope", "rule")
             .with_help("help message")
@@ -194,8 +270,20 @@ mod test {
     }
 
     #[test]
+    fn format_github_fileless_error_ignores_prefix() {
+        let error = OxcDiagnostic::warn("warning message")
+            .with_error_code("scope", "rule")
+            .with_help("help message")
+            .with_note("note message");
+
+        let result = format_github(&error.into(), Some(Path::new("packages/foo")));
+
+        assert_eq!(result, "::warning title=scope(rule)::warning message\n");
+    }
+
+    #[test]
     fn reporter_fileless_error_uses_error_annotation() {
-        let mut reporter = GithubReporter;
+        let mut reporter = GithubReporter { repo_path_prefix: None };
         let error = OxcDiagnostic::error("error message")
             .with_error_code("scope", "rule")
             .with_help("help message")
@@ -214,7 +302,8 @@ mod test {
             .with_label(Span::new(0, 1300))
             .with_source_code(NamedSource::new("file://test.ts", source_text));
 
-        let (mut service, sender) = DiagnosticService::new(Box::new(GithubReporter));
+        let (mut service, sender) =
+            DiagnosticService::new(Box::new(GithubReporter { repo_path_prefix: None }));
         sender.send(vec![diagnostic]).unwrap();
         drop(sender);
 

--- a/apps/oxlint/src/output_formatter/gitlab.rs
+++ b/apps/oxlint/src/output_formatter/gitlab.rs
@@ -11,7 +11,7 @@ use oxc_diagnostics::{
     reporter::{DiagnosticReporter, DiagnosticResult, Info},
 };
 
-use crate::output_formatter::InternalFormatter;
+use crate::output_formatter::{InternalFormatter, get_repo_path_prefix};
 
 #[derive(Debug, Default)]
 pub struct GitlabOutputFormatter;
@@ -41,44 +41,6 @@ impl InternalFormatter for GitlabOutputFormatter {
     fn get_diagnostic_reporter(&self) -> Box<dyn DiagnosticReporter> {
         Box::new(GitlabReporter::default())
     }
-}
-
-/// Find the git repository root by walking up from the current directory.
-/// Returns `None` if no `.git` directory is found.
-fn find_git_root() -> Option<PathBuf> {
-    let cwd = std::env::current_dir().ok()?;
-    find_git_root_from(&cwd)
-}
-
-/// Find the git repository root by walking up from the given path.
-fn find_git_root_from(start: &Path) -> Option<PathBuf> {
-    let mut current = start.to_path_buf();
-    loop {
-        if current.join(".git").exists() {
-            return Some(current);
-        }
-        if !current.pop() {
-            return None;
-        }
-    }
-}
-
-/// Get the path prefix from CWD to the git repository root.
-/// This prefix should be prepended to CWD-relative paths to make them repo-relative.
-///
-/// For example, if git root is `/repo` and CWD is `/repo/packages/foo`,
-/// this returns `Some("packages/foo")`.
-fn get_repo_path_prefix() -> Option<PathBuf> {
-    let cwd = std::env::current_dir().ok()?;
-    let git_root = find_git_root()?;
-
-    // Get the relative path from git root to CWD
-    let relative = cwd.strip_prefix(&git_root).ok()?;
-    if relative.as_os_str().is_empty() {
-        return None;
-    }
-
-    Some(relative.to_path_buf())
 }
 
 /// Renders reports as a Gitlab Code Quality Report
@@ -164,7 +126,7 @@ fn format_gitlab(diagnostics: &mut Vec<Error>, repo_path_prefix: Option<&Path>) 
 
 #[cfg(test)]
 mod test {
-    use std::path::{Path, PathBuf};
+    use std::path::Path;
 
     use oxc_diagnostics::{
         Error, NamedSource, OxcDiagnostic,
@@ -172,7 +134,7 @@ mod test {
     };
     use oxc_span::Span;
 
-    use super::{GitlabReporter, find_git_root_from, format_gitlab};
+    use super::{GitlabReporter, format_gitlab};
 
     #[test]
     fn reporter() {
@@ -205,24 +167,6 @@ mod test {
         let lines = location["lines"].as_object().unwrap();
         assert_eq!(lines["begin"], 1);
         assert_eq!(lines["end"], 1);
-    }
-
-    #[test]
-    fn find_git_root_from_current_dir() {
-        // This test runs from within the oxc repo, so we should find a git root
-        let cwd = std::env::current_dir().unwrap();
-        let git_root = find_git_root_from(&cwd);
-        assert!(git_root.is_some());
-        assert!(git_root.unwrap().join(".git").exists());
-    }
-
-    #[test]
-    fn find_git_root_from_nonexistent() {
-        // A path that doesn't exist or has no git repo
-        let path = PathBuf::from("/");
-        let git_root = find_git_root_from(&path);
-        // Root directory typically doesn't have a .git folder
-        assert!(git_root.is_none() || *git_root.unwrap() == *"/");
     }
 
     #[test]

--- a/apps/oxlint/src/output_formatter/mod.rs
+++ b/apps/oxlint/src/output_formatter/mod.rs
@@ -10,6 +10,7 @@ mod stylish;
 mod unix;
 mod xml_utils;
 
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::time::Duration;
 
@@ -62,6 +63,44 @@ impl FromStr for OutputFormat {
             _ => Err(format!("'{s}' is not a known format")),
         }
     }
+}
+
+/// Find the git repository root by walking up from the current directory.
+/// Returns `None` if no `.git` directory is found.
+fn find_git_root() -> Option<PathBuf> {
+    let cwd = std::env::current_dir().ok()?;
+    find_git_root_from(&cwd)
+}
+
+/// Find the git repository root by walking up from the given path.
+fn find_git_root_from(start: &Path) -> Option<PathBuf> {
+    let mut current = start.to_path_buf();
+    loop {
+        if current.join(".git").exists() {
+            return Some(current);
+        }
+        if !current.pop() {
+            return None;
+        }
+    }
+}
+
+/// Get the path prefix from CWD to the git repository root.
+/// This prefix should be prepended to CWD-relative paths to make them repo-relative.
+///
+/// For example, if git root is `/repo` and CWD is `/repo/packages/foo`,
+/// this returns `Some("packages/foo")`.
+fn get_repo_path_prefix() -> Option<PathBuf> {
+    let cwd = std::env::current_dir().ok()?;
+    let git_root = find_git_root()?;
+
+    // Get the relative path from git root to CWD
+    let relative = cwd.strip_prefix(&git_root).ok()?;
+    if relative.as_os_str().is_empty() {
+        return None;
+    }
+
+    Some(relative.to_path_buf())
 }
 
 /// Some extra lint information, which can be outputted
@@ -188,9 +227,30 @@ impl OutputFormatter {
 
 #[cfg(test)]
 mod test {
+    use std::path::PathBuf;
+
+    use super::find_git_root_from;
     use crate::tester::Tester;
 
     const TEST_CWD: &str = "fixtures/cli/output_formatter_diagnostic";
+
+    #[test]
+    fn find_git_root_from_current_dir() {
+        // This test runs from within the oxc repo, so we should find a git root
+        let cwd = std::env::current_dir().unwrap();
+        let git_root = find_git_root_from(&cwd);
+        assert!(git_root.is_some());
+        assert!(git_root.unwrap().join(".git").exists());
+    }
+
+    #[test]
+    fn find_git_root_from_nonexistent() {
+        // A path that doesn't exist or has no git repo
+        let path = PathBuf::from("/");
+        let git_root = find_git_root_from(&path);
+        // Root directory typically doesn't have a .git folder
+        assert!(git_root.is_none() || *git_root.unwrap() == *"/");
+    }
 
     #[test]
     fn test_output_formatter_diagnostic_formats() {

--- a/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=github --report-unused-disable-directives disable-directive.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=github --report-unused-disable-directives disable-directive.js@oxlint.snap
@@ -5,9 +5,9 @@ source: apps/oxlint/src/tester.rs
 arguments: --format=github --report-unused-disable-directives disable-directive.js
 working directory: fixtures/cli/output_formatter_diagnostic
 ----------
-::warning file=disable-directive.js,line=9,endLine=9,col=1,endColumn=40,title=oxlint::Unused eslint-disable directive (no problems were reported).
-::warning file=disable-directive.js,line=12,endLine=12,col=1,endColumn=40,title=oxlint::Unused oxlint-disable directive (no problems were reported).
-::warning file=disable-directive.js,line=15,endLine=15,col=1,endColumn=47,title=oxlint::Unused oxlint-disable directive (no problems were reported).
+::warning file=apps/oxlint/disable-directive.js,line=9,endLine=9,col=1,endColumn=40,title=oxlint::Unused eslint-disable directive (no problems were reported).
+::warning file=apps/oxlint/disable-directive.js,line=12,endLine=12,col=1,endColumn=40,title=oxlint::Unused oxlint-disable directive (no problems were reported).
+::warning file=apps/oxlint/disable-directive.js,line=15,endLine=15,col=1,endColumn=47,title=oxlint::Unused oxlint-disable directive (no problems were reported).
 
 Found 3 warnings and 0 errors.
 Finished in <variable>ms on 1 file with 2 rules using 1 threads.

--- a/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=github parser-error.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=github parser-error.js@oxlint.snap
@@ -5,7 +5,7 @@ source: apps/oxlint/src/tester.rs
 arguments: --format=github parser-error.js
 working directory: fixtures/cli/output_formatter_diagnostic
 ----------
-::error file=parser-error.js,line=3,endLine=3,col=9,endColumn=10,title=oxlint::Expected `;` but found `:`
+::error file=apps/oxlint/parser-error.js,line=3,endLine=3,col=9,endColumn=10,title=oxlint::Expected `;` but found `:`
 
 Found 0 warnings and 1 error.
 Finished in <variable>ms on 1 file with 2 rules using 1 threads.

--- a/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=github test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=github test.js@oxlint.snap
@@ -5,9 +5,9 @@ source: apps/oxlint/src/tester.rs
 arguments: --format=github test.js
 working directory: fixtures/cli/output_formatter_diagnostic
 ----------
-::warning file=test.js,line=1,endLine=1,col=10,endColumn=13,title=eslint(no-unused-vars)::Function 'foo' is declared but never used.
-::warning file=test.js,line=1,endLine=1,col=17,endColumn=18,title=eslint(no-unused-vars)::Parameter 'b' is declared but never used. Unused parameters should start with a '_'.
-::error file=test.js,line=5,endLine=5,col=1,endColumn=10,title=eslint(no-debugger)::`debugger` statement is not allowed
+::warning file=apps/oxlint/test.js,line=1,endLine=1,col=10,endColumn=13,title=eslint(no-unused-vars)::Function 'foo' is declared but never used.
+::warning file=apps/oxlint/test.js,line=1,endLine=1,col=17,endColumn=18,title=eslint(no-unused-vars)::Parameter 'b' is declared but never used. Unused parameters should start with a '_'.
+::error file=apps/oxlint/test.js,line=5,endLine=5,col=1,endColumn=10,title=eslint(no-debugger)::`debugger` statement is not allowed
 
 Found 2 warnings and 1 error.
 Finished in <variable>ms on 1 file with 2 rules using 1 threads.


### PR DESCRIPTION
### AI usage disclosure

I used Claude Code to help trace the root cause and draft the fix and tests. I have reviewed, understood, and verified everything below myself (including reproducing with the released `oxlint` binary and verifying the fix end-to-end with a locally built one).

### Summary

Closes #12352

`oxlint --format=github` emits annotation paths relative to the process CWD. GitHub Actions roots relative paths in workflow commands against the workspace (repository) root, not the CWD ([ADR 0276 — Rooting the file](https://github.com/actions/runner/blob/ed48ddd08c9350e49b7fdfaf42512091585af4e1/docs/adrs/0276-problem-matchers.md#rooting-the-file)). So when oxlint runs in a subdirectory of a monorepo (e.g. `working-directory: packages/foo`), annotations point at nonexistent files and silently fail to attach:

```
$ cd packages/foo && oxlint --format=github index.js
::warning file=index.js,...        # resolved as <workspace>/index.js — does not exist
```

### The fix

Same approach as the merged gitlab-formatter fix (#18165): `GithubReporter` captures the CWD→git-root prefix at construction and prepends it to the annotation path, making paths repo-relative:

```
::warning file=packages/foo/index.js,...
```

The `find_git_root` / `get_repo_path_prefix` helpers are moved from `gitlab.rs` up to `output_formatter/mod.rs` and shared by both reporters (no behavior change for gitlab). Windows backslash normalization mirrors the gitlab implementation. When there is no `.git` ancestor, behavior is unchanged.

Repo-relative was chosen over absolute paths (the issue title's suggestion) for consistency with the merged gitlab precedent; per ADR 0276 both forms resolve correctly on the runner (absolute paths under the workspace are relativized automatically, repo-relative paths are rooted at the workspace).

### Testing

New unit test failing before the fix:

```
---- output_formatter::github::test::format_github_with_prefix stdout ----
assertion `left == right` failed
  left: "::warning file=example.js,line=1,endLine=1,col=1,endColumn=9,title=oxlint::error message\n"
 right: "::warning file=packages/foo/example.js,line=1,endLine=1,col=1,endColumn=9,title=oxlint::error message\n"
```

After the fix all output formatter tests pass (`cargo test -p oxlint --lib output_formatter`: 48 passed). CLI snapshots for `--format=github` updated to the repo-relative form (now consistent with the existing gitlab snapshots).

End-to-end with a locally built oxlint:
- from a monorepo subdirectory: `file=packages/foo/index.js` (fixed)
- from the repo root: unchanged
- outside a git repository: unchanged (no prefix)
