### PR TITLE
feat(oxlint,oxfmt): auto-discover `.mts` config files

### DIFF
--- a/apps/oxfmt/src/core/config/mod.rs
+++ b/apps/oxfmt/src/core/config/mod.rs
@@ -40,7 +40,7 @@ use super::{
 const OXFMT_CONFIG_FILE_NAMES: ConfigFileNames = ConfigFileNames {
     json: ".oxfmtrc.json",
     jsonc: ".oxfmtrc.jsonc",
-    js: "oxfmt.config.ts",
+    js: &["oxfmt.config.ts", "oxfmt.config.mts"],
     vite: "vite.config.ts",
 };
 

--- a/apps/oxfmt/test/cli/js_config_mts/0.snap.md
+++ b/apps/oxfmt/test/cli/js_config_mts/0.snap.md
@@ -1,0 +1,36 @@
+# Input
+
+## Command
+```
+oxfmt --check test.ts
+```
+
+## File tree
+```
+- fixtures/ <CWD>
+  - oxfmt.config.mts
+  - test.ts
+```
+
+# Result
+
+## Exit code
+1
+
+## stdout
+```
+Checking formatting...
+
+test.ts (<time>)
+
+Format issues found in above 1 files. Run without `--check` to fix.
+Finished in <time> on 1 files using 1 threads.
+```
+
+## stderr
+```
+
+```
+
+## File changes
+No changes

--- a/apps/oxfmt/test/cli/js_config_mts/fixtures/oxfmt.config.mts
+++ b/apps/oxfmt/test/cli/js_config_mts/fixtures/oxfmt.config.mts
@@ -1,0 +1,3 @@
+export default {
+  semi: false,
+};

--- a/apps/oxfmt/test/cli/js_config_mts/fixtures/test.ts
+++ b/apps/oxfmt/test/cli/js_config_mts/fixtures/test.ts
@@ -1,0 +1,1 @@
+const answer = 42;

--- a/apps/oxfmt/test/cli/js_config_mts/options.json
+++ b/apps/oxfmt/test/cli/js_config_mts/options.json
@@ -1,0 +1,1 @@
+[{ "args": ["--check", "test.ts"] }]

--- a/apps/oxfmt/test/lsp/init/init.test.ts
+++ b/apps/oxfmt/test/lsp/init/init.test.ts
@@ -34,10 +34,25 @@ describe("LSP initialization", () => {
   });
 
   it.each([
-    [undefined, ["**/.oxfmtrc.json", "**/.oxfmtrc.jsonc", "**/oxfmt.config.ts", ".editorconfig"]],
+    [
+      undefined,
+      [
+        "**/.oxfmtrc.json",
+        "**/.oxfmtrc.jsonc",
+        "**/oxfmt.config.ts",
+        "**/oxfmt.config.mts",
+        ".editorconfig",
+      ],
+    ],
     [
       { "fmt.configPath": "" },
-      ["**/.oxfmtrc.json", "**/.oxfmtrc.jsonc", "**/oxfmt.config.ts", ".editorconfig"],
+      [
+        "**/.oxfmtrc.json",
+        "**/.oxfmtrc.jsonc",
+        "**/oxfmt.config.ts",
+        "**/oxfmt.config.mts",
+        ".editorconfig",
+      ],
     ],
     [{ "fmt.configPath": "./custom-config.json" }, ["custom-config.json", ".editorconfig"]],
   ])(

--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -147,7 +147,7 @@ pub struct BasicOptions {
     ///  * you can use comments in configuration files.
     ///  * tries to be compatible with ESLint v8's format
     ///
-    /// If not provided, Oxlint will look for a `.oxlintrc.json`, `.oxlintrc.jsonc`, or `oxlint.config.ts` file in the current working directory.
+    /// If not provided, Oxlint will look for a `.oxlintrc.json`, `.oxlintrc.jsonc`, `oxlint.config.ts`, or `oxlint.config.mts` file in the current working directory.
     #[bpaf(long, short, argument("./.oxlintrc.json"))]
     pub config: Option<PathBuf>,
 

--- a/apps/oxlint/src/config_loader.rs
+++ b/apps/oxlint/src/config_loader.rs
@@ -16,7 +16,10 @@ use oxc_linter::{
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 
 use crate::utils::normalize_path;
-use crate::{DEFAULT_JSONC_OXLINTRC_NAME, DEFAULT_OXLINTRC_NAME, DEFAULT_TS_OXLINTRC_NAME};
+use crate::{
+    DEFAULT_JSONC_OXLINTRC_NAME, DEFAULT_MTS_OXLINTRC_NAME, DEFAULT_OXLINTRC_NAME,
+    DEFAULT_TS_OXLINTRC_NAME,
+};
 use crate::{VITE_CONFIG_NAME, vp_version};
 
 const GIT_DIR: &str = ".git";
@@ -35,7 +38,7 @@ pub struct JsConfigResult {
 const OXLINT_CONFIG_FILE_NAMES: ConfigFileNames = ConfigFileNames {
     json: DEFAULT_OXLINTRC_NAME,
     jsonc: DEFAULT_JSONC_OXLINTRC_NAME,
-    js: DEFAULT_TS_OXLINTRC_NAME,
+    js: &[DEFAULT_TS_OXLINTRC_NAME, DEFAULT_MTS_OXLINTRC_NAME],
     vite: VITE_CONFIG_NAME,
 };
 
@@ -506,7 +509,8 @@ impl<'a> ConfigLoader<'a> {
     /// Try to load config from a specific directory.
     ///
     /// In Vite+ mode (`VP_VERSION` set): only checks for `vite.config.ts`.
-    /// Otherwise: checks for `.oxlintrc.json`, `.oxlintrc.jsonc`, and `oxlint.config.ts`.
+    /// Otherwise: checks for `.oxlintrc.json`, `.oxlintrc.jsonc`, `oxlint.config.ts`,
+    /// and `oxlint.config.mts`.
     ///
     /// Returns `Ok(Some(config))` if found, `Ok(None)` if not found, or `Err` on error.
     fn try_load_config_from_dir(
@@ -523,7 +527,10 @@ impl<'a> ConfigLoader<'a> {
             }
             Some(DiscoveredConfigFile::Js(path)) => {
                 let config = self.load_root_js_config(&path)?;
-                debug_assert!(config.is_some(), "oxlint.config.ts should always return a config");
+                debug_assert!(
+                    config.is_some(),
+                    "oxlint JS/TS config should always return a config"
+                );
                 Ok(config)
             }
             Some(DiscoveredConfigFile::Vite(path)) => self.load_root_js_config(&path),

--- a/apps/oxlint/src/lib.rs
+++ b/apps/oxlint/src/lib.rs
@@ -61,6 +61,7 @@ static GLOBAL: mimalloc_safe::MiMalloc = mimalloc_safe::MiMalloc;
 const DEFAULT_OXLINTRC_NAME: &str = ".oxlintrc.json";
 const DEFAULT_JSONC_OXLINTRC_NAME: &str = ".oxlintrc.jsonc";
 const DEFAULT_TS_OXLINTRC_NAME: &str = "oxlint.config.ts";
+const DEFAULT_MTS_OXLINTRC_NAME: &str = "oxlint.config.mts";
 /// Vite config file that may contain oxlint config under a `.lint` field.
 const VITE_CONFIG_NAME: &str = "vite.config.ts";
 

--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -955,10 +955,11 @@ mod test_watchers {
             let patterns =
                 Tester::new("fixtures/lsp/watchers/default", json!({})).get_watcher_patterns();
 
-            assert_eq!(patterns.len(), 3);
+            assert_eq!(patterns.len(), 4);
             assert_eq!(patterns[0], "**/.oxlintrc.json".to_string());
             assert_eq!(patterns[1], "**/.oxlintrc.jsonc".to_string());
             assert_eq!(patterns[2], "**/oxlint.config.ts".to_string());
+            assert_eq!(patterns[3], "**/oxlint.config.mts".to_string());
         }
 
         #[test]
@@ -971,10 +972,11 @@ mod test_watchers {
             )
             .get_watcher_patterns();
 
-            assert_eq!(patterns.len(), 3);
+            assert_eq!(patterns.len(), 4);
             assert_eq!(patterns[0], "**/.oxlintrc.json".to_string());
             assert_eq!(patterns[1], "**/.oxlintrc.jsonc".to_string());
             assert_eq!(patterns[2], "**/oxlint.config.ts".to_string());
+            assert_eq!(patterns[3], "**/oxlint.config.mts".to_string());
         }
 
         #[test]
@@ -996,12 +998,14 @@ mod test_watchers {
             let patterns = Tester::new("fixtures/lsp/watchers/linter_extends", json!({}))
                 .get_watcher_patterns();
 
-            // The `.oxlintrc.json` extends `./lint.json` -> 4 watchers (json, jsonc, ts, lint.json)
-            assert_eq!(patterns.len(), 4);
+            // The `.oxlintrc.json` extends `./lint.json` -> 5 watchers
+            // (json, jsonc, ts, mts, lint.json)
+            assert_eq!(patterns.len(), 5);
             assert_eq!(patterns[0], "**/.oxlintrc.json".to_string());
             assert_eq!(patterns[1], "**/.oxlintrc.jsonc".to_string());
             assert_eq!(patterns[2], "**/oxlint.config.ts".to_string());
-            assert_eq!(patterns[3], "lint.json".to_string());
+            assert_eq!(patterns[3], "**/oxlint.config.mts".to_string());
+            assert_eq!(patterns[4], "lint.json".to_string());
         }
 
         #[test]
@@ -1029,11 +1033,12 @@ mod test_watchers {
             )
             .get_watcher_patterns();
 
-            assert_eq!(patterns.len(), 4);
+            assert_eq!(patterns.len(), 5);
             assert_eq!(patterns[0], "**/.oxlintrc.json".to_string());
             assert_eq!(patterns[1], "**/.oxlintrc.jsonc".to_string());
             assert_eq!(patterns[2], "**/oxlint.config.ts".to_string());
-            assert_eq!(patterns[3], "**/tsconfig*.json".to_string());
+            assert_eq!(patterns[3], "**/oxlint.config.mts".to_string());
+            assert_eq!(patterns[4], "**/tsconfig*.json".to_string());
         }
     }
 
@@ -1084,11 +1089,12 @@ mod test_watchers {
                         "typeAware": true
                     }));
             assert!(watch_patterns.is_some());
-            assert_eq!(watch_patterns.as_ref().unwrap().len(), 4);
+            assert_eq!(watch_patterns.as_ref().unwrap().len(), 5);
             assert_eq!(watch_patterns.as_ref().unwrap()[0], "**/.oxlintrc.json".to_string());
             assert_eq!(watch_patterns.as_ref().unwrap()[1], "**/.oxlintrc.jsonc".to_string());
             assert_eq!(watch_patterns.as_ref().unwrap()[2], "**/oxlint.config.ts".to_string());
-            assert_eq!(watch_patterns.as_ref().unwrap()[3], "**/tsconfig*.json".to_string());
+            assert_eq!(watch_patterns.as_ref().unwrap()[3], "**/oxlint.config.mts".to_string());
+            assert_eq!(watch_patterns.as_ref().unwrap()[4], "**/tsconfig*.json".to_string());
         }
     }
 }

