### PR TITLE
perf(transformer): fix Rust 1.97 performance regression

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/mod.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/mod.rs
@@ -343,45 +343,9 @@ impl<'a> Traverse<'a, TransformState<'a>> for ClassProperties<'a> {
     fn enter_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         // All of transforms below only act on `PrivateFieldExpression`s or `PrivateInExpression`s.
         // If we're not inside a class which has private fields, `#prop` can't be present here,
-        // so exit early - fast path for common case.
-        if self.private_field_count == 0 {
-            return;
-        }
-
-        match expr {
-            // `object.#prop`
-            Expression::PrivateFieldExpression(_) => {
-                self.transform_private_field_expression(expr, ctx);
-            }
-            // `object.#prop()`
-            Expression::CallExpression(_) => {
-                self.transform_call_expression(expr, ctx);
-            }
-            // `object.#prop = value`, `object.#prop += value`, `object.#prop ??= value` etc
-            Expression::AssignmentExpression(_) => {
-                self.transform_assignment_expression(expr, ctx);
-            }
-            // `object.#prop++`, `--object.#prop`
-            Expression::UpdateExpression(_) => {
-                self.transform_update_expression(expr, ctx);
-            }
-            // `object?.#prop`
-            Expression::ChainExpression(_) => {
-                self.transform_chain_expression(expr, ctx);
-            }
-            // `delete object?.#prop.xyz`
-            Expression::UnaryExpression(_) => {
-                self.transform_unary_expression(expr, ctx);
-            }
-            // "object.#prop`xyz`"
-            Expression::TaggedTemplateExpression(_) => {
-                self.transform_tagged_template_expression(expr, ctx);
-            }
-            // "#prop in object"
-            Expression::PrivateInExpression(_) => {
-                self.transform_private_in_expression(expr, ctx);
-            }
-            _ => {}
+        // so skip the slow path - fast path for common case.
+        if self.private_field_count != 0 {
+            self.enter_expression_with_private_fields(expr, ctx);
         }
     }
 
@@ -425,5 +389,52 @@ impl<'a> Traverse<'a, TransformState<'a>> for ClassProperties<'a> {
 
     fn exit_static_block(&mut self, _block: &mut StaticBlock<'a>, _ctx: &mut TraverseCtx<'a>) {
         self.flag_exiting_static_property_or_block();
+    }
+}
+
+impl<'a> ClassProperties<'a> {
+    // Keep the rare private-field transform body out of the hot expression visitor.
+    // Rust 1.97 otherwise inlines these large branches into the generated walker.
+    #[inline(never)]
+    fn enter_expression_with_private_fields(
+        &mut self,
+        expr: &mut Expression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        match expr {
+            // `object.#prop`
+            Expression::PrivateFieldExpression(_) => {
+                self.transform_private_field_expression(expr, ctx);
+            }
+            // `object.#prop()`
+            Expression::CallExpression(_) => {
+                self.transform_call_expression(expr, ctx);
+            }
+            // `object.#prop = value`, `object.#prop += value`, `object.#prop ??= value` etc
+            Expression::AssignmentExpression(_) => {
+                self.transform_assignment_expression(expr, ctx);
+            }
+            // `object.#prop++`, `--object.#prop`
+            Expression::UpdateExpression(_) => {
+                self.transform_update_expression(expr, ctx);
+            }
+            // `object?.#prop`
+            Expression::ChainExpression(_) => {
+                self.transform_chain_expression(expr, ctx);
+            }
+            // `delete object?.#prop.xyz`
+            Expression::UnaryExpression(_) => {
+                self.transform_unary_expression(expr, ctx);
+            }
+            // "object.#prop`xyz`"
+            Expression::TaggedTemplateExpression(_) => {
+                self.transform_tagged_template_expression(expr, ctx);
+            }
+            // "#prop in object"
+            Expression::PrivateInExpression(_) => {
+                self.transform_private_in_expression(expr, ctx);
+            }
+            _ => {}
+        }
     }
 }

--- a/crates/oxc_transformer/src/es2022/mod.rs
+++ b/crates/oxc_transformer/src/es2022/mod.rs
@@ -50,6 +50,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for ES2022<'a> {
         }
     }
 
