### PR TITLE
fix(linter): preserve explicit plugins in extended configs

### DIFF
--- a/apps/oxlint/src/config_loader.rs
+++ b/apps/oxlint/src/config_loader.rs
@@ -757,7 +757,7 @@ fn nested_respect_eslint_disable_directives_not_supported(path: &Path) -> OxcDia
 mod test {
     use std::path::PathBuf;
 
-    use oxc_linter::{ConfigStoreBuilder, ExternalPluginStore};
+    use oxc_linter::{ConfigStoreBuilder, ExternalPluginStore, LintPlugins};
 
     use super::{ConfigLoadError, ConfigLoader};
     #[cfg(feature = "napi")]
@@ -967,6 +967,34 @@ mod test {
         );
         assert!(errors.is_empty());
         assert_eq!(configs.len(), 1);
+    }
+
+    #[test]
+    fn test_nested_json_config_extends_preserves_explicit_plugins() {
+        let root_dir = tempfile::tempdir().unwrap();
+        let base_path = root_dir.path().join(".oxlintrc.json");
+        let nested_path = root_dir.path().join("test/.oxlintrc.json");
+        std::fs::create_dir_all(nested_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &base_path,
+            r#"{
+                "categories": { "correctness": "error" },
+                "options": { "typeAware": true },
+                "plugins": ["unicorn", "oxc", "import", "promise"]
+            }"#,
+        )
+        .unwrap();
+        std::fs::write(&nested_path, r#"{ "extends": ["../.oxlintrc.json"] }"#).unwrap();
+
+        let mut external_plugin_store = ExternalPluginStore::new(false);
+        let mut loader = ConfigLoader::new(None, &mut external_plugin_store, &[], None);
+        let (configs, errors) = loader.load_discovered_with_root_dir(
+            root_dir.path(),
+            [DiscoveredConfigFile::Json(nested_path)],
+        );
+        assert!(errors.is_empty());
+        assert_eq!(configs.len(), 1);
+        assert!(!configs[0].config.plugins().contains(LintPlugins::TYPESCRIPT));
     }
 
     #[cfg(feature = "napi")]

--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -1446,13 +1446,10 @@ mod test {
         assert_eq!(parent_config.plugins(), LintPlugins::REACT | LintPlugins::TYPESCRIPT);
 
         // Test 3: Child config that extends parent without specifying plugins
-        // Should inherit parent's plugins and apply the default plugins from the child config
+        // Should inherit only the parent's plugins
         let child_no_plugins_config =
             config_store_from_path("fixtures/extends_config/plugins/child_no_plugins.json");
-        assert_eq!(
-            child_no_plugins_config.plugins(),
-            LintPlugins::REACT | LintPlugins::TYPESCRIPT | LintPlugins::OXC | LintPlugins::UNICORN
-        );
+        assert_eq!(child_no_plugins_config.plugins(), LintPlugins::REACT | LintPlugins::TYPESCRIPT);
 
         // Test 4: Child config that extends parent and specifies additional plugins
         // Should have parent's plugins plus its own
@@ -1523,14 +1520,11 @@ mod test {
             "Extending a config with a plugin is the same as adding it directly"
         );
 
-        // Test 9: Child Config with plugins extends parent with default plugins (not specified by user)
+        // Test 9: Child config with plugins extends parent without plugins
         let child_with_plugins_parent_no_plugin_config = config_store_from_path(
             "fixtures/extends_config/plugins/child_with_plugins_parent_default_plugin.json",
         );
-        assert_eq!(
-            child_with_plugins_parent_no_plugin_config.plugins(),
-            LintPlugins::JEST | LintPlugins::UNICORN | LintPlugins::TYPESCRIPT | LintPlugins::OXC
-        );
+        assert_eq!(child_with_plugins_parent_no_plugin_config.plugins(), LintPlugins::JEST);
     }
 
     #[test]

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -408,8 +408,8 @@ impl Oxlintrc {
 
         let plugins = match (self.plugins, other.plugins) {
             (Some(self_plugins), Some(other_plugins)) => Some(self_plugins | other_plugins),
-            (Some(self_plugins), None) => Some(self_plugins | LintPlugins::default()),
-            (None, Some(other_plugins)) => Some(other_plugins | LintPlugins::default()),
+            (Some(self_plugins), None) => Some(self_plugins),
+            (None, Some(other_plugins)) => Some(other_plugins),
             (None, None) => None,
         };
 
@@ -722,6 +722,26 @@ mod test {
         let config: Oxlintrc =
             serde_json::from_str(r#"{ "plugins": ["typescript", "@typescript-eslint"] }"#).unwrap();
         assert_eq!(config.plugins, Some(LintPlugins::TYPESCRIPT));
+    }
+
+    #[test]
+    fn test_oxlintrc_merge_does_not_add_default_plugins() {
+        let child: Oxlintrc = serde_json::from_str(r"{}").unwrap();
+        let base: Oxlintrc =
+            serde_json::from_str(r#"{ "plugins": ["unicorn", "oxc", "import", "promise"] }"#)
+                .unwrap();
+        let merged = child.merge(base);
+
+        assert_eq!(
+            merged.plugins,
+            Some(
+                LintPlugins::UNICORN
+                    | LintPlugins::OXC
+                    | LintPlugins::IMPORT
+                    | LintPlugins::PROMISE
+            )
+        );
+        assert!(!merged.plugins.unwrap().contains(LintPlugins::TYPESCRIPT));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #24291.

Nested configs that extended a config with an explicit `plugins` list were merging in `LintPlugins::default()` when either side omitted `plugins`. That made `typescript` active for the nested config even when the extended root config intentionally excluded it. This changes config merging so an omitted `plugins` field preserves the other side as-is, while the final config-building path still applies defaults when no config in the chain specifies plugins.

This adds regression coverage for the nested JSON config shape from the issue and updates existing plugin-extends expectations to match the corrected behavior.

Verification:
- `cargo fmt --check`
- `cargo clippy -p oxc_linter`
- `cargo test -p oxc_linter`
- `env -u NO_COLOR TERM=xterm-256color cargo test -p oxlint`
- Manual repro for #24291: nested config extending root explicit plugins now reports only `eslint(no-unused-vars)`, not `typescript(await-thenable)`.

Prepared with AI assistance; reviewed and tested before submission.