### PR TITLE
fix(minifier): make `__proto__` write tracking execution-order independent

### DIFF
--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -449,7 +449,6 @@ impl<'a> PeepholeOptimizations {
 impl<'a> Traverse<'a> for PeepholeOptimizations {
     fn enter_program(&mut self, program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
         ctx.state.symbol_values.reset();
-        ctx.state.proto_write_symbols.clear();
         // Any module loader (`import`, `export * from`, `export … from`) can, on a
         // cycle, evaluate a foreign module that observes a not-yet-assigned binding
         // our exports close over. So the program root starts its prelude "unsafe"

--- a/crates/oxc_minifier/src/peephole/normalize.rs
+++ b/crates/oxc_minifier/src/peephole/normalize.rs
@@ -123,12 +123,10 @@ impl<'a> Traverse<'a> for Normalize {
         Self::set_no_side_effects_to_call_expr(e, ctx);
     }
 
-    // The three hooks below seed the `MEMBER_WRITE_HAZARD` fact in
-    // `MinifierState::symbol_facts` (see its docs). Normalize always runs before
-    // the fixed-point loop, so the loop starts with a program-wide,
-    // execution-order-independent view of hazardous member writes. Skipped in DCE
-    // mode — the default-path drop of write-only property assignments that
-    // consumes the fact is full-minify only.
+    // The three hooks below seed `MinifierState::symbol_facts` (see its docs)
+    // with a program-wide, execution-order-independent view of member writes
+    // before the fixed-point loop runs. `MinifierState::seeds_symbol_facts`
+    // says when any consumer is live.
 
     /// Covers `=` / compound / logical assignment lefts, destructuring member
     /// targets (`[o.x] = arr`), and for-in/of lefts (`for (o.x in y)`).
@@ -137,7 +135,7 @@ impl<'a> Traverse<'a> for Normalize {
         node: &mut AssignmentTarget<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        if ctx.state.dce {
+        if !ctx.state.seeds_symbol_facts() {
             return;
         }
         let Some(target) = node.as_simple_assignment_target() else { return };
@@ -152,7 +150,7 @@ impl<'a> Traverse<'a> for Normalize {
 
     /// `o.x++` / `--o.x` read the property before writing.
     fn exit_update_expression(&mut self, e: &mut UpdateExpression<'a>, ctx: &mut TraverseCtx<'a>) {
-        if ctx.state.dce {
+        if !ctx.state.seeds_symbol_facts() {
             return;
         }
         Self::record_simple_target_member_write_hazard(
@@ -166,13 +164,14 @@ impl<'a> Traverse<'a> for Normalize {
     /// single-level delete is harmless — but a CHAINED delete (`delete a.b.c`)
     /// reads the intermediate object `a.b`, hazarding the base `a`.
     fn exit_unary_expression(&mut self, e: &mut UnaryExpression<'a>, ctx: &mut TraverseCtx<'a>) {
-        if ctx.state.dce {
+        if !ctx.state.seeds_symbol_facts() {
             return;
         }
         if e.operator.is_delete()
             && let Some(member) = e.argument.get_inner_expression().as_member_expression()
         {
-            // Both flags false: the hazard applies only when depth > 1.
+            // Both flags false: `delete` installs no setter, so the hazard applies
+            // only when depth > 1 (the chained intermediate object).
             Self::record_member_write_hazard(
                 member.object(),
                 /* key_is_unsafe */ false,
@@ -540,61 +539,55 @@ impl<'a> Normalize {
         is_read_modify: bool,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        let (object, key_is_unsafe) = match target {
-            SimpleAssignmentTarget::StaticMemberExpression(e) => {
-                (&e.object, e.property.name == "__proto__")
-            }
-            SimpleAssignmentTarget::ComputedMemberExpression(e) => {
-                (&e.object, !PeepholeOptimizations::member_key_is_safe(&e.expression))
+        // Direct member targets, or the inner member of TS wrappers
+        // (`(o.x as any) = 1`); plain identifier targets have no member write.
+        let Some(member) = target.as_member_expression().or_else(|| {
+            target
+                .get_expression()
+                .map(Expression::get_inner_expression)
+                .and_then(Expression::as_member_expression)
+        }) else {
+            return;
+        };
+        let key_is_unsafe = match member {
+            MemberExpression::StaticMemberExpression(e) => e.property.name == "__proto__",
+            MemberExpression::ComputedMemberExpression(e) => {
+                !PeepholeOptimizations::member_key_is_safe(&e.expression)
             }
             // Private fields can't be `__proto__` and aren't affected by the
             // prototype chain.
-            SimpleAssignmentTarget::PrivateFieldExpression(e) => (&e.object, false),
-            // TS wrappers (`(o.x as any) = 1`): unwrap to the inner member.
-            SimpleAssignmentTarget::TSAsExpression(_)
-            | SimpleAssignmentTarget::TSSatisfiesExpression(_)
-            | SimpleAssignmentTarget::TSNonNullExpression(_)
-            | SimpleAssignmentTarget::TSTypeAssertion(_) => {
-                let Some(member) = target
-                    .get_expression()
-                    .map(Expression::get_inner_expression)
-                    .and_then(Expression::as_member_expression)
-                else {
-                    return;
-                };
-                let key_is_unsafe = match member {
-                    MemberExpression::StaticMemberExpression(e) => e.property.name == "__proto__",
-                    MemberExpression::ComputedMemberExpression(e) => {
-                        !PeepholeOptimizations::member_key_is_safe(&e.expression)
-                    }
-                    MemberExpression::PrivateFieldExpression(_) => false,
-                };
-                Self::record_member_write_hazard(
-                    member.object(),
-                    key_is_unsafe,
-                    is_read_modify,
-                    ctx,
-                );
-                return;
-            }
-            SimpleAssignmentTarget::AssignmentTargetIdentifier(_) => return,
+            MemberExpression::PrivateFieldExpression(_) => false,
         };
-        Self::record_member_write_hazard(object, key_is_unsafe, is_read_modify, ctx);
+        Self::record_member_write_hazard(member.object(), key_is_unsafe, is_read_modify, ctx);
     }
 
     /// Record the base symbol of a hazardous member write in
-    /// the `MEMBER_WRITE_HAZARD` fact in `MinifierState::symbol_facts`. `object`
-    /// is the member expression's object; walking it to the base identifier
-    /// determines the chain depth. The hazard applies iff the op reads the property
+    /// `MinifierState::symbol_facts`. `object` is the member expression's object;
+    /// walking it to the base identifier determines the chain depth.
+    ///
+    /// Sets `MEMBER_WRITE_HAZARD` iff the op reads the property
     /// (`is_read_modify`), the write is chained (`a.b.c = 1` — dropping the
-    /// intermediate `a.b = {}` would throw), or the key may be `"__proto__"`
-    /// (`key_is_unsafe` — the write may install setters).
+    /// intermediate `a.b = {}` would throw), or the key may be `"__proto__"` or a
+    /// non-literal computed value (`key_is_unsafe` — the write may install
+    /// setters).
+    ///
+    /// Additionally sets `PROTO_WRITTEN` for the same unsafe keys — a purely
+    /// syntactic fact; the sole-reference exemption is applied at the consumer
+    /// (`is_member_assign_to_unused_binding`), where the reference count is
+    /// current rather than frozen at seed time.
     fn record_member_write_hazard(
         object: &Expression<'a>,
         key_is_unsafe: bool,
         is_read_modify: bool,
         ctx: &mut TraverseCtx<'a>,
     ) {
+        // In DCE mode only `PROTO_WRITTEN` has a live consumer (the opt-in
+        // drop); `MEMBER_WRITE_HAZARD`'s default-path reader is full-minify
+        // only. Skip hazard-only work (safe-key read-modify ops, chained
+        // writes, chained deletes) before walking the chain.
+        if ctx.state.dce && !key_is_unsafe {
+            return;
+        }
         let mut depth = 1u32;
         let mut object = object;
         let base = loop {
@@ -617,7 +610,11 @@ impl<'a> Normalize {
         let Some(symbol_id) = ctx.scoping().get_reference(base.reference_id()).symbol_id() else {
             return;
         };
-        ctx.state.symbol_facts.insert(symbol_id, SymbolFact::MEMBER_WRITE_HAZARD);
+        let mut facts = SymbolFact::MEMBER_WRITE_HAZARD;
+        if key_is_unsafe {
+            facts |= SymbolFact::PROTO_WRITTEN;
+        }
+        ctx.state.symbol_facts.insert(symbol_id, facts);
     }
 
     fn remove_unused_use_strict_directive(body: &mut FunctionBody<'a>, ctx: &TraverseCtx<'a>) {

--- a/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
@@ -799,12 +799,6 @@ impl<'a> PeepholeOptimizations {
         }
         let Expression::AssignmentExpression(assign_expr) = &*e else { unreachable!() };
 
-        // Track `__proto__` and computed member writes before checking side effects.
-        // Even if this expression has side effects and can't be removed, we need to
-        // record proto writes so that subsequent property writes on the same symbol
-        // are preserved (the `__proto__` assignment may install setters).
-        Self::track_proto_write(assign_expr, ctx);
-
         let Some(symbol_id) = Self::resolve_member_assign_object_symbol(assign_expr, ctx) else {
             return false;
         };
@@ -940,38 +934,6 @@ impl<'a> PeepholeOptimizations {
         }
     }
 
-    /// Track `__proto__` and computed member writes on local bindings.
-    /// Must be called before side-effect checks so that proto writes with
-    /// side-effectful RHS still mark the symbol.
-    fn track_proto_write(assign_expr: &AssignmentExpression<'a>, ctx: &mut TraverseCtx<'a>) {
-        // Skip when property_write_side_effects is true (default) — the optimization
-        // that drops member writes is disabled, so tracking is unnecessary.
-        if ctx.state.options.treeshake.property_write_side_effects {
-            return;
-        }
-        // Match only potential `__proto__` writes: explicit `a.__proto__` or
-        // computed `a[b]` (where the key could evaluate to `"__proto__"`).
-        let object = match &assign_expr.left {
-            AssignmentTarget::StaticMemberExpression(e) if e.property.name == "__proto__" => {
-                &e.object
-            }
-            // Computed key like `a[b]` could be `"__proto__"`
-            AssignmentTarget::ComputedMemberExpression(e) => &e.object,
-            _ => return,
-        };
-        let Expression::Identifier(ident) = object else { return };
-        let reference_id = ident.reference_id();
-        let Some(symbol_id) = ctx.scoping().get_reference(reference_id).symbol_id() else {
-            return;
-        };
-        // Only mark if there are other member writes — if __proto__ is the only
-        // reference, the setter is installed but never triggered, so dropping is safe.
-        let ref_count = ctx.scoping().get_resolved_reference_ids(symbol_id).len();
-        if ref_count > 1 {
-            ctx.state.proto_write_symbols.insert(symbol_id);
-        }
-    }
-
     /// Resolve the symbol ID of a member assignment's base object identifier.
     /// Returns `None` for chained access (`a.b.c`), non-identifier bases, or
     /// non-member assignment targets.
@@ -995,15 +957,22 @@ impl<'a> PeepholeOptimizations {
     /// `symbol_id` is the resolved base-object symbol
     /// (`resolve_member_assign_object_symbol`).
     ///
-    /// Three conditions must hold:
+    /// Four conditions must hold:
     /// 1. The target is a single-level member expression (`A.foo`, not `a.b.c`)
     /// 2. ALL references to the symbol are member write targets
     /// 3. The symbol creates a fresh value (not an alias) and is not exported
-    /// 4. The symbol has no `__proto__` member writes (which could install setters)
+    /// 4. No `__proto__` write may have installed a setter that another
+    ///    reference could trigger
     fn is_member_assign_to_unused_binding(symbol_id: SymbolId, ctx: &TraverseCtx<'a>) -> bool {
-        // If this symbol has `__proto__` or computed member writes, don't drop any
-        // property writes — the `__proto__` assignment may have installed setters.
-        if ctx.state.proto_write_symbols.contains(&symbol_id) {
+        // A potential `__proto__` write anywhere in the program (`PROTO_WRITTEN`
+        // is seeded by `Normalize`, so traversal order doesn't matter) may have
+        // installed a setter that a sibling property write triggers. Bail while
+        // any OTHER reference exists; when the candidate is the symbol's only
+        // remaining reference, it either is the proto write itself or the proto
+        // write is already gone, so no setter can ever fire.
+        if ctx.state.symbol_facts.has(symbol_id, SymbolFact::PROTO_WRITTEN)
+            && ctx.scoping().get_resolved_reference_ids(symbol_id).len() > 1
+        {
             return false;
         }
 

--- a/crates/oxc_minifier/src/state.rs
+++ b/crates/oxc_minifier/src/state.rs
@@ -75,14 +75,10 @@ pub struct MinifierState<'a> {
     /// Private member usage for classes
     pub class_symbols_stack: ClassSymbolsStack<'a>,
 
-    /// Symbols that have `__proto__` member writes.
-    /// Writing to `__proto__` changes the prototype chain, potentially installing
-    /// setters that make subsequent property writes side-effectful.
-    pub proto_write_symbols: FxHashSet<SymbolId>,
-
-    /// Program-wide, monotone per-symbol facts (currently the member-write
-    /// hazard consumed by the DEFAULT-mode write-only property drop). See
-    /// [`PersistentSymbolFacts`] for the lifecycle contract every fact obeys.
+    /// Program-wide, monotone per-symbol facts. See
+    /// [`SymbolFact`](crate::symbol_facts::SymbolFact) for each bit and its
+    /// consumer, and [`PersistentSymbolFacts`] for the lifecycle contract
+    /// every fact obeys.
     pub symbol_facts: PersistentSymbolFacts,
 
     /// One frame per enclosing function body (program root at the bottom).
@@ -127,13 +123,24 @@ impl<'a> MinifierState<'a> {
             pure_functions: FxHashMap::default(),
             symbol_values: SymbolValues::new(scoping.symbols_len()),
             class_symbols_stack: ClassSymbolsStack::new(),
-            proto_write_symbols: FxHashSet::default(),
             symbol_facts: PersistentSymbolFacts::default(),
             body_unsafe_stack: NonEmptyStack::new((scoping.root_scope_id(), false)),
             mutated: false,
             dirty: PassDirty::new(scoping.references_len(), allocator),
             concat_scratch: String::new(),
         }
+    }
+
+    /// Whether `Normalize`'s member-write scan should seed `symbol_facts`,
+    /// i.e. whether any consumer is live in this configuration. In full
+    /// minify the default-mode write-only property drop reads
+    /// `MEMBER_WRITE_HAZARD` and the shared drop predicate reads
+    /// `PROTO_WRITTEN`. In DCE mode the default path is disabled and only the
+    /// `property_write_side_effects: false` opt-in drop runs (reading
+    /// `PROTO_WRITTEN`), so with the knob left on nothing reads the facts and
+    /// seeding is skipped.
+    pub fn seeds_symbol_facts(&self) -> bool {
+        !self.dce || !self.options.treeshake.property_write_side_effects
     }
 
     /// Returns whether the AST was mutated since the last call, and resets.

--- a/crates/oxc_minifier/src/symbol_facts.rs
+++ b/crates/oxc_minifier/src/symbol_facts.rs
@@ -5,12 +5,8 @@ use oxc_syntax::symbol::SymbolId;
 
 bitflags! {
     /// A set of monotone facts held about a single symbol. See
-    /// [`PersistentSymbolFacts`] for the lifecycle every bit must obey.
-    ///
-    /// Planned follow-up bits (do not add one without a consumer): `PROTO_WRITTEN`,
-    /// migrating `MinifierState::proto_write_symbols` — recording it here (seeded
-    /// by `Normalize`) would make it execution-order independent and fix that
-    /// field's order-dependence TODO.
+    /// [`PersistentSymbolFacts`] for the lifecycle every bit must obey. Do not
+    /// add a bit without a consumer.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
     pub struct SymbolFact: u8 {
         /// The symbol has a hazardous member-write operation anywhere in the
@@ -22,6 +18,28 @@ bitflags! {
         /// install setters. The DEFAULT-mode drop of write-only property
         /// assignments (`remove_unused_member_assignment`) must skip such symbols.
         const MEMBER_WRITE_HAZARD = 1 << 0;
+
+        /// The symbol has a potential `__proto__` write anywhere in the program:
+        /// an explicit `.__proto__` static-key write, or a computed-key write
+        /// whose key is unsafe per `member_key_is_safe` (not provably a string
+        /// other than `"__proto__"`). Either can install a setter that makes a
+        /// later property write on the symbol side-effectful. This deliberately
+        /// reuses the hazard scan's key class: literal `o[null]`/`o[true]` keys
+        /// can never coerce to `"__proto__"`, but distinguishing them would only
+        /// drop more in shapes that don't occur in real code, at the cost of a
+        /// second key classifier.
+        ///
+        /// A purely syntactic fact: consumed by the shared drop predicate
+        /// (`is_member_assign_to_unused_binding`, guarding both the default and
+        /// opt-in write-only property drops), which pairs it with a query-time
+        /// reference count to exempt a sole-reference proto write.
+        ///
+        /// Seeded entirely by `Normalize`; the fixed-point loop cannot create a
+        /// proto write Normalize did not see. A computed non-literal key is seeded
+        /// before any folding, so a key later folded to the literal `"__proto__"`
+        /// was already covered, and forming a compound assignment only changes the
+        /// operator, never the key.
+        const PROTO_WRITTEN = 1 << 1;
     }
 }
 
@@ -29,8 +47,8 @@ bitflags! {
 ///
 /// Lifecycle contract (also the fit criterion for any future [`SymbolFact`] bit):
 /// - seeded by `Normalize` before the fixed-point loop, so membership is
-///   execution-order independent (unlike the per-pass `proto_write_symbols` used
-///   by the `property_write_side_effects: false` opt-in path);
+///   execution-order independent (a per-pass set populated during the same
+///   traversal that drops writes would be traversal-order dependent);
 /// - extended mid-loop only where a pass CREATES a new fact instance (e.g.
 ///   forming a new compound assignment in `mark_assignment_target_as_read`);
 /// - monotone: bits are only ever set, never cleared —

--- a/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
@@ -898,6 +898,13 @@ fn test_property_write_side_effects() {
         "const a = {}; a[b] = { set a(v) { console.log('setter'); } }, a.a = 1;",
         &options,
     );
+    // Literal non-string keys can't coerce to `"__proto__"` but are kept
+    // conservatively — see `SymbolFact::PROTO_WRITTEN` docs.
+    test_options(
+        "const a = {}; a[null] = 1; a.a = 1;",
+        "const a = {}; a[null] = 1, a.a = 1;",
+        &options,
+    );
 
     // `__proto__` in object literal initializer installs setters via prototype chain
     test_same_options(
@@ -910,14 +917,27 @@ fn test_property_write_side_effects() {
         &options,
     );
 
-    // TODO: `__proto__` assignment inside a hoisted function — setter is installed when f() is called.
-    // This case is not handled yet because the `__proto__` write inside the function body
-    // is encountered after `obj.a = 1` during traversal. Uncomment when two-pass tracking
-    // is implemented.
-    // test_same_options(
-    //     "const obj = {}; f(); obj.a = 1; function f() { obj.__proto__ = { set a(v) { console.log('hello'); } }; }",
-    //     &options,
-    // );
+    // `__proto__` assignment inside a hoisted function — traversal reaches the
+    // function body only AFTER `obj.a = 1`, so the old per-pass tracking never saw
+    // it in time and wrongly dropped `obj.a = 1`. `PROTO_WRITTEN` is seeded by
+    // `Normalize` before the fixed-point loop, so it is caught regardless of
+    // order. `f` has an observable side effect (`g()`), so it is not tree-shaken:
+    // the setter really is installed when `f()` runs, and the sibling `obj.a = 1`
+    // that would trigger it must survive.
+    test_options(
+        "const obj = {}; f(); obj.a = 1; function f() { g(); obj.__proto__ = { set a(v) { console.log('hello'); } }; }",
+        "const obj = {};\nf(), obj.a = 1;\nfunction f() {\n\tg(), obj.__proto__ = { set a(v) {\n\t\tconsole.log('hello');\n\t} };\n}\n",
+        &options,
+    );
+
+    // Destructuring proto write (`[o.__proto__] = [x]`) is now caught by the
+    // Normalize scan (the old per-pass tracking only saw `=` assignments), so the
+    // sibling `o.a = 1` is kept.
+    test_options(
+        "var o = {}; [o.__proto__] = [x]; o.a = 1;",
+        "var o = {};\n[o.__proto__] = [x], o.a = 1;\n",
+        &options,
+    );
 
     // Default options (property_write_side_effects: true) also drop these now —
     // see `test_drop_write_only_property_assignments_by_default`.
@@ -997,8 +1017,8 @@ fn test_drop_write_only_property_assignments_by_default() {
     test_smallest("var a = {}; a.b = {}; a.b.c = 1;", "var a = {}; a.b = {}, a.b.c = 1;");
 
     // `__proto__` write in a hoisted function runs before the property write —
-    // the hazard scan is execution-order independent (unlike the per-pass
-    // `proto_write_symbols` used by the opt-in path).
+    // the hazard scan is execution-order independent because `Normalize` seeds
+    // the facts before the fixed-point loop.
     test_smallest(
         "const obj = {}; f(); obj.a = 1; function f() { obj.__proto__ = { set a(v) { console.log(v); } }; }",
         "const obj = {}; f(), obj.a = 1; function f() { obj.__proto__ = { set a(v) { console.log(v); } }; }",


### PR DESCRIPTION
Fixes #21248

### What

In `propertyWriteSideEffects: false` mode, the minifier must keep a property write when the object's `__proto__` was written somewhere, because that write may have installed a setter. This tracking ran inside the same pass that removes writes, so a `__proto__` write the traversal reaches later — for example inside a hoisted function — was not recorded yet, and the property write was wrongly dropped.

### How

The per-pass `proto_write_symbols` set is replaced by a `PROTO_WRITTEN` bit on `PersistentSymbolFacts` (introduced in the parent PR). The `Normalize` pass seeds it for the whole program before the fixed-point loop starts, so the order the loop visits expressions no longer matters. `track_proto_write` and the old set are deleted. The scan also catches shapes the old tracking never saw, such as destructuring targets (`[o.__proto__] = arr`).

Default mode is unaffected: a symbol with a `__proto__` write already carries `MEMBER_WRITE_HAZARD`, which the default path checks separately. `tasks/minsize` output is byte-identical; the previously commented-out ordering test in `remove_unused_expression.rs` now runs.

### Example

With `propertyWriteSideEffects: false`:

```js
const obj = {};
f();
obj.a = 1;
function f() {
  g();
  obj.__proto__ = { set a(v) { console.log(v); } };
}
```

Before: `obj.a = 1` was dropped. The setter installed when `f()` runs never fires, so `console.log(1)` is lost.

After: `obj.a = 1` is kept.
