### PR TITLE
feat(semantic): record const enums in EnumData

### DIFF
--- a/crates/oxc_semantic/src/scoping.rs
+++ b/crates/oxc_semantic/src/scoping.rs
@@ -693,6 +693,10 @@ impl Scoping {
 
     /// Get the body scopes for an enum declaration symbol.
     /// Returns multiple scopes for merged enum declarations.
+    ///
+    /// Unlike the enum bits in `SymbolFlags`, this stays valid after the transformer
+    /// lowers the enum to a `var`/`let` binding, so it identifies enums at any point
+    /// during a transform.
     pub fn get_enum_body_scopes(&self, symbol_id: SymbolId) -> Option<&[ScopeId]> {
         self.enum_data.get_body_scopes(symbol_id)
     }
@@ -701,6 +705,19 @@ impl Scoping {
     /// Appends to the list (supports merged enum declarations).
     pub(crate) fn add_enum_body_scope(&mut self, symbol_id: SymbolId, scope_id: ScopeId) {
         self.enum_data.add_body_scope(symbol_id, scope_id);
+    }
+
+    /// Whether the symbol is a `const enum` declaration.
+    ///
+    /// Returns `false` for regular enums and non-enum symbols alike — gate on
+    /// [`Self::get_enum_body_scopes`] to identify enums.
+    pub fn is_const_enum(&self, symbol_id: SymbolId) -> bool {
+        self.enum_data.is_const_enum(symbol_id)
+    }
+
+    /// Mark a symbol as a `const enum` declaration.
+    pub(crate) fn add_const_enum(&mut self, symbol_id: SymbolId) {
+        self.enum_data.add_const_enum(symbol_id);
     }
 }
 

--- a/crates/oxc_semantic/src/ts_enum/data.rs
+++ b/crates/oxc_semantic/src/ts_enum/data.rs
@@ -1,4 +1,4 @@
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use oxc_syntax::{constant_value::ConstantValue, scope::ScopeId, symbol::SymbolId};
 
@@ -12,6 +12,12 @@ pub struct EnumData {
     member_values: FxHashMap<SymbolId, ConstantValue>,
     /// Maps enum declaration `SymbolId` → body `ScopeId`s (one per declaration).
     body_scopes: FxHashMap<SymbolId, Vec<ScopeId>>,
+    /// `const enum` declaration symbols.
+    ///
+    /// Stored here rather than read from `SymbolFlags` so consumers can still tell
+    /// const enums apart after the transformer has lowered them to `var`/`let`
+    /// bindings and updated their symbol flags accordingly.
+    const_enums: FxHashSet<SymbolId>,
 }
 
 impl EnumData {
@@ -29,5 +35,13 @@ impl EnumData {
 
     pub(crate) fn add_body_scope(&mut self, symbol_id: SymbolId, scope_id: ScopeId) {
         self.body_scopes.entry(symbol_id).or_default().push(scope_id);
+    }
+
+    pub fn is_const_enum(&self, symbol_id: SymbolId) -> bool {
+        self.const_enums.contains(&symbol_id)
+    }
+
+    pub(crate) fn add_const_enum(&mut self, symbol_id: SymbolId) {
+        self.const_enums.insert(symbol_id);
     }
 }

--- a/crates/oxc_semantic/src/ts_enum/eval.rs
+++ b/crates/oxc_semantic/src/ts_enum/eval.rs
@@ -42,6 +42,9 @@ pub fn evaluate_enum_members(decl: &TSEnumDeclaration<'_>, scoping: &mut Scoping
     let enum_symbol_id = decl.id.symbol_id.get();
     if let Some(id) = enum_symbol_id {
         scoping.add_enum_body_scope(id, scope_id);
+        if decl.r#const {
+            scoping.add_const_enum(id);
+        }
     }
 
     // Sentinel: the first member with no initializer evaluates to `-1.0 + 1.0 = 0.0`.

--- a/tasks/track_memory_allocations/allocs_semantic.snap
+++ b/tasks/track_memory_allocations/allocs_semantic.snap
@@ -1,6 +1,6 @@
 File                       | File size      || Sys allocs     | Sys reallocs   || Arena allocs   | Arena reallocs 
 ---------------------------------------------------------------------------------------------------------------------------
-checker.ts                 | 2.92 MB        ||             46 |              0 ||              0 |              0
+checker.ts                 | 2.92 MB        ||             50 |              0 ||              0 |              0
 
 App.tsx                    | 415.34 kB      ||             11 |              0 ||              0 |              0
 
@@ -10,7 +10,7 @@ pdf.mjs                    | 567.30 kB      ||             16 |              0 |
 
 antd.js                    | 6.69 MB        ||             28 |              0 ||              0 |              0
 
-binder.ts                  | 193.08 kB      ||             17 |              0 ||              0 |              0
+binder.ts                  | 193.08 kB      ||             18 |              0 ||              0 |              0
 
-kitchen-sink.tsx           | 732.90 kB      ||             36 |              0 ||              0 |              0
+kitchen-sink.tsx           | 732.90 kB      ||             37 |              0 ||              0 |              0
 


### PR DESCRIPTION
Record which enums are `const` in `EnumData` and expose it as `Scoping::is_const_enum`. Same pattern as the existing `no_side_effects` set.

The transformer needs to tell const enums apart even after lowering, but #24269 makes lowering rewrite the enum's `SymbolFlags`, so the flags can no longer answer that. `EnumData` stays valid for the whole transform.

The small `allocs_semantic.snap` bump is the new hash set.

Needed by #24269.
