### PR TITLE
refactor(react_compiler): remove unnecessary clones

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -2795,9 +2795,9 @@ pub fn compile_program<'a, 'p>(
             );
             let gating_name = instrument_config.gating.as_ref().map(|g| {
                 let spec = context.add_import_specifier(&g.source, &g.import_specifier_name, None);
-                spec.name.clone()
+                spec.name
             });
-            (Some(fn_spec.name.clone()), gating_name)
+            (Some(fn_spec.name), gating_name)
         } else {
             (None, None)
         };
@@ -2809,7 +2809,7 @@ pub fn compile_program<'a, 'p>(
                 &hook_guard_config.import_specifier_name,
                 None,
             );
-            spec.name.clone()
+            spec.name
         });
 
     // Store pre-resolved names on context for pipeline access
@@ -2820,15 +2820,11 @@ pub fn compile_program<'a, 'p>(
     // Find all functions to compile
     let queue = find_functions_to_compile(program, &options, &mut context);
 
-    // Clone env_config once for all function compilations (avoids per-function clone
-    // while satisfying the borrow checker — compile_fn needs &mut context + &env_config)
-    let env_config = options.environment.clone();
-
     // Process each function and collect compiled results
     let mut compiled_fns: Vec<CompiledFunction<'_, '_, '_>> = Vec::new();
 
     for source in &queue {
-        match process_fn(&ast, source, &scope, output_mode, &env_config, &mut context) {
+        match process_fn(&ast, source, &scope, output_mode, &options.environment, &mut context) {
             Ok(Some(codegen_fn)) => {
                 compiled_fns.push(CompiledFunction { kind: source.kind, source, codegen_fn });
             }

--- a/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
@@ -398,7 +398,7 @@ impl<'a> Environment<'a> {
                                 ErrorCategory::Config,
                                 "Invalid type configuration for module",
                             )
-                            .with_description(first_error.to_string())
+                            .with_description(first_error)
                             .with_span(span),
                         )?;
                     }
@@ -442,7 +442,7 @@ impl<'a> Environment<'a> {
                                 ErrorCategory::Config,
                                 "Invalid type configuration for module",
                             )
-                            .with_description(first_error.to_string())
+                            .with_description(first_error)
                             .with_span(span),
                         )?;
                     }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
@@ -1449,7 +1449,7 @@ fn apply_effect(
                         .or_insert_with(ValueId::new);
                     state.initialize(
                         value_id,
-                        AbstractValue { kind: from_value.kind, reason: from_value.reason.clone() },
+                        AbstractValue { kind: from_value.kind, reason: from_value.reason },
                     );
                     state.define(into.identifier, value_id);
                 }
@@ -1462,7 +1462,7 @@ fn apply_effect(
                         .or_insert_with(ValueId::new);
                     state.initialize(
                         value_id,
-                        AbstractValue { kind: from_value.kind, reason: from_value.reason.clone() },
+                        AbstractValue { kind: from_value.kind, reason: from_value.reason },
                     );
                     state.define(into.identifier, value_id);
                 }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
@@ -646,7 +646,7 @@ fn traverse_optional_block(
         identifier: base_object.identifier,
         reactive: base_object.reactive,
         path: {
-            let mut p = base_object.path.clone();
+            let mut p = base_object.path;
             p.push(DependencyPathEntry {
                 property: match_result.property.clone(),
                 optional: is_optional,

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -1519,7 +1519,7 @@ fn lower_binding_assignment<'a>(
                 builder,
                 InstructionValue::Destructure {
                     lvalue: LValuePattern { pattern: Pattern::Array(ArrayPattern { items }), kind },
-                    value: value.clone(),
+                    value,
                     span,
                 },
             )?;
@@ -1689,7 +1689,7 @@ fn lower_binding_assignment<'a>(
                         pattern: Pattern::Object(ObjectPattern { properties }),
                         kind,
                     },
-                    value: value.clone(),
+                    value,
                     span,
                 },
             )?;
