### PR TITLE
perf(transformer): outline slow React call mutations

### DIFF
--- a/crates/oxc_transformer/src/jsx/display_name.rs
+++ b/crates/oxc_transformer/src/jsx/display_name.rs
@@ -70,6 +70,14 @@ impl<'a> Traverse<'a, TransformState<'a>> for ReactDisplayName {
             return;
         };
 
+        Self::add_display_name_from_ancestors(obj_expr, ctx);
+    }
+}
+
+impl<'a> ReactDisplayName {
+    // Keep the slow ancestor scan and property insertion out of the call expression walker.
+    #[inline(never)]
+    fn add_display_name_from_ancestors(obj_expr: &mut ObjectExpression<'a>, ctx: &TraverseCtx<'a>) {
         let mut ancestors = ctx.ancestors();
         let name = loop {
             let Some(ancestor) = ancestors.next() else {
@@ -125,9 +133,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for ReactDisplayName {
 
         Self::add_display_name(obj_expr, name, ctx);
     }
-}
 
-impl<'a> ReactDisplayName {
     /// Get the object from `React.createClass({})` or `createReactClass({})`
     fn get_object_from_create_class<'b>(
         call_expr: &'b mut CallExpression<'a>,

--- a/crates/oxc_transformer/src/jsx/refresh.rs
+++ b/crates/oxc_transformer/src/jsx/refresh.rs
@@ -348,6 +348,20 @@ impl<'a> Traverse<'a, TransformState<'a>> for ReactRefresh<'a> {
             return;
         }
 
+        self.record_hook(call_expr, current_scope_id, hook_name, ctx);
+    }
+}
+
+impl<'a> ReactRefresh<'a> {
+    // Keep hook recording and string construction out of the call expression walker.
+    #[inline(never)]
+    fn record_hook(
+        &mut self,
+        call_expr: &CallExpression<'a>,
+        current_scope_id: ScopeId,
+        hook_name: Str<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
         if !is_builtin_hook(&hook_name) {
             // Check if a corresponding binding exists where we emit the signature.
             let (binding_name, middle_property, is_member_expression): (


### PR DESCRIPTION
## Summary

Split cheap React call recognition from slow mutation/recording work in the transformer call-expression visitor:

- keep display-name plugin enablement plus `React.createClass` / `createReactClass` recognition inline, then call an out-of-line ancestor-scan/property-insertion helper;
- keep React Refresh enablement, function-scope, callee-kind, and `use*` recognition inline, then call an out-of-line hook-recording helper;
- leave styled-components unchanged because it already has the desired layout: inline filtering followed by an out-of-line mutation helper.

The new helpers are explicitly `#[inline(never)]`. They are only called after a matching React call has been recognized, so enabling either plugin does not add an unconditional call for every `CallExpression`.

## Why

With Rust 1.97 and the transformer benchmark's optimized configuration (opt-level 3, fat LTO, one codegen unit, panic=abort), the specialized generated walker

`oxc_traverse::generated::walk::walk_call_expression<TransformState, TransformerImpl>`

contained the display-name ancestor traversal/property insertion and React Refresh hook recording/string construction. This produced a 5,624-byte function with a 160-byte frame and saved every callee-saved GPR from `x19` through `x28`.

Most calls only need the plugin guards and recognition checks. Keeping mutation code in the walker increases instruction-cache footprint and register pressure on that common path.

## AArch64 code generation

Both versions were built with Rust 1.97 using identical release/bench-equivalent settings. LLVM inline remarks were captured and demangled, and the final Mach-O walker was disassembled.

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Walker symbol size | 5,624 B (`0x15f8`) | 1,292 B (`0x50c`) | −4,332 B / −77% |
| Normal return offset | `+0xf1c` | `+0x4c0` | −2,652 B |
| Extent through normal return | 3,872 B | 1,220 B | −2,652 B |
| Cold code strictly after normal return | 1,752 B | 72 B | −1,680 B |
| Stack frame | 160 B | 64 B | −96 B |
| Saved GPRs | `x19–x28` | `x19–x24` | four fewer |

Exact symbol boundaries:

```text
before: 0x1001b9bc0 .. 0x1001bb1b8 = 0x15f8 (5,624 bytes)
after:  0x1001b9bc0 .. 0x1001ba0cc = 0x050c (1,292 bytes)
```

### Prologue before

```asm
sub sp, sp, #0xa0
stp x28, x27, [sp, #0x40]
stp x26, x25, [sp, #0x50]
stp x24, x23, [sp, #0x60]
stp x22, x21, [sp, #0x70]
stp x20, x19, [sp, #0x80]
stp x29, x30, [sp, #0x90]
add x29, sp, #0x90
```

### Prologue after

```asm
stp x24, x23, [sp, #-0x40]!
stp x22, x21, [sp, #0x10]
stp x20, x19, [sp, #0x20]
stp x29, x30, [sp, #0x30]
add x29, sp, #0x30
```

## Plugin contributions

### Display name

The plugin flag, callee recognition, one-argument check, and object-expression check remain in the walker. Only a recognized create-class call reaches the helper:

```asm
ldr x0, [x8, #0x8]
mov x1, x19
bl  <ReactDisplayName::add_display_name_from_ancestors>
```

The out-of-line helper is 1,100 bytes. It contains the ancestor scan, inferred-name allocation, existing-property check, and `displayName` insertion.

### React Refresh

The walker still checks:

1. whether Refresh is enabled;
2. whether the current scope is a function;
3. whether the callee is an identifier or static member;
4. whether the hook name matches `use*`.

Only a recognized hook reaches the recording helper:

```asm
cmp  w8, #0x19
b.hi <ordinary traversal>
mov  x0, x20
mov  x1, x21
mov  x5, x19
bl   <ReactRefresh::record_hook>
```

The out-of-line helper is 3,276 bytes. It contains non-builtin binding resolution, bound-reference creation, argument/declarator source extraction, hash-map updates, allocation, and signature-string construction.

### Styled-components

Styled-components already follows this shape. Its option and ancestor checks stay inline, while the 968-byte `add_display_name_and_component_id` helper remains out of line:

```asm
; before, walker +0x1b0
bl <StyledComponents::add_display_name_and_component_id>

; after, walker +0x1a4
bl <StyledComponents::add_display_name_and_component_id>
```

The address shift is only surrounding layout movement; this PR does not change styled-components.

## LLVM inline decisions

Before:

- `TransformerImpl::enter_call_expression` into the generated walker: inlined, cost 190 / threshold 250;
- display-name entry at its direct `Jsx` callsite: missed, cost 1995 / threshold 250;
- Refresh entry at its direct `Jsx` callsite: missed, cost 4500 / threshold 250;
- styled-components mutation helper: missed, cost 1290 / threshold 250.

Despite the direct React callsite misses in the remark stream, fat-LTO specialization left both React bodies physically folded into the final walker, as confirmed by the assembly and the absence of separate entry calls.

After:

- `TransformerImpl::enter_call_expression` into the walker: inlined, cost 125 / threshold 250;
- display-name recognition into `Jsx`: inlined, cost 235 / threshold 250;
- Refresh recognition into `Jsx`: narrowly missed, cost 255 / threshold 250, while the final specialized walker still contains the recognition checks directly;
- both new slow helpers: not inlined with `cost=never`, matching their `#[inline(never)]` boundary.

## Code-size tradeoff

The new out-of-line helpers total 4,376 bytes:

- display-name helper: 1,100 bytes;
- Refresh helper: 3,276 bytes.

The new walker plus both helpers is 5,668 bytes, only 44 bytes larger in total text than the old 5,624-byte walker alone. In exchange, the ordinary walker loses 4,332 bytes, 96 bytes of stack frame, four register saves/restores, and almost all post-return cold landing-pad code.

Matching `createClass` and `use*` calls pay one call/return around work that already performs ancestry traversal, semantic lookup, map mutation, allocation, or string construction. Non-matching calls pay no additional helper call.

Runtime benchmarking is intentionally left for follow-up; this PR is based on the code-generation result.

## AI assistance disclosure

This change and the assembly investigation were developed with AI assistance. The author reviewed the resulting diff, generated assembly, and inline remarks and remains responsible for the submitted change.