### PR TITLE
refactor(react_compiler): drop redundant IdentifierLocEntry.start field

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -352,7 +352,7 @@ fn lower_block_statement_inner<'a>(
                 .chain(decl_start.iter().copied())
                 .filter_map(|ref_nid| {
                     let entry = builder.identifier_spans().get(&ref_nid)?;
-                    let ref_start = entry.start;
+                    let ref_start = entry.span.start;
                     if ref_start < stmt_start || ref_start >= stmt_end {
                         return None;
                     }
@@ -3470,7 +3470,7 @@ fn gather_captured_context(
         let declaration_start = scope.declaration_start(symbol_id);
         for ref_nid in scope.reference_positions(symbol_id) {
             // Range check: use the position stored in identifier_spans
-            let ref_start = identifier_spans.get(&ref_nid).map(|e| e.start).unwrap_or(0);
+            let ref_start = identifier_spans.get(&ref_nid).map(|e| e.span.start).unwrap_or(0);
             if ref_start < func_start || ref_start >= func_end {
                 continue;
             }

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/find_context_identifiers.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/find_context_identifiers.rs
@@ -498,7 +498,7 @@ pub fn find_context_identifiers(
                 continue;
             }
             let ref_pos = match identifier_spans.get(&ref_nid) {
-                Some(entry) => entry.start,
+                Some(entry) => entry.span.start,
                 None => continue,
             };
             // Check if ref_pos is inside a nested function scope

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/identifier_loc_index.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/identifier_loc_index.rs
@@ -42,10 +42,8 @@ use crate::react_compiler_lowering::FunctionNode;
 
 /// Source location and whether the identifier is a JSXIdentifier.
 pub struct IdentifierLocEntry {
-    /// The byte offset of the identifier (base.start). Stored here so that
-    /// callers iterating by node_id can still do position-range containment
-    /// checks without a separate bridge map.
-    pub start: u32,
+    /// The identifier's span. `span.start` is the node_id (also the map key), so
+    /// callers can do position-range containment checks without a separate field.
     pub span: Span,
     pub is_jsx: bool,
     /// For JSX identifiers that are the root name of a JSXOpeningElement,
@@ -85,7 +83,6 @@ impl IdentifierLocVisitor {
         // generic binding-identifier walk re-visits them, so the declaration
         // entry wins, matching the original visitor.
         self.index.entry(span.start).or_insert(IdentifierLocEntry {
-            start: span.start,
             span,
             is_jsx,
             opening_element_span,


### PR DESCRIPTION
## What

`IdentifierLocEntry` stored a `start: u32` alongside `span: Span`, but `start` duplicated data already present:

- it's the **map key** (`node_id`), and
- it equals **`span.start`** (`node_id == span.start` by construction).

The only non-derivable position data is `span.end`, which `span` already carries. So `start` was pure duplication — dropped it and read `span.start` at the three use sites (`gather_captured_context`, the statement-range filter in `build_hir`, and `find_context_identifiers`).

No behavior change: the 1806-fixture snapshot corpus and integration tests are byte-identical.
