### PR TITLE
refactor(semantic): remove unused `NodeFlags::Class`

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -944,7 +944,6 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
     fn visit_class(&mut self, class: &Class<'a>) {
         let kind = AstKind::Class(self.alloc(class));
         self.enter_node(kind);
-        self.node_store.current_node_flags |= NodeFlags::Class;
         if class.is_declaration() {
             class.bind(self);
         }
@@ -979,7 +978,6 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
 
         self.leave_scope();
         self.leave_node(kind);
-        self.node_store.current_node_flags -= NodeFlags::Class;
         self.class_table_builder.pop_class();
     }
 

--- a/crates/oxc_syntax/src/node.rs
+++ b/crates/oxc_syntax/src/node.rs
@@ -59,8 +59,6 @@ bitflags! {
     pub struct NodeFlags: u8 {
         /// Set if the Node has a JSDoc comment attached
         const JSDoc     = 1 << 0;
-        /// Set on Nodes inside classes
-        const Class     = 1 << 1;
         /// Set functions containing yield statements
         const HasYield  = 1 << 2;
         /// Set for `export { specifier }`
@@ -73,12 +71,6 @@ impl NodeFlags {
     #[inline]
     pub fn has_jsdoc(self) -> bool {
         self.contains(Self::JSDoc)
-    }
-
-    /// Returns `true` if this node is inside a class.
-    #[inline]
-    pub fn has_class(self) -> bool {
-        self.contains(Self::Class)
     }
 
     /// Returns `true` if this function has a yield statement.


### PR DESCRIPTION
## Summary

- remove the unused `NodeFlags::Class` bit and `has_class` accessor
- stop maintaining unread class ancestry state in the semantic builder
- preserve the remaining flag bit values
