### PR TITLE
fix(formatter_css): Keep glued-braket-value tight

### DIFF
--- a/crates/oxc_formatter_css/AGENTS.md
+++ b/crates/oxc_formatter_css/AGENTS.md
@@ -226,7 +226,12 @@ Notable divergences are:
     - We print `(not (screen and (color)))`
   - Reproducing the half-normalization is pure tokenizer-artifact matching;
     - Gap-based spacing never fuses tokens the source kept apart (`and (` can't become a function token `and(`)
-- `@custom-media` preludes always print structured (e.g. `--viewport-medium (width <= 50rem)`)
+- A source-glued value-position `[...]` stays glued to ANY typed left neighbor and prints verbatim
+  - `theme(fontSize.af-md[0])`, `foo[0.50]`: matching Prettier, which lexes the run as ONE postcss word;
+    But also `var(--x)[0]`, where Prettier prints `var(--x) [0]`)
+    - Prettier's space there is a word-lexing artifact (`[` extends a word, but not across `)`)
+    - Ours is one gap-based rule for all variants: never add a space the source doesn't have
+  - Less lookups (`@config[@key]`) are unaffected: the typed lookup rule wins and keeps printing structurally
   - With the name GLUED to the `(` (`--viewport-medium(width<=50rem)`)
   - Prettier keeps the whole prelude verbatim (ONE `media-type` token)
 - A declaration swallowed by a `;`-less css-in-js placeholder (`${m}\ncolor: red`)

