### PR TITLE
refactor(react_compiler): fold compile_program tail into one return

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -2880,18 +2880,14 @@ pub fn compile_program<'a, 'p>(
     // Drop the discovery results (and their borrows of `file.program`).
     drop(queue);
 
-    if replacements.is_empty() {
-        // No functions to replace. Return renames for the Babel plugin to apply
-        // (e.g., variable shadowing renames in lint mode). Imports are NOT added
-        // when there are no replacements — matching TS behavior where
-        // addImportsToProgram is only called when compiledFns.length > 0.
-        return CompileResult::Success { ast: None, diagnostics: context.diagnostics };
+    // `ast` is `None` when nothing was compiled — always so in lint mode, which
+    // applies nothing — skipping `ox_splice_program`'s whole-program clone. Splicing
+    // each compiled function in for its original (matched by `span.start ==
+    // fn_node_id`) is also what inserts the memo-cache / gating imports, so (matching
+    // TS `addImportsToProgram`) they're added only when there are replacements.
+    CompileResult::Success {
+        ast: (!replacements.is_empty())
+            .then(|| ox_splice_program(&ast, program, &replacements, &mut context)),
+        diagnostics: context.diagnostics,
     }
-
-    // Build the memoized oxc program: splice each compiled oxc function in for its
-    // original (matched by `span.start == fn_node_id`), apply gating, insert outlined
-    // functions, and add the memo-cache / gating imports.
-    let compiled_program = ox_splice_program(&ast, program, &replacements, &mut context);
-
-    CompileResult::Success { ast: Some(compiled_program), diagnostics: context.diagnostics }
 }


### PR DESCRIPTION
## What

Collapses the tail of `compile_program` — the `replacements.is_empty()` early return plus the splice-and-return — into a single `CompileResult::Success` whose `ast` is computed with `bool::then`:

```rust
CompileResult::Success {
    ast: (!replacements.is_empty())
        .then(|| ox_splice_program(&ast, program, &replacements, &mut context)),
    diagnostics: context.diagnostics,
}
```

The comment records the useful fact behind it: **lint mode always lands in the empty-`replacements` case** (it applies no compiled functions), so `ox_splice_program`'s whole-program clone never runs in lint — the whole-program AST is never reconstructed when linting.

## Not a behavior change

Codegen (`codegen_function`) still runs in lint mode. An earlier version of this PR skipped it for speed, but codegen also records bailout `Todo` diagnostics that `reportAllBailouts` surfaces, so skipping it dropped those (raised in review). Rather than gate the skip behind an option, this drops the skip entirely — codegen runs exactly as before, so no diagnostics change. What remains is the return-folding refactor above.
