### PR TITLE
perf(parser): pre-size ArenaVec capacities for common lists

### DIFF
--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -11,6 +11,15 @@ use crate::{
     lexer::{Kind, LexerCheckpoint, Token, cold_branch},
 };
 
+/// Initial capacity for comma-separated lists (call args, array/object elements, type params, …).
+///
+/// Empty `ArenaVec`s grow 1 → 2 → 4 → 8 (see `RawVec::grow_amortized`), so a short list of 3–5
+/// items pays for several arena reallocs. Pre-sizing to 4 covers the common case in one alloc.
+const DELIMITED_LIST_CAPACITY: usize = 4;
+
+/// Initial capacity for brace-delimited bodies (blocks, class bodies, switch case lists, …).
+const BODY_LIST_CAPACITY: usize = 8;
+
 #[derive(Clone)]
 pub struct ParserCheckpoint<'a> {
     lexer: LexerCheckpoint<'a>,
@@ -390,6 +399,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     {
         let opening_span = self.cur_token().span();
         self.expect(open);
+        // Keep empty bodies (`{}`) allocation-free; reserve only once the first element arrives.
         let mut list = ArenaVec::new_in(self);
         loop {
             let kind = self.cur_kind();
@@ -398,6 +408,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 || self.fatal_error.is_some()
             {
                 break;
+            }
+            if list.capacity() == 0 {
+                list.reserve(BODY_LIST_CAPACITY);
             }
             list.push(f(self));
         }
@@ -422,6 +435,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 break;
             }
             if let Some(e) = f(self) {
+                if list.capacity() == 0 {
+                    list.reserve(BODY_LIST_CAPACITY);
+                }
                 list.push(e);
             } else {
                 break;
@@ -441,15 +457,16 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     where
         F: FnMut(&mut Self) -> T,
     {
-        let mut list = ArenaVec::new_in(self);
         // Cache cur_kind() to avoid redundant calls in compound checks
         let kind = self.cur_kind();
         if kind == close
             || matches!(kind, Kind::Eof | Kind::Undetermined)
             || self.fatal_error.is_some()
         {
-            return (list, None);
+            // Empty list — no allocation.
+            return (ArenaVec::new_in(self), None);
         }
+        let mut list = ArenaVec::with_capacity_in(DELIMITED_LIST_CAPACITY, self);
         list.push(f(self));
         loop {
             let kind = self.cur_kind();
@@ -496,6 +513,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             || self.fatal_error.is_some()
         {
             return None;
+        }
+        if list.capacity() == 0 {
+            list.reserve(DELIMITED_LIST_CAPACITY);
         }
         list.push(f(self));
         loop {
@@ -585,6 +605,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             if kind == Kind::Dot3 {
                 rest.replace(parse_rest(self));
             } else {
+                if list.capacity() == 0 {
+                    list.reserve(DELIMITED_LIST_CAPACITY);
+                }
                 list.push(parse_element(self));
             }
         }

--- a/crates/oxc_parser/src/js/declaration.rs
+++ b/crates/oxc_parser/src/js/declaration.rs
@@ -83,7 +83,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         decl_parent: VariableDeclarationParent,
         declare: bool,
     ) -> ArenaBox<'a, VariableDeclaration<'a>> {
-        let mut declarations = ArenaVec::new_in(self);
+        // Most declarations are a single binding (`let x = 1`); multi-declarator is uncommon.
+        let mut declarations = ArenaVec::with_capacity_in(1, self);
         loop {
             let declaration = self.parse_variable_declarator(decl_parent, kind);
             declarations.push(declaration);
@@ -204,7 +205,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
 
         // BindingList[?In, ?Yield, ?Await, ~Pattern]
-        let mut declarations = ArenaVec::new_in(self);
+        let mut declarations = ArenaVec::with_capacity_in(1, self);
         loop {
             let decl_parent = if matches!(statement_ctx, StatementContext::For) {
                 VariableDeclarationParent::For

--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -70,6 +70,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         func_kind: FunctionKind,
         opening_span: Span,
     ) -> (ArenaVec<'a, FormalParameter<'a>>, Option<ArenaBox<'a, FormalParameterRest<'a>>>) {
+        // Empty param lists stay allocation-free; reserve on first param.
         let mut list = ArenaVec::new_in(self);
         let mut rest: Option<ArenaBox<'a, FormalParameterRest<'a>>> = None;
         let mut first = true;
@@ -143,6 +144,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     self,
                 ));
             } else {
+                if list.capacity() == 0 {
+                    list.reserve(4);
+                }
                 list.push(self.parse_formal_parameter_with_decorators(func_kind, span, decorators));
             }
         }

--- a/crates/oxc_parser/src/js/grammar.rs
+++ b/crates/oxc_parser/src/js/grammar.rs
@@ -97,10 +97,11 @@ impl<'a, C: Config> CoverGrammar<'a, ArrayExpression<'a>, C> for ArrayAssignment
     // would otherwise carry this body's large stack frame + callee-saved spills on every call.
     #[inline(never)]
     fn cover(expr: ArrayExpression<'a>, p: &mut ParserImpl<'a, C>) -> Self {
-        let mut elements = ArenaVec::new_in(p);
+        let len = expr.elements.len();
+        // Exact capacity known from the expression being converted.
+        let mut elements = ArenaVec::with_capacity_in(len, p);
         let mut rest = None;
 
-        let len = expr.elements.len();
         for (i, elem) in expr.elements.into_iter().enumerate() {
             match elem {
                 match_expression!(ArrayExpressionElement) => {
@@ -174,10 +175,11 @@ impl<'a, C: Config> CoverGrammar<'a, ObjectExpression<'a>, C> for ObjectAssignme
     // inlining this large body into the hot `AssignmentTarget::cover` dispatcher.
     #[inline(never)]
     fn cover(expr: ObjectExpression<'a>, p: &mut ParserImpl<'a, C>) -> Self {
-        let mut properties = ArenaVec::new_in(p);
+        let len = expr.properties.len();
+        // Exact capacity known from the expression being converted.
+        let mut properties = ArenaVec::with_capacity_in(len, p);
         let mut rest = None;
 
-        let len = expr.properties.len();
         for (i, elem) in expr.properties.into_iter().enumerate() {
             match elem {
                 ObjectPropertyKind::ObjectProperty(property) => {

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -34,6 +34,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
         in_ts_namespace_body: bool,
     ) -> (ArenaVec<'a, Directive<'a>>, ArenaVec<'a, Statement<'a>>) {
+        // Empty blocks stay allocation-free; reserve once the first item arrives so short
+        // bodies avoid the empty-Vec 1→2→4→8 growth chain.
         let mut directives = ArenaVec::new_in(self);
         let mut statements = ArenaVec::new_in(self);
 
@@ -93,6 +95,10 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                             [string.span.start as usize + 1..string.span.end as usize - 1];
                         let directive =
                             Directive::new(expr.span, (*string).clone(), Str::from(src), self);
+                        if directives.capacity() == 0 {
+                            // Directive prologues are almost always short.
+                            directives.reserve(4);
+                        }
                         directives.push(directive);
                         continue;
                     }
@@ -111,6 +117,10 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             {
                 self.error(diagnostics::statement_in_ambient_context(stmt.span()));
                 reported_ambient_statement = true;
+            }
+            if statements.capacity() == 0 {
+                // Top-level and nested statement lists; 8 covers typical short bodies.
+                statements.reserve(8);
             }
             statements.push(stmt);
         }
@@ -750,6 +760,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 self.error(diagnostics::using_declaration_not_allowed_in_switch_bare_case(
                     stmt.span(),
                 ));
+            }
+            if consequent.capacity() == 0 {
+                consequent.reserve(4);
             }
             consequent.push(stmt);
         }

--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -235,6 +235,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
         in_jsx_child: bool,
     ) -> (ArenaVec<'a, JSXChild<'a>>, JSXClosing<'a>) {
+        // Empty children stay allocation-free; reserve once the first child arrives.
         let mut children = ArenaVec::new_in(self);
         loop {
             if self.fatal_error.is_some() {
@@ -243,7 +244,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 return (children, JSXClosing::Fragment(closing));
             }
 
-            match self.cur_kind() {
+            let child = match self.cur_kind() {
                 Kind::LAngle => {
                     let span = self.start_span();
                     self.bump_any(); // bump `<`
@@ -251,25 +252,19 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
                     // <> open nested fragment
                     if kind == Kind::RAngle {
-                        children.push(JSXChild::Fragment(self.parse_jsx_fragment(span, true)));
-                        continue;
-                    }
-
+                        JSXChild::Fragment(self.parse_jsx_fragment(span, true))
                     // <ident open nested element
-                    if kind == Kind::Ident || kind.is_any_keyword() {
-                        children.push(JSXChild::Element(self.parse_jsx_element(span, true)));
-                        continue;
-                    }
-
+                    } else if kind == Kind::Ident || kind.is_any_keyword() {
+                        JSXChild::Element(self.parse_jsx_element(span, true))
                     // </ closing tag - parse it inline and return
-                    if kind == Kind::Slash {
+                    } else if kind == Kind::Slash {
                         self.bump_any(); // bump `/`
                         let closing = self.parse_jsx_closing_inline(span, in_jsx_child);
                         return (children, closing);
+                    } else {
+                        // Unexpected token after `<`
+                        return (children, self.unexpected());
                     }
-
-                    // Unexpected token after `<`
-                    return (children, self.unexpected());
                 }
                 Kind::LCurly => {
                     let span_start = self.start_span();
@@ -277,25 +272,25 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
                     // {...expr}
                     if self.eat(Kind::Dot3) {
-                        children.push(JSXChild::Spread(self.parse_jsx_spread_child(span_start)));
-                        continue;
-                    }
-                    // {expr}
-                    children.push(JSXChild::ExpressionContainer(
-                        self.parse_jsx_expression_container(
+                        JSXChild::Spread(self.parse_jsx_spread_child(span_start))
+                    } else {
+                        // {expr}
+                        JSXChild::ExpressionContainer(self.parse_jsx_expression_container(
                             span_start, /* in_jsx_child */ true,
-                        ),
-                    ));
+                        ))
+                    }
                 }
                 // text
-                Kind::JSXText => {
-                    children.push(JSXChild::Text(self.parse_jsx_text()));
-                }
+                Kind::JSXText => JSXChild::Text(self.parse_jsx_text()),
                 _ => {
                     // Unexpected token in JSX children
                     return (children, self.unexpected());
                 }
+            };
+            if children.capacity() == 0 {
+                children.reserve(4);
             }
+            children.push(child);
         }
     }
 
@@ -397,6 +392,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 }
                 _ => JSXAttributeItem::Attribute(self.parse_jsx_attribute()),
             };
+            if attributes.capacity() == 0 {
+                attributes.reserve(4);
+            }
             attributes.push(attribute);
         }
         attributes

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -1261,6 +1261,10 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 }
             }
 
