### PR TITLE
fix(transformer): remove stale enum member bindings

### DIFF
--- a/crates/oxc_semantic/src/scoping.rs
+++ b/crates/oxc_semantic/src/scoping.rs
@@ -1041,7 +1041,7 @@ impl Scoping {
         });
     }
 
-    /// Remove bindings that exist only in TypeScript type space.
+    /// Remove bindings that exist only in TypeScript syntax.
     pub fn delete_typescript_bindings(&mut self) {
         #[expect(
             clippy::inline_always,
@@ -1073,7 +1073,8 @@ impl Scoping {
                     !flags.intersects(
                         SymbolFlags::TypeAlias
                             | SymbolFlags::Interface
-                            | SymbolFlags::TypeParameter,
+                            | SymbolFlags::TypeParameter
+                            | SymbolFlags::EnumMember,
                     )
                 });
             }

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -2,7 +2,7 @@ commit: 1fb0b771
 
 semantic_babel Summary:
 AST Parsed     : 2236/2236 (100.00%)
-Positive Passed: 2139/2236 (95.66%)
+Positive Passed: 2146/2236 (95.97%)
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/decorators/decorators-after-export/input.js
 Symbol flags mismatch for "_default":
 after transform: SymbolId(3): SymbolFlags(Class)
@@ -12,11 +12,6 @@ semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/comment
 Symbol flags mismatch for "_default":
 after transform: SymbolId(3): SymbolFlags(Class)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/typescript/TSEnumBody-trailing-comma/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "E"]
-rebuilt        : ScopeId(1): ["E"]
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/class-private-properties/await-in-private-property-in-params-of-async-arrow/input.js
 Bindings mismatch:
@@ -59,11 +54,6 @@ rebuilt        : ["arguments", "of", "require"]
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/class-private-method/typescript-invalid-abstract/input.ts
 'abstract' modifier cannot be used with a private identifier.
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/typescript/enum/input.js
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "a", "r"]
-rebuilt        : ScopeId(1): ["A"]
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/typescript/loc-index-property/input.js
 Bindings mismatch:
@@ -212,31 +202,6 @@ semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescr
 Bindings mismatch:
 after transform: ScopeId(0): ["E"]
 rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/members/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "E"]
-rebuilt        : ScopeId(1): ["E"]
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/members-reserved-words/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["E", "const", "default"]
-rebuilt        : ScopeId(1): ["E"]
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/members-strings/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["E", "bar", "foo"]
-rebuilt        : ScopeId(1): ["E"]
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/members-trailing-comma/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "E"]
-rebuilt        : ScopeId(1): ["E"]
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/members-trailing-comma-with-initializer/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "E"]
-rebuilt        : ScopeId(1): ["E"]
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/export/declare/input.ts
 Bindings mismatch:

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -1,6 +1,6 @@
 semantic_misc Summary:
 AST Parsed     : 70/70 (100.00%)
-Positive Passed: 65/70 (92.86%)
+Positive Passed: 66/70 (94.29%)
 semantic Error: tasks/coverage/misc/pass/declare-let-private.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["private"]
@@ -89,30 +89,4 @@ semantic Error: tasks/coverage/misc/pass/oxc-13284.ts
 Symbol reference IDs mismatch for "_super":
 after transform: SymbolId(18): [ReferenceId(14)]
 rebuilt        : SymbolId(9): []
-
-semantic Error: tasks/coverage/misc/pass/oxc-4449.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "baz"]
-rebuilt        : ScopeId(1): ["A"]
-Bindings mismatch:
-after transform: ScopeId(2): ["B", "baz"]
-rebuilt        : ScopeId(2): ["B"]
-Bindings mismatch:
-after transform: ScopeId(3): ["C", "baz"]
-rebuilt        : ScopeId(3): ["C"]
-Bindings mismatch:
-after transform: ScopeId(4): ["D", "baz"]
-rebuilt        : ScopeId(4): ["D"]
-Bindings mismatch:
-after transform: ScopeId(5): ["E", "baz"]
-rebuilt        : ScopeId(5): ["E"]
-Bindings mismatch:
-after transform: ScopeId(6): ["F", "baz"]
-rebuilt        : ScopeId(6): ["F"]
-Bindings mismatch:
-after transform: ScopeId(7): ["G", "baz"]
-rebuilt        : ScopeId(7): ["G"]
-Bindings mismatch:
-after transform: ScopeId(8): ["H", "baz"]
-rebuilt        : ScopeId(8): ["H"]
 

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -2,7 +2,7 @@ commit: 7964e22f
 
 semantic_typescript Summary:
 AST Parsed     : 4720/4720 (100.00%)
-Positive Passed: 3353/4720 (71.04%)
+Positive Passed: 3462/4720 (73.35%)
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/APISample_Watch.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["console", "formatHost", "os", "process", "reportDiagnostic", "reportWatchStatusChanged", "ts", "watchMain"]
@@ -201,11 +201,6 @@ rebuilt        : SymbolId(0): Span { start: 30, end: 33 }
 Symbol redeclarations mismatch for "foo":
 after transform: SymbolId(0): [Span { start: 14, end: 17 }, Span { start: 30, end: 33 }]
 rebuilt        : SymbolId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/ambientConstLiterals.ts
