### PR TITLE
refactor(react_compiler): remove CompilerError, use OxcDiagnostic and Diagnostics directly

### DIFF
--- a/crates/oxc_react_compiler/src/diagnostics.rs
+++ b/crates/oxc_react_compiler/src/diagnostics.rs
@@ -6,11 +6,14 @@
 //! Compiler diagnostics, built directly on [`oxc_diagnostics`].
 //!
 //! Passes construct [`OxcDiagnostic`]s eagerly via [`ErrorCategory::diagnostic`],
-//! whose deterministic `[ReactCompiler] <Category>: ` message prefix lets the
-//! aggregate [`CompilerError`] recover the category for control flow
-//! (Invariant/Config checks, panic-threshold severity) without a parallel data
-//! model. No other field encodes compiler state, so consumers see plain
-//! `OxcDiagnostic`s.
+//! whose deterministic `[ReactCompiler] <Category>: ` message prefix lets
+//! consumers recover the category for control flow (Invariant/Config checks,
+//! panic-threshold severity) without a parallel data model.
+//!
+//! Errors "thrown" by a pass (TS: exceptions escaping a pass) propagate as a
+//! single `Err(OxcDiagnostic)`; errors accumulated on the Environment and
+//! returned at the end of the pipeline travel as
+//! [`Diagnostics`](oxc_diagnostics::Diagnostics).
 
 use oxc_diagnostics::{OxcDiagnostic, Severity};
 use oxc_span::Span;
@@ -76,7 +79,7 @@ impl ErrorCategory {
 
     /// Displayed severity, matching the TS compiler's `getRuleForCategory()`.
     /// `PreserveManualMemo` displays as an error but does not count towards
-    /// `panicThreshold: critical_errors` (see [`CompilerError::has_errors`]).
+    /// `panicThreshold: critical_errors` (see [`has_critical_errors`]).
     const fn severity(self) -> Severity {
         match self {
             Self::IncompatibleLibrary | Self::UnsupportedSyntax | Self::Todo => Severity::Warning,
@@ -108,114 +111,39 @@ impl ErrorCategory {
     }
 }
 
-/// Aggregate compiler error: the diagnostics of one failed compilation attempt.
-/// This is the main error type returned by pipeline passes.
-#[derive(Debug, Clone)]
-pub struct CompilerError {
-    pub diagnostics: Vec<OxcDiagnostic>,
-    /// When false, this error was accumulated on the Environment via
-    /// `record_error()` / `record_diagnostic()` and returned at the end
-    /// of the pipeline. In TS, `CompileUnexpectedThrow` is only emitted
-    /// for errors that are **thrown** (not accumulated). Defaults to `true`
-    /// because errors created directly (e.g., via `?` from a pass) are
-    /// analogous to thrown errors in the TS code.
-    pub is_thrown: bool,
+/// Whether any diagnostic is an error at the TS compiler's *internal*
+/// severity, which decides `panicThreshold: critical_errors`. Internal and
+/// displayed severity agree except for `PreserveManualMemo`, which displays
+/// as an error but is internally a warning (it must not trigger the panic
+/// threshold).
+pub fn has_critical_errors(diagnostics: &[OxcDiagnostic]) -> bool {
+    diagnostics
+        .iter()
+        .any(|d| d.severity == Severity::Error && !ErrorCategory::PreserveManualMemo.matches(d))
 }
 
-impl CompilerError {
-    pub fn new() -> Self {
-        Self { diagnostics: Vec::new(), is_thrown: true }
+/// Format a thrown diagnostic as a string matching the TS
+/// `CompilerError.toString()` output, used for the `data` field of
+/// `CompileUnexpectedThrow` events: `"<Heading>: <reason>. <description>."`.
+/// The reason is the message minus the deterministic prefix added by
+/// [`ErrorCategory::diagnostic`].
+pub fn to_string_for_event(diagnostic: &OxcDiagnostic) -> String {
+    let category = ErrorCategory::of(diagnostic);
+    let heading = match category {
+        Some("IncompatibleLibrary" | "PreserveManualMemo" | "UnsupportedSyntax") => {
+            "Compilation Skipped"
+        }
+        Some(heading @ ("Invariant" | "Todo")) => heading,
+        _ => "Error",
+    };
+    let reason = category
+        .and_then(|c| diagnostic.message.strip_prefix(&format!("[ReactCompiler] {c}: ")))
+        .unwrap_or(&diagnostic.message);
+    let mut buf = format!("{heading}: {reason}");
+    if let Some(help) = &diagnostic.help {
+        buf.push_str(&format!(". {help}."));
     }
-
-    pub fn push(&mut self, diagnostic: OxcDiagnostic) {
-        self.diagnostics.push(diagnostic);
-    }
-
-    pub fn merge(&mut self, other: CompilerError) {
-        self.diagnostics.extend(other.diagnostics);
-    }
-
-    /// Whether any diagnostic is an error at the TS compiler's *internal*
-    /// severity, which decides `panicThreshold: critical_errors`. Internal and
-    /// displayed severity agree except for `PreserveManualMemo`, which displays
-    /// as an error but is internally a warning (it must not trigger the panic
-    /// threshold).
-    pub fn has_errors(&self) -> bool {
-        self.diagnostics
-            .iter()
-            .any(|d| d.severity == Severity::Error && !ErrorCategory::PreserveManualMemo.matches(d))
-    }
-
-    pub fn has_any_errors(&self) -> bool {
-        !self.diagnostics.is_empty()
-    }
-
-    pub fn has_invariant_errors(&self) -> bool {
-        self.diagnostics.iter().any(|d| ErrorCategory::Invariant.matches(d))
-    }
-
-    /// In TS, this is used to determine if an error thrown during compilation
-    /// should be logged as CompileUnexpectedThrow.
-    pub fn is_all_non_invariant(&self) -> bool {
-        !self.diagnostics.iter().any(|d| ErrorCategory::Invariant.matches(d))
-    }
-
-    /// Format as a string matching the TS `CompilerError.toString()` output,
-    /// used for the `data` field of `CompileUnexpectedThrow` events:
-    /// `"<Heading>: <reason>. <description>."` per diagnostic, joined by `"\n\n"`.
-    /// The reason is the message minus the deterministic prefix added by
-    /// [`ErrorCategory::diagnostic`].
-    pub fn to_string_for_event(&self) -> String {
-        self.diagnostics
-            .iter()
-            .map(|d| {
-                let category = ErrorCategory::of(d);
-                let heading = match category {
-                    Some("IncompatibleLibrary" | "PreserveManualMemo" | "UnsupportedSyntax") => {
-                        "Compilation Skipped"
-                    }
-                    Some(heading @ ("Invariant" | "Todo")) => heading,
-                    _ => "Error",
-                };
-                let reason = category
-                    .and_then(|c| d.message.strip_prefix(&format!("[ReactCompiler] {c}: ")))
-                    .unwrap_or(&d.message);
-                let mut buf = format!("{heading}: {reason}");
-                if let Some(help) = &d.help {
-                    buf.push_str(&format!(". {help}."));
-                }
-                buf
-            })
-            .collect::<Vec<_>>()
-            .join("\n\n")
-    }
-}
-
-impl Default for CompilerError {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl From<OxcDiagnostic> for CompilerError {
-    fn from(diagnostic: OxcDiagnostic) -> Self {
-        let mut error = CompilerError::new();
-        error.push(diagnostic);
-        error
-    }
-}
-
-/// Allow `?` to convert a `CompilerError` into an `OxcDiagnostic` when the
-/// enclosing function returns `Result<T, OxcDiagnostic>`. This typically happens
-/// when `record_error()` returns `Err(CompilerError)` for an Invariant error;
-/// the conversion extracts the first diagnostic from the aggregate error.
-impl From<CompilerError> for OxcDiagnostic {
-    fn from(err: CompilerError) -> Self {
-        err.diagnostics
-            .into_iter()
-            .next()
-            .unwrap_or_else(|| ErrorCategory::Invariant.diagnostic("Unknown compiler error"))
-    }
+    buf
 }
 
 /// Owned copy of a diagnostic for the log accumulator, labelling the enclosing

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
@@ -8,7 +8,10 @@
 //! Analogous to TS `Pipeline.ts` (`compileFn` → `run` → `runWithEnvironment`).
 //! Currently runs BuildHIR (lowering) and PruneMaybeThrows.
 
-use crate::diagnostics::{CompilerError, ErrorCategory};
+use oxc_diagnostics::{Diagnostics, OxcDiagnostic};
+use oxc_span::Span;
+
+use crate::diagnostics::{ErrorCategory, to_string_for_event};
 use crate::react_compiler_hir::ReactFunctionType;
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::environment::OutputMode;
@@ -86,9 +89,10 @@ use crate::options::CompilerOutputMode;
 
 /// Run the compilation pipeline on a single function.
 ///
-/// Currently: creates an Environment, runs BuildHIR (lowering), and produces
-/// debug output via the context. Returns a CodegenFunction with zeroed memo
-/// stats on success (codegen is not yet implemented).
+/// On failure, returns the diagnostics of the failed compilation attempt.
+/// An error thrown by a pass (in TS: an exception escaping the pass) that is
+/// not an Invariant additionally surfaces a `CompileUnexpectedThrow`
+/// diagnostic, matching TS `tryCompileFunction`'s catch block.
 #[allow(clippy::too_many_arguments)]
 pub fn compile_fn<'a>(
     ast: &oxc_ast::builder::AstBuilder<'a>,
@@ -98,7 +102,42 @@ pub fn compile_fn<'a>(
     mode: CompilerOutputMode,
     env_config: &EnvironmentConfig,
     context: &mut ProgramContext,
-) -> Result<Option<CodegenFunction<'a>>, CompilerError> {
+    fn_span: Option<Span>,
+) -> Result<Option<CodegenFunction<'a>>, Diagnostics> {
+    match run_pipeline(ast, func, scope, fn_type, mode, env_config, context) {
+        Ok(result) => result,
+        Err(thrown) => {
+            if !ErrorCategory::Invariant.matches(&thrown) {
+                let mut diagnostic = OxcDiagnostic::error(format!(
+                    "[ReactCompiler] Unexpected error: {}",
+                    to_string_for_event(&thrown)
+                ));
+                if let Some(span) = fn_span {
+                    diagnostic = diagnostic.with_label(span);
+                }
+                context.diagnostics.push(diagnostic);
+            }
+            Err(Diagnostics::from(thrown))
+        }
+    }
+}
+
+/// The pass pipeline: creates an Environment, runs BuildHIR (lowering), the
+/// HIR/reactive-scope passes, and codegen.
+///
+/// `Err(OxcDiagnostic)` is an error thrown by a pass (a TS exception);
+/// Invariant and end-of-pipeline accumulated errors return as
+/// `Ok(Err(diagnostics))` since they must not surface `CompileUnexpectedThrow`.
+#[allow(clippy::too_many_arguments)]
+fn run_pipeline<'a>(
+    ast: &oxc_ast::builder::AstBuilder<'a>,
+    func: &FunctionNode<'_>,
+    scope: &ScopeResolver<'_, '_>,
+    fn_type: ReactFunctionType,
+    mode: CompilerOutputMode,
+    env_config: &EnvironmentConfig,
+    context: &mut ProgramContext,
+) -> Result<Result<Option<CodegenFunction<'a>>, Diagnostics>, OxcDiagnostic> {
     let mut env = Environment::with_config(env_config.clone());
     env.fn_type = fn_type;
     env.output_mode = match mode {
@@ -120,14 +159,14 @@ pub fn compile_fn<'a>(
     // the HIR entry is logged. The thrown error contains ONLY the Invariant error,
     // not other recorded (non-Invariant) errors.
     if env.has_invariant_errors() {
-        return Err(env.take_invariant_errors());
+        return Ok(Err(env.take_invariant_errors()));
     }
 
     // Lowering flags this when the function uses `using`/`await using`, whose disposal
     // semantics aren't preserved yet. Skip compiling it silently — no diagnostic — so
     // other functions in the file still compile.
     if env.skip_compilation {
-        return Ok(None);
+        return Ok(Ok(None));
     }
 
     prune_maybe_throws(&mut hir, &mut env.functions)?;
@@ -171,7 +210,7 @@ pub fn compile_fn<'a>(
     analyse_functions(&mut hir, &mut env, &mut |_inner_func, _inner_env| {})?;
 
     if env.has_invariant_errors() {
-        return Err(env.take_invariant_errors());
+        return Ok(Err(env.take_invariant_errors()));
     }
 
     infer_mutation_aliasing_effects(&mut hir, &mut env, false)?;
@@ -336,7 +375,7 @@ pub fn compile_fn<'a>(
 
     // Simulate unexpected exception for testing (matches TS Pipeline.ts)
     if env.config.throw_unknown_exception_testonly {
-        return Err(CompilerError::from(ErrorCategory::Invariant.diagnostic("unexpected error")));
+        return Err(ErrorCategory::Invariant.diagnostic("unexpected error"));
     }
 
     // Check for accumulated errors at the end of the pipeline
@@ -350,7 +389,7 @@ pub fn compile_fn<'a>(
         if let Some(uid_names) = env.take_uid_known_names() {
             context.merge_uid_known_names(&uid_names);
         }
-        return Err(env.take_errors());
+        return Ok(Err(env.take_errors()));
     }
 
     // Re-compile outlined functions through the full pipeline.
@@ -392,7 +431,7 @@ pub fn compile_fn<'a>(
         context.merge_uid_known_names(&uid_names);
     }
 
-    Ok(Some(CodegenFunction {
+    Ok(Ok(Some(CodegenFunction {
         span: codegen_result.span,
         id: codegen_result.id,
         name_hint: codegen_result.name_hint,
@@ -406,7 +445,7 @@ pub fn compile_fn<'a>(
         pruned_memo_blocks: codegen_result.pruned_memo_blocks,
         pruned_memo_values: codegen_result.pruned_memo_values,
         outlined: compiled_outlined,
-    }))
+    })))
 }
 
 /// Compile an outlined function's codegen AST through the full pipeline.
@@ -417,12 +456,12 @@ pub fn compile_fn<'a>(
 /// functions are inserted into the program AST and re-compiled from scratch.
 pub fn compile_outlined_fn<'a>(
     codegen_fn: CodegenFunction<'a>,
-) -> Result<CodegenFunction<'a>, CompilerError> {
+) -> Result<CodegenFunction<'a>, OxcDiagnostic> {
     Ok(codegen_fn)
 }
 
-/// Push a compiler error's diagnostics (validation / lint / telemetry path),
+/// Push a pass's diagnostics (validation / lint / telemetry path),
 /// matching TS `env.logErrors()`. No enclosing-function fallback label.
-fn log_errors_as_events(errors: &CompilerError, context: &mut ProgramContext) {
-    context.diagnostics.extend(errors.diagnostics.iter().cloned());
+fn log_errors_as_events(errors: &Diagnostics, context: &mut ProgramContext) {
+    context.diagnostics.extend(errors.iter().cloned());
 }

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -20,7 +20,7 @@ use oxc_diagnostics::{Diagnostics, OxcDiagnostic};
 use oxc_span::{GetSpan, SPAN, Span};
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use crate::diagnostics::{CompilerError, ErrorCategory, with_fallback_label};
+use crate::diagnostics::{ErrorCategory, has_critical_errors, with_fallback_label};
 use crate::react_compiler_hir::ReactFunctionType;
 use crate::react_compiler_hir::environment_config::EnvironmentConfig;
 use crate::react_compiler_lowering::FunctionNode;
@@ -37,7 +37,7 @@ use super::pipeline;
 use super::suppression::SuppressionRange;
 use super::suppression::filter_suppressions_that_affect_function;
 use super::suppression::find_program_suppressions;
-use super::suppression::suppressions_to_compiler_error;
+use super::suppression::suppressions_to_diagnostics;
 use crate::options::{
     CompilationMode, CompilerOutputMode, GatingConfig, PanicThreshold, PluginOptions,
 };
@@ -94,7 +94,7 @@ enum CompileSourceKind {
 fn try_find_directive_enabling_memoization<'a>(
     directives: &'a [String],
     opts: &PluginOptions,
-) -> Result<Option<&'a str>, CompilerError> {
+) -> Result<Option<&'a str>, Diagnostics> {
     // Check standard opt-in directives
     let opt_in = directives.iter().find(|d| OPT_IN_DIRECTIVES.contains(&d.as_str()));
     if let Some(directive) = opt_in {
@@ -132,13 +132,13 @@ struct DynamicGatingResult<'a> {
 fn find_directives_dynamic_gating<'a>(
     directives: &'a [String],
     opts: &PluginOptions,
-) -> Result<Option<DynamicGatingResult<'a>>, CompilerError> {
+) -> Result<Option<DynamicGatingResult<'a>>, Diagnostics> {
     let dynamic_gating = match &opts.dynamic_gating {
         Some(dg) => dg,
         None => return Ok(None),
     };
 
-    let mut errors = CompilerError::new();
+    let mut errors = Diagnostics::new();
     let mut matches: Vec<(&'a str, String)> = Vec::new();
 
     for directive in directives {
@@ -155,13 +155,13 @@ fn find_directives_dynamic_gating<'a>(
         }
     }
 
