### PR TITLE
fix(linter): error on `ignorePatterns` that cannot match files aoutside the config directory

### DIFF
--- a/apps/oxfmt/src/core/config/mod.rs
+++ b/apps/oxfmt/src/core/config/mod.rs
@@ -563,18 +563,7 @@ fn build_ignore_glob(
 
     let mut builder = GitignoreBuilder::new(config_dir);
     for pattern in ignore_patterns {
-        // Matching is rooted at the config file's directory and gitignore semantics cannot reach outside that root,
-        // so a `..` component can never match anything.
-        // Reject it instead of silently accepting a dead pattern.
-        let path_part = pattern.strip_prefix('!').unwrap_or(pattern);
-        let path_part = if path_part.ends_with("\\ ") { path_part } else { path_part.trim_end() };
-        // Split by `/` instead of `Path::components()`,
-        // since Gitignore patterns use `/` as the separator on all platforms.
-        if path_part.split('/').any(|segment| segment == "..") {
-            return Err(format!(
-                "Invalid pattern `{pattern}` in `ignorePatterns`: `..` is not supported, patterns are resolved within the config file's directory"
-            ));
-        }
+        oxc_config::validate_ignore_pattern(pattern)?;
 
         if builder.add_line(None, pattern).is_err() {
             return Err(format!("Failed to add ignore pattern `{pattern}` from `ignorePatterns`"));
@@ -685,28 +674,19 @@ mod tests_ignore_patterns_validation {
         build_ignore_glob(Some(Path::new("/repo/config")), &[pattern.to_string()]).map(|_| ())
     }
 
+    // Pattern-level cases are covered by `oxc_config::validate_ignore_pattern` tests;
+    // these only check that `build_ignore_glob` rejects a config containing one.
     #[test]
     fn rejects_parent_directory_components() {
-        for pattern in
-            ["../src/skip.js", "!../src/keep.js", "src/../skip.js", "src/..", ".. ", "src/.. "]
-        {
-            let error = build(pattern).unwrap_err();
-            assert_eq!(
-                error,
-                format!(
-                    "Invalid pattern `{pattern}` in `ignorePatterns`: `..` is not supported, patterns are resolved within the config file's directory"
-                )
-            );
-        }
+        let error = build("../src/skip.js").unwrap_err();
+        assert_eq!(
+            error,
+            "Invalid pattern `../src/skip.js` in `ignorePatterns`: `..` is not supported, patterns are resolved within the config file's directory"
+        );
     }
 
     #[test]
     fn accepts_patterns_without_parent_directory_components() {
-        // `..\ ` (escaped trailing space) literally matches a file named `.. `, not a parent directory
-        for pattern in
-            ["src/skip.js", "!src/keep.js", "ignored/", "*.gen.js", "foo..bar.js", "..\\ "]
-        {
-            assert!(build(pattern).is_ok(), "pattern `{pattern}` should be accepted");
-        }
+        assert!(build("src/skip.js").is_ok());
     }
 }

--- a/apps/oxlint/fixtures/cli/config_ignore_patterns/parent_reference/config/.oxlintrc.json
+++ b/apps/oxlint/fixtures/cli/config_ignore_patterns/parent_reference/config/.oxlintrc.json
@@ -1,0 +1,3 @@
+{
+  "ignorePatterns": ["../src/skipMe.js"]
+}

--- a/apps/oxlint/fixtures/cli/config_ignore_patterns/parent_reference/src/skipMe.js
+++ b/apps/oxlint/fixtures/cli/config_ignore_patterns/parent_reference/src/skipMe.js
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -545,6 +545,8 @@ export interface Oxlintrc {
   /**
    * Globs to ignore during linting. Patterns use gitignore-style matching,
    * rooted at the directory containing the configuration file.
+   * Files outside that directory cannot be matched; patterns containing `..`
+   * are rejected as a configuration error.
    */
   ignorePatterns?: string[];
   /**

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -1287,6 +1287,16 @@ mod test {
             .test_and_snapshot(args);
     }
 
+    #[test]
+    fn test_config_ignore_patterns_parent_reference() {
+        // Patterns containing `..` can never match (matching is rooted at the
+        // config file's directory), so they are rejected as a configuration error.
+        let args = &["-c", "./config/.oxlintrc.json", "."];
+        Tester::new()
+            .with_cwd("fixtures/cli/config_ignore_patterns/parent_reference".into())
+            .test_and_snapshot(args);
+    }
+
     // Issue: <https://github.com/oxc-project/oxc/pull/7566>
     #[test]
     fn ignore_path_with_relative_files() {

--- a/apps/oxlint/src/snapshots/fixtures__cli__config_ignore_patterns__parent_reference_-c .__config__.oxlintrc.json .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__config_ignore_patterns__parent_reference_-c .__config__.oxlintrc.json .@oxlint.snap
@@ -1,0 +1,15 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: -c ./config/.oxlintrc.json .
+working directory: fixtures/cli/config_ignore_patterns/parent_reference
+----------
+Failed to parse oxlint configuration file.
+
+  x invalid config file <cwd>/fixtures/cli/config_ignore_patterns/parent_reference/config/.oxlintrc.json: Invalid pattern `../src/skipMe.js` in `ignorePatterns`: `..`
+  | is not supported, patterns are resolved within the config file's directory
+
+----------
+CLI result: InvalidOptionConfig
+----------

--- a/crates/oxc_config/src/ignore_patterns.rs
+++ b/crates/oxc_config/src/ignore_patterns.rs
@@ -1,0 +1,48 @@
+/// Validate a single config `ignorePatterns` entry.
+///
+/// Matching is rooted at the config file's directory and gitignore semantics cannot reach outside that root,
+/// so a `..` component can never match anything.
+/// Reject it with an error message instead of silently accepting a dead pattern.
+///
+/// # Errors
+/// Returns the error message when the pattern contains a `..` path segment.
+pub fn validate_ignore_pattern(pattern: &str) -> Result<(), String> {
+    let path_part = pattern.strip_prefix('!').unwrap_or(pattern);
+    // gitignore ignores unescaped trailing spaces; a trailing `\ ` escapes a literal space
+    let path_part = if path_part.ends_with("\\ ") { path_part } else { path_part.trim_end() };
+    // Split by `/` instead of `Path::components()`,
+    // since gitignore patterns use `/` as the separator on all platforms.
+    if path_part.split('/').any(|segment| segment == "..") {
+        return Err(format!(
+            "Invalid pattern `{pattern}` in `ignorePatterns`: `..` is not supported, patterns are resolved within the config file's directory"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::validate_ignore_pattern;
+
+    #[test]
+    fn rejects_parent_dir_segments() {
+        for pattern in ["../src", "!../src", "src/../dist", "..", "../", ".. ", "src/.. "] {
+            assert!(
+                validate_ignore_pattern(pattern).is_err(),
+                "pattern `{pattern}` should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn accepts_patterns_without_parent_dir_segments() {
+        // `..` is only special as a whole path segment.
+        // `..\ ` (escaped trailing space) literally matches a file named `.. `, not a parent directory.
+        for pattern in ["dist", "*.min.js", "**/dist", "!dist", "..foo", "a..b", "foo..", "..\\ "] {
+            assert!(
+                validate_ignore_pattern(pattern).is_ok(),
+                "pattern `{pattern}` should be accepted"
+            );
+        }
+    }
+}

