### PR TITLE
chore(deps): update oxc-grahql-parser 0.0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1684,9 +1684,9 @@ dependencies = [
 
 [[package]]
 name = "oxc-graphql-parser"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ebd9d6368dfae2414de284c732b24d12afd4f4cce605d2be9441c65de6b4d0b"
+checksum = "6dbfe4bcfc9d9946554801de4806f08394fa580fe134e5c4e140680cfa64f94a"
 dependencies = [
  "memchr",
  "oxc_allocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,7 +193,7 @@ oxc_sourcemap = "8.0.2" # Source map generation
 #
 allocator-api2 = "=0.2.21" # Allocator trait
 anyhow = "1.0" # Flexible error handling
-oxc-graphql-parser = "0.0.5" # GraphQL parser (direct AST; apollo-parser 0.8.6 fork aligned with graphql-js 17 syntax)
+oxc-graphql-parser = "0.0.6" # GraphQL parser (direct AST; apollo-parser 0.8.6 fork aligned with graphql-js 17 syntax)
 base64 = "0.22.1" # Base64 encoding
 bitflags = "2.13.0" # Bitflag types
 bpaf = "0.9.26" # CLI parser


### PR DESCRIPTION
I thought there might be some code changes, but there weren't, so simply a version bump.