### PR TITLE
fix(linter/oxc/bad-replace-all-arg): add note to enhance diagnostic

### DIFF
--- a/crates/oxc_linter/src/rules/oxc/bad_replace_all_arg.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_replace_all_arg.rs
@@ -16,6 +16,7 @@ use crate::{
 fn bad_replace_all_arg_diagnostic(replace_all_span: Span, regex_span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Global flag (g) is missing in the regular expression supplied to the `replaceAll` method.")
         .with_help("To replace all occurrences of a string, use the `replaceAll` method with the global flag (g) in the regular expression.")
+        .with_note("Unlike `replace`, `replaceAll` throws a `TypeError` when passed a non-global regular expression instead of replacing only the first match.")
         .with_labels([
             replace_all_span.label("`replaceAll` called here"),
             regex_span.label("RegExp supplied here"),
@@ -32,7 +33,8 @@ declare_oxc_lint!(
     ///
     /// ### Why is this bad?
     ///
-    /// The `replaceAll` method replaces all occurrences of a string with another string. If the global flag (g) is not used in the regular expression, only the first occurrence of the string will be replaced.
+    /// When called with a regular expression, the `replaceAll` method requires the global flag (g).
+    /// Otherwise, it throws a `TypeError` at runtime instead of performing a replacement.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/snapshots/oxc_bad_replace_all_arg.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_bad_replace_all_arg.snap
@@ -10,6 +10,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ╰── `replaceAll` called here
    ╰────
   help: To replace all occurrences of a string, use the `replaceAll` method with the global flag (g) in the regular expression.
+  note: Unlike `replace`, `replaceAll` throws a `TypeError` when passed a non-global regular expression instead of replacing only the first match.
 
   ⚠ oxc(bad-replace-all-arg): Global flag (g) is missing in the regular expression supplied to the `replaceAll` method.
    ╭─[bad_replace_all_arg.tsx:1:12]
@@ -19,6 +20,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ╰── `replaceAll` called here
    ╰────
   help: To replace all occurrences of a string, use the `replaceAll` method with the global flag (g) in the regular expression.
+  note: Unlike `replace`, `replaceAll` throws a `TypeError` when passed a non-global regular expression instead of replacing only the first match.
 
   ⚠ oxc(bad-replace-all-arg): Global flag (g) is missing in the regular expression supplied to the `replaceAll` method.
    ╭─[bad_replace_all_arg.tsx:1:12]
@@ -28,6 +30,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ╰── `replaceAll` called here
    ╰────
   help: To replace all occurrences of a string, use the `replaceAll` method with the global flag (g) in the regular expression.
+  note: Unlike `replace`, `replaceAll` throws a `TypeError` when passed a non-global regular expression instead of replacing only the first match.
 
   ⚠ oxc(bad-replace-all-arg): Global flag (g) is missing in the regular expression supplied to the `replaceAll` method.
    ╭─[bad_replace_all_arg.tsx:1:12]
@@ -37,6 +40,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ╰── `replaceAll` called here
    ╰────
   help: To replace all occurrences of a string, use the `replaceAll` method with the global flag (g) in the regular expression.
+  note: Unlike `replace`, `replaceAll` throws a `TypeError` when passed a non-global regular expression instead of replacing only the first match.
 
   ⚠ oxc(bad-replace-all-arg): Global flag (g) is missing in the regular expression supplied to the `replaceAll` method.
    ╭─[bad_replace_all_arg.tsx:2:25]
@@ -51,6 +55,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │         
    ╰────
   help: To replace all occurrences of a string, use the `replaceAll` method with the global flag (g) in the regular expression.
+  note: Unlike `replace`, `replaceAll` throws a `TypeError` when passed a non-global regular expression instead of replacing only the first match.
 
   ⚠ oxc(bad-replace-all-arg): Global flag (g) is missing in the regular expression supplied to the `replaceAll` method.
    ╭─[bad_replace_all_arg.tsx:2:25]
@@ -65,6 +70,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │         
    ╰────
   help: To replace all occurrences of a string, use the `replaceAll` method with the global flag (g) in the regular expression.
+  note: Unlike `replace`, `replaceAll` throws a `TypeError` when passed a non-global regular expression instead of replacing only the first match.
 
   ⚠ oxc(bad-replace-all-arg): Global flag (g) is missing in the regular expression supplied to the `replaceAll` method.
    ╭─[bad_replace_all_arg.tsx:2:25]
@@ -79,3 +85,4 @@ source: crates/oxc_linter/src/tester.rs
  5 │         
    ╰────
   help: To replace all occurrences of a string, use the `replaceAll` method with the global flag (g) in the regular expression.
+  note: Unlike `replace`, `replaceAll` throws a `TypeError` when passed a non-global regular expression instead of replacing only the first match.


### PR DESCRIPTION
## Summary

- add a diagnostic note explaining that replaceAll throws a TypeError for a non-global regular expression
- correct the rule documentation to describe the runtime behavior accurately
- update the diagnostic snapshot

Follow-up to #24340.
