### PR TITLE
feat(minifier): collect whole-program symbol liveness during compression

### DIFF
--- a/crates/oxc_minifier/src/compressor.rs
+++ b/crates/oxc_minifier/src/compressor.rs
@@ -117,21 +117,36 @@ impl<'a> Compressor<'a> {
         let initial_references_len = ctx.get_mut().scoping().references_len();
         // Consume the drops Normalize recorded (`void x` -> `void 0`,
         // drop_console), so pass 1 already observes the pruned reference
-        // counts and Normalize's drops cost no extra peephole pass.
-        PeepholeOptimizations::flush_pass_dirty(program, ctx.get_mut());
+        // counts and Normalize's drops cost no extra peephole pass. Its
+        // traversal also doubled as the first liveness collection (see
+        // `symbol_liveness::begin_pass`), so the same end-of-pass sequence
+        // makes source-level dead cycles (`function f() { f() }`) visible
+        // to pass 1 — no standalone walk anywhere. The continue signal is
+        // irrelevant pre-loop: the loop below always runs at least once.
+        PeepholeOptimizations::end_pass(program, ctx.get_mut());
         // Start the loop from a clean signal: Normalize's drops are flushed
         // above, so a Normalize-only mutation must not force a pointless
         // extra iteration.
         ctx.state_mut().take_mutated();
         loop {
             PeepholeOptimizations.run_once(program, ctx);
-            // A pass with no recorded mutation cannot have recorded drops
-            // (every drop helper also records a mutation), so the terminal
-            // iteration skips the flush.
-            if !ctx.state_mut().take_mutated() {
+            let mutated = ctx.state_mut().take_mutated();
+            // Flush and consume the liveness collection even on quiet
+            // passes (every flush step is a cheap no-op then): pass N's
+            // late mutations can kill a cycle that only pass N+1's —
+            // otherwise quiet — collection observes. Stopping without
+            // consuming it would strand the removal; deferring consumption
+            // to the fixed point was measured to LOSE output (other passes
+            // rewrite late-exposed dead cycles into non-candidate shapes),
+            // so one-pass staleness is the freshness contract.
+            let needs_liveness_pass = PeepholeOptimizations::end_pass(program, ctx.get_mut());
+            // Convergence: another pass is demanded only for a NEW dead
+            // symbol (bounded by the symbol table — see
+            // `propagate_collected`); the iteration cap backstops
+            // pathological churn.
+            if !mutated && !needs_liveness_pass {
                 break;
             }
-            PeepholeOptimizations::flush_pass_dirty(program, ctx.get_mut());
             if let Some(max) = max_iterations {
                 if iteration >= max {
                     break;

--- a/crates/oxc_minifier/src/lib.rs
+++ b/crates/oxc_minifier/src/lib.rs
@@ -52,6 +52,7 @@ mod options;
 mod peephole;
 mod state;
 mod symbol_facts;
+mod symbol_liveness;
 mod symbol_value;
 mod traverse_context;
 

--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -30,7 +30,7 @@ use oxc_ast::ast::*;
 
 use crate::{
     ReusableTraverseCtx, Traverse, TraverseCtx, minifier_traverse::traverse_mut_with_ctx,
-    traverse_context::as_direct_eval_call,
+    symbol_liveness, traverse_context::as_direct_eval_call,
 };
 
 pub use self::normalize::{Normalize, NormalizeOptions};
@@ -394,11 +394,11 @@ impl<'a> PeepholeOptimizations {
     /// references from scoping, refresh direct-eval flags if an `eval(...)`
     /// call was dropped, and re-initialize the accumulator.
     ///
-    /// The `Compressor` driver calls this after `Normalize` (so the
-    /// fixed-point loop starts against already-pruned scoping and
-    /// Normalize's drops cost no extra peephole pass) and after every
-    /// peephole pass.
-    pub(crate) fn flush_pass_dirty(program: &Program<'a>, ctx: &mut TraverseCtx<'a>) {
+    /// [`Self::end_pass`] calls this after `Normalize` (so the fixed-point
+    /// loop starts against already-pruned scoping and Normalize's drops cost
+    /// no extra peephole pass) and after every peephole pass — quiet ones
+    /// included, where every step below is a cheap no-op.
+    fn flush_pass_dirty(program: &Program<'a>, ctx: &mut TraverseCtx<'a>) {
         let had_dead = !ctx.state.dirty.dead_refs.is_empty();
 
         // (1) Resolved references — direct consumption, no walk.
@@ -444,10 +444,23 @@ impl<'a> PeepholeOptimizations {
         }
         ctx.state.dirty.eval_dropped = false;
     }
+
+    /// End-of-pass sequence: flush the dirty accumulator into scoping, then
+    /// consume the pass's liveness collection — which must observe the
+    /// post-flush scoping (its debug ground-truth walk validates against
+    /// it), so fusing the pair makes the ordering structural. Returns
+    /// whether liveness demands another pass (see
+    /// `symbol_liveness::propagate_collected`).
+    pub(crate) fn end_pass(program: &Program<'a>, ctx: &mut TraverseCtx<'a>) -> bool {
+        Self::flush_pass_dirty(program, ctx);
+        symbol_liveness::propagate_collected(ctx)
+    }
 }
 
 impl<'a> Traverse<'a> for PeepholeOptimizations {
     fn enter_program(&mut self, program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
+        // Reset the in-pass liveness collection (runs in dce mode too).
+        symbol_liveness::begin_pass(ctx);
         ctx.state.symbol_values.reset();
         // Any module loader (`import`, `export * from`, `export … from`) can, on a
         // cycle, evaluate a foreign module that observes a not-yet-assigned binding
@@ -466,6 +479,26 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
             (ctx.scoping().root_scope_id(), module_has_loaders);
         // `PassDirty` is managed by the `Compressor` driver via
         // `flush_pass_dirty`, not reset per traversal.
+    }
+
+    // Liveness-collection delegations — keep this set in sync with the
+    // identical one in `Normalize` (both traversals collect; the membership
+    // is part of the analysis contract, see the `symbol_liveness` module
+    // doc). Deliberately no dce gating: collection runs in dce mode too.
+    fn enter_identifier_reference(
+        &mut self,
+        node: &mut IdentifierReference<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        symbol_liveness::collect_identifier_reference(node, ctx);
+    }
+
+    fn enter_function(&mut self, node: &mut Function<'a>, ctx: &mut TraverseCtx<'a>) {
+        symbol_liveness::collect_enter_function(node, ctx);
+    }
+
+    fn exit_function(&mut self, _node: &mut Function<'a>, ctx: &mut TraverseCtx<'a>) {
+        symbol_liveness::collect_exit_function(ctx);
     }
 
     fn enter_function_body(&mut self, _body: &mut FunctionBody<'a>, ctx: &mut TraverseCtx<'a>) {

--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -501,6 +501,18 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
         symbol_liveness::collect_exit_function(ctx);
     }
 
+    fn enter_class(&mut self, node: &mut Class<'a>, ctx: &mut TraverseCtx<'a>) {
+        symbol_liveness::collect_enter_class(node, ctx);
+    }
+
+    fn enter_variable_declarator(
+        &mut self,
+        node: &mut VariableDeclarator<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        symbol_liveness::collect_enter_variable_declarator(node, ctx);
+    }
+
     fn enter_function_body(&mut self, _body: &mut FunctionBody<'a>, ctx: &mut TraverseCtx<'a>) {
         ctx.state.body_unsafe_stack.push((ctx.current_scope_id(), false));
     }

--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -453,7 +453,7 @@ impl<'a> PeepholeOptimizations {
     /// `symbol_liveness::propagate_collected`).
     pub(crate) fn end_pass(program: &Program<'a>, ctx: &mut TraverseCtx<'a>) -> bool {
         Self::flush_pass_dirty(program, ctx);
-        symbol_liveness::propagate_collected(ctx)
+        symbol_liveness::propagate_collected(program, ctx)
     }
 }
 

--- a/crates/oxc_minifier/src/peephole/normalize.rs
+++ b/crates/oxc_minifier/src/peephole/normalize.rs
@@ -11,7 +11,7 @@ use oxc_syntax::scope::ScopeFlags;
 use super::PeepholeOptimizations;
 use crate::{
     ReusableTraverseCtx, Traverse, TraverseCtx, minifier_traverse::traverse_mut_with_ctx,
-    symbol_facts::SymbolFact,
+    symbol_facts::SymbolFact, symbol_liveness,
 };
 
 #[derive(Default)]
@@ -52,10 +52,38 @@ impl<'a> Normalize {
 }
 
 impl<'a> Traverse<'a> for Normalize {
+    fn enter_program(&mut self, _node: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
+        // Normalize's traversal doubles as the first liveness collection
+        // pass, replacing a standalone pre-loop walk. See `symbol_liveness`.
+        symbol_liveness::begin_pass(ctx);
+    }
+
     fn exit_program(&mut self, node: &mut Program<'a>, _ctx: &mut TraverseCtx<'a>) {
         if self.options.remove_unnecessary_use_strict && node.source_type.is_module() {
             node.directives.drain_filter(|d| d.directive.as_str() == "use strict");
         }
+    }
+
+    // Liveness-collection delegations — keep this set in sync with the
+    // identical one in `PeepholeOptimizations` (both traversals collect;
+    // the membership is part of the analysis contract, see the
+    // `symbol_liveness` module doc). Normalize's mutations during
+    // collection only diverge toward-live (drops were already visited;
+    // mints are logged at the choke point and force-rooted at flush).
+    fn enter_identifier_reference(
+        &mut self,
+        node: &mut IdentifierReference<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        symbol_liveness::collect_identifier_reference(node, ctx);
+    }
+
+    fn enter_function(&mut self, node: &mut Function<'a>, ctx: &mut TraverseCtx<'a>) {
+        symbol_liveness::collect_enter_function(node, ctx);
+    }
+
+    fn exit_function(&mut self, _node: &mut Function<'a>, ctx: &mut TraverseCtx<'a>) {
+        symbol_liveness::collect_exit_function(ctx);
     }
 
     fn exit_statements(

--- a/crates/oxc_minifier/src/peephole/normalize.rs
+++ b/crates/oxc_minifier/src/peephole/normalize.rs
@@ -86,6 +86,18 @@ impl<'a> Traverse<'a> for Normalize {
         symbol_liveness::collect_exit_function(ctx);
     }
 
+    fn enter_class(&mut self, node: &mut Class<'a>, ctx: &mut TraverseCtx<'a>) {
+        symbol_liveness::collect_enter_class(node, ctx);
+    }
+
+    fn enter_variable_declarator(
+        &mut self,
+        node: &mut VariableDeclarator<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        symbol_liveness::collect_enter_variable_declarator(node, ctx);
+    }
+
     fn exit_statements(
         &mut self,
         stmts: &mut ArenaVec<'a, Statement<'a>>,

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -573,6 +573,14 @@ impl<'a> PeepholeOptimizations {
         let is_null_symbol_id =
             ctx.scoping().get_reference(is_null_id_ref.reference_id()).symbol_id();
 
+        // These mints happen behind the traversal cursor, so the liveness
+        // collection never visits them: log them for force-rooting at the
+        // flush (`LivenessCollect::force_root_log`), as every minting call
+        // site must.
+        for symbol_id in [typeof_symbol_id, is_null_symbol_id].into_iter().flatten() {
+            ctx.state.liveness.log_force_root(symbol_id);
+        }
+
         // Plain `clone_in` resets every `reference_id` to `None`, making id
         // aliasing structurally impossible; the loop below installs the one
         // fresh reference the clone needs.

--- a/crates/oxc_minifier/src/state.rs
+++ b/crates/oxc_minifier/src/state.rs
@@ -119,6 +119,25 @@ pub struct MinifierState<'a> {
     /// minted after the last refresh are beyond capacity and read as live.
     pub(crate) dead_symbols: BitSet<'a>,
 
+    /// Symbols the analysis PINNED this pass — bindings whose observability
+    /// no reference count can express. Exactly three producers today, all in
+    /// `symbol_liveness`: export-wrapped declarations (importers observe the
+    /// binding), for-in/of heads, and `using` declarators (no removal site
+    /// handles either). Enabling sloppy sources will add script-globals and
+    /// Annex B alias blockers.
+    ///
+    /// Pinning is strictly stronger than force-rooting, and both are needed:
+    /// force-rooting keeps the symbol out of `dead_symbols`, but the removal
+    /// sites consult `symbol_is_unused` TOO — and this analysis is exactly
+    /// what drives a reference count to zero, by deleting the dead cycle that
+    /// held the last reference. Without the pin, the count arm then removes
+    /// the very declaration the force-root exists to protect (`export var f;`
+    /// silently loses its initializer).
+    ///
+    /// Refreshed at every flush alongside `dead_symbols` and read only through
+    /// [`MinifierState::symbol_is_pinned`]. Bits are `SymbolId::index()`.
+    pub(crate) pinned_symbols: BitSet<'a>,
+
     /// In-traversal liveness collection for the CURRENT peephole pass; see
     /// `symbol_liveness` for the architecture. Reset at `enter_program`,
     /// consumed by `symbol_liveness::propagate_collected` at flush.
@@ -149,6 +168,7 @@ impl<'a> MinifierState<'a> {
             mutated: false,
             dirty: PassDirty::new(scoping.references_len(), allocator),
             dead_symbols: BitSet::new_in(0, allocator),
+            pinned_symbols: BitSet::new_in(0, allocator),
             liveness: LivenessCollect::new(allocator),
             concat_scratch: String::new(),
         }

--- a/crates/oxc_minifier/src/state.rs
+++ b/crates/oxc_minifier/src/state.rs
@@ -8,7 +8,10 @@ use oxc_span::SourceType;
 use oxc_str::Str;
 use oxc_syntax::{scope::ScopeId, symbol::SymbolId};
 
-use crate::{CompressOptions, symbol_facts::PersistentSymbolFacts, symbol_value::SymbolValues};
+use crate::{
+    CompressOptions, symbol_facts::PersistentSymbolFacts, symbol_liveness::LivenessCollect,
+    symbol_value::SymbolValues,
+};
 
 /// Dirty data accumulated by the `replace_*` / `drop_*` helper calls between
 /// two consumption points. Live from `MinifierState::new` so the pre-loop
@@ -103,6 +106,24 @@ pub struct MinifierState<'a> {
     /// the incremental scoping refresh.
     pub(crate) dirty: PassDirty<'a>,
 
+    /// Candidate symbols proven unreachable by the whole-program liveness
+    /// analysis (`symbol_liveness`): declarations whose every reference sits
+    /// inside their own — or their reference cycle's — removable bodies, so
+    /// no live code can ever reach them (#13105). Seeded pre-loop from the
+    /// collection gathered during `Normalize`'s traversal (see
+    /// `symbol_liveness::begin_pass`), then refreshed at every flush
+    /// from the collection the peephole traversal gathered during the pass
+    /// (see [`LivenessCollect`]) — always exactly one pass stale. Consumed
+    /// alongside `symbol_is_unused` by the removal sites in
+    /// `remove_unused_declaration.rs`. Bits are `SymbolId::index()`; ids
+    /// minted after the last refresh are beyond capacity and read as live.
+    pub(crate) dead_symbols: BitSet<'a>,
+
+    /// In-traversal liveness collection for the CURRENT peephole pass; see
+    /// `symbol_liveness` for the architecture. Reset at `enter_program`,
+    /// consumed by `symbol_liveness::propagate_collected` at flush.
+    pub(crate) liveness: LivenessCollect<'a>,
+
     /// Scratch buffer reused by `try_fold_concat` to build template literal
     /// quasis without allocating a fresh `String` per call.
     pub concat_scratch: String,
@@ -127,6 +148,8 @@ impl<'a> MinifierState<'a> {
             body_unsafe_stack: NonEmptyStack::new((scoping.root_scope_id(), false)),
             mutated: false,
             dirty: PassDirty::new(scoping.references_len(), allocator),
+            dead_symbols: BitSet::new_in(0, allocator),
+            liveness: LivenessCollect::new(allocator),
             concat_scratch: String::new(),
         }
     }

--- a/crates/oxc_minifier/src/symbol_liveness/mod.rs
+++ b/crates/oxc_minifier/src/symbol_liveness/mod.rs
@@ -57,10 +57,32 @@
 //!
 //! ## Rule 2 applied: observability the reference count cannot express
 //!
-//! Non-candidate declarations cannot be removed BY THE ANALYSIS, but their
-//! observability can exceed what references express (an export-wrapped
-//! function is observed by importers). Such declarations force-root their
-//! symbols at the hook.
+//! Non-candidate declarations cannot be removed BY THE ANALYSIS, but the
+//! count-based removal arm still consults their reference counts — and
+//! removing a dead function cycle discards the references that cycle held,
+//! driving an observable binding's count to zero. Pins mark the bindings
+//! whose observability the count cannot express — in a module, exactly
+//! these (each row prevents a reviewed wrong-code repro):
+//!
+//! | gate | what it prevents |
+//! |---|---|
+//! | export-wrapped declarations | `export var f;` carries no reference, yet importers observe the binding — a removable sibling site would strip the initializer |
+//! | for-in/of head and `using` declarators | no removal site handles them; their survival must not depend on counts |
+//!
+//! (Sloppy sources add script-globals and Annex B block-function aliases
+//! to this table; that is why they are not analyzed yet.)
+//!
+//! Every gate in this table PINS (`pin_live_root`), which is strictly
+//! stronger than force-rooting, and the difference is load-bearing. Rooting
+//! only keeps a symbol out of `dead_symbols` — but the removal sites ask
+//! `symbol_is_unused || symbol_is_dead`, and removing a dead cycle DISCARDS
+//! the references that cycle held. So a symbol whose surviving references all
+//! sat in the cycle we just deleted drops to ZERO references, and the count
+//! arm removes the very declaration the gate exists to protect: `export var f;`
+//! silently loses its initializer. Reference counting alone can never reach
+//! that state — which is exactly why main needs none of these gates, and why
+//! rooting looked sufficient until it wasn't. A pin closes both arms
+//! (`MinifierState::pinned_symbols`).
 //!
 //! ## Rule 3 applied: cadence and the force-root log
 //!
@@ -117,6 +139,7 @@
 
 use oxc_allocator::{Allocator, BitSet, GetAllocator, Vec as ArenaVec};
 use oxc_ast::ast::*;
+use oxc_ecmascript::BoundNames;
 use oxc_semantic::Scoping;
 use oxc_span::SourceType;
 use oxc_syntax::symbol::{SymbolFlags, SymbolId};
@@ -231,6 +254,10 @@ pub struct LivenessCollect<'a> {
     /// `MinifierState::dead_symbols` at flush.
     dead_next: BitSet<'a>,
     /// Scratch for the next PINNED set; swapped with
+    /// `MinifierState::pinned_symbols` at flush. A pin is a force-root that
+    /// also survives the reference-COUNT removal arm (the module doc's
+    /// Rule 2 explains why rooting alone is not enough).
+    pinned_next: BitSet<'a>,
     /// Symbols this pass's collection may have under-observed, force-rooted
     /// at the flush. One producer: a bound reference minted behind the
     /// traversal cursor (each minting pass logs at its call site —
@@ -255,6 +282,7 @@ impl<'a> LivenessCollect<'a> {
             frames: ArenaVec::new_in(&allocator),
             current_candidate: None,
             dead_next: BitSet::new_in(0, allocator),
+            pinned_next: BitSet::new_in(0, allocator),
             force_root_log: ArenaVec::new_in(&allocator),
         }
     }
@@ -276,7 +304,9 @@ impl<'a> LivenessCollect<'a> {
         // Symbols minted mid-pass are past these capacities and read as
         // live everywhere (the `PassDirty::dead_refs` convention); their
         // declarations enter the analysis next pass.
-        for bits in [&mut self.candidates, &mut self.live, &mut self.dead_next] {
+        for bits in
+            [&mut self.candidates, &mut self.live, &mut self.dead_next, &mut self.pinned_next]
+        {
             if bits.capacity() == symbols_len {
                 bits.clear();
             } else {
@@ -302,6 +332,17 @@ impl<'a> LivenessCollect<'a> {
         if index < self.live.capacity() && !self.live.has_bit(index) {
             self.live.set_bit(index);
             self.roots.push(symbol_id);
+        }
+    }
+
+    /// Force-root a symbol AND pin it against the reference-count removal
+    /// arm; see the module doc's Rule 2 for why rooting alone is not
+    /// enough, and `MinifierState::pinned_symbols` for the consumer side.
+    fn pin_live_root(&mut self, symbol_id: SymbolId) {
+        self.mark_live_root(symbol_id);
+        let index = symbol_id.index();
+        if index < self.pinned_next.capacity() {
+            self.pinned_next.set_bit(index);
         }
     }
 
@@ -381,7 +422,7 @@ pub fn collect_enter_function<'a>(func: &Function<'a>, ctx: &mut TraverseCtx<'a>
         && let Some(symbol_id) = func.id.as_ref().and_then(|id| id.symbol_id.get())
     {
         if parent_is_export(ctx.parent()) {
-            ctx.state.liveness.mark_live_root(symbol_id);
+            ctx.state.liveness.pin_live_root(symbol_id);
         } else if ctx.state.liveness.admit_candidate(symbol_id) {
             candidate = Some(symbol_id);
         }
@@ -393,8 +434,57 @@ pub fn collect_enter_function<'a>(func: &Function<'a>, ctx: &mut TraverseCtx<'a>
     }
 }
 
+/// `Traverse::enter_class` body. Classes are never candidates (see the
+/// module doc), but an export-wrapped class still PINS: importers observe
+/// the binding while removing a dead function cycle can zero its
+/// reference count.
+pub fn collect_enter_class<'a>(class: &Class<'a>, ctx: &mut TraverseCtx<'a>) {
+    if !ctx.state.liveness.active {
+        return;
+    }
+    if class.is_declaration()
+        && let Some(symbol_id) = class.id.as_ref().and_then(|id| id.symbol_id.get())
+        && parent_is_export(ctx.parent())
+    {
+        ctx.state.liveness.pin_live_root(symbol_id);
+    }
+}
+
+/// `Traverse::enter_variable_declarator` body. Declarators are never
+/// candidates (see the module doc), but bindings whose observability the
+/// reference count cannot express still pin, because removing a dead
+/// function cycle can zero their counts: an export-wrapped declaration
+/// (importers observe the binding through a sibling `export var f;`), and
+/// for-in/of heads and `using` declarators (no removal site handles them;
+/// their survival must not depend on counts). All of these are STABLE
+/// properties of the declaration — no rewrite can grant or revoke them
+/// mid-pass.
+pub fn collect_enter_variable_declarator<'a>(
+    decl: &VariableDeclarator<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    if !ctx.state.liveness.active {
+        return;
+    }
+    let grandparent = ctx.ancestor(1);
+    let stable_position_fail = decl.kind.is_using()
+        || grandparent.is_parent_of_for_statement_left()
+        || matches!(grandparent, Ancestor::ExportNamedDeclarationDeclaration(_));
+    if stable_position_fail {
+        // Stable-position site: PIN every symbol it binds (see the module
+        // doc), destructuring included.
+        let lv = &mut ctx.state.liveness;
+        decl.id.bound_names(&mut |ident| {
+            if let Some(symbol_id) = ident.symbol_id.get() {
+                lv.pin_live_root(symbol_id);
+            }
+        });
+    }
+}
+
 /// `Traverse::exit_function` body: close the region frame the enter hook
-/// opened. Functions are the only region-openers.
+/// opened. Functions are the only region-openers — classes and declarators
+/// only pin, so they need no exit hook.
 pub fn collect_exit_function(ctx: &mut TraverseCtx<'_>) {
     let lv = &mut ctx.state.liveness;
     if lv.active {
@@ -416,7 +506,7 @@ pub fn collect_exit_function(ctx: &mut TraverseCtx<'_>) {
 /// post-flush fresh.
 pub fn propagate_collected(ctx: &mut TraverseCtx<'_>) -> bool {
     let TraverseCtx { state, .. } = ctx;
-    let crate::state::MinifierState { liveness, dead_symbols, .. } = state;
+    let crate::state::MinifierState { liveness, dead_symbols, pinned_symbols, .. } = state;
     let lv = liveness;
     if !lv.active {
         return false;
@@ -436,6 +526,7 @@ pub fn propagate_collected(ctx: &mut TraverseCtx<'_>) -> bool {
     // runs so a stale dead set from the previous pass clears.
     if lv.candidates.is_empty() {
         std::mem::swap(dead_symbols, &mut lv.dead_next);
+        std::mem::swap(pinned_symbols, &mut lv.pinned_next);
         return false;
     }
 
@@ -463,5 +554,13 @@ pub fn propagate_collected(ctx: &mut TraverseCtx<'_>) -> bool {
         !lv.dead_next.is_empty() && lv.dead_next.ones().any(|bit| !dead_symbols.contains(bit));
 
     std::mem::swap(dead_symbols, &mut lv.dead_next);
+    std::mem::swap(pinned_symbols, &mut lv.pinned_next);
+    // A released pin never strands a waiting removal here: v1 pins sit on
+    // export wrappers (never removed) or on for-in/of heads and `using`
+    // declarators, whose bindings can only disappear WITH their whole
+    // statement (unreachable-code removal) — declaration and references
+    // die together, so no consult is left waiting on the stale pin. Sloppy
+    // sources will need a release-driven extra pass (Annex B blockers);
+    // that arrives with them.
     found_new_dead
 }

--- a/crates/oxc_minifier/src/symbol_liveness/mod.rs
+++ b/crates/oxc_minifier/src/symbol_liveness/mod.rs
@@ -146,6 +146,11 @@ use oxc_syntax::symbol::{SymbolFlags, SymbolId};
 
 use crate::{CompressOptions, CompressOptionsUnused, TraverseCtx, generated::ancestor::Ancestor};
 
+#[cfg(debug_assertions)]
+mod validate;
+#[cfg(debug_assertions)]
+pub use validate::compute_dead_symbols;
+
 // ========================================================================
 // Shared predicates: the gate definitions (rules 1 and 2)
 // ========================================================================
@@ -502,57 +507,66 @@ pub fn collect_exit_function(ctx: &mut TraverseCtx<'_>) {
 /// bits only ever come from the symbol table, and a quiet re-run of an
 /// unchanged tree finds no new ones.
 ///
-/// Must run after `flush_pass_dirty` so consumed reference counts are
-/// post-flush fresh.
-pub fn propagate_collected(ctx: &mut TraverseCtx<'_>) -> bool {
-    let TraverseCtx { state, .. } = ctx;
-    let crate::state::MinifierState { liveness, dead_symbols, pinned_symbols, .. } = state;
-    let lv = liveness;
-    if !lv.active {
-        return false;
-    }
-    debug_assert!(lv.frames.is_empty(), "unbalanced liveness region frames at flush");
-
-    // References minted behind the traversal cursor were never visited by
-    // the collection and must stay live this flush (see the
-    // `force_root_log` field doc).
-    while let Some(symbol_id) = lv.force_root_log.pop() {
-        lv.mark_live_root(symbol_id);
-    }
-
-    // No candidates admitted ⇒ no edges (an edge needs an enclosing
-    // candidate region) and no dead set: skip the worklist drain and the
-    // set scan (mirrors `compute_dead_symbols`' early-out). The swap still
-    // runs so a stale dead set from the previous pass clears.
-    if lv.candidates.is_empty() {
-        std::mem::swap(dead_symbols, &mut lv.dead_next);
-        std::mem::swap(pinned_symbols, &mut lv.pinned_next);
-        return false;
-    }
-
-    // Candidacy is fully known post-collection, so drop the (measured
-    // 77-84%) edges whose targets can never be dead before they hit the
-    // sort. A removed edge's only effect was a live mark on a
-    // non-candidate, which nothing consults.
-    {
-        let LivenessCollect { edges, candidates, .. } = lv;
-        edges.retain(|&(_, target)| candidates.contains(target.index()));
-    }
-
-    propagate(&lv.candidates, &mut lv.live, &mut lv.roots, &mut lv.edges);
-
-    for candidate in lv.candidates.ones() {
-        if !lv.live.contains(candidate) {
-            lv.dead_next.set_bit(candidate);
+/// Must run after `flush_pass_dirty` so the debug ground-truth walk sees
+/// post-flush scoping.
+pub fn propagate_collected<'a>(
+    #[cfg_attr(not(debug_assertions), expect(unused_variables))] program: &Program<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) -> bool {
+    let found_new_dead = {
+        let crate::state::MinifierState { liveness: lv, dead_symbols, pinned_symbols, .. } =
+            &mut ctx.state;
+        if !lv.active {
+            return false;
         }
-    }
+        debug_assert!(lv.frames.is_empty(), "unbalanced liveness region frames at flush");
 
-    // Per-bit scan; a word-level set-difference helper would make this
-    // O(words) — a possible `oxc_allocator` follow-up. Until then, gate the
-    // common terminal-pass case (empty dead set).
-    let found_new_dead =
-        !lv.dead_next.is_empty() && lv.dead_next.ones().any(|bit| !dead_symbols.contains(bit));
+        // References minted behind the traversal cursor were never visited
+        // by the collection and must stay live this flush (see the
+        // `force_root_log` field doc).
+        while let Some(symbol_id) = lv.force_root_log.pop() {
+            lv.mark_live_root(symbol_id);
+        }
 
+        // No candidates admitted ⇒ no edges (an edge needs an enclosing
+        // candidate region) and no dead set: skip the worklist drain and the
+        // set scan (mirrors `compute_dead_symbols`' early-out). The swap
+        // still runs so a stale dead set from the previous pass clears.
+        if lv.candidates.is_empty() {
+            std::mem::swap(dead_symbols, &mut lv.dead_next);
+            std::mem::swap(pinned_symbols, &mut lv.pinned_next);
+            return false;
+        }
+
+        // Candidacy is fully known post-collection, so drop the edges whose
+        // targets were never admitted (exported functions,
+        // function-expression names) before they hit the sort — such a
+        // target can never be dead. A removed edge's only effect was a live
+        // mark on a non-candidate, which nothing consults.
+        {
+            let LivenessCollect { edges, candidates, .. } = &mut *lv;
+            edges.retain(|&(_, target)| candidates.contains(target.index()));
+        }
+
+        propagate(&lv.candidates, &mut lv.live, &mut lv.roots, &mut lv.edges);
+
+        for candidate in lv.candidates.ones() {
+            if !lv.live.contains(candidate) {
+                lv.dead_next.set_bit(candidate);
+            }
+        }
+
+        // Per-bit scan; a word-level set-difference helper would make this
+        // O(words) — a possible `oxc_allocator` follow-up. Until then, gate
+        // the common terminal-pass case (empty dead set).
+        !lv.dead_next.is_empty() && lv.dead_next.ones().any(|bit| !dead_symbols.contains(bit))
+    };
+
+    #[cfg(debug_assertions)]
+    validate_flush(program, ctx);
+
+    let crate::state::MinifierState { liveness: lv, dead_symbols, pinned_symbols, .. } =
+        &mut ctx.state;
     std::mem::swap(dead_symbols, &mut lv.dead_next);
     std::mem::swap(pinned_symbols, &mut lv.pinned_next);
     // A released pin never strands a waiting removal here: v1 pins sit on
@@ -563,4 +577,43 @@ pub fn propagate_collected(ctx: &mut TraverseCtx<'_>) -> bool {
     // sources will need a release-driven extra pass (Annex B blockers);
     // that arrives with them.
     found_new_dead
+}
+
+/// Debug-only flush validation, before the swaps: the fresh sets are still
+/// in [`LivenessCollect`], the consumed sets still in `MinifierState`. Both
+/// nets sit behind the dead-set gate (their checks are vacuous when this
+/// pass marked nothing dead), so the whole test and conformance corpus
+/// doubles as a collection-vs-truth differ at zero release cost.
+#[cfg(debug_assertions)]
+fn validate_flush<'a>(program: &Program<'a>, ctx: &TraverseCtx<'a>) {
+    let lv = &ctx.state.liveness;
+    if lv.dead_next.is_empty() {
+        return;
+    }
+    let (walk_dead, walk_candidates, walk_pins) =
+        compute_dead_symbols(program, ctx.scoping(), &ctx.state.options, ctx.allocator());
+    // Ground-truth net: everything the in-pass collection calls dead must
+    // be dead per a standalone walk of the settled tree — for symbols
+    // whose declarations still exist (a declaration removed this pass
+    // legitimately lingers in the stale set for one flush, with nothing
+    // left to remove).
+    for bit in lv.dead_next.ones() {
+        assert!(
+            !walk_candidates.contains(bit) || walk_dead.contains(bit),
+            "in-pass liveness collection marked symbol {bit} dead but the ground-truth walk \
+             sees it live",
+        );
+    }
+    // Pin net: every pin the settled tree demands must have been
+    // collected. A missed pin is SILENT wrong code — the count arm deletes
+    // an observable binding while the dead set stays perfectly correct —
+    // so no dead-set check can catch it; this is the one direction the net
+    // above cannot see.
+    for bit in walk_pins.ones() {
+        assert!(
+            lv.pinned_next.contains(bit),
+            "collection failed to pin symbol {bit} (`{}`) that the ground-truth walk pins",
+            ctx.scoping().symbol_name(SymbolId::from_usize(bit)),
+        );
+    }
 }

--- a/crates/oxc_minifier/src/symbol_liveness/mod.rs
+++ b/crates/oxc_minifier/src/symbol_liveness/mod.rs
@@ -1,0 +1,467 @@
+//! Whole-program symbol liveness for unused-declaration removal (#13105).
+//!
+//! `Scoping::symbol_is_unused` is reference-count based; a reference cycle
+//! keeps every member's count above zero forever, so `function c() { d() }
+//! function d() { c() }` survives even though no live code can reach it.
+//! This module computes reachability instead. ESM MODULES ONLY (see
+//! [`collection_enabled`]): sloppy sources — scripts, CommonJS — carry
+//! observability the reference count cannot express (script-globals,
+//! Annex B block-function aliases) and are deliberately not analyzed yet;
+//! they take a zero-cost off path. Three rules generate everything in this
+//! file — hold these, and read the rest as their application to specific
+//! constructs:
+//!
+//! 1. **A reference either EXECUTES or sits inside a REMOVABLE
+//!    declaration.** Executing references are roots. References inside a
+//!    candidate declaration's deferred region (its function body) are edges
+//!    `(owner -> target)` that count only if the owner is live. Propagating
+//!    from the roots reaches exactly the live set; a dead cycle is simply
+//!    never reached — there is no cycle detection anywhere.
+//! 2. **If removal cannot fully delete a site, its symbols must count as
+//!    live** (force-root). Deadness is consumed per SYMBOL but removal
+//!    happens per SITE — and `var`s redeclare — so one undeletable site
+//!    must protect every site of the symbol.
+//! 3. **The tree mutates under the analysis**, so re-collect every pass,
+//!    and force-root whatever an in-pass collection provably could not
+//!    have seen.
+//!
+//! ## Rule 1 applied: candidacy and the gate-mirror invariant
+//!
+//! Candidacy is FUNCTION DECLARATIONS ONLY. Declarator and class candidacy
+//! were built, hardened over several review rounds, and then measured to
+//! contribute exactly zero output bytes on 17 real artifacts (the 10-bundle
+//! minsize corpus plus 7 modern ESM artifacts, including a real
+//! rolldown-treeshaken Vue chunk) while owning the majority of the
+//! analysis's hazard surface — statement-relocation movers, init-shape
+//! staleness, class-removability fold-flips — so they were cut. Real-world
+//! dead cycles are function-declaration cycles.
+//!
+//! Candidacy must be a SUBSET of what the removal sites in
+//! `remove_unused_declaration.rs` delete cleanly, with zero residue: a dead
+//! cycle is removed whole in one pass, and a blocked member would leave
+//! references to deleted peers (ReferenceError). The definitions are shared
+//! structurally so the two sides cannot drift:
+//!
+//! - global gates: `can_remove_unused_declarators` delegates to
+//!   [`removal_enabled`] (`unused != Keep` plus the root
+//!   `ScopeFlags::DirectEval` skip — the flag propagates to the root from
+//!   any direct eval, subsuming per-site checks); the collection arms on
+//!   [`collection_enabled`], a strict SUBSET that adds the module-only
+//!   condition, so candidacy is only ever granted where removal is allowed;
+//! - function declarations always drop whole — there is no shape axis for
+//!   them, which is exactly why functions-only candidacy is cheap to keep
+//!   sound.
+//!
+//! Non-candidacy is self-correcting: no region opens, so the declaration's
+//! interior references record as roots — the conservative direction.
+//!
+//! ## Rule 2 applied: observability the reference count cannot express
+//!
+//! Non-candidate declarations cannot be removed BY THE ANALYSIS, but their
+//! observability can exceed what references express (an export-wrapped
+//! function is observed by importers). Such declarations force-root their
+//! symbols at the hook.
+//!
+//! ## Rule 3 applied: cadence and the force-root log
+//!
+//! `Normalize` seeds the first set — source-level cycles are removable in
+//! pass 1, before the loop's rewrites can spoil their candidate shape.
+//! Every peephole pass then re-collects while it mutates, and every flush
+//! ([`propagate_collected`]) publishes a fresh set, so the set a pass
+//! consumes is always exactly one pass stale. Freshness is load-bearing:
+//! rewrites EXPOSE cycles mid-loop (a call dropped once its callee is
+//! proven pure, a folded define-replacement branch), and every cheaper
+//! cadence was built and falsified — a standalone walk per pass cost
+//! +15-22% wall; lazy/fixed-point-tail consumption lost output (exposed
+//! cycles perish); one-shot and two-shot variants failed monitor-oxc's
+//! idempotency gate on real npm packages (js_of_ocaml bundles), because
+//! any fixed number of early collections stays one rewrite behind. A
+//! record-time edge filter was also net-negative; junk edges are dropped
+//! post-collection instead.
+//!
+//! In-pass collection can diverge from a settled-tree walk in one dangerous
+//! direction — publishing a live-referenced symbol as dead — and the single
+//! rewrite that can cause it is logged into
+//! [`LivenessCollect::force_root_log`] and force-rooted at the flush: a
+//! bound reference MINTED behind the traversal cursor (each minting pass
+//! logs at its call site — the typeof rewrite in
+//! `substitute_alternate_syntax` is the only minter today, and the debug
+//! ground-truth validator flags an unlogged mint anywhere in the corpus).
+//! Function-declaration sites have no other staleness axis: statement
+//! movers relocate whole function declarations between slots
+//! `exit_statement` visits either way, folds cannot change what a function
+//! declaration is, and substitution never rewrites one. (Declarator
+//! candidacy needed a relocation log, a substitution log, and a settled-
+//! shape gate for exactly these axes — that machinery left with it.)
+//!
+//! ## The oracle
+//!
+//! In debug builds every flushed set is validated against an INDEPENDENT
+//! re-derivation on the settled tree (`validate.rs`), so the whole test and
+//! conformance corpus doubles as a differ between the in-pass collection
+//! and ground truth. Read that file to CHECK this one, not to understand
+//! it.
+//!
+//! ## Allocation discipline
+//!
+//! Everything sized by the program lives in the arena, like
+//! `PassDirty::dead_refs`. References are filtered at record time on
+//! candidate-kind `SymbolFlags` — `Function` only, so locals and parameters
+//! never earn storage; only references to function declarations record at
+//! all (when the wider declarator/class candidacy existed, 77-84% of edges
+//! were unusable junk). Roots are deduplicated at record time by marking
+//! them live immediately, and the edge "graph" is a flat list sorted by
+//! source symbol, range-scanned via `partition_point` — no per-candidate
+//! allocations. The in-pass collection buffers are `clear()`-reused across
+//! passes, keeping system allocations untouched.
+
+use oxc_allocator::{Allocator, BitSet, GetAllocator, Vec as ArenaVec};
+use oxc_ast::ast::*;
+use oxc_semantic::Scoping;
+use oxc_span::SourceType;
+use oxc_syntax::symbol::{SymbolFlags, SymbolId};
+
+use crate::{CompressOptions, CompressOptionsUnused, TraverseCtx, generated::ancestor::Ancestor};
+
+// ========================================================================
+// Shared predicates: the gate definitions (rules 1 and 2)
+// ========================================================================
+
+/// Symbol kinds a liveness candidate can have: function declarations only
+/// (see the module doc for why declarator and class candidacy were cut). A
+/// necessary (not sufficient) condition for candidacy; doubles as the
+/// record-time reference filter, so references to anything else earn no
+/// storage.
+const CANDIDATE_KINDS: SymbolFlags = SymbolFlags::Function;
+
+/// Whether unused-declaration removal is enabled for this program state.
+/// The single definition of the global gates: `can_remove_unused_declarators`
+/// (the removal sites' guard) delegates here, so candidacy and removal
+/// cannot drift. Any direct eval flags the root via ancestor propagation —
+/// see `refresh_direct_eval_flags`.
+pub fn removal_enabled(scoping: &Scoping, options: &CompressOptions) -> bool {
+    options.unused != CompressOptionsUnused::Keep
+        && !scoping.root_scope_flags().contains_direct_eval()
+}
+
+/// Whether the liveness COLLECTION arms for this program: [`removal_enabled`]
+/// plus ESM modules only. `source_type` is the PARSER-RESOLVED kind
+/// (ambiguous `.js`/`.ts` resolves by content), so anything that is not
+/// certainly a strict ES module — scripts, CommonJS,
+/// ambiguous-resolved-script — takes the existing zero-cost off path: no
+/// allocation, no per-node work, and the count-based removal arm behaves
+/// exactly as on `main`. Sloppy sources add observability the reference
+/// count cannot express (script-globals, Annex B block-function aliases);
+/// enabling them is deliberate follow-up work, not a missing `!`.
+///
+/// A strict subset of [`removal_enabled`], which keeps the gate-mirror
+/// invariant structural: candidacy (collection) is only ever granted where
+/// removal is already allowed.
+pub fn collection_enabled(
+    scoping: &Scoping,
+    source_type: SourceType,
+    options: &CompressOptions,
+) -> bool {
+    source_type.is_module() && removal_enabled(scoping, options)
+}
+
+// ========================================================================
+// Propagation: worklist over the flat edge list (rule 1)
+// ========================================================================
+
+/// Worklist propagation shared by the standalone walk and the in-pass
+/// collection. The flat edge list sorted by source symbol is the adjacency
+/// "map": a live symbol's targets are one `partition_point` range scan away.
+/// Roots are already marked live (record-time dedup); marking non-candidate
+/// targets live is harmless — only candidates are consulted for deadness.
+fn propagate(
+    candidates: &BitSet<'_>,
+    live: &mut BitSet<'_>,
+    worklist: &mut ArenaVec<'_, SymbolId>,
+    edges: &mut ArenaVec<'_, (SymbolId, SymbolId)>,
+) {
+    edges.sort_unstable_by_key(|&(from, _)| from.index());
+    while let Some(symbol_id) = worklist.pop() {
+        // Only candidates have outgoing edges by construction.
+        if !candidates.contains(symbol_id.index()) {
+            continue;
+        }
+        let start = edges.partition_point(|&(from, _)| from.index() < symbol_id.index());
+        for &(from, target) in &edges[start..] {
+            if from != symbol_id {
+                break;
+            }
+            if !live.contains(target.index()) {
+                live.set_bit(target.index());
+                worklist.push(target);
+            }
+        }
+    }
+}
+
+// ========================================================================
+// Collection: rides Normalize and every peephole pass (rule 3)
+// ========================================================================
+
+/// Per-pass in-traversal liveness collection: the peephole `Traverse` hooks
+/// record candidates, roots, and edges as the pass visits each node, so no
+/// standalone walk is needed to refresh the dead set. All buffers are
+/// `clear()`-reused across passes.
+pub struct LivenessCollect<'a> {
+    /// Collection is running this pass. Set at `enter_program` from
+    /// [`collection_enabled`]; stable for the whole pass, so every hook's
+    /// enter/exit pair is balanced.
+    active: bool,
+    /// Candidates admitted this pass (per-site gates at enter time, on the
+    /// pre-fold shape — folds only purify, so this under-approves relative
+    /// to the settled tree: the sound direction, self-correcting next pass).
+    candidates: BitSet<'a>,
+    /// Marked at record time for roots, during propagation for edge targets.
+    live: BitSet<'a>,
+    /// Deduplicated roots; doubles as the propagation worklist.
+    roots: ArenaVec<'a, SymbolId>,
+    /// `(innermost enclosing candidate, referenced candidate-kind symbol)`.
+    edges: ArenaVec<'a, (SymbolId, SymbolId)>,
+    /// Saved `current_candidate` values; one frame per FUNCTION node,
+    /// pushed at enter, popped at exit.
+    frames: ArenaVec<'a, Option<SymbolId>>,
+    /// Innermost candidate whose deferred region the traversal is inside.
+    current_candidate: Option<SymbolId>,
+    /// Scratch for the next dead set; swapped with
+    /// `MinifierState::dead_symbols` at flush.
+    dead_next: BitSet<'a>,
+    /// Scratch for the next PINNED set; swapped with
+    /// Symbols this pass's collection may have under-observed, force-rooted
+    /// at the flush. One producer: a bound reference minted behind the
+    /// traversal cursor (each minting pass logs at its call site —
+    /// `substitute_alternate_syntax`'s typeof rewrite is the only one
+    /// today, and the debug ground-truth validator flags an unlogged mint
+    /// across the whole corpus). An unlogged mint would otherwise publish a
+    /// live-referenced symbol as dead. Cleared every pass.
+    force_root_log: ArenaVec<'a, SymbolId>,
+}
+
+impl<'a> LivenessCollect<'a> {
+    /// Everything starts zero-capacity (like `MinifierState::dead_symbols`):
+    /// the first ACTIVE `reset_for_pass` sizes the bitsets, so a compile with
+    /// the analysis off (`unused: Keep`, root direct eval) never allocates.
+    pub fn new(allocator: &'a Allocator) -> Self {
+        Self {
+            active: false,
+            candidates: BitSet::new_in(0, allocator),
+            live: BitSet::new_in(0, allocator),
+            roots: ArenaVec::new_in(&allocator),
+            edges: ArenaVec::new_in(&allocator),
+            frames: ArenaVec::new_in(&allocator),
+            current_candidate: None,
+            dead_next: BitSet::new_in(0, allocator),
+            force_root_log: ArenaVec::new_in(&allocator),
+        }
+    }
+
+    fn reset_for_pass(&mut self, active: bool, symbols_len: usize, allocator: &'a Allocator) {
+        self.active = active;
+        self.current_candidate = None;
+        self.frames.clear();
+        // A pass observes rewrites made DURING it; anything already in the
+        // log predates this pass's traversal, which will visit those
+        // references as part of the tree. Cleared even when inactive so the
+        // log stays bounded with the analysis off.
+        self.force_root_log.clear();
+        if !active {
+            return;
+        }
+        self.roots.clear();
+        self.edges.clear();
+        // Symbols minted mid-pass are past these capacities and read as
+        // live everywhere (the `PassDirty::dead_refs` convention); their
+        // declarations enter the analysis next pass.
+        for bits in [&mut self.candidates, &mut self.live, &mut self.dead_next] {
+            if bits.capacity() == symbols_len {
+                bits.clear();
+            } else {
+                *bits = BitSet::new_in(symbols_len, allocator);
+            }
+        }
+    }
+
+    /// Force-root `symbol_id` at this pass's flush; see the
+    /// `force_root_log` field doc.
+    /// No-op while collection is off (the flush would discard the entry
+    /// anyway), so minting call sites need no gate of their own.
+    pub fn log_force_root(&mut self, symbol_id: SymbolId) {
+        if self.active {
+            self.force_root_log.push(symbol_id);
+        }
+    }
+
+    /// Mark a symbol live and enqueue it for propagation; deduplicated at
+    /// record time.
+    fn mark_live_root(&mut self, symbol_id: SymbolId) {
+        let index = symbol_id.index();
+        if index < self.live.capacity() && !self.live.has_bit(index) {
+            self.live.set_bit(index);
+            self.roots.push(symbol_id);
+        }
+    }
+
+    /// Admit a candidacy-eligible declaration; refuses mid-pass-minted
+    /// symbols (past capacity — they read as live and retry next pass).
+    fn admit_candidate(&mut self, symbol_id: SymbolId) -> bool {
+        let index = symbol_id.index();
+        if index < self.candidates.capacity() {
+            self.candidates.set_bit(index);
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// `Traverse::enter_program` body for both collecting traversals —
+/// `Normalize` (whose collection produces the initial dead set for pass 1)
+/// and every peephole pass: reset the collection for the pass.
+pub fn begin_pass(ctx: &mut TraverseCtx<'_>) {
+    let allocator = ctx.allocator();
+    let TraverseCtx { state, scoping, .. } = ctx;
+    let enabled = collection_enabled(scoping.scoping(), state.source_type, &state.options);
+    let symbols_len = scoping.scoping().symbols_len();
+    state.liveness.reset_for_pass(enabled, symbols_len, allocator);
+}
+
+/// `Traverse::enter_identifier_reference` body. Runs for every
+/// `IdentifierReference` (including assignment targets), so the inactive
+/// path is one load and branch.
+pub fn collect_identifier_reference<'a>(
+    ident: &IdentifierReference<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    let TraverseCtx { state, scoping, .. } = ctx;
+    let lv = &mut state.liveness;
+    if !lv.active {
+        return;
+    }
+    let scoping = scoping.scoping();
+    let Some(reference_id) = ident.reference_id.get() else { return };
+    let Some(symbol_id) = scoping.get_reference(reference_id).symbol_id() else { return };
+    // Kind-based edge-vs-root: a reference to a candidate-kind target inside
+    // a deferred region is an edge whether or not the target is admitted
+    // this pass — its candidacy bit lands via its own declaration hook in
+    // the same pass, so a newly-eligible dead symbol is found at this very
+    // flush. References to every other kind (locals, parameters, imports,
+    // classes) earn no storage at all.
+    if !scoping.symbol_flags(symbol_id).intersects(CANDIDATE_KINDS) {
+        return;
+    }
+    match lv.current_candidate {
+        None => lv.mark_live_root(symbol_id),
+        Some(from) => lv.edges.push((from, symbol_id)),
+    }
+}
+
+fn parent_is_export(parent: Ancestor<'_, '_>) -> bool {
+    matches!(
+        parent,
+        Ancestor::ExportNamedDeclarationDeclaration(_)
+            | Ancestor::ExportDefaultDeclarationDeclaration(_)
+    )
+}
+
+/// `Traverse::enter_function` body: decide candidacy at the same position
+/// the removal site evaluates (the hook fires before the function's scope is
+/// entered, so `current_scope_id` is the containing scope — identical to the
+/// `exit_statement` frame that runs `remove_unused_function_declaration`).
+/// The only position failure a module can express is an export wrapper.
+pub fn collect_enter_function<'a>(func: &Function<'a>, ctx: &mut TraverseCtx<'a>) {
+    if !ctx.state.liveness.active {
+        return;
+    }
+    let mut candidate = None;
+    if func.is_declaration()
+        && let Some(symbol_id) = func.id.as_ref().and_then(|id| id.symbol_id.get())
+    {
+        if parent_is_export(ctx.parent()) {
+            ctx.state.liveness.mark_live_root(symbol_id);
+        } else if ctx.state.liveness.admit_candidate(symbol_id) {
+            candidate = Some(symbol_id);
+        }
+    }
+    let lv = &mut ctx.state.liveness;
+    lv.frames.push(lv.current_candidate);
+    if candidate.is_some() {
+        lv.current_candidate = candidate;
+    }
+}
+
+/// `Traverse::exit_function` body: close the region frame the enter hook
+/// opened. Functions are the only region-openers.
+pub fn collect_exit_function(ctx: &mut TraverseCtx<'_>) {
+    let lv = &mut ctx.state.liveness;
+    if lv.active {
+        debug_assert!(!lv.frames.is_empty(), "unbalanced liveness region frames");
+        lv.current_candidate = lv.frames.pop().flatten();
+    }
+}
+
+/// Consume the pass's collection: force-root symbols that received freshly
+/// minted references (the one toward-dead divergence of in-pass collection),
+/// propagate liveness, refresh `MinifierState::dead_symbols`, and report
+/// whether the driver must run another pass: a NEW dead symbol appeared,
+/// and its removal must be consumed with the same one-pass freshness as
+/// everything else. Convergence is bounded by dead-set growth alone — dead
+/// bits only ever come from the symbol table, and a quiet re-run of an
+/// unchanged tree finds no new ones.
+///
+/// Must run after `flush_pass_dirty` so consumed reference counts are
+/// post-flush fresh.
+pub fn propagate_collected(ctx: &mut TraverseCtx<'_>) -> bool {
+    let TraverseCtx { state, .. } = ctx;
+    let crate::state::MinifierState { liveness, dead_symbols, .. } = state;
+    let lv = liveness;
+    if !lv.active {
+        return false;
+    }
+    debug_assert!(lv.frames.is_empty(), "unbalanced liveness region frames at flush");
+
+    // References minted behind the traversal cursor were never visited by
+    // the collection and must stay live this flush (see the
+    // `force_root_log` field doc).
+    while let Some(symbol_id) = lv.force_root_log.pop() {
+        lv.mark_live_root(symbol_id);
+    }
+
+    // No candidates admitted ⇒ no edges (an edge needs an enclosing
+    // candidate region) and no dead set: skip the worklist drain and the
+    // set scan (mirrors `compute_dead_symbols`' early-out). The swap still
+    // runs so a stale dead set from the previous pass clears.
+    if lv.candidates.is_empty() {
+        std::mem::swap(dead_symbols, &mut lv.dead_next);
+        return false;
+    }
+
+    // Candidacy is fully known post-collection, so drop the (measured
+    // 77-84%) edges whose targets can never be dead before they hit the
+    // sort. A removed edge's only effect was a live mark on a
+    // non-candidate, which nothing consults.
+    {
+        let LivenessCollect { edges, candidates, .. } = lv;
+        edges.retain(|&(_, target)| candidates.contains(target.index()));
+    }
+
+    propagate(&lv.candidates, &mut lv.live, &mut lv.roots, &mut lv.edges);
+
+    for candidate in lv.candidates.ones() {
+        if !lv.live.contains(candidate) {
+            lv.dead_next.set_bit(candidate);
+        }
+    }
+
+    // Per-bit scan; a word-level set-difference helper would make this
+    // O(words) — a possible `oxc_allocator` follow-up. Until then, gate the
+    // common terminal-pass case (empty dead set).
+    let found_new_dead =
+        !lv.dead_next.is_empty() && lv.dead_next.ones().any(|bit| !dead_symbols.contains(bit));
+
+    std::mem::swap(dead_symbols, &mut lv.dead_next);
+    found_new_dead
+}

--- a/crates/oxc_minifier/src/symbol_liveness/validate.rs
+++ b/crates/oxc_minifier/src/symbol_liveness/validate.rs
@@ -1,0 +1,243 @@
+//! Ground-truth validation for the in-pass liveness collection.
+//!
+//! [`compute_dead_symbols`] re-derives the dead and pinned sets with an
+//! INDEPENDENT standalone walk of the settled tree — its own
+//! export/for-head state, only the shared gate predicates from the parent
+//! module. [`super::propagate_collected`] asserts every flushed in-pass set
+//! against it, so the whole test and conformance corpus diffs the
+//! interleaved collection against ground truth. Deliberately a second
+//! implementation: sharing traversal code with the hooks would make the
+//! oracle blind to exactly the bugs it exists to catch.
+
+use oxc_allocator::{Allocator, BitSet, Vec as ArenaVec};
+use oxc_ast::ast::*;
+use oxc_ast_visit::{
+    Visit,
+    walk::{
+        walk_arrow_function_expression, walk_class, walk_export_default_declaration,
+        walk_export_named_declaration, walk_for_statement_left, walk_function,
+        walk_variable_declarator,
+    },
+};
+use oxc_ecmascript::BoundNames;
+use oxc_semantic::Scoping;
+use oxc_syntax::scope::ScopeFlags;
+use oxc_syntax::symbol::SymbolId;
+
+use crate::CompressOptions;
+
+use super::{CANDIDATE_KINDS, collection_enabled, propagate};
+
+/// Compute the dead and expected-pin sets with a standalone walk of a
+/// settled tree. Returns `(dead, candidates, pins)`; bits are
+/// `SymbolId::index()`.
+///
+/// Debug-only ground truth: the release pipeline never walks — collection
+/// rides the Normalize and peephole traversals — but every
+/// [`super::propagate_collected`] validates its flushed sets against this
+/// walk of the post-flush tree, so the whole test corpus checks the in-pass
+/// collection.
+pub fn compute_dead_symbols<'a>(
+    program: &Program<'a>,
+    scoping: &Scoping,
+    options: &CompressOptions,
+    allocator: &'a Allocator,
+) -> (BitSet<'a>, BitSet<'a>, BitSet<'a>) {
+    let empty = || {
+        (BitSet::new_in(0, allocator), BitSet::new_in(0, allocator), BitSet::new_in(0, allocator))
+    };
+    if !collection_enabled(scoping, program.source_type, options) {
+        return empty();
+    }
+
+    let symbols_len = scoping.symbols_len();
+    let mut collector = Collector {
+        scoping,
+        in_export: false,
+        in_for_head: false,
+        enclosing_candidate: None,
+        candidates: BitSet::new_in(symbols_len, allocator),
+        live: BitSet::new_in(symbols_len, allocator),
+        pins: BitSet::new_in(symbols_len, allocator),
+        roots: ArenaVec::new_in(&allocator),
+        edges: ArenaVec::new_in(&allocator),
+    };
+    collector.visit_program(program);
+
+    let Collector { candidates, mut live, pins, roots, mut edges, .. } = collector;
+    if candidates.is_empty() {
+        return (BitSet::new_in(0, allocator), BitSet::new_in(0, allocator), pins);
+    }
+
+    let mut worklist = roots;
+    propagate(&candidates, &mut live, &mut worklist, &mut edges);
+
+    let mut dead = BitSet::new_in(symbols_len, allocator);
+    for candidate in candidates.ones() {
+        if !live.contains(candidate) {
+            dead.set_bit(candidate);
+        }
+    }
+    (dead, candidates, pins)
+}
+
+struct Collector<'a, 'b> {
+    scoping: &'b Scoping,
+    /// The visited node is the `declaration` of an export statement (or a
+    /// sibling declarator of one). Cleared for the declaration's subtree so
+    /// declarations nested inside an exported function/class stay eligible.
+    in_export: bool,
+    /// The innermost declarator being visited sits in a for-in/of HEAD —
+    /// no removal site handles heads, so their bindings force-root.
+    in_for_head: bool,
+    /// Innermost candidate whose deferred region we are inside.
+    enclosing_candidate: Option<SymbolId>,
+    candidates: BitSet<'a>,
+    /// Marked at record time for roots, during propagation for edge targets.
+    live: BitSet<'a>,
+    /// Every symbol a pin position demands (export wrappers, for-in/of
+    /// heads, `using`): the expected-pin set the flush asserts
+    /// `pinned_next` covers. A missed pin is silent wrong code the dead-set
+    /// checks cannot see — the count arm deletes an observable binding
+    /// while the dead set stays correct.
+    pins: BitSet<'a>,
+    /// Deduplicated live-context references to candidate-kind symbols (plus
+    /// pinned position-ineligible declarations); the propagation worklist.
+    roots: ArenaVec<'a, SymbolId>,
+    /// `(innermost enclosing candidate, referenced candidate-kind symbol)`.
+    /// May contain duplicates (one entry per reference); propagation dedups
+    /// via the `live` bitset.
+    edges: ArenaVec<'a, (SymbolId, SymbolId)>,
+}
+
+impl Collector<'_, '_> {
+    /// Mark a symbol live and enqueue it for propagation; deduplicated at
+    /// record time via the `live` bitset.
+    fn mark_live_root(&mut self, symbol_id: SymbolId) {
+        if !self.live.contains(symbol_id.index()) {
+            self.live.set_bit(symbol_id.index());
+            self.roots.push(symbol_id);
+        }
+    }
+
+    /// Root AND record an expected pin — mirrors the release collection's
+    /// `pin_live_root` for the pin positions this walk re-derives.
+    fn pin_live_root(&mut self, symbol_id: SymbolId) {
+        self.mark_live_root(symbol_id);
+        self.pins.set_bit(symbol_id.index());
+    }
+
+    /// Shared visitor skeleton for the three declaration kinds: clear
+    /// `in_export` for the subtree, track the innermost enclosing candidate
+    /// across the walk, restore both.
+    fn walk_declaration(&mut self, candidate: Option<SymbolId>, walk: impl FnOnce(&mut Self)) {
+        let saved_export = std::mem::replace(&mut self.in_export, false);
+        let saved_candidate = self.enclosing_candidate;
+        if let Some(symbol_id) = candidate {
+            self.candidates.set_bit(symbol_id.index());
+            self.enclosing_candidate = Some(symbol_id);
+        }
+        walk(self);
+        self.enclosing_candidate = saved_candidate;
+        self.in_export = saved_export;
+    }
+}
+
+impl<'a> Visit<'a> for Collector<'_, '_> {
+    fn visit_identifier_reference(&mut self, it: &IdentifierReference<'a>) {
+        if let Some(reference_id) = it.reference_id.get()
+            && let Some(symbol_id) = self.scoping.get_reference(reference_id).symbol_id()
+            && self.scoping.symbol_flags(symbol_id).intersects(CANDIDATE_KINDS)
+        {
+            match self.enclosing_candidate {
+                None => self.mark_live_root(symbol_id),
+                Some(from) => self.edges.push((from, symbol_id)),
+            }
+        }
+    }
+
+    fn visit_export_named_declaration(&mut self, it: &ExportNamedDeclaration<'a>) {
+        let saved = std::mem::replace(&mut self.in_export, true);
+        walk_export_named_declaration(self, it);
+        self.in_export = saved;
+    }
+
+    fn visit_export_default_declaration(&mut self, it: &ExportDefaultDeclaration<'a>) {
+        let saved = std::mem::replace(&mut self.in_export, true);
+        walk_export_default_declaration(self, it);
+        self.in_export = saved;
+    }
+
+    fn visit_for_statement_left(&mut self, it: &ForStatementLeft<'a>) {
+        let saved = std::mem::replace(&mut self.in_for_head, true);
+        walk_for_statement_left(self, it);
+        self.in_for_head = saved;
+    }
+
+    /// An arrow bounds the export flag exactly like the other function
+    /// forms do (via [`Self::walk_declaration`]): in
+    /// `export default (w) => { function f() {} }`, `f` is an ordinary
+    /// candidate, not the exported declaration. Arrows are the one
+    /// function form `visit_function` never sees, and they can never BE a
+    /// declaration, so only the flag needs clearing — the enclosing
+    /// candidate stays (an arrow inside a candidate's body is part of its
+    /// deferred region).
+    fn visit_arrow_function_expression(&mut self, it: &ArrowFunctionExpression<'a>) {
+        let saved = std::mem::replace(&mut self.in_export, false);
+        walk_arrow_function_expression(self, it);
+        self.in_export = saved;
+    }
+
+    fn visit_function(&mut self, it: &Function<'a>, flags: ScopeFlags) {
+        let mut candidate = None;
+        if it.is_declaration()
+            && let Some(symbol_id) = it.id.as_ref().and_then(|id| id.symbol_id.get())
+        {
+            if self.in_export {
+                self.pin_live_root(symbol_id);
+            } else {
+                candidate = Some(symbol_id);
+            }
+        }
+        self.walk_declaration(candidate, |v| walk_function(v, it, flags));
+    }
+
+    fn visit_class(&mut self, it: &Class<'a>) {
+        // Classes are never candidates; only the export-observability pin
+        // applies (mirrors `collect_enter_class`).
+        if it.is_declaration()
+            && let Some(symbol_id) = it.id.as_ref().and_then(|id| id.symbol_id.get())
+            && self.in_export
+        {
+            self.pin_live_root(symbol_id);
+        }
+        self.walk_declaration(None, |v| walk_class(v, it));
+    }
+
+    fn visit_variable_declarator(&mut self, it: &VariableDeclarator<'a>) {
+        // Declarators are never candidates; mirror the stable pins of
+        // `collect_enter_variable_declarator`. For-in/of heads root but are
+        // NOT demanded as expected pins: the head merge in
+        // `minimize_statements` (`var a; for (a in b)` -> `for (var a in b)`)
+        // legitimately creates head declarators mid-pass that the enter-time
+        // collection never saw, and a merged head is init-less with no other
+        // declaration site left to consult — the release pin for
+        // enter-time heads is defensive, not load-bearing.
+        if it.kind.is_using() || self.in_export {
+            // Expect a pin for every symbol the site binds, destructuring
+            // included.
+            it.id.bound_names(&mut |ident| {
+                if let Some(symbol_id) = ident.symbol_id.get() {
+                    self.pin_live_root(symbol_id);
+                }
+            });
+        } else if self.in_for_head {
+            it.id.bound_names(&mut |ident| {
+                if let Some(symbol_id) = ident.symbol_id.get() {
+                    self.mark_live_root(symbol_id);
+                }
+            });
+        }
+        self.walk_declaration(None, |v| walk_variable_declarator(v, it));
+    }
+}

--- a/tasks/track_memory_allocations/allocs_minifier.snap
+++ b/tasks/track_memory_allocations/allocs_minifier.snap
@@ -1,16 +1,16 @@
 File                       | File size      || Sys allocs     | Sys reallocs   || Arena allocs   | Arena reallocs 
 ---------------------------------------------------------------------------------------------------------------------------
-checker.ts                 | 2.92 MB        ||            155 |              5 ||         152755 |          28253
+checker.ts                 | 2.92 MB        ||            155 |              5 ||         152770 |          28279
 
-App.tsx                    | 415.34 kB      ||             63 |              8 ||          17028 |           2702
+App.tsx                    | 415.34 kB      ||             63 |              8 ||          17042 |           2707
 
-RadixUIAdoptionSection.jsx | 2.52 kB        ||             21 |              0 ||             32 |              6
+RadixUIAdoptionSection.jsx | 2.52 kB        ||             21 |              0 ||             45 |              6
 
-pdf.mjs                    | 567.30 kB      ||           2469 |            205 ||          47471 |           7742
+pdf.mjs                    | 567.30 kB      ||           2469 |            205 ||          47505 |           7807
 
-antd.js                    | 6.69 MB        ||           1044 |             56 ||         372632 |          76745
+antd.js                    | 6.69 MB        ||           1044 |             56 ||         372638 |          76745
 
-binder.ts                  | 193.08 kB      ||             33 |              1 ||           7076 |            824
+binder.ts                  | 193.08 kB      ||             33 |              1 ||           7091 |            842
 
-kitchen-sink.tsx           | 732.90 kB      ||           2309 |            175 ||          88129 |          15654
+kitchen-sink.tsx           | 732.90 kB      ||           2309 |            175 ||          88205 |          15843
 


### PR DESCRIPTION
Reference counting cannot tell that a declaration is dead when its only references live inside itself or inside a cycle: `function c() { d() } function d() { c() }` never reaches zero references. Removing these needs reachability, not counts. This PR adds the analysis; the PR above consumes it at the removal sites. Output does not change here.

References in executing code are roots. References inside a candidate declaration's body only count once that candidate itself is live. A dead cycle is never reached, so there is no cycle detection. Candidacy is function declarations only — declarator and class candidacy were built, hardened, and then measured to contribute exactly zero output bytes on 17 real artifacts, so they were cut.

The analysis runs for ES modules only. In strict ESM the hard cases cannot occur: Annex B block-function aliases are sloppy-only, and module top-level bindings are module-local, not cross-script-observable globals. Sloppy sources (scripts, `.cjs`) skip the analysis entirely — the existing option-off fast path: zero allocation, and per node only the one disarmed-hook boolean check — and behave exactly as main, byte-for-byte. Enabling sloppy sources, with the script-global pins and conservative Annex B handling they need, is a planned follow-up; every piece of it exists verified in this branch's history.

There is no standalone analysis walk. The analysis is collected during the traversals the minifier already runs: Normalize seeds it, every peephole pass re-collects, every flush propagates and swaps in the fresh set. The set consumed by a pass is always exactly one pass stale.

Three kinds of declarations are pinned — counted live no matter what the numbers say — because removing a dead cycle discards the references it held, so a reference count of zero does not mean unobservable afterwards: export-wrapped declarations (importers observe the binding), `for`-in/of heads (no removal site handles them), and `using` declarators (removal always bails). The one rewrite the collection cannot see — a bound reference minted behind the traversal cursor (the typeof rewrite is the only minter today) — is logged and force-rooted at the flush. In debug builds every flushed set is checked against a standalone ground-truth walk, so the whole test and conformance corpus doubles as a checker.

Per-pass freshness is the load-bearing choice, and the cheaper cadences were each built and falsified rather than assumed away. A one-shot variant — collect during Normalize, publish once, consume in the first pass — was fully implemented: byte-identical on the minsize fixtures at roughly half the overhead, but real npm packages expose cycles mid-loop through rewrites no collection-time analysis can anticipate. In js_of_ocaml-compiled bundles (flow-parser, prettier's flow plugins, @vue/server-renderer), dropping `t0 && B0(...)` once `B0` is proven pure removes a cycle's last live read; under one-shot the cycle then survives this minify and falls on a re-minify, and monitor-oxc's idempotency gate fails on exactly those files. A record-time dead-branch filter and a two-shot cadence were also built and falsified. Only per-pass re-collection passes the gate.

Cost, measured with paired interleaved runs against main (wall time, includes parse and codegen): antd.js (6.7 MB script) +1.4% (+1.0ms) — the analysis never constructs for scripts and the residue is one boolean check per node, down from +2.4% when scripts were analyzed; vue.runtime.esm-browser (385 kB module) +1.5% (+0.2ms) and a rolldown-built Vue chunk (197 kB module) +2.0% (+0.2ms) — module files of rolldown's per-module size sit at the sub-millisecond noise floor.

Output is byte-identical on every fixture, and iteration counts do not change. The minsize corpus parses as sloppy script, so it is untouched by construction; the size win lands with the consumer PR's module-shaped inputs and, for scripts, with the follow-up.

Review map: the mechanism is `symbol_liveness/mod.rs` below the module doc (read the doc's three rules first — everything else is their application); `validate.rs` is the debug-only mirror, mechanical by design; the hook blocks in `normalize.rs`/`peephole/mod.rs` are identical twins. The one paragraph to scrutinize is the pin rationale in the module doc: "removing a dead cycle deletes the references it held, so counts lie afterward."

Implemented with AI assistance (Claude Code); design, review, and verification driven by the author per the repo AI-usage policy.
