### PR TITLE
test(react_compiler): cross-check lint against transform in snapshot tests

### DIFF
--- a/crates/oxc_react_compiler/tests/snapshot.rs
+++ b/crates/oxc_react_compiler/tests/snapshot.rs
@@ -29,7 +29,7 @@ use oxc_react_compiler::{
     BuiltInTypeRef, CompilationMode, CompilerOutputMode, DynamicGatingConfig, Effect,
     EnvironmentConfig, ExhaustiveEffectDepsMode, ExternalFunctionConfig, FunctionTypeConfig,
     FxIndexMap, GatingConfig, HookTypeConfig, InstrumentationConfig, ObjectTypeConfig,
-    PanicThreshold, PluginOptions, TypeConfig, TypeReferenceConfig, ValueKind, transform,
+    PanicThreshold, PluginOptions, TypeConfig, TypeReferenceConfig, ValueKind, lint, transform,
 };
 use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
@@ -51,7 +51,8 @@ fn normalize_newlines(source: &str) -> String {
     source.cow_replace("\r\n", "\n").cow_replace('\r', "\n").into_owned()
 }
 
-/// Parse, analyse, compile, and render the compiled program + diagnostics.
+/// Parse, analyse, compile, and render the compiled program + diagnostics, plus any
+/// divergence between the read-only `lint` entry point and `transform`.
 fn run_fixture(source: &str) -> String {
     let (source_type, options) = parse_pragma(source);
     // In lint output mode the compiler validates without rewriting the program, so
@@ -69,11 +70,16 @@ fn run_fixture(source: &str) -> String {
     // Surface parse failures rather than silently compiling a recovered/dummy AST.
     push_diagnostics(&mut out, "Parse errors", parsed.diagnostics.as_slice());
 
-    // `transform` borrows a `Semantic` built from the pristine program; scope the
-    // borrow so it ends before we swap in the compiled program.
-    let mut result = {
+    // `transform` and `lint` both borrow a `Semantic` built from the pristine program;
+    // scope the borrow so it ends before we swap in the compiled program. `transform`
+    // runs first on the untouched allocator so its output stays byte-identical to a
+    // transform-only run; `lint` then re-runs the shared `compile` pipeline read-only so
+    // we can cross-check its diagnostics against `transform`'s below.
+    let (mut result, lint_diagnostics) = {
         let semantic = SemanticBuilder::new().with_build_nodes(true).build(&program).semantic;
-        transform(&program, &semantic, &allocator, options)
+        let result = transform(&program, &semantic, &allocator, options.clone());
+        let lint_diagnostics = lint(&program, &semantic, &allocator, options).diagnostics;
+        (result, lint_diagnostics)
     };
     if let Some(compiled) = result.program.take() {
         program = compiled;
@@ -94,20 +100,43 @@ fn run_fixture(source: &str) -> String {
     } else {
         out.push_str("No changes.");
     }
+
+    // Cross-check the read-only `lint` entry point against `transform`. Both funnel
+    // through the same `compile` pipeline, so their diagnostics are identical for almost
+    // every fixture. They diverge only where the pipeline gates a validation on lint
+    // output mode: `@validateNoSetStateInEffects` / `@validateNoJSXInTryStatements` /
+    // `@validateStaticComponents` / `@validateNoDerivedComputationsInEffectsExp` fixtures
+    // gain lint-only findings, while `@enableEmitHookGuards` conversely errors only when
+    // emitting. Surface any divergence in the snapshot so it stays reviewed rather than
+    // drifting silently.
+    let transform_body = diagnostics_body(result.diagnostics.as_slice());
+    let lint_body = diagnostics_body(lint_diagnostics.as_slice());
+    if lint_body != transform_body {
+        out.push_str("\n\nLint-mode diagnostics (differ from transform):\n\n");
+        out.push_str(if lint_body.is_empty() { "(none)\n" } else { &lint_body });
+    }
     out
 }
 
 /// Append a `"{label}:\n\n{diag}\n…\n"` section, or nothing when there are none.
 fn push_diagnostics(out: &mut String, label: &str, diagnostics: &[impl std::fmt::Debug]) {
-    if diagnostics.is_empty() {
+    let body = diagnostics_body(diagnostics);
+    if body.is_empty() {
         return;
     }
     out.push_str(label);
     out.push_str(":\n\n");
-    for diagnostic in diagnostics {
-        out.push_str(&format!("{diagnostic:?}\n"));
-    }
+    out.push_str(&body);
     out.push('\n');
+}
+
+/// Render diagnostics as one `{diag:?}` line each, or `""` when there are none.
+fn diagnostics_body(diagnostics: &[impl std::fmt::Debug]) -> String {
+    let mut body = String::new();
+    for diagnostic in diagnostics {
+        body.push_str(&format!("{diagnostic:?}\n"));
+    }
+    body
 }
 
 /// Snapshot name = fixture path under `fixtures/`, extension dropped and path

--- a/crates/oxc_react_compiler/tests/snapshots/invalid-set-state-in-effect-verbose-derived-event.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/invalid-set-state-in-effect-verbose-derived-event.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/oxc_react_compiler/tests/snapshot.rs
+assertion_line: 45
 input_file: crates/oxc_react_compiler/fixtures/invalid-set-state-in-effect-verbose-derived-event.js
 ---
 import { c as _c } from "react/compiler-runtime";
@@ -41,3 +42,8 @@ export const FIXTURE_ENTRYPOINT = {
 	fn: VideoPlayer,
 	params: [{ isPlaying: true }]
 };
+
+
+Lint-mode diagnostics (differ from transform):
+
+OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] EffectSetState: Calling setState synchronously within an effect can trigger cascading renders", labels: One([LabeledSpan { label: Some("Avoid calling setState() directly within an effect"), span: SourceSpan { offset: SourceOffset(266), length: 13 }, primary: false }]), help: Some("Effects are intended to synchronize state between React and external systems. Calling setState synchronously causes cascading renders that hurt performance.\n\nThis pattern may indicate one of several issues:\n\n**1. Non-local derived data**: If the value being set could be computed from props/state but requires data from a parent component, consider restructuring state ownership so the derivation can happen during render in the component that owns the relevant state.\n\n**2. Derived event pattern**: If you're detecting when a prop changes (e.g., `isPlaying` transitioning from false to true), this often indicates the parent should provide an event callback (like `onPlay`) instead of just the current state. Request access to the original event.\n\n**3. Force update / external sync**: If you're forcing a re-render to sync with an external data source (mutable values outside React), use `useSyncExternalStore` to properly subscribe to external state changes.\n\nSee: https://react.dev/learn/you-might-not-need-an-effect"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }

--- a/crates/oxc_react_compiler/tests/snapshots/invalid-set-state-in-effect-verbose-non-local-derived.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/invalid-set-state-in-effect-verbose-non-local-derived.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/oxc_react_compiler/tests/snapshot.rs
+assertion_line: 45
 input_file: crates/oxc_react_compiler/fixtures/invalid-set-state-in-effect-verbose-non-local-derived.js
 ---
 import { c as _c } from "react/compiler-runtime";
@@ -42,3 +43,8 @@ export const FIXTURE_ENTRYPOINT = {
 		lastName: "Doe"
 	}]
 };
+
+
+Lint-mode diagnostics (differ from transform):
+
+OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] EffectSetState: Calling setState synchronously within an effect can trigger cascading renders", labels: One([LabeledSpan { label: Some("Avoid calling setState() directly within an effect"), span: SourceSpan { offset: SourceOffset(221), length: 11 }, primary: false }]), help: Some("Effects are intended to synchronize state between React and external systems. Calling setState synchronously causes cascading renders that hurt performance.\n\nThis pattern may indicate one of several issues:\n\n**1. Non-local derived data**: If the value being set could be computed from props/state but requires data from a parent component, consider restructuring state ownership so the derivation can happen during render in the component that owns the relevant state.\n\n**2. Derived event pattern**: If you're detecting when a prop changes (e.g., `isPlaying` transitioning from false to true), this often indicates the parent should provide an event callback (like `onPlay`) instead of just the current state. Request access to the original event.\n\n**3. Force update / external sync**: If you're forcing a re-render to sync with an external data source (mutable values outside React), use `useSyncExternalStore` to properly subscribe to external state changes.\n\nSee: https://react.dev/learn/you-might-not-need-an-effect"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }


### PR DESCRIPTION
## What

The React Compiler fixture snapshot harness (`crates/oxc_react_compiler/tests/snapshot.rs`) only ran `transform`. It now also runs the read-only `lint` entry point on every fixture and cross-checks its diagnostics against `transform`'s, surfacing any divergence directly in the snapshot.

## Why not a hard assert

`lint` sets `no_emit = true`, which resolves to `CompilerOutputMode::Lint`. The pipeline deliberately gates several validations on Lint mode — `validate_no_set_state_in_effects`, `validate_no_jsx_in_try_statements`, `validate_static_components`, `validate_no_derived_computations_in_effects_exp` — and conversely `@enableEmitHookGuards` errors only while emitting (Client). So the two entry points are *expected* to diverge for a handful of pragma-gated fixtures. Surfacing the difference in the snapshot (rather than asserting strict equality) documents those cases and still catches any unexpected drift.

## Result

`transform` runs first on the untouched allocator, so its output stays byte-identical to a transform-only run. Only **2** fixtures diverge — both `@validateNoSetStateInEffects` cases where `lint` reports the `EffectSetState` finding that `transform` silently compiles past. Their snapshots gained a `Lint-mode diagnostics (differ from transform)` section (additive: 12 insertions, 0 deletions). The test is green.