@@ -2146,7 +2146,7 @@ fn lower_assignment_target<'a>(
                 builder,
                 InstructionValue::Destructure {
                     lvalue: LValuePattern { pattern: Pattern::Array(ArrayPattern { items }), kind },
-                    value: value.clone(),
+                    value,
                     span,
                 },
             )?;
@@ -2441,7 +2441,7 @@ fn lower_assignment_target<'a>(
                         pattern: Pattern::Object(ObjectPattern { properties }),
                         kind,
                     },
-                    value: value.clone(),
+                    value,
                     span,
                 },
             )?;
@@ -4067,7 +4067,7 @@ fn lower_expression<'a>(
                             InstructionValue::PropertyStore {
                                 object,
                                 property: prop_literal,
-                                value: updated.clone(),
+                                value: updated,
                                 span: member_span,
                             },
                         )?,
@@ -4076,7 +4076,7 @@ fn lower_expression<'a>(
                             InstructionValue::ComputedStore {
                                 object,
                                 property: prop_place,
-                                value: updated.clone(),
+                                value: updated,
                                 span: member_span,
                             },
                         )?,
@@ -4745,7 +4745,7 @@ fn lower_jsx_element_expr<'a>(
                 return Err(CompilerDiagnostic::new(ErrorCategory::Invariant, &reason, None)
                     .with_detail(CompilerDiagnosticDetail::Error {
                         span: id_span,
-                        message: Some(reason.clone()),
+                        message: Some(reason),
                     })
                     .into());
             }
@@ -6220,11 +6220,7 @@ fn lower_statement<'a>(
             let left_span = builder.source_location(for_of.left.span());
             let advance_iterator = lower_value_to_temporary(
                 builder,
-                InstructionValue::IteratorNext {
-                    iterator: iterator.clone(),
-                    collection: value.clone(),
-                    span: left_span,
-                },
+                InstructionValue::IteratorNext { iterator, collection: value, span: left_span },
             )?;
 
             let assign_result =

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/build_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/build_reactive_function.rs
@@ -1229,7 +1229,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
         } else {
             ValueBlockResult {
                 block: block_id,
-                place: place.clone(),
+                place,
                 value: ReactiveValue::SequenceExpression {
                     instructions: remaining,
                     id,

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/extract_scope_declarations_from_destructuring.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/extract_scope_declarations_from_destructuring.rs
@@ -142,7 +142,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
                         span: None, // GeneratedSource — matches TS createTemporaryPlace
                     };
                     let original = place;
-                    renamed.push((original.clone(), temporary.clone()));
+                    renamed.push((original, temporary.clone()));
                     temporary
                 });
 


### PR DESCRIPTION
## What

Removes unnecessary clones in `oxc_react_compiler`.

- **The program-level `env_config` clone** was a spurious borrow-checker workaround. `env_config = options.environment.clone()` was cloned "to satisfy the borrow checker", but it came from the `options` param — which is a *different* variable from `context` (context holds its own `options.clone()`). So `process_fn` can take `&options.environment` directly alongside `&mut context` with no conflict. The comment's rationale didn't hold.
- **19 genuinely-redundant clones** (value cloned, then the original dropped without further use) across `program`, `environment`, `build_hir`, `infer_mutation_aliasing_effects`, `propagate_scope_dependencies_hir`, `build_reactive_function`, `extract_scope_declarations_from_destructuring` — found with `clippy::redundant_clone`, plus a few `field: x.clone()` → `field: x` shorthands.

No behavior change: the 1806-fixture snapshot corpus and integration tests are byte-identical.

## Follow-up (not in this PR)

Two per-function clones remain that are *by design* rather than redundant — `Environment` deep-clones program-wide immutable data once per compiled function:
- `env.reference_node_ids = scope.all_reference_positions().clone()` — the whole file's `FxHashSet<u32>`, read-only, used only in codegen.
- `Environment::with_config(env_config.clone())` — the 53-field config (mostly bools), never mutated.

Fixing these means having `Environment` borrow (a lifetime — ~118 spellings) or share via `Rc` (no `Rc` in the crate today), so I left them out pending a direction.