--- a/crates/oxc_formatter_css/src/print/value.rs
+++ b/crates/oxc_formatter_css/src/print/value.rs
@@ -389,7 +389,7 @@ fn is_func_like(value: &ComponentValue<'_>) -> bool {
 /// but postcss lexes the whole contiguous run as ONE word
 /// (an xstyled / tailwind-theme token, or plugin-processed pseudo-math).
 ///
-/// Such a number stays glued (`Separator::Tight`) and prints raw.
+/// Such a number stays glued and prints raw (`Separator::Word`).
 /// `.10` must not normalize to `0.1`, `+1` must not gain a space.
 /// Two glued number-ish values can never be valid CSS,
 /// so a number-ish neighbor is as sure a word sign as a word-like one.
@@ -853,7 +853,7 @@ pub(super) fn write_comma_group<'a>(
             while run_end < values.len()
                 && matches!(
                     separator_between(values, run_end, ctx, source),
-                    Separator::Tight | Separator::Space
+                    Separator::Tight | Separator::Word | Separator::Space
                 )
             {
                 run_end += 1;
@@ -871,9 +871,9 @@ pub(super) fn write_comma_group<'a>(
                         if sep == Separator::Space {
                             write!(f, " ");
                         }
-                        // A word-glued number prints raw, not normalized (see `is_word_glued_number`);
-                        // gated on Tight so the spacing and text halves always come from one rule.
-                        if sep == Separator::Tight && is_word_glued_number(values, run_start + j) {
+                        // A word continuation prints raw, not normalized
+                        // (`sandstone.10`, `[0.50]` must survive as-is).
+                        if sep == Separator::Word {
                             write!(f, text(source.text_for(&to_span(v.span()))));
                             continue;
                         }
@@ -961,6 +961,9 @@ pub(super) fn write_comma_group<'a>(
 enum Separator {
     /// No separator (components merged into one run).
     Tight,
+    /// `Tight`, AND the right component prints raw from source:
+    /// the pair continues ONE postcss word (`sandstone.10`, `foo[0.50]`).
+    Word,
     /// Plain space, no break opportunity (word before a math operator).
     Space,
     /// Breakable, no space when flat (placeholder glued to a paren group).
@@ -1089,6 +1092,21 @@ fn separator_between(
         return Separator::Tight;
     }
 
+    // A source-glued `[...]` is part of ONE postcss word
+    // (`theme(fontSize.af-md[0])`, `foo[0]bar`, `10px[0]`): keep the glue and print verbatim;
+    // a source gap (`af-md [0]`) keeps two words.
+    // Less lookup chains never reach here (the rule above wins),
+    // so their brackets still print structurally.
+    // NOTE: Prettier re-splits SOME glued neighbors (`var(--x)[0]` -> `var(--x) [0]`,
+    // a word-lexing artifact of `[` not extending a word across `)`);
+    // one gap-based rule never adds a space the source doesn't have.
+    if gap_empty
+        && (matches!(curr, ComponentValue::BracketBlock(_))
+            || matches!(prev, ComponentValue::BracketBlock(_)))
+    {
+        return Separator::Word;
+    }
+
     // Raw token punctuation:
     // `:` hugs left and spaces right, braces hug their contents (custom-property JSON-ish values).
     {
@@ -1208,10 +1226,9 @@ fn separator_between(
         return Separator::Tight;
     }
 
-    // A word-glued number is part of ONE postcss word (`sandstone.10`);
-    // it also prints raw, see `is_word_glued_number`.
+    // A word-glued number is part of ONE postcss word (`sandstone.10`); see `is_word_glued_number`.
     if gap_empty && is_word_glued_number(values, i) {
-        return Separator::Tight;
+        return Separator::Word;
     }
 
     // postcss-values lexes `1#{$var}` as ONE word:

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/word-glued-bracket.css
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/word-glued-bracket.css
@@ -1,0 +1,28 @@
+/* tailwind theme paths: a source-glued `[...]` is part of ONE postcss word */
+a {
+  font-size: theme(fontSize.af-md[0]);
+  line-height: theme(fontSize.sm[1].lineHeight);
+}
+/* a source gap keeps two words */
+b {
+  font-size: theme(fontSize.af-md [0]);
+}
+/* not theme()-specific: any source-glued `[...]` in value position is one word */
+c {
+  width: foo[0];
+  height: foo[0]bar;
+  margin: foo [0] bar;
+}
+/* the word prints raw: no number normalization inside */
+d {
+  font-size: theme(fontSize.af-md[0.50]);
+  width: 10px[0];
+}
+/* the glue is kept for ANY typed left neighbor; `var(--x)[0]` DIVERGES from
+   Prettier (`var(--x) [0]`, a word-lexing artifact of `[` not extending a word
+   across `)`) — see "Known divergences". `2*[0]` is token-soup math (raw
+   tokens, not a typed bracket) and its spacing matches Prettier */
+e {
+  width: var(--x)[0];
+  height: 2*[0];
+}

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/word-glued-bracket.css.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/word-glued-bracket.css.snap
@@ -1,0 +1,99 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+/* tailwind theme paths: a source-glued `[...]` is part of ONE postcss word */
+a {
+  font-size: theme(fontSize.af-md[0]);
+  line-height: theme(fontSize.sm[1].lineHeight);
+}
+/* a source gap keeps two words */
+b {
+  font-size: theme(fontSize.af-md [0]);
+}
+/* not theme()-specific: any source-glued `[...]` in value position is one word */
+c {
+  width: foo[0];
+  height: foo[0]bar;
+  margin: foo [0] bar;
+}
+/* the word prints raw: no number normalization inside */
+d {
+  font-size: theme(fontSize.af-md[0.50]);
+  width: 10px[0];
+}
+/* the glue is kept for ANY typed left neighbor; `var(--x)[0]` DIVERGES from
+   Prettier (`var(--x) [0]`, a word-lexing artifact of `[` not extending a word
+   across `)`) — see "Known divergences". `2*[0]` is token-soup math (raw
+   tokens, not a typed bracket) and its spacing matches Prettier */
+e {
+  width: var(--x)[0];
+  height: 2*[0];
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+/* tailwind theme paths: a source-glued `[...]` is part of ONE postcss word */
+a {
+  font-size: theme(fontSize.af-md[0]);
+  line-height: theme(fontSize.sm[1].lineHeight);
+}
+/* a source gap keeps two words */
+b {
+  font-size: theme(fontSize.af-md [0]);
+}
+/* not theme()-specific: any source-glued `[...]` in value position is one word */
+c {
+  width: foo[0];
+  height: foo[0]bar;
+  margin: foo [0] bar;
+}
+/* the word prints raw: no number normalization inside */
+d {
+  font-size: theme(fontSize.af-md[0.50]);
+  width: 10px[0];
+}
+/* the glue is kept for ANY typed left neighbor; `var(--x)[0]` DIVERGES from
+   Prettier (`var(--x) [0]`, a word-lexing artifact of `[` not extending a word
+   across `)`) — see "Known divergences". `2*[0]` is token-soup math (raw
+   tokens, not a typed bracket) and its spacing matches Prettier */
+e {
+  width: var(--x)[0];
+  height: 2 * [0];
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+/* tailwind theme paths: a source-glued `[...]` is part of ONE postcss word */
+a {
+  font-size: theme(fontSize.af-md[0]);
+  line-height: theme(fontSize.sm[1].lineHeight);
+}
+/* a source gap keeps two words */
+b {
+  font-size: theme(fontSize.af-md [0]);
+}
+/* not theme()-specific: any source-glued `[...]` in value position is one word */
+c {
+  width: foo[0];
+  height: foo[0]bar;
+  margin: foo [0] bar;
+}
+/* the word prints raw: no number normalization inside */
+d {
+  font-size: theme(fontSize.af-md[0.50]);
+  width: 10px[0];
+}
+/* the glue is kept for ANY typed left neighbor; `var(--x)[0]` DIVERGES from
+   Prettier (`var(--x) [0]`, a word-lexing artifact of `[` not extending a word
+   across `)`) — see "Known divergences". `2*[0]` is token-soup math (raw
+   tokens, not a typed bracket) and its spacing matches Prettier */
+e {
+  width: var(--x)[0];
+  height: 2 * [0];
+}
+
+===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/dotted-word-tokens.scss
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/dotted-word-tokens.scss
@@ -9,4 +9,7 @@ a {
   e: colors.modes.dark;
   f: sandstone.10;
   g: theme(colors.blue.500);
+  h: theme(fontSize.sm[1].lineHeight);
+  i: $var[0];
+  j: #fff[0];
 }

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/dotted-word-tokens.scss.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/dotted-word-tokens.scss.snap
@@ -13,6 +13,9 @@ a {
   e: colors.modes.dark;
   f: sandstone.10;
   g: theme(colors.blue.500);
+  h: theme(fontSize.sm[1].lineHeight);
+  i: $var[0];
+  j: #fff[0];
 }
 
 ==================== Output ====================
@@ -30,6 +33,9 @@ a {
   e: colors.modes.dark;
   f: sandstone.10;
   g: theme(colors.blue.500);
+  h: theme(fontSize.sm[1].lineHeight);
+  i: $var[0];
+  j: #fff[0];
 }
 
 -------------------
@@ -46,6 +52,9 @@ a {
   e: colors.modes.dark;
   f: sandstone.10;
   g: theme(colors.blue.500);
+  h: theme(fontSize.sm[1].lineHeight);
+  i: $var[0];
+  j: #fff[0];
 }
 
 ===================== End =====================


### PR DESCRIPTION
Fixes #24334
