### PR TITLE
feat(ci): add `disable-next-line` opt-out for `typos`

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -42,6 +42,7 @@ extend-exclude = [
 [default]
 extend-ignore-re = [
   "(?Rm)^.*(#|//)\\s*spellchecker:disable-line$",
+  "(?Rm)^\\s*(#|//)\\s*spellchecker:disable-next-line\\s*\\n.*",
   "(?s)(#|//)\\s*spellchecker:off.*?\\n\\s*(#|//)\\s*spellchecker:on",
 ]
 


### PR DESCRIPTION
We already support `// spellchecker:disable-line` comments to disable `typos` for a line of code. Support `// spellchecker:disable-next-line` too.