### PR TITLE
fix(formatter): add parens for import and private field in new callee chain

### DIFF
--- a/crates/oxc_formatter/src/parentheses/expression.rs
+++ b/crates/oxc_formatter/src/parentheses/expression.rs
@@ -303,6 +303,9 @@ impl NeedsParentheses<'_> for AstNode<'_, TaggedTemplateExpression<'_>> {
         // `class A extends (tag`x`) {}`; keep in sync with the wrapped-in-`!` case
         // in `class_extends_needs_parens_through_non_null`.
         is_class_extends(self.span, self.parent())
+            // `new (import("foo")`bar`)()`; a tag containing a call/import
+            // cannot appear in a new callee without parens
+            || (self.is_new_callee() && member_chain_callee_needs_parens(&self.tag))
     }
 }
 
@@ -1032,11 +1035,12 @@ fn member_chain_callee_needs_parens(e: &Expression) -> bool {
     std::iter::successors(Some(e), |e| match e {
         Expression::ComputedMemberExpression(e) => Some(&e.object),
         Expression::StaticMemberExpression(e) => Some(&e.object),
+        Expression::PrivateFieldExpression(e) => Some(&e.object),
         Expression::TaggedTemplateExpression(e) => Some(&e.tag),
         Expression::TSNonNullExpression(e) => Some(&e.expression),
         _ => None,
     })
-    .any(|object| matches!(object, Expression::CallExpression(_)))
+    .any(|object| matches!(object, Expression::CallExpression(_) | Expression::ImportExpression(_)))
 }
 
 #[derive(Clone, Copy)]

--- a/crates/oxc_formatter/tests/fixtures/js/new-expression/parenthesis.js
+++ b/crates/oxc_formatter/tests/fixtures/js/new-expression/parenthesis.js
@@ -1,4 +1,16 @@
 new (this.b().#c)()
 
+new (this.b().#c.d)()
+
 new (this.b().c)()
+
+new (import("foo"))()
+
+new (import("foo").bar)()
+
+new (import("foo")`bar`)()
+
+new (foo()`bar`)()
+
+new (foo`bar`)()
 

--- a/crates/oxc_formatter/tests/fixtures/js/new-expression/parenthesis.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/new-expression/parenthesis.js.snap
@@ -1,10 +1,23 @@
 ---
 source: crates/oxc_formatter/tests/fixtures/mod.rs
+assertion_line: 142
 ---
 ==================== Input ====================
 new (this.b().#c)()
 
+new (this.b().#c.d)()
+
 new (this.b().c)()
+
+new (import("foo"))()
+
+new (import("foo").bar)()
+
+new (import("foo")`bar`)()
+
+new (foo()`bar`)()
+
+new (foo`bar`)()
 
 
 ==================== Output ====================
@@ -13,13 +26,37 @@ new (this.b().c)()
 ------------------
 new (this.b().#c)();
 
+new (this.b().#c.d)();
+
 new (this.b().c)();
+
+new (import("foo"))();
+
+new (import("foo").bar)();
+
+new (import("foo")`bar`)();
+
+new (foo()`bar`)();
+
+new foo`bar`();
 
 -------------------
 { printWidth: 100 }
 -------------------
 new (this.b().#c)();
 
+new (this.b().#c.d)();
+
 new (this.b().c)();
+
+new (import("foo"))();
+
+new (import("foo").bar)();
+
+new (import("foo")`bar`)();
+
+new (foo()`bar`)();
+
+new foo`bar`();
 
 ===================== End =====================

--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,4 +1,4 @@
-js compatibility: 763/808 (94.43%), 23 files skipped
+js compatibility: 764/808 (94.55%), 23 files skipped
 
 # Failed
 
@@ -35,7 +35,6 @@ js compatibility: 763/808 (94.43%), 23 files skipped
 | js/if/condition-break/unary-expression.js | 💥 | 59.59% |
 | js/last-argument-expansion/dangling-comment-in-arrow-function.js | 💥 | 0.00% |
 | js/logical-expressions/in-unary-expression.js | 💥 | 33.33% |
-| js/new-expression/parentheses.js | 💥 | 33.33% |
 | js/no-semi/debugger-statement.js | 💥💥 | 91.18% |
 | js/no-semi/for-in-statement.js | 💥💥 | 63.89% |
 | js/no-semi/for-of-statement.js | 💥💥 | 66.67% |

--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -1,4 +1,4 @@
-ts compatibility: 623/663 (93.97%), 19 files skipped
+ts compatibility: 624/663 (94.12%), 19 files skipped
 
 # Failed
 
@@ -22,7 +22,6 @@ ts compatibility: 623/663 (93.97%), 19 files skipped
 | typescript/intersection/intersection-parens.ts | 💥💥 | 85.64% |
 | typescript/intersection/consistent-with-flow/intersection-parens.ts | 💥 | 67.44% |
 | typescript/intersection/consistent-with-flow/single-member.ts | 💥 | 78.00% |
-| typescript/new/parentheses.ts | 💥 | 0.00% |
 | typescript/object-type/comments/11307.ts | 💥 | 66.67% |
 | typescript/property-signature/consistent-with-flow/comments.ts | 💥 | 80.00% |
 | typescript/property-signature/consistent-with-flow/union.ts | 💥 | 80.00% |


### PR DESCRIPTION
This fixes idempotency issue.

```js
// These parens should be preserved
new (this.b().#c.d)();
new (import("foo"))();
```
