### PR TITLE
perf(transformer): outline class expression exit

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/class.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class.rs
@@ -575,6 +575,7 @@ impl<'a> ClassProperties<'a> {
     ///
     /// `let C = class { static [foo()] = 123; static { bar(); } };`
     /// -> `let C = (_foo = foo(), _Class = class {}, _Class[_foo] = 123, bar(), _Class);`
+    #[inline(never)]
     pub(super) fn transform_class_expression_on_exit(
         &mut self,
         expr: &mut Expression<'a>,


### PR DESCRIPTION
## Summary

Keep the cheap `ClassExpression` discriminant check inline in the transformer expression walker, while forcing the complete class-properties class-expression exit path out of line.

This includes the transform-required branch, class element rewriting, class-stack pop, and private-field accounting. The source change is intentionally limited to `#[inline(never)]` on `ClassProperties::transform_class_expression_on_exit`.

## Stack context

The Rust 1.97 private-field inlining fix used for both assembly builds has landed on `main` as #24354. This PR is rebased directly onto that merge result and its review diff remains one commit and one added attribute.

## Motivation

With Rust 1.97, fat LTO internalizes the class-expression exit work into:

```text
oxc_traverse::generated::walk::walk_expression<
    TransformState,
    TransformerImpl,
>
```

That generic walker handles every transformed expression, while class-expression exit work is comparatively rare. Keeping the slow path in the walker increases its instruction footprint even for ordinary expressions.

The inline caller still performs the fast guard:

```rust
if matches!(expr, Expression::ClassExpression(_)) {
    self.transform_class_expression_on_exit(expr, ctx);
}
```

Only matching class expressions pay the out-of-line call.

## Compiler setup

Both binaries were built on AArch64 Apple Darwin with Rust 1.97.0 using the transformer benchmark target without running it:

```sh
RUSTFLAGS='-C remark=inline -C strip=none' \
cargo +1.97.0 bench -p oxc_benchmark \
  --bench transformer \
  --no-default-features \
  --features compiler \
  --no-run
```

This uses the workspace bench/release settings: `opt-level=3`, fat LTO, one codegen unit, and `panic=abort`.

LLVM inline remarks were captured and demangled, and the final Mach-O binary was inspected with `llvm-nm` and `llvm-objdump`.

## Before and after

| Measurement | Before | After | Change |
| --- | ---: | ---: | ---: |
| `walk_expression` symbol | 104,576 B | 27,908 B | -76,668 B |
| Entry through first normal return | 28,568 B | 25,440 B | -3,128 B |
| Walker stack frame | 880 B | 880 B | unchanged |
| Walker register saves | `d8-d9`, `x19-x28`, `x29/x30` | same | unchanged |
| Outlined exit helper | absent | 3,896 B | new symbol |
| Helper entry through first normal return | absent | 3,448 B | new region |
| Helper stack frame | absent | 224 B | class expressions only |
| Helper register saves | absent | `x19-x28`, `x29/x30` | class expressions only |

The 76,668-byte symbol reduction should not be interpreted as 76 KiB of removed hot code. The baseline symbol tail includes reachable allocation slow paths, error blocks, unwind landing pads, and compiler-outlined bodies attributed to the walker symbol.

The more defensible normal-region comparison is the entry-to-first-return extent: it shrinks by 3,128 bytes, or about 11%. Even this region contains uncommon expression-variant branches, so it is a code-layout measurement rather than a direct runtime result.

## Assembly

Before, the class-expression guard falls through into the complete exit work inside `walk_expression`:

```asm
100153e80: cmp   w21, #0x11          ; ClassExpression
100153e84: b.ne  0x100154c48
100153e88: ldr   x8, [sp, #0x90]
...
100153eb0: bl    transform_class_elements
...
100154be4: ldr   x9, [x20, #0x440]  ; class-stack pop/accounting
...
100154c18: str   x9, [x20, #0x478]  ; private_field_count adjustment
100154c48: ...
```

After, the same guard remains in the walker but branches to one direct call:

```asm
100153f84: cmp   w21, #0x11          ; ClassExpression
100153f88: b.ne  0x100153f98
100153f8c: add   x0, x20, #0x3f8
100153f90: ldp   x2, x1, [sp, #0x88]
100153f94: bl    transform_class_expression_on_exit
100153f98: ...
```

The helper is now a standalone symbol with its own 224-byte frame:

```asm
transform_class_expression_on_exit:
1001bb1ec: sub   sp, sp, #0xe0
1001bb1f0: stp   x28, x27, [sp, #0x80]
...
1001bb204: stp   x29, x30, [sp, #0xd0]
1001bb20c: ldrb  w8, [x1]
1001bb210: cmp   w8, #0x11
...
1001bbf5c: add   sp, sp, #0xe0
1001bbf60: ret
```

## Inline remarks

Before this change, LLVM reported `TransformerImpl::exit_expression` inlining into `walk_expression` at cost 230 with a threshold of 250. It also reported `transform_class_expression_on_exit_impl` folding into the outer exit routine. Although another optimization pass reported the outer call as too costly at 5,640/250, the final LTO binary emitted no standalone outer-exit symbol and placed the exit body in the walker. The final disassembly is therefore the authoritative layout result.

After this change, the relevant remark becomes:

```text
transform_class_expression_on_exit not inlined into walk_expression
because it should never be inlined (cost=never): noinline function attribute
```

The final binary also contains the expected standalone helper symbol.

## Tradeoffs

- Ordinary expressions retain the inline discriminant check and avoid the helper frame.
- Class expressions now pay one direct call and a 224-byte helper frame.
- The walker frame remains 880 bytes because other transformer paths still require it.
- Actual class-expression transformations have slightly worse locality, in exchange for a materially smaller general expression-walker region.
- Runtime benchmarking is intentionally left as a follow-up. The assembly result is promising, but a benchmark should confirm that reduced instruction pressure outweighs the rare call overhead.

## AI disclosure

This change and its assembly investigation were prepared with AI assistance. The contributor remains responsible for reviewing and understanding the change before merge.

