### PR TITLE
refactor(react_compiler): prune dangling comments in place after compile

### DIFF
--- a/crates/oxc_react_compiler/src/lib.rs
+++ b/crates/oxc_react_compiler/src/lib.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{Allocator, ArenaVec};
+use oxc_allocator::Allocator;
 
 mod diagnostics;
 mod options;
@@ -133,24 +133,25 @@ fn compile<'a>(
 
     let compiled = program_ast.map(|mut compiled: Program<'a>| {
         compiled.source_type = program.source_type;
-        preserve_comments(&mut compiled, program, allocator);
+        prune_inner_comments(&mut compiled);
         compiled
     });
 
     (compiled, diagnostics)
 }
 
-/// Carry over the comments attached to top-level statements of the compiled
-/// program, so codegen can re-emit them. The `react_compiler_ast` roundtrip
-/// drops comments, so we reuse the ones from the original `source` program
-/// (already parsed) rather than re-parsing the source.
-fn preserve_comments<'a>(
-    compiled: &mut Program<'a>,
-    source: &Program<'a>,
-    allocator: &'a Allocator,
-) {
-    // Keep only comments attached to a top-level statement; inner comments have
-    // `attached_to` positions that match no top-level statement.
+/// Drop comments left dangling by compilation.
+///
+/// `ox_splice_program` clones the source program — `comments` and `source_text`
+/// included — so `compiled` already carries every original comment. The compiled
+/// functions were rebuilt with fresh spans, though, so a comment that pointed
+/// inside one no longer lines up with any statement and codegen would re-emit it
+/// at a stale position. Keep only the comments still anchored to a top-level
+/// statement.
+fn prune_inner_comments(compiled: &mut Program<'_>) {
+    if compiled.comments.is_empty() {
+        return;
+    }
     let mut top_level_starts = FxHashSet::default();
     top_level_starts.insert(0u32);
     for stmt in &compiled.body {
@@ -159,17 +160,5 @@ fn preserve_comments<'a>(
             top_level_starts.insert(start);
         }
     }
-
-    // Copy only comments attached to top-level statements.
-    let mut comments = ArenaVec::with_capacity_in(source.comments.len(), &allocator);
-    for comment in &source.comments {
-        if top_level_starts.contains(&comment.attached_to) {
-            comments.push(*comment);
-        }
-    }
-    compiled.comments = comments;
-
-    // Codegen reads comment content from `source_text` via span offsets, so the
-    // compiled program must point at the same source as the original.
-    compiled.source_text = source.source_text;
+    compiled.comments.retain(|comment| top_level_starts.contains(&comment.attached_to));
 }

--- a/crates/oxc_react_compiler/tests/transform.rs
+++ b/crates/oxc_react_compiler/tests/transform.rs
@@ -403,9 +403,9 @@ fn diagnostics_preserve_compiler_severity() {
     );
 }
 
-/// Comments are dropped by the `react_compiler_ast` roundtrip, so
-/// `preserve_comments` carries top-level comments over from the original
-/// program. Comments inside a compiled function are not recovered.
+/// Compilation clones the source program, so top-level comments survive; comments
+/// inside a compiled function are pruned because their anchor no longer resolves to
+/// a statement (see `prune_inner_comments`).
 #[test]
 fn top_level_comments_are_preserved() {
     let source = "\


### PR DESCRIPTION
## What

Simplify the post-compile comment cleanup in `oxc_react_compiler`.

The output program is built by cloning the source (`ox_splice_program` → `program.clone_in()`), and `CloneIn` for `Program` copies both `comments` and `source_text`. So the compiled program already carries every original comment and the correct `source_text` before the cleanup step runs.

The old `preserve_comments` re-derived that from scratch:

- allocated a second `ArenaVec` and re-filtered `source.comments` into it, then
- re-assigned an already-correct `source_text`,

which forced it to take `source: &Program` and `allocator` params it didn't need.

## Change

Filter the already-cloned `compiled.comments` in place with `retain`, dropping the extra allocation, the redundant `source_text` write, and both params. Renamed to `prune_inner_comments`, and corrected the doc comments — the old ones claimed the roundtrip *drops* comments, when it actually clones them and this step prunes only the ones anchored inside rewritten functions (whose spans no longer resolve).

## Verification

Output is unchanged: the fixture snapshot suite passes byte-identical (no `.snap` updates) and all 15 unit tests pass. `cargo clippy -p oxc_react_compiler --all-targets` is clean.
