### PR TITLE
feat(linter): add partial loader for GlimmerJS / GlimmerTS (Ember.js framework templates)

### DIFF
--- a/apps/oxlint/fixtures/cli/glimmer/consistent-type-imports.json
+++ b/apps/oxlint/fixtures/cli/glimmer/consistent-type-imports.json
@@ -1,0 +1,10 @@
+{
+  "plugins": ["eslint", "typescript"],
+  "categories": {
+    "correctness": "off"
+  },
+  "rules": {
+    "no-debugger": "error",
+    "typescript/consistent-type-imports": "error"
+  }
+}

--- a/apps/oxlint/fixtures/cli/glimmer/hook-in-template.gjs
+++ b/apps/oxlint/fixtures/cli/glimmer/hook-in-template.gjs
@@ -1,0 +1,15 @@
+// `rules-of-hooks` must be skipped for loader-derived Glimmer sources: `useX`
+// helpers are common in Ember and would false-positive. `useThing` calls a hook
+// conditionally, which the rule would otherwise flag. The `debugger` statement
+// proves other native rules still run.
+import { useState } from "ember-hook";
+
+export function useThing(cond) {
+  if (cond) {
+    useState();
+  }
+}
+
+debugger;
+
+export default <template>{{useThing}}</template>;

--- a/apps/oxlint/fixtures/cli/glimmer/no-template.gjs
+++ b/apps/oxlint/fixtures/cli/glimmer/no-template.gjs
@@ -1,0 +1,4 @@
+// A `.gjs` file with no `<template>` block is plain JS: the loader returns it as a
+// whole (non-partial) source, so template-sensitive rules like `no-unused-vars` run
+// normally here (unlike a template-bearing Glimmer file, where they are skipped).
+const unused = 1;

--- a/apps/oxlint/fixtures/cli/glimmer/rules-of-hooks.json
+++ b/apps/oxlint/fixtures/cli/glimmer/rules-of-hooks.json
@@ -1,0 +1,10 @@
+{
+  "plugins": ["eslint", "react"],
+  "categories": {
+    "correctness": "off"
+  },
+  "rules": {
+    "no-debugger": "error",
+    "react/rules-of-hooks": "error"
+  }
+}

--- a/apps/oxlint/fixtures/cli/glimmer/template-only.gjs
+++ b/apps/oxlint/fixtures/cli/glimmer/template-only.gjs
@@ -1,0 +1,1 @@
+<template>Hello</template>

--- a/apps/oxlint/fixtures/cli/glimmer/type-import-in-template.gts
+++ b/apps/oxlint/fixtures/cli/glimmer/type-import-in-template.gts
@@ -1,0 +1,13 @@
+// `Button` is used as a value in the template below (which the partial loader
+// blanks out) and only in a *type* position in the surrounding module, so
+// `consistent-type-imports` would wrongly report it as type-only and its autofix
+// would rewrite the value import to `import type`, breaking the runtime use. The
+// rule must be skipped for loader-derived Glimmer TS sources. The `debugger`
+// statement proves other native rules still run.
+import Button from "./button";
+
+export type ButtonRef = Button;
+
+debugger;
+
+export default <template><Button /></template>;

--- a/apps/oxlint/fixtures/cli/glimmer/unused-in-template.gjs
+++ b/apps/oxlint/fixtures/cli/glimmer/unused-in-template.gjs
@@ -1,0 +1,7 @@
+// `greeting` is only used inside the template, which the partial loader blanks
+// out, so `no-unused-vars` must not run on loader-derived Glimmer sources.
+// The `debugger` statement proves other native rules still run.
+const greeting = "hello";
+debugger;
+
+export default <template>{{greeting}}</template>;

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -1062,6 +1062,23 @@ mod test {
     }
 
     #[test]