--- a/crates/oxc_config/src/lib.rs
+++ b/crates/oxc_config/src/lib.rs
@@ -2,10 +2,12 @@
 
 mod discovery;
 mod glob_set;
+mod ignore_patterns;
 mod walk;
 
 pub use discovery::{
     ConfigConflict, ConfigDiscovery, ConfigFileNames, DiscoveredConfigFile, is_js_config_path,
 };
 pub use glob_set::GlobSet;
+pub use ignore_patterns::validate_ignore_pattern;
 pub use walk::{all_paths_have_vcs_boundary, configure_walk_builder};

--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -227,6 +227,8 @@ impl ConfigStoreBuilder {
             Ok((oxlintrc, extended_paths))
         }
 
+        validate_ignore_patterns(&oxlintrc)?;
+
         let (oxlintrc, extended_paths) = resolve_oxlintrc_config(oxlintrc, false, &mut Vec::new())?;
 
         // Collect external plugins from both base config and overrides
@@ -723,6 +725,18 @@ fn get_name(plugin_name: &str, rule_name: &str) -> CompactStr {
     }
 }
 
+/// Validate each entry of `ignorePatterns`; see [`oxc_config::validate_ignore_pattern`].
+fn validate_ignore_patterns(oxlintrc: &Oxlintrc) -> Result<(), ConfigBuilderError> {
+    oxlintrc
+        .ignore_patterns
+        .iter()
+        .try_for_each(|pattern| oxc_config::validate_ignore_pattern(pattern))
+        .map_err(|reason| ConfigBuilderError::InvalidConfigFile {
+            file: oxlintrc.path.display().to_string(),
+            reason,
+        })
+}
+
 impl Debug for ConfigStoreBuilder {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ConfigStoreBuilder")
@@ -909,6 +923,29 @@ mod test {
         let builder = ConfigStoreBuilder::empty();
         assert_eq!(builder.plugins(), LintPlugins::default());
         assert!(builder.rules.is_empty());
+    }
+
+    #[test]
+    fn test_ignore_patterns_with_parent_reference_rejected() {
+        fn from_ignore_pattern(pattern: &str) -> Result<ConfigStoreBuilder, ConfigBuilderError> {
+            let oxlintrc =
+                Oxlintrc { ignore_patterns: vec![pattern.to_string()], ..Oxlintrc::default() };
+            ConfigStoreBuilder::from_oxlintrc(
+                true,
+                oxlintrc,
+                None,
+                &mut ExternalPluginStore::default(),
+                None,
+            )
+        }
+
+        // Pattern-level cases are covered by `oxc_config::validate_ignore_pattern` tests;
+        // this only checks that `from_oxlintrc` rejects a config containing one.
+        assert!(matches!(
+            from_ignore_pattern("../src"),
+            Err(ConfigBuilderError::InvalidConfigFile { .. })
+        ));
+        assert!(from_ignore_pattern("dist").is_ok());
     }
 
     #[test]

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -278,6 +278,8 @@ pub struct Oxlintrc {
     pub path: PathBuf,
     /// Globs to ignore during linting. Patterns use gitignore-style matching,
     /// rooted at the directory containing the configuration file.
+    /// Files outside that directory cannot be matched; patterns containing `..`
+    /// are rejected as a configuration error.
     #[serde(rename = "ignorePatterns")]
     pub ignore_patterns: Vec<String>,
     /// Paths of configuration files that this configuration file extends (inherits from). The files

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -48,13 +48,13 @@
       "markdownDescription": "Enabled or disabled specific global variables."
     },
     "ignorePatterns": {
-      "description": "Globs to ignore during linting. Patterns use gitignore-style matching,\nrooted at the directory containing the configuration file.",
+      "description": "Globs to ignore during linting. Patterns use gitignore-style matching,\nrooted at the directory containing the configuration file.\nFiles outside that directory cannot be matched; patterns containing `..`\nare rejected as a configuration error.",
       "default": [],
       "type": "array",
       "items": {
         "type": "string"
       },
-      "markdownDescription": "Globs to ignore during linting. Patterns use gitignore-style matching,\nrooted at the directory containing the configuration file."
+      "markdownDescription": "Globs to ignore during linting. Patterns use gitignore-style matching,\nrooted at the directory containing the configuration file.\nFiles outside that directory cannot be matched; patterns containing `..`\nare rejected as a configuration error."
     },
     "jsPlugins": {
       "description": "JS plugins, allows usage of ESLint plugins with Oxlint.\n\nRead more about JS plugins in\n[the docs](https://oxc.rs/docs/guide/usage/linter/js-plugins.html).\n\nNote: JS plugins are in alpha and not subject to semver.\n\nExamples:\n\nBasic usage with a local plugin path.\n\n```json\n{\n\"jsPlugins\": [\"./custom-plugin.js\"],\n\"rules\": {\n\"custom/rule-name\": \"warn\"\n}\n}\n```\n\nBasic usage with a TypeScript plugin and a local plugin path.\n\nTypeScript plugin files are supported in the following environments:\n- Deno and Bun: TypeScript files are supported natively.\n- Node.js >=22.18.0 and Node.js ^20.19.0: TypeScript files are supported natively with built-in\ntype-stripping enabled by default.\n\nFor older Node.js versions, TypeScript plugins are not supported. Please use JavaScript plugins or upgrade your Node version.\n\n```json\n{\n\"jsPlugins\": [\"./custom-plugin.ts\"],\n\"rules\": {\n\"custom/rule-name\": \"warn\"\n}\n}\n```\n\nUsing a built-in Rust plugin alongside a JS plugin with the same name\nby giving the JS plugin an alias.\n\n```json\n{\n\"plugins\": [\"import\"],\n\"jsPlugins\": [\n{ \"name\": \"import-js\", \"specifier\": \"eslint-plugin-import\" }\n],\n\"rules\": {\n\"import/no-cycle\": \"error\",\n\"import-js/no-unresolved\": \"warn\"\n}\n}\n```",

--- a/tasks/website_linter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_linter/src/snapshots/schema_markdown.snap
@@ -285,6 +285,8 @@ default: `[]`
 
 Globs to ignore during linting. Patterns use gitignore-style matching,
 rooted at the directory containing the configuration file.
+Files outside that directory cannot be matched; patterns containing `..`
+are rejected as a configuration error.
 
 
 ## jsPlugins


### PR DESCRIPTION
Follow up on #24339

- Added the same guard as Oxfmt
- Since they are identical, I moved them into `oxc_config` so they can be shared