+            if properties.capacity() == 0 {
+                properties.reserve(4);
+            }
+
             // Check for spread element
             if self.at(Kind::Dot3) {
                 let spread_span = self.cur_token().span();

--- a/tasks/track_memory_allocations/allocs_parser.snap
+++ b/tasks/track_memory_allocations/allocs_parser.snap
@@ -1,16 +1,16 @@
 File                       | File size      || Sys allocs     | Sys reallocs   || Arena allocs   | Arena reallocs 
 ---------------------------------------------------------------------------------------------------------------------------
-checker.ts                 | 2.92 MB        ||           1818 |             10 ||         264366 |          22860
+checker.ts                 | 2.92 MB        ||           1818 |             10 ||         264366 |           2609
 
-App.tsx                    | 415.34 kB      ||            360 |             13 ||          44464 |           3537
+App.tsx                    | 415.34 kB      ||            360 |             13 ||          44464 |            448
 
-RadixUIAdoptionSection.jsx | 2.52 kB        ||              1 |              0 ||            367 |             66
+RadixUIAdoptionSection.jsx | 2.52 kB        ||              1 |              0 ||            367 |             11
 
-pdf.mjs                    | 567.30 kB      ||            337 |             67 ||          90583 |           8153
+pdf.mjs                    | 567.30 kB      ||            337 |             67 ||          90583 |            978
 
-antd.js                    | 6.69 MB        ||           3661 |            221 ||         528577 |          55355
+antd.js                    | 6.69 MB        ||           3661 |            221 ||         528577 |           6965
 
-binder.ts                  | 193.08 kB      ||             85 |              0 ||          16620 |           1476
+binder.ts                  | 193.08 kB      ||             85 |              0 ||          16620 |            223
 
-kitchen-sink.tsx           | 732.90 kB      ||           2051 |            160 ||         138059 |          11905
+kitchen-sink.tsx           | 732.90 kB      ||           2051 |            160 ||         138059 |           2009
 

--- a/tasks/track_memory_allocations/allocs_transformer.snap
+++ b/tasks/track_memory_allocations/allocs_transformer.snap
@@ -12,5 +12,5 @@ antd.js                    | 6.69 MB        ||             13 |              0 |
 
 binder.ts                  | 193.08 kB      ||             15 |              0 ||            154 |              0
 
-kitchen-sink.tsx           | 732.90 kB      ||            182 |              3 ||           6132 |            280
+kitchen-sink.tsx           | 732.90 kB      ||            182 |              3 ||           6132 |            235
 


### PR DESCRIPTION
## Summary

Empty `ArenaVec`s grow `1 → 2 → 4 → 8` (`RawVec::grow_amortized`), so short comma/brace lists pay several arena reallocs for a handful of elements.

This change pre-sizes common list capacities while keeping truly empty lists allocation-free:

- Shared helpers in `cursor.rs`: `DELIMITED_LIST_CAPACITY = 4`, `BODY_LIST_CAPACITY = 8`
- Reserve on first element for bodies, statement lists, params, JSX children/attributes, TS object types
- `with_capacity` when the list is known non-empty (delimited lists)
- Exact capacity for cover-grammar array/object conversion
- Variable declarations: capacity 1 (almost always a single declarator)

Allocation snapshots updated via the track-memory-allocations harness.

## Measurements

### Arena reallocs (`allocs_parser.snap`)

| File | Before | After | Δ |
|------|--------|-------|---|
| checker.ts | 22 860 | 2 609 | −89% |
| antd.js | 55 355 | 6 965 | −87% |
| App.tsx | 3 537 | 448 | −87% |
| kitchen-sink.tsx | 11 905 | 2 009 | −83% |
| pdf.mjs | 8 153 | 978 | −88% |
| binder.ts | 1 476 | 223 | −85% |

Arena alloc counts and system allocs are unchanged (same AST node count; fewer growth steps). Transformer kitchen-sink reallocs 280 → 235 as a secondary snapshot update.

### Criterion (`oxc_benchmark` parser, vs `main` baseline)

`sample-size 30`, warm-up 1s, measurement 5s:

| Bench | Change | Criterion |
|-------|--------|-----------|
| kitchen-sink.tsx | −6.6% | Performance has improved |
| binder.ts | −4.4% | Performance has improved |
| estree_tokens/checker.ts | −4.8% | Performance has improved |
| App.tsx | −2.8% | Within noise threshold |
| estree/checker.ts | −1.4% | Within noise threshold |
| react.development.js | ~0% | No change |
| RadixUIAdoptionSection.jsx | ~0% | No change |

## AI usage

This PR was developed with assistance from an AI coding tool (Grok). I reviewed the changes, ran tests/benches/alloc snapshots, and take responsibility for the content.

## Test plan

- [x] `cargo test -p oxc_parser --lib`
- [x] Allocation snapshots updated (`allocs_parser.snap`, `allocs_transformer.snap`)
- [x] Criterion parser bench vs `main` baseline
- [ ] CI green