### PR TITLE
fix(semantic): mark declared computed `MethodDefinition`s as type references

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -412,6 +412,14 @@ impl<'a> SemanticBuilder<'a> {
         self.node_store.ancestry()
     }
 
+    fn is_declare_class_element(&self) -> bool {
+        // Class elements are children of `ClassBody`, whose parent is `Class`.
+        matches!(
+            self.ancestry().ancestor_kinds().nth(1),
+            Some(AstKind::Class(class)) if class.declare
+        )
+    }
+
     pub(crate) fn in_declare_scope(&self) -> bool {
         self.source_type.is_typescript_definition()
             || self
@@ -2454,22 +2462,35 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         self.leave_node(kind);
     }
 
+    fn visit_method_definition(&mut self, method: &MethodDefinition<'a>) {
+        let kind = AstKind::MethodDefinition(self.alloc(method));
+        self.enter_node(kind);
+        self.visit_span(&method.span);
+        self.visit_decorators(&method.decorators);
+        if method.computed && (method.r#type.is_abstract() || self.is_declare_class_element()) {
+            // declare class A { [prop](): string }
+            //                    ^^^^  The property can reference value or [`SymbolFlags::TypeImport`] symbol
+            self.current_reference_flags = ReferenceFlags::ValueAsType;
+        }
+        self.visit_property_key(&method.key);
+        self.current_reference_flags = ReferenceFlags::empty();
+        let flags = match method.kind {
+            MethodDefinitionKind::Get => ScopeFlags::Function | ScopeFlags::GetAccessor,
+            MethodDefinitionKind::Set => ScopeFlags::Function | ScopeFlags::SetAccessor,
+            MethodDefinitionKind::Constructor => ScopeFlags::Function | ScopeFlags::Constructor,
+            MethodDefinitionKind::Method => ScopeFlags::Function,
+        };
+        self.visit_function(&method.value, flags);
+        self.leave_node(kind);
+    }
+
     fn visit_property_definition(&mut self, prop: &PropertyDefinition<'a>) {
         let kind = AstKind::PropertyDefinition(self.alloc(prop));
         self.enter_node(kind);
         self.visit_span(&prop.span);
         self.visit_decorators(&prop.decorators);
         if prop.computed
-            && (prop.declare
-                || prop.r#type.is_abstract()
-                || self
-                    .ancestry()
-                    .ancestor_kinds()
-                    .find_map(|kind| match kind {
-                        AstKind::Class(class) => Some(class.declare),
-                        _ => None,
-                    })
-                    .unwrap_or(false))
+            && (prop.declare || prop.r#type.is_abstract() || self.is_declare_class_element())
         {
             // class A { declare [prop]: string }
             //                   ^^^^^ The property can reference value or [`SymbolFlags::TypeImport`] symbol

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/declare-computed-class-methods.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/declare-computed-class-methods.snap
@@ -1,0 +1,199 @@
+---
+source: crates/oxc_semantic/tests/main.rs
+input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/declare-computed-class-methods.ts
+---
+[
+  {
+    "children": [
+      {
+        "children": [
+          {
+            "children": [],
+            "flags": "ScopeFlags(StrictMode | Function)",
+            "id": 2,
+            "node": "Function(<anonymous>)",
+            "symbols": []
+          },
+          {
+            "children": [],
+            "flags": "ScopeFlags(StrictMode | Function | GetAccessor)",
+            "id": 3,
+            "node": "Function(<anonymous>)",
+            "symbols": []
+          },
+          {
+            "children": [],
+            "flags": "ScopeFlags(StrictMode | Function)",
+            "id": 4,
+            "node": "Function(<anonymous>)",
+            "symbols": []
+          }
+        ],
+        "flags": "ScopeFlags(StrictMode)",
+        "id": 1,
+        "node": "Class(AmbientFoo)",
+        "symbols": []
+      },
+      {
+        "children": [
+          {
+            "children": [],
+            "flags": "ScopeFlags(StrictMode | Function)",
+            "id": 6,
+            "node": "Function(<anonymous>)",
+            "symbols": []
+          },
+          {
+            "children": [],
+            "flags": "ScopeFlags(StrictMode | Function | SetAccessor)",
+            "id": 7,
+            "node": "Function(<anonymous>)",
+            "symbols": [
+              {
+                "flags": "SymbolFlags(FunctionScopedVariable)",
+                "id": 8,
+                "name": "value",
+                "node": "FormalParameter(value)",
+                "references": []
+              }
+            ]
+          },
+          {
+            "children": [],
+            "flags": "ScopeFlags(StrictMode | Function)",
+            "id": 8,
+            "node": "Function(<anonymous>)",
+            "symbols": []
+          },
+          {
+            "children": [],
+            "flags": "ScopeFlags(StrictMode | Function)",
+            "id": 9,
+            "node": "Function(<anonymous>)",
+            "symbols": []
+          }
+        ],
+        "flags": "ScopeFlags(StrictMode)",
+        "id": 5,
+        "node": "Class(AbstractFoo)",
+        "symbols": []
+      }
+    ],
+    "flags": "ScopeFlags(StrictMode | Top)",
+    "id": 0,
+    "node": "Program",
+    "symbols": [
+      {
+        "flags": "SymbolFlags(TypeImport)",
+        "id": 0,
+        "name": "importedKey",
+        "node": "ImportDefaultSpecifier",
+        "references": [
+          {
+            "flags": "ReferenceFlags(Type)",
+            "id": 7,
+            "name": "importedKey",
+            "node_id": 46,
+            "scope_id": 1
+          },
+          {
+            "flags": "ReferenceFlags(Type)",
+            "id": 10,
+            "name": "importedKey",
+            "node_id": 69,
+            "scope_id": 5
+          }
+        ]
+      },
+      {
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "id": 1,
+        "name": "declaredMethodKey",
+        "node": "VariableDeclarator(declaredMethodKey)",
+        "references": [
+          {
+            "flags": "ReferenceFlags(Type)",
+            "id": 5,
+            "name": "declaredMethodKey",
+            "node_id": 34,
+            "scope_id": 1
+          }
+        ]
+      },
+      {
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "id": 2,
+        "name": "declaredGetterKey",
+        "node": "VariableDeclarator(declaredGetterKey)",
+        "references": [
+          {
+            "flags": "ReferenceFlags(Type)",
+            "id": 6,
+            "name": "declaredGetterKey",
+            "node_id": 40,
+            "scope_id": 1
+          }
+        ]
+      },
+      {
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "id": 3,
+        "name": "abstractMethodKey",
+        "node": "VariableDeclarator(abstractMethodKey)",
+        "references": [
+          {
+            "flags": "ReferenceFlags(Type)",
+            "id": 8,
+            "name": "abstractMethodKey",
+            "node_id": 55,
+            "scope_id": 5
+          }
+        ]
+      },
+      {
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "id": 4,
+        "name": "abstractSetterKey",
+        "node": "VariableDeclarator(abstractSetterKey)",
+        "references": [
+          {
+            "flags": "ReferenceFlags(Type)",
+            "id": 9,
+            "name": "abstractSetterKey",
+            "node_id": 61,
+            "scope_id": 5
+          }
+        ]
+      },
+      {
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "id": 5,
+        "name": "runtimeMethodKey",
+        "node": "VariableDeclarator(runtimeMethodKey)",
+        "references": [
+          {
+            "flags": "ReferenceFlags(Read)",
+            "id": 11,
+            "name": "runtimeMethodKey",
+            "node_id": 75,
+            "scope_id": 5
+          }
+        ]
+      },
+      {
+        "flags": "SymbolFlags(Class | Ambient)",
+        "id": 6,
+        "name": "AmbientFoo",
+        "node": "Class(AmbientFoo)",
+        "references": []
+      },
+      {
+        "flags": "SymbolFlags(Class)",
+        "id": 7,
+        "name": "AbstractFoo",
+        "node": "Class(AbstractFoo)",
+        "references": []
+      }
+    ]
+  }
+]

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/declare-computed-class-methods.ts
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/declare-computed-class-methods.ts
@@ -1,0 +1,20 @@
+import type importedKey from "mod";
+
+const declaredMethodKey = Symbol();
+const declaredGetterKey = Symbol();
+const abstractMethodKey = Symbol();
+const abstractSetterKey = Symbol();
+const runtimeMethodKey = Symbol();
+
+declare class AmbientFoo {
+    [declaredMethodKey](): string;
+    get [declaredGetterKey](): string;
+    [importedKey](): string;
+}
+
+abstract class AbstractFoo {
+    abstract [abstractMethodKey](): string;
+    abstract set [abstractSetterKey](value: string);
+    abstract [importedKey](): string;
+    [runtimeMethodKey](): string;
+}

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -16114,7 +16114,7 @@ Reference symbol mismatch for "lhs0":
 after transform: SymbolId(32) "lhs0"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Symbol"]
+after transform: []
 rebuilt        : ["A", "B", "Rhs10", "Rhs11", "Rhs12", "Rhs13", "Rhs7", "Rhs8", "Rhs9", "lhs0", "lhs1", "lhs2", "lhs3", "lhs4", "obj", "rhs0", "rhs1", "rhs14", "rhs15", "rhs2", "rhs3", "rhs4", "rhs5", "rhs6"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/functionExpressionContextualTyping3.ts
@@ -18567,9 +18567,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascr
 Bindings mismatch:
 after transform: ScopeId(0): ["C"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Symbol"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty4.ts
 Bindings mismatch:


### PR DESCRIPTION
## Summary

- mark computed method keys in ambient and abstract classes as type references
- preserve runtime read flags for concrete computed methods
- bound declare-class ancestry checks to the containing class
- add semantic snapshot coverage and update the TypeScript conformance snapshot

Follows the work done in 588d9971ac09155ab68cd35db887cf827692a374,  9b95632179a63f18b4658159a6b3e6e47e551aba