### PR TITLE
fix(linter/eslint/no-loop-func): do not error on catch variables

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_loop_func.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_loop_func.rs
@@ -217,6 +217,11 @@ impl NoLoopFunc {
             return false;
         }
 
+        // catch variables are safe because they are scoped to their catch block
+        if flags.is_catch_variable() {
+            return false;
+        }
+
         // Import bindings are always safe (immutable)
         if flags.is_import() {
             return false;
@@ -676,6 +681,8 @@ fn test() {
         "for (var i = 0; i < 10; ++i) { using foo = bar(i); (function() { foo; }) }",
         "for (var i = 0; i < 10; ++i) { await using foo = bar(i); (function() { foo; }) }",
         "for (let i = 0; i < 10; ++i) { for (let x in xs.filter(x => x != i)) {  } }",
+        "for (var i=0; i<l; i++) { try { } catch (e) { (function() { e; }) }  }",
+        "while (i<l) { try { } catch (e) { (function() { e; }) }  }",
         "let a = 0; for (let i=0; i<l; i++) { (function() { a; }); }",
         "let a = 0; for (let i in {}) { (function() { a; }); }",
         "let a = 0; for (let i of {}) { (function() { a; }); }",

--- a/crates/oxc_linter/src/rules/eslint/no_loop_func.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_loop_func.rs
@@ -217,14 +217,16 @@ impl NoLoopFunc {
             return false;
         }
 
-        // catch variables are safe because they are scoped to their catch block
-        if flags.is_catch_variable() {
-            return false;
-        }
-
         // Import bindings are always safe (immutable)
         if flags.is_import() {
             return false;
+        }
+
+        // Catch parameters are lexical bindings. A catch clause inside the loop creates a fresh
+        // binding each iteration, while a catch clause outside the loop may share a mutable binding.
+        if flags.is_catch_variable() {
+            let symbol_decl_node = nodes.get_node(scoping.symbol_declaration(symbol_id));
+            return Self::is_let_unsafe_in_loop(symbol_id, symbol_decl_node, loop_node, ctx);
         }
 
         // Get the declaration node for the symbol
@@ -678,6 +680,8 @@ fn test() {
         "for (const i of {}) { (function() { i; }) }",
         "for (using i of foo) { (function() { i; }) }",
         "for (await using i of foo) { (function() { i; }) }",
+        "for (let i = 0; i < 10; i++) { try {} catch (e) { setTimeout(() => console.log(e)); } }",
+        "for (let i = 0; i < 10; i++) { try {} catch (e) { setTimeout(() => console.log(e)); e = next(); } }",
         "for (var i = 0; i < 10; ++i) { using foo = bar(i); (function() { foo; }) }",
         "for (var i = 0; i < 10; ++i) { await using foo = bar(i); (function() { foo; }) }",
         "for (let i = 0; i < 10; ++i) { for (let x in xs.filter(x => x != i)) {  } }",
@@ -1110,6 +1114,13 @@ fn test() {
             arr.push(function () { return i; });
             arr.push(() => i);
         } while (i++ < 5);",
+        // A catch parameter declared outside the loop is shared across iterations.
+        "try {} catch (e) {
+            for (let i = 0; i < 10; i++) {
+                callbacks.push(() => e);
+                e = next();
+            }
+        }",
     ];
 
     Tester::new(NoLoopFunc::NAME, NoLoopFunc::PLUGIN, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/snapshots/eslint_no_loop_func.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_loop_func.snap
@@ -442,3 +442,12 @@ source: crates/oxc_linter/src/tester.rs
  4 │         } while (i++ < 5);
    ╰────
   help: Variables declared with 'var' are function-scoped, not block-scoped. Consider using 'let' or 'const' for block-scoped variables, or move the function outside the loop.
+
+  ⚠ eslint(no-loop-func): Function declared in a loop contains unsafe references to variable(s)
+   ╭─[no_loop_func.tsx:3:32]
+ 2 │             for (let i = 0; i < 10; i++) {
+ 3 │                 callbacks.push(() => e);
+   ·                                ───────
+ 4 │                 e = next();
+   ╰────
+  help: Variables declared with 'var' are function-scoped, not block-scoped. Consider using 'let' or 'const' for block-scoped variables, or move the function outside the loop.


### PR DESCRIPTION
Fixes #24315 

## Summary

When a catch variable (i.e. "error" in `try { } catch(error) { }`) is referenced by a function expression in its catch block (while the catch block is within a loop), the `no-loop-func` rule will currently error if its error level is set to error.

This type of usage should be considered safe, because the catch variable us scoped to its catch block and is not hoisted outside of the loop.

## The fix

This fix returns false if the reference is flagged as a `CatchVariable` and updates the test cases to assert they now pass in this case.

This is my first PR here, so I'm happy to make changes/hear feedback!