-Bindings mismatch:
-after transform: ScopeId(2): ["A", "B", "C", "E", "non identifier"]
-rebuilt        : ScopeId(2): ["E"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/ambientEnumElementInitializer1.ts
 Bindings mismatch:
@@ -435,11 +430,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["Point"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatForEnums.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["One", "TokenType", "Two"]
-rebuilt        : ScopeId(1): ["TokenType"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability1.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -473,11 +463,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability9.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/assignmentNonObjectTypeConstraints.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "C", "E"]
-rebuilt        : ScopeId(1): ["E"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionContextuallyTypedReturns.ts
 Bindings mismatch:
@@ -616,18 +601,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Bindings mismatch:
 after transform: ScopeId(0): ["m4", "m4a", "m4b", "m4c", "m4d", "m5"]
 rebuilt        : ScopeId(0): ["m4a", "m4b", "m4d", "m5"]
-Bindings mismatch:
-after transform: ScopeId(4): ["One", "m4a"]
-rebuilt        : ScopeId(3): ["m4a"]
-Bindings mismatch:
-after transform: ScopeId(6): ["One", "m4b"]
-rebuilt        : ScopeId(5): ["m4b"]
-Bindings mismatch:
-after transform: ScopeId(10): ["One", "m4c"]
-rebuilt        : ScopeId(6): ["m4c"]
-Bindings mismatch:
-after transform: ScopeId(14): ["One", "m4d"]
-rebuilt        : ScopeId(10): ["m4d"]
 Symbol redeclarations mismatch for "m4a":
 after transform: SymbolId(1): [Span { start: 80, end: 83 }, Span { start: 104, end: 107 }]
 rebuilt        : SymbolId(1): []
@@ -657,12 +630,6 @@ after transform: []
 rebuilt        : ["m4", "m4c"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/autonumberingInEnums.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["Foo", "a"]
-rebuilt        : ScopeId(1): ["Foo"]
-Bindings mismatch:
-after transform: ScopeId(2): ["Foo", "b"]
-rebuilt        : ScopeId(2): ["Foo"]
 Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(0): [Span { start: 5, end: 8 }, Span { start: 29, end: 32 }]
 rebuilt        : SymbolId(0): []
@@ -1327,12 +1294,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/coAndContraVarian
 Bindings mismatch:
 after transform: ScopeId(0): ["SyntaxKind", "SyntaxKind1", "assertNode", "bar", "canHaveLocals", "cast", "consume", "every", "f1", "f2", "f3", "foo", "isC", "isClassLike", "isExpression", "isNodeArray", "maybeClassStatement", "statement", "tryCast", "types", "useA", "x"]
 rebuilt        : ScopeId(0): ["SyntaxKind", "SyntaxKind1", "bar", "f1", "f2", "f3", "foo", "maybeClassStatement", "x"]
-Bindings mismatch:
-after transform: ScopeId(17): ["Block", "CaseClause", "FunctionDeclaration", "FunctionExpression", "Identifier", "SyntaxKind"]
-rebuilt        : ScopeId(6): ["SyntaxKind"]
-Bindings mismatch:
-after transform: ScopeId(36): ["ClassExpression", "ClassStatement", "SyntaxKind1"]
-rebuilt        : ScopeId(9): ["SyntaxKind1"]
 Reference symbol mismatch for "cast":
 after transform: SymbolId(3) "cast"
 rebuilt        : <None>
@@ -1413,9 +1374,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/coAndContraVarian
 Bindings mismatch:
 after transform: ScopeId(0): ["DISALLOW_DECORATORS", "SyntaxKind", "buildOverload", "createBinder", "createOverload", "every", "foo", "isArray", "isAssertClause", "isDecorator", "isExpression", "isImportClause", "isModifier", "modifiers", "updateImportDeclaration"]
 rebuilt        : ScopeId(0): ["SyntaxKind", "foo"]
-Bindings mismatch:
-after transform: ScopeId(32): ["AssertClause", "Decorator", "ImportClause", "ImportDeclaration", "Modifier", "SyntaxKind"]
-rebuilt        : ScopeId(1): ["SyntaxKind"]
 Reference symbol mismatch for "buildOverload":
 after transform: SymbolId(47) "buildOverload"
 rebuilt        : <None>
@@ -1487,9 +1445,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/coAndContraVarian
 Bindings mismatch:
 after transform: ScopeId(0): ["SyntaxKind", "every", "foo", "isDecorator", "isModifier", "modifiers"]
 rebuilt        : ScopeId(0): ["SyntaxKind", "foo"]
-Bindings mismatch:
-after transform: ScopeId(1): ["Decorator", "Modifier", "SyntaxKind"]
-rebuilt        : ScopeId(1): ["SyntaxKind"]
 Reference symbol mismatch for "every":
 after transform: SymbolId(10) "every"
 rebuilt        : <None>
@@ -1554,11 +1509,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["fn", "x", "y"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenEnumWithEnumMemberConflict.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["Color", "Thing"]
-rebuilt        : ScopeId(1): ["Color"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithAccessorChildren.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Symbol redeclarations mismatch for "M":
@@ -1570,11 +1520,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 111, end: 112 }, Span { start: 198, end: 199 }]
 rebuilt        : SymbolId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithEnumMemberConflict.ts
-Bindings mismatch:
-after transform: ScopeId(2): ["e", "m1", "m2"]
-rebuilt        : ScopeId(2): ["e"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithFunctionChildren.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -1723,11 +1668,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["_this"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndEnumInGlobal.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["_this", "_thisVal1", "_thisVal2"]
-rebuilt        : ScopeId(1): ["_this"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndLocalVarInLambda.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["alert", "x"]
@@ -1839,11 +1779,6 @@ Bindings mismatch:
 after transform: ScopeId(0): ["ElidedModule", "ElidedModule2"]
 rebuilt        : ScopeId(0): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/commentOnExportEnumDeclaration.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["Color", "b", "g", "r"]
-rebuilt        : ScopeId(1): ["Color"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/commentOnSignature1.ts
 Symbol span mismatch for "foo":
 after transform: SymbolId(0): Span { start: 114, end: 117 }
@@ -1868,11 +1803,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["c"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/comparableRelationBidirectional.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["AutomationMode", "LOCATION", "NONE", "SYSTEM", "TIME"]
-rebuilt        : ScopeId(1): ["AutomationMode"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/complexNarrowingWithAny.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 
@@ -1891,9 +1821,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/computedEnumMembe
 Missing ReferenceId: "Foo"
 Missing ReferenceId: "Foo"
 Missing ReferenceId: "Foo"
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "C", "F", "Foo", "G", "H", "I", "J"]
-rebuilt        : ScopeId(1): ["Foo"]
 Symbol reference IDs mismatch for "Foo":
 after transform: SymbolId(10): [ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(24)]
 rebuilt        : SymbolId(2): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(9), ReferenceId(11), ReferenceId(12), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(24)]
@@ -1904,9 +1831,6 @@ Missing ReferenceId: "Foo"
 Missing ReferenceId: "Foo"
 Missing ReferenceId: "Foo"
 Missing ReferenceId: "Foo"
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "C", "D", "E1", "E2", "F", "Foo", "G", "H", "I", "J"]
-rebuilt        : ScopeId(1): ["Foo"]
 Symbol reference IDs mismatch for "Foo":
 after transform: SymbolId(14): [ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(32), ReferenceId(33)]
 rebuilt        : SymbolId(3): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(14), ReferenceId(15), ReferenceId(17), ReferenceId(18), ReferenceId(20), ReferenceId(21), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(30), ReferenceId(31), ReferenceId(32), ReferenceId(33)]
@@ -1915,12 +1839,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/computedEnumTypeW
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "E", "E2", "MyDeclaredEnum", "MyEnum", "_defineProperty", "c1", "c2", "computed", "f1", "f2", "f3", "f4", "v1", "v2", "val1", "val2"]
 rebuilt        : ScopeId(0): ["C", "E", "MyEnum", "_defineProperty", "c1", "c2", "f1", "f2", "f3", "f4", "v1", "v2", "val1", "val2"]
-Bindings mismatch:
-after transform: ScopeId(2): ["A", "B", "C", "D", "E"]
-rebuilt        : ScopeId(1): ["E"]
-Bindings mismatch:
-after transform: ScopeId(9): ["A", "B", "C", "MyEnum"]
-rebuilt        : ScopeId(8): ["MyEnum"]
 Reference symbol mismatch for "computed":
 after transform: SymbolId(0) "computed"
 rebuilt        : <None>
@@ -1950,9 +1868,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/computedPropertie
 Bindings mismatch:
 after transform: ScopeId(0): ["Props", "foo", "k"]
 rebuilt        : ScopeId(0): ["Props", "k"]
-Bindings mismatch:
-after transform: ScopeId(1): ["Props", "k"]
-rebuilt        : ScopeId(1): ["Props"]
 Reference symbol mismatch for "foo":
 after transform: SymbolId(6) "foo"
 rebuilt        : <None>
@@ -2036,67 +1951,11 @@ Bindings mismatch:
 after transform: ScopeId(0): ["M", "c1", "c2", "c3", "c4", "c5"]
 rebuilt        : ScopeId(0): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/constEnumDeclarations.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "C", "E"]
-rebuilt        : ScopeId(1): ["E"]
-Bindings mismatch:
-after transform: ScopeId(2): ["A", "B", "C", "E2"]
-rebuilt        : ScopeId(2): ["E2"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/constEnumNamespaceReferenceCausesNoImport.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["ConstFooEnum", "Here", "Some", "Values"]
-rebuilt        : ScopeId(1): ["ConstFooEnum"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/constEnumNamespaceReferenceCausesNoImport2.ts
-Bindings mismatch:
-after transform: ScopeId(2): ["ConstFooEnum", "Here", "Some", "Values"]
-rebuilt        : ScopeId(2): ["ConstFooEnum"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/constEnumNoEmitReexport.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["Bar", "Foo", "MyConstEnum"]
-rebuilt        : ScopeId(1): ["MyConstEnum"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/constEnumOnlyModuleMerging.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Bindings mismatch:
-after transform: ScopeId(3): ["A", "X"]
-rebuilt        : ScopeId(3): ["A"]
 Symbol redeclarations mismatch for "Outer":
 after transform: SymbolId(0): [Span { start: 10, end: 15 }, Span { start: 53, end: 58 }]
 rebuilt        : SymbolId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/constEnumPreserveEmitNamedExport1.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "Foo"]
-rebuilt        : ScopeId(1): ["A"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/constEnumPreserveEmitNamedExport2.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "Foo"]
-rebuilt        : ScopeId(1): ["A"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/constEnumPreserveEmitReexport.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["Bar", "Foo", "MyConstEnum"]
-rebuilt        : ScopeId(1): ["MyConstEnum"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/constEnumSyntheticNodesComments.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "C", "D", "En"]
-rebuilt        : ScopeId(1): ["En"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/constEnumToStringNoComments.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "C", "Foo", "X", "Y", "Z"]
-rebuilt        : ScopeId(1): ["Foo"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/constEnumToStringWithComments.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "C", "Foo", "X", "Y", "Z"]
-rebuilt        : ScopeId(1): ["Foo"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/constructorOverloads5.ts
 Bindings mismatch:
@@ -2883,11 +2742,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["cond", "foo"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowBreakContinueWithLabel.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "User"]
-rebuilt        : ScopeId(1): ["User"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowCommaExpressionAssertionWithinTernary.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["assert", "foo2"]
@@ -3012,11 +2866,6 @@ Unresolved references mismatch:
 after transform: ["Promise", "Set", "require"]
 rebuilt        : ["Promise", "Set", "ctor", "require", "x"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowManyConsecutiveConditionsNoTimeout.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["Choice", "One", "Two"]
-rebuilt        : ScopeId(1): ["Choice"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowPropertyDeclarations.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["HTMLDOMPropertyConfig", "HTMLtoJSX", "StyleParser", "_defineProperty", "endsWith", "hyphenToCamelCase", "isConvertiblePixelValue", "isEmpty", "mapFrom", "propname", "repeatString", "require", "trimEnd"]
@@ -3064,28 +2913,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["console", "document", "undefined"]
 rebuilt        : ["bar", "console", "document", "makeCompleteLookupMapping", "r1", "r2", "undefined", "xx"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileEnumUsedAsValue.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["a", "b", "c", "e"]
-rebuilt        : ScopeId(1): ["e"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileEnums.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["a", "b", "c", "e1"]
-rebuilt        : ScopeId(1): ["e1"]
-Bindings mismatch:
-after transform: ScopeId(2): ["a", "b", "c", "e2"]
-rebuilt        : ScopeId(2): ["e2"]
-Bindings mismatch:
-after transform: ScopeId(3): ["a", "b", "c", "e3"]
-rebuilt        : ScopeId(3): ["e3"]
-Bindings mismatch:
-after transform: ScopeId(4): ["a", "b", "c", "d", "e", "e4"]
-rebuilt        : ScopeId(4): ["e4"]
-Bindings mismatch:
-after transform: ScopeId(5): ["Friday", "Saturday", "Sunday", "Weekend days", "e5"]
-rebuilt        : ScopeId(5): ["e5"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileExportAssignmentImportInternalModule.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -3147,11 +2974,6 @@ Bindings mismatch:
 after transform: ScopeId(0): ["c1", "c2"]
 rebuilt        : ScopeId(0): ["c1"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileTypeofEnum.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["days", "friday", "monday", "saturday", "sunday", "thursday", "tuesday", "wednesday"]
-rebuilt        : ScopeId(1): ["days"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileTypeofFunction.ts
 Symbol span mismatch for "f":
 after transform: SymbolId(0): Span { start: 9, end: 10 }
@@ -3165,11 +2987,6 @@ rebuilt        : SymbolId(1): Span { start: 176, end: 177 }
 Symbol redeclarations mismatch for "g":
 after transform: SymbolId(3): [Span { start: 110, end: 111 }, Span { start: 143, end: 144 }, Span { start: 176, end: 177 }]
 rebuilt        : SymbolId(1): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileTypeofInAnonymousType.ts
-Bindings mismatch:
-after transform: ScopeId(3): ["e", "holiday", "weekday", "weekend"]
-rebuilt        : ScopeId(3): ["e"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declFileTypeofModule.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -3224,11 +3041,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["objWrapper", "stringWrapper", "unwrap"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedNameConstEnumAlias.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["EnumExample", "TEST"]
-rebuilt        : ScopeId(1): ["EnumExample"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedNameWithQuestionToken.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["WithData", "a", "dataSomething", "something"]
@@ -3250,11 +3062,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["create"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedPropertyNameEnum1.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "Enum"]
-rebuilt        : ScopeId(1): ["Enum"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringArrayPattern3.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -3289,11 +3096,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["add"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitEnumReadonlyProperty.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "E"]
-rebuilt        : ScopeId(1): ["E"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitEnumReferenceViaImportEquals.ts
 Bindings mismatch:
@@ -3491,9 +3293,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Bindings mismatch:
-after transform: ScopeId(14): ["D", "f"]
-rebuilt        : ScopeId(13): ["D"]
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 243, end: 244 }]
 rebuilt        : SymbolId(0): []
@@ -3514,11 +3313,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNa
 Symbol redeclarations mismatch for "Bar":
 after transform: SymbolId(1): [Span { start: 51, end: 54 }, Span { start: 87, end: 90 }]
 rebuilt        : SymbolId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNoNonRequiredParens.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "C", "Test"]
-rebuilt        : ScopeId(1): ["Test"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitOfFuncspace.ts
 Symbol flags mismatch for "ExpandoMerge":
@@ -3547,16 +3341,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPa
 Bindings mismatch:
 after transform: ScopeId(0): ["N", "o"]
 rebuilt        : ScopeId(0): ["o"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitSpreadStringlyKeyedEnum.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["0-17", "18-22", "23-27", "28-34", "35-44", "45-59", "60-150", "AgeGroups"]
-rebuilt        : ScopeId(1): ["AgeGroups"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitStringEnumUsedInNonlocalSpread.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["Test1", "Test2", "TestEnum"]
-rebuilt        : ScopeId(1): ["TestEnum"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationImportTypeAliasInferredAndEmittable.ts
 Bindings mismatch:
@@ -4023,12 +3807,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/discriminantPrope
 Bindings mismatch:
 after transform: ScopeId(0): ["BarEnum", "DoesNotWork", "Types", "WorksProperly", "doTestingStuff", "f", "foo", "foo1", "foo2", "foo3", "foo4", "foo5", "foo6", "func2", "func3", "goo1", "goo2", "isType", "never", "onlyPlus", "u"]
 rebuilt        : ScopeId(0): ["BarEnum", "DoesNotWork", "Types", "WorksProperly", "doTestingStuff", "f", "foo", "foo1", "foo2", "foo3", "foo4", "foo5", "foo6", "func2", "func3", "goo1", "goo2", "onlyPlus", "u"]
-Bindings mismatch:
-after transform: ScopeId(21): ["Num", "Str", "Types"]
-rebuilt        : ScopeId(17): ["Types"]
-Bindings mismatch:
-after transform: ScopeId(44): ["BarEnum", "bar1", "bar2"]
-rebuilt        : ScopeId(28): ["BarEnum"]
 Reference symbol mismatch for "never":
 after transform: SymbolId(44) "never"
 rebuilt        : <None>
@@ -4093,11 +3871,6 @@ Unresolved references mismatch:
 after transform: ["Error", "undefined"]
 rebuilt        : ["Error", "c", "undefined"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/discriminantsAndPrimitives.ts
-Bindings mismatch:
-after transform: ScopeId(15): ["Disjunction", "EnumTypeNode", "Pattern"]
-rebuilt        : ScopeId(13): ["EnumTypeNode"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/discriminateWithDivergentAccessors1.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["weirdoBox", "weirdoBox2"]
@@ -4153,11 +3926,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["getVariableValues"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/discriminatedUnionJsxElement.tsx
-Bindings mismatch:
-after transform: ScopeId(4): ["Avatar", "ListItemVariant", "OneLine"]
-rebuilt        : ScopeId(2): ["ListItemVariant"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/discriminatingUnionWithUnionPropertyAgainstUndefinedWithoutStrictNullChecks.ts
 Bindings mismatch:
@@ -4217,9 +3985,6 @@ after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 174, e
 rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/doubleUnderscoreEnumEmit.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["(Anonymous class)", "(Anonymous function)", "Foo", "__a", "__call"]
-rebuilt        : ScopeId(1): ["Foo"]
 Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(0): [Span { start: 5, end: 8 }, Span { start: 117, end: 120 }]
 rebuilt        : SymbolId(0): []
@@ -4423,139 +4188,21 @@ rebuilt        : ScopeId(0): []
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumAssignmentCompat4.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Bindings mismatch:
-after transform: ScopeId(2): ["BAR", "MyEnum"]
-rebuilt        : ScopeId(2): ["MyEnum"]
-Bindings mismatch:
-after transform: ScopeId(4): ["FOO", "MyEnum"]
-rebuilt        : ScopeId(4): ["MyEnum"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumCodeGenNewLines1.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["b", "c", "d", "foo"]
-rebuilt        : ScopeId(1): ["foo"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumDecl1.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["mAmbient"]
 rebuilt        : ScopeId(0): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumDeclarationEmitInitializerHasImport.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["Enum", "Value1", "Value2"]
-rebuilt        : ScopeId(1): ["Enum"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumFromExternalModule.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["Mode", "Open"]
-rebuilt        : ScopeId(1): ["Mode"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumIndexer.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["MyEnumType", "bar", "foo"]
-rebuilt        : ScopeId(1): ["MyEnumType"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumInitializersWithExponents.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["E"]
 rebuilt        : ScopeId(0): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumKeysQuotedAsObjectPropertiesInDeclarationEmit.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["LEFT_BUTTON", "MIDDLE_BUTTON", "MouseButton", "NO_BUTTON", "RIGHT_BUTTON", "XBUTTON1_BUTTON", "XBUTTON2_BUTTON"]
-rebuilt        : ScopeId(1): ["MouseButton"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumLiteralUnionNotWidened.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "one", "two"]
-rebuilt        : ScopeId(1): ["A"]
-Bindings mismatch:
-after transform: ScopeId(2): ["B", "bar", "foo"]
-rebuilt        : ScopeId(2): ["B"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumLiteralsSubtypeReduction.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["E", "E0", "E1", "E10", "E100", "E1000", "E1001", "E1002", "E1003", "E1004", "E1005", "E1006", "E1007", "E1008", "E1009", "E101", "E1010", "E1011", "E1012", "E1013", "E1014", "E1015", "E1016", "E1017", "E1018", "E1019", "E102", "E1020", "E1021", "E1022", "E1023", "E103", "E104", "E105", "E106", "E107", "E108", "E109", "E11", "E110", "E111", "E112", "E113", "E114", "E115", "E116", "E117", "E118", "E119", "E12", "E120", "E121", "E122", "E123", "E124", "E125", "E126", "E127", "E128", "E129", "E13", "E130", "E131", "E132", "E133", "E134", "E135", "E136", "E137", "E138", "E139", "E14", "E140", "E141", "E142", "E143", "E144", "E145", "E146", "E147", "E148", "E149", "E15", "E150", "E151", "E152", "E153", "E154", "E155", "E156", "E157", "E158", "E159", "E16", "E160", "E161", "E162", "E163", "E164", "E165", "E166", "E167", "E168", "E169", "E17", "E170", "E171", "E172", "E173", "E174", "E175", "E176", "E177", "E178", "E179", "E18", "E180", "E181", "E182", "E183", "E184", "E185", "E186", "E187", "E188", "E189", "E19", "E190", "E191", "E192", "E193", "E194", "E195", "E196", "E197", "E198", "E199", "E2", "E20", "E200", "E201", "E202", "E203", "E204", "E205", "E206", "E207", "E208", "E209", "E21", "E210", "E211", "E212", "E213", "E214", "E215", "E216", "E217", "E218", "E219", "E22", "E220", "E221", "E222", "E223", "E224", "E225", "E226", "E227", "E228", "E229", "E23", "E230", "E231", "E232", "E233", "E234", "E235", "E236", "E237", "E238", "E239", "E24", "E240", "E241", "E242", "E243", "E244", "E245", "E246", "E247", "E248", "E249", "E25", "E250", "E251", "E252", "E253", "E254", "E255", "E256", "E257", "E258", "E259", "E26", "E260", "E261", "E262", "E263", "E264", "E265", "E266", "E267", "E268", "E269", "E27", "E270", "E271", "E272", "E273", "E274", "E275", "E276", "E277", "E278", "E279", "E28", "E280", "E281", "E282", "E283", "E284", "E285", "E286", "E287", "E288", "E289", "E29", "E290", "E291", "E292", "E293", "E294", "E295", "E296", "E297", "E298", "E299", "E3", "E30", "E300", "E301", "E302", "E303", "E304", "E305", "E306", "E307", "E308", "E309", "E31", "E310", "E311", "E312", "E313", "E314", "E315", "E316", "E317", "E318", "E319", "E32", "E320", "E321", "E322", "E323", "E324", "E325", "E326", "E327", "E328", "E329", "E33", "E330", "E331", "E332", "E333", "E334", "E335", "E336", "E337", "E338", "E339", "E34", "E340", "E341", "E342", "E343", "E344", "E345", "E346", "E347", "E348", "E349", "E35", "E350", "E351", "E352", "E353", "E354", "E355", "E356", "E357", "E358", "E359", "E36", "E360", "E361", "E362", "E363", "E364", "E365", "E366", "E367", "E368", "E369", "E37", "E370", "E371", "E372", "E373", "E374", "E375", "E376", "E377", "E378", "E379", "E38", "E380", "E381", "E382", "E383", "E384", "E385", "E386", "E387", "E388", "E389", "E39", "E390", "E391", "E392", "E393", "E394", "E395", "E396", "E397", "E398", "E399", "E4", "E40", "E400", "E401", "E402", "E403", "E404", "E405", "E406", "E407", "E408", "E409", "E41", "E410", "E411", "E412", "E413", "E414", "E415", "E416", "E417", "E418", "E419", "E42", "E420", "E421", "E422", "E423", "E424", "E425", "E426", "E427", "E428", "E429", "E43", "E430", "E431", "E432", "E433", "E434", "E435", "E436", "E437", "E438", "E439", "E44", "E440", "E441", "E442", "E443", "E444", "E445", "E446", "E447", "E448", "E449", "E45", "E450", "E451", "E452", "E453", "E454", "E455", "E456", "E457", "E458", "E459", "E46", "E460", "E461", "E462", "E463", "E464", "E465", "E466", "E467", "E468", "E469", "E47", "E470", "E471", "E472", "E473", "E474", "E475", "E476", "E477", "E478", "E479", "E48", "E480", "E481", "E482", "E483", "E484", "E485", "E486", "E487", "E488", "E489", "E49", "E490", "E491", "E492", "E493", "E494", "E495", "E496", "E497", "E498", "E499", "E5", "E50", "E500", "E501", "E502", "E503", "E504", "E505", "E506", "E507", "E508", "E509", "E51", "E510", "E511", "E512", "E513", "E514", "E515", "E516", "E517", "E518", "E519", "E52", "E520", "E521", "E522", "E523", "E524", "E525", "E526", "E527", "E528", "E529", "E53", "E530", "E531", "E532", "E533", "E534", "E535", "E536", "E537", "E538", "E539", "E54", "E540", "E541", "E542", "E543", "E544", "E545", "E546", "E547", "E548", "E549", "E55", "E550", "E551", "E552", "E553", "E554", "E555", "E556", "E557", "E558", "E559", "E56", "E560", "E561", "E562", "E563", "E564", "E565", "E566", "E567", "E568", "E569", "E57", "E570", "E571", "E572", "E573", "E574", "E575", "E576", "E577", "E578", "E579", "E58", "E580", "E581", "E582", "E583", "E584", "E585", "E586", "E587", "E588", "E589", "E59", "E590", "E591", "E592", "E593", "E594", "E595", "E596", "E597", "E598", "E599", "E6", "E60", "E600", "E601", "E602", "E603", "E604", "E605", "E606", "E607", "E608", "E609", "E61", "E610", "E611", "E612", "E613", "E614", "E615", "E616", "E617", "E618", "E619", "E62", "E620", "E621", "E622", "E623", "E624", "E625", "E626", "E627", "E628", "E629", "E63", "E630", "E631", "E632", "E633", "E634", "E635", "E636", "E637", "E638", "E639", "E64", "E640", "E641", "E642", "E643", "E644", "E645", "E646", "E647", "E648", "E649", "E65", "E650", "E651", "E652", "E653", "E654", "E655", "E656", "E657", "E658", "E659", "E66", "E660", "E661", "E662", "E663", "E664", "E665", "E666", "E667", "E668", "E669", "E67", "E670", "E671", "E672", "E673", "E674", "E675", "E676", "E677", "E678", "E679", "E68", "E680", "E681", "E682", "E683", "E684", "E685", "E686", "E687", "E688", "E689", "E69", "E690", "E691", "E692", "E693", "E694", "E695", "E696", "E697", "E698", "E699", "E7", "E70", "E700", "E701", "E702", "E703", "E704", "E705", "E706", "E707", "E708", "E709", "E71", "E710", "E711", "E712", "E713", "E714", "E715", "E716", "E717", "E718", "E719", "E72", "E720", "E721", "E722", "E723", "E724", "E725", "E726", "E727", "E728", "E729", "E73", "E730", "E731", "E732", "E733", "E734", "E735", "E736", "E737", "E738", "E739", "E74", "E740", "E741", "E742", "E743", "E744", "E745", "E746", "E747", "E748", "E749", "E75", "E750", "E751", "E752", "E753", "E754", "E755", "E756", "E757", "E758", "E759", "E76", "E760", "E761", "E762", "E763", "E764", "E765", "E766", "E767", "E768", "E769", "E77", "E770", "E771", "E772", "E773", "E774", "E775", "E776", "E777", "E778", "E779", "E78", "E780", "E781", "E782", "E783", "E784", "E785", "E786", "E787", "E788", "E789", "E79", "E790", "E791", "E792", "E793", "E794", "E795", "E796", "E797", "E798", "E799", "E8", "E80", "E800", "E801", "E802", "E803", "E804", "E805", "E806", "E807", "E808", "E809", "E81", "E810", "E811", "E812", "E813", "E814", "E815", "E816", "E817", "E818", "E819", "E82", "E820", "E821", "E822", "E823", "E824", "E825", "E826", "E827", "E828", "E829", "E83", "E830", "E831", "E832", "E833", "E834", "E835", "E836", "E837", "E838", "E839", "E84", "E840", "E841", "E842", "E843", "E844", "E845", "E846", "E847", "E848", "E849", "E85", "E850", "E851", "E852", "E853", "E854", "E855", "E856", "E857", "E858", "E859", "E86", "E860", "E861", "E862", "E863", "E864", "E865", "E866", "E867", "E868", "E869", "E87", "E870", "E871", "E872", "E873", "E874", "E875", "E876", "E877", "E878", "E879", "E88", "E880", "E881", "E882", "E883", "E884", "E885", "E886", "E887", "E888", "E889", "E89", "E890", "E891", "E892", "E893", "E894", "E895", "E896", "E897", "E898", "E899", "E9", "E90", "E900", "E901", "E902", "E903", "E904", "E905", "E906", "E907", "E908", "E909", "E91", "E910", "E911", "E912", "E913", "E914", "E915", "E916", "E917", "E918", "E919", "E92", "E920", "E921", "E922", "E923", "E924", "E925", "E926", "E927", "E928", "E929", "E93", "E930", "E931", "E932", "E933", "E934", "E935", "E936", "E937", "E938", "E939", "E94", "E940", "E941", "E942", "E943", "E944", "E945", "E946", "E947", "E948", "E949", "E95", "E950", "E951", "E952", "E953", "E954", "E955", "E956", "E957", "E958", "E959", "E96", "E960", "E961", "E962", "E963", "E964", "E965", "E966", "E967", "E968", "E969", "E97", "E970", "E971", "E972", "E973", "E974", "E975", "E976", "E977", "E978", "E979", "E98", "E980", "E981", "E982", "E983", "E984", "E985", "E986", "E987", "E988", "E989", "E99", "E990", "E991", "E992", "E993", "E994", "E995", "E996", "E997", "E998", "E999"]
-rebuilt        : ScopeId(1): ["E"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumMapBackIntoItself.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["Large", "Medium", "Small", "TShirtSize"]
-rebuilt        : ScopeId(1): ["TShirtSize"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumMemberNameNonIdentifier.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["123startsWithNumber", "E", "has space", "hyphen-member", "regular", "Ϳ"]
-rebuilt        : ScopeId(1): ["E"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumMemberReduction.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "C", "MyEnum"]
-rebuilt        : ScopeId(1): ["MyEnum"]
-Bindings mismatch:
-after transform: ScopeId(2): ["A", "B", "C", "MyStringEnum"]
-rebuilt        : ScopeId(2): ["MyStringEnum"]
-Bindings mismatch:
-after transform: ScopeId(3): ["A", "B", "C", "MyStringEnumWithEmpty"]
-rebuilt        : ScopeId(3): ["MyStringEnumWithEmpty"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumNegativeLiteral1.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["E", "a", "b", "c"]
-rebuilt        : ScopeId(1): ["E"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumNumbering1.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "C", "D", "E", "Test"]
-rebuilt        : ScopeId(1): ["Test"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumOperations.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["Enum", "None"]
-rebuilt        : ScopeId(1): ["Enum"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumWithInfinityProperty.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "Infinity"]
-rebuilt        : ScopeId(1): ["A"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumWithNaNProperty.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "NaN"]
-rebuilt        : ScopeId(1): ["A"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumWithNegativeInfinityProperty.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["-Infinity", "A"]
-rebuilt        : ScopeId(1): ["A"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumWithQuotedElementName1.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["E", "fo\"o"]
-rebuilt        : ScopeId(1): ["E"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumWithQuotedElementName2.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["E", "fo'o"]
-rebuilt        : ScopeId(1): ["E"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumWithUnicodeEscape1.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["E", "gold ✰"]
-rebuilt        : ScopeId(1): ["E"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumWithoutInitializerAfterComputedMember.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["E", "a", "b", "c"]
-rebuilt        : ScopeId(1): ["E"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumsWithMultipleDeclarations3.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["E"]
 rebuilt        : ScopeId(0): []
-Bindings mismatch:
-after transform: ScopeId(2): ["A", "E"]
-rebuilt        : ScopeId(1): ["E"]
 Reference symbol mismatch for "E":
 after transform: SymbolId(0) "E"
 rebuilt        : <None>
@@ -4630,66 +4277,6 @@ Bindings mismatch:
 after transform: ScopeId(0): ["c", "m", "uninstantiated", "x"]
 rebuilt        : ScopeId(0): ["c", "m", "x"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ModuleConstEnumDeclaration.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["a", "b", "c", "e1"]
-rebuilt        : ScopeId(1): ["e1"]
-Bindings mismatch:
-after transform: ScopeId(2): ["e2", "x", "y", "z"]
-rebuilt        : ScopeId(2): ["e2"]
-Bindings mismatch:
-after transform: ScopeId(4): ["a", "b", "c", "e3"]
-rebuilt        : ScopeId(4): ["e3"]
-Bindings mismatch:
-after transform: ScopeId(5): ["e4", "x", "y", "z"]
-rebuilt        : ScopeId(5): ["e4"]
-Bindings mismatch:
-after transform: ScopeId(7): ["a", "b", "c", "e5"]
-rebuilt        : ScopeId(7): ["e5"]
-Bindings mismatch:
-after transform: ScopeId(8): ["e6", "x", "y", "z"]
-rebuilt        : ScopeId(8): ["e6"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ModuleConstEnumDeclaration2.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["a", "b", "c", "e1"]
-rebuilt        : ScopeId(1): ["e1"]
-Bindings mismatch:
-after transform: ScopeId(2): ["e2", "x", "y", "z"]
-rebuilt        : ScopeId(2): ["e2"]
-Bindings mismatch:
-after transform: ScopeId(4): ["a", "b", "c", "e3"]
-rebuilt        : ScopeId(4): ["e3"]
-Bindings mismatch:
-after transform: ScopeId(5): ["e4", "x", "y", "z"]
-rebuilt        : ScopeId(5): ["e4"]
-Bindings mismatch:
-after transform: ScopeId(7): ["a", "b", "c", "e5"]
-rebuilt        : ScopeId(7): ["e5"]
-Bindings mismatch:
-after transform: ScopeId(8): ["e6", "x", "y", "z"]
-rebuilt        : ScopeId(8): ["e6"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ModuleEnumDeclaration.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["a", "b", "c", "e1"]
-rebuilt        : ScopeId(1): ["e1"]
-Bindings mismatch:
-after transform: ScopeId(2): ["e2", "x", "y", "z"]
-rebuilt        : ScopeId(2): ["e2"]
-Bindings mismatch:
-after transform: ScopeId(4): ["a", "b", "c", "e3"]
-rebuilt        : ScopeId(4): ["e3"]
-Bindings mismatch:
-after transform: ScopeId(5): ["e4", "x", "y", "z"]
-rebuilt        : ScopeId(5): ["e4"]
-Bindings mismatch:
-after transform: ScopeId(7): ["a", "b", "c", "e5"]
-rebuilt        : ScopeId(7): ["e5"]
-Bindings mismatch:
-after transform: ScopeId(8): ["e6", "x", "y", "z"]
-rebuilt        : ScopeId(8): ["e6"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ModuleInternalImport.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 
@@ -4755,11 +4342,6 @@ rebuilt        : SymbolId(1): Span { start: 155, end: 161 }
 Symbol redeclarations mismatch for "server":
 after transform: SymbolId(2): [Span { start: 85, end: 91 }, Span { start: 155, end: 161 }]
 rebuilt        : SymbolId(1): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentEnum.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "C", "E"]
-rebuilt        : ScopeId(1): ["E"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/exportDeclarationsInAmbientNamespaces.ts
 Bindings mismatch:
@@ -4897,16 +4479,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/externalModuleWit
 Bindings mismatch:
 after transform: ScopeId(0): ["M"]
 rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/fakeInfinity2.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "Foo"]
-rebuilt        : ScopeId(1): ["Foo"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/fakeInfinity3.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "Foo"]
-rebuilt        : ScopeId(1): ["Foo"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/fallFromLastCase1.ts
 Bindings mismatch:
@@ -5764,11 +5336,6 @@ Unresolved references mismatch:
 after transform: ["x"]
 rebuilt        : []
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/importElisionEnum.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["MyEnum", "a", "b", "c", "d"]
-rebuilt        : ScopeId(1): ["MyEnum"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/importElisionExportNonExportAndDefault.ts
 Bindings mismatch:
 after transform: ScopeId(0): []
@@ -6465,21 +6032,12 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasEnum.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Bindings mismatch:
-after transform: ScopeId(2): ["Friday", "Saturday", "Sunday", "weekend"]
-rebuilt        : ScopeId(2): ["weekend"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasEnumInsideLocalModuleWithExport.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Bindings mismatch:
-after transform: ScopeId(2): ["Friday", "Saturday", "Sunday", "weekend"]
-rebuilt        : ScopeId(2): ["weekend"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasEnumInsideLocalModuleWithoutExport.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Bindings mismatch:
-after transform: ScopeId(2): ["Friday", "Saturday", "Sunday", "weekend"]
-rebuilt        : ScopeId(2): ["weekend"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasFunction.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -6587,17 +6145,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["f"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/intersectionTypeNormalization.ts
-Bindings mismatch:
-after transform: ScopeId(27): ["A", "a1", "a2", "a3", "a75", "a76", "a77"]
-rebuilt        : ScopeId(4): ["A"]
-Bindings mismatch:
-after transform: ScopeId(28): ["B", "b1", "b2", "b86", "b87"]
-rebuilt        : ScopeId(5): ["B"]
-Bindings mismatch:
-after transform: ScopeId(29): ["C", "c1", "c2", "c210", "c211"]
-rebuilt        : ScopeId(6): ["C"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/intersectionWithConstructSignaturePrototypeResult.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["EmberObject"]
@@ -6672,21 +6219,6 @@ Bindings mismatch:
 after transform: ScopeId(0): ["a1", "a10", "a11", "a12", "a13", "a14", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9", "f1", "f10", "f11", "f12", "f13", "f14", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "x1", "x10", "x11", "x12", "x13", "x14", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9"]
 rebuilt        : ScopeId(0): ["a1", "a10", "a11", "a12", "a13", "a14", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesImportConstEnum.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["BAR", "Foo"]
-rebuilt        : ScopeId(1): ["Foo"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesImportConstEnumTypeOnly.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["Bar", "Foo"]
-rebuilt        : ScopeId(1): ["Foo"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesNonAmbientConstEnum.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["E", "X"]
-rebuilt        : ScopeId(1): ["E"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesPlainFile-ES6.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["run"]
@@ -6733,11 +6265,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["p1", "shouldBeIdentity"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsdocAccessEnumType.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "E"]
-rebuilt        : ScopeId(1): ["E"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsxCallbackWithDestructuring.tsx
 Reference symbol mismatch for "Component":
@@ -6957,18 +6484,10 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["use"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/localImportNameVsGlobalName.ts
-Bindings mismatch:
-after transform: ScopeId(2): ["DOWN", "Key", "LEFT", "RIGHT", "UP"]
-rebuilt        : ScopeId(2): ["Key"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/mappedToToIndexSignatureInference.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["E", "a", "enumValues", "fn", "x"]
 rebuilt        : ScopeId(0): ["E", "x"]
-Bindings mismatch:
-after transform: ScopeId(4): ["A", "B", "E"]
-rebuilt        : ScopeId(1): ["E"]
 Reference symbol mismatch for "fn":
 after transform: SymbolId(0) "fn"
 rebuilt        : <None>
@@ -7129,12 +6648,6 @@ after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 101, e
 rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/mergedEnumDeclarationCodeGen.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["E", "a", "b"]
-rebuilt        : ScopeId(1): ["E"]
-Bindings mismatch:
-after transform: ScopeId(2): ["E", "c"]
-rebuilt        : ScopeId(2): ["E"]
 Symbol redeclarations mismatch for "E":
 after transform: SymbolId(0): [Span { start: 5, end: 6 }, Span { start: 33, end: 34 }]
 rebuilt        : SymbolId(0): []
@@ -7178,9 +6691,6 @@ after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 56, en
 rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/metadataOfUnion.ts
-Bindings mismatch:
-after transform: ScopeId(4): ["A", "B", "C", "D", "E"]
-rebuilt        : ScopeId(5): ["E"]
 Unresolved references mismatch:
 after transform: ["Boolean", "Number", "Object", "String", "require"]
 rebuilt        : ["Boolean", "Number", "Object", "require"]
@@ -7207,12 +6717,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/mixedTypeEnumComp
 Bindings mismatch:
 after transform: ScopeId(0): ["E", "E2", "someNumber", "someString", "someValue", "unionOfEnum"]
 rebuilt        : ScopeId(0): ["E", "E2"]
-Bindings mismatch:
-after transform: ScopeId(1): ["E", "N1", "N2", "S1", "S2"]
-rebuilt        : ScopeId(1): ["E"]
-Bindings mismatch:
-after transform: ScopeId(6): ["C1", "E2", "N1", "S1"]
-rebuilt        : ScopeId(5): ["E2"]
 Reference symbol mismatch for "someNumber":
 after transform: SymbolId(5) "someNumber"
 rebuilt        : <None>
@@ -7369,14 +6873,6 @@ rebuilt        : ScopeId(0): []
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleCodeGenTest3.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleCodeGenTest5.ts
-Bindings mismatch:
-after transform: ScopeId(7): ["A", "E1"]
-rebuilt        : ScopeId(9): ["E1"]
-Bindings mismatch:
-after transform: ScopeId(8): ["B", "E2"]
-rebuilt        : ScopeId(10): ["E2"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleCodegenTest4.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 
@@ -7448,11 +6944,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["require"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleSameValueDuplicateExportedBindings2.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["Animals", "Cat", "Dog"]
-rebuilt        : ScopeId(1): ["Animals"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleSharesNameWithImportDeclarationInsideIt4.ts
 Bindings mismatch:
 after transform: ScopeId(5): ["_M2", "bar"]
@@ -7504,9 +6995,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Bindings mismatch:
 after transform: ScopeId(5): ["B", "C", "E", "InnerMod", "_M", "exported_var", "someModuleFunction", "someModuleVar", "x", "y"]
 rebuilt        : ScopeId(5): ["B", "C", "E", "InnerMod", "_M", "someModuleFunction", "someModuleVar", "x", "y"]
-Bindings mismatch:
-after transform: ScopeId(8): ["A", "B", "C", "E"]
-rebuilt        : ScopeId(8): ["E"]
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(5): [Span { start: 243, end: 244 }, Span { start: 1079, end: 1080 }]
 rebuilt        : SymbolId(8): []
@@ -7983,11 +7471,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["direct", "hasZField", "nested", "nestedUnion"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/neverAsDiscriminantType.ts
-Bindings mismatch:
-after transform: ScopeId(14): ["DISPATCH", "GatewayOpcode", "HEARTBEAT", "HEARTBEAT_ACK", "HELLO", "IDENTIFY", "INVALID_SESSION", "PRESENCE_UPDATE", "RECONNECT", "REQUEST_GUILD_MEMBERS", "RESUME", "VOICE_STATE_UPDATE"]
-rebuilt        : ScopeId(5): ["GatewayOpcode"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/noCircularDefinitionOnExportOfPrivateInMergedNamespace.ts
 Symbol reference IDs mismatch for "cat":
 after transform: SymbolId(0): [ReferenceId(1)]
@@ -8070,17 +7553,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["get", "log"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/noUncheckedIndexAccess.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["Bacon", "Meat", "Sausage"]
-rebuilt        : ScopeId(1): ["Meat"]
-Bindings mismatch:
-after transform: ScopeId(2): ["A", "a", "b", "c"]
-rebuilt        : ScopeId(2): ["A"]
-Bindings mismatch:
-after transform: ScopeId(3): ["B", "x", "y", "z"]
-rebuilt        : ScopeId(3): ["B"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/nodeModuleReexportFromDottedPath.ts
 Bindings mismatch:
@@ -8214,15 +7686,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/numericEnumMapped
 Bindings mismatch:
 after transform: ScopeId(0): ["E", "E1", "E2", "N1", "N2", "b1", "b2", "e", "e1", "e2", "val", "x"]
 rebuilt        : ScopeId(0): ["E1", "N1", "N2", "b1", "b2", "e", "e1", "e2", "x"]
-Bindings mismatch:
-after transform: ScopeId(1): ["E1", "ONE", "THREE", "TWO"]
-rebuilt        : ScopeId(1): ["E1"]
-Bindings mismatch:
-after transform: ScopeId(8): ["A", "B", "N1"]
-rebuilt        : ScopeId(2): ["N1"]
-Bindings mismatch:
-after transform: ScopeId(9): ["C", "D", "N2"]
-rebuilt        : ScopeId(3): ["N2"]
 Reference symbol mismatch for "E2":
 after transform: SymbolId(4) "E2"
 rebuilt        : <None>
@@ -8305,14 +7768,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["create"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/objectLiteralEnumPropertyNames.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "Strs"]
-rebuilt        : ScopeId(1): ["Strs"]
-Bindings mismatch:
-after transform: ScopeId(4): ["A", "B", "Nums"]
-rebuilt        : ScopeId(2): ["Nums"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/objectRestBindingContextualInference.ts
 Bindings mismatch:
@@ -8494,11 +7949,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["f"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/parseEntityNameWithReservedWord.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["Bool", "false"]
-rebuilt        : ScopeId(1): ["Bool"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/parseGenericArrowRatherThanLeftShift.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["a", "b", "foo"]
@@ -8561,11 +8011,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["use"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/preserveConstEnums.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["E", "Value", "Value2"]
-rebuilt        : ScopeId(1): ["E"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/primitiveTypeAsmoduleName.ts
 Bindings mismatch:
@@ -8715,14 +8160,8 @@ Bindings mismatch:
 after transform: ScopeId(1): ["_m_private", "c_private", "e_private", "f_private", "mi_private", "mu_private", "v_private"]
 rebuilt        : ScopeId(1): ["_m_private", "c_private", "e_private", "f_private", "mi_private", "v_private"]
 Bindings mismatch:
-after transform: ScopeId(3): ["Grumpy", "Happy", "e_private"]
-rebuilt        : ScopeId(3): ["e_private"]
-Bindings mismatch:
 after transform: ScopeId(10): ["_m_public", "c_public", "e_public", "f_public", "mi_public", "mu_public", "v_public"]
 rebuilt        : ScopeId(7): ["_m_public", "c_public", "e_public", "f_public", "mi_public", "v_public"]
-Bindings mismatch:
-after transform: ScopeId(12): ["Grumpy", "Happy", "e_public"]
-rebuilt        : ScopeId(9): ["e_public"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/promiseType.ts
 Bindings mismatch:
@@ -9773,11 +9212,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["Tag"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/recursiveArrayNotCircular.ts
-Bindings mismatch:
-after transform: ScopeId(3): ["ActionType", "Bar", "Batch", "Baz", "Foo"]
-rebuilt        : ScopeId(1): ["ActionType"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/recursiveBaseConstructorCreation2.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["abc", "bar", "base", "xyz"]
@@ -9879,11 +9313,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["opt1", "opt2", "opt3"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/reducibleIndexedAccessTypes.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "C", "Type"]
-rebuilt        : ScopeId(1): ["Type"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/reexportNameAliasedAndHoisted.ts
 Bindings mismatch:
@@ -10949,9 +10378,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/stableTypeOrderin
 Bindings mismatch:
 after transform: ScopeId(0): ["Color", "Message", "_defineProperty", "checkType", "enumUnion", "mixedUnion", "p", "person", "result1", "takeMessageOrArray"]
 rebuilt        : ScopeId(0): ["Color", "Message", "_defineProperty", "checkType", "enumUnion", "mixedUnion", "p", "result1", "takeMessageOrArray"]
-Bindings mismatch:
-after transform: ScopeId(5): ["Blue", "Color", "Green", "Red"]
-rebuilt        : ScopeId(6): ["Color"]
 Reference symbol mismatch for "person":
 after transform: SymbolId(18) "person"
 rebuilt        : <None>
@@ -11116,11 +10542,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["a", "acceptA", "acceptUnion", "b", "coAndContra", "coAndContraArray", "f1", "f2", "f3", "f4", "fo", "foo", "fs", "fx", "never"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/strictModeEnumMemberNameReserved.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["E", "static"]
-rebuilt        : ScopeId(1): ["E"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/stringLiteralObjectLiteralDeclaration1.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -11295,11 +10716,6 @@ rebuilt        : ["Component", "require"]
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/topLevel.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/trackedSymbolsNoCrash.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["Node0", "Node1", "Node10", "Node11", "Node12", "Node13", "Node14", "Node15", "Node16", "Node17", "Node18", "Node19", "Node2", "Node20", "Node21", "Node22", "Node23", "Node24", "Node25", "Node26", "Node27", "Node28", "Node29", "Node3", "Node30", "Node31", "Node32", "Node33", "Node34", "Node35", "Node36", "Node37", "Node38", "Node39", "Node4", "Node40", "Node41", "Node42", "Node43", "Node44", "Node45", "Node46", "Node47", "Node48", "Node49", "Node5", "Node50", "Node51", "Node52", "Node53", "Node54", "Node55", "Node56", "Node57", "Node58", "Node59", "Node6", "Node60", "Node61", "Node62", "Node63", "Node64", "Node65", "Node66", "Node67", "Node68", "Node69", "Node7", "Node70", "Node71", "Node72", "Node73", "Node74", "Node75", "Node76", "Node77", "Node78", "Node79", "Node8", "Node80", "Node81", "Node82", "Node83", "Node84", "Node85", "Node86", "Node87", "Node88", "Node89", "Node9", "Node90", "Node91", "Node92", "Node93", "Node94", "Node95", "Node96", "Node97", "Node98", "Node99", "SyntaxKind"]
-rebuilt        : ScopeId(1): ["SyntaxKind"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/transformsElideNullUndefinedType.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["C1", "C2", "C3", "C4", "C5", "C6", "C7", "D", "_defineProperty", "f0", "f1", "f10", "f11", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "fn", "v0", "v1"]
@@ -11343,11 +10759,6 @@ rebuilt        : SymbolId(1): SymbolFlags(Function)
 Symbol redeclarations mismatch for "createElement":
 after transform: SymbolId(2): [Span { start: 125, end: 138 }, Span { start: 243, end: 256 }]
 rebuilt        : SymbolId(1): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/tsxDefaultImports.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["SomeEnum", "one"]
-rebuilt        : ScopeId(1): ["SomeEnum"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/tsxDiscriminantPropertyInference.tsx
 Bindings mismatch:
@@ -11546,9 +10957,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsI
 Bindings mismatch:
 after transform: ScopeId(0): ["E", "m"]
 rebuilt        : ScopeId(0): ["E"]
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "E"]
-rebuilt        : ScopeId(1): ["E"]
 Reference symbol mismatch for "m":
 after transform: SymbolId(3) "m"
 rebuilt        : <None>
@@ -11563,9 +10971,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsI
 Bindings mismatch:
 after transform: ScopeId(0): ["E", "m"]
 rebuilt        : ScopeId(0): ["E"]
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "E"]
-rebuilt        : ScopeId(1): ["E"]
 Reference symbol mismatch for "m":
 after transform: SymbolId(3) "m"
 rebuilt        : <None>
@@ -11821,11 +11226,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["Collection"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/unaryPlus.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["E", "some", "thing"]
-rebuilt        : ScopeId(1): ["E"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/uncalledFunctionChecksInConditionalPerf.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["b"]
@@ -11974,9 +11374,6 @@ after transform: ["undefined"]
 rebuilt        : ["s", "undefined"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/underscoreEscapedNameInEnum.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["E", "__foo", "bar"]
-rebuilt        : ScopeId(1): ["E"]
 Symbol reference IDs mismatch for "E":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(6)]
 rebuilt        : SymbolId(0): [ReferenceId(5)]
@@ -12055,11 +11452,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["a", "tmp"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/unionOfEnumInference.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "C", "Enum"]
-rebuilt        : ScopeId(1): ["Enum"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/unionReductionMutualSubtypes.ts
 Bindings mismatch:
@@ -13388,21 +12780,6 @@ Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(1))
 rebuilt        : ScopeId(8): Some(ScopeId(0))
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnum1.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["E", "a", "b", "c", "d", "e", "f", "g", "h"]
-rebuilt        : ScopeId(1): ["E"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnum3.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["TestType", "bar", "foo"]
-rebuilt        : ScopeId(1): ["TestType"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnumPropertyAccess3.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "C", "D", "E"]
-rebuilt        : ScopeId(1): ["E"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/controlFlow/constLocalsInFunctionExpressions.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["f1", "f2", "f3", "f4", "f5", "getStringOrNumber"]
@@ -14042,70 +13419,8 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["ValidSomeCondition", "directory", "getSpecifier", "moduleFile", "whatToLoad"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/enums/enumBasics.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "C", "E1"]
-rebuilt        : ScopeId(1): ["E1"]
-Bindings mismatch:
-after transform: ScopeId(2): ["A", "B", "C", "E2"]
-rebuilt        : ScopeId(2): ["E2"]
-Bindings mismatch:
-after transform: ScopeId(3): ["E3", "X", "Y", "Z"]
-rebuilt        : ScopeId(3): ["E3"]
-Bindings mismatch:
-after transform: ScopeId(4): ["E4", "X", "Y", "Z"]
-rebuilt        : ScopeId(4): ["E4"]
-Bindings mismatch:
-after transform: ScopeId(5): ["A", "B", "C", "E5"]
-rebuilt        : ScopeId(5): ["E5"]
-Bindings mismatch:
-after transform: ScopeId(6): ["A", "B", "C", "E6"]
-rebuilt        : ScopeId(6): ["E6"]
-Bindings mismatch:
-after transform: ScopeId(7): ["A", "E7"]
-rebuilt        : ScopeId(7): ["E7"]
-Bindings mismatch:
-after transform: ScopeId(8): ["B", "E8"]
-rebuilt        : ScopeId(8): ["E8"]
-Bindings mismatch:
-after transform: ScopeId(9): ["A", "B", "E9"]
-rebuilt        : ScopeId(9): ["E9"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/enums/enumClassification.ts
 Missing ReferenceId: "E20"
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "E01"]
-rebuilt        : ScopeId(1): ["E01"]
-Bindings mismatch:
-after transform: ScopeId(2): ["A", "E02"]
-rebuilt        : ScopeId(2): ["E02"]
-Bindings mismatch:
-after transform: ScopeId(3): ["A", "E03"]
-rebuilt        : ScopeId(3): ["E03"]
-Bindings mismatch:
-after transform: ScopeId(4): ["A", "B", "C", "E04"]
-rebuilt        : ScopeId(4): ["E04"]
-Bindings mismatch:
-after transform: ScopeId(5): ["A", "B", "C", "E05"]
-rebuilt        : ScopeId(5): ["E05"]
-Bindings mismatch:
-after transform: ScopeId(6): ["A", "B", "C", "E06"]
-rebuilt        : ScopeId(6): ["E06"]
-Bindings mismatch:
-after transform: ScopeId(7): ["A", "B", "C", "D", "E", "E07", "F"]
-rebuilt        : ScopeId(7): ["E07"]
-Bindings mismatch:
-after transform: ScopeId(8): ["A", "B", "C", "D", "E", "E08"]
-rebuilt        : ScopeId(8): ["E08"]
-Bindings mismatch:
-after transform: ScopeId(10): ["A", "B", "C", "E11"]
-rebuilt        : ScopeId(10): ["E11"]
-Bindings mismatch:
-after transform: ScopeId(11): ["A", "B", "C", "E12"]
-rebuilt        : ScopeId(11): ["E12"]
-Bindings mismatch:
-after transform: ScopeId(12): ["A", "B", "C", "D", "E20"]
-rebuilt        : ScopeId(12): ["E20"]
 Symbol reference IDs mismatch for "E20":
 after transform: SymbolId(56): [ReferenceId(77), ReferenceId(78), ReferenceId(79), ReferenceId(80), ReferenceId(81), ReferenceId(82), ReferenceId(83), ReferenceId(84)]
 rebuilt        : SymbolId(23): [ReferenceId(72), ReferenceId(73), ReferenceId(74), ReferenceId(75), ReferenceId(76), ReferenceId(77), ReferenceId(78), ReferenceId(79), ReferenceId(81)]
@@ -14114,55 +13429,13 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/enums/enumCons
 Bindings mismatch:
 after transform: ScopeId(0): ["T1", "T2", "T3", "T4", "T5", "T6"]
 rebuilt        : ScopeId(0): ["T1", "T2", "T3", "T4", "T5"]
-Bindings mismatch:
-after transform: ScopeId(1): ["T1", "a", "b", "c"]
-rebuilt        : ScopeId(1): ["T1"]
-Bindings mismatch:
-after transform: ScopeId(2): ["T2", "a", "b"]
-rebuilt        : ScopeId(2): ["T2"]
-Bindings mismatch:
-after transform: ScopeId(3): ["T3", "a", "b"]
-rebuilt        : ScopeId(3): ["T3"]
-Bindings mismatch:
-after transform: ScopeId(4): ["T4", "a"]
-rebuilt        : ScopeId(4): ["T4"]
-Bindings mismatch:
-after transform: ScopeId(5): ["T5", "a"]
-rebuilt        : ScopeId(5): ["T5"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/enums/enumConstantMemberWithTemplateLiteralsEmitDeclaration.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["T1", "T2", "T3", "T4", "T5", "T6", "T7"]
 rebuilt        : ScopeId(0): ["T1", "T2", "T3", "T4", "T5", "T6"]
-Bindings mismatch:
-after transform: ScopeId(1): ["T1", "a"]
-rebuilt        : ScopeId(1): ["T1"]
-Bindings mismatch:
-after transform: ScopeId(2): ["T2", "a", "b", "c"]
-rebuilt        : ScopeId(2): ["T2"]
-Bindings mismatch:
-after transform: ScopeId(3): ["T3", "a"]
-rebuilt        : ScopeId(3): ["T3"]
-Bindings mismatch:
-after transform: ScopeId(4): ["T4", "a", "b", "c", "d", "e"]
-rebuilt        : ScopeId(4): ["T4"]
-Bindings mismatch:
-after transform: ScopeId(5): ["T5", "a", "b", "c", "d"]
-rebuilt        : ScopeId(5): ["T5"]
-Bindings mismatch:
-after transform: ScopeId(6): ["T6", "a", "b"]
-rebuilt        : ScopeId(6): ["T6"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/enums/enumExportMergingES6.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["Animals", "Cat"]
-rebuilt        : ScopeId(1): ["Animals"]
-Bindings mismatch:
-after transform: ScopeId(2): ["Animals", "Dog"]
-rebuilt        : ScopeId(2): ["Animals"]
-Bindings mismatch:
-after transform: ScopeId(3): ["Animals", "CatDog"]
-rebuilt        : ScopeId(3): ["Animals"]
 Symbol redeclarations mismatch for "Animals":
 after transform: SymbolId(0): [Span { start: 12, end: 19 }, Span { start: 45, end: 52 }, Span { start: 78, end: 85 }]
 rebuilt        : SymbolId(0): []
@@ -14171,42 +13444,6 @@ after transform: ["Cat", "Dog"]
 rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/enums/enumMerging.ts
-Bindings mismatch:
-after transform: ScopeId(2): ["A", "B", "C", "EImpl1"]
-rebuilt        : ScopeId(2): ["EImpl1"]
-Bindings mismatch:
-after transform: ScopeId(3): ["D", "E", "EImpl1", "F"]
-rebuilt        : ScopeId(3): ["EImpl1"]
-Bindings mismatch:
-after transform: ScopeId(4): ["A", "B", "C", "EConst1"]
-rebuilt        : ScopeId(4): ["EConst1"]
-Bindings mismatch:
-after transform: ScopeId(5): ["D", "E", "EConst1", "F"]
-rebuilt        : ScopeId(5): ["EConst1"]
-Bindings mismatch:
-after transform: ScopeId(7): ["A", "B", "C", "EComp2"]
-rebuilt        : ScopeId(7): ["EComp2"]
-Bindings mismatch:
-after transform: ScopeId(8): ["D", "E", "EComp2", "F"]
-rebuilt        : ScopeId(8): ["EComp2"]
-Bindings mismatch:
-after transform: ScopeId(10): ["A", "B", "EInit"]
-rebuilt        : ScopeId(10): ["EInit"]
-Bindings mismatch:
-after transform: ScopeId(11): ["C", "D", "E", "EInit"]
-rebuilt        : ScopeId(11): ["EInit"]
-Bindings mismatch:
-after transform: ScopeId(13): ["Blue", "Color", "Green", "Red"]
-rebuilt        : ScopeId(13): ["Color"]
-Bindings mismatch:
-after transform: ScopeId(15): ["Blue", "Color", "Green", "Red"]
-rebuilt        : ScopeId(15): ["Color"]
-Bindings mismatch:
-after transform: ScopeId(18): ["Blue", "Color", "Green", "Red"]
-rebuilt        : ScopeId(18): ["Color"]
-Bindings mismatch:
-after transform: ScopeId(21): ["Color", "Yellow"]
-rebuilt        : ScopeId(21): ["Color"]
 Symbol redeclarations mismatch for "EImpl1":
 after transform: SymbolId(1): [Span { start: 200, end: 206 }, Span { start: 241, end: 247 }]
 rebuilt        : SymbolId(2): []
@@ -14564,19 +13801,6 @@ Unresolved references mismatch:
 after transform: ["require"]
 rebuilt        : ["Factory", "require"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames47_ES6.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["E1", "x"]
-rebuilt        : ScopeId(1): ["E1"]
-Bindings mismatch:
-after transform: ScopeId(2): ["E2", "x"]
-rebuilt        : ScopeId(2): ["E2"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames7_ES6.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["E", "member"]
-rebuilt        : ScopeId(1): ["E"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType6_ES6.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["foo"]
@@ -14835,48 +14059,24 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "D", "E", "M", "N", "a", "f", "v"]
 rebuilt        : ScopeId(0): ["C", "D", "E", "M", "a", "f", "v"]
-Bindings mismatch:
-after transform: ScopeId(4): ["A", "B", "C", "E"]
-rebuilt        : ScopeId(3): ["E"]
-Bindings mismatch:
-after transform: ScopeId(5): ["A", "B", "C", "D"]
-rebuilt        : ScopeId(4): ["D"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports1.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "D", "E", "M", "N", "a", "f", "v"]
 rebuilt        : ScopeId(0): ["C", "D", "E", "M", "a", "f", "v"]
-Bindings mismatch:
-after transform: ScopeId(4): ["A", "B", "C", "E"]
-rebuilt        : ScopeId(3): ["E"]
-Bindings mismatch:
-after transform: ScopeId(5): ["A", "B", "C", "D"]
-rebuilt        : ScopeId(4): ["D"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports3-es6.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "D", "E", "M", "N", "a", "f", "v"]
 rebuilt        : ScopeId(0): ["C", "D", "E", "M", "a", "f", "v"]
-Bindings mismatch:
-after transform: ScopeId(4): ["A", "B", "C", "E"]
-rebuilt        : ScopeId(3): ["E"]
-Bindings mismatch:
-after transform: ScopeId(5): ["A", "B", "C", "D"]
-rebuilt        : ScopeId(4): ["D"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports3.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "D", "E", "M", "N", "a", "f", "v"]
 rebuilt        : ScopeId(0): ["C", "D", "E", "M", "a", "f", "v"]
-Bindings mismatch:
-after transform: ScopeId(4): ["A", "B", "C", "E"]
-rebuilt        : ScopeId(3): ["E"]
-Bindings mismatch:
-after transform: ScopeId(5): ["A", "B", "C", "D"]
-rebuilt        : ScopeId(4): ["D"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesWithModule.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -16161,12 +15361,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/ar
 Bindings mismatch:
 after transform: ScopeId(0): ["AppStyle", "AppType", "appTypeStylesWithError", "b1", "b2", "foo"]
 rebuilt        : ScopeId(0): ["AppStyle", "AppType", "appTypeStylesWithError", "b1", "b2"]
-Bindings mismatch:
-after transform: ScopeId(1): ["AdvancedList", "AppType", "Composite", "HeaderDetail", "HeaderMultiDetail", "ListOnly", "ModuleSettings", "Relationship", "Report", "Standard"]
-rebuilt        : ScopeId(1): ["AppType"]
-Bindings mismatch:
-after transform: ScopeId(2): ["AppStyle", "MiniApp", "PivotTable", "Standard", "Tree", "TreeEntity"]
-rebuilt        : ScopeId(2): ["AppStyle"]
 Reference symbol mismatch for "foo":
 after transform: SymbolId(17) "foo"
 rebuilt        : <None>
@@ -16235,9 +15429,6 @@ rebuilt        : ["foo"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithAnyAndEveryType.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Bindings mismatch:
-after transform: ScopeId(4): ["E", "a", "b", "c"]
-rebuilt        : ScopeId(5): ["E"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnOptionalProperty.ts
 Bindings mismatch:
@@ -16926,11 +16117,6 @@ Unresolved references mismatch:
 after transform: ["Symbol"]
 rebuilt        : ["A", "B", "Rhs10", "Rhs11", "Rhs12", "Rhs13", "Rhs7", "Rhs8", "Rhs9", "lhs0", "lhs1", "lhs2", "lhs3", "lhs4", "obj", "rhs0", "rhs1", "rhs14", "rhs15", "rhs2", "rhs3", "rhs4", "rhs5", "rhs6"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/functionExpressionContextualTyping1.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["E", "blue", "red"]
-rebuilt        : ScopeId(1): ["E"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/functionExpressionContextualTyping3.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["f"]
@@ -16954,9 +16140,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/el
 Bindings mismatch:
 after transform: ScopeId(0): ["E", "e", "item", "snb"]
 rebuilt        : ScopeId(0): ["E", "snb"]
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "C", "E"]
-rebuilt        : ScopeId(1): ["E"]
 Reference symbol mismatch for "item":
 after transform: SymbolId(5) "item"
 rebuilt        : <None>
@@ -18359,16 +17542,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["empty", "flags"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeAssertions/constAssertionOnEnum.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "Foo"]
-rebuilt        : ScopeId(1): ["Foo"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/TypeGuardWithEnumUnion.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["B", "Color", "G", "R"]
-rebuilt        : ScopeId(1): ["Color"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardFunction.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "D", "_defineProperty", "a", "acceptingBoolean", "acceptingTypeGuardFunction", "b", "f1", "f2", "isA", "isB", "isC", "isC_multipleParams", "obj", "retC", "subType", "union", "union2", "union3"]
@@ -18551,11 +17724,6 @@ Unresolved references mismatch:
 after transform: ["console"]
 rebuilt        : ["checkM", "checkTruths", "console"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/bitwiseNotOperator/bitwiseNotOperatorWithEnumType.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["", "A", "B", "ENUM1"]
-rebuilt        : ScopeId(1): ["ENUM1"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherType.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 
@@ -18564,11 +17732,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/voidOperator/voidOperatorWithBooleanType.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/voidOperator/voidOperatorWithEnumType.ts
-Bindings mismatch:
-after transform: ScopeId(2): ["", "A", "B", "ENUM1"]
-rebuilt        : ScopeId(2): ["ENUM1"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/voidOperator/voidOperatorWithNumberType.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -18580,9 +17743,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModule
 Bindings mismatch:
 after transform: ScopeId(0): ["C1", "E1", "M1", "_defineProperty"]
 rebuilt        : ScopeId(0): ["C1", "E1", "_defineProperty"]
-Bindings mismatch:
-after transform: ScopeId(5): ["A", "B", "C", "E1"]
-rebuilt        : ScopeId(3): ["E1"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentMergedModule.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
@@ -18651,16 +17811,6 @@ Symbol redeclarations mismatch for "B":
 after transform: SymbolId(1): [Span { start: 67, end: 68 }, Span { start: 83, end: 84 }]
 rebuilt        : SymbolId(1): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/verbatimModuleSyntaxConstEnum.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "E"]
-rebuilt        : ScopeId(1): ["E"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/verbatimModuleSyntaxConstEnumUsage.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["Foo", "a", "b", "c"]
-rebuilt        : ScopeId(1): ["Foo"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/functions/functionOverloadCompatibilityWithVoid02.ts
 Symbol span mismatch for "f":
 after transform: SymbolId(0): Span { start: 9, end: 10 }
@@ -18681,9 +17831,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/generators/gen
 Bindings mismatch:
 after transform: ScopeId(0): ["Directive", "StepResult", "_wrapAsyncGenerator", "canPickStepContinue", "createPickStep", "f1", "f2", "showStep"]
 rebuilt        : ScopeId(0): ["Directive", "StepResult", "_wrapAsyncGenerator", "canPickStepContinue", "createPickStep", "showStep"]
-Bindings mismatch:
-after transform: ScopeId(7): ["Back", "Cancel", "Directive", "LoadMore", "Noop"]
-rebuilt        : ScopeId(3): ["Directive"]
 Symbol redeclarations mismatch for "Directive":
 after transform: SymbolId(12): [Span { start: 318, end: 327 }, Span { start: 381, end: 390 }]
 rebuilt        : SymbolId(3): []
@@ -18806,9 +17953,6 @@ after transform: SymbolId(5): [Span { start: 227, end: 232 }, Span { start: 371,
 rebuilt        : SymbolId(8): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/EnumAndModuleWithSameNameAndCommonRoot.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["Blue", "Red", "enumdule"]
-rebuilt        : ScopeId(1): ["enumdule"]
 Symbol redeclarations mismatch for "enumdule":
 after transform: SymbolId(0): [Span { start: 5, end: 13 }, Span { start: 43, end: 51 }]
 rebuilt        : SymbolId(0): []
@@ -18817,9 +17961,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModule
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ModuleAndEnumWithSameNameAndCommonRoot.ts
-Bindings mismatch:
-after transform: ScopeId(4): ["Blue", "Red", "enumdule"]
-rebuilt        : ScopeId(4): ["enumdule"]
 Symbol redeclarations mismatch for "enumdule":
 after transform: SymbolId(0): [Span { start: 10, end: 18 }, Span { start: 121, end: 129 }]
 rebuilt        : SymbolId(0): []
@@ -18917,11 +18058,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["mod1"]
 rebuilt        : ["mod2", "pack2"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocLinkTag9.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["Enum", "EnumValue"]
-rebuilt        : ScopeId(1): ["Enum"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/seeTag1.ts
 Bindings mismatch:
@@ -19326,50 +18462,10 @@ Bindings mismatch:
 after transform: ScopeId(0): ["Enumerator"]
 rebuilt        : ScopeId(0): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum1.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["IsIndexer", "IsNumberIndexer", "IsStringIndexer", "None", "SignatureFlags"]
-rebuilt        : ScopeId(1): ["SignatureFlags"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum2.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["IsIndexer", "IsNumberIndexer", "IsStringIndexer", "None", "SignatureFlags"]
-rebuilt        : ScopeId(1): ["SignatureFlags"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum6.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "C", "E"]
-rebuilt        : ScopeId(1): ["E"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnumDeclaration1.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["Bar", "E", "Foo"]
-rebuilt        : ScopeId(1): ["E"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnumDeclaration3.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["E"]
 rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnumDeclaration5.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "C", "D", "E"]
-rebuilt        : ScopeId(1): ["E"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnumDeclaration6.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "C", "D", "E"]
-rebuilt        : ScopeId(1): ["E"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserInterfaceKeywordInEnum.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["Bar", "interface"]
-rebuilt        : ScopeId(1): ["Bar"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserInterfaceKeywordInEnum1.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["Bar", "interface"]
-rebuilt        : ScopeId(1): ["Bar"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration5.ts
 Symbol span mismatch for "foo":
@@ -19489,11 +18585,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/salsa/sourceFi
 Bindings mismatch:
 after transform: ScopeId(0): ["foo"]
 rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannerEnum1.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["CodeGenTarget", "ES3", "ES5"]
-rebuilt        : ScopeId(1): ["CodeGenTarget"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsNamedEvaluationDecoratorsAndClassFields.ts
 Bindings mismatch:
@@ -19640,11 +18731,6 @@ Unresolved references mismatch:
 after transform: ["undefined"]
 rebuilt        : ["q", "undefined"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionOfUnionOfUnitTypes.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "C", "D", "E", "F"]
-rebuilt        : ScopeId(1): ["E"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionTypeInference2.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["a", "b", "f", "f2", "obj"]
@@ -19743,9 +18829,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/
 Bindings mismatch:
 after transform: ScopeId(0): ["Choice", "assertNever", "f1", "f10", "f11", "f12", "f13", "f2", "f20", "f21", "f3", "f4", "f5", "g"]
 rebuilt        : ScopeId(0): ["Choice", "assertNever", "f1", "f10", "f11", "f12", "f13", "f2", "f20", "f21", "f3", "f4", "f5"]
-Bindings mismatch:
-after transform: ScopeId(1): ["Choice", "No", "Unknown", "Yes"]
-rebuilt        : ScopeId(1): ["Choice"]
 Reference symbol mismatch for "g":
 after transform: SymbolId(21) "g"
 rebuilt        : <None>
@@ -19769,9 +18852,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/
 Bindings mismatch:
 after transform: ScopeId(0): ["Choice", "assertNever", "f1", "f10", "f11", "f12", "f13", "f2", "f20", "f21", "f3", "f4", "f5", "g"]
 rebuilt        : ScopeId(0): ["Choice", "assertNever", "f1", "f10", "f11", "f12", "f13", "f2", "f20", "f21", "f3", "f4", "f5"]
-Bindings mismatch:
-after transform: ScopeId(1): ["Choice", "No", "Unknown", "Yes"]
-rebuilt        : ScopeId(1): ["Choice"]
 Reference symbol mismatch for "g":
 after transform: SymbolId(21) "g"
 rebuilt        : <None>
@@ -19795,9 +18875,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/
 Bindings mismatch:
 after transform: ScopeId(0): ["E", "Set", "_excluded", "_objectSpread", "_objectWithoutProperties", "a", "arr", "b", "doWork", "f", "f1", "f2", "f3", "f4", "f5", "f6", "increment", "isFailure", "isSuccess", "keys", "langCodeSet", "langCodes", "nonWidening", "onMouseOver", "result", "test", "widening", "x"]
 rebuilt        : ScopeId(0): ["E", "FAILURE", "Set", "_excluded", "_objectSpread", "_objectWithoutProperties", "a", "arr", "b", "doWork", "f1", "f2", "f3", "f4", "f5", "f6", "increment", "isFailure", "isSuccess", "keys", "langCodeSet", "langCodes", "onMouseOver", "result", "test", "x"]
-Bindings mismatch:
-after transform: ScopeId(26): ["A", "B", "E"]
-rebuilt        : ScopeId(18): ["E"]
 Symbol flags mismatch for "FAILURE":
 after transform: SymbolId(65): SymbolFlags(BlockScopedVariable | ConstVariable | TypeAlias)
 rebuilt        : SymbolId(62): SymbolFlags(BlockScopedVariable | ConstVariable)
@@ -19836,9 +18913,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/
 Bindings mismatch:
 after transform: ScopeId(0): ["C1", "C2", "E", "_defineProperty", "a", "aa", "append", "cond", "f1", "f10", "f11", "f12", "f2", "f20", "f3", "f4", "f5", "f6", "g1", "g2", "g3", "g4", "g5", "g6", "g7", "g8", "makeArray", "x1", "x10", "x11", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9"]
 rebuilt        : ScopeId(0): ["C1", "C2", "E", "_defineProperty", "a", "aa", "append", "cond", "f1", "f10", "f11", "f12", "f2", "f20", "f3", "f4", "f5", "f6", "makeArray", "x1", "x10", "x11", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9"]
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "C", "E"]
-rebuilt        : ScopeId(1): ["E"]
 Reference symbol mismatch for "g1":
 after transform: SymbolId(98) "g1"
 rebuilt        : <None>
@@ -19975,9 +19049,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/
 Bindings mismatch:
 after transform: ScopeId(0): ["Choice", "assertNever", "f1", "f10", "f11", "f12", "f13", "f2", "f20", "f21", "f3", "f5", "g"]
 rebuilt        : ScopeId(0): ["Choice", "assertNever", "f1", "f10", "f11", "f12", "f13", "f2", "f20", "f21", "f3", "f5"]
-Bindings mismatch:
-after transform: ScopeId(1): ["Choice", "No", "Unknown", "Yes"]
-rebuilt        : ScopeId(1): ["Choice"]
 Reference symbol mismatch for "g":
 after transform: SymbolId(18) "g"
 rebuilt        : <None>
@@ -20001,9 +19072,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/
 Bindings mismatch:
 after transform: ScopeId(0): ["Choice", "assertNever", "f1", "f10", "f11", "f12", "f13", "f2", "f20", "f21", "f3", "f5", "g"]
 rebuilt        : ScopeId(0): ["Choice", "assertNever", "f1", "f10", "f11", "f12", "f13", "f2", "f20", "f21", "f3", "f5"]
-Bindings mismatch:
-after transform: ScopeId(1): ["Choice", "No", "Unknown", "Yes"]
-rebuilt        : ScopeId(1): ["Choice"]
 Reference symbol mismatch for "g":
 after transform: SymbolId(18) "g"
 rebuilt        : <None>
@@ -20045,11 +19113,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["f1"]
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/templateLiteralTypes8.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["E", "a", "b"]
-rebuilt        : ScopeId(1): ["E"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/mapped/isomorphicMappedTypeInference.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["applySpec", "assignBoxified", "box", "boxify", "clone", "f1", "f10", "f2", "f20", "f21", "f22", "f23", "f24", "f3", "f4", "f5", "f6", "foo", "g1", "g2", "getProps", "makeDictionary", "makeRecord", "myAny", "o", "o1", "o2", "unbox", "unboxify", "validate", "validateAndClone", "x0", "x1", "x2", "x3", "x4"]
@@ -20087,14 +19150,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["applySpec", "clone", "f20", "f21", "f22", "f23", "f24", "validate", "validateAndClone"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeOverlappingStringEnumKeys.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["CAT", "DOG", "TerrestrialAnimalTypes"]
-rebuilt        : ScopeId(1): ["TerrestrialAnimalTypes"]
-Bindings mismatch:
-after transform: ScopeId(2): ["AlienAnimalTypes", "CAT"]
-rebuilt        : ScopeId(2): ["AlienAnimalTypes"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypes1.ts
 Bindings mismatch:
@@ -20280,9 +19335,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Bindings mismatch:
-after transform: ScopeId(32): ["A", "e1"]
-rebuilt        : ScopeId(31): ["e1"]
 Symbol redeclarations mismatch for "m1":
 after transform: SymbolId(44): [Span { start: 1248, end: 1250 }, Span { start: 1277, end: 1279 }]
 rebuilt        : SymbolId(43): []
@@ -20319,16 +19371,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/objectTy
 Bindings mismatch:
 after transform: ScopeId(0): ["f"]
 rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/propertySignatures/propertyNamesOfReservedWords.ts
-Bindings mismatch:
-after transform: ScopeId(3): ["E", "abstract", "as", "boolean", "break", "byte", "case", "catch", "char", "class", "const", "continue", "debugger", "default", "delete", "do", "double", "else", "enum", "export", "extends", "false", "final", "finally", "float", "for", "function", "goto", "if", "implements", "import", "in", "instanceof", "int", "interface", "is", "long", "namespace", "native", "new", "null", "package", "private", "protected", "public", "return", "short", "static", "super", "switch", "synchronized", "this", "throw", "throws", "transient", "true", "try", "typeof", "use", "var", "void", "volatile", "while", "with"]
-rebuilt        : ScopeId(3): ["E"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/primitives/number/validNumberAssignments.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "E"]
-rebuilt        : ScopeId(1): ["E"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/primitives/stringLiteral/stringLiteralType.ts
 Symbol span mismatch for "f":
@@ -21154,9 +20196,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typePara
 Bindings mismatch:
 after transform: ScopeId(0): ["E", "FileRouter", "UploadThingServerHelper", "_asyncToGenerator", "_wrapAsyncGenerator", "nestedResult1", "nestedResult2", "nestedResult3", "outer1", "outer2", "outer3", "overloadA", "overloadB", "overloadC", "overloadD", "overloadE", "overloadF", "overloadG", "overloadH", "overloadI", "overloadJ", "overloaded1", "overloaded2", "overloaded3", "overloaded4", "overloaded5", "result1", "result10", "result11", "result12", "result13", "result14", "result15", "result16", "result17", "result18", "result19", "result2", "result20", "result21", "result22", "result3", "result4", "result5", "result6", "result7", "result8", "result9", "test1", "test2", "test3", "test4"]
 rebuilt        : ScopeId(0): ["E", "FileRouter", "UploadThingServerHelper", "_asyncToGenerator", "_wrapAsyncGenerator", "nestedResult1", "nestedResult2", "nestedResult3", "outer1", "outer2", "outer3", "overloadA", "overloadB", "overloadC", "overloadD", "overloadE", "overloadF", "overloadG", "overloadH", "overloadI", "overloadJ", "result1", "result10", "result11", "result12", "result13", "result14", "result15", "result16", "result17", "result18", "result19", "result2", "result20", "result21", "result22", "result3", "result4", "result5", "result6", "result7", "result8", "result9"]
-Bindings mismatch:
-after transform: ScopeId(1): ["E", "Val", "Val2"]
-rebuilt        : ScopeId(1): ["E"]
 Reference symbol mismatch for "test1":
 after transform: SymbolId(3) "test1"
 rebuilt        : <None>
@@ -21297,9 +20336,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Bindings mismatch:
 after transform: ScopeId(0): ["A", "A2", "CC", "E", "_defineProperty", "a", "f", "foo10", "foo11", "foo12", "foo13", "foo14", "foo15", "foo16", "foo17", "foo18", "foo2", "foo3", "foo4", "foo5", "foo6", "foo7", "foo8", "foo9", "r3"]
 rebuilt        : ScopeId(0): ["A", "A2", "CC", "E", "_defineProperty", "a", "f", "r3"]
-Bindings mismatch:
-after transform: ScopeId(33): ["A", "E"]
-rebuilt        : ScopeId(5): ["E"]
 Symbol redeclarations mismatch for "f":
 after transform: SymbolId(54): [Span { start: 1850, end: 1851 }, Span { start: 1868, end: 1869 }]
 rebuilt        : SymbolId(7): []
@@ -21364,9 +20400,6 @@ rebuilt        : ["foo2", "foo3", "require"]
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/anyAssignableToEveryType2.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Bindings mismatch:
-after transform: ScopeId(18): ["A", "E"]
-rebuilt        : ScopeId(5): ["E"]
 Symbol redeclarations mismatch for "f":
 after transform: SymbolId(22): [Span { start: 1018, end: 1019 }, Span { start: 1036, end: 1037 }]
 rebuilt        : SymbolId(5): []
@@ -21384,11 +20417,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["source"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/nullAssignableToEveryType.ts
-Bindings mismatch:
-after transform: ScopeId(3): ["A", "E"]
-rebuilt        : ScopeId(3): ["E"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/bestCommonType/heterogeneousArrayLiterals.ts
 Symbol redeclarations mismatch for "Derived":
@@ -21458,9 +20486,6 @@ rebuilt        : SymbolId(12): []
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/nullIsSubtypeOfEverythingButUndefined.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Bindings mismatch:
-after transform: ScopeId(8): ["A", "E"]
-rebuilt        : ScopeId(9): ["E"]
 Symbol redeclarations mismatch for "f":
 after transform: SymbolId(30): [Span { start: 1216, end: 1217 }, Span { start: 1234, end: 1235 }]
 rebuilt        : SymbolId(27): []
@@ -21471,9 +20496,6 @@ rebuilt        : SymbolId(32): []
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfAny.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-Bindings mismatch:
-after transform: ScopeId(18): ["A", "E"]
-rebuilt        : ScopeId(5): ["E"]
 Symbol redeclarations mismatch for "f":
 after transform: SymbolId(22): [Span { start: 951, end: 952 }, Span { start: 969, end: 970 }]
 rebuilt        : SymbolId(5): []
@@ -21688,9 +20710,6 @@ after transform: SymbolId(71): [Span { start: 1586, end: 1591 }, Span { start: 1
 rebuilt        : SymbolId(38): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentity2.ts
-Bindings mismatch:
-after transform: ScopeId(5): ["A", "E"]
-rebuilt        : ScopeId(7): ["E"]
 Symbol span mismatch for "foo5":
 after transform: SymbolId(9): Span { start: 234, end: 238 }
 rebuilt        : SymbolId(8): Span { start: 282, end: 286 }
@@ -25891,9 +24910,6 @@ after transform: SymbolId(99): [Span { start: 2264, end: 2269 }, Span { start: 2
 rebuilt        : SymbolId(55): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/primtiveTypesAreIdentical.ts
-Bindings mismatch:
-after transform: ScopeId(17): ["A", "E"]
-rebuilt        : ScopeId(6): ["E"]
 Symbol span mismatch for "foo1":
 after transform: SymbolId(0): Span { start: 98, end: 102 }
 rebuilt        : SymbolId(0): Span { start: 150, end: 154 }
@@ -26234,11 +25250,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["undefined"]
 rebuilt        : ["f", "undefined"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/union/discriminatedUnionTypes4.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["AnimalType", "cat", "dog"]
-rebuilt        : ScopeId(1): ["AnimalType"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeCallSignatures7.ts
 Bindings mismatch:

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 1fb0b771
 
-Passed: 750/1165
+Passed: 761/1165
 
 # All Passed:
 * babel-plugin-transform-logical-assignment-operators
@@ -1070,7 +1070,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-typescript (98/157)
+# babel-plugin-transform-typescript (109/157)
 * class/accessor-allowDeclareFields-false/input.ts
 
   x TS(18010): An accessibility modifier cannot be used with a private
@@ -1159,23 +1159,7 @@ Bindings mismatch:
 after transform: ScopeId(0): ["P"]
 rebuilt        : ScopeId(0): []
 
-* enum/boolean-value/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "E"]
-rebuilt        : ScopeId(1): ["E"]
-
-* enum/constant-folding/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["E", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r"]
-rebuilt        : ScopeId(1): ["E"]
-
 * enum/enum-merging-inner-references/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["Animals", "Cat", "Dog"]
-rebuilt        : ScopeId(1): ["Animals"]
-Bindings mismatch:
-after transform: ScopeId(2): ["Animals", "CatDog"]
-rebuilt        : ScopeId(2): ["Animals"]
 Symbol redeclarations mismatch for "Animals":
 after transform: SymbolId(0): [Span { start: 5, end: 12 }, Span { start: 41, end: 48 }]
 rebuilt        : SymbolId(0): []
@@ -1184,15 +1168,6 @@ after transform: ["Cat", "Dog"]
 rebuilt        : []
 
 * enum/enum-merging-inner-references-shadow/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["Animals", "Cat"]
-rebuilt        : ScopeId(1): ["Animals"]
-Bindings mismatch:
-after transform: ScopeId(2): ["Animals", "Dog"]
-rebuilt        : ScopeId(2): ["Animals"]
-Bindings mismatch:
-after transform: ScopeId(3): ["Animals", "CatDog"]
-rebuilt        : ScopeId(3): ["Animals"]
 Symbol reference IDs mismatch for "Cat":
 after transform: SymbolId(0): [ReferenceId(0)]
 rebuilt        : SymbolId(0): []
@@ -1204,25 +1179,9 @@ after transform: SymbolId(2): [Span { start: 38, end: 45 }, Span { start: 65, en
 rebuilt        : SymbolId(2): []
 
 * enum/export/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "E"]
-rebuilt        : ScopeId(1): ["E"]
-Bindings mismatch:
-after transform: ScopeId(2): ["B", "E"]
-rebuilt        : ScopeId(2): ["E"]
 Symbol redeclarations mismatch for "E":
 after transform: SymbolId(0): [Span { start: 12, end: 13 }, Span { start: 40, end: 41 }]
 rebuilt        : SymbolId(0): []
-
-* enum/inferred/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["E", "x", "y"]
-rebuilt        : ScopeId(1): ["E"]
-
-* enum/inner-references/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["E", "a", "b"]
-rebuilt        : ScopeId(1): ["E"]
 
 * enum/mix-references/input.ts
 x Output mismatch
@@ -1230,57 +1189,22 @@ x Output mismatch
 * enum/non-constant-member-reference/input.ts
 Missing ReferenceId: "Foo"
 Missing ReferenceId: "Foo"
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "C", "D", "Foo"]
-rebuilt        : ScopeId(1): ["Foo"]
 Symbol reference IDs mismatch for "Foo":
 after transform: SymbolId(7): [ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12)]
 rebuilt        : SymbolId(2): [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(12)]
 
-* enum/non-foldable-constant/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["E", "a", "b"]
-rebuilt        : ScopeId(1): ["E"]
-
 * enum/non-scoped/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["E", "x", "y"]
-rebuilt        : ScopeId(1): ["E"]
-Bindings mismatch:
-after transform: ScopeId(2): ["E", "z"]
-rebuilt        : ScopeId(2): ["E"]
 Symbol redeclarations mismatch for "E":
 after transform: SymbolId(0): [Span { start: 5, end: 6 }, Span { start: 40, end: 41 }]
 rebuilt        : SymbolId(0): []
 
 * enum/outer-references/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["IPC", "SERVER", "SOCKET", "socketType"]
-rebuilt        : ScopeId(1): ["socketType"]
-Bindings mismatch:
-after transform: ScopeId(2): ["IPC", "SERVER", "SOCKET", "UV_READABLE", "UV_WRITABLE", "constants"]
-rebuilt        : ScopeId(2): ["constants"]
 Symbol reference IDs mismatch for "socketType":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(10)]
 rebuilt        : SymbolId(0): [ReferenceId(7)]
 
 * enum/reverse-mappings-syntactically-determinable/input.ts
 x Output mismatch
-
-* enum/string-value/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "A2", "B", "B2", "E"]
-rebuilt        : ScopeId(1): ["E"]
-
-* enum/string-value-template/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "E"]
-rebuilt        : ScopeId(1): ["E"]
-
-* enum/string-values-computed/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "E"]
-rebuilt        : ScopeId(1): ["E"]
 
 * enum/ts5.0-const-foldable/input.ts
 x Output mismatch
@@ -1314,12 +1238,6 @@ rebuilt        : SymbolId(2): []
 Bindings mismatch:
 after transform: ScopeId(0): ["BB", "BB2", "C", "C2", "E", "N", "f", "foo", "x"]
 rebuilt        : ScopeId(0): ["BB", "BB2", "C2", "foo"]
-Bindings mismatch:
-after transform: ScopeId(11): ["BB", "K"]
-rebuilt        : ScopeId(2): ["BB"]
-Bindings mismatch:
-after transform: ScopeId(12): ["BB", "L"]
-rebuilt        : ScopeId(3): ["BB"]
 Symbol redeclarations mismatch for "BB":
 after transform: SymbolId(10): [Span { start: 445, end: 447 }, Span { start: 461, end: 463 }]
 rebuilt        : SymbolId(1): []
@@ -1343,16 +1261,6 @@ Symbol redeclarations mismatch for "f":
 after transform: SymbolId(0): [Span { start: 9, end: 10 }, Span { start: 29, end: 30 }]
 rebuilt        : SymbolId(0): []
 
-* imports/enum-id/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "Enum"]
-rebuilt        : ScopeId(1): ["Enum"]
-
-* imports/enum-value/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["Enum", "id"]
-rebuilt        : ScopeId(1): ["Enum"]
-
 * imports/type-only-export-specifier-2/input.ts
 x Output mismatch
 
@@ -1373,9 +1281,6 @@ after transform: SymbolId(0): [Span { start: 6, end: 7 }, Span { start: 22, end:
 rebuilt        : SymbolId(0): []
 
 * namespace/clobber-enum/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "C"]
-rebuilt        : ScopeId(1): ["A"]
 Symbol redeclarations mismatch for "A":
 after transform: SymbolId(0): [Span { start: 5, end: 6 }, Span { start: 30, end: 31 }]
 rebuilt        : SymbolId(0): []
@@ -1439,12 +1344,6 @@ rebuilt        : SymbolId(0): []
 
 
 * namespace/nested/input.ts
-Bindings mismatch:
-after transform: ScopeId(9): ["H", "I", "J", "K"]
-rebuilt        : ScopeId(9): ["H"]
-Bindings mismatch:
-after transform: ScopeId(13): ["L", "M"]
-rebuilt        : ScopeId(13): ["L"]
 Symbol redeclarations mismatch for "A":
 after transform: SymbolId(0): [Span { start: 6, end: 7 }, Span { start: 22, end: 23 }]
 rebuilt        : SymbolId(0): []
@@ -1462,9 +1361,6 @@ rebuilt        : SymbolId(14): []
 Bindings mismatch:
 after transform: ScopeId(1): ["B", "G", "_A"]
 rebuilt        : ScopeId(1): ["G", "_A"]
-Bindings mismatch:
-after transform: ScopeId(4): ["G", "H"]
-rebuilt        : ScopeId(2): ["G"]
 
 * namespace/same-name/input.ts
 Symbol redeclarations mismatch for "N":
@@ -1491,18 +1387,7 @@ x Output mismatch
 * optimize-const-enums/exported/input.ts
 x Output mismatch
 
-* optimize-const-enums/local/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "x", "y"]
-rebuilt        : ScopeId(1): ["A"]
-
 * optimize-const-enums/merged/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "x", "y"]
-rebuilt        : ScopeId(1): ["A"]
-Bindings mismatch:
-after transform: ScopeId(2): ["A", "z"]
-rebuilt        : ScopeId(2): ["A"]
 Symbol redeclarations mismatch for "A":
 after transform: SymbolId(0): [Span { start: 11, end: 12 }, Span { start: 36, end: 37 }]
 rebuilt        : SymbolId(0): []

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 1fb0b771
 
-Passed: 256/398
+Passed: 267/398
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -48,41 +48,19 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-typescript (28/60)
+# babel-plugin-transform-typescript (38/60)
 * allow-declare-fields-false/input.ts
 Unresolved references mismatch:
 after transform: ["dce"]
 rebuilt        : []
 
 * computed-constant-value/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "a", "b", "c", "d", "e"]
-rebuilt        : ScopeId(1): ["A"]
-Bindings mismatch:
-after transform: ScopeId(2): ["B", "a", "b", "c", "d", "e"]
-rebuilt        : ScopeId(2): ["B"]
-Bindings mismatch:
-after transform: ScopeId(3): ["C", "a", "b", "c"]
-rebuilt        : ScopeId(3): ["C"]
-Bindings mismatch:
-after transform: ScopeId(4): ["D", "a", "b", "c"]
-rebuilt        : ScopeId(4): ["D"]
 Unresolved references mismatch:
 after transform: ["Infinity", "NaN"]
 rebuilt        : ["Infinity"]
 Unresolved reference IDs mismatch for "Infinity":
 after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(8), ReferenceId(11), ReferenceId(14), ReferenceId(18)]
 rebuilt        : [ReferenceId(2), ReferenceId(5), ReferenceId(8), ReferenceId(12)]
-
-* const-enum-mixed-refs/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["Phase", "one", "two"]
-rebuilt        : ScopeId(1): ["Phase"]
-
-* const-enum-value-ref-kept/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["Phase", "one", "two"]
-rebuilt        : ScopeId(1): ["Phase"]
 
 * declare-and-definite-with-initializer/input.ts
 
@@ -115,21 +93,6 @@ rebuilt        : ScopeId(0): []
 Missing ReferenceId: "Foo"
 Missing ReferenceId: "Merge"
 Missing ReferenceId: "NestInner"
-Bindings mismatch:
-after transform: ScopeId(1): ["Foo", "a", "b", "c"]
-rebuilt        : ScopeId(1): ["Foo"]
-Bindings mismatch:
-after transform: ScopeId(2): ["Merge", "x"]
-rebuilt        : ScopeId(2): ["Merge"]
-Bindings mismatch:
-after transform: ScopeId(3): ["Merge", "y"]
-rebuilt        : ScopeId(3): ["Merge"]
-Bindings mismatch:
-after transform: ScopeId(4): ["NestOuter", "a", "b"]
-rebuilt        : ScopeId(4): ["NestOuter"]
-Bindings mismatch:
-after transform: ScopeId(6): ["NestInner", "a", "b"]
-rebuilt        : ScopeId(6): ["NestInner"]
 Symbol reference IDs mismatch for "x":
 after transform: SymbolId(0): [ReferenceId(2), ReferenceId(4)]
 rebuilt        : SymbolId(0): [ReferenceId(7)]
@@ -147,23 +110,11 @@ after transform: SymbolId(18): [ReferenceId(31), ReferenceId(32), ReferenceId(33
 rebuilt        : SymbolId(9): [ReferenceId(25), ReferenceId(26), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31)]
 
 * enum-string-alias-member/input.ts
-Bindings mismatch:
-after transform: ScopeId(2): ["Color", "Green", "Primary", "Red"]
-rebuilt        : ScopeId(1): ["Color"]
 Symbol reference IDs mismatch for "Color":
 after transform: SymbolId(4): [ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(12)]
 rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(7), ReferenceId(8)]
 
 * enum-template-literal/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["LARGE", "SMALL", "Size"]
-rebuilt        : ScopeId(1): ["Size"]
-Bindings mismatch:
-after transform: ScopeId(2): ["Animal", "CAT", "DOG"]
-rebuilt        : ScopeId(2): ["Animal"]
-Bindings mismatch:
-after transform: ScopeId(3): ["AnimalSize", "LARGE_DOG", "SMALL_CAT"]
-rebuilt        : ScopeId(3): ["AnimalSize"]
 Symbol reference IDs mismatch for "Size":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(7)]
 rebuilt        : SymbolId(0): [ReferenceId(3)]
@@ -172,23 +123,11 @@ after transform: SymbolId(3): [ReferenceId(1), ReferenceId(3), ReferenceId(11)]
 rebuilt        : SymbolId(2): [ReferenceId(7)]
 
 * enum-template-literal-number/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["NUM_1", "NUM_2", "NUM_3", "NUM_4", "NumberEnum"]
-rebuilt        : ScopeId(1): ["NumberEnum"]
-Bindings mismatch:
-after transform: ScopeId(2): ["COMPUTED_1", "COMPUTED_2", "ComputedEnum"]
-rebuilt        : ScopeId(2): ["ComputedEnum"]
 Symbol reference IDs mismatch for "NumberEnum":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(13)]
 rebuilt        : SymbolId(0): [ReferenceId(9)]
 
 * enum-template-literal-trailing-quasi/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "NumberEnum"]
-rebuilt        : ScopeId(1): ["NumberEnum"]
-Bindings mismatch:
-after transform: ScopeId(2): ["C", "ComputedEnum", "D"]
-rebuilt        : ScopeId(2): ["ComputedEnum"]
 Symbol reference IDs mismatch for "NumberEnum":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(8)]
 rebuilt        : SymbolId(0): [ReferenceId(5)]
@@ -213,9 +152,6 @@ after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
 rebuilt        : SymbolId(0): [ReferenceId(2)]
 
 * namespace/redeclaration-with-enum/input.ts
-Bindings mismatch:
-after transform: ScopeId(2): ["x", "y"]
-rebuilt        : ScopeId(2): ["x"]
 Symbol redeclarations mismatch for "x":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 39, end: 40 }]
 rebuilt        : SymbolId(0): []
@@ -238,53 +174,10 @@ Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(0): [Span { start: 17, end: 20 }, Span { start: 62, end: 65 }]
 rebuilt        : SymbolId(0): []
 
-* optimize-enums/auto-increment-after-string/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "Mixed"]
-rebuilt        : ScopeId(1): ["Mixed"]
-
-* optimize-enums/exported-not-removed/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["Direction", "Down", "Up"]
-rebuilt        : ScopeId(1): ["Direction"]
-
 * optimize-enums/merged-enum/input.ts
 Unresolved references mismatch:
 after transform: ["A"]
 rebuilt        : []
-
-* optimize-enums/non-evaluable-kept/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["Runtime", "X", "Y"]
-rebuilt        : ScopeId(1): ["Runtime"]
-
-* optimize-enums/optional-chain-value-kept/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "Foo"]
-rebuilt        : ScopeId(1): ["Foo"]
-
-* optimize-enums/passed-as-argument-kept/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["Active", "Inactive", "Status"]
-rebuilt        : ScopeId(1): ["Status"]
-
-* optimize-enums/re-exported-not-removed/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "X"]
-rebuilt        : ScopeId(1): ["A"]
-Bindings mismatch:
-after transform: ScopeId(2): ["B", "Y"]
-rebuilt        : ScopeId(2): ["B"]
-
-* optimize-enums/typeof-kept/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["Bar", "X"]
-rebuilt        : ScopeId(1): ["Bar"]
-
-* optimize-enums/value-usage-kept/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "Foo"]
-rebuilt        : ScopeId(1): ["Foo"]
 
 * redeclarations/input.ts
 Bindings mismatch:
@@ -345,7 +238,7 @@ x Output mismatch
 x Output mismatch
 
 
-# legacy-decorators (19/106)
+# legacy-decorators (20/106)
 * oxc/accessor/input.ts
 x Output mismatch
 
@@ -464,32 +357,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["Object", "babelHelpers"]
 rebuilt        : ["Object", "babelHelpers", "dec"]
-
-* oxc/metadata/enum-types/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["StringEnum", "bar", "foo"]
-rebuilt        : ScopeId(1): ["StringEnum"]
-Bindings mismatch:
-after transform: ScopeId(2): ["TemplateStringEnum", "mixed", "template"]
-rebuilt        : ScopeId(2): ["TemplateStringEnum"]
-Bindings mismatch:
-after transform: ScopeId(3): ["NumberEnum", "a", "b"]
-rebuilt        : ScopeId(3): ["NumberEnum"]
-Bindings mismatch:
-after transform: ScopeId(4): ["UnaryEnum", "bitwise", "negative", "positive"]
-rebuilt        : ScopeId(4): ["UnaryEnum"]
-Bindings mismatch:
-after transform: ScopeId(6): ["UnaryOtherEnum", "bitwise", "negative", "positive"]
-rebuilt        : ScopeId(6): ["UnaryOtherEnum"]
-Bindings mismatch:
-after transform: ScopeId(7): ["AutoIncrementEnum", "first", "second", "third"]
-rebuilt        : ScopeId(7): ["AutoIncrementEnum"]
-Bindings mismatch:
-after transform: ScopeId(8): ["MixedEnum", "num", "str"]
-rebuilt        : ScopeId(8): ["MixedEnum"]
-Bindings mismatch:
-after transform: ScopeId(9): ["ComputedEnum", "computed", "expression"]
-rebuilt        : ScopeId(9): ["ComputedEnum"]
 
 * oxc/metadata/erased-import-no-type-keyword/input.ts
 Bindings mismatch:


### PR DESCRIPTION
## Summary

Remove TypeScript enum-member bindings after transformation.

Enum members are represented as bindings during semantic analysis so the transformer can resolve member values, fold references, and handle merged enums. Once TypeScript transformation finishes, those bindings no longer correspond to emitted JavaScript declarations.

Include `EnumMember` in the existing final TypeScript binding cleanup instead of removing bindings during enum lowering, where later references may still need them.

This fixes `discriminatedUnionTypes4.ts` and removes the same stale binding mismatch from other enum cases.
