### PR TITLE
fix(napi/parser): eagerly move serialized AST out of native ParseResult to prevent unbounded memory growth in synchronous parse loops

### DIFF
--- a/napi/parser/src-js/wrap.js
+++ b/napi/parser/src-js/wrap.js
@@ -1,14 +1,15 @@
 export function wrap(result) {
-  // Eagerly move the serialized AST out of the native `ParseResult`, so its Rust-side
-  // memory is freed as soon as this function returns.
+  // Eagerly move the JSON-serialized AST string out of the native `ParseResult`,
+  // so its Rust-side memory is freed before this function returns.
   //
   // The native object's memory is only freed by a NAPI finalizer, and finalizers only
-  // run on event-loop turns. If the serialized AST (typically 10-20x the size of the
+  // run on event-loop turns. If the AST JSON (typically 10-20x the size of the
   // source text) stayed inside the native object, code which calls `parseSync` in a
   // loop without yielding to the event loop would retain the serialized AST of every
   // file it parses - gigabytes over enough files - with no way for GC to reclaim it,
   // because V8 cannot see native memory. Moving it into a JS string here hands it to
   // V8, which frees it under normal GC pressure.
+  //
   // Deserializing the AST itself (`JSON.parse`) remains lazy, as do the other fields,
   // whose conversion cost is not worth paying for callers that never read them
   // (their retained native memory is small compared to the serialized AST).

--- a/napi/parser/src-js/wrap.js
+++ b/napi/parser/src-js/wrap.js
@@ -1,8 +1,22 @@
 export function wrap(result) {
+  // Eagerly move the serialized AST out of the native `ParseResult`, so its Rust-side
+  // memory is freed as soon as this function returns.
+  //
+  // The native object's memory is only freed by a NAPI finalizer, and finalizers only
+  // run on event-loop turns. If the serialized AST (typically 10-20x the size of the
+  // source text) stayed inside the native object, code which calls `parseSync` in a
+  // loop without yielding to the event loop would retain the serialized AST of every
+  // file it parses - gigabytes over enough files - with no way for GC to reclaim it,
+  // because V8 cannot see native memory. Moving it into a JS string here hands it to
+  // V8, which frees it under normal GC pressure.
+  // Deserializing the AST itself (`JSON.parse`) remains lazy, as do the other fields,
+  // whose conversion cost is not worth paying for callers that never read them
+  // (their retained native memory is small compared to the serialized AST).
+  const programJson = result.program;
   let program, module, comments, errors;
   return {
     get program() {
-      if (!program) program = jsonParseAst(result.program);
+      if (!program) program = jsonParseAst(programJson);
       return program;
     },
     get module() {


### PR DESCRIPTION
> [!NOTE]
> AI disclosure: found, analyzed, and fixed with the help of Claude Fable. All numbers below were verified by running the linked repro and the test suite.

## Description

Calling `parseSync` in a synchronous loop retains the serialized AST of every file parsed — RSS grows by 10-20x the source size per call and GC cannot reclaim it, even with `--expose-gc`. Over a large repo this reaches many GiB and OOMs CI containers. 

I have an isolated repro here: https://github.com/walkerdb/oxc-parser-memory-repro (50k parses of ~5KB modules: 7.3 GiB RSS; 10.3 GiB with forced GC).

Cause: `ParseResult` is a NAPI class. Its Rust struct — dominated by the AST-as-JSON string — is only freed by a NAPI finalizer, and [finalizers run on event-loop turns](https://nodejs.org/api/n-api.html#finalization). A synchronous loop never yields, so nothing is ever freed, and V8 can't see the native memory so it feels no pressure. The same loop in pure Rust runs flat at ~110 MiB, so the retention is specific to the NAPI boundary.

Fix: `wrap()` eagerly moves the serialized AST string out of the native object (`get_program` is a `mem::take`, so the Rust side frees it immediately). As a JS string it's V8-owned and reclaimed under normal GC pressure. `JSON.parse` remains lazy, and `module`/`comments`/`errors` remain lazy getters.

Performance:

- `bench.bench.js` reads all four properties per iteration, so the measured work is unchanged. `.program` readers pay nothing extra — the string conversion just happens earlier.
- Parse-and-read-nothing microbench: 1.55s → 1.7s per 50k parses (the utf8→utf16 copy lazy consumers previously skipped). Never-read results still retain their small native module/comments/errors until finalizers run.
- Rejected: reporting retained bytes via `napi_adjust_external_memory` — tested on Node 22 (V8 12.4); the counter updates but has no effect on GC, so it doesn't help.
- Alternative available: eagerly extract all four fields. Flat ~145 MiB even when nothing is read, but 3.3x slower on the no-touch microbench. Happy to switch if full eviction is preferred.

## How was this change tested?

- [ ] Automated test (unit, integration, etc.)
- [x] Manual test (provide reproducible testing steps below)

Applied this exact JS change to the published `oxc-parser@0.139.0` package (real release binary) and ran the repro's 50k-parse synchronous loop reading `.module`: RSS stays flat at ~160 MiB instead of growing to 7.3 GiB, with no measurable wall-clock difference. The `napi/parser` vitest suite (113 tests) passes.

## Screenshots