### PR TITLE
fix(linter/no-unused-vars): delete whole statement when all declarators are unused

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/fix_vars.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/fix_vars.rs
@@ -69,7 +69,24 @@ impl NoUnusedVars {
             let binding_info = symbol.get_binding_info(&decl.id);
 
             match binding_info {
-                BindingInfo::SingleDestructure | BindingInfo::NotDestructure => {
+                BindingInfo::NotDestructure => {
+                    if has_neighbors {
+                        // if every other declarator in this statement is also
+                        // a plain (non-destructured) unused binding that's
+                        // safe to remove, delete the whole declaration
+                        // instead of leaving the other dead declarators
+                        // behind. e.g. `let a = 1, b = 2;` (both unused)
+                        // should become `` rather than `let b = 2;`.
+                        // Destructured neighbors are left to
+                        // `delete_from_list` below (see #16832).
+                        if self.all_other_declarators_removable(symbol, decl, declarations) {
+                            return fixer.delete_range(span).dangerously();
+                        }
+                        return symbol.delete_from_list(fixer, declarations, decl).dangerously();
+                    }
+                    return fixer.delete_range(span).dangerously();
+                }
+                BindingInfo::SingleDestructure => {
                     if has_neighbors {
                         return symbol.delete_from_list(fixer, declarations, decl).dangerously();
                     }
@@ -116,6 +133,44 @@ impl NoUnusedVars {
         }
 
         fixer.noop()
+    }
+
+    /// Checks if every declarator in `declarations` other than `own` is also
+    /// safe to remove, i.e. it has no simple `BindingIdentifier` bindings that
+    /// are used, exported, ignored, or otherwise excluded from removal.
+    ///
+    /// Destructured declarators (e.g. `const { a } = obj`) are treated as not
+    /// removable here; they're left for `Symbol::delete_from_list` to handle
+    /// declarator-by-declarator, since collapsing them into a whole-statement
+    /// deletion needs more care (see #16832's destructure-in-multi-declarator
+    /// bug).
+    fn all_other_declarators_removable<'a>(
+        &self,
+        symbol: &Symbol<'_, 'a>,
+        own: &VariableDeclarator<'a>,
+        declarations: &[VariableDeclarator<'a>],
+    ) -> bool {
+        declarations.iter().all(|other| {
+            if std::ptr::eq(other, own) {
+                return true;
+            }
+
+            let Some(binding) = other.id.get_binding_identifier() else {
+                // destructured or otherwise non-trivial bindings are left to
+                // the existing per-declarator removal logic
+                return false;
+            };
+
+            if other.init.as_ref().is_some_and(|init| is_skipped_init(symbol, init)) {
+                return false;
+            }
+
+            let other_symbol = symbol.with_symbol_id(binding.symbol_id());
+            !other_symbol.has_references()
+                && !other_symbol.is_exported_binding()
+                && !self.is_allowed_variable_declaration(&other_symbol, other)
+                && self.is_ignored(&other_symbol).is_none()
+        })
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/symbol.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/symbol.rs
@@ -41,6 +41,14 @@ impl<'s, 'a> Symbol<'s, 'a> {
         Self { semantic, module_record, id: symbol_id, flags }
     }
 
+    /// Create a [`Symbol`] for another [`SymbolId`], reusing this symbol's
+    /// [`Semantic`] and [`ModuleRecord`]. Useful for inspecting sibling
+    /// bindings, e.g. other declarators in the same `VariableDeclaration`.
+    #[inline]
+    pub fn with_symbol_id(&self, symbol_id: SymbolId) -> Self {
+        Self::new(self.semantic, self.module_record, symbol_id)
+    }
+
     #[inline]
     pub fn id(&self) -> SymbolId {
         self.id

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -93,8 +93,25 @@ fn test_vars_simple() {
     let fix = vec![
         // unused vars should be removed
         ("let a = 1;", "", None, FixKind::DangerousSuggestion),
-        // FIXME: b should be deleted as well.
-        ("let a = 1, b = 2;", "let b = 2;", None, FixKind::DangerousSuggestion),
+        // when every declarator in a multi-declarator statement is unused,
+        // the whole statement is deleted instead of leaving dead declarators
+        // behind (https://github.com/oxc-project/oxc/issues/16832)
+        ("let a = 1, b = 2;", "", None, FixKind::DangerousSuggestion),
+        ("let a = 1, b = 2, c = 3;", "", None, FixKind::DangerousSuggestion),
+        // a sibling that's exported or ignored by name pattern must not be
+        // swept away by the whole-statement deletion
+        (
+            "let a = 1, b = 2; export { b };",
+            "let b = 2; export { b };",
+            None,
+            FixKind::DangerousSuggestion,
+        ),
+        (
+            "let a = 1, _b = 2;",
+            "let _b = 2;",
+            Some(json!([{ "varsIgnorePattern": "^_" }])),
+            FixKind::DangerousSuggestion,
+        ),
         (
             "let a = 1; let b = 2; console.log(a);",
             "let a = 1;  console.log(a);",


### PR DESCRIPTION
When a multi-declarator statement like `let a = 1, b = 2;` has both declarators unused, the fixer only deleted `a` and left `let b = 2;` behind. Each unused declarator's fix only knew about its own comma-adjacent slice, so it never checked whether its siblings were also dead.

`rename_or_remove_var_declaration` now checks, for plain (non-destructured) declarators, whether every other declarator in the same statement is also unused, not exported, not exempted by an ignore pattern, and otherwise safe to remove. When that's true it deletes the whole `VariableDeclaration` span instead of just its own slice. Destructured declarators (`const { a } = obj, b = 1`) still go through the old per-declarator path; that's a related but separate bug also listed in the issue, and this PR doesn't touch it.

Addresses the multi-declarator cleanup bug from #16832 (that issue is a meta/checklist tracking many separate improvements to this fixer, most already done in other PRs; this is just the one item).

Added test cases to `test_vars_simple` covering both-unused with 2 and 3 declarators, plus two guard cases (an exported sibling and a `varsIgnorePattern`-matched sibling) to make sure those aren't swept away by the whole-statement deletion. Ran the full `oxc_linter` test suite (1169 tests), `cargo fmt --check`, and `cargo clippy` with no issues.

Disclosure: I used an AI assistant (Claude) to help investigate and write this fix, and reviewed and tested the change myself before submitting.