--- a/apps/oxlint/test/fixtures/js_config_mts/files/test.js
+++ b/apps/oxlint/test/fixtures/js_config_mts/files/test.js
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/test/fixtures/js_config_mts/output.snap.md
+++ b/apps/oxlint/test/fixtures/js_config_mts/output.snap.md
@@ -1,0 +1,19 @@
+# Exit code
+1
+
+# stdout
+```
+  x eslint(no-debugger): `debugger` statement is not allowed
+   ,-[files/test.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+  help: Remove the debugger statement
+
+Found 0 warnings and 1 error.
+Finished in Xms on 1 file with 95 rules using X threads.
+```
+
+# stderr
+```
+```

--- a/apps/oxlint/test/fixtures/js_config_mts/oxlint.config.mts
+++ b/apps/oxlint/test/fixtures/js_config_mts/oxlint.config.mts
@@ -1,0 +1,7 @@
+import { defineConfig } from "#oxlint";
+
+export default defineConfig({
+  rules: {
+    "no-debugger": "error",
+  },
+});

--- a/apps/oxlint/test/lsp/init/init.test.ts
+++ b/apps/oxlint/test/lsp/init/init.test.ts
@@ -55,8 +55,14 @@ describe("LSP initialization", () => {
   });
 
   it.each([
-    [undefined, ["**/.oxlintrc.json", "**/.oxlintrc.jsonc", "**/oxlint.config.ts"]],
-    [{ configPath: "" }, ["**/.oxlintrc.json", "**/.oxlintrc.jsonc", "**/oxlint.config.ts"]],
+    [
+      undefined,
+      ["**/.oxlintrc.json", "**/.oxlintrc.jsonc", "**/oxlint.config.ts", "**/oxlint.config.mts"],
+    ],
+    [
+      { configPath: "" },
+      ["**/.oxlintrc.json", "**/.oxlintrc.jsonc", "**/oxlint.config.ts", "**/oxlint.config.mts"],
+    ],
     [{ configPath: "./custom-config.json" }, ["custom-config.json"]],
   ])(
     "should send correct dynamic watch pattern registration for config: %s",

--- a/crates/oxc_config/src/discovery.rs
+++ b/crates/oxc_config/src/discovery.rs
@@ -45,8 +45,9 @@ pub struct ConfigFileNames {
     pub json: &'static str,
     /// JSONC config file name, such as `.oxlintrc.jsonc`.
     pub jsonc: &'static str,
-    /// JavaScript or TypeScript config file name, such as `oxlint.config.ts`.
-    pub js: &'static str,
+    /// JavaScript or TypeScript config file names, such as `oxlint.config.ts`
+    /// and `oxlint.config.mts`.
+    pub js: &'static [&'static str],
     /// Vite config file name used when Vite mode is enabled.
     pub vite: &'static str,
 }