+    fn lint_glimmer_file() {
+        // `no-unused-vars` must be skipped for loader-derived Glimmer sources
+        // (`greeting` is only used in the blanked-out template), while other
+        // native rules (`no-debugger`) still run.
+        let args = &["fixtures/cli/glimmer/unused-in-template.gjs"];
+        Tester::new().test_and_snapshot(args);
+    }
+
+    #[test]
+    fn lint_glimmer_template_only_file() {
+        // The loader turns a top-level template into a bare `undefined` expression
+        // statement; `no-unused-expressions` must not flag the synthesized placeholder.
+        let args = &["fixtures/cli/glimmer/template-only.gjs"];
+        Tester::new().test_and_snapshot(args);
+    }
+
+    #[test]
     fn lint_svelte_module_and_instance_scripts() {
         let output =
             Tester::new().test_output_verbose(&["fixtures/cli/svelte/module-script.svelte"]);

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -1079,6 +1079,45 @@ mod test {
     }
 
     #[test]
+    fn lint_glimmer_no_template_file() {
+        // A `.gjs` with no `<template>` block is returned by the loader as a whole,
+        // non-partial source, so template-sensitive rules still run: `no-unused-vars`
+        // must flag the unused `const`.
+        let args = &["fixtures/cli/glimmer/no-template.gjs"];
+        Tester::new().test_and_snapshot(args);
+    }
+
+    #[test]
+    fn lint_glimmer_gts_consistent_type_imports() {
+        // `typescript/consistent-type-imports` must be skipped for loader-derived
+        // Glimmer TS: `Button` is used as a value in the blanked-out template but
+        // looks type-only after stripping, so the rule would emit an incorrect
+        // `import type` fix. Other native rules (`no-debugger`) still run. The rule
+        // is not in the default set, so an explicit config enables it.
+        let args = &[
+            "-c",
+            "fixtures/cli/glimmer/consistent-type-imports.json",
+            "fixtures/cli/glimmer/type-import-in-template.gts",
+        ];
+        Tester::new().test_and_snapshot(args);
+    }
+
+    #[test]
+    fn lint_glimmer_rules_of_hooks() {
+        // `react/rules-of-hooks` must be skipped for loader-derived Glimmer sources:
+        // `useThing` calls a hook conditionally, which the rule would otherwise flag,
+        // but `useX` helpers are common in Ember. Other native rules (`no-debugger`)
+        // still run. The rule is not in the default set, so an explicit config
+        // enables it.
+        let args = &[
+            "-c",
+            "fixtures/cli/glimmer/rules-of-hooks.json",
+            "fixtures/cli/glimmer/hook-in-template.gjs",
+        ];
+        Tester::new().test_and_snapshot(args);
+    }
+
+    #[test]
     fn lint_svelte_module_and_instance_scripts() {
         let output =
             Tester::new().test_output_verbose(&["fixtures/cli/svelte/module-script.svelte"]);

--- a/apps/oxlint/src/snapshots/_-c fixtures__cli__glimmer__consistent-type-imports.json fixtures__cli__glimmer__type-import-in-template.gts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__cli__glimmer__consistent-type-imports.json fixtures__cli__glimmer__type-import-in-template.gts@oxlint.snap
@@ -1,0 +1,22 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: -c fixtures/cli/glimmer/consistent-type-imports.json fixtures/cli/glimmer/type-import-in-template.gts
+working directory: 
+----------
+
+  x eslint(no-debugger): `debugger` statement is not allowed
+    ,-[fixtures/cli/glimmer/type-import-in-template.gts:11:1]
+ 10 | 
+ 11 | debugger;
+    : ^^^^^^^^^
+ 12 | 
+    `----
+  help: Remove the debugger statement
+
+Found 0 warnings and 1 error.
+Finished in <variable>ms on 1 file with 2 rules using 1 threads.
+----------
+CLI result: LintFoundErrors
+----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__cli__glimmer__rules-of-hooks.json fixtures__cli__glimmer__hook-in-template.gjs@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__cli__glimmer__rules-of-hooks.json fixtures__cli__glimmer__hook-in-template.gjs@oxlint.snap
@@ -1,0 +1,22 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: -c fixtures/cli/glimmer/rules-of-hooks.json fixtures/cli/glimmer/hook-in-template.gjs
+working directory: 
+----------
+
+  x eslint(no-debugger): `debugger` statement is not allowed
+    ,-[fixtures/cli/glimmer/hook-in-template.gjs:13:1]
+ 12 | 
+ 13 | debugger;
+    : ^^^^^^^^^
+ 14 | 
+    `----
+  help: Remove the debugger statement
+
+Found 0 warnings and 1 error.
+Finished in <variable>ms on 1 file with 2 rules using 1 threads.
+----------
+CLI result: LintFoundErrors
+----------

--- a/apps/oxlint/src/snapshots/_fixtures__cli__glimmer__no-template.gjs@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__cli__glimmer__no-template.gjs@oxlint.snap
@@ -1,0 +1,22 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: fixtures/cli/glimmer/no-template.gjs
+working directory: 
+----------
+
+  ! eslint(no-unused-vars): Variable 'unused' is declared but never used. Unused variables should start with a '_'.
+   ,-[fixtures/cli/glimmer/no-template.gjs:4:7]
+ 3 | // normally here (unlike a template-bearing Glimmer file, where they are skipped).
+ 4 | const unused = 1;
+   :       ^^^|^^
+   :          `-- 'unused' is declared here
+   `----
+  help: Consider removing this declaration.
+
+Found 1 warning and 0 errors.
+Finished in <variable>ms on 1 file with 95 rules using 1 threads.
+----------
+CLI result: LintSucceeded
+----------

--- a/apps/oxlint/src/snapshots/_fixtures__cli__glimmer__template-only.gjs@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__cli__glimmer__template-only.gjs@oxlint.snap
@@ -1,0 +1,12 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: fixtures/cli/glimmer/template-only.gjs
+working directory: 
+----------
+Found 0 warnings and 0 errors.
+Finished in <variable>ms on 1 file with 95 rules using 1 threads.
+----------
+CLI result: LintSucceeded
+----------

--- a/apps/oxlint/src/snapshots/_fixtures__cli__glimmer__unused-in-template.gjs@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__cli__glimmer__unused-in-template.gjs@oxlint.snap
@@ -1,0 +1,22 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: fixtures/cli/glimmer/unused-in-template.gjs
+working directory: 
+----------
+
+  ! eslint(no-debugger): `debugger` statement is not allowed
+   ,-[fixtures/cli/glimmer/unused-in-template.gjs:5:1]
+ 4 | const greeting = "hello";
+ 5 | debugger;
+   : ^^^^^^^^^
+ 6 | 
+   `----
+  help: Remove the debugger statement
+
+Found 1 warning and 0 errors.
+Finished in <variable>ms on 1 file with 95 rules using 1 threads.
+----------
+CLI result: LintSucceeded
+----------

--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -46,6 +46,9 @@ pub struct ContextSubHost<'a> {
     pub(super) parser_tokens: ArenaBox<'a, [Token]>,
     /// The source text offset of the sub host
     pub(super) source_text_offset: u32,
+    /// Whether this source was extracted by a partial loader (e.g. a `<script>`
+    /// block in a `.vue` file, or a `.gjs`/`.gts` file with templates blanked out).
+    pub(super) from_partial_loader: bool,
 }
 
 impl<'a> ContextSubHost<'a> {
@@ -79,6 +82,7 @@ impl<'a> ContextSubHost<'a> {
             disable_directives,
             framework_options: options.framework_options,
             parser_tokens: options.parser_tokens,
+            from_partial_loader: options.from_partial_loader,
         }
     }
 
@@ -110,6 +114,7 @@ pub struct ContextSubHostOptions<'a> {
     pub framework_options: FrameworkOptions,
     pub parser_tokens: ArenaBox<'a, [Token]>,
     pub respect_eslint_disable_directives: bool,
+    pub from_partial_loader: bool,
 }
 
 impl Default for ContextSubHostOptions<'_> {
@@ -118,6 +123,7 @@ impl Default for ContextSubHostOptions<'_> {
             framework_options: FrameworkOptions::Default,
             parser_tokens: ArenaBox::new_empty_boxed_slice(),
             respect_eslint_disable_directives: true,
+            from_partial_loader: false,
         }
     }
 }
@@ -278,6 +284,15 @@ impl<'a> ContextHost<'a> {
     #[inline]
     pub fn file_extension(&self) -> Option<&OsStr> {
         self.file_extension.as_deref()
+    }
+
+    /// Whether the source currently being linted was extracted by a partial
+    /// loader (e.g. a `<script>` block in a `.vue` file, or a `.gjs`/`.gts`
+    /// file with its templates blanked out). Sources produced by other means
+    /// (whole files, custom parsers) return `false`.
+    #[inline]
+    pub fn is_from_partial_loader(&self) -> bool {
+        self.current_sub_host().from_partial_loader
     }
 
     /// The source type of the file being linted, e.g. JavaScript, TypeScript,

--- a/crates/oxc_linter/src/loader/mod.rs
+++ b/crates/oxc_linter/src/loader/mod.rs
@@ -64,6 +64,8 @@ mod test {
             "foo.astro",
             "foo.svelte",
             "foo.vue",
+            "foo.gjs",
+            "foo.gts",
         ];
 
         for path in paths {

--- a/crates/oxc_linter/src/loader/partial_loader/glimmer.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/glimmer.rs
@@ -1,0 +1,587 @@
+//! # Glimmer JS / Glimmer TS partial loader
+//!
+//! Strips `<template>...</template>` blocks out of `.gjs` / `.gts` files so the
+//! surrounding JavaScript / TypeScript can be linted as ordinary modules.
+//!
+//! ## Source material
+//!
+//! The `<template>` JS/TS embedding originates from [Ember RFC #779] and is implemented
+//! in production by [content-tag] (a Rust crate built on [`@glimmer/syntax`]). For full
+//! correctness an oxc loader should ultimately delegate to (or mirror) content-tag.
+//!
+//! [Ember RFC #779]: https://rfcs.emberjs.com/id/0779-first-class-component-templates/
+//! [content-tag]: https://github.com/embroider-build/content-tag
+//! [`@glimmer/syntax`]: https://github.com/glimmerjs/glimmer-vm
+//!
+//! ## Approach
+//!
+//! Rather than parsing the file twice, this loader rewrites every
+//! `<template>...</template>` block into a same-byte-length JS/TS expression so that:
+//!
+//! * source spans for the surrounding code remain accurate for diagnostics, and
+//! * the result is valid in *every* position where a template tag is legal: top-level,
+//!   expression position (`const c = <template>...</template>`) and class body
+//!   (`class C { <template>...</template> }`).
+//!
+//! The `<template>` opener (10 bytes) is replaced by `undefined ` (also 10 bytes — the
+//! identifier `undefined` followed by a single space). The remaining bytes — including
+//! the `</template>` closer — are replaced byte-for-byte with ASCII spaces, except for
+//! `\n`, which is preserved so line/column reporting is unaffected.
+//!
+//! `undefined` was chosen specifically because it is:
+//! * a valid expression in any expression position,
+//! * a legal class field name (in class-body position the substitution becomes a class
+//!   field declaration named `undefined` with no initializer), and
+//! * already a built-in global, so it does not introduce bindings.
+//!
+//! **Do not change the substitution string without re-checking the byte-length invariant
+//! and the validity in both expression and class-body positions.**
+//!
+//! ## Scanning
+//!
+//! A minimal single-pass state machine ([`template_regions`]) classifies every byte as
+//! code, a line/block comment, or a single/double/backtick string, and only recognizes a
+//! `<template>` opener in *code* position. So `<template>` appearing inside a comment or
+//! a string is left untouched. Once inside a template, its body is HTML-ish and treated
+//! as opaque — quotes, slashes, and `//` in it are not JS — so only `</template>` ends
+//! it. It is not a JS/TS lexer, but it is enough to keep the common cases correct without
+//! parsing the file twice.
+//!
+//! ## Known limitations
+//!
+//! The scanner is deliberately smaller than a real lexer, so a few (unlikely) cases are
+//! still handled by the byte pattern alone rather than by grammar. These produce
+//! incorrect output; dedicated tests pin them:
+//!
+//! * inside a regex literal: `/<template>/` — telling a regex from division needs
+//!   expression-vs-operator context this scanner does not track, so `/` is treated as an
+//!   ordinary code byte and the `<template>` inside is seen as a real opener.
+//! * inside JSX text in a `.gjs` file: `<div><template>literal</template></div>`.
+//! * inside a `${...}` interpolation in a backtick string — the interpolation's contents
+//!   are treated as opaque string, not re-scanned as code.
+//! * a `<template>`-shaped substring that is really adjacent comparisons or a TS generic
+//!   named `template` (`Array<template>`), which the byte pattern cannot distinguish from
+//!   an opener.
+//! * an unclosed `<template>` in code position greedily consumes up to the next
+//!   `</template>` later in the file (or, if there is none, is left untouched).
+//!
+//! A future rewrite can delegate to the [content-tag] crate for exact extraction.
+
+use oxc_allocator::{Allocator, StringBuilder};
+use oxc_span::SourceType;
+
+use crate::loader::JavaScriptSource;
+
+const TEMPLATE_START: &str = "<template>";
+const TEMPLATE_END: &str = "</template>";
+
+/// Where the single-pass scanner currently is while walking the source bytes.
+#[derive(Clone, Copy)]
+enum ScanState {
+    /// Ordinary JS/TS code: the only state in which a `<template>` opener is recognized.
+    Code,
+    /// Inside a `// ...` line comment, ended by the next `\n`.
+    LineComment,
+    /// Inside a `/* ... */` block comment, ended by the next `*/`.
+    BlockComment,
+    /// Inside a string; the byte is the closing delimiter (`'`, `"`, or `` ` ``). A raw
+    /// newline also ends a `'`/`"` string (they cannot span lines); backtick strings may.
+    Str(u8),
+    /// Inside a `<template>` body, holding the byte offset of its `<template>` opener. The
+    /// body is HTML-ish and opaque — quotes, slashes, and `//` in it are *not* JS — so
+    /// only `</template>` ends it.
+    Template(usize),
+}
+
+/// Byte offsets `(open_start, close_end)` of every `<template>...</template>` region that
+/// opens in code position — not inside a comment or string.
+///
+/// A minimal single-pass state machine classifies each byte so that a literal
+/// `<template>` inside a comment or string is not mistaken for a tag, and so that the
+/// HTML-ish template body (which routinely contains quotes and slashes) is treated as
+/// opaque rather than lexed as JS. The returned regions are ordered and disjoint. See the
+/// module-level docs for the scanner's remaining limitations.
+fn template_regions(source_text: &str) -> Vec<(usize, usize)> {
+    let bytes = source_text.as_bytes();
+    let len = bytes.len();
+    let mut regions: Vec<(usize, usize)> = Vec::new();
+    let mut state = ScanState::Code;
+    let mut i = 0;
+
+    while i < len {
+        match state {
+            ScanState::Code => {
+                let rest = &bytes[i..];
+                if rest.starts_with(b"//") {
+                    state = ScanState::LineComment;
+                    i += 2;
+                } else if rest.starts_with(b"/*") {
+                    state = ScanState::BlockComment;
+                    i += 2;
+                } else if matches!(bytes[i], b'\'' | b'"' | b'`') {
+                    state = ScanState::Str(bytes[i]);
+                    i += 1;
+                } else if rest.starts_with(TEMPLATE_START.as_bytes()) {
+                    // Enter the template body. `</template>` starts with `<` too, but its
+                    // second byte is `/` and the opener's is `t`, so this never matches a
+                    // close; a stray `</template>` in code has no opener and is ignored.
+                    state = ScanState::Template(i);
+                    i += TEMPLATE_START.len();
+                } else {
+                    i += 1;
+                }
+            }
+            ScanState::LineComment => {
+                if bytes[i] == b'\n' {
+                    state = ScanState::Code;
+                }
+                i += 1;
+            }
+            ScanState::BlockComment => {
+                if bytes[i..].starts_with(b"*/") {
+                    state = ScanState::Code;
+                    i += 2;
+                } else {
+                    i += 1;
+                }
+            }
+            ScanState::Str(delimiter) => match bytes[i] {
+                // A backslash escapes the next byte (including a `'`/`"`/`` ` `` or a
+                // line-continuation newline), so skip both.
+                b'\\' => i += 2,
+                // A raw newline cannot appear in a `'`/`"` string, so it was unterminated;
+                // recover to code rather than swallowing the rest of the file.
+                b'\n' if delimiter != b'`' => {
+                    state = ScanState::Code;
+                    i += 1;
+                }
+                b if b == delimiter => {
+                    state = ScanState::Code;
+                    i += 1;
+                }
+                _ => i += 1,
+            },
+            ScanState::Template(open_start) => {
+                if bytes[i..].starts_with(TEMPLATE_END.as_bytes()) {
+                    let end = i + TEMPLATE_END.len();
+                    regions.push((open_start, end));
+                    state = ScanState::Code;
+                    i = end;
+                } else {
+                    i += 1;
+                }
+            }
+        }
+    }
+
+    regions
+}
+
+pub struct GlimmerPartialLoader<'a> {
+    source_text: &'a str,
+    allocator: &'a Allocator,
+}
+
+impl<'a> GlimmerPartialLoader<'a> {
+    pub fn new(source_text: &'a str, allocator: &'a Allocator) -> Self {
+        Self { source_text, allocator }
+    }
+
+    pub fn parse(self, ext: &str) -> Vec<JavaScriptSource<'a>> {
+        // `.gjs` is unconditionally an ESM module per Ember RFC #779: top-level
+        // `<template>` and the file format itself presuppose module semantics, so we
+        // use `mjs()` rather than `unambiguous()` to avoid script-mode fallback for
+        // files that happen to contain no `import`/`export` statements.
+        // `.gts` uses `SourceType::ts()` whose unambiguous module kind is resolved to
+        // a module by the parser on the first ESM construct.
+        let source_type = if ext == "gts" { SourceType::ts() } else { SourceType::mjs() };
+        let cleaned = self.strip_templates();
+        vec![JavaScriptSource::partial(cleaned, source_type, 0)]
+    }
+
+    /// Replace `<template>...</template>` blocks with same-byte-length JS that is
+    /// valid in expression and class-body position, while preserving newlines so
+    /// byte offsets and line/column information for surrounding JS code remain
+    /// accurate for diagnostic reporting. See the module-level docs for the
+    /// substitution invariants and the known limitations of this byte-level scan.
+    fn strip_templates(&self) -> &'a str {
+        let regions = template_regions(self.source_text);
+        if regions.is_empty() {
+            return self.source_text;
+        }
+
+        let source_bytes = self.source_text.as_bytes();
+        let mut builder = StringBuilder::with_capacity_in(source_bytes.len(), self.allocator);
+        let mut cursor = 0;
+        for (region_start, region_end) in regions {
+            builder.push_str(&self.source_text[cursor..region_start]);
+            // 10-byte opener `<template>` -> 10-byte `undefined `; see module-level
+            // docs for why this exact identifier was chosen.
+            builder.push_str("undefined ");
+            for &byte in &source_bytes[region_start + TEMPLATE_START.len()..region_end] {
+                if byte == b'\n' {
+                    builder.push_ascii_byte(b'\n');
+                } else {
+                    builder.push_ascii_byte(b' ');
+                }
+            }
+            cursor = region_end;
+        }
+        builder.push_str(&self.source_text[cursor..]);
+        builder.into_str()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use oxc_allocator::Allocator;
+    use oxc_parser::Parser;
+
+    use super::GlimmerPartialLoader;
+    use crate::loader::JavaScriptSource;
+
+    fn parse_gjs<'a>(source_text: &'a str, allocator: &'a Allocator) -> JavaScriptSource<'a> {
+        let sources = GlimmerPartialLoader::new(source_text, allocator).parse("gjs");
+        *sources.first().unwrap()
+    }
+
+    fn parse_gts<'a>(source_text: &'a str, allocator: &'a Allocator) -> JavaScriptSource<'a> {
+        let sources = GlimmerPartialLoader::new(source_text, allocator).parse("gts");
+        *sources.first().unwrap()
+    }
+
+    /// Parse the loader's cleaned output through `oxc_parser` and assert it has no
+    /// parse errors. Only checks parse-level validity; semantic issues (the synthesized
+    /// `undefined` field/expression) are out of scope for this assertion.
+    fn assert_cleaned_parses(source_text: &str, ext: &str) {
+        let allocator = Allocator::new();
+        let sources = GlimmerPartialLoader::new(source_text, &allocator).parse(ext);
+        let cleaned = sources.first().unwrap();
+        let ret = Parser::new(&allocator, cleaned.source_text, cleaned.source_type).parse();
+        assert!(
+            !ret.panicked && ret.errors.is_empty(),
+            "cleaned output failed to parse for ext {ext}:\n--- input ---\n{source_text}\n--- cleaned ---\n{}\n--- errors ---\n{:#?}",
+            cleaned.source_text,
+            ret.errors,
+        );
+    }
+
+    #[test]
+    fn test_no_templates_gjs() {
+        let allocator = Allocator::new();
+        let source_text = "export default class Foo {}";
+        let result = parse_gjs(source_text, &allocator);
+        assert_eq!(result.source_text, source_text);
+        assert!(!result.source_type.is_typescript());
+        // `.gjs` is unconditionally a module; see `parse` doc.
+        assert!(result.source_type.is_module());
+        assert!(!result.source_type.is_unambiguous());
+        assert_eq!(result.start, 0);
+    }
+
+    #[test]
+    fn test_no_templates_gts() {
+        let allocator = Allocator::new();
+        let source_text = "export default class Foo {}";
+        let result = parse_gts(source_text, &allocator);
+        assert!(result.source_type.is_typescript());
+        assert!(result.source_type.is_unambiguous());
+        assert_eq!(result.start, 0);
+    }
+
+    #[test]
+    fn test_single_template_stripped() {
+        let allocator = Allocator::new();
+        let source_text = "import x from 'y';\n<template>\n  <h1>Hello</h1>\n</template>\n";
+        let result = parse_gjs(source_text, &allocator);
+        assert!(!result.source_text.contains("<h1>"));
+        assert!(result.source_text.starts_with("import x from 'y';\n"));
+        // <template> is replaced with `undefined ` — valid JS, same byte length
+        assert!(result.source_text.contains("undefined "));
+        let orig_nl = source_text.chars().filter(|&c| c == '\n').count();
+        let result_nl = result.source_text.chars().filter(|&c| c == '\n').count();
+        assert_eq!(orig_nl, result_nl);
+        assert_eq!(result.source_text.len(), source_text.len());
+        assert_eq!(result.start, 0);
+    }
+
+    #[test]
+    fn test_expression_position_template() {
+        let allocator = Allocator::new();
+        let source_text = "const component = <template>Hello</template>;";
+        let result = parse_gjs(source_text, &allocator);
+        // Must produce valid JS: `const component = undefined           ;`
+        assert!(result.source_text.starts_with("const component = undefined "));
+        assert!(result.source_text.ends_with(';'));
+        assert_eq!(result.source_text.len(), source_text.len());
+    }
+
+    #[test]
+    fn test_class_with_template() {
+        let allocator = Allocator::new();
+        let source_text = r"
+import Component from '@glimmer/component';
+export default class MyComponent extends Component {
+  <template>
+    <h1>Hello World!</h1>
+  </template>
+}
+";
+        let result = parse_gjs(source_text, &allocator);
+        assert!(result.source_text.contains("class MyComponent"));
+        assert!(!result.source_text.contains("<h1>"));
+        let orig_nl = source_text.chars().filter(|&c| c == '\n').count();
+        let result_nl = result.source_text.chars().filter(|&c| c == '\n').count();
+        assert_eq!(orig_nl, result_nl);
+    }
+
+    #[test]
+    fn test_top_level_template() {
+        let allocator = Allocator::new();
+        let source_text = "<template>\n  <h1>Hello World!</h1>\n</template>\n";
+        let result = parse_gjs(source_text, &allocator);
+        assert!(!result.source_text.contains("<h1>"));
+        let orig_nl = source_text.chars().filter(|&c| c == '\n').count();
+        let result_nl = result.source_text.chars().filter(|&c| c == '\n').count();
+        assert_eq!(orig_nl, result_nl);
+    }
+
+    #[test]
+    fn test_multiple_templates() {
+        let allocator = Allocator::new();
+        let source_text =
+            "const A = <template><p>A</p></template>;\nconst B = <template><p>B</p></template>;\n";
+        let result = parse_gjs(source_text, &allocator);
+        assert!(!result.source_text.contains("<p>"));
+        assert!(result.source_text.contains("const A ="));
+        assert!(result.source_text.contains("const B ="));
+    }
+
+    #[test]
+    fn test_returns_single_source() {
+        let allocator = Allocator::new();
+        let source_text = "const x = 1;\n<template>\n  foo\n</template>\n";
+        let sources = GlimmerPartialLoader::new(source_text, &allocator).parse("gjs");
+        assert_eq!(sources.len(), 1);
+    }
+
+    /// The cleaned output must be parseable JS in every supported template position;
+    /// otherwise downstream rules see a phantom AST.
+    #[test]
+    fn test_cleaned_output_parses_top_level() {
+        assert_cleaned_parses("<template>\n  <h1>hi</h1>\n</template>\n", "gjs");
+    }
+
+    #[test]
+    fn test_cleaned_output_parses_expression_position() {
+        assert_cleaned_parses("const c = <template>hi</template>;", "gjs");
+    }
+
+    #[test]
+    fn test_cleaned_output_parses_class_body() {
+        assert_cleaned_parses(
+            "import Component from '@glimmer/component';\nexport default class C extends Component {\n  <template>x</template>\n}\n",
+            "gjs",
+        );
+    }
+
+    #[test]
+    fn test_cleaned_output_parses_gts_with_generics() {
+        assert_cleaned_parses(
+            "import type Owner from '@ember/owner';\nexport default class C<T> {\n  value!: T;\n  <template>x</template>\n}\n",
+            "gts",
+        );
+    }
+
+    #[test]
+    fn test_cleaned_output_parses_no_templates() {
+        assert_cleaned_parses("import x from 'y';\nexport const v = x;\n", "gjs");
+    }
+
+    /// Byte offsets of tokens *after* a `<template>` block must be unchanged after
+    /// stripping; this is what makes diagnostic spans correct without a remap.
+    #[test]
+    fn test_byte_offsets_preserved_after_template() {
+        let allocator = Allocator::new();
+        let source_text = "<template>x</template>;\nconst bar = 1;\n";
+        let result = parse_gjs(source_text, &allocator);
+
+        let orig_offset = source_text.find("bar").expect("token in original");
+        let cleaned_offset = result.source_text.find("bar").expect("token in cleaned");
+        assert_eq!(orig_offset, cleaned_offset);
+        assert_eq!(source_text.len(), result.source_text.len());
+    }
+
+    #[test]
+    fn test_byte_offsets_preserved_across_multiple_templates() {
+        let allocator = Allocator::new();
+        let source_text = "const A = <template>a</template>;\nconst B = <template>b</template>;\nconst foo = 1;\n";
+        let result = parse_gjs(source_text, &allocator);
+
+        let orig_offset = source_text.find("foo").expect("token in original");
+        let cleaned_offset = result.source_text.find("foo").expect("token in cleaned");
+        assert_eq!(orig_offset, cleaned_offset);
+    }
+
+    /// An unclosed `<template>` with no `</template>` anywhere after it produces no
+    /// region, so the file is returned verbatim; the parser then surfaces the
+    /// malformedness.
+    #[test]
+    fn test_unclosed_template_does_not_pair_across_boundary() {
+        let allocator = Allocator::new();
+        let source_text = "const a = 1;\n<template>oops\nconst b = 2;\n";
+        let result = parse_gjs(source_text, &allocator);
+        // No `</template>` exists, so no rewriting should occur and the original
+        // source must be returned verbatim.
+        assert_eq!(result.source_text, source_text);
+    }
+
+    #[test]
+    fn test_well_formed_then_unclosed_only_strips_well_formed() {
+        let allocator = Allocator::new();
+        let source_text = "<template>good</template>;\nconst a = 1;\n<template>oops\n";
+        let result = parse_gjs(source_text, &allocator);
+        // First (well-formed) template stripped to `undefined `+spaces.
+        assert!(result.source_text.starts_with("undefined "));
+        assert!(!result.source_text.contains("good"));
+        // Second (unclosed) template's open is preserved.
+        assert!(result.source_text.contains("<template>oops"));
+        // Byte length is unchanged.
+        assert_eq!(result.source_text.len(), source_text.len());
+    }
+
+    /// A `<template>` sitting inside a line comment *above* a real template must not be
+    /// treated as an opener: the scanner skips comment bytes, so the comment is left
+    /// verbatim and only the real template below it is stripped.
+    #[test]
+    fn test_line_comment_template_open_before_real_template() {
+        let allocator = Allocator::new();
+        let source_text = "// <template>\n<template>\n  <h1>Hello</h1>\n</template>\n";
+        let result = parse_gjs(source_text, &allocator);
+        // The comment is untouched: its `<template>` is not a real opener.
+        assert!(result.source_text.starts_with("// <template>\n"));
+        // The real template below the comment is still stripped.
+        assert!(!result.source_text.contains("<h1>"));
+        assert!(result.source_text.contains("undefined "));
+        assert_eq!(result.source_text.len(), source_text.len());
+        let orig_nl = source_text.chars().filter(|&c| c == '\n').count();
+        let result_nl = result.source_text.chars().filter(|&c| c == '\n').count();
+        assert_eq!(orig_nl, result_nl);
+        assert_cleaned_parses(source_text, "gjs");
+    }
+
+    /// Real code between a comment's `<template>` and the actual template must survive:
+    /// the comment's `<template>` is not an opener, so the `import` here is not swallowed.
+    #[test]
+    fn test_line_comment_open_preserves_intervening_code() {
+        let allocator = Allocator::new();
+        let source_text =
+            "// <template>\nimport x from 'y';\nexport const c = <template>hi</template>;\n";
+        let result = parse_gjs(source_text, &allocator);
+        assert!(result.source_text.starts_with("// <template>\n"));
+        // The import between the comment and the real template is not swallowed.
+        assert!(result.source_text.contains("import x from 'y';"));
+        // Only the real template is neutralized.
+        assert!(result.source_text.contains("export const c = undefined "));
+        assert!(!result.source_text.contains("<template>hi"));
+        assert_eq!(result.source_text.len(), source_text.len());
+        assert_cleaned_parses(source_text, "gjs");
+    }
+
+    // -- Comments and strings are skipped by the scanner ------------------------------
+    //
+    // A `<template>` / `</template>` byte sequence inside a comment or string is not a
+    // real tag; the single-pass scanner leaves it untouched.
+
+    /// A complete `<template>...</template>` inside a string literal is not code, so the
+    /// string is preserved verbatim rather than clobbered.
+    #[test]
+    fn test_template_inside_string_literal_is_left_untouched() {
+        let allocator = Allocator::new();
+        let source_text = r#"const s = "<template>x</template>";"#;
+        let result = parse_gjs(source_text, &allocator);
+        assert_eq!(result.source_text, source_text);
+        assert_cleaned_parses(source_text, "gjs");
+    }
+
+    /// A `</template>` inside a string must not close a later real template, and that real
+    /// template must still be stripped.
+    #[test]
+    fn test_template_bytes_in_string_do_not_break_a_real_template() {
+        let allocator = Allocator::new();
+        let source_text = "const s = \"</template>\";\nexport const c = <template>hi</template>;\n";
+        let result = parse_gjs(source_text, &allocator);
+        // The string is preserved.
+        assert!(result.source_text.contains("\"</template>\""));
+        // The real template after it is stripped.
+        assert!(result.source_text.contains("export const c = undefined "));
+        assert!(!result.source_text.contains("<template>hi"));
+        assert_eq!(result.source_text.len(), source_text.len());
+        assert_cleaned_parses(source_text, "gjs");
+    }
+
+    /// A backtick string (including its `${...}` interpolation) is preserved, so the
+    /// reference to `x` survives and no spurious unused-variable diagnostic appears.
+    #[test]
+    fn test_template_inside_backtick_string_preserves_substitution() {
+        let allocator = Allocator::new();
+        let source_text = "const x = 1;\nconst t = `<template>${x}</template>`;\n";
+        let result = parse_gjs(source_text, &allocator);
+        assert_eq!(result.source_text, source_text);
+    }
+
+    /// A complete `<template>...</template>` inside a line comment is not code, so the
+    /// comment is preserved verbatim.
+    #[test]
+    fn test_template_inside_line_comment_is_left_untouched() {
+        let allocator = Allocator::new();
+        let source_text = "// <template>x</template>\nconst a = 1;\n";
+        let result = parse_gjs(source_text, &allocator);
+        assert_eq!(result.source_text, source_text);
+    }
+
+    /// A `<template>...</template>` inside a block comment is skipped; only the real
+    /// template after it is stripped.
+    #[test]
+    fn test_template_inside_block_comment_is_left_untouched() {
+        let allocator = Allocator::new();
+        let source_text =
+            "/* <template>x</template> */\nexport const c = <template>hi</template>;\n";
+        let result = parse_gjs(source_text, &allocator);
+        assert!(result.source_text.starts_with("/* <template>x</template> */"));
+        assert!(result.source_text.contains("export const c = undefined "));
+        assert!(!result.source_text.contains("<template>hi"));
+        assert_eq!(result.source_text.len(), source_text.len());
+        assert_cleaned_parses(source_text, "gjs");
+    }
+
+    /// A template body is HTML-ish and routinely contains quotes, apostrophes, and
+    /// slashes; the scanner must treat the body as opaque rather than lexing those as JS
+    /// strings/comments, which would swallow the `</template>` and leave the tag in place.
+    #[test]
+    fn test_template_body_with_quotes_and_slashes_is_stripped() {
+        let allocator = Allocator::new();
+        let source_text =
+            "<template>\n  <a href=\"/x\" title='it\\'s'>hi // there</a>\n</template>\n";
+        let result = parse_gjs(source_text, &allocator);
+        assert!(result.source_text.starts_with("undefined "));
+        assert!(!result.source_text.contains("<a "));
+        assert!(!result.source_text.contains("href"));
+        assert_eq!(result.source_text.len(), source_text.len());
+        assert_cleaned_parses(source_text, "gjs");
+    }
+
+    // -- Remaining byte-pattern limitations (pinned) ----------------------------------
+
+    /// Regex literals are not tracked: a real regex containing `</template>` is treated as
+    /// code, so the bytes between a preceding `<template>` and the regex's `</template>`
+    /// are (incorrectly) stripped. This escaped-close regex happens to be left intact
+    /// because `<\/template>` is not the `</template>` byte sequence.
+    #[test]
+    fn test_known_limitation_regex_with_escaped_close_is_left_intact() {
+        let allocator = Allocator::new();
+        let source_text = "const r = /<template>x<\\/template>/;\n";
+        let result = parse_gjs(source_text, &allocator);
+        assert_eq!(result.source_text, source_text);
+    }
+}

