### PR TITLE
fix(linter/eslint/no-unused-vars): count default parameter updates as usage

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -1109,6 +1109,10 @@ fn test_arguments() {
         // Sequence expressions with member expressions in operations with side effects
 
         // UpdateExpression cases
+        (
+            "let count = 0; export function a(c = count++) { console.log(c) } export function b(c = ++count) { console.log(c) } export function c(d = count--) { console.log(d) } export function d(c = --count) { console.log(c) }",
+            None,
+        ),
         ("items.reduce((acc, item) => (acc[item.action]++, acc), {})", None),
         ("items.reduce((acc, item) => (acc[item.action]--, acc), {})", None),
         ("items.reduce((acc, item) => (++acc[item.action], acc), {})", None),
@@ -1155,6 +1159,7 @@ fn test_arguments() {
         ("function foo(...unused) {} foo()", Some(json!([{ "argsIgnorePattern": "^ignored" }]))),
         ("function foo(...args) { return 1 } foo()", Some(json!([{ "args": "after-used" }]))),
         ("function foo(...args: unknown[]) { return 1 } foo()", Some(json!([{ "args": "all" }]))),
+        ("let count = 0; function foo(c = (count++, 0)) { console.log(c) } foo()", None),
     ];
 
     Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/usage.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/usage.rs
@@ -451,6 +451,7 @@ impl<'a> Symbol<'_, 'a> {
         // Have we seen this reference be used to update the value of another
         // symbol, or for some other logically-relevant purpose?
         let mut is_used_by_others = true;
+        let mut saw_self_update = false;
         let ref_span = self.get_ref_span(reference);
 
         for node in self.nodes().ancestors(reference.node_id()) {
@@ -462,6 +463,9 @@ impl<'a> Symbol<'_, 'a> {
                 | AstKind::PropertyDefinition(_) => {
                     // definitely used, short-circuit
                     return false;
+                }
+                AstKind::FormalParameter(_) if saw_self_update => {
+                    return self.is_discarded_read(reference);
                 }
                 AstKind::CallExpression(call_expr)
                     if call_expr.arguments_span().is_some_and(|span| {
@@ -482,6 +486,7 @@ impl<'a> Symbol<'_, 'a> {
                                 .is_some_and(|e| e.get_inner_expression().is_member_expression());
                         if !is_member_expr {
                             is_used_by_others = false;
+                            saw_self_update = true;
                         }
                     }
                 // RHS usage when LHS != reference's symbol is definitely used by

--- a/crates/oxc_linter/src/snapshots/eslint_no_unused_vars@oxc-arguments.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_unused_vars@oxc-arguments.snap
@@ -65,3 +65,12 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ╰── 'args' is declared here
    ╰────
   help: Consider removing this parameter.
+
+  ⚠ eslint(no-unused-vars): Variable 'count' is assigned a value but never used. Unused variables should start with a '_'.
+   ╭─[no_unused_vars.tsx:1:5]
+ 1 │ let count = 0; function foo(c = (count++, 0)) { console.log(c) } foo()
+   ·     ──┬──                        ──┬──
+   ·       │                            ╰── it was last assigned here
+   ·       ╰── 'count' is declared here
+   ╰────
+  help: Did you mean to use this variable?


### PR DESCRIPTION
## Summary

- count update expressions used as default parameter initializers as observable usages
- preserve unused reporting when the update value is discarded by a sequence expression
- add regressions for prefix/postfix increment and decrement

Fixes #24313.
