### PR TITLE
perf(allocator): remove `unwrap` from `ReplaceWith`

### DIFF
--- a/crates/oxc_allocator/src/replace_with.rs
+++ b/crates/oxc_allocator/src/replace_with.rs
@@ -296,11 +296,9 @@ fn fresh_dummy_allocator() -> &'static Allocator {
     // ~`isize::MAX` entries.
     let mut allocators = DUMMY_ALLOCATORS.lock().unwrap();
 
-    // Create an `Allocator` and store it in a `Box` in `DUMMY_ALLOCATORS`
-    allocators.push(StdBox::new(Allocator::new()));
-
-    // Get reference to the `Allocator` on the heap
-    let allocator = allocators.last().unwrap().as_ref();
+    // Create an `Allocator` and store it in a `Box` in `DUMMY_ALLOCATORS`.
+    // Get reference to the `Allocator` on the heap.
+    let allocator = &**allocators.push_mut(StdBox::new(Allocator::new()));
 
     // Extend `&Allocator`'s lifetime to `'static`.
     // SAFETY: The `Allocator` is owned by `DUMMY_ALLOCATORS`, a `static` from which allocators


### PR DESCRIPTION
#24359 bumped our MSRV to 1.95.0. We can now use `Vec::push_mut`.

Use it in `ReplaceWith` to remove an infallible `unwrap` which compiler previously couldn't prove was infallible. Previously it emitted a panicking branch, now it doesn't.

This code is on a cold path, so perf impact is miniscule, but why not use the best API for the job?