### PR TITLE
chore(ci): use CARGO_BUILD_WARNINGS=deny instead of clippy `-D warnings`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -479,6 +479,8 @@ jobs:
   lint:
     name: Lint
     runs-on: namespace-profile-linux-x64-default
+    env:
+      CARGO_BUILD_WARNINGS: deny
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
       - uses: oxc-project/setup-node@4c588e9266bd930b6ddc34307df0659ed511d187 # v1.3.1
@@ -489,15 +491,15 @@ jobs:
             rust
             pnpm
       - run: rustup component add clippy
-      - run: cargo lint -- -D warnings
+      - run: cargo lint
       # Catch lints which only fire with `debug_assertions` off (i.e. release mode),
       # e.g. code becoming unused when a `#[cfg(debug_assertions)]` block vanishes.
       # Main-only and without `--all-targets`: these failures are rare and a post-merge
       # failure pinpoints the culprit commit, so not worth doubling clippy time on every PR.
       # `--all-targets` is omitted because test/bench code is never built in release mode
-      # with `-D warnings`.
+      # with warnings denied.
       - if: ${{ github.ref_name == 'main' }}
-        run: cargo clippy --all-features --profile dev-no-debug-assertions -- -D warnings
+        run: cargo clippy --all-features --profile dev-no-debug-assertions
       - run: pnpm --filter oxlint-app build-js
       - run: pnpm --filter oxfmt-app build-js
       - run: node --run lint

--- a/justfile
+++ b/justfile
@@ -55,8 +55,8 @@ test:
   cargo test --all-features
 
 # Lint the whole project
-lint:
-  cargo lint -- --deny warnings
+lint $CARGO_BUILD_WARNINGS="deny":
+  cargo lint
 
 # Format all files
 fmt:


### PR DESCRIPTION
Rust 1.97 stabilized [`build.warnings`](https://blog.rust-lang.org/2026/07/09/Rust-1.97.0/#cargo-support-for-denying-warnings) / `CARGO_BUILD_WARNINGS`, which denies warnings at the cargo level instead of via clippy args.

Unlike `-D warnings`, the env var is not part of the build fingerprint, so `just lint`, plain `cargo lint`, and rust-analyzer now share one check cache instead of re-linting the workspace whenever the flags alternate. Cached warnings are still replayed and denied, so warm caches leave no enforcement hole.

Verified on cargo 1.97: clippy-only lints are denied (exit 101) despite the cargo reference only mentioning "rustc lints", and denial fires from a fully cached run. The justfile recipe exports the variable via a just parameter (cross-platform, and overridable with `just lint warn`).

rustdoc keeps `RUSTDOCFLAGS='-D warnings'` — `build.warnings` does not cover rustdoc lints.