### PR TITLE
fix(formatter): preserve blank lines between JSX attrs

### DIFF
--- a/crates/oxc_formatter/src/print/jsx/mod.rs
+++ b/crates/oxc_formatter/src/print/jsx/mod.rs
@@ -310,13 +310,11 @@ impl<'a> FormatWrite<'a> for AstNode<'a, JSXEmptyExpression> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArenaVec<'a, JSXAttributeItem<'a>>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let line_break = if f.options().attribute_position == AttributePosition::Multiline {
-            hard_line_break()
+        if f.options().attribute_position == AttributePosition::Multiline {
+            f.join_nodes_with_hardline().entries(self.iter());
         } else {
-            soft_line_break_or_space()
-        };
-
-        f.join_with(&line_break).entries(self.iter());
+            f.join_nodes_with_soft_line().entries(self.iter());
+        }
     }
 }
 

--- a/crates/oxc_formatter/tests/fixtures/js/jsx/attribute-blank-lines-with-comments.jsx
+++ b/crates/oxc_formatter/tests/fixtures/js/jsx/attribute-blank-lines-with-comments.jsx
@@ -1,0 +1,28 @@
+// Blank line, then comment, then next attribute
+const a = (
+  <Component
+    first={1}
+
+    // comment
+    second={2}
+  />
+);
+
+// Comment, then blank line, then next attribute
+const b = (
+  <Component
+    first={1}
+    // comment
+
+    second={2}
+  />
+);
+
+// Same-line trailing comment, then blank line, then next attribute
+const c = (
+  <Component
+    first={1} // trailing
+
+    second={2}
+  />
+);

--- a/crates/oxc_formatter/tests/fixtures/js/jsx/attribute-blank-lines-with-comments.jsx.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/jsx/attribute-blank-lines-with-comments.jsx.snap
@@ -1,0 +1,99 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Blank line, then comment, then next attribute
+const a = (
+  <Component
+    first={1}
+
+    // comment
+    second={2}
+  />
+);
+
+// Comment, then blank line, then next attribute
+const b = (
+  <Component
+    first={1}
+    // comment
+
+    second={2}
+  />
+);
+
+// Same-line trailing comment, then blank line, then next attribute
+const c = (
+  <Component
+    first={1} // trailing
+
+    second={2}
+  />
+);
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Blank line, then comment, then next attribute
+const a = (
+  <Component
+    first={1}
+
+    // comment
+    second={2}
+  />
+);
+
+// Comment, then blank line, then next attribute
+const b = (
+  <Component
+    first={1}
+    // comment
+
+    second={2}
+  />
+);
+
+// Same-line trailing comment, then blank line, then next attribute
+const c = (
+  <Component
+    first={1} // trailing
+
+    second={2}
+  />
+);
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Blank line, then comment, then next attribute
+const a = (
+  <Component
+    first={1}
+
+    // comment
+    second={2}
+  />
+);
+
+// Comment, then blank line, then next attribute
+const b = (
+  <Component
+    first={1}
+    // comment
+
+    second={2}
+  />
+);
+
+// Same-line trailing comment, then blank line, then next attribute
+const c = (
+  <Component
+    first={1} // trailing
+
+    second={2}
+  />
+);
+
+===================== End =====================

--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,4 +1,4 @@
-js compatibility: 760/808 (94.06%), 23 files skipped
+js compatibility: 762/808 (94.31%), 23 files skipped
 
 # Failed
 
@@ -50,8 +50,6 @@ js compatibility: 760/808 (94.06%), 23 files skipped
 | js/template-literals/expressions.js | 💥 | 97.64% |
 | js/test-declarations/jest-each.js | 💥💥 | 95.71% |
 | js/unary-expression/comments.js | 💥 | 96.47% |
-| jsx/attribute-blank-lines/attribute-blank-lines.js | 💥💥 | 62.82% |
-| jsx/jsx/quotes.js | 💥💥💥💥 | 89.47% |
 
 # Skipped (parse error, TODO: should be ignored or supported)
 

--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -1,11 +1,9 @@
-ts compatibility: 605/663 (91.25%), 19 files skipped
+ts compatibility: 608/663 (91.70%), 19 files skipped
 
 # Failed
 
 | Spec path | Failed or Passed | Match ratio |
 | :-------- | :--------------: | :---------: |
-| jsx/attribute-blank-lines/attribute-blank-lines.js | 💥💥 | 62.82% |
-| jsx/jsx/quotes.js | 💥💥💥💥 | 89.47% |
 | typescript/arrow/return-type/18588.ts | 💥 | 58.82% |
 | typescript/as/as.ts | 💥 | 97.74% |
 | typescript/as/break-after-keyword/18148.ts | 💥 | 93.33% |
@@ -43,7 +41,6 @@ ts compatibility: 605/663 (91.25%), 19 files skipped
 | typescript/quote-props/interfaces.ts | 💥✨✨ | 30.30% |
 | typescript/quote-props/type-literal.ts | 💥✨✨ | 30.30% |
 | typescript/template-literals/member-expression.ts | 💥 | 55.00% |
-| typescript/tsx/attribute-blank-lines.tsx | 💥 | 0.00% |
 | typescript/tsx/optional-chaining.tsx | 💥 | 73.33% |
 | typescript/type-parameters-arguments/10732.ts | 💥 | 50.00% |
 | typescript/type-parameters-arguments/18041.ts | 💥 | 91.43% |


### PR DESCRIPTION
```jsx
<div
  a="1"
  b="2"

  c="3"
  d={{
    e: 1,
    f: 2,

    g: 3,
  }}
/>;
```

Blank line between `b` and `c` is now preserved, as like between `f` and `g`.
