### PR TITLE
fix(formatter): keep comment inside of empty `switch` block

### DIFF
--- a/crates/oxc_formatter/src/print/switch_statement.rs
+++ b/crates/oxc_formatter/src/print/switch_statement.rs
@@ -21,8 +21,19 @@ impl<'a> FormatWrite<'a> for AstNode<'a, SwitchStatement<'a>> {
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         let discriminant = self.discriminant();
         let cases = self.cases();
-        let format_cases =
-            format_with(|f| if cases.is_empty() { hard_line_break().fmt(f) } else { cases.fmt(f) });
+        let format_cases = format_with(|f| {
+            if cases.is_empty() {
+                // Comments inside empty braces (`switch (a) { /* comment */ }`)
+                // would otherwise leak behind the closing brace.
+                if f.context().comments().has_comment_before(self.span.end) {
+                    format_dangling_comments(self.span).fmt(f);
+                } else {
+                    hard_line_break().fmt(f);
+                }
+            } else {
+                cases.fmt(f);
+            }
+        });
         write!(
             f,
             [

--- a/crates/oxc_formatter/tests/fixtures/js/comments/empty-containers.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/empty-containers.js
@@ -29,3 +29,8 @@ class WithStatic {
   static {/* static */}
 }
 try {/* try */} catch {/* catch */}
+// Prettier moves the comment into the discriminant (`switch (a /* switch */) {`),
+// an attachment artifact; we keep it inside the braces like other statement bodies
+switch (a) {/* switch */}
+switch (b) {// line
+}

--- a/crates/oxc_formatter/tests/fixtures/js/comments/empty-containers.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/empty-containers.js.snap
@@ -33,6 +33,11 @@ class WithStatic {
   static {/* static */}
 }
 try {/* try */} catch {/* catch */}
+// Prettier moves the comment into the discriminant (`switch (a /* switch */) {`),
+// an attachment artifact; we keep it inside the braces like other statement bodies
+switch (a) {/* switch */}
+switch (b) {// line
+}
 
 ==================== Output ====================
 ------------------
@@ -80,6 +85,14 @@ try {
 } catch {
   /* catch */
 }
+// Prettier moves the comment into the discriminant (`switch (a /* switch */) {`),
+// an attachment artifact; we keep it inside the braces like other statement bodies
+switch (a) {
+  /* switch */
+}
+switch (b) {
+  // line
+}
 
 -------------------
 { printWidth: 100 }
@@ -125,6 +138,14 @@ try {
   /* try */
 } catch {
   /* catch */
+}
+// Prettier moves the comment into the discriminant (`switch (a /* switch */) {`),
+// an attachment artifact; we keep it inside the braces like other statement bodies
+switch (a) {
+  /* switch */
+}
+switch (b) {
+  // line
 }
 
 ===================== End =====================


### PR DESCRIPTION
Input:

```js
switch (a) {
  /*c*/
}
```

Before this PR:

```js
switch (a) {
}
/*c*/
```

After this PR:

```js
switch (a) {
  /*c*/
}
```

NOTE prettier 3.9.4:

```js
switch (
  a
  /*c*/
) {
}
```

👉🏻 Will be fixed in next version: https://github.com/prettier/prettier/issues/19578