### PR TITLE
feat(formatter_core): expose `SourceText::as_str()`

### DIFF
--- a/crates/oxc_formatter_core/src/source_text.rs
+++ b/crates/oxc_formatter_core/src/source_text.rs
@@ -32,6 +32,16 @@ impl<'a> SourceText<'a> {
         Self { text }
     }
 
+    /// The full source as `&'a str`.
+    ///
+    /// `Deref<Target = str>` re-borrows through `&self`,
+    /// which is too short for consumers that need source-lifetime slices.
+    /// (e.g. `oxc-css-parser` has span-backed accessors whose results reach the `text()` builder)
+    /// This hands back the `'a`-lived text itself.
+    pub fn as_str(&self) -> &'a str {
+        self.text
+    }
+
     // Text slicing
     /// Get text between two positions
     pub fn slice_range(&self, start: u32, end: u32) -> &'a str {


### PR DESCRIPTION
For updating `oxc-css-parser` to 0.0.6, which contains breaking changes.