-    if errors.has_any_errors() {
+    if !errors.is_empty() {
         return Err(errors);
     }
 
     if matches.len() > 1 {
         let names: Vec<&str> = matches.iter().map(|(d, _)| *d).collect();
-        return Err(CompilerError::from(
+        return Err(Diagnostics::from(
             ErrorCategory::Gating
                 .diagnostic("Multiple dynamic gating directives found")
                 .with_help(format!("Expected a single directive but found [{}]", names.join(", "))),
@@ -1078,16 +1078,13 @@ fn get_callee_name_if_react_api<'e>(callee: &'e oxc::Expression) -> Option<&'e s
 // Error handling
 // -----------------------------------------------------------------------
 
-/// Push a compiler error's diagnostics onto the accumulator.
-fn log_error(err: &CompilerError, fn_span: Option<Span>, diagnostics: &mut Diagnostics) {
+/// Push a failed compilation attempt's diagnostics onto the accumulator.
+fn log_error(err: &Diagnostics, fn_span: Option<Span>, diagnostics: &mut Diagnostics) {
     // Detect simulated unknown exception (throwUnknownException__testonly). In TS,
-    // non-CompilerError exceptions surface as a pipeline error carrying the error
-    // message rather than a per-detail compiler error.
-    let is_simulated_unknown = err.diagnostics.len() == 1
-        && err
-            .diagnostics
-            .iter()
-            .all(|d| d.message == "[ReactCompiler] Invariant: unexpected error");
+    // exceptions that are not compiler errors surface as a pipeline error carrying
+    // the error message rather than a per-detail compiler error.
+    let is_simulated_unknown = err.len() == 1
+        && err.iter().all(|d| d.message == "[ReactCompiler] Invariant: unexpected error");
     if is_simulated_unknown {
         let mut diagnostic =
             OxcDiagnostic::error("[ReactCompiler] Pipeline error: Error: unexpected error");
@@ -1098,7 +1095,7 @@ fn log_error(err: &CompilerError, fn_span: Option<Span>, diagnostics: &mut Diagn
         return;
     }
 
-    for diagnostic in &err.diagnostics {
+    for diagnostic in err {
         diagnostics.push(with_fallback_label(diagnostic, fn_span));
     }
 }
@@ -1107,7 +1104,7 @@ fn log_error(err: &CompilerError, fn_span: Option<Span>, diagnostics: &mut Diagn
 /// Returns Some(CompileResult::Error) if the error should be surfaced as fatal,
 /// otherwise returns None (error was logged only).
 fn handle_error<'a>(
-    err: &CompilerError,
+    err: &Diagnostics,
     fn_span: Option<Span>,
     panic_threshold: PanicThreshold,
     diagnostics: &mut Diagnostics,
@@ -1117,12 +1114,12 @@ fn handle_error<'a>(
 
     let should_panic = match panic_threshold {
         PanicThreshold::AllErrors => true,
-        PanicThreshold::CriticalErrors => err.has_errors(),
+        PanicThreshold::CriticalErrors => has_critical_errors(err),
         PanicThreshold::None => false,
     };
 
     // Config errors always cause a panic
-    let is_config_error = err.diagnostics.iter().any(|d| ErrorCategory::Config.matches(d));
+    let is_config_error = err.iter().any(|d| ErrorCategory::Config.matches(d));
 
     if should_panic || is_config_error {
         // The per-detail diagnostics were already pushed by `log_error`; the fatal
@@ -1139,7 +1136,7 @@ fn handle_error<'a>(
 
 /// Attempt to compile a single function.
 ///
-/// Returns `CodegenFunction` on success or `CompilerError` on failure.
+/// Returns `CodegenFunction` on success or the failed attempt's diagnostics.
 /// Debug log entries are accumulated on `context.debug_logs`.
 fn try_compile_function<'a>(
     ast: &AstBuilder<'a>,
@@ -1148,17 +1145,14 @@ fn try_compile_function<'a>(
     output_mode: CompilerOutputMode,
     env_config: &EnvironmentConfig,
     context: &mut ProgramContext,
-) -> Result<Option<CodegenFunction<'a>>, CompilerError> {
-    // Check for suppressions that affect this function
+) -> Result<Option<CodegenFunction<'a>>, Diagnostics> {
+    // Check for suppressions that affect this function. Suppression errors are
+    // returned (not thrown), so they do NOT trigger CompileUnexpectedThrow.
     if let (Some(start), Some(end)) = (source.fn_start, source.fn_end) {
         let affecting = filter_suppressions_that_affect_function(&context.suppressions, start, end);
         if !affecting.is_empty() {
             let owned: Vec<SuppressionRange> = affecting.into_iter().cloned().collect();
-            let mut err = suppressions_to_compiler_error(&owned);
-            // Suppression errors are returned (not thrown), so they should NOT
-            // trigger CompileUnexpectedThrow.
-            err.is_thrown = false;
-            return Err(err);
+            return Err(suppressions_to_diagnostics(&owned));
         }
     }
 
@@ -1172,6 +1166,7 @@ fn try_compile_function<'a>(
         output_mode,
         env_config,
         context,
+        source.fn_ast_span,
     )
 }
 
@@ -1219,20 +1214,6 @@ fn process_fn<'a>(
 
     match compile_result {
         Err(err) => {
-            // Surface errors "thrown" from a pass (not accumulated via
-            // env.record_error) that have all non-Invariant details, matching TS
-            // tryCompileFunction()'s catch block.
-            if err.is_thrown && err.is_all_non_invariant() {
-                let mut diagnostic = OxcDiagnostic::error(format!(
-                    "[ReactCompiler] Unexpected error: {}",
-                    err.to_string_for_event()
-                ));
-                if let Some(span) = source.fn_ast_span {
-                    diagnostic = diagnostic.with_label(span);
-                }
-                context.diagnostics.push(diagnostic);
-            }
-
             if opt_out.is_some() {
                 // If there's an opt-out, just log the error (don't escalate)
                 log_error(&err, source.fn_ast_span, &mut context.diagnostics);
@@ -2983,7 +2964,7 @@ pub fn compile_program<'a, 'p>(
     if has_module_scope_opt_out {
         if !compiled_fns.is_empty() {
             let err =
-                CompilerError::from(ErrorCategory::Invariant.diagnostic(
+                Diagnostics::from(ErrorCategory::Invariant.diagnostic(
                     "Unexpected compiled functions when module scope opt-out is present",
                 ));
             handle_error(&err, None, context.opts.panic_threshold, &mut context.diagnostics);

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/suppression.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/suppression.rs
@@ -1,3 +1,4 @@
+use oxc_diagnostics::Diagnostics;
 /**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
@@ -6,7 +7,7 @@
  */
 use oxc_span::Span;
 
-use crate::diagnostics::{CompilerError, ErrorCategory};
+use crate::diagnostics::ErrorCategory;
 
 /// A comment's text and byte range, plus the byte-offset span that surfaces as the
 /// labeled span on a suppression diagnostic. The former Babel front-end carried
@@ -250,11 +251,11 @@ pub fn filter_suppressions_that_affect_function(
     suppressions_in_scope
 }
 
-/// Convert suppression ranges to a CompilerError.
-pub fn suppressions_to_compiler_error(suppressions: &[SuppressionRange]) -> CompilerError {
+/// Convert suppression ranges to diagnostics.
+pub fn suppressions_to_diagnostics(suppressions: &[SuppressionRange]) -> Diagnostics {
     assert!(!suppressions.is_empty(), "Expected at least one suppression comment source range");
 
-    let mut error = CompilerError::new();
+    let mut error = Diagnostics::new();
 
     for suppression in suppressions {
         let reason = match suppression.source {

--- a/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
@@ -4,9 +4,9 @@ use cow_utils::CowUtils;
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 
-use oxc_diagnostics::OxcDiagnostic;
+use oxc_diagnostics::{Diagnostics, OxcDiagnostic};
 
-use crate::diagnostics::{CompilerError, ErrorCategory};
+use crate::diagnostics::ErrorCategory;
 
 use crate::react_compiler_hir::default_module_type_provider::default_module_type_provider;
 use crate::react_compiler_hir::environment_config::EnvironmentConfig;
@@ -54,7 +54,7 @@ pub struct Environment<'a> {
     pub functions: Vec<HirFunction<'a>>,
 
     // Error accumulation
-    pub errors: CompilerError,
+    pub errors: Diagnostics,
 
     // Set during lowering when the function uses syntax the compiler can't handle
     // yet (currently `using`/`await using`, whose disposal semantics aren't
@@ -179,7 +179,7 @@ impl<'a> Environment<'a> {
             types: Vec::new(),
             scopes: Vec::new(),
             functions: Vec::new(),
-            errors: CompilerError::new(),
+            errors: Diagnostics::new(),
             skip_compilation: false,
             fn_type: ReactFunctionType::Other,
             output_mode: OutputMode::Client,
@@ -279,10 +279,10 @@ impl<'a> Environment<'a> {
         id
     }
 
-    pub fn record_error(&mut self, diagnostic: OxcDiagnostic) -> Result<(), CompilerError> {
+    pub fn record_error(&mut self, diagnostic: OxcDiagnostic) -> Result<(), OxcDiagnostic> {
         if ErrorCategory::Invariant.matches(&diagnostic) {
             self.errors.push(diagnostic.clone());
-            return Err(CompilerError::from(diagnostic));
+            return Err(diagnostic);
         }
         self.errors.push(diagnostic);
         Ok(())
@@ -293,40 +293,29 @@ impl<'a> Environment<'a> {
     }
 
     pub fn has_errors(&self) -> bool {
-        self.errors.has_any_errors()
+        !self.errors.is_empty()
     }
 
     /// Check if any recorded errors have Invariant category.
     /// In TS, Invariant errors throw immediately from recordError(),
     /// which aborts the current operation.
     pub fn has_invariant_errors(&self) -> bool {
-        self.errors.has_invariant_errors()
+        self.errors.iter().any(|d| ErrorCategory::Invariant.matches(d))
     }
 
-    pub fn take_errors(&mut self) -> CompilerError {
-        let mut errors = take(&mut self.errors);
-        // Mark as not thrown — these are accumulated errors returned at the end
-        // of the pipeline, not errors thrown by a pass.
-        errors.is_thrown = false;
-        errors
+    /// Take the accumulated errors, to be returned at the end of the pipeline.
+    pub fn take_errors(&mut self) -> Diagnostics {
+        take(&mut self.errors)
     }
 
     /// Take only the Invariant errors, leaving non-Invariant errors in place.
-    /// In TS, Invariant errors throw as a separate CompilerError, so only
-    /// the Invariant error is surfaced.
-    pub fn take_invariant_errors(&mut self) -> CompilerError {
-        let mut invariant = CompilerError::new();
-        let mut remaining = CompilerError::new();
-        let old = take(&mut self.errors);
-        for diagnostic in old.diagnostics {
-            if ErrorCategory::Invariant.matches(&diagnostic) {
-                invariant.push(diagnostic);
-            } else {
-                remaining.push(diagnostic);
-            }
-        }
-        self.errors = remaining;
-        invariant
+    /// In TS, Invariant errors throw as a separate error, so only the
+    /// Invariant error is surfaced.
+    pub fn take_invariant_errors(&mut self) -> Diagnostics {
+        let (invariant, remaining): (Vec<_>, Vec<_>) =
+            take(&mut self.errors).into_iter().partition(|d| ErrorCategory::Invariant.matches(d));
+        self.errors = remaining.into();
+        invariant.into()
     }
 
     /// Check if a binding has been hoisted (via DeclareContext) already.
@@ -351,7 +340,7 @@ impl<'a> Environment<'a> {
         &mut self,
         binding: &NonLocalBinding,
         span: Option<Span>,
-    ) -> Result<Option<Global>, CompilerError> {
+    ) -> Result<Option<Global>, OxcDiagnostic> {
         match binding {
             NonLocalBinding::ModuleLocal { name, .. } => {
                 if is_hook_name(name) {

--- a/crates/oxc_react_compiler/src/react_compiler_inference/align_object_method_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/align_object_method_scopes.rs
@@ -51,7 +51,7 @@ fn find_scopes_to_merge(func: &HirFunction, env: &Environment) -> DisjointSet<Sc
                             let lvalue_scope =
                                 env.identifiers[instr.lvalue.identifier.0 as usize].scope;
 
-                            // TS: CompilerError.invariant(operandScope != null && lvalueScope != null, ...)
+                            // TS: Diagnostics.invariant(operandScope != null && lvalueScope != null, ...)
                             let operand_sid = operand_scope.expect(
                                 "Internal error: Expected all ObjectExpressions and ObjectMethods to have non-null scope.",
                             );

--- a/crates/oxc_react_compiler/src/react_compiler_inference/analyse_functions.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/analyse_functions.rs
@@ -131,7 +131,7 @@ where
 
     // rewriteInstructionKindsBasedOnReassignment
     if let Err(err) = rewrite_instruction_kinds_based_on_reassignment(func, env) {
-        env.errors.merge(err);
+        env.errors.push(err);
         return Ok(());
     }
 

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_ranges.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_ranges.rs
@@ -645,7 +645,7 @@ pub fn infer_mutation_aliasing_ranges(
                         // Expected for MaybeThrow terminals, skip
                     }
                     _ => {
-                        // TS: CompilerError.invariant(effect.kind === 'Freeze', ...)
+                        // TS: Diagnostics.invariant(effect.kind === 'Freeze', ...)
                         // We skip non-Alias, non-Freeze effects
                     }
                 }

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -1,7 +1,6 @@
 use cow_utils::CowUtils;
 use rustc_hash::FxHashSet;
 
-use crate::diagnostics::CompilerError;
 use crate::diagnostics::ErrorCategory;
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::*;
@@ -29,12 +28,12 @@ use crate::react_compiler_lowering::identifier_loc_index::build_identifier_loc_i
 fn validate_ts_this_parameter(
     scope: &ScopeResolver<'_, '_>,
     function_scope: ScopeId,
-) -> Result<(), CompilerError> {
+) -> Result<(), OxcDiagnostic> {
     let Some(symbol_id) = scope.get_binding(function_scope, "this") else {
         return Ok(());
     };
     if matches!(scope.binding_kind(symbol_id), AstBindingKind::Param) {
-        return Err(CompilerError::from(reserved_identifier_diagnostic("this")));
+        return Err(reserved_identifier_diagnostic("this"));
     }
     Ok(())
 }
@@ -47,7 +46,7 @@ fn validate_ts_this_parameters_in_function_range(
     scope: &ScopeResolver<'_, '_>,
     start: u32,
     end: u32,
-) -> Result<(), CompilerError> {
+) -> Result<(), OxcDiagnostic> {
     if start >= end {
         return Ok(());
     }
@@ -81,7 +80,7 @@ fn promote_temporary(builder: &mut HirBuilder<'_, '_>, identifier_id: Identifier
 fn lower_value_to_temporary<'a>(
     builder: &mut HirBuilder<'a, '_>,
     value: InstructionValue<'a>,
-) -> Result<Place, CompilerError> {
+) -> Result<Place, OxcDiagnostic> {
     // Optimization: if loading an unnamed temporary, skip creating a new instruction
     if let InstructionValue::LoadLocal { ref place, .. } = value {
         let ident = &builder.environment().identifiers[place.identifier.0 as usize];
@@ -104,7 +103,7 @@ fn lower_value_to_temporary<'a>(
 fn lower_expression_to_temporary<'a>(
     builder: &mut HirBuilder<'a, '_>,
     expr: &'a oxc::Expression<'a>,
-) -> Result<Place, CompilerError> {
+) -> Result<Place, OxcDiagnostic> {
     let value = lower_expression(builder, expr)?;
     lower_value_to_temporary(builder, value)
 }
@@ -197,7 +196,7 @@ fn lower_block_statement<'a>(
     statements: &'a [oxc::Statement<'a>],
     block_scope: Option<ScopeId>,
     parent_scope: Option<ScopeId>,
-) -> Result<(), CompilerError> {
+) -> Result<(), OxcDiagnostic> {
     let _ = lower_block_statement_inner(builder, statements, block_scope, None, parent_scope);
     Ok(())
 }
@@ -206,7 +205,7 @@ fn lower_block_statement_with_scope<'a>(
     builder: &mut HirBuilder<'a, '_>,
     statements: &'a [oxc::Statement<'a>],
     scope_override: ScopeId,
-) -> Result<(), CompilerError> {
+) -> Result<(), OxcDiagnostic> {
     let _ = lower_block_statement_inner(builder, statements, None, Some(scope_override), None);
     Ok(())
 }
@@ -525,7 +524,7 @@ enum FunctionBody<'a> {
 
 type LowerInnerResult<'a> = Result<
     (HirFunction<'a>, FxIndexMap<String, SymbolId>, FxIndexMap<SymbolId, IdentifierId>),
-    CompilerError,
+    OxcDiagnostic,
 >;
 
 /// Main entry point: lower a function AST node into HIR.
@@ -535,7 +534,7 @@ pub fn lower<'a>(
     func: &'a FunctionNode<'a>,
     scope: &ScopeResolver<'_, 'a>,
     env: &mut Environment<'a>,
-) -> Result<HirFunction<'a>, CompilerError> {
+) -> Result<HirFunction<'a>, OxcDiagnostic> {
     // Extract params, body, generator, is_async, span, scope_id, and the AST function's own id
     // Note: `id` param may include inferred names (e.g., from `const Foo = () => {}`),
     // but the HIR function's `id` field should only include the function's own AST id
@@ -671,9 +670,7 @@ fn lower_inner<'a>(
             && let oxc::BindingPattern::BindingIdentifier(ident) = &param.pattern
         {
             if is_always_reserved_word(ident.name.as_str()) {
-                return Err(CompilerError::from(reserved_identifier_diagnostic(
-                    ident.name.as_str(),
-                )));
+                return Err(reserved_identifier_diagnostic(ident.name.as_str()));
             }
             let param_span = builder.source_location(ident.span);
             let mut binding = builder.resolve_identifier(
@@ -855,7 +852,7 @@ fn lower_identifier(
     name: &str,
     span: Option<Span>,
     symbol: Option<SymbolId>,
-) -> Result<Place, CompilerError> {
+) -> Result<Place, OxcDiagnostic> {
     let binding = builder.resolve_identifier(name, span, symbol)?;
     match binding {
         VariableBinding::Identifier { identifier, .. } => {
@@ -949,7 +946,7 @@ struct LoweredMemberExpression<'a> {
 fn lower_member_expression<'a>(
     builder: &mut HirBuilder<'a, '_>,
     member: &'a oxc::MemberExpression<'a>,
-) -> Result<LoweredMemberExpression<'a>, CompilerError> {
+) -> Result<LoweredMemberExpression<'a>, OxcDiagnostic> {
     lower_member_expression_impl(builder, member, None)
 }
 
@@ -957,7 +954,7 @@ fn lower_member_expression_impl<'a>(
     builder: &mut HirBuilder<'a, '_>,
     member: &'a oxc::MemberExpression<'a>,
     lowered_object: Option<Place>,
-) -> Result<LoweredMemberExpression<'a>, CompilerError> {
+) -> Result<LoweredMemberExpression<'a>, OxcDiagnostic> {
     match member {
         oxc::MemberExpression::StaticMemberExpression(m) => {
             let span = builder.source_location(m.span);
@@ -1042,7 +1039,7 @@ fn template_quasi_from_oxc(q: &oxc::TemplateElement) -> TemplateQuasi {
 fn lower_import_keyword_to_temporary(
     builder: &mut HirBuilder<'_, '_>,
     span: &Option<Span>,
-) -> Result<Place, CompilerError> {
+) -> Result<Place, OxcDiagnostic> {
     builder.record_error(
         ErrorCategory::Todo
             .diagnostic("(BuildHIR::lowerExpression) Handle Import expressions")
@@ -1060,7 +1057,7 @@ fn lower_import_keyword_to_temporary(
 fn lower_private_name_to_temporary(
     builder: &mut HirBuilder<'_, '_>,
     span: oxc_span::Span,
-) -> Result<Place, CompilerError> {
+) -> Result<Place, OxcDiagnostic> {
     let span = builder.source_location(span);
     builder.record_error(
         ErrorCategory::Todo
@@ -1118,7 +1115,7 @@ fn lower_type_cast_expression<'a>(
     expression: &'a oxc::Expression<'a>,
     type_annotation: &'a oxc::TSType<'a>,
     type_annotation_kind: &str,
-) -> Result<InstructionValue<'a>, CompilerError> {
+) -> Result<InstructionValue<'a>, OxcDiagnostic> {
     let span = builder.source_location(span);
     let value = lower_expression_to_temporary(builder, expression)?;
     // `lower_ts_type` allocates a type var (via `make_type`); keep the call for
@@ -1138,7 +1135,7 @@ fn lower_type_cast_expression<'a>(
 fn lower_member_expression_from_simple_target<'a>(
     builder: &mut HirBuilder<'a, '_>,
     target: &'a oxc::SimpleAssignmentTarget<'a>,
-) -> Result<LoweredMemberExpression<'a>, CompilerError> {
+) -> Result<LoweredMemberExpression<'a>, OxcDiagnostic> {
     match target {
         oxc::SimpleAssignmentTarget::StaticMemberExpression(m) => {
             let span = builder.source_location(m.span);
@@ -1206,7 +1203,7 @@ fn lower_member_expression_from_simple_target<'a>(
 fn lower_arguments<'a>(
     builder: &mut HirBuilder<'a, '_>,
     args: &'a [oxc::Argument<'a>],
-) -> Result<Vec<PlaceOrSpread>, CompilerError> {
+) -> Result<Vec<PlaceOrSpread>, OxcDiagnostic> {
     let mut result = Vec::new();
     for arg in args {
         match arg {
@@ -1239,7 +1236,7 @@ fn lower_identifier_for_assignment(
     kind: InstructionKind,
     name: &str,
     symbol: Option<SymbolId>,
-) -> Result<Option<IdentifierForAssignment>, CompilerError> {
+) -> Result<Option<IdentifierForAssignment>, OxcDiagnostic> {
     let mut binding = builder.resolve_identifier(name, ident_span, symbol)?;
     if !matches!(binding, VariableBinding::Identifier { .. }) && kind != InstructionKind::Reassign {
         if let Some(symbol_id) =
@@ -1323,7 +1320,7 @@ fn lower_binding_assignment<'a>(
     target: &'a oxc::BindingPattern<'a>,
     value: Place,
     assignment_style: AssignmentStyle,
-) -> Result<Option<Place>, CompilerError> {
+) -> Result<Option<Place>, OxcDiagnostic> {
     match target {
         oxc::BindingPattern::BindingIdentifier(id) => {
             let id_span = builder.source_location(id.span);
@@ -1705,7 +1702,7 @@ fn lower_default_to_temp<'a>(
     pat_span: Option<Span>,
     default: &'a oxc::Expression<'a>,
     value: Place,
-) -> Result<Place, CompilerError> {
+) -> Result<Place, OxcDiagnostic> {
     let temp = build_temporary_place(builder, pat_span);
 
     let test_block = builder.reserve(BlockKind::Value);
@@ -1800,7 +1797,7 @@ fn lower_member_assignment_target<'a>(
     kind: InstructionKind,
     target: &'a oxc::SimpleAssignmentTarget<'a>,
     value: Place,
-) -> Result<Option<Place>, CompilerError> {
+) -> Result<Option<Place>, OxcDiagnostic> {
     // MemberExpression may only appear in an assignment expression (Reassign).
     if kind != InstructionKind::Reassign {
         builder.record_error(
@@ -1872,7 +1869,7 @@ fn lower_member_assignment_target<'a>(
 fn assignment_target_is_local_identifier(
     builder: &mut HirBuilder<'_, '_>,
     maybe: &oxc::AssignmentTargetMaybeDefault,
-) -> Result<bool, CompilerError> {
+) -> Result<bool, OxcDiagnostic> {
     match maybe {
         oxc::AssignmentTargetMaybeDefault::AssignmentTargetIdentifier(id) => {
             if builder.is_context_identifier(builder.scope().resolve_reference(id)) {
@@ -1900,7 +1897,7 @@ fn lower_assignment_target<'a>(
     target: &'a oxc::AssignmentTarget<'a>,
     value: Place,
     assignment_style: AssignmentStyle,
-) -> Result<Option<Place>, CompilerError> {
+) -> Result<Option<Place>, OxcDiagnostic> {
     match target {
         oxc::AssignmentTarget::AssignmentTargetIdentifier(id) => {
             let id_span = builder.source_location(id.span);
@@ -2459,7 +2456,7 @@ fn lower_identifier_followup_store(
     kind: InstructionKind,
     id: &oxc::IdentifierReference,
     value: Place,
-) -> Result<Option<Place>, CompilerError> {
+) -> Result<Option<Place>, OxcDiagnostic> {
     let id_span = builder.source_location(id.span);
     let result = lower_identifier_for_assignment(
         builder,
@@ -2505,7 +2502,7 @@ fn lower_followup_target<'a>(
     target: FollowupTarget<'a>,
     value: Place,
     assignment_style: AssignmentStyle,
-) -> Result<Option<Place>, CompilerError> {
+) -> Result<Option<Place>, OxcDiagnostic> {
     match target {
         FollowupTarget::Target(t) => {
             let followup_span = builder.source_location(t.span()).or(span);
@@ -2540,7 +2537,7 @@ fn lower_assignment_target_maybe_default<'a>(
     maybe: &'a oxc::AssignmentTargetMaybeDefault<'a>,
     value: Place,
     assignment_style: AssignmentStyle,
-) -> Result<Option<Place>, CompilerError> {
+) -> Result<Option<Place>, OxcDiagnostic> {
     match maybe {
         oxc::AssignmentTargetMaybeDefault::AssignmentTargetWithDefault(with_default) => {
             lower_assignment_target_default(
@@ -2572,7 +2569,7 @@ fn lower_assignment_target_default<'a>(
     binding: FollowupBinding<'a>,
     value: Place,
     assignment_style: AssignmentStyle,
-) -> Result<Option<Place>, CompilerError> {
+) -> Result<Option<Place>, OxcDiagnostic> {
     let pat_span = builder.source_location(span);
 
     let temp = build_temporary_place(builder, pat_span);
@@ -2701,7 +2698,7 @@ fn expr_contains_optional(expr: &oxc::Expression) -> bool {
 fn lower_chain_expression<'a>(
     builder: &mut HirBuilder<'a, '_>,
     chain: &'a oxc::ChainExpression<'a>,
-) -> Result<InstructionValue<'a>, CompilerError> {
+) -> Result<InstructionValue<'a>, OxcDiagnostic> {
     match &chain.expression {
         oxc::ChainElement::CallExpression(call) => {
             lower_optional_call_expression_impl(builder, call, None)
@@ -2734,7 +2731,7 @@ fn lower_chain_expression<'a>(
 fn lower_chain_subexpr<'a>(
     builder: &mut HirBuilder<'a, '_>,
     expr: &'a oxc::Expression<'a>,
-) -> Result<InstructionValue<'a>, CompilerError> {
+) -> Result<InstructionValue<'a>, OxcDiagnostic> {
     match expr {
         oxc::Expression::StaticMemberExpression(_)
         | oxc::Expression::ComputedMemberExpression(_)
@@ -2761,7 +2758,7 @@ fn lower_optional_member_expression_impl<'a>(
     builder: &mut HirBuilder<'a, '_>,
     member: &'a oxc::MemberExpression<'a>,
     parent_alternate: Option<BlockId>,
-) -> Result<(Place, Place), CompilerError> {
+) -> Result<(Place, Place), OxcDiagnostic> {
     let optional = member.optional();
     let span = builder.source_location(member.span());
     let place = build_temporary_place(builder, span);
@@ -2873,7 +2870,7 @@ fn lower_optional_call_expression_impl<'a>(
     builder: &mut HirBuilder<'a, '_>,
     call: &'a oxc::CallExpression<'a>,
     parent_alternate: Option<BlockId>,
-) -> Result<InstructionValue<'a>, CompilerError> {
+) -> Result<InstructionValue<'a>, OxcDiagnostic> {
     let span = builder.source_location(call.span);
     let place = build_temporary_place(builder, span);
     let continuation_block = builder.reserve(builder.current_block_kind());
@@ -3034,7 +3031,7 @@ fn lower_function_to_value<'a>(
     builder: &mut HirBuilder<'a, '_>,
     func: FunctionNode<'a>,
     expr_type: FunctionExpressionType,
-) -> Result<InstructionValue<'a>, CompilerError> {
+) -> Result<InstructionValue<'a>, OxcDiagnostic> {
     let span = match func {
         FunctionNode::Arrow(arrow) => builder.source_location(arrow.span),
         FunctionNode::Function(f) => builder.source_location(f.span),
@@ -3058,7 +3055,7 @@ fn lower_function_to_value<'a>(
 fn lower_function<'a>(
     builder: &mut HirBuilder<'a, '_>,
     func: FunctionNode<'a>,
-) -> Result<LoweredFunction, CompilerError> {
+) -> Result<LoweredFunction, OxcDiagnostic> {
     // Extract function parts from the AST node
     let (params, body, id, generator, is_async, func_start, func_end, func_span) = match func {
         FunctionNode::Arrow(arrow) => {
@@ -3157,7 +3154,7 @@ fn lower_function<'a>(
 fn lower_function_declaration<'a>(
     builder: &mut HirBuilder<'a, '_>,
     func_decl: &'a oxc::Function<'a>,
-) -> Result<(), CompilerError> {
+) -> Result<(), OxcDiagnostic> {
     let span = builder.source_location(func_decl.span);
     let func_start = func_decl.span.start;
     let func_end = func_decl.span.end;
@@ -3341,7 +3338,7 @@ fn lower_function_for_object_method<'a>(
     body: &'a oxc::FunctionBody<'a>,
     generator: bool,
     is_async: bool,
-) -> Result<LoweredFunction, CompilerError> {
+) -> Result<LoweredFunction, OxcDiagnostic> {
     let func_start = method_span.start;
     let func_end = method_span.end;
     let func_span = builder.source_location(method_span);
@@ -3510,7 +3507,7 @@ fn capture_scopes(
 fn lower_expression<'a>(
     builder: &mut HirBuilder<'a, '_>,
     expr: &'a oxc::Expression<'a>,
-) -> Result<InstructionValue<'a>, CompilerError> {
+) -> Result<InstructionValue<'a>, OxcDiagnostic> {
     match expr {
         oxc::Expression::Identifier(ident) => {
             let span = builder.source_location(ident.span);
@@ -4257,7 +4254,7 @@ fn lower_expression<'a>(
 fn lower_assignment_expression<'a>(
     builder: &mut HirBuilder<'a, '_>,
     assign: &'a oxc::AssignmentExpression<'a>,
-) -> Result<InstructionValue<'a>, CompilerError> {
+) -> Result<InstructionValue<'a>, OxcDiagnostic> {
     let span = builder.source_location(assign.span);
 
     if matches!(assign.operator, oxc::AssignmentOperator::Assign) {
@@ -4570,7 +4567,7 @@ fn lower_assignment_expression<'a>(
 fn lower_jsx_element_expr<'a>(
     builder: &mut HirBuilder<'a, '_>,
     jsx_element: &'a oxc::JSXElement<'a>,
-) -> Result<InstructionValue<'a>, CompilerError> {
+) -> Result<InstructionValue<'a>, OxcDiagnostic> {
     let span = builder.source_location(jsx_element.span);
     let opening_span = builder.source_location(jsx_element.opening_element.span);
     let closing_span =
@@ -4667,7 +4664,7 @@ fn lower_jsx_element_expr<'a>(
     let is_fbt = matches!(&tag, JsxTag::Builtin(b) if b.name == "fbt" || b.name == "fbs");
 
     // Check that fbt/fbs tags are module-level imports, not local bindings.
-    // Matches TS: CompilerError.invariant(tagIdentifier.kind !== 'Identifier', ...)
+    // Matches TS: Diagnostics.invariant(tagIdentifier.kind !== 'Identifier', ...)
     if is_fbt {
         let tag_name = match &tag {
             JsxTag::Builtin(b) => b.name.clone(),
@@ -4689,8 +4686,7 @@ fn lower_jsx_element_expr<'a>(
                 let reason = format!("<{}> tags should be module-level imports", tag_name);
                 return Err(ErrorCategory::Invariant
                     .diagnostic(&reason)
-                    .with_labels(id_span.map(|s| s.label(reason)))
-                    .into());
+                    .with_labels(id_span.map(|s| s.label(reason))));
             }
         }
     }
@@ -4768,7 +4764,7 @@ fn lower_jsx_element_expr<'a>(
 fn lower_jsx_fragment_expr<'a>(
     builder: &mut HirBuilder<'a, '_>,
     jsx_fragment: &'a oxc::JSXFragment<'a>,
-) -> Result<InstructionValue<'a>, CompilerError> {
+) -> Result<InstructionValue<'a>, OxcDiagnostic> {
     let span = builder.source_location(jsx_fragment.span);
 
     // Lower children
@@ -4791,14 +4787,14 @@ fn lower_jsx_fragment_expr<'a>(
 fn lower_jsx_element_name(
     builder: &mut HirBuilder<'_, '_>,
     name: &oxc::JSXElementName,
-) -> Result<JsxTag, CompilerError> {
+) -> Result<JsxTag, OxcDiagnostic> {
     // Lower a simple JSX tag identifier (component-vs-builtin split on case).
     fn lower_tag_identifier(
         builder: &mut HirBuilder<'_, '_>,
         tag: &str,
         span: oxc_span::Span,
         symbol: Option<SymbolId>,
-    ) -> Result<JsxTag, CompilerError> {
+    ) -> Result<JsxTag, OxcDiagnostic> {
         let span = builder.source_location(span);
         if tag.starts_with(|c: char| c.is_ascii_uppercase()) {
             // Component tag: resolve as identifier and load
@@ -4863,7 +4859,7 @@ fn lower_jsx_element_name(
 fn lower_jsx_member_expression(
     builder: &mut HirBuilder<'_, '_>,
     expr: &oxc::JSXMemberExpression,
-) -> Result<Place, CompilerError> {
+) -> Result<Place, OxcDiagnostic> {
     // Use the full member expression's span for instruction locs (matching TS: exprPath.node.span)
     let expr_span = builder.source_location(expr.span);
     let object = match &expr.object {
@@ -4902,7 +4898,7 @@ fn lower_jsx_member_object_identifier(
     span: oxc_span::Span,
     symbol: Option<SymbolId>,
     expr_span: &Option<Span>,
-) -> Result<Place, CompilerError> {
+) -> Result<Place, OxcDiagnostic> {
     let id_span = builder.source_location(span);
     let place = lower_identifier(builder, name, id_span, symbol)?;
     let load_value = if builder.is_context_identifier(symbol) {
@@ -4918,7 +4914,7 @@ fn lower_jsx_member_object_identifier(
 fn lower_jsx_element<'a>(
     builder: &mut HirBuilder<'a, '_>,
     child: &'a oxc::JSXChild<'a>,
-) -> Result<Option<Place>, CompilerError> {
+) -> Result<Option<Place>, OxcDiagnostic> {
     match child {
         oxc::JSXChild::Text(text) => {
             // oxc keeps JSX text raw; decode entities first so the value matches
@@ -5406,7 +5402,7 @@ fn expression_type_name(expr: &oxc::Expression) -> &'static str {
 fn lower_object_method<'a>(
     builder: &mut HirBuilder<'a, '_>,
     method: &'a oxc::ObjectProperty<'a>,
-) -> Result<Option<ObjectProperty>, CompilerError> {
+) -> Result<Option<ObjectProperty>, OxcDiagnostic> {
     // In oxc, a shorthand method is encoded as `kind: Init, method: true`; only
     // getters/setters carry a non-`Init` `PropertyKind`.
     let is_method = method.method && matches!(method.kind, oxc::PropertyKind::Init);
@@ -5457,7 +5453,7 @@ fn lower_object_property_key<'a>(
     builder: &mut HirBuilder<'a, '_>,
     key: &'a oxc::PropertyKey<'a>,
     computed: bool,
-) -> Result<Option<ObjectPropertyKey>, CompilerError> {
+) -> Result<Option<ObjectPropertyKey>, OxcDiagnostic> {
     match key {
         // Property keys stay String-typed; oxc atoms are valid UTF-8, so
         // `to_string()` reproduces the marker wire form for non-pathological keys.
@@ -5499,7 +5495,7 @@ fn lower_object_property_key<'a>(
 fn lower_reorderable_expression<'a>(
     builder: &mut HirBuilder<'a, '_>,
     expr: &'a oxc::Expression<'a>,
-) -> Result<Place, CompilerError> {
+) -> Result<Place, OxcDiagnostic> {
     if !is_reorderable_expression(builder, expr, true) {
         builder.record_error(
             ErrorCategory::Todo
@@ -6646,7 +6642,7 @@ fn lower_for_in_of_left<'a>(
     left: &'a oxc::ForStatementLeft<'a>,
     left_span: Option<Span>,
     value: Place,
-) -> Result<Option<Place>, CompilerError> {
+) -> Result<Option<Place>, OxcDiagnostic> {
     match left {
         oxc::ForStatementLeft::VariableDeclaration(var_decl) => {
             if var_decl.declarations.len() != 1 {

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/find_context_identifiers.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/find_context_identifiers.rs
@@ -32,10 +32,10 @@ use oxc_ast::ast as oxc;
 use oxc_ast::ast::AssignmentTargetMaybeDefault;
 use oxc_ast::match_assignment_target;
 use oxc_ast_visit::Visit;
+use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::Span;
 use oxc_syntax::scope::ScopeFlags;
 
-use crate::diagnostics::CompilerError;
 use crate::diagnostics::ErrorCategory;
 use crate::scope::ScopeId;
 use crate::scope::ScopeResolver;
@@ -60,7 +60,7 @@ struct ContextIdentifierVisitor<'a> {
     /// Empty when at the top level of the function being compiled.
     function_stack: Vec<ScopeId>,
     binding_info: FxHashMap<SymbolId, BindingInfo>,
-    error: Option<CompilerError>,
+    error: Option<OxcDiagnostic>,
 }
 
 impl<'a> ContextIdentifierVisitor<'a> {
@@ -393,14 +393,12 @@ impl<'a> ContextIdentifierVisitor<'a> {
 /// aborting before BuildHIR ever runs or logs, so this must return Err rather
 /// than record-and-continue: otherwise Rust emits HIR debug entries for a
 /// function TS never lowered.
-fn make_unsupported_lval_error(type_name: &str, span: Option<Span>) -> CompilerError {
-    CompilerError::from(
-        ErrorCategory::Todo
-            .diagnostic(format!(
-                "[FindContextIdentifiers] Cannot handle Object destructuring assignment target {type_name}"
-            ))
-            .with_labels(span),
-    )
+fn make_unsupported_lval_error(type_name: &str, span: Option<Span>) -> OxcDiagnostic {
+    ErrorCategory::Todo
+        .diagnostic(format!(
+            "[FindContextIdentifiers] Cannot handle Object destructuring assignment target {type_name}"
+        ))
+        .with_labels(span)
 }
 
 /// Check if a binding declared at `binding_scope` is captured by a function at `function_scope`.
@@ -428,7 +426,7 @@ pub fn find_context_identifiers(
     func: &FunctionNode<'_>,
     scope: &ScopeResolver<'_, '_>,
     identifier_spans: &crate::react_compiler_lowering::identifier_loc_index::IdentifierLocIndex,
-) -> Result<FxHashSet<SymbolId>, CompilerError> {
+) -> Result<FxHashSet<SymbolId>, OxcDiagnostic> {
     let func_scope = func.scope_id().unwrap_or_else(|| scope.program_scope());
 
     let mut visitor = ContextIdentifierVisitor {

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/hir_builder.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/hir_builder.rs
@@ -1,4 +1,3 @@
-use crate::diagnostics::CompilerError;
 use crate::diagnostics::ErrorCategory;
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::visitors::each_terminal_successor;
@@ -19,7 +18,7 @@ use crate::react_compiler_lowering::identifier_loc_index::IdentifierLocIndex;
 
 type BuildResult<'a> = Result<
     (HIR, Vec<Instruction<'a>>, FxIndexMap<String, SymbolId>, FxIndexMap<SymbolId, IdentifierId>),
-    CompilerError,
+    OxcDiagnostic,
 >;
 
 // ---------------------------------------------------------------------------
@@ -552,7 +551,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
 
     /// Record an error on the environment.
     /// Returns `Err` for Invariant errors (matching TS throw behavior).
-    pub fn record_error(&mut self, error: OxcDiagnostic) -> Result<(), CompilerError> {
+    pub fn record_error(&mut self, error: OxcDiagnostic) -> Result<(), OxcDiagnostic> {
         self.env.record_error(error)
     }
 
@@ -645,7 +644,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
         &mut self,
         name: &str,
         symbol_id: SymbolId,
-    ) -> Result<IdentifierId, CompilerError> {
+    ) -> Result<IdentifierId, OxcDiagnostic> {
         self.resolve_binding_with_span(name, symbol_id, None)
     }
 
@@ -655,7 +654,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
         name: &str,
         symbol_id: SymbolId,
         span: Option<Span>,
-    ) -> Result<IdentifierId, CompilerError> {
+    ) -> Result<IdentifierId, OxcDiagnostic> {
         // Check for unsupported names BEFORE the cache check.
         // In TS, resolveBinding records fbt errors when node.name === 'fbt'. After a name collision
         // causes a rename (e.g., "fbt" -> "fbt_0"), TS's scope.rename changes the AST node's name,
@@ -696,7 +695,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
 
         if is_always_reserved_word(name) {
             // Match TS behavior: makeIdentifierName throws for reserved words.
-            return Err(CompilerError::from(reserved_identifier_diagnostic(name)));
+            return Err(reserved_identifier_diagnostic(name));
         }
 
         // Find a unique name: start with the original name, then try name_0, name_1, ...
@@ -763,7 +762,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
         name: &str,
         span: Option<Span>,
         symbol: Option<SymbolId>,
-    ) -> Result<VariableBinding, CompilerError> {
+    ) -> Result<VariableBinding, OxcDiagnostic> {
         let Some(symbol_id) = symbol else {
             // No binding found: this is a global
             return Ok(VariableBinding::Global { name: name.to_string() });

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
@@ -13,7 +13,7 @@
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 
-use crate::diagnostics::{CompilerError, ErrorCategory};
+use crate::diagnostics::ErrorCategory;
 use crate::react_compiler_hir::ArrayElement;
 use crate::react_compiler_hir::ArrayPattern;
 use crate::react_compiler_hir::BlockId;
@@ -89,7 +89,7 @@ pub fn codegen_function<'a, 'h>(
     env: &mut Environment<'h>,
     unique_identifiers: FxHashSet<String>,
     fbt_operands: FxHashSet<IdentifierId>,
-) -> Result<crate::react_compiler::entrypoint::compile_result::CodegenFunction<'a>, CompilerError> {
+) -> Result<crate::react_compiler::entrypoint::compile_result::CodegenFunction<'a>, OxcDiagnostic> {
     use crate::react_compiler::entrypoint::compile_result::CodegenFunction as OxcCodegenFunction;
     use oxc_span::SPAN;
 
@@ -206,15 +206,14 @@ fn ox_codegen_outlined<'a>(
     fbt_operands: FxHashSet<IdentifierId>,
 ) -> Result<
     Vec<crate::react_compiler::entrypoint::compile_result::OutlinedFunction<'a>>,
-    CompilerError,
+    OxcDiagnostic,
 > {
     use crate::react_compiler::entrypoint::compile_result::OutlinedFunction as OxcOutlinedFunction;
 
     let entries = env.take_outlined_functions();
     let mut outlined = Vec::with_capacity(entries.len());
     for entry in entries {
-        let mut reactive_function =
-            build_reactive_function(&entry.func, env).map_err(CompilerError::from)?;
+        let mut reactive_function = build_reactive_function(&entry.func, env)?;
         prune_unused_labels(&mut reactive_function, env)?;
         prune_unused_lvalues(&mut reactive_function, env);
         prune_hoisted_contexts(&mut reactive_function, env)?;
@@ -343,7 +342,7 @@ impl<'a, 'env, 'h> OxcContext<'a, 'env, 'h> {
     }
 
     #[allow(dead_code)]
-    fn record_error(&mut self, diagnostic: OxcDiagnostic) -> Result<(), CompilerError> {
+    fn record_error(&mut self, diagnostic: OxcDiagnostic) -> Result<(), OxcDiagnostic> {
         self.env.record_error(diagnostic)
     }
 }
@@ -516,7 +515,7 @@ fn ox_cache_index<'a>(
 fn ox_codegen_reactive_function<'a, 'h>(
     cx: &mut OxcContext<'a, '_, 'h>,
     func: &ReactiveFunction<'h>,
-) -> Result<OxcCompiledFunction<'a>, CompilerError> {
+) -> Result<OxcCompiledFunction<'a>, OxcDiagnostic> {
     // Register parameters
     for param in &func.params {
         let place = match param {
@@ -572,7 +571,7 @@ fn ox_codegen_reactive_function<'a, 'h>(
 fn ox_convert_parameters<'a>(
     cx: &mut OxcContext<'a, '_, '_>,
     params: &[ParamPattern],
-) -> Result<oxc_allocator::Box<'a, oxc::FormalParameters<'a>>, CompilerError> {
+) -> Result<oxc_allocator::Box<'a, oxc::FormalParameters<'a>>, OxcDiagnostic> {
     let mut items: Vec<oxc::FormalParameter<'a>> = Vec::new();
     let mut rest: Option<oxc::FormalParameterRest<'a>> = None;
     for param in params {
@@ -618,7 +617,7 @@ fn ox_convert_parameters<'a>(
 fn ox_binding_for_identifier<'a>(
     cx: &OxcContext<'a, '_, '_>,
     identifier_id: IdentifierId,
-) -> Result<oxc::BindingPattern<'a>, CompilerError> {
+) -> Result<oxc::BindingPattern<'a>, OxcDiagnostic> {
     let name = ox_identifier_name(cx.env, identifier_id)?;
     Ok(oxc_ast::ast::BindingPattern::new_binding_identifier(SPAN, ox_str(&cx.ast, &name), &cx.ast))
 }
@@ -626,7 +625,7 @@ fn ox_binding_for_identifier<'a>(
 fn ox_identifier_name(
     env: &Environment,
     identifier_id: IdentifierId,
-) -> Result<String, CompilerError> {
+) -> Result<String, OxcDiagnostic> {
     let ident = &env.identifiers[identifier_id.0 as usize];
     match &ident.name {
         Some(crate::react_compiler_hir::IdentifierName::Named(n)) => Ok(n.clone()),
@@ -645,7 +644,7 @@ fn ox_identifier_name(
 fn ox_codegen_block<'a, 'h>(
     cx: &mut OxcContext<'a, '_, 'h>,
     block: &ReactiveBlock<'h>,
-) -> Result<oxc_allocator::Vec<'a, oxc::Statement<'a>>, CompilerError> {
+) -> Result<oxc_allocator::Vec<'a, oxc::Statement<'a>>, OxcDiagnostic> {
     let temp_snapshot = ox_clone_temporaries(&cx.ast, &cx.temp);
     let result = ox_codegen_block_no_reset(cx, block)?;
     cx.temp = temp_snapshot;
@@ -655,7 +654,7 @@ fn ox_codegen_block<'a, 'h>(
 fn ox_codegen_block_no_reset<'a, 'h>(
     cx: &mut OxcContext<'a, '_, 'h>,
     block: &ReactiveBlock<'h>,
-) -> Result<oxc_allocator::Vec<'a, oxc::Statement<'a>>, CompilerError> {
+) -> Result<oxc_allocator::Vec<'a, oxc::Statement<'a>>, OxcDiagnostic> {
     let mut statements: oxc_allocator::Vec<'a, oxc::Statement<'a>> =
         oxc_allocator::ArenaVec::new_in(&cx.ast);
     for item in block {
@@ -727,7 +726,7 @@ fn ox_codegen_block_no_reset<'a, 'h>(
 fn ox_codegen_block_statement<'a, 'h>(
     cx: &mut OxcContext<'a, '_, 'h>,
     block: &ReactiveBlock<'h>,
-) -> Result<oxc::BlockStatement<'a>, CompilerError> {
+) -> Result<oxc::BlockStatement<'a>, OxcDiagnostic> {
     let body = ox_codegen_block(cx, block)?;
     Ok(oxc_ast::ast::BlockStatement::new(SPAN, body, &cx.ast))
 }
@@ -741,7 +740,7 @@ fn ox_codegen_reactive_scope<'a, 'h>(
     statements: &mut oxc_allocator::Vec<'a, oxc::Statement<'a>>,
     scope_id: ScopeId,
     block: &ReactiveBlock<'h>,
-) -> Result<(), CompilerError> {
+) -> Result<(), OxcDiagnostic> {
     let scope_deps = cx.env.scopes[scope_id.0 as usize].dependencies.clone();
     let scope_decls = cx.env.scopes[scope_id.0 as usize].declarations.clone();
     let scope_reassignments = cx.env.scopes[scope_id.0 as usize].reassignments.clone();
@@ -965,7 +964,7 @@ fn ast_member_target<'a>(
 fn ox_codegen_terminal<'a, 'h>(
     cx: &mut OxcContext<'a, '_, 'h>,
     terminal: &ReactiveTerminal<'h>,
-) -> Result<Option<oxc::Statement<'a>>, CompilerError> {
+) -> Result<Option<oxc::Statement<'a>>, OxcDiagnostic> {
     match terminal {
         ReactiveTerminal::Break { target, target_kind, .. } => {
             if *target_kind == ReactiveTerminalTargetKind::Implicit {
@@ -1144,7 +1143,7 @@ fn ox_codegen_for_in<'a, 'h>(
     init: &ReactiveValue<'h>,
     loop_block: &ReactiveBlock<'h>,
     span: Option<Span>,
-) -> Result<Option<oxc::Statement<'a>>, CompilerError> {
+) -> Result<Option<oxc::Statement<'a>>, OxcDiagnostic> {
     let ReactiveValue::SequenceExpression { instructions, .. } = init else {
         return Err(invariant_err("Expected a sequence expression init for for..in", None));
     };
@@ -1187,7 +1186,7 @@ fn ox_codegen_for_of<'a, 'h>(
     test: &ReactiveValue<'h>,
     loop_block: &ReactiveBlock<'h>,
     span: Option<Span>,
-) -> Result<Option<oxc::Statement<'a>>, CompilerError> {
+) -> Result<Option<oxc::Statement<'a>>, OxcDiagnostic> {
     let ReactiveValue::SequenceExpression { instructions: init_instrs, .. } = init else {
         return Err(invariant_err("Expected a sequence expression init for for..of", None));
     };
@@ -1243,7 +1242,7 @@ fn ox_extract_for_in_of_lval<'a>(
     instr_value: &InstructionValue,
     context_name: &str,
     span: Option<Span>,
-) -> Result<(oxc::BindingPattern<'a>, oxc::VariableDeclarationKind), CompilerError> {
+) -> Result<(oxc::BindingPattern<'a>, oxc::VariableDeclarationKind), OxcDiagnostic> {
     let (lval, kind) = match instr_value {
         InstructionValue::StoreLocal { lvalue, .. } => {
             (ox_codegen_lvalue(cx, &LvalueRef::Place(&lvalue.place))?, lvalue.kind)
@@ -1289,7 +1288,7 @@ fn ox_extract_for_in_of_lval<'a>(
 fn ox_codegen_for_init<'a, 'h>(
     cx: &mut OxcContext<'a, '_, 'h>,
     init: &ReactiveValue<'h>,
-) -> Result<Option<oxc::ForStatementInit<'a>>, CompilerError> {
+) -> Result<Option<oxc::ForStatementInit<'a>>, OxcDiagnostic> {
     if let ReactiveValue::SequenceExpression { instructions, .. } = init {
         let block_items: Vec<ReactiveStatement> =
             instructions.iter().map(|i| ReactiveStatement::Instruction(i.clone())).collect();
@@ -1386,7 +1385,7 @@ fn ox_convert_value_to_expression<'a>(
 fn ox_codegen_instruction_nullable<'a, 'h>(
     cx: &mut OxcContext<'a, '_, 'h>,
     instr: &ReactiveInstruction<'h>,
-) -> Result<Option<oxc::Statement<'a>>, CompilerError> {
+) -> Result<Option<oxc::Statement<'a>>, OxcDiagnostic> {
     if let ReactiveValue::Instruction(ref value) = instr.value {
         match value {
             InstructionValue::StoreLocal { .. }
@@ -1437,7 +1436,7 @@ fn ox_codegen_store_or_declare<'a, 'h>(
     cx: &mut OxcContext<'a, '_, 'h>,
     instr: &ReactiveInstruction<'h>,
     value: &InstructionValue,
-) -> Result<Option<oxc::Statement<'a>>, CompilerError> {
+) -> Result<Option<oxc::Statement<'a>>, OxcDiagnostic> {
     match value {
         InstructionValue::StoreLocal { lvalue, value: val, .. } => {
             let mut kind = lvalue.kind;
@@ -1480,7 +1479,7 @@ fn ox_emit_store<'a, 'h>(
     kind: InstructionKind,
     lvalue: &LvalueRef,
     value: Option<oxc::Expression<'a>>,
-) -> Result<Option<oxc::Statement<'a>>, CompilerError> {
+) -> Result<Option<oxc::Statement<'a>>, OxcDiagnostic> {
     match kind {
         InstructionKind::Const => {
             if instr.lvalue.is_some() {
@@ -1615,7 +1614,7 @@ fn ox_codegen_instruction<'a, 'h>(
     cx: &mut OxcContext<'a, '_, 'h>,
     instr: &ReactiveInstruction<'h>,
     value: OxValue<'a>,
-) -> Result<oxc::Statement<'a>, CompilerError> {
+) -> Result<oxc::Statement<'a>, OxcDiagnostic> {
     let Some(ref lvalue) = instr.lvalue else {
         let expr = ox_convert_value_to_expression(&cx.ast, value);
         return Ok(oxc_ast::ast::Statement::new_expression_statement(SPAN, expr, &cx.ast));
@@ -1656,7 +1655,7 @@ fn ox_codegen_instruction<'a, 'h>(
 fn ox_codegen_instruction_value_to_expression<'a, 'h>(
     cx: &mut OxcContext<'a, '_, 'h>,
     instr_value: &ReactiveValue<'h>,
-) -> Result<oxc::Expression<'a>, CompilerError> {
+) -> Result<oxc::Expression<'a>, OxcDiagnostic> {
     let value = ox_codegen_instruction_value(cx, instr_value)?;
     Ok(ox_convert_value_to_expression(&cx.ast, value))
 }
@@ -1664,7 +1663,7 @@ fn ox_codegen_instruction_value_to_expression<'a, 'h>(
 fn ox_codegen_instruction_value<'a, 'h>(
     cx: &mut OxcContext<'a, '_, 'h>,
     instr_value: &ReactiveValue<'h>,
-) -> Result<OxValue<'a>, CompilerError> {
+) -> Result<OxValue<'a>, OxcDiagnostic> {
     match instr_value {
         ReactiveValue::Instruction(iv) => ox_codegen_base_instruction_value(cx, iv),
         ReactiveValue::LogicalExpression { operator, left, right, .. } => {
@@ -1776,7 +1775,7 @@ fn ox_make_optional<'a>(
     cx: &mut OxcContext<'a, '_, '_>,
     expr: oxc::Expression<'a>,
     optional: bool,
-) -> Result<OxValue<'a>, CompilerError> {
+) -> Result<OxValue<'a>, OxcDiagnostic> {
     let chain_element: oxc::ChainElement<'a> = match expr {
         oxc::Expression::ChainExpression(chain) => {
             // Already a chain; update the optional flag on the head element.
@@ -1857,7 +1856,7 @@ fn ox_make_optional<'a>(
 fn ox_codegen_base_instruction_value<'a>(
     cx: &mut OxcContext<'a, '_, '_>,
     iv: &InstructionValue,
-) -> Result<OxValue<'a>, CompilerError> {
+) -> Result<OxValue<'a>, OxcDiagnostic> {
     match iv {
         InstructionValue::Primitive { value, .. } => {
             Ok(OxValue::Expression(ox_codegen_primitive_value(&cx.ast, value)))
@@ -1903,15 +1902,11 @@ fn ox_codegen_base_instruction_value<'a>(
             let member_expr = ox_codegen_place_to_expression(cx, property)?;
             if !ox_is_member_like(&member_expr) {
                 let msg = format!("Got: '{}'", ox_expression_type_name(&member_expr));
-                let mut err = CompilerError::new();
-                err.push(
-                    ErrorCategory::Invariant
-                        .diagnostic(
-                            "[Codegen] Internal error: MethodCall::property must be an unpromoted + unmemoized MemberExpression",
-                        )
-                        .with_labels(property.span.map(|s| s.label(msg))),
-                );
-                return Err(err);
+                return Err(ErrorCategory::Invariant
+                    .diagnostic(
+                        "[Codegen] Internal error: MethodCall::property must be an unpromoted + unmemoized MemberExpression",
+                    )
+                    .with_labels(property.span.map(|s| s.label(msg))));
             }
             let arguments = ox_codegen_arguments(cx, args)?;
             let call = ox_create_call_expression(cx, member_expr, arguments, property.identifier);
@@ -2254,7 +2249,7 @@ fn ox_template_literal<'a>(
 fn ox_codegen_arguments<'a>(
     cx: &mut OxcContext<'a, '_, '_>,
     args: &[PlaceOrSpread],
-) -> Result<oxc_allocator::Vec<'a, oxc::Argument<'a>>, CompilerError> {
+) -> Result<oxc_allocator::Vec<'a, oxc::Argument<'a>>, OxcDiagnostic> {
     let mut out: oxc_allocator::Vec<'a, oxc::Argument<'a>> =
         oxc_allocator::ArenaVec::new_in(&cx.ast);
     for arg in args {
@@ -2266,7 +2261,7 @@ fn ox_codegen_arguments<'a>(
 fn ox_codegen_argument<'a>(
     cx: &mut OxcContext<'a, '_, '_>,
     arg: &PlaceOrSpread,
-) -> Result<oxc::Argument<'a>, CompilerError> {
+) -> Result<oxc::Argument<'a>, OxcDiagnostic> {
     match arg {
         PlaceOrSpread::Place(place) => {
             Ok(oxc::Argument::from(ox_codegen_place_to_expression(cx, place)?))
@@ -2304,7 +2299,7 @@ fn ox_expression_type_name(expr: &oxc::Expression) -> &'static str {
 fn ox_codegen_place_to_expression<'a>(
     cx: &mut OxcContext<'a, '_, '_>,
     place: &Place,
-) -> Result<oxc::Expression<'a>, CompilerError> {
+) -> Result<oxc::Expression<'a>, OxcDiagnostic> {
     let value = ox_codegen_place(cx, place)?;
     Ok(ox_convert_value_to_expression(&cx.ast, value))
 }
@@ -2312,7 +2307,7 @@ fn ox_codegen_place_to_expression<'a>(
 fn ox_codegen_place<'a>(
     cx: &mut OxcContext<'a, '_, '_>,
     place: &Place,
-) -> Result<OxValue<'a>, CompilerError> {
+) -> Result<OxValue<'a>, OxcDiagnostic> {
     let ident = &cx.env.identifiers[place.identifier.0 as usize];
     let declaration_id = ident.declaration_id;
     if let Some(tmp) = cx.temp.get(&declaration_id) {
@@ -2339,7 +2334,7 @@ fn ox_codegen_place<'a>(
 fn ox_codegen_lvalue<'a>(
     cx: &mut OxcContext<'a, '_, '_>,
     pattern: &LvalueRef,
-) -> Result<oxc::BindingPattern<'a>, CompilerError> {
+) -> Result<oxc::BindingPattern<'a>, OxcDiagnostic> {
     match pattern {
         LvalueRef::Place(place) => ox_binding_for_identifier(cx, place.identifier),
         LvalueRef::Pattern(pat) => match pat {
@@ -2353,7 +2348,7 @@ fn ox_codegen_lvalue<'a>(
 fn ox_codegen_array_pattern<'a>(
     cx: &mut OxcContext<'a, '_, '_>,
     pattern: &ArrayPattern,
-) -> Result<oxc::BindingPattern<'a>, CompilerError> {
+) -> Result<oxc::BindingPattern<'a>, OxcDiagnostic> {
     let mut elements: oxc_allocator::Vec<'a, Option<oxc::BindingPattern<'a>>> =
         oxc_allocator::ArenaVec::new_in(&cx.ast);
     let mut rest: Option<oxc::BindingRestElement<'a>> = None;
@@ -2377,7 +2372,7 @@ fn ox_codegen_array_pattern<'a>(
 fn ox_codegen_object_pattern<'a>(
     cx: &mut OxcContext<'a, '_, '_>,
     pattern: &ObjectPattern,
-) -> Result<oxc::BindingPattern<'a>, CompilerError> {
+) -> Result<oxc::BindingPattern<'a>, OxcDiagnostic> {
     let mut properties: oxc_allocator::Vec<'a, oxc::BindingProperty<'a>> =
         oxc_allocator::ArenaVec::new_in(&cx.ast);
     let mut rest: Option<oxc::BindingRestElement<'a>> = None;
@@ -2411,7 +2406,7 @@ fn ox_codegen_object_pattern<'a>(
 fn ox_codegen_object_property_key<'a>(
     cx: &mut OxcContext<'a, '_, '_>,
     key: &ObjectPropertyKey,
-) -> Result<(oxc::PropertyKey<'a>, bool), CompilerError> {
+) -> Result<(oxc::PropertyKey<'a>, bool), OxcDiagnostic> {
     match key {
         ObjectPropertyKey::String { name } => Ok((
             oxc::PropertyKey::from(oxc_ast::ast::Expression::new_string_literal(
@@ -2436,7 +2431,7 @@ fn ox_codegen_object_property_key<'a>(
 fn ox_codegen_dependency<'a>(
     cx: &mut OxcContext<'a, '_, '_>,
     dep: &crate::react_compiler_hir::ReactiveScopeDependency,
-) -> Result<oxc::Expression<'a>, CompilerError> {
+) -> Result<oxc::Expression<'a>, OxcDiagnostic> {
     let name = ox_identifier_name(cx.env, dep.identifier)?;
     let mut object =
         oxc_ast::ast::Expression::new_identifier(SPAN, ox_str(&cx.ast, &name), &cx.ast);
@@ -2511,7 +2506,7 @@ fn ox_codegen_dependency<'a>(
 fn ox_binding_pattern_to_assignment_target<'a>(
     cx: &OxcContext<'a, '_, '_>,
     pattern: oxc::BindingPattern<'a>,
-) -> Result<oxc::AssignmentTarget<'a>, CompilerError> {
+) -> Result<oxc::AssignmentTarget<'a>, OxcDiagnostic> {
     match pattern {
         oxc::BindingPattern::BindingIdentifier(id) => {
             let id = id.unbox();
@@ -2555,7 +2550,7 @@ fn ox_binding_pattern_to_assignment_target<'a>(
 fn ox_binding_pattern_to_maybe_default<'a>(
     cx: &OxcContext<'a, '_, '_>,
     pattern: oxc::BindingPattern<'a>,
-) -> Result<oxc::AssignmentTargetMaybeDefault<'a>, CompilerError> {
+) -> Result<oxc::AssignmentTargetMaybeDefault<'a>, OxcDiagnostic> {
     match pattern {
         oxc::BindingPattern::AssignmentPattern(assign) => {
             let assign = assign.unbox();
@@ -2578,7 +2573,7 @@ fn ox_binding_pattern_to_maybe_default<'a>(
 fn ox_binding_property_to_assignment_property<'a>(
     cx: &OxcContext<'a, '_, '_>,
     prop: oxc::BindingProperty<'a>,
-) -> Result<oxc::AssignmentTargetProperty<'a>, CompilerError> {
+) -> Result<oxc::AssignmentTargetProperty<'a>, OxcDiagnostic> {
     if prop.shorthand {
         let (binding, init) = match prop.value {
             oxc::BindingPattern::BindingIdentifier(id) => (id.unbox(), None),
@@ -2618,7 +2613,7 @@ fn ox_binding_property_to_assignment_property<'a>(
 fn ox_binding_rest_to_assignment_rest<'a>(
     cx: &OxcContext<'a, '_, '_>,
     rest: Option<oxc_allocator::Box<'a, oxc::BindingRestElement<'a>>>,
-) -> Result<Option<oxc::AssignmentTargetRest<'a>>, CompilerError> {
+) -> Result<Option<oxc::AssignmentTargetRest<'a>>, OxcDiagnostic> {
     match rest {
         Some(rest) => {
             let target = ox_binding_pattern_to_assignment_target(cx, rest.unbox().argument)?;
@@ -2632,7 +2627,7 @@ fn ox_binding_rest_to_assignment_rest<'a>(
 fn ox_expression_to_simple_assignment_target<'a>(
     cx: &OxcContext<'a, '_, '_>,
     expr: oxc::Expression<'a>,
-) -> Result<oxc::SimpleAssignmentTarget<'a>, CompilerError> {
+) -> Result<oxc::SimpleAssignmentTarget<'a>, OxcDiagnostic> {
     match expr {
         oxc::Expression::Identifier(id) => {
             let id = id.unbox();
@@ -2660,7 +2655,7 @@ fn ox_codegen_function_expression<'a>(
     name_hint: &Option<String>,
     lowered_func: &crate::react_compiler_hir::LoweredFunction,
     expr_type: &FunctionExpressionType,
-) -> Result<OxValue<'a>, CompilerError> {
+) -> Result<OxValue<'a>, OxcDiagnostic> {
     let func = cx.env.functions[lowered_func.func.0 as usize].clone();
     let mut reactive_fn = build_reactive_function(&func, cx.env)?;
     prune_unused_labels(&mut reactive_fn, cx.env)?;
@@ -2792,7 +2787,7 @@ fn ox_build_arrow<'a>(
 fn ox_codegen_inner_function<'a, 'h>(
     cx: &mut OxcContext<'a, '_, 'h>,
     reactive_fn: &ReactiveFunction<'h>,
-) -> Result<OxcCompiledFunction<'a>, CompilerError> {
+) -> Result<OxcCompiledFunction<'a>, OxcDiagnostic> {
     let fn_name = reactive_fn.id.as_deref().unwrap_or("[[ anonymous ]]").to_string();
     let mut inner_cx = OxcContext::new(
         oxc_ast::builder::AstBuilder::new(cx.ast.allocator()),
@@ -2808,7 +2803,7 @@ fn ox_codegen_inner_function<'a, 'h>(
 fn ox_codegen_object_expression<'a>(
     cx: &mut OxcContext<'a, '_, '_>,
     properties: &[ObjectPropertyOrSpread],
-) -> Result<OxValue<'a>, CompilerError> {
+) -> Result<OxValue<'a>, OxcDiagnostic> {
     let mut props: oxc_allocator::Vec<'a, oxc::ObjectPropertyKind<'a>> =
         oxc_allocator::ArenaVec::new_in(&cx.ast);
     for prop in properties {
@@ -2909,7 +2904,7 @@ fn ox_codegen_jsx_expression<'a>(
     tag: &JsxTag,
     props: &[JsxAttribute],
     children: &Option<Vec<Place>>,
-) -> Result<OxValue<'a>, CompilerError> {
+) -> Result<OxValue<'a>, OxcDiagnostic> {
     let mut attributes: oxc_allocator::Vec<'a, oxc::JSXAttributeItem<'a>> =
         oxc_allocator::ArenaVec::new_in(&cx.ast);
     for attr in props {
@@ -2997,7 +2992,7 @@ fn ox_encode_jsx_text(raw: &str) -> String {
 fn ox_codegen_jsx_attribute<'a>(
     cx: &mut OxcContext<'a, '_, '_>,
     attr: &JsxAttribute,
-) -> Result<oxc::JSXAttributeItem<'a>, CompilerError> {
+) -> Result<oxc::JSXAttributeItem<'a>, OxcDiagnostic> {
     match attr {
         JsxAttribute::Attribute { name, place } => {
             let prop_name = if name.contains(':') {
@@ -3041,7 +3036,7 @@ fn ox_codegen_jsx_attribute<'a>(
 fn ox_codegen_jsx_element<'a>(
     cx: &mut OxcContext<'a, '_, '_>,
     place: &Place,
-) -> Result<oxc::JSXChild<'a>, CompilerError> {
+) -> Result<oxc::JSXChild<'a>, OxcDiagnostic> {
     let value = ox_codegen_place(cx, place)?;
     match value {
         OxValue::JsxText(text) => {
@@ -3094,7 +3089,7 @@ fn ox_codegen_jsx_element<'a>(
 fn ox_codegen_jsx_fbt_child_element<'a>(
     cx: &mut OxcContext<'a, '_, '_>,
     place: &Place,
-) -> Result<oxc::JSXChild<'a>, CompilerError> {
+) -> Result<oxc::JSXChild<'a>, OxcDiagnostic> {
     let value = ox_codegen_place(cx, place)?;
     match value {
         OxValue::JsxText(text) => {
@@ -3124,7 +3119,7 @@ fn ox_codegen_jsx_fbt_child_element<'a>(
 fn ox_expression_to_jsx_tag<'a>(
     cx: &OxcContext<'a, '_, '_>,
     expr: &oxc::Expression<'a>,
-) -> Result<oxc::JSXElementName<'a>, CompilerError> {
+) -> Result<oxc::JSXElementName<'a>, OxcDiagnostic> {
     match expr {
         oxc::Expression::Identifier(ident) => Ok(ox_jsx_element_name_from_ident(cx, &ident.name)),
         oxc::Expression::StaticMemberExpression(_)
@@ -3170,7 +3165,7 @@ fn ox_jsx_element_name_from_ident<'a>(
 fn ox_convert_member_expression_to_jsx<'a>(
     cx: &OxcContext<'a, '_, '_>,
     expr: &oxc::Expression<'a>,
-) -> Result<(oxc::JSXMemberExpressionObject<'a>, oxc::JSXIdentifier<'a>), CompilerError> {
+) -> Result<(oxc::JSXMemberExpressionObject<'a>, oxc::JSXIdentifier<'a>), OxcDiagnostic> {
     let oxc::Expression::StaticMemberExpression(me) = expr else {
         return Err(invariant_err("Expected JSX member expression property to be a string", None));
     };
@@ -3532,18 +3527,18 @@ fn codegen_label(id: BlockId) -> String {
 
 fn get_instruction_value<'x, 'a>(
     reactive_value: &'x ReactiveValue<'a>,
-) -> Result<&'x InstructionValue<'a>, CompilerError> {
+) -> Result<&'x InstructionValue<'a>, OxcDiagnostic> {
     match reactive_value {
         ReactiveValue::Instruction(iv) => Ok(iv),
         _ => Err(invariant_err("Expected base instruction value", None)),
     }
 }
 
-fn invariant(condition: bool, reason: &str, span: Option<Span>) -> Result<(), CompilerError> {
+fn invariant(condition: bool, reason: &str, span: Option<Span>) -> Result<(), OxcDiagnostic> {
     if !condition { Err(invariant_err(reason, span)) } else { Ok(()) }
 }
 
-fn invariant_err(reason: &str, span: Option<Span>) -> CompilerError {
+fn invariant_err(reason: &str, span: Option<Span>) -> OxcDiagnostic {
     invariant_err_with_detail_message(reason, reason, span)
 }
 
@@ -3551,12 +3546,10 @@ fn invariant_err_with_detail_message(
     reason: &str,
     message: &str,
     span: Option<Span>,
-) -> CompilerError {
-    CompilerError::from(
-        ErrorCategory::Invariant
-            .diagnostic(reason)
-            .with_labels(span.map(|s| s.label(message.to_string()))),
-    )
+) -> OxcDiagnostic {
+    ErrorCategory::Invariant
+        .diagnostic(reason)
+        .with_labels(span.map(|s| s.label(message.to_string())))
 }
 
 fn compare_scope_dependency(

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/extract_scope_declarations_from_destructuring.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/extract_scope_declarations_from_destructuring.rs
@@ -10,7 +10,8 @@
 
 use rustc_hash::FxHashSet;
 
-use crate::diagnostics::CompilerError;
+use oxc_diagnostics::OxcDiagnostic;
+
 use crate::react_compiler_hir::{
     DeclarationId, IdentifierId, IdentifierName, InstructionKind, InstructionValue, LValue,
     ParamPattern, Place, ReactiveFunction, ReactiveInstruction, ReactiveScopeBlock,
@@ -31,7 +32,7 @@ use crate::react_compiler_reactive_scopes::visitors::{
 pub fn extract_scope_declarations_from_destructuring<'a>(
     func: &mut ReactiveFunction<'a>,
     env: &mut Environment<'a>,
-) -> Result<(), CompilerError> {
+) -> Result<(), OxcDiagnostic> {
     let mut declared: FxHashSet<DeclarationId> = FxHashSet::default();
     for param in &func.params {
         let place = match param {
@@ -65,7 +66,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
         &mut self,
         scope: &mut ReactiveScopeBlock<'a>,
         state: &mut ExtractState,
-    ) -> Result<(), CompilerError> {
+    ) -> Result<(), OxcDiagnostic> {
         let scope_data = &self.env.scopes[scope.scope.0 as usize];
         let decl_ids: Vec<DeclarationId> = scope_data
             .declarations
@@ -85,7 +86,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
         &mut self,
         instruction: &mut ReactiveInstruction<'a>,
         state: &mut ExtractState,
-    ) -> Result<Transformed<ReactiveStatement<'a>>, CompilerError> {
+    ) -> Result<Transformed<ReactiveStatement<'a>>, OxcDiagnostic> {
         self.visit_instruction(instruction, state)?;
 
         let mut extra_instructions: Option<Vec<ReactiveInstruction<'a>>> = None;

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/merge_reactive_scopes_that_invalidate_together.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/merge_reactive_scopes_that_invalidate_together.rs
@@ -12,7 +12,9 @@ use std::mem::take;
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use crate::diagnostics::{CompilerError, ErrorCategory};
+use oxc_diagnostics::OxcDiagnostic;
+
+use crate::diagnostics::ErrorCategory;
 use crate::react_compiler_hir::{
     DeclarationId, DependencyPathEntry, EvaluationOrder, InstructionKind, InstructionValue, Place,
     ReactiveBlock, ReactiveFunction, ReactiveScopeBlock, ReactiveScopeDependency,
@@ -35,7 +37,7 @@ use crate::react_compiler_reactive_scopes::visitors::{
 pub fn merge_reactive_scopes_that_invalidate_together<'a>(
     func: &mut ReactiveFunction<'a>,
     env: &mut Environment<'a>,
-) -> Result<(), CompilerError> {
+) -> Result<(), OxcDiagnostic> {
     // Pass 1: find last usage of each declaration
     let visitor = FindLastUsageVisitor { env: &*env };
     let mut last_usage: FxHashMap<DeclarationId, EvaluationOrder> = FxHashMap::default();
@@ -95,7 +97,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for MergeTransform<'a, 'e> {
         &mut self,
         scope: &mut ReactiveScopeBlock<'a>,
         state: &mut Self::State,
-    ) -> Result<Transformed<ReactiveStatement<'a>>, CompilerError> {
+    ) -> Result<Transformed<ReactiveStatement<'a>>, OxcDiagnostic> {
         let scope_deps = self.env.scopes[scope.scope.0 as usize].dependencies.clone();
         // Save parent state and recurse with this scope's deps as state
         let parent_state = state.take();
@@ -119,7 +121,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for MergeTransform<'a, 'e> {
         &mut self,
         block: &mut ReactiveBlock<'a>,
         state: &mut Self::State,
-    ) -> Result<(), CompilerError> {
+    ) -> Result<(), OxcDiagnostic> {
         // Pass 1: traverse nested (scope flattening handled by transform_scope)
         self.traverse_block(block, state)?;
         // Pass 2+3: merge consecutive scopes in this block
@@ -133,7 +135,7 @@ impl<'a, 'e> MergeTransform<'a, 'e> {
     fn merge_scopes_in_block(
         &mut self,
         block: &mut ReactiveBlock<'a>,
-    ) -> Result<(), CompilerError> {
+    ) -> Result<(), OxcDiagnostic> {
         // Pass 2: identify scopes for merging
         struct MergedScope {
             scope_id: ScopeId,
@@ -352,8 +354,7 @@ impl<'a, 'e> MergeTransform<'a, 'e> {
                 ReactiveStatement::Scope(s) => s.clone(),
                 _ => {
                     return Err(ErrorCategory::Invariant
-                        .diagnostic("MergeConsecutiveScopes: Expected scope at starting index")
-                        .into());
+                        .diagnostic("MergeConsecutiveScopes: Expected scope at starting index"));
                 }
             };
             index += 1;

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/propagate_early_returns.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/propagate_early_returns.rs
@@ -12,7 +12,8 @@
 
 use std::mem::take;
 
-use crate::diagnostics::CompilerError;
+use oxc_diagnostics::OxcDiagnostic;
+
 use crate::react_compiler_hir::{
     BlockId, Effect, EvaluationOrder, IdentifierId, IdentifierName, InstructionKind,
     InstructionValue, LValue, NonLocalBinding, Place, PlaceOrSpread, PrimitiveValue,
@@ -79,7 +80,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
         &mut self,
         scope_block: &mut ReactiveScopeBlock<'a>,
         parent_state: &mut State,
-    ) -> Result<(), CompilerError> {
+    ) -> Result<(), OxcDiagnostic> {
         let scope_id = scope_block.scope;
 
         // Exit early if an earlier pass has already created an early return
@@ -111,7 +112,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
         &mut self,
         stmt: &mut ReactiveTerminalStatement<'a>,
         state: &mut State,
-    ) -> Result<Transformed<ReactiveStatement<'a>>, CompilerError> {
+    ) -> Result<Transformed<ReactiveStatement<'a>>, OxcDiagnostic> {
         if state.within_reactive_scope {
             if let ReactiveTerminal::Return { value, .. } = &stmt.terminal {
                 let span = value.span;

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_always_invalidating_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_always_invalidating_scopes.rs
@@ -15,7 +15,8 @@ use std::mem::take;
 
 use rustc_hash::FxHashSet;
 
-use crate::diagnostics::CompilerError;
+use oxc_diagnostics::OxcDiagnostic;
+
 use crate::react_compiler_hir::{
     IdentifierId, InstructionValue, PrunedReactiveScopeBlock, ReactiveFunction,
     ReactiveInstruction, ReactiveScopeBlock, ReactiveStatement, ReactiveValue,
@@ -32,7 +33,7 @@ use crate::react_compiler_reactive_scopes::visitors::{
 pub fn prune_always_invalidating_scopes<'a>(
     func: &mut ReactiveFunction<'a>,
     env: &Environment<'a>,
-) -> Result<(), CompilerError> {
+) -> Result<(), OxcDiagnostic> {
     let mut transform = Transform {
         env,
         always_invalidating_values: FxHashSet::default(),
@@ -59,7 +60,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
         &mut self,
         instruction: &mut ReactiveInstruction<'a>,
         within_scope: &mut bool,
-    ) -> Result<Transformed<ReactiveStatement<'a>>, CompilerError> {
+    ) -> Result<Transformed<ReactiveStatement<'a>>, OxcDiagnostic> {
         self.visit_instruction(instruction, within_scope)?;
 
         let lvalue = &instruction.lvalue;
@@ -109,7 +110,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
         &mut self,
         scope: &mut ReactiveScopeBlock<'a>,
         _within_scope: &mut bool,
-    ) -> Result<Transformed<ReactiveStatement<'a>>, CompilerError> {
+    ) -> Result<Transformed<ReactiveStatement<'a>>, OxcDiagnostic> {
         let mut within_scope = true;
         self.visit_scope(scope, &mut within_scope)?;
 

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_hoisted_contexts.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_hoisted_contexts.rs
@@ -10,7 +10,9 @@
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use crate::diagnostics::{CompilerError, ErrorCategory};
+use oxc_diagnostics::OxcDiagnostic;
+
+use crate::diagnostics::ErrorCategory;
 use crate::react_compiler_hir::{
     EvaluationOrder, IdentifierId, InstructionKind, InstructionValue, Place, ReactiveFunction,
     ReactiveInstruction, ReactiveScopeBlock, ReactiveStatement, ReactiveValue,
@@ -31,7 +33,7 @@ use crate::react_compiler_reactive_scopes::visitors::{
 pub fn prune_hoisted_contexts<'a>(
     func: &mut ReactiveFunction<'a>,
     env: &Environment<'a>,
-) -> Result<(), CompilerError> {
+) -> Result<(), OxcDiagnostic> {
     let mut transform = Transform { env };
     let mut state = VisitorState { active_scopes: Vec::new(), uninitialized: FxHashMap::default() };
     transform_reactive_function(func, &mut transform, &mut state)
@@ -78,7 +80,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
         &mut self,
         scope: &mut ReactiveScopeBlock<'a>,
         state: &mut VisitorState,
-    ) -> Result<(), CompilerError> {
+    ) -> Result<(), OxcDiagnostic> {
         let scope_data = &self.env.scopes[scope.scope.0 as usize];
         let decl_ids: FxHashSet<IdentifierId> =
             scope_data.declarations.iter().map(|(id, _)| *id).collect();
@@ -105,18 +107,14 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
         _id: EvaluationOrder,
         place: &Place,
         state: &mut VisitorState,
-    ) -> Result<(), CompilerError> {
+    ) -> Result<(), OxcDiagnostic> {
         if let Some(UninitializedKind::Func { definition }) =
             state.uninitialized.get(&place.identifier)
         {
             if *definition != Some(place.identifier) {
-                let mut err = CompilerError::new();
-                err.push(
-                    ErrorCategory::Todo
-                        .diagnostic("[PruneHoistedContexts] Rewrite hoisted function references")
-                        .with_labels(place.span),
-                );
-                return Err(err);
+                return Err(ErrorCategory::Todo
+                    .diagnostic("[PruneHoistedContexts] Rewrite hoisted function references")
+                    .with_labels(place.span));
             }
         }
         Ok(())
@@ -126,7 +124,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
         &mut self,
         instruction: &mut ReactiveInstruction<'a>,
         state: &mut VisitorState,
-    ) -> Result<Transformed<ReactiveStatement<'a>>, CompilerError> {
+    ) -> Result<Transformed<ReactiveStatement<'a>>, OxcDiagnostic> {
         // Remove hoisted declarations to preserve TDZ
         if let ReactiveValue::Instruction(InstructionValue::DeclareContext { lvalue, .. }) =
             &instruction.value
@@ -158,28 +156,20 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
                     } else if lvalue.kind == InstructionKind::Function {
                         if let Some(kind) = state.uninitialized.get(&lvalue_id) {
                             if !matches!(kind, UninitializedKind::Func { .. }) {
-                                let mut err = CompilerError::new();
-                                err.push(
-                                    ErrorCategory::Invariant
-                                        .diagnostic(
-                                            "[PruneHoistedContexts] Unexpected hoisted function",
-                                        )
-                                        .with_labels(instruction.span),
-                                );
-                                return Err(err);
+                                return Err(ErrorCategory::Invariant
+                                    .diagnostic(
+                                        "[PruneHoistedContexts] Unexpected hoisted function",
+                                    )
+                                    .with_labels(instruction.span));
                             }
                             // References to hoisted functions are now "safe" as
                             // variable assignments have finished.
                             state.uninitialized.remove(&lvalue_id);
                         }
                     } else {
-                        let mut err = CompilerError::new();
-                        err.push(
-                            ErrorCategory::Todo
-                                .diagnostic("[PruneHoistedContexts] Unexpected kind")
-                                .with_labels(instruction.span),
-                        );
-                        return Err(err);
+                        return Err(ErrorCategory::Todo
+                            .diagnostic("[PruneHoistedContexts] Unexpected kind")
+                            .with_labels(instruction.span));
                     }
                 }
             }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_escaping_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_escaping_scopes.rs
@@ -13,7 +13,8 @@ use std::mem::take;
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 
-use crate::diagnostics::CompilerError;
+use oxc_diagnostics::OxcDiagnostic;
+
 use crate::react_compiler_hir::ArrayPatternElement;
 use crate::react_compiler_hir::DeclarationId;
 use crate::react_compiler_hir::Effect;
@@ -60,7 +61,7 @@ type ScopeMemoNodes = FxHashMap<ScopeId, (Vec<DeclarationId>, bool)>;
 pub fn prune_non_escaping_scopes<'a>(
     func: &mut ReactiveFunction<'a>,
     env: &mut Environment<'a>,
-) -> Result<(), CompilerError> {
+) -> Result<(), OxcDiagnostic> {
     // First build up a map of which instructions are involved in creating which values,
     // and which values are returned.
     let mut state = CollectState::new();
@@ -1078,7 +1079,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for PruneScopesTransform<'a, 'e> {
         &mut self,
         scope: &mut ReactiveScopeBlock<'a>,
         state: &mut FxHashSet<DeclarationId>,
-    ) -> Result<Transformed<ReactiveStatement<'a>>, CompilerError> {
+    ) -> Result<Transformed<ReactiveStatement<'a>>, OxcDiagnostic> {
         self.visit_scope(scope, state)?;
 
         let scope_id = scope.scope;
@@ -1112,7 +1113,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for PruneScopesTransform<'a, 'e> {
         &mut self,
         instruction: &mut ReactiveInstruction<'a>,
         state: &mut FxHashSet<DeclarationId>,
-    ) -> Result<Transformed<ReactiveStatement<'a>>, CompilerError> {
+    ) -> Result<Transformed<ReactiveStatement<'a>>, OxcDiagnostic> {
         self.traverse_instruction(instruction, state)?;
 
         match &mut instruction.value {

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_reactive_dependencies.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_reactive_dependencies.rs
@@ -10,7 +10,8 @@
 
 use rustc_hash::FxHashSet;
 
-use crate::diagnostics::CompilerError;
+use oxc_diagnostics::OxcDiagnostic;
+
 use crate::react_compiler_hir::{
     EvaluationOrder, IdentifierId, InstructionValue, Place, PrunedReactiveScopeBlock,
     ReactiveFunction, ReactiveInstruction, ReactiveScopeBlock, ReactiveValue, Type,
@@ -149,7 +150,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for PruneVisitor<'a, 'e> {
         &mut self,
         instruction: &mut ReactiveInstruction<'a>,
         state: &mut Self::State,
-    ) -> Result<(), CompilerError> {
+    ) -> Result<(), OxcDiagnostic> {
         self.traverse_instruction(instruction, state)?;
 
         let lvalue = &instruction.lvalue;
@@ -219,7 +220,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for PruneVisitor<'a, 'e> {
         &mut self,
         scope: &mut ReactiveScopeBlock<'a>,
         state: &mut Self::State,
-    ) -> Result<(), CompilerError> {
+    ) -> Result<(), OxcDiagnostic> {
         self.traverse_scope(scope, state)?;
 
         let scope_id = scope.scope;

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_unused_labels.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_unused_labels.rs
@@ -12,7 +12,8 @@ use std::mem::take;
 
 use rustc_hash::FxHashSet;
 
-use crate::diagnostics::CompilerError;
+use oxc_diagnostics::OxcDiagnostic;
+
 use crate::react_compiler_hir::{
     BlockId, ReactiveFunction, ReactiveStatement, ReactiveTerminal, ReactiveTerminalStatement,
     ReactiveTerminalTargetKind, environment::Environment,
@@ -26,7 +27,7 @@ use crate::react_compiler_reactive_scopes::visitors::{
 pub fn prune_unused_labels<'a>(
     func: &mut ReactiveFunction<'a>,
     env: &Environment<'a>,
-) -> Result<(), CompilerError> {
+) -> Result<(), OxcDiagnostic> {
     let mut transform = Transform { env };
     let mut labels: FxHashSet<BlockId> = FxHashSet::default();
     transform_reactive_function(func, &mut transform, &mut labels)
@@ -47,7 +48,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
         &mut self,
         stmt: &mut ReactiveTerminalStatement<'a>,
         state: &mut FxHashSet<BlockId>,
-    ) -> Result<Transformed<ReactiveStatement<'a>>, CompilerError> {
+    ) -> Result<Transformed<ReactiveStatement<'a>>, OxcDiagnostic> {
         // Traverse children first
         self.traverse_terminal(stmt, state)?;
 

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_unused_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_unused_scopes.rs
@@ -9,7 +9,8 @@
 
 use std::mem::take;
 
-use crate::diagnostics::CompilerError;
+use oxc_diagnostics::OxcDiagnostic;
+
 use crate::react_compiler_hir::{
     PrunedReactiveScopeBlock, ReactiveFunction, ReactiveScope, ReactiveScopeBlock,
     ReactiveStatement, ReactiveTerminal, ReactiveTerminalStatement, ScopeId,
@@ -29,7 +30,7 @@ struct State {
 pub fn prune_unused_scopes<'a>(
     func: &mut ReactiveFunction<'a>,
     env: &Environment<'a>,
-) -> Result<(), CompilerError> {
+) -> Result<(), OxcDiagnostic> {
     let mut transform = Transform { env };
     let mut state = State { has_return_statement: false };
     transform_reactive_function(func, &mut transform, &mut state)
@@ -50,7 +51,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
         &mut self,
         stmt: &mut ReactiveTerminalStatement<'a>,
         state: &mut State,
-    ) -> Result<(), CompilerError> {
+    ) -> Result<(), OxcDiagnostic> {
         self.traverse_terminal(stmt, state)?;
         if matches!(stmt.terminal, ReactiveTerminal::Return { .. }) {
             state.has_return_statement = true;
@@ -62,7 +63,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
         &mut self,
         scope: &mut ReactiveScopeBlock<'a>,
         _state: &mut State,
-    ) -> Result<Transformed<ReactiveStatement<'a>>, CompilerError> {
+    ) -> Result<Transformed<ReactiveStatement<'a>>, OxcDiagnostic> {
         let mut scope_state = State { has_return_statement: false };
         self.visit_scope(scope, &mut scope_state)?;
 

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/stabilize_block_ids.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/stabilize_block_ids.rs
@@ -12,7 +12,8 @@
 
 use rustc_hash::FxHashMap;
 
-use crate::diagnostics::CompilerError;
+use oxc_diagnostics::OxcDiagnostic;
+
 use crate::react_compiler_hir::{
     BlockId, ReactiveFunction, ReactiveScopeBlock, ReactiveTerminal, ReactiveTerminalStatement,
     environment::Environment,
@@ -102,7 +103,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for RewriteBlockIds<'a, 'e> {
         &mut self,
         scope: &mut ReactiveScopeBlock<'a>,
         state: &mut Self::State,
-    ) -> Result<(), CompilerError> {
+    ) -> Result<(), OxcDiagnostic> {
         let scope_data = &mut self.env.scopes[scope.scope.0 as usize];
         if let Some(ref mut early_return) = scope_data.early_return_value {
             early_return.label = get_or_insert_mapping(state, early_return.label);
@@ -114,7 +115,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for RewriteBlockIds<'a, 'e> {
         &mut self,
         stmt: &mut ReactiveTerminalStatement<'a>,
         state: &mut Self::State,
-    ) -> Result<(), CompilerError> {
+    ) -> Result<(), OxcDiagnostic> {
         if let Some(ref mut label) = stmt.label {
             label.id = get_or_insert_mapping(state, label.id);
         }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/visitors.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/visitors.rs
@@ -9,7 +9,8 @@
 
 use std::mem::replace;
 
-use crate::diagnostics::CompilerError;
+use oxc_diagnostics::OxcDiagnostic;
+
 use crate::react_compiler_hir::visitors::{
     each_instruction_value_lvalue, each_instruction_value_operand, each_terminal_operand,
 };
@@ -316,7 +317,7 @@ pub trait ReactiveFunctionTransform<'a> {
         &mut self,
         _id: EvaluationOrder,
         _state: &mut Self::State,
-    ) -> Result<(), CompilerError> {
+    ) -> Result<(), OxcDiagnostic> {
         Ok(())
     }
 
@@ -325,7 +326,7 @@ pub trait ReactiveFunctionTransform<'a> {
         _id: EvaluationOrder,
         _place: &Place,
         _state: &mut Self::State,
-    ) -> Result<(), CompilerError> {
+    ) -> Result<(), OxcDiagnostic> {
         Ok(())
     }
 
@@ -334,7 +335,7 @@ pub trait ReactiveFunctionTransform<'a> {
         _id: EvaluationOrder,
         _lvalue: &Place,
         _state: &mut Self::State,
-    ) -> Result<(), CompilerError> {
+    ) -> Result<(), OxcDiagnostic> {
         Ok(())
     }
 
@@ -343,7 +344,7 @@ pub trait ReactiveFunctionTransform<'a> {
         id: EvaluationOrder,
         value: &mut ReactiveValue<'a>,
         state: &mut Self::State,
-    ) -> Result<(), CompilerError> {
+    ) -> Result<(), OxcDiagnostic> {
         self.traverse_value(id, value, state)
     }
 
@@ -352,7 +353,7 @@ pub trait ReactiveFunctionTransform<'a> {
         id: EvaluationOrder,
         value: &mut ReactiveValue<'a>,
         state: &mut Self::State,
-    ) -> Result<(), CompilerError> {
+    ) -> Result<(), OxcDiagnostic> {
         match value {
             ReactiveValue::OptionalExpression { value: inner, .. } => {
                 let next = self.transform_value(id, inner, state)?;
@@ -412,7 +413,7 @@ pub trait ReactiveFunctionTransform<'a> {
         &mut self,
         instruction: &mut ReactiveInstruction<'a>,
         state: &mut Self::State,
-    ) -> Result<(), CompilerError> {
+    ) -> Result<(), OxcDiagnostic> {
         self.traverse_instruction(instruction, state)
     }
 
@@ -421,7 +422,7 @@ pub trait ReactiveFunctionTransform<'a> {
         id: EvaluationOrder,
         value: &mut ReactiveValue<'a>,
         state: &mut Self::State,
-    ) -> Result<TransformedValue<'a>, CompilerError> {
+    ) -> Result<TransformedValue<'a>, OxcDiagnostic> {
         self.visit_value(id, value, state)?;
         Ok(TransformedValue::Keep)
     }
@@ -430,7 +431,7 @@ pub trait ReactiveFunctionTransform<'a> {
         &mut self,
         instruction: &mut ReactiveInstruction<'a>,
         state: &mut Self::State,
-    ) -> Result<(), CompilerError> {
+    ) -> Result<(), OxcDiagnostic> {
         self.visit_id(instruction.id, state)?;
         // Visit instruction-level lvalue
         if let Some(lvalue) = &instruction.lvalue {
@@ -453,7 +454,7 @@ pub trait ReactiveFunctionTransform<'a> {
         &mut self,
         stmt: &mut ReactiveTerminalStatement<'a>,
         state: &mut Self::State,
-    ) -> Result<(), CompilerError> {
+    ) -> Result<(), OxcDiagnostic> {
         self.traverse_terminal(stmt, state)
     }
 
@@ -461,7 +462,7 @@ pub trait ReactiveFunctionTransform<'a> {
         &mut self,
         stmt: &mut ReactiveTerminalStatement<'a>,
         state: &mut Self::State,
-    ) -> Result<(), CompilerError> {
+    ) -> Result<(), OxcDiagnostic> {
         let terminal = &mut stmt.terminal;
         let id = terminal_id(terminal);
         self.visit_id(id, state)?;
@@ -565,7 +566,7 @@ pub trait ReactiveFunctionTransform<'a> {
         &mut self,
         scope: &mut ReactiveScopeBlock<'a>,
         state: &mut Self::State,
-    ) -> Result<(), CompilerError> {
+    ) -> Result<(), OxcDiagnostic> {
         self.traverse_scope(scope, state)
     }
 
@@ -573,7 +574,7 @@ pub trait ReactiveFunctionTransform<'a> {
         &mut self,
         scope: &mut ReactiveScopeBlock<'a>,
         state: &mut Self::State,
-    ) -> Result<(), CompilerError> {
+    ) -> Result<(), OxcDiagnostic> {
         self.visit_block(&mut scope.instructions, state)
     }
 
@@ -581,7 +582,7 @@ pub trait ReactiveFunctionTransform<'a> {
         &mut self,
         scope: &mut PrunedReactiveScopeBlock<'a>,
         state: &mut Self::State,
-    ) -> Result<(), CompilerError> {
+    ) -> Result<(), OxcDiagnostic> {
         self.traverse_pruned_scope(scope, state)
     }
 
@@ -589,7 +590,7 @@ pub trait ReactiveFunctionTransform<'a> {
         &mut self,
         scope: &mut PrunedReactiveScopeBlock<'a>,
         state: &mut Self::State,
-    ) -> Result<(), CompilerError> {
+    ) -> Result<(), OxcDiagnostic> {
         self.visit_block(&mut scope.instructions, state)
     }
 
@@ -597,7 +598,7 @@ pub trait ReactiveFunctionTransform<'a> {
         &mut self,
         block: &mut ReactiveBlock<'a>,
         state: &mut Self::State,
-    ) -> Result<(), CompilerError> {
+    ) -> Result<(), OxcDiagnostic> {
         self.traverse_block(block, state)
     }
 
@@ -605,7 +606,7 @@ pub trait ReactiveFunctionTransform<'a> {
         &mut self,
         instruction: &mut ReactiveInstruction<'a>,
         state: &mut Self::State,
-    ) -> Result<Transformed<ReactiveStatement<'a>>, CompilerError> {
+    ) -> Result<Transformed<ReactiveStatement<'a>>, OxcDiagnostic> {
         self.visit_instruction(instruction, state)?;
         Ok(Transformed::Keep)
     }
@@ -614,7 +615,7 @@ pub trait ReactiveFunctionTransform<'a> {
         &mut self,
         stmt: &mut ReactiveTerminalStatement<'a>,
         state: &mut Self::State,
-    ) -> Result<Transformed<ReactiveStatement<'a>>, CompilerError> {
+    ) -> Result<Transformed<ReactiveStatement<'a>>, OxcDiagnostic> {
         self.visit_terminal(stmt, state)?;
         Ok(Transformed::Keep)
     }
@@ -623,7 +624,7 @@ pub trait ReactiveFunctionTransform<'a> {
         &mut self,
         scope: &mut ReactiveScopeBlock<'a>,
         state: &mut Self::State,
-    ) -> Result<Transformed<ReactiveStatement<'a>>, CompilerError> {
+    ) -> Result<Transformed<ReactiveStatement<'a>>, OxcDiagnostic> {
         self.visit_scope(scope, state)?;
         Ok(Transformed::Keep)
     }
@@ -632,7 +633,7 @@ pub trait ReactiveFunctionTransform<'a> {
         &mut self,
         scope: &mut PrunedReactiveScopeBlock<'a>,
         state: &mut Self::State,
-    ) -> Result<Transformed<ReactiveStatement<'a>>, CompilerError> {
+    ) -> Result<Transformed<ReactiveStatement<'a>>, OxcDiagnostic> {
         self.visit_pruned_scope(scope, state)?;
         Ok(Transformed::Keep)
     }
@@ -641,7 +642,7 @@ pub trait ReactiveFunctionTransform<'a> {
         &mut self,
         block: &mut ReactiveBlock<'a>,
         state: &mut Self::State,
-    ) -> Result<(), CompilerError> {
+    ) -> Result<(), OxcDiagnostic> {
         let mut next_block: Option<Vec<ReactiveStatement<'a>>> = None;
         let len = block.len();
         for i in 0..len {
@@ -709,7 +710,7 @@ pub fn transform_reactive_function<'a, T: ReactiveFunctionTransform<'a>>(
     func: &mut ReactiveFunction<'a>,
     transform: &mut T,
     state: &mut T::State,
-) -> Result<(), CompilerError> {
+) -> Result<(), OxcDiagnostic> {
     transform.visit_block(&mut func.body, state)
 }
 

--- a/crates/oxc_react_compiler/src/react_compiler_ssa/rewrite_instruction_kinds_based_on_reassignment.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_ssa/rewrite_instruction_kinds_based_on_reassignment.rs
@@ -19,7 +19,9 @@ use std::borrow::Cow;
 
 use rustc_hash::FxHashMap;
 
-use crate::diagnostics::{CompilerError, ErrorCategory};
+use oxc_diagnostics::OxcDiagnostic;
+
+use crate::diagnostics::ErrorCategory;
 use crate::react_compiler_hir::visitors::each_pattern_operand;
 use crate::react_compiler_hir::{
     BlockKind, DeclarationId, HirFunction, InstructionKind, InstructionValue, ParamPattern, Place,
@@ -28,10 +30,10 @@ use crate::react_compiler_hir::{
 
 use crate::react_compiler_hir::environment::Environment;
 
-/// Create an invariant CompilerError (matches TS CompilerError.invariant).
+/// Create an invariant diagnostic (matches TS CompilerError.invariant).
 /// When a span is provided, it is attached as a labelled span
 /// (matching TS CompilerError.invariant which uses .withDetails()).
-fn invariant_error(reason: &str, description: Option<String>) -> CompilerError {
+fn invariant_error(reason: &str, description: Option<String>) -> OxcDiagnostic {
     invariant_error_with_span(reason, description, None)
 }
 
@@ -39,13 +41,13 @@ fn invariant_error_with_span(
     reason: &str,
     description: Option<String>,
     span: Option<Span>,
-) -> CompilerError {
+) -> OxcDiagnostic {
     let mut diagnostic =
         ErrorCategory::Invariant.diagnostic(reason).with_labels(span.map(|s| s.label(reason)));
     if let Some(description) = description {
         diagnostic = diagnostic.with_help(description);
     }
-    CompilerError::from(diagnostic)
+    diagnostic
 }
 
 /// Format an InstructionKind variant name (matches TS `${kind}` interpolation).
@@ -97,7 +99,7 @@ enum DeclarationLoc {
 pub fn rewrite_instruction_kinds_based_on_reassignment(
     func: &mut HirFunction,
     env: &Environment,
-) -> Result<(), CompilerError> {
+) -> Result<(), OxcDiagnostic> {
     // Phase 1: Collect all information about which declarations need updates.
     //
     // Track: for each DeclarationId, the location of its first declaration,
@@ -178,7 +180,7 @@ pub fn rewrite_instruction_kinds_based_on_reassignment(
                             reassign_spans.push((block_index, local_idx));
                         } else {
                             // First store — mark as Const
-                            // Mirrors TS: CompilerError.invariant(!declarations.has(...))
+                            // Mirrors TS: Diagnostics.invariant(!declarations.has(...))
                             if declarations.contains_key(&decl_id) {
                                 return Err(invariant_error_with_span(
                                     "Expected variable not to be defined prior to declaration",

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_context_variable_lvalues.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_context_variable_lvalues.rs
@@ -2,9 +2,9 @@ use rustc_hash::FxHashMap;
 use std::fmt::Display;
 use std::fmt::Formatter;
 
-use oxc_diagnostics::OxcDiagnostic;
+use oxc_diagnostics::{Diagnostics, OxcDiagnostic};
 
-use crate::diagnostics::{CompilerError, ErrorCategory};
+use crate::diagnostics::ErrorCategory;
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::visitors::{each_instruction_value_lvalue, each_pattern_operand};
 use crate::react_compiler_hir::{
@@ -53,7 +53,7 @@ pub fn validate_context_variable_lvalues_with_errors(
     func: &HirFunction,
     functions: &[HirFunction],
     identifiers: &[Identifier],
-    errors: &mut CompilerError,
+    errors: &mut Diagnostics,
 ) -> Result<(), OxcDiagnostic> {
     let mut identifier_kinds: IdentifierKinds = FxHashMap::default();
     validate_context_variable_lvalues_impl(
@@ -70,7 +70,7 @@ fn validate_context_variable_lvalues_impl(
     identifier_kinds: &mut IdentifierKinds,
     functions: &[HirFunction],
     identifiers: &[Identifier],
-    errors: &mut CompilerError,
+    errors: &mut Diagnostics,
 ) -> Result<(), OxcDiagnostic> {
     let mut inner_function_ids: Vec<FunctionId> = Vec::new();
 
@@ -162,7 +162,7 @@ fn visit(
     place: &Place,
     kind: VarRefKind,
     env_identifiers: &[Identifier],
-    errors: &mut CompilerError,
+    errors: &mut Diagnostics,
 ) -> Result<(), OxcDiagnostic> {
     if let Some((prev_place, prev_kind)) = identifiers.get(&place.identifier) {
         let was_context = *prev_kind == VarRefKind::Context;

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_hooks_usage.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_hooks_usage.rs
@@ -16,7 +16,7 @@ use rustc_hash::FxHashMap;
 
 use oxc_diagnostics::OxcDiagnostic;
 
-use crate::diagnostics::{CompilerError, ErrorCategory};
+use crate::diagnostics::ErrorCategory;
 use crate::react_compiler_hir::dominator::compute_unconditional_blocks;
 use crate::react_compiler_hir::environment::{Environment, is_hook_name};
 use crate::react_compiler_hir::object_shape::HookKind;
@@ -87,7 +87,7 @@ fn visit_place(
     value_kinds: &FxHashMap<IdentifierId, Kind>,
     errors_by_span: &mut FxIndexMap<Span, OxcDiagnostic>,
     env: &mut Environment,
-) -> Result<(), CompilerError> {
+) -> Result<(), OxcDiagnostic> {
     let kind = value_kinds.get(&place.identifier).copied();
     if kind == Some(Kind::KnownHook) {
         record_invalid_hook_usage_error(place, errors_by_span, env)?;
@@ -100,7 +100,7 @@ fn record_conditional_hook_error(
     value_kinds: &mut FxHashMap<IdentifierId, Kind>,
     errors_by_span: &mut FxIndexMap<Span, OxcDiagnostic>,
     env: &mut Environment,
-) -> Result<(), CompilerError> {
+) -> Result<(), OxcDiagnostic> {
     value_kinds.insert(place.identifier, Kind::Error);
     let reason = "Hooks must always be called in a consistent order, and may not be called conditionally. See the Rules of Hooks (https://react.dev/warnings/invalid-hook-call-warning)";
     if let Some(span) = place.span {
@@ -119,7 +119,7 @@ fn record_invalid_hook_usage_error(
     place: &Place,
     errors_by_span: &mut FxIndexMap<Span, OxcDiagnostic>,
     env: &mut Environment,
-) -> Result<(), CompilerError> {
+) -> Result<(), OxcDiagnostic> {
     let reason = "Hooks may not be referenced as normal values, they must be called. See https://react.dev/reference/rules/react-calls-components-and-hooks#never-pass-around-hooks-as-regular-values";
     if let Some(span) = place.span {
         if !errors_by_span.contains_key(&span) {
@@ -135,7 +135,7 @@ fn record_dynamic_hook_usage_error(
     place: &Place,
     errors_by_span: &mut FxIndexMap<Span, OxcDiagnostic>,
     env: &mut Environment,
-) -> Result<(), CompilerError> {
+) -> Result<(), OxcDiagnostic> {
     let reason = "Hooks must be the same function on every render, but this value may change over time to a different function. See https://react.dev/reference/rules/react-calls-components-and-hooks#dont-dynamically-use-hooks";
     if let Some(span) = place.span {
         if !errors_by_span.contains_key(&span) {
@@ -370,7 +370,7 @@ pub fn validate_hooks_usage(
 fn visit_function_expression(
     env: &mut Environment,
     func_id: FunctionId,
-) -> Result<(), CompilerError> {
+) -> Result<(), OxcDiagnostic> {
     // Collect items in instruction order to process them sequentially.
     // Each item is either a call to check or a nested function to visit.
     enum Item {
@@ -462,7 +462,7 @@ fn visit_all_operands(
     value_kinds: &FxHashMap<IdentifierId, Kind>,
     errors_by_span: &mut FxIndexMap<Span, OxcDiagnostic>,
     env: &mut Environment,
-) -> Result<(), CompilerError> {
+) -> Result<(), OxcDiagnostic> {
     let operands = visitors::each_instruction_value_operand(value, &*env);
     for place in &operands {
         visit_place(place, value_kinds, errors_by_span, env)?;

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_capitalized_calls.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_capitalized_calls.rs
@@ -1,7 +1,9 @@
 use cow_utils::CowUtils;
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use crate::diagnostics::{CompilerError, ErrorCategory};
+use oxc_diagnostics::OxcDiagnostic;
+
+use crate::diagnostics::ErrorCategory;
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::{HirFunction, IdentifierId, InstructionValue, PropertyLiteral};
 
@@ -11,7 +13,7 @@ use crate::react_compiler_hir::{HirFunction, IdentifierId, InstructionValue, Pro
 pub fn validate_no_capitalized_calls(
     func: &HirFunction,
     env: &mut Environment,
-) -> Result<(), CompilerError> {
+) -> Result<(), OxcDiagnostic> {
     // Build the allow list from global registry keys + config entries
     let mut allow_list: FxHashSet<String> = env.globals().keys().map(str::to_owned).collect();
     if let Some(config_entries) = &env.config.validate_no_capitalized_calls {

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_derived_computations_in_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_derived_computations_in_effects.rs
@@ -13,9 +13,9 @@
 use crate::react_compiler_utils::{FxIndexMap, FxIndexSet};
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use oxc_diagnostics::OxcDiagnostic;
+use oxc_diagnostics::{Diagnostics, OxcDiagnostic};
 
-use crate::diagnostics::{CompilerError, ErrorCategory};
+use crate::diagnostics::ErrorCategory;
 use crate::react_compiler_hir::BasicBlock;
 use crate::react_compiler_hir::Instruction;
 use crate::react_compiler_hir::Terminal;
@@ -271,7 +271,7 @@ fn is_mutable_at(
 pub fn validate_no_derived_computations_in_effects_exp(
     func: &HirFunction,
     env: &Environment,
-) -> Result<CompilerError, OxcDiagnostic> {
+) -> Result<Diagnostics, OxcDiagnostic> {
     let identifiers = &env.identifiers;
 
     let mut context = ValidationContext {
@@ -344,7 +344,7 @@ pub fn validate_no_derived_computations_in_effects_exp(
     }
 
     // Validate all effect sites
-    let mut errors = CompilerError::new();
+    let mut errors = Diagnostics::new();
     let effects_cache: Vec<(IdentifierId, FunctionId, Vec<DepElement>)> = context
         .effects_cache
         .iter()
@@ -736,7 +736,7 @@ fn validate_effect(
     dependencies: &[DepElement],
     context: &mut ValidationContext,
     env: &Environment,
-    errors: &mut CompilerError,
+    errors: &mut Diagnostics,
 ) {
     let identifiers = &env.identifiers;
     let types = &env.types;
@@ -976,7 +976,7 @@ fn validate_effect(
 pub fn validate_no_derived_computations_in_effects(
     func: &HirFunction,
     env: &mut Environment,
-) -> Result<(), CompilerError> {
+) -> Result<(), OxcDiagnostic> {
     // Phase 1: Collect effect call sites (func_id + resolved deps).
     // Done with only immutable borrows of env fields.
     let effects_to_validate: Vec<(FunctionId, Vec<IdentifierId>)> = {

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_jsx_in_try_statement.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_jsx_in_try_statement.rs
@@ -15,12 +15,14 @@
 //!
 //! Port of ValidateNoJSXInTryStatement.ts.
 
-use crate::diagnostics::{CompilerError, ErrorCategory};
+use oxc_diagnostics::Diagnostics;
+
+use crate::diagnostics::ErrorCategory;
 use crate::react_compiler_hir::{BlockId, HirFunction, InstructionValue, Terminal};
 
-pub fn validate_no_jsx_in_try_statement(func: &HirFunction) -> CompilerError {
+pub fn validate_no_jsx_in_try_statement(func: &HirFunction) -> Diagnostics {
     let mut active_try_blocks: Vec<BlockId> = Vec::new();
-    let mut error = CompilerError::new();
+    let mut error = Diagnostics::new();
 
     for (_block_id, block) in &func.body.blocks {
         // Remove completed try blocks (retainWhere equivalent)

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_set_state_in_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_set_state_in_effects.rs
@@ -14,9 +14,9 @@
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use oxc_diagnostics::OxcDiagnostic;
+use oxc_diagnostics::{Diagnostics, OxcDiagnostic};
 
-use crate::diagnostics::{CompilerError, ErrorCategory};
+use crate::diagnostics::ErrorCategory;
 use crate::react_compiler_hir::ArrayPatternElement;
 use crate::react_compiler_hir::ObjectPropertyOrSpread;
 use crate::react_compiler_hir::Pattern;
@@ -32,14 +32,14 @@ use crate::react_compiler_hir::{
 pub fn validate_no_set_state_in_effects(
     func: &HirFunction,
     env: &Environment,
-) -> Result<CompilerError, OxcDiagnostic> {
+) -> Result<Diagnostics, OxcDiagnostic> {
     let identifiers = &env.identifiers;
     let types = &env.types;
     let functions = &env.functions;
 
     // Map from IdentifierId to the Place where the setState originated
     let mut set_state_functions: FxHashMap<IdentifierId, SetStateInfo> = FxHashMap::default();
-    let mut errors = CompilerError::new();
+    let mut errors = Diagnostics::new();
 
     for (_block_id, block) in &func.body.blocks {
         for &instr_id in &block.instructions {
@@ -152,7 +152,7 @@ fn is_set_state_type_by_id(
     is_set_state_type(ty)
 }
 
-fn push_error(errors: &mut CompilerError, info: &SetStateInfo, enable_verbose: bool) {
+fn push_error(errors: &mut Diagnostics, info: &SetStateInfo, enable_verbose: bool) {
     if enable_verbose {
         errors.push(
             ErrorCategory::EffectSetState

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_preserved_manual_memoization.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_preserved_manual_memoization.rs
@@ -183,7 +183,7 @@ fn visit_instruction(instr: &ReactiveInstruction, state: &mut VisitorState<'_, '
             has_invalid_deps,
             ..
         }) => {
-            // TS: CompilerError.invariant(state.manualMemoState == null, ...)
+            // TS: Diagnostics.invariant(state.manualMemoState == null, ...)
             if state.manual_memo_state.is_some() {
                 return;
             }
@@ -238,7 +238,7 @@ fn visit_instruction(instr: &ReactiveInstruction, state: &mut VisitorState<'_, '
                 return;
             }
 
-            // TS: CompilerError.invariant(state.manualMemoState.manualMemoId === value.manualMemoId, ...)
+            // TS: Diagnostics.invariant(state.manualMemoState.manualMemoId === value.manualMemoId, ...)
             if state.manual_memo_state.as_ref().is_none_or(|s| s.manual_memo_id != *manual_memo_id)
             {
                 state.manual_memo_state = None;
@@ -637,7 +637,7 @@ fn validate_inferred_dep(
         ManualMemoDependency { root: temp.root.clone(), path, span: temp.span }
     } else {
         let ident = &env.identifiers[dep_id.0 as usize];
-        // TS: CompilerError.invariant(dep.identifier.name?.kind === 'named', ...)
+        // TS: Diagnostics.invariant(dep.identifier.name?.kind === 'named', ...)
         if !is_named(ident) {
             return;
         }

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_static_components.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_static_components.rs
@@ -11,15 +11,17 @@
 
 use rustc_hash::FxHashMap;
 
-use crate::diagnostics::{CompilerError, ErrorCategory};
+use oxc_diagnostics::Diagnostics;
+
+use crate::diagnostics::ErrorCategory;
 use crate::react_compiler_hir::{HirFunction, IdentifierId, InstructionValue, JsxTag, Span};
 
 /// Validates that components used in JSX are not dynamically created during render.
 ///
-/// Returns a CompilerError containing all diagnostics found (may be empty).
+/// Returns the diagnostics found (may be empty).
 /// Called via `env.logErrors()` pattern in Pipeline.ts.
-pub fn validate_static_components(func: &HirFunction) -> CompilerError {
-    let mut error = CompilerError::new();
+pub fn validate_static_components(func: &HirFunction) -> Diagnostics {
+    let mut error = Diagnostics::new();
     let mut known_dynamic_components: FxHashMap<IdentifierId, Option<Span>> = FxHashMap::default();
 
     for (_block_id, block) in &func.body.blocks {

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_use_memo.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_use_memo.rs
@@ -1,6 +1,8 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use crate::diagnostics::{CompilerError, ErrorCategory};
+use oxc_diagnostics::Diagnostics;
+
+use crate::diagnostics::ErrorCategory;
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::visitors::{
     each_instruction_value_operand_with_functions, each_terminal_operand,
@@ -14,7 +16,7 @@ use crate::react_compiler_hir::{
 ///
 /// Port of ValidateUseMemo.ts.
 /// Returns VoidUseMemo errors separately (for logging via logErrors, not as compile errors).
-pub fn validate_use_memo(func: &HirFunction, env: &mut Environment) -> CompilerError {
+pub fn validate_use_memo(func: &HirFunction, env: &mut Environment) -> Diagnostics {
     validate_use_memo_impl(
         func,
         &env.functions,
@@ -32,10 +34,10 @@ struct FuncExprInfo {
 fn validate_use_memo_impl(
     func: &HirFunction,
     functions: &[HirFunction],
-    errors: &mut CompilerError,
+    errors: &mut Diagnostics,
     validate_no_void_use_memo: bool,
-) -> CompilerError {
-    let mut void_memo_errors = CompilerError::new();
+) -> Diagnostics {
+    let mut void_memo_errors = Diagnostics::new();
     let mut use_memos: FxHashSet<IdentifierId> = FxHashSet::default();
     let mut react: FxHashSet<IdentifierId> = FxHashSet::default();
     let mut func_exprs: FxHashMap<IdentifierId, FuncExprInfo> = FxHashMap::default();
@@ -139,8 +141,8 @@ fn validate_use_memo_impl(
 #[allow(clippy::too_many_arguments)]
 fn handle_possible_use_memo_call(
     functions: &[HirFunction],
-    errors: &mut CompilerError,
-    void_memo_errors: &mut CompilerError,
+    errors: &mut Diagnostics,
+    void_memo_errors: &mut Diagnostics,
     use_memos: &FxHashSet<IdentifierId>,
     func_exprs: &FxHashMap<IdentifierId, FuncExprInfo>,
     unused_use_memos: &mut FxHashMap<IdentifierId, (Span, Option<String>)>,
@@ -222,7 +224,7 @@ fn handle_possible_use_memo_call(
     }
 }
 
-fn validate_no_context_variable_assignment(func: &HirFunction, errors: &mut CompilerError) {
+fn validate_no_context_variable_assignment(func: &HirFunction, errors: &mut Diagnostics) {
     let context: FxHashSet<IdentifierId> =
         func.context.iter().map(|place| place.identifier).collect();
 


### PR DESCRIPTION
Follow-up to #24322, which slimmed `CompilerError` to `Vec<OxcDiagnostic>` + control-flow flags. This deletes the type entirely.

### End state

- Pass functions return `Result<T, OxcDiagnostic>` — every thrown error was verifiably a single diagnostic, so the aggregate wrapper (and the lossy `From<CompilerError> for OxcDiagnostic` first-diagnostic bridge) just disappears. `env.record_error` returns `Err(OxcDiagnostic)` directly.
- Genuine aggregates use `oxc_diagnostics::Diagnostics`: `Environment::errors`, the collection-returning lint validators, suppression/gating errors, and `compile_fn`'s error channel.
- `diagnostics.rs` keeps `ErrorCategory` plus two free functions: `has_critical_errors` (the `panicThreshold: critical_errors` check, preserving the `PreserveManualMemo` displays-as-error/internally-warning exception that `Diagnostics::has_errors()` does not have) and `to_string_for_event` (single-diagnostic now).

### Where `is_thrown` went

The flag distinguished thrown pass errors (which surface `CompileUnexpectedThrow`, matching TS `tryCompileFunction`'s catch block) from accumulated/suppression errors (which must not). That bit is now encoded structurally: the pipeline body moves into `run_pipeline`, whose outer `Err(OxcDiagnostic)` is a thrown error while invariant/accumulated failures return as `Ok(Err(Diagnostics))`. `compile_fn` does the "Unexpected error" surfacing at that boundary (it takes the function span for the label); suppression errors are built as `Diagnostics` in `try_compile_function` and never pass the surfacing point. Diagnostic push ordering is unchanged (surfacing before `log_error`'s per-detail pushes).

A uniform `Result<T, Diagnostics>` everywhere would have erased thrown-ness through auto-`?` conversion (and `Result<T, Vec<_>>` trips the orphan rule), so the single-vs-collection split is deliberate.

### Output parity

Zero output change. The 1806-fixture snapshot corpus — 341 of which snapshot diagnostics across all 24 error categories, including the `Unexpected error` surfacing, the simulated-unknown `Pipeline error`, Suppression, Gating, Config, and `PreserveManualMemo` — passes unchanged, as does the oxlint `react/react-compiler` rule snapshot. `take_invariant_errors` keeps all invariants (not first-only) specifically to avoid drift.

Net −66 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
