### PR TITLE
feat(tools): `just` commands `check`, `test`, `lint`, `doc` take args

### DIFF
--- a/justfile
+++ b/justfile
@@ -47,16 +47,21 @@ ready:
   git status
 
 # Run cargo check
-check:
-  cargo ck
+check *args:
+  cargo ck {{args}}
 
 # Run all the tests
-test:
-  cargo test --all-features
+test *args:
+  cargo test --all-features {{args}}
 
 # Lint the whole project
-lint $CARGO_BUILD_WARNINGS="deny":
-  cargo lint
+[unix]
+lint *args:
+  CARGO_BUILD_WARNINGS=deny cargo lint {{args}}
+
+[windows]
+lint *args:
+  $Env:CARGO_BUILD_WARNINGS='deny'; cargo lint {{args}}
 
 # Format all files
 fmt:
@@ -65,12 +70,12 @@ fmt:
   node --run fmt
 
 [unix]
-doc:
-  RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --document-private-items --all-features
+doc *args:
+  RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --document-private-items --all-features {{args}}
 
 [windows]
-doc:
-  $Env:RUSTDOCFLAGS='-D warnings'; cargo doc --no-deps --document-private-items --all-features
+doc *args:
+  $Env:RUSTDOCFLAGS='-D warnings'; cargo doc --no-deps --document-private-items --all-features {{args}}
 
 # Fix all auto-fixable format and lint issues
 fix:


### PR DESCRIPTION
Sometimes it can be useful to run a command just for a specific crate.

Alter `just` commands to support e.g. `just test -p oxc_parser`, `just doc -p oxc_semantic`.