### PR TITLE
fix(linter): resolve `ignorePatterns` relative to the config dir

### DIFF
--- a/apps/oxlint/fixtures/cli/ignore_patterns_ancestor_config/.oxlintrc.json
+++ b/apps/oxlint/fixtures/cli/ignore_patterns_ancestor_config/.oxlintrc.json
@@ -1,0 +1,3 @@
+{
+  "ignorePatterns": ["packages/foo/dist"]
+}

--- a/apps/oxlint/fixtures/cli/ignore_patterns_ancestor_config/packages/foo/dist/bundle.js
+++ b/apps/oxlint/fixtures/cli/ignore_patterns_ancestor_config/packages/foo/dist/bundle.js
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/fixtures/cli/ignore_patterns_ancestor_config/packages/foo/src/index.js
+++ b/apps/oxlint/fixtures/cli/ignore_patterns_ancestor_config/packages/foo/src/index.js
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -543,7 +543,8 @@ export interface Oxlintrc {
    */
   globals?: OxlintGlobals;
   /**
-   * Globs to ignore during linting. These are resolved from the configuration file path.
+   * Globs to ignore during linting. Patterns use gitignore-style matching,
+   * rooted at the directory containing the configuration file.
    */
   ignorePatterns?: string[];
   /**

--- a/apps/oxlint/src/config_loader.rs
+++ b/apps/oxlint/src/config_loader.rs
@@ -15,6 +15,7 @@ use oxc_linter::{
 };
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 
+use crate::utils::normalize_path;
 use crate::{DEFAULT_JSONC_OXLINTRC_NAME, DEFAULT_OXLINTRC_NAME, DEFAULT_TS_OXLINTRC_NAME};
 use crate::{VITE_CONFIG_NAME, vp_version};
 
@@ -571,7 +572,11 @@ impl<'a> ConfigLoader<'a> {
         cwd: &Path,
         config_path: &Path,
     ) -> Result<Oxlintrc, OxcDiagnostic> {
-        let full_path = cwd.join(config_path);
+        // Normalize away `.`/`..` components:
+        // this path (config's parent directory) becomes the root for `ignorePatterns` matching,
+        // which is compared against the (normalized) lint target paths as a literal prefix.
+        // If a root containing `..`, it never matches.
+        let full_path = normalize_path(cwd.join(config_path));
         if is_js_config_path(&full_path) {
             return self.load_root_js_config(&full_path)?.ok_or_else(|| {
                 OxcDiagnostic::error(format!(
@@ -826,13 +831,9 @@ mod test {
         let result = loader.load_root_config(&cwd, Some(&valid_parent_config));
         assert!(result.is_ok(), "Expected config lookup to succeed with parent directory syntax");
 
-        // Verify the resolved path is correct
+        // Verify the resolved path is normalized, without `.`/`..` components
         if let Ok(config) = result {
-            assert_eq!(
-                config.path.file_name().unwrap().to_str().unwrap(),
-                "eslintrc.json",
-                "Config file name should be preserved after path resolution"
-            );
+            assert_eq!(config.path, cwd.join("fixtures/cli/linter/eslintrc.json"));
         }
     }
 

--- a/apps/oxlint/src/lib.rs
+++ b/apps/oxlint/src/lib.rs
@@ -10,6 +10,7 @@ pub mod lsp;
 mod mode;
 mod output_formatter;
 mod result;
+mod utils;
 mod walk;
 
 #[cfg(test)]

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -289,8 +289,6 @@ impl CliRunner {
         enable_plugins.apply_overrides(&mut plugins);
         root_config.plugins = Some(plugins);
 
-        let base_ignore_patterns = root_config.ignore_patterns.clone();
-
         let config_builder = match ConfigStoreBuilder::from_oxlintrc(
             false,
             root_config.clone(),
@@ -334,8 +332,13 @@ impl CliRunner {
             return crate::mode::run_rules(&lint_config, &output_formatter, stdout);
         }
 
-        let ignore_matcher =
-            { LintIgnoreMatcher::new(&base_ignore_patterns, &self.cwd, nested_ignore_patterns) };
+        let ignore_matcher = LintIgnoreMatcher::new(
+            &root_config.ignore_patterns,
+            // Without a config file there are no patterns and the root is never consulted,
+            // so the CWD fallback is an arbitrary placeholder.
+            root_config.dir().unwrap_or(&self.cwd),
+            nested_ignore_patterns,
+        );
 
         let files_to_lint = paths
             .into_iter()
@@ -842,6 +845,28 @@ mod test {
         Tester::new()
             .with_cwd("fixtures/cli/ignore_patterns_relative".into())
             .test_and_snapshot_multiple(&[args1, args2]);
+    }
+
+    #[test]
+    // https://github.com/oxc-project/oxc/issues/24310
+    fn ignore_patterns_ancestor_config() {
+        // Config is found via ancestor search; its `ignorePatterns` should be
+        // rooted at the config file's directory, not CWD.
+        let args = &["."];
+        Tester::new()
+            .with_cwd("fixtures/cli/ignore_patterns_ancestor_config/packages/foo".into())
+            .test_and_snapshot(args);
+    }
+
+    #[test]
+    fn ignore_patterns_config_path_with_parent_references() {
+        // `..` components in a `--config` path must be normalized before the config's
+        // directory is used as the root for `ignorePatterns`, otherwise the patterns
+        // silently never match.
+        let args = &["-c", "./packages/../.oxlintrc.json", "."];
+        Tester::new()
+            .with_cwd("fixtures/cli/ignore_patterns_ancestor_config".into())
+            .test_and_snapshot(args);
     }
 
     #[test]

--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -47,8 +47,9 @@ use crate::{
         options::{
             LintOptions as LSPLintOptions, RulesCustomization, Run, UnusedDisableDirectives,
         },
-        utils::{normalize_path, range_overlaps},
+        utils::range_overlaps,
     },
+    utils::normalize_path,
 };
 
 #[derive(Default)]
@@ -130,6 +131,9 @@ impl ServerLinterBuilder {
         };
 
         let base_patterns = oxlintrc.ignore_patterns.clone();
+        // Without a config file there are no patterns and the root is never consulted,
+        // so the `root_path` fallback is an arbitrary placeholder.
+        let base_ignore_root = oxlintrc.dir().unwrap_or(&root_path).to_path_buf();
 
         let config_builder = match ConfigStoreBuilder::from_oxlintrc(
             false,
@@ -228,7 +232,7 @@ impl ServerLinterBuilder {
         ServerLinter::new(
             options.run,
             root_path.to_path_buf(),
-            LintIgnoreMatcher::new(&base_patterns, &root_path, nested_ignore_patterns),
+            LintIgnoreMatcher::new(&base_patterns, &base_ignore_root, nested_ignore_patterns),
             Self::create_ignore_glob(&root_path),
             extended_paths,
             runner,

--- a/apps/oxlint/src/lsp/utils.rs
+++ b/apps/oxlint/src/lsp/utils.rs
@@ -1,35 +1,7 @@
-use std::{
-    borrow::Cow,
-    path::{Component, Path, PathBuf},
-};
+use std::borrow::Cow;
 
 use oxc_diagnostics::OxcCode;
 use tower_lsp_server::ls_types::Range;
-
-/// Normalize a path by removing `.` and resolving `..` components,
-/// without touching the filesystem.
-pub fn normalize_path<P: AsRef<Path>>(path: P) -> PathBuf {
-    let mut result = PathBuf::new();
-
-    for component in path.as_ref().components() {
-        match component {
-            Component::ParentDir => {
-                result.pop();
-            }
-            Component::CurDir => {
-                // Skip current directory component
-            }
-            Component::Normal(c) => {
-                result.push(c);
-            }
-            Component::RootDir | Component::Prefix(_) => {
-                result.push(component.as_os_str());
-            }
-        }
-    }
-
-    result
-}
 
 /// Returns `true` if LSP ranges `a` and `b` overlap or touch (share a boundary point).
 ///
@@ -59,22 +31,12 @@ pub fn get_full_rule_name(rule_code: &OxcCode) -> Option<Cow<'_, str>> {
 
 #[cfg(test)]
 mod test {
-    use std::path::Path;
-
     use tower_lsp_server::ls_types::{Position, Range};
 
-    use crate::lsp::utils::{normalize_path, range_overlaps};
+    use crate::lsp::utils::range_overlaps;
 
     fn range(sl: u32, sc: u32, el: u32, ec: u32) -> Range {
         Range::new(Position::new(sl, sc), Position::new(el, ec))
-    }
-
-    #[test]
-    fn test_normalize_path() {
-        assert_eq!(
-            normalize_path(Path::new("/root/directory/./.oxlintrc.json")),
-            Path::new("/root/directory/.oxlintrc.json")
-        );
     }
 
     #[test]

--- a/apps/oxlint/src/snapshots/fixtures__cli__config_ignore_patterns__with_oxlintrc_-c .__test__eslintrc.json --ignore-pattern _.ts .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__config_ignore_patterns__with_oxlintrc_-c .__test__eslintrc.json --ignore-pattern _.ts .@oxlint.snap
@@ -5,8 +5,14 @@ source: apps/oxlint/src/tester.rs
 arguments: -c ./test/eslintrc.json --ignore-pattern *.ts .
 working directory: fixtures/cli/config_ignore_patterns/with_oxlintrc
 ----------
-No files found to lint. Please check your paths and ignore patterns.
-Finished in <variable>ms on 0 files with 95 rules using 1 threads.
+
+  ! unicorn(no-empty-file): Empty files are not allowed.
+   ,-[main.js:1:1]
+   `----
+  help: Delete this file or add some code to it.
+
+Found 1 warning and 0 errors.
+Finished in <variable>ms on 1 file with 95 rules using 1 threads.
 ----------
-CLI result: LintNoFilesFound
+CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__ignore_patterns_ancestor_config_-c .__packages__..__.oxlintrc.json .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__ignore_patterns_ancestor_config_-c .__packages__..__.oxlintrc.json .@oxlint.snap
@@ -1,0 +1,20 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: -c ./packages/../.oxlintrc.json .
+working directory: fixtures/cli/ignore_patterns_ancestor_config
+----------
+
+  ! eslint(no-debugger): `debugger` statement is not allowed
+   ,-[packages/foo/src/index.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+  help: Remove the debugger statement
+
+Found 1 warning and 0 errors.
+Finished in <variable>ms on 1 file with 95 rules using 1 threads.
+----------
+CLI result: LintSucceeded
+----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__ignore_patterns_ancestor_config__packages__foo_.@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__ignore_patterns_ancestor_config__packages__foo_.@oxlint.snap
@@ -1,0 +1,20 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: .
+working directory: fixtures/cli/ignore_patterns_ancestor_config/packages/foo
+----------
+
+  ! eslint(no-debugger): `debugger` statement is not allowed
+   ,-[src/index.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+  help: Remove the debugger statement
+
+Found 1 warning and 0 errors.
+Finished in <variable>ms on 1 file with 95 rules using 1 threads.
+----------
+CLI result: LintSucceeded
+----------

--- a/apps/oxlint/src/utils.rs
+++ b/apps/oxlint/src/utils.rs
@@ -1,0 +1,45 @@
+use std::path::{Component, Path, PathBuf};
+
+/// Normalize a path by removing `.` and resolving `..` components,
+/// without touching the filesystem.
+pub fn normalize_path<P: AsRef<Path>>(path: P) -> PathBuf {
+    let mut result = PathBuf::new();
+
+    for component in path.as_ref().components() {
+        match component {
+            Component::ParentDir => {
+                result.pop();
+            }
+            Component::CurDir => {
+                // Skip current directory component
+            }
+            Component::Normal(c) => {
+                result.push(c);
+            }
+            Component::RootDir | Component::Prefix(_) => {
+                result.push(component.as_os_str());
+            }
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod test {
+    use std::path::Path;
+
+    use super::normalize_path;
+
+    #[test]
+    fn test_normalize_path() {
+        assert_eq!(
+            normalize_path(Path::new("/root/directory/./.oxlintrc.json")),
+            Path::new("/root/directory/.oxlintrc.json")
+        );
+        assert_eq!(
+            normalize_path(Path::new("/root/directory/../.oxlintrc.json")),
+            Path::new("/root/.oxlintrc.json")
+        );
+    }
+}

--- a/crates/oxc_linter/src/config/ignore_matcher.rs
+++ b/crates/oxc_linter/src/config/ignore_matcher.rs
@@ -18,7 +18,9 @@ impl LintIgnoreMatcher {
         base_root: &Path,
         mut nested: Vec<(Vec<String>, PathBuf)>,
     ) -> Self {
-        let base_gi = {
+        let base_gi = if base_patterns.is_empty() {
+            None
+        } else {
             let mut builder = GitignoreBuilder::new(base_root);
             for pat in base_patterns {
                 let _ = builder.add_line(None, pat);

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -276,7 +276,8 @@ pub struct Oxlintrc {
     /// Absolute path to the configuration file.
     #[serde(skip)]
     pub path: PathBuf,
-    /// Globs to ignore during linting. These are resolved from the configuration file path.
+    /// Globs to ignore during linting. Patterns use gitignore-style matching,
+    /// rooted at the directory containing the configuration file.
     #[serde(rename = "ignorePatterns")]
     pub ignore_patterns: Vec<String>,
     /// Paths of configuration files that this configuration file extends (inherits from). The files
@@ -349,6 +350,14 @@ impl Oxlintrc {
         config.set_config_dir(&config_dir);
 
         Ok(config)
+    }
+
+    /// Returns the directory containing this configuration file.
+    ///
+    /// Returns `None` when the configuration was not loaded from a file (`path` is empty),
+    /// e.g. when no configuration file was found.
+    pub fn dir(&self) -> Option<&Path> {
+        self.path.parent()
     }
 
     /// # Errors

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -48,13 +48,13 @@
       "markdownDescription": "Enabled or disabled specific global variables."
     },
     "ignorePatterns": {
-      "description": "Globs to ignore during linting. These are resolved from the configuration file path.",
+      "description": "Globs to ignore during linting. Patterns use gitignore-style matching,\nrooted at the directory containing the configuration file.",
       "default": [],
       "type": "array",
       "items": {
         "type": "string"
       },
-      "markdownDescription": "Globs to ignore during linting. These are resolved from the configuration file path."
+      "markdownDescription": "Globs to ignore during linting. Patterns use gitignore-style matching,\nrooted at the directory containing the configuration file."
     },
     "jsPlugins": {
       "description": "JS plugins, allows usage of ESLint plugins with Oxlint.\n\nRead more about JS plugins in\n[the docs](https://oxc.rs/docs/guide/usage/linter/js-plugins.html).\n\nNote: JS plugins are in alpha and not subject to semver.\n\nExamples:\n\nBasic usage with a local plugin path.\n\n```json\n{\n\"jsPlugins\": [\"./custom-plugin.js\"],\n\"rules\": {\n\"custom/rule-name\": \"warn\"\n}\n}\n```\n\nBasic usage with a TypeScript plugin and a local plugin path.\n\nTypeScript plugin files are supported in the following environments:\n- Deno and Bun: TypeScript files are supported natively.\n- Node.js >=22.18.0 and Node.js ^20.19.0: TypeScript files are supported natively with built-in\ntype-stripping enabled by default.\n\nFor older Node.js versions, TypeScript plugins are not supported. Please use JavaScript plugins or upgrade your Node version.\n\n```json\n{\n\"jsPlugins\": [\"./custom-plugin.ts\"],\n\"rules\": {\n\"custom/rule-name\": \"warn\"\n}\n}\n```\n\nUsing a built-in Rust plugin alongside a JS plugin with the same name\nby giving the JS plugin an alias.\n\n```json\n{\n\"plugins\": [\"import\"],\n\"jsPlugins\": [\n{ \"name\": \"import-js\", \"specifier\": \"eslint-plugin-import\" }\n],\n\"rules\": {\n\"import/no-cycle\": \"error\",\n\"import-js/no-unresolved\": \"warn\"\n}\n}\n```",

--- a/tasks/website_linter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_linter/src/snapshots/schema_markdown.snap
@@ -283,7 +283,8 @@ type: `string[]`
 
 default: `[]`
 
-Globs to ignore during linting. These are resolved from the configuration file path.
+Globs to ignore during linting. Patterns use gitignore-style matching,
+rooted at the directory containing the configuration file.
 
 
 ## jsPlugins


### PR DESCRIPTION
Fixes #24310

Root config's `ignorePatterns` are now resolved relative to the directory containing the config file, instead of CWD.

Also fixes a latent issue: a `--config <path>` containing `..` silently disabled all `ignorePatterns` (the unnormalized parent dir never prefix-matches lint target paths). Explicit config paths are now lexically normalized, same as Oxfmt.

### Behavior change

The new anchoring applies in all cases, including `--config` / LSP `configPath`. This intentionally differs from ESLint, which resolves alternate-config ignore patterns relative to CWD:

- `extends`, `overrides[].files`, and JS plugin specifiers are already config-file-relative, including via `--config`
  - rooting only `ignorePatterns` at CWD would give one file two coordinate systems
- Wrappers like Vite+ pass `--config <workspace-root config>` as an implementation detail while CWD stays at the invocation directory, so "`--config` means CWD-relative" does not hold in practice
  - #24276

Impact should be small: bare names (`dist`, `*.min.js`) and `**/`-prefixed patterns are unaffected by the anchor.

The updated `config_ignore_patterns/with_oxlintrc` snapshot shows the `--config` case.