### PR TITLE
fix(linter): merge `settings`, `env`, and `globals` in `Oxlintrc::merge`

### DIFF
--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -399,9 +399,19 @@ impl Oxlintrc {
             .map(|rule| (**rule).clone())
             .collect::<Vec<_>>();
 
-        let settings = self.settings.clone();
-        let env = self.env.clone();
-        let globals = self.globals.clone();
+        // Merge `settings`, `env`, and `globals` from both configs. `self` (the extending
+        // config) overrides `other` (the extended base) on any conflicting keys. Previously
+        // these were cloned from `self` only, which silently dropped values declared in the
+        // parent — inconsistent with `rules`, `plugins`, `overrides`, and `categories`,
+        // which all combine both sides.
+        let mut settings = other.settings.clone();
+        self.settings.override_settings(&mut settings);
+
+        let mut env = other.env.clone();
+        self.env.override_envs(&mut env);
+
+        let mut globals = other.globals.clone();
+        self.globals.override_globals(&mut globals);
 
         let mut overrides = other.overrides;
         overrides.extend(self.overrides.clone());
@@ -807,6 +817,85 @@ mod test {
         let config2: Oxlintrc = serde_json::from_str(r#"{"jsPlugins": ["./plugin2.ts"]}"#).unwrap();
         let merged = config1.merge(config2);
         assert_eq!(merged.external_plugins.unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_oxlintrc_settings_merge() {
+        // Base config declares a plugin's settings; extending config has no `settings` block.
+        // The base settings should survive the merge (previously dropped).
+        let extending: Oxlintrc = serde_json::from_str(r#"{}"#).unwrap();
+        let base: Oxlintrc = serde_json::from_str(
+            r#"{"settings": {"tailwindcss": {"entryPoint": "./styles/tailwind.css"}}}"#,
+        )
+        .unwrap();
+        let merged = extending.merge(base);
+        let tw = merged.settings.json.as_ref().and_then(|j| j.get("tailwindcss"));
+        assert_eq!(
+            tw.and_then(|t| t.get("entryPoint")).and_then(|e| e.as_str()),
+            Some("./styles/tailwind.css"),
+            "base config's settings.tailwindcss.entryPoint should survive the merge",
+        );
+
+        // Extending config's settings win on conflicts, base's other keys survive.
+        let extending: Oxlintrc = serde_json::from_str(
+            r#"{"settings": {"tailwindcss": {"entryPoint": "./child.css"}}}"#,
+        )
+        .unwrap();
+        let base: Oxlintrc = serde_json::from_str(
+            r#"{"settings": {"tailwindcss": {"entryPoint": "./parent.css", "timeout": 1000}}}"#,
+        )
+        .unwrap();
+        let merged = extending.merge(base);
+        let tw = merged.settings.json.as_ref().and_then(|j| j.get("tailwindcss")).unwrap();
+        assert_eq!(
+            tw.get("entryPoint").and_then(|e| e.as_str()),
+            Some("./child.css"),
+            "extending config's entryPoint should win over base's",
+        );
+        assert_eq!(
+            tw.get("timeout").and_then(|t| t.as_u64()),
+            Some(1000),
+            "base config's `timeout` should survive since the extending config didn't set it",
+        );
+    }
+
+    #[test]
+    fn test_oxlintrc_env_merge() {
+        // Base declares an env; extending has none. Base env should survive.
+        let extending: Oxlintrc = serde_json::from_str(r#"{}"#).unwrap();
+        let base: Oxlintrc = serde_json::from_str(r#"{"env": {"browser": true}}"#).unwrap();
+        let merged = extending.merge(base);
+        assert!(merged.env.contains("browser"));
+
+        // Extending overrides base for the same key, other keys survive.
+        let extending: Oxlintrc =
+            serde_json::from_str(r#"{"env": {"browser": false}}"#).unwrap();
+        let base: Oxlintrc =
+            serde_json::from_str(r#"{"env": {"browser": true, "node": true}}"#).unwrap();
+        let merged = extending.merge(base);
+        assert!(!merged.env.contains("browser"));
+        assert!(merged.env.contains("node"));
+    }
+
+    #[test]
+    fn test_oxlintrc_globals_merge() {
+        // Base declares a global; extending has none. Base global should survive.
+        let extending: Oxlintrc = serde_json::from_str(r#"{}"#).unwrap();
+        let base: Oxlintrc =
+            serde_json::from_str(r#"{"globals": {"MY_GLOBAL": "readonly"}}"#).unwrap();
+        let merged = extending.merge(base);
+        assert!(merged.globals.is_enabled("MY_GLOBAL"));
+
+        // Extending overrides base for the same key, other keys survive.
+        let extending: Oxlintrc =
+            serde_json::from_str(r#"{"globals": {"MY_GLOBAL": "off"}}"#).unwrap();
+        let base: Oxlintrc = serde_json::from_str(
+            r#"{"globals": {"MY_GLOBAL": "readonly", "OTHER": "writable"}}"#,
+        )
+        .unwrap();
+        let merged = extending.merge(base);
+        assert!(!merged.globals.is_enabled("MY_GLOBAL"));
+        assert!(merged.globals.is_enabled("OTHER"));
     }
 
     #[test]

--- a/crates/oxc_linter/src/config/settings/mod.rs
+++ b/crates/oxc_linter/src/config/settings/mod.rs
@@ -117,11 +117,10 @@ impl<'de> Deserialize<'de> for OxlintSettings {
 }
 
 impl OxlintSettings {
-    // Note: We don't merge settings in overrides at present.
-    // So this is dead code, but keeping it for now, as we may want to enable merging settings in the future.
-    #[expect(dead_code)]
-    /// Mutates `settings_to_override` by reading from `self`.
-    fn override_settings(&self, settings_to_override: &mut OxlintSettings) {
+    /// Mutates `settings_to_override` by reading from `self`. Values on `self` take precedence.
+    /// Used by `Oxlintrc::merge` to combine settings from an extended base config with the
+    /// extending config, and reserved for use by override rules in the future.
+    pub(crate) fn override_settings(&self, settings_to_override: &mut OxlintSettings) {
         // If `None`, `self` has nothing configured, so we don't need to mutate `settings_to_override` at all.
         if let Some(self_json) = &self.json {
             if let Some(override_json) = &settings_to_override.json {


### PR DESCRIPTION
## Summary

`Oxlintrc::merge` was cloning `settings`, `env`, and `globals` from `self` only, silently dropping those fields when they were declared in the extended base config. `rules`, `plugins`, `overrides`, `categories`, and `external_plugins` already combine both sides, so this was inconsistent.

## Impact

A child `.oxlintrc.json` that inherits (via `extends`) from a base config which is the only place `settings` is declared saw an empty `settings` at plugin runtime. So JS plugins that read `context.settings.<plugin>.<option>` failed even when the option was configured in the base.

Real-world repro: I hit this on a codebase with `.oxlintrc.vscode.json` extending `.oxlintrc.json`, where the base declares `settings.tailwindcss.entryPoint` for the [`oxlint-tailwindcss`](https://github.com/sergioazoc/oxlint-tailwindcss) plugin. Lint from the CLI works (linting `.oxlintrc.json` directly). The VS Code oxc extension loads `.oxlintrc.vscode.json` and every DS-dependent tailwindcss rule fires `MissingEntryPointError`, because the merged config's `settings` came from the child (which didn't declare `settings`) and dropped the base's.

Also lightly relevant: [oxc-project/oxc#20892](https://github.com/oxc-project/oxc/issues/20892) commenter `christophehurpeau` observed the same "settings dropped by extends" in a slightly different context.

## The change

`Oxlintrc::merge`:
- Start `settings`/`env`/`globals` from `other` (the extended base), then apply `self` on top using the existing `override_settings` / `override_envs` / `override_globals` helpers.
- Semantics match ESLint: the extending config wins on conflicts; the base's keys survive when the extending config doesn't declare them.

`OxlintSettings::override_settings`:
- Was `#[expect(dead_code)]` and private. Promoted to `pub(crate)` so `Oxlintrc::merge` can call it. Existing behavior is unchanged.
- Doc-comment updated to describe the new caller and drop the "we don't merge settings at present" note.

## Tests

- `test_oxlintrc_settings_merge` — base-only settings survive the merge; child overrides base on conflicts while other keys survive.
- `test_oxlintrc_env_merge` — analogous coverage for `env`.
- `test_oxlintrc_globals_merge` — analogous coverage for `globals`.

All 18 tests in `config::oxlintrc::test::` pass locally (`cargo test -p oxc_linter --lib config::oxlintrc::test::`).

## AI disclosure

Per the AI Usage Policy in `CONTRIBUTING.md`: this PR was prepared with Claude Code assistance. I reviewed and tested every change.