### PR TITLE
refactor(react_compiler): remove for_kv_map, question_mark, unneeded_wildcard_pattern clippy allows

### DIFF
--- a/crates/oxc_react_compiler/Cargo.toml
+++ b/crates/oxc_react_compiler/Cargo.toml
@@ -70,9 +70,6 @@ collapsible_if = "allow"
 needless_return = "allow"
 unnecessary_unwrap = "allow"
 result_large_err = "allow" # `Result<T, OxcDiagnostic>` everywhere; same trade-off as the workspace allow
-for_kv_map = "allow"
-question_mark = "allow"
-unneeded_wildcard_pattern = "allow"
 
 # The vendored modules' doc comments reference types like `Vec<PatternLike>`
 # without backticks; relax rustdoc for them rather than editing upstream code.

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
@@ -2035,7 +2035,7 @@ fn compute_signature_for_instruction(
                 }
             }
         }
-        InstructionValue::JsxFragment { children: _, .. } => {
+        InstructionValue::JsxFragment { .. } => {
             effects.push(AliasingEffect::Create {
                 into: lvalue.clone(),
                 value: ValueKind::Frozen,
@@ -2164,7 +2164,7 @@ fn compute_signature_for_instruction(
                 reason: ValueReason::Other,
             });
         }
-        InstructionValue::StoreGlobal { name, value: sg_value, span: _, .. } => {
+        InstructionValue::StoreGlobal { name, value: sg_value, .. } => {
             let variable = format!("`{}`", name);
             let diagnostic = ErrorCategory::Globals
                 .diagnostic("Cannot reassign variables declared outside of the component/hook")

--- a/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
@@ -1100,7 +1100,7 @@ fn get_assumed_invoked_functions_impl(
         changed = false;
         // Two-phase: collect then insert
         let mut to_add = Vec::new();
-        for (_, (func_id, may_invoke)) in temporaries.iter() {
+        for (func_id, may_invoke) in temporaries.values() {
             if hoistable.contains(func_id) {
                 for &called in may_invoke {
                     if !hoistable.contains(&called) {

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
@@ -474,10 +474,7 @@ fn evaluate_instruction<'a>(
                 // No subexpressions: join all cooked quasis
                 let mut result_string = String::new();
                 for q in quasis {
-                    match &q.cooked {
-                        Some(cooked) => result_string.push_str(cooked),
-                        None => return None,
-                    }
+                    result_string.push_str(q.cooked.as_ref()?);
                 }
                 let span = *span;
                 let result = Constant::Primitive {
@@ -519,10 +516,7 @@ fn evaluate_instruction<'a>(
                     PrimitiveValue::Undefined => return None,
                 };
 
-                let suffix = match &quasis[quasi_index].cooked {
-                    Some(s) => s.clone(),
-                    None => return None,
-                };
+                let suffix = quasis[quasi_index].cooked.clone()?;
                 quasi_index += 1;
 
                 result_string.push_str(&expression_str);

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_exhaustive_dependencies.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_exhaustive_dependencies.rs
@@ -1243,7 +1243,7 @@ fn validate_dependencies(
                 }
                 continue;
             }
-            InferredDependency::Local { identifier, path, span: _, .. } => {
+            InferredDependency::Local { identifier, path, .. } => {
                 // Skip effect event functions
                 let ty = get_identifier_type(*identifier, identifiers, types);
                 if is_effect_event_function_type(ty) {


### PR DESCRIPTION
Remove three clippy lint allows from `oxc_react_compiler` and fix the six spots that triggered them:

- `unneeded_wildcard_pattern` (3): drop redundant `children: _` / `span: _` fields next to `..` in match patterns
- `for_kv_map` (1): iterate `temporaries.values()` instead of discarding the key from `iter()`
- `question_mark` (2): replace `match`-with-`return None` arms with `?` in `constant_propagation.rs` (same early-return semantics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)