@@ -74,7 +75,9 @@ impl ConfigDiscovery {
             return vec![self.config_file_names.vite];
         }
 
-        vec![self.config_file_names.json, self.config_file_names.jsonc, self.config_file_names.js]
+        let mut names = vec![self.config_file_names.json, self.config_file_names.jsonc];
+        names.extend_from_slice(self.config_file_names.js);
+        names
     }
 
     /// Find the unique config file directly inside `dir` using a single `read_dir`.
@@ -108,7 +111,7 @@ impl ConfigDiscovery {
             let name_supported = if self.vite_plus_mode {
                 name == names.vite
             } else {
-                name == names.json || name == names.jsonc || name == names.js
+                name == names.json || name == names.jsonc || names.js.iter().any(|js| name == *js)
             };
             if !name_supported {
                 continue;
@@ -158,7 +161,7 @@ impl ConfigDiscovery {
         if file_name == self.config_file_names.jsonc {
             return Some(DiscoveredConfigFile::Jsonc(candidate.to_path_buf()));
         }
-        if file_name == self.config_file_names.js {
+        if self.config_file_names.js.iter().any(|js| file_name == *js) {
             return Some(DiscoveredConfigFile::Js(candidate.to_path_buf()));
         }
         None
@@ -259,7 +262,7 @@ mod test {
     const NAMES: ConfigFileNames = ConfigFileNames {
         json: ".oxlintrc.json",
         jsonc: ".oxlintrc.jsonc",
-        js: "oxlint.config.ts",
+        js: &["oxlint.config.ts", "oxlint.config.mts"],
         vite: "vite.config.ts",
     };
 
@@ -317,6 +320,26 @@ mod test {
 
         let found = discovery().find_unique_config_by_readdir(temp_dir.path(), false).unwrap();
         assert!(matches!(found, Some(DiscoveredConfigFile::Json(p)) if p == cfg_path));
+    }
+
+    #[test]
+    fn readdir_finds_unique_mts_config() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let cfg_path = temp_dir.path().join(NAMES.js[1]);
+        fs::write(&cfg_path, "export default {};").unwrap();
+
+        let found = discovery().find_unique_config_by_readdir(temp_dir.path(), false).unwrap();
+        assert!(matches!(found, Some(DiscoveredConfigFile::Js(p)) if p == cfg_path));
+    }
+
+    #[test]
+    fn readdir_returns_conflict_for_multiple_js_configs() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        for name in NAMES.js {
+            fs::write(temp_dir.path().join(name), "export default {};").unwrap();
+        }
+
+        assert!(discovery().find_unique_config_by_readdir(temp_dir.path(), false).is_err());
     }
 
     #[test]

--- a/tasks/website_linter/src/snapshots/cli.snap
+++ b/tasks/website_linter/src/snapshots/cli.snap
@@ -18,7 +18,7 @@ search: false
 * you can use comments in configuration files.
 * tries to be compatible with ESLint v8's format
 
-  If not provided, Oxlint will look for a `.oxlintrc.json`, `.oxlintrc.jsonc`, or `oxlint.config.ts` file in the current working directory.
+  If not provided, Oxlint will look for a `.oxlintrc.json`, `.oxlintrc.jsonc`, `oxlint.config.ts`, or `oxlint.config.mts` file in the current working directory.
 - **`    --tsconfig`**=_`<./tsconfig.json>`_ &mdash; 
   Override the TypeScript config used for import resolution. Oxlint automatically discovers the relevant `tsconfig.json` for each file. Use this only when your project uses a non-standard tsconfig name or location.
 


### PR DESCRIPTION
## Summary

- auto-discover `oxfmt.config.mts` and `oxlint.config.mts`
- watch `.mts` configs in the language server and reject `.ts`/`.mts` conflicts
- add focused CLI and LSP coverage
