### PR TITLE
fix(semantic): allow reserved keywords in ambient declaration types

### DIFF
--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -159,8 +159,7 @@ pub fn check_identifier(
 ) {
     // reserved keywords are allowed in ambient contexts
     fn is_allowed_context(symbol_id: Option<SymbolId>, ctx: &SemanticBuilder<'_>) -> bool {
-        ctx.source_type.is_typescript_definition()
-            || is_current_node_ambient_binding(symbol_id, ctx)
+        ctx.source_type.is_typescript_definition() || is_in_ambient_context(symbol_id, ctx)
     }
 
     match name {
@@ -192,7 +191,7 @@ pub fn check_identifier(
     }
 }
 
-fn is_current_node_ambient_binding(symbol_id: Option<SymbolId>, ctx: &SemanticBuilder<'_>) -> bool {
+fn is_in_ambient_context(symbol_id: Option<SymbolId>, ctx: &SemanticBuilder<'_>) -> bool {
     if ctx.current_scope_flags().is_ts_module_block() {
         return true;
     }
@@ -200,14 +199,14 @@ fn is_current_node_ambient_binding(symbol_id: Option<SymbolId>, ctx: &SemanticBu
     if let Some(symbol_id) = symbol_id
         && ctx.scoping.symbol_flags(symbol_id).contains(SymbolFlags::Ambient)
     {
-        true
-    } else if let AstKind::BindingIdentifier(id) = ctx.ancestry().current_kind()
-        && let Some(symbol_id) = id.symbol_id.get()
-    {
-        ctx.scoping.symbol_flags(symbol_id).contains(SymbolFlags::Ambient)
-    } else {
-        false
+        return true;
     }
+
+    ctx.ancestry().ancestor_kinds().any(|kind| match kind {
+        AstKind::VariableDeclaration(decl) => decl.declare,
+        AstKind::PropertyDefinition(prop) => prop.declare,
+        _ => false,
+    })
 }
 
 pub fn check_binding_identifier(ident: &BindingIdentifier, ctx: &SemanticBuilder<'_>) {

--- a/tasks/coverage/misc/pass/reserved-kw-ambient-context.ts
+++ b/tasks/coverage/misc/pass/reserved-kw-ambient-context.ts
@@ -1,0 +1,4 @@
+export {};
+
+declare let f: (package: number) => interface;
+class C2 { declare  field: package; }

--- a/tasks/coverage/snapshots/codegen_misc.snap
+++ b/tasks/coverage/snapshots/codegen_misc.snap
@@ -1,3 +1,3 @@
 codegen_misc Summary:
-AST Parsed     : 70/70 (100.00%)
-Positive Passed: 70/70 (100.00%)
+AST Parsed     : 71/71 (100.00%)
+Positive Passed: 71/71 (100.00%)

--- a/tasks/coverage/snapshots/formatter_misc.snap
+++ b/tasks/coverage/snapshots/formatter_misc.snap
@@ -1,3 +1,3 @@
 formatter_misc Summary:
-AST Parsed     : 70/70 (100.00%)
-Positive Passed: 70/70 (100.00%)
+AST Parsed     : 71/71 (100.00%)
+Positive Passed: 71/71 (100.00%)

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,6 +1,6 @@
 parser_misc Summary:
-AST Parsed     : 70/70 (100.00%)
-Positive Passed: 70/70 (100.00%)
+AST Parsed     : 71/71 (100.00%)
+Positive Passed: 71/71 (100.00%)
 Negative Passed: 149/149 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -1,6 +1,6 @@
 semantic_misc Summary:
-AST Parsed     : 70/70 (100.00%)
-Positive Passed: 66/70 (94.29%)
+AST Parsed     : 71/71 (100.00%)
+Positive Passed: 66/71 (92.96%)
 semantic Error: tasks/coverage/misc/pass/declare-let-private.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["private"]
@@ -89,4 +89,9 @@ semantic Error: tasks/coverage/misc/pass/oxc-13284.ts
 Symbol reference IDs mismatch for "_super":
 after transform: SymbolId(18): [ReferenceId(14)]
 rebuilt        : SymbolId(9): []
+
+semantic Error: tasks/coverage/misc/pass/reserved-kw-ambient-context.ts
+Bindings mismatch:
+after transform: ScopeId(0): ["C2", "f"]
+rebuilt        : ScopeId(0): ["C2"]
 

--- a/tasks/coverage/snapshots/transformer_misc.snap
+++ b/tasks/coverage/snapshots/transformer_misc.snap
@@ -1,3 +1,3 @@
 transformer_misc Summary:
-AST Parsed     : 70/70 (100.00%)
-Positive Passed: 70/70 (100.00%)
+AST Parsed     : 71/71 (100.00%)
+Positive Passed: 71/71 (100.00%)


### PR DESCRIPTION
Recognize identifiers nested within `declare` variable declarations and declared class properties as being in an ambient context.

This prevents valid TypeScript from incorrectly producing reserved-keyword diagnostics.

### Examples

Function types inside ambient variable declarations are now accepted:

```ts
declare let f: (package: number) => interface;
```

Type references inside declared class properties are also accepted:

```ts
class C {
  declare field: package;
}
```
Previously, package and interface were incorrectly reported as reserved keywords.