+    #[inline]
     fn enter_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         if let Some(class_properties) = &mut self.class_properties {
             class_properties.enter_expression(expr, ctx);


### PR DESCRIPTION
## What regressed?

The Rust 1.97 upgrade changed LLVM’s inlining decisions around the ES2022 transformer expression visitor.

The hot benchmark path is:

```text
oxc_traverse::generated::walk::walk_expression
  -> TransformerImpl::enter_expression
  -> ES2022::enter_expression
  -> ClassProperties::enter_expression
```

`ClassProperties::enter_expression` is meant to be cheap for most expressions. It first checks whether we are currently inside a class with private fields:

```rust
if self.private_field_count == 0 {
    return;
}
```

For most benchmark files, this is the common path. If there are no active private fields, none of the private-field expression transforms can apply.

With Rust 1.96, LLVM kept the large private-field transform implementations out of the hot visitor, so `ES2022::enter_expression` was still small enough to inline into the generated walker:

```text
Rust 1.96:
<ES2022 as Traverse>::enter_expression
  inlined into oxc_traverse::generated::walk::walk_expression
  cost=-11965, threshold=250
```

With Rust 1.97, LLVM started inlining several large private-field transform bodies into `ES2022::enter_expression` first:

```text
Rust 1.97:
transform_assignment_expression_impl
  inlined into ES2022::enter_expression
  cost=-8825, threshold=250

transform_update_expression_impl
  inlined into ES2022::enter_expression
  cost=-5390, threshold=250

transform_tagged_template_expression_impl
  inlined into ES2022::enter_expression
  cost=-14555, threshold=250
```

After those large branches were pulled in, `ES2022::enter_expression` became too large to inline into the generated walker:

```text
Rust 1.97:
<ES2022 as Traverse>::enter_expression
  not inlined into oxc_traverse::generated::walk::walk_expression
  cost=4265, threshold=250
```

So the regression is not a semantic change. It is a codegen shape change: the generated walker lost a very cheap inlined fast path and started paying an extra call / worse layout on every expression visit.

## Assembly shape

In the Rust 1.96 build, `walk_expression` had the ES2022/ClassProperties fast path inlined. The walker checks whether the class-properties transform is active and whether private fields are currently in scope, then only branches into private-field handling when needed.

A representative part of the Rust 1.96 walker looked like this:

```asm
; ClassProperties state exists?
ldr     x8, [x20, #0x478]
cbz     x8, <skip_private_field_transform>

; Load expression discriminant
ldr     x8, [sp, #0x88]
ldrb    w8, [x8]

; Dispatch only to relevant expression cases
cmp     w8, #0xc
b.eq    <assignment_expression_case>
...
cmp     w8, #0x1d
b.ne    <skip_private_field_transform>

; Only call the heavy helper after matching the expression kind
bl      transform_update_expression_impl
b       <skip_private_field_transform>
```

For example, the clean Rust 1.96 walker still had direct calls to the rare helpers, but only behind expression-kind checks:

```asm
bl transform_call_expression_impl
bl transform_update_expression_impl
bl transform_tagged_template_expression_impl
bl transform_private_field_expression_impl
bl transform_assignment_expression_impl
bl transform_unary_expression_impl
bl transform_chain_expression_impl
```

In the bad Rust 1.97 shape, the outer ES2022 visitor was no longer inlined into `walk_expression`, because LLVM had already inflated it by inlining the large private-field branches. That left the hot walker path with a call to the ES2022 expression visitor instead of the cheap inlined guard.

## Fix

This PR makes the intended hot/cold split explicit:

```rust
#[inline]
fn enter_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
    if let Some(class_properties) = &mut self.class_properties {
        class_properties.enter_expression(expr, ctx);
    }
}
```

and:

```rust
#[inline]
fn enter_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
    if self.private_field_count != 0 {
        self.enter_expression_with_private_fields(expr, ctx);
    }
}

#[inline(never)]
fn enter_expression_with_private_fields(...) {
    match expr {
        Expression::PrivateFieldExpression(_) => ...
        Expression::CallExpression(_) => ...
        Expression::AssignmentExpression(_) => ...
        ...
    }
}
```

The important bit is that the common case remains tiny:

```text
if private_field_count != 0 {
    slow_private_field_dispatch(...)
}
```

The large private-field expression dispatch is still available, but it no longer pollutes the hot expression visitor and no longer prevents the ES2022 hook from being inlined into the generated walker.

The patched walker now has the intended shape:

```asm
; Check class-properties/private-field state
ldr     x8, [x20, #0x478]
cbz     x8, <skip_private_field_transform>

; Only call out when private fields are active
add     x0, x20, #0x3f8
ldr     x1, [sp, #0x90]
mov     x2, x28
bl      ClassProperties::enter_expression_with_private_fields

<skip_private_field_transform>:
```

This keeps the common no-private-fields path small while preventing Rust 1.97 from re-inlining the large rare private-field transform bodies into the generated walker.
