### PR TITLE
refactor(semantic): remove unused export specifier node flag

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -2361,12 +2361,8 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         self.enter_node(kind);
         self.visit_span(&it.span);
 
-        self.node_store.current_node_flags |= NodeFlags::ExportSpecifier;
-
         self.visit_module_export_name(&it.local);
         self.visit_module_export_name(&it.exported);
-
-        self.node_store.current_node_flags -= NodeFlags::ExportSpecifier;
 
         self.leave_node(kind);
     }

--- a/crates/oxc_syntax/src/node.rs
+++ b/crates/oxc_syntax/src/node.rs
@@ -61,8 +61,6 @@ bitflags! {
         const JSDoc     = 1 << 0;
         /// Set functions containing yield statements
         const HasYield  = 1 << 2;
-        /// Set for `export { specifier }`
-        const ExportSpecifier  = 1 << 3;
     }
 }
 
@@ -77,11 +75,5 @@ impl NodeFlags {
     #[inline]
     pub fn has_yield(self) -> bool {
         self.contains(Self::HasYield)
-    }
-
-    /// Returns `true` if this function has an export specifier.
-    #[inline]
-    pub fn has_export_specifier(self) -> bool {
-        self.contains(Self::ExportSpecifier)
     }
 }


### PR DESCRIPTION
## Summary

- remove the unused `NodeFlags::ExportSpecifier` bit and `has_export_specifier` accessor
- stop maintaining unread export-specifier state in the semantic builder

Stacked on #24363.