--- a/crates/oxc_linter/src/loader/partial_loader/glimmer.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/glimmer.rs
@@ -195,7 +195,15 @@ impl<'a> GlimmerPartialLoader<'a> {
         // `.gts` uses `SourceType::ts()` whose unambiguous module kind is resolved to
         // a module by the parser on the first ESM construct.
         let source_type = if ext == "gts" { SourceType::ts() } else { SourceType::mjs() };
-        let cleaned = self.strip_templates();
+        let regions = template_regions(self.source_text);
+        if regions.is_empty() {
+            // No `<template>` block: nothing is rewritten, so this is a plain, complete
+            // JS/TS file. Return it as a whole (non-partial) source — `is_partial()`
+            // is `false` — so rules that are skipped for template-rewritten Glimmer
+            // sources still run here.
+            return vec![JavaScriptSource::new(self.source_text, source_type)];
+        }
+        let cleaned = self.strip_templates(&regions);
         vec![JavaScriptSource::partial(cleaned, source_type, 0)]
     }
 
@@ -204,16 +212,14 @@ impl<'a> GlimmerPartialLoader<'a> {
     /// byte offsets and line/column information for surrounding JS code remain
     /// accurate for diagnostic reporting. See the module-level docs for the
     /// substitution invariants and the known limitations of this byte-level scan.
-    fn strip_templates(&self) -> &'a str {
-        let regions = template_regions(self.source_text);
-        if regions.is_empty() {
-            return self.source_text;
-        }
-
+    ///
+    /// `regions` must be the non-empty [`template_regions`] of this loader's source;
+    /// the caller handles the template-less case (see [`Self::parse`]).
+    fn strip_templates(&self, regions: &[(usize, usize)]) -> &'a str {
         let source_bytes = self.source_text.as_bytes();
         let mut builder = StringBuilder::with_capacity_in(source_bytes.len(), self.allocator);
         let mut cursor = 0;
-        for (region_start, region_end) in regions {
+        for &(region_start, region_end) in regions {
             builder.push_str(&self.source_text[cursor..region_start]);
             // 10-byte opener `<template>` -> 10-byte `undefined `; see module-level
             // docs for why this exact identifier was chosen.
@@ -277,6 +283,8 @@ mod test {
         assert!(result.source_type.is_module());
         assert!(!result.source_type.is_unambiguous());
         assert_eq!(result.start, 0);
+        // No `<template>`: returned as a whole, non-partial source.
+        assert!(!result.is_partial());
     }
 
     #[test]
@@ -287,6 +295,8 @@ mod test {
         assert!(result.source_type.is_typescript());
         assert!(result.source_type.is_unambiguous());
         assert_eq!(result.start, 0);
+        // No `<template>`: returned as a whole, non-partial source.
+        assert!(!result.is_partial());
     }
 
     #[test]
@@ -296,6 +306,8 @@ mod test {
         let result = parse_gjs(source_text, &allocator);
         assert!(!result.source_text.contains("<h1>"));
         assert!(result.source_text.starts_with("import x from 'y';\n"));
+        // A `<template>` was rewritten, so this is a partial (loader-derived) source.
+        assert!(result.is_partial());
         // <template> is replaced with `undefined ` — valid JS, same byte length
         assert!(result.source_text.contains("undefined "));
         let orig_nl = source_text.chars().filter(|&c| c == '\n').count();
@@ -355,6 +367,8 @@ export default class MyComponent extends Component {
         assert!(!result.source_text.contains("<p>"));
         assert!(result.source_text.contains("const A ="));
         assert!(result.source_text.contains("const B ="));
+        // Both stripped regions must leave valid JS behind, not just remove the markup.
+        assert_cleaned_parses(source_text, "gjs");
     }
 
     #[test]
@@ -398,20 +412,10 @@ export default class MyComponent extends Component {
         assert_cleaned_parses("import x from 'y';\nexport const v = x;\n", "gjs");
     }
 
-    /// Byte offsets of tokens *after* a `<template>` block must be unchanged after
-    /// stripping; this is what makes diagnostic spans correct without a remap.
-    #[test]
-    fn test_byte_offsets_preserved_after_template() {
-        let allocator = Allocator::new();
-        let source_text = "<template>x</template>;\nconst bar = 1;\n";
-        let result = parse_gjs(source_text, &allocator);
-
-        let orig_offset = source_text.find("bar").expect("token in original");
-        let cleaned_offset = result.source_text.find("bar").expect("token in cleaned");
-        assert_eq!(orig_offset, cleaned_offset);
-        assert_eq!(source_text.len(), result.source_text.len());
-    }
-
+    /// Byte offsets of tokens *after* `<template>` blocks must be unchanged after
+    /// stripping; this is what makes diagnostic spans correct without a remap. Uses two
+    /// templates so it also pins the cumulative offset math across multiple regions (the
+    /// single-template case is a strict subset of this one).
     #[test]
     fn test_byte_offsets_preserved_across_multiple_templates() {
         let allocator = Allocator::new();
@@ -421,6 +425,7 @@ export default class MyComponent extends Component {
         let orig_offset = source_text.find("foo").expect("token in original");
         let cleaned_offset = result.source_text.find("foo").expect("token in cleaned");
         assert_eq!(orig_offset, cleaned_offset);
+        assert_eq!(source_text.len(), result.source_text.len());
     }
 
     /// An unclosed `<template>` with no `</template>` anywhere after it produces no

--- a/crates/oxc_linter/src/loader/partial_loader/glimmer.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/glimmer.rs
@@ -259,10 +259,10 @@ mod test {
         let cleaned = sources.first().unwrap();
         let ret = Parser::new(&allocator, cleaned.source_text, cleaned.source_type).parse();
         assert!(
-            !ret.panicked && ret.errors.is_empty(),
+            !ret.panicked && ret.diagnostics.is_empty(),
             "cleaned output failed to parse for ext {ext}:\n--- input ---\n{source_text}\n--- cleaned ---\n{}\n--- errors ---\n{:#?}",
             cleaned.source_text,
-            ret.errors,
+            ret.diagnostics,
         );
     }
 

--- a/crates/oxc_linter/src/loader/partial_loader/mod.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/mod.rs
@@ -1,12 +1,15 @@
 use memchr::{memmem::Finder, memmem::FinderRev};
+use oxc_allocator::Allocator;
 use oxc_span::VALID_EXTENSIONS;
 
 use crate::loader::JavaScriptSource;
 
 mod astro;
+mod glimmer;
 mod svelte;
 mod vue;
 pub use astro::AstroPartialLoader;
+pub use glimmer::GlimmerPartialLoader;
 pub use svelte::SveltePartialLoader;
 pub use vue::VuePartialLoader;
 
@@ -17,7 +20,7 @@ const COMMENT_END: &str = "-->";
 
 /// File extensions that can contain JS/TS code in certain parts, such as in `<script>` tags, and can
 /// be loaded using the [`PartialLoader`].
-pub const LINT_PARTIAL_LOADER_EXTENSIONS: &[&str] = &["vue", "astro", "svelte"];
+pub const LINT_PARTIAL_LOADER_EXTENSIONS: &[&str] = &["vue", "astro", "svelte", "gjs", "gts"];
 
 /// All valid JavaScript/TypeScript extensions, plus additional framework files that
 /// contain JavaScript/TypeScript code in them (e.g., Vue, Astro, Svelte, etc.).
@@ -29,11 +32,16 @@ pub struct PartialLoader;
 impl PartialLoader {
     /// Extract js section of special files.
     /// Returns `None` if the special file does not have a js section.
-    pub fn parse<'a>(ext: &str, source_text: &'a str) -> Option<Vec<JavaScriptSource<'a>>> {
+    pub fn parse<'a>(
+        ext: &str,
+        source_text: &'a str,
+        allocator: &'a Allocator,
+    ) -> Option<Vec<JavaScriptSource<'a>>> {
         match ext {
             "vue" => Some(VuePartialLoader::new(source_text).parse()),
             "astro" => Some(AstroPartialLoader::new(source_text).parse()),
             "svelte" => Some(SveltePartialLoader::new(source_text).parse()),
+            "gjs" | "gts" => Some(GlimmerPartialLoader::new(source_text, allocator).parse(ext)),
             _ => None,
         }
     }

--- a/crates/oxc_linter/src/loader/source.rs
+++ b/crates/oxc_linter/src/loader/source.rs
@@ -10,7 +10,6 @@ pub struct JavaScriptSource<'a> {
     /// The javascript source could be embedded in some file,
     /// use `start` to record start offset of js block in the original file.
     pub start: u32,
-    #[expect(dead_code)]
     is_partial: bool,
 
     // some partial sources can have special options defined, like Vue's `<script setup>`.
@@ -44,6 +43,13 @@ impl<'a> JavaScriptSource<'a> {
         start: u32,
     ) -> Self {
         Self { source_text, source_type, start, is_partial: true, framework_options }
+    }
+
+    /// `true` if this source was extracted from a container file by a
+    /// [`PartialLoader`](super::PartialLoader) (e.g. a `<script>` block in a
+    /// `.vue` file, or a `.gjs`/`.gts` file with its templates blanked out).
+    pub fn is_partial(&self) -> bool {
+        self.is_partial
     }
 
     pub fn as_str(&self) -> &'a str {

--- a/crates/oxc_linter/src/rules/eslint/no_unused_expressions.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_expressions.rs
@@ -72,11 +72,12 @@ declare_oxc_lint!(
 
 impl Rule for NoUnusedExpressions {
     fn should_run(&self, ctx: &ContextHost) -> bool {
-        // Glimmer (`.gjs`/`.gts`) is only skipped when the source came from the partial
-        // loader, which replaces each `<template>` with a synthesized `undefined`
-        // placeholder — in statement position (e.g. a template-only component) that is a
-        // bare expression statement this rule would flag. Other pipelines (e.g. a custom
-        // parser) don't produce the placeholder, so the rule stays enabled there.
+        // Base: only consider partial-loader-extracted sources for exclusion. Then opt
+        // in the Glimmer (`.gjs`/`.gts`) extensions specifically: their loader replaces
+        // each `<template>` with a synthesized `undefined` placeholder that is a bare
+        // expression statement this rule would otherwise flag. Vue/Svelte/Astro
+        // `<script>` blocks are not rewritten that way, so they keep running (broadening
+        // the exclusion to them is left to a separate change).
         !(ctx.is_from_partial_loader()
             && ctx.file_extension().is_some_and(|ext| ext == "gjs" || ext == "gts"))
     }

--- a/crates/oxc_linter/src/rules/eslint/no_unused_expressions.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_expressions.rs
@@ -11,7 +11,7 @@ use serde_json::Value;
 
 use crate::{
     AstNode,
-    context::LintContext,
+    context::{ContextHost, LintContext},
     rule::{DefaultRuleConfig, Rule},
 };
 
@@ -71,6 +71,16 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUnusedExpressions {
+    fn should_run(&self, ctx: &ContextHost) -> bool {
+        // Glimmer (`.gjs`/`.gts`) is only skipped when the source came from the partial
+        // loader, which replaces each `<template>` with a synthesized `undefined`
+        // placeholder — in statement position (e.g. a template-only component) that is a
+        // bare expression statement this rule would flag. Other pipelines (e.g. a custom
+        // parser) don't produce the placeholder, so the rule stays enabled there.
+        !(ctx.is_from_partial_loader()
+            && ctx.file_extension().is_some_and(|ext| ext == "gjs" || ext == "gts"))
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::ExpressionStatement(expression_stmt) = node.kind() else {
             return;

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
@@ -237,13 +237,19 @@ impl Rule for NoUnusedVars {
     }
 
     fn should_run(&self, ctx: &ContextHost) -> bool {
-        // ignore .d.ts and vue/svelte/astro/gjs/gts files.
+        // ignore .d.ts and vue/svelte/astro files.
         // 1. declarations have side effects (they get merged together)
-        // 2. these scripts declare variables that get used in the template, which we can't detect
-        !ctx.source_type().is_typescript_definition()
-            && !ctx.file_extension().is_some_and(|ext| {
-                ext == "vue" || ext == "svelte" || ext == "astro" || ext == "gjs" || ext == "gts"
-            })
+        // 2. vue/svelte/astro scripts declare variables that get used in the template, which
+        //    we can't detect
+        // Glimmer (`.gjs`/`.gts`) is only skipped when the source came from the partial loader,
+        // which blanks out templates; other pipelines (e.g. a custom parser) keep template
+        // usage visible, so the rule stays correct there.
+        !(ctx.source_type().is_typescript_definition()
+            || ctx
+                .file_extension()
+                .is_some_and(|ext| ext == "vue" || ext == "svelte" || ext == "astro")
+            || (ctx.is_from_partial_loader()
+                && ctx.file_extension().is_some_and(|ext| ext == "gjs" || ext == "gts")))
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
@@ -237,19 +237,12 @@ impl Rule for NoUnusedVars {
     }
 
     fn should_run(&self, ctx: &ContextHost) -> bool {
-        // ignore .d.ts and vue/svelte/astro files.
-        // 1. declarations have side effects (they get merged together)
-        // 2. vue/svelte/astro scripts declare variables that get used in the template, which
-        //    we can't detect
-        // Glimmer (`.gjs`/`.gts`) is only skipped when the source came from the partial loader,
-        // which blanks out templates; other pipelines (e.g. a custom parser) keep template
-        // usage visible, so the rule stays correct there.
-        !(ctx.source_type().is_typescript_definition()
-            || ctx
-                .file_extension()
-                .is_some_and(|ext| ext == "vue" || ext == "svelte" || ext == "astro")
-            || (ctx.is_from_partial_loader()
-                && ctx.file_extension().is_some_and(|ext| ext == "gjs" || ext == "gts")))
+        // Skip:
+        // 1. `.d.ts` files — declarations have side effects (they get merged together).
+        // 2. Any partial-loader-extracted source (Vue/Svelte/Astro `<script>` blocks,
+        //    Glimmer `<template>` files): variables declared in the script are used in
+        //    the template, which is not part of the linted JS, so they look unused.
+        !(ctx.source_type().is_typescript_definition() || ctx.is_from_partial_loader())
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
@@ -237,14 +237,13 @@ impl Rule for NoUnusedVars {
     }
 
     fn should_run(&self, ctx: &ContextHost) -> bool {
-        // ignore .d.ts and vue/svelte/astro files.
+        // ignore .d.ts and vue/svelte/astro/gjs/gts files.
         // 1. declarations have side effects (they get merged together)
-        // 2. vue/svelte/astro scripts declare variables that get used in the template, which
-        //    we can't detect
+        // 2. these scripts declare variables that get used in the template, which we can't detect
         !ctx.source_type().is_typescript_definition()
-            && !ctx
-                .file_extension()
-                .is_some_and(|ext| ext == "vue" || ext == "svelte" || ext == "astro")
+            && !ctx.file_extension().is_some_and(|ext| {
+                ext == "vue" || ext == "svelte" || ext == "astro" || ext == "gjs" || ext == "gts"
+            })
     }
 }
 

--- a/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
+++ b/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
@@ -260,10 +260,11 @@ declare_oxc_lint!(
 
 impl Rule for RulesOfHooks {
     fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
-        // disable this rule in vue/nuxt and svelte(kit) files
+        // disable this rule in vue/nuxt, svelte(kit), and Glimmer (`.gjs`/`.gts`) files
         // react hook can be build in only `.ts` files,
         // but `useX` functions are popular and can be false positive in other frameworks
-        !ctx.file_extension().is_some_and(|ext| ext == "vue" || ext == "svelte")
+        !ctx.file_extension()
+            .is_some_and(|ext| ext == "vue" || ext == "svelte" || ext == "gjs" || ext == "gts")
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
+++ b/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
@@ -260,11 +260,15 @@ declare_oxc_lint!(
 
 impl Rule for RulesOfHooks {
     fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
-        // disable this rule in vue/nuxt, svelte(kit), and Glimmer (`.gjs`/`.gts`) files
+        // disable this rule in vue/nuxt and svelte(kit) files
         // react hook can be build in only `.ts` files,
         // but `useX` functions are popular and can be false positive in other frameworks
-        !ctx.file_extension()
-            .is_some_and(|ext| ext == "vue" || ext == "svelte" || ext == "gjs" || ext == "gts")
+        // Glimmer (`.gjs`/`.gts`) is only skipped on the zero-config partial-loader path;
+        // when the file is processed by another pipeline (e.g. an ESLint-compatible custom
+        // parser), behavior follows ESLint, which doesn't special-case these files.
+        !(ctx.file_extension().is_some_and(|ext| ext == "vue" || ext == "svelte")
+            || (ctx.is_from_partial_loader()
+                && ctx.file_extension().is_some_and(|ext| ext == "gjs" || ext == "gts")))
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
+++ b/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
@@ -260,15 +260,15 @@ declare_oxc_lint!(
 
 impl Rule for RulesOfHooks {
     fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
-        // disable this rule in vue/nuxt and svelte(kit) files
-        // react hook can be build in only `.ts` files,
-        // but `useX` functions are popular and can be false positive in other frameworks
-        // Glimmer (`.gjs`/`.gts`) is only skipped on the zero-config partial-loader path;
-        // when the file is processed by another pipeline (e.g. an ESLint-compatible custom
-        // parser), behavior follows ESLint, which doesn't special-case these files.
-        !(ctx.file_extension().is_some_and(|ext| ext == "vue" || ext == "svelte")
-            || (ctx.is_from_partial_loader()
-                && ctx.file_extension().is_some_and(|ext| ext == "gjs" || ext == "gts")))
+        // `useX` functions are popular in component frameworks and can be false
+        // positives. Base: only consider partial-loader-extracted sources for exclusion.
+        // Then opt in the extensions this rule excludes — Vue and Svelte, plus Glimmer
+        // (`.gjs`/`.gts`). Astro keeps running (broadening the exclusion to it is left to
+        // a separate change).
+        !(ctx.is_from_partial_loader()
+            && ctx
+                .file_extension()
+                .is_some_and(|ext| ext == "vue" || ext == "svelte" || ext == "gjs" || ext == "gts"))
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
@@ -331,9 +331,9 @@ impl Rule for ConsistentTypeImports {
 
     fn should_run(&self, ctx: &ContextHost) -> bool {
         ctx.source_type().is_typescript()
-            && !ctx
-                .file_extension()
-                .is_some_and(|ext| ext == "vue" || ext == "svelte" || ext == "astro")
+            && !ctx.file_extension().is_some_and(|ext| {
+                ext == "vue" || ext == "svelte" || ext == "astro" || ext == "gts"
+            })
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
@@ -330,16 +330,10 @@ impl Rule for ConsistentTypeImports {
     }
 
     fn should_run(&self, ctx: &ContextHost) -> bool {
-        // Glimmer TS (`.gts`) is only skipped when the source came from the partial loader,
-        // which blanks out templates: an import used only as a value in a template would
-        // look type-only and get an incorrect `import type` fix. Other pipelines (e.g. a
-        // custom parser) keep template usage visible.
-        ctx.source_type().is_typescript()
-            && !(ctx
-                .file_extension()
-                .is_some_and(|ext| ext == "vue" || ext == "svelte" || ext == "astro")
-                || (ctx.is_from_partial_loader()
-                    && ctx.file_extension().is_some_and(|ext| ext == "gts")))
+        // Skip any partial-loader-extracted source (Vue/Svelte/Astro `<script>` blocks,
+        // Glimmer `<template>` files): an import used only as a value in the template
+        // looks type-only after extraction and would get an incorrect `import type` fix.
+        ctx.source_type().is_typescript() && !ctx.is_from_partial_loader()
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
@@ -330,10 +330,16 @@ impl Rule for ConsistentTypeImports {
     }
 
     fn should_run(&self, ctx: &ContextHost) -> bool {
+        // Glimmer TS (`.gts`) is only skipped when the source came from the partial loader,
+        // which blanks out templates: an import used only as a value in a template would
+        // look type-only and get an incorrect `import type` fix. Other pipelines (e.g. a
+        // custom parser) keep template usage visible.
         ctx.source_type().is_typescript()
-            && !ctx.file_extension().is_some_and(|ext| {
-                ext == "vue" || ext == "svelte" || ext == "astro" || ext == "gts"
-            })
+            && !(ctx
+                .file_extension()
+                .is_some_and(|ext| ext == "vue" || ext == "svelte" || ext == "astro")
+                || (ctx.is_from_partial_loader()
+                    && ctx.file_extension().is_some_and(|ext| ext == "gts")))
     }
 }
 

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -1071,7 +1071,7 @@ impl Runtime {
         allocator: &'a Allocator,
         mut out_sections: Option<&mut SectionContents<'a>>,
     ) -> SmallVec<[Result<ResolvedModuleRecord, Vec<OxcDiagnostic>>; 1]> {
-        let section_sources = PartialLoader::parse(ext, source_text)
+        let section_sources = PartialLoader::parse(ext, source_text, allocator)
             .unwrap_or_else(|| vec![JavaScriptSource::partial(source_text, source_type, 0)]);
 
         let mut section_module_records = SmallVec::<

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -1074,8 +1074,13 @@ impl Runtime {
         allocator: &'a Allocator,
         mut out_sections: Option<&mut SectionContents<'a>>,
     ) -> SmallVec<[Result<ResolvedModuleRecord, Vec<OxcDiagnostic>>; 1]> {
+        // When no partial loader matches, the whole file is a single, complete source
+        // (a plain `.js`/`.ts`/etc.). Use `new` (not `partial`) so it is correctly
+        // reported as non-partial: `is_from_partial_loader()` must return `false` for
+        // whole files. Only sources carved out by a `PartialLoader` (Vue/Svelte/Astro
+        // `<script>` blocks, Glimmer templates) are partial.
         let section_sources = PartialLoader::parse(ext, source_text, allocator)
-            .unwrap_or_else(|| vec![JavaScriptSource::partial(source_text, source_type, 0)]);
+            .unwrap_or_else(|| vec![JavaScriptSource::new(source_text, source_type)]);
 
         let mut section_module_records = SmallVec::<
             [Result<ResolvedModuleRecord, Vec<OxcDiagnostic>>; 1],

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -648,6 +648,7 @@ impl Runtime {
                                         framework_options: section.source.framework_options,
                                         parser_tokens: section.parser_tokens,
                                         respect_eslint_disable_directives,
+                                        from_partial_loader: section.source.is_partial(),
                                         ..Default::default()
                                     },
                                 )),
@@ -786,6 +787,7 @@ impl Runtime {
                                             framework_options: section.source.framework_options,
                                             parser_tokens: section.parser_tokens,
                                             respect_eslint_disable_directives,
+                                            from_partial_loader: section.source.is_partial(),
                                             ..Default::default()
                                         },
                                     )),
@@ -929,6 +931,7 @@ impl Runtime {
                                         framework_options: section.source.framework_options,
                                         parser_tokens: section.parser_tokens,
                                         respect_eslint_disable_directives,
+                                        from_partial_loader: section.source.is_partial(),
                                         ..Default::default()
                                     },
                                 )),


### PR DESCRIPTION
# Glimmer Partial Loader

Zero-config native linting for Ember template-tag files, gets `.gjs`, `.gts` working out-of-the-box.

Follows and improves on the `.vue`/`.svelte`/`.astro` partial-loader pattern.

Implemented with the assistance of Claude Code (Opus 4.7 / 4.8, Fable 5).

Reviewed by myself and tested against a large proprietary corpus of Ember code.

## Implementation

- New `GlimmerPartialLoader` (`loader/partial_loader/glimmer.rs`): scans for `<template>...</template>` regions and neutralizes them in place, preserving byte offsets exactly — the 10-byte opener becomes `undefined ` (10 bytes), the rest of the region becomes spaces with `\n` kept. Diagnostics outside templates keep correct spans with no offset bookkeeping. `undefined` is valid in expression position, is a legal class-field name, and introduces no binding.
- Returns a single `JavaScriptSource` with `start = 0`; the whole file is one JS/TS unit with templates blanked.
- `.gjs` → `SourceType::mjs()` (ESM per [Ember RFC #779](https://rfcs.emberjs.com/id/0779-first-class-component-templates/)); `.gts` → `SourceType::ts()`.
- `gjs`/`gts` added to `LINT_PARTIAL_LOADER_EXTENSIONS`; `PartialLoader::parse` gains an allocator param (cleaned text is arena-built).
- Region detection is a single-pass state machine (code / line comment / block comment / single-double-backtick string / template body). `<template>` is only recognized in code position, so an opener inside a comment or string is left untouched. The body is opaque, so only `</template>` closes it and content like `class="x"` or `it's` can't swallow the closer.

## Rule gating

The previous pattern was to skip some rules based on file extension. Some of these exceptions also apply to partially-applied Glimmer files, but this PR generalizes the logic to prepare for future work on custom parsers (see below).

Exclusions are now keyed on the source _coming from the partial loader_ (new `ContextHost::is_from_partial_loader()`, fed from `JavaScriptSource::is_partial`), not on file extension:

- `no-unused-vars` and `react/rules_of_hooks` skip loader-derived `.gjs`/`.gts` (variables used only inside templates are invisible after blanking; `useX` helpers are common in Ember).
- `ts/consistent_type_imports` skips loader-derived `.gts`.
- `no-unused-expressions` skips loader-derived `.gjs`/`.gts` (a statement-position template becomes a bare `undefined` statement).

Files reaching the linter through other pipelines (e.g. a custom parser) keep all four rules enabled. **The vue/svelte/astro extension checks retain their current behavior** when the source comes from the partial loader.

## Known limitations

The state machine is deliberately smaller than a full JS/TS lexer, so a few unlikely cases fall back to the byte pattern: regex literals (`/<template>/`), JSX text in a `.gjs`, `${...}` contents inside a backtick string, a `<template>`-shaped substring that is really adjacent comparisons or a TS generic, and an unclosed `<template>` in code position. Module docs enumerate them; dedicated tests pin each. A future rewrite can delegate to the `content-tag` crate for exact extraction. Template _contents_ are not linted.

## Relationship to future custom-parser work

I have another in-progress PR #24262 that adds js custom parser support, which will improve coverage beyond what is possible with a partial loader (e.g. enables `no-unused-vars`). This PR future-proofs partial loaders for that world, where they are still useful for module graph analysis.

- Without a configured parser, this PR is the only thing linting `.gjs`/`.gts` — zero-config baseline.
- With `ember-eslint-parser`, files take the custom-parser path (AST-accurate masking, scope-aware ref injection); the loader still provides module-graph content, making `.gts` imports resolvable and `import/no-cycle` edges visible.
- `should_run` keys on "source came from the partial loader", so the two PRs compose: on the custom-parser path, ref injection keeps `no-unused-vars` correct and enabled.

## Test plan

25 unit tests in `glimmer.rs`: extraction round-trips through the real parser (top-level, expression-position, class-body templates, `.gts` generics), byte-offset preservation, multiple templates per file, unclosed-template behavior, comment/string awareness, opaque bodies, and explicit pins of each byte-pattern limitation. 5 CLI snapshot tests pin the gating end-to-end: `no-unused-vars` (unused-in-template), `rules_of_hooks` (hook-in-template), `consistent_type_imports` (type-import-in-template.gts), `no-unused-expressions` (template-only), and a `.gjs` with no template lints as plain JS (no-template).

Tested on a real-world production codebase; accurately linted 251 `.gts` files in 285ms.
