### PR TITLE
feat(data_structures): add `likely` and `unlikely` functions

### DIFF
--- a/crates/oxc_data_structures/Cargo.toml
+++ b/crates/oxc_data_structures/Cargo.toml
@@ -29,6 +29,7 @@ default = []
 all = [
   "assert_unchecked",
   "box_macros",
+  "branch_hints",
   "code_buffer",
   "fieldless_enum",
   "inline_string",
@@ -40,6 +41,7 @@ all = [
 ]
 assert_unchecked = []
 box_macros = []
+branch_hints = []
 code_buffer = ["assert_unchecked"]
 fieldless_enum = []
 inline_string = ["assert_unchecked"]

--- a/crates/oxc_data_structures/README.md
+++ b/crates/oxc_data_structures/README.md
@@ -16,6 +16,7 @@ This crate provides specialized data structures and utilities that are used thro
 - **Box macros**: Macros for creating boxed arrays / slices (similar to `vec!` macro)
 - **Fieldless enums macro**: Macro for creating enums with a `VARIANTS` constant listing all variants
 - **Non-null pointers**: `NonNullConst<T>` and `NonNullMut<T>` - non-null pointer types with explicit const/mut permissions
+- **Branch prediction hints**: `likely` and `unlikely` functions to hint to the compiler whether a branch is likely to be taken (also re-exports `std::hint::cold_path`)
 - **`StringExt` trait**: Add methods to `String` to push without capacity checks
 
 ## Architecture

--- a/crates/oxc_data_structures/src/branch_hints.rs
+++ b/crates/oxc_data_structures/src/branch_hints.rs
@@ -1,0 +1,98 @@
+//! `likely` and `unlikely` branch prediction hint functions.
+//!
+//! Also re-exports [`std::hint::cold_path`].
+
+/// Re-export of [`std::hint::cold_path`].
+pub use std::hint::cold_path;
+
+/// Hint to the compiler that the condition `cond` is likely to be `true`.
+///
+/// No-op at runtime. Just hints to compiler how to arrange code so the likely branch
+/// is the default. Any alternative branch is a "cold path".
+///
+/// Returns `cond` unchanged.
+///
+/// This is a wrapper around [`std::hint::cold_path`].
+/// See documentation for [`std::hint::cold_path`] for more details.
+///
+/// # Example
+/// ```
+/// use oxc_data_structures::branch_hints::likely;
+///
+/// fn char_width(ch: char) -> usize {
+///     // Source text is expected to be mostly ASCII
+///     if likely(ch.is_ascii()) {
+///         1
+///     } else {
+///         ch.len_utf8()
+///     }
+/// }
+/// ```
+//
+// `#[inline(always)]` because is no-op at runtime, and would have no effect unless inlined
+#[expect(clippy::inline_always)]
+#[inline(always)]
+pub const fn likely(cond: bool) -> bool {
+    if !cond {
+        cold_path();
+    }
+    cond
+}
+
+/// Hint to the compiler that the condition `cond` is likely to be `false`.
+///
+/// No-op at runtime. Just hints to compiler how to arrange code so the likely branch
+/// is the default. Any alternative branch is a "cold path".
+///
+/// Returns `cond` unchanged.
+///
+/// This is a wrapper around [`std::hint::cold_path`].
+/// See documentation for [`std::hint::cold_path`] for more details.
+///
+/// # Example
+/// ```
+/// use oxc_data_structures::branch_hints::unlikely;
+///
+/// fn contains_zero(bytes: &[u8]) -> bool {
+///     for &byte in bytes {
+///         // Most bytes are expected to be non-zero
+///         if unlikely(byte == 0) {
+///             return true;
+///         }
+///     }
+///     false
+/// }
+/// ```
+//
+// `#[inline(always)]` because is no-op at runtime, and would have no effect unless inlined
+#[expect(clippy::inline_always)]
+#[inline(always)]
+pub const fn unlikely(cond: bool) -> bool {
+    if cond {
+        cold_path();
+    }
+    cond
+}
+
+#[cfg(test)]
+mod test {
+    use super::{likely, unlikely};
+
+    #[test]
+    fn likely_returns_input_unchanged() {
+        assert!(likely(true));
+        assert!(!likely(false));
+    }
+
+    #[test]
+    fn unlikely_returns_input_unchanged() {
+        assert!(unlikely(true));
+        assert!(!unlikely(false));
+    }
+
+    #[test]
+    fn usable_in_const_context() {
+        const { assert!(likely(true)) };
+        const { assert!(!unlikely(false)) };
+    }
+}

--- a/crates/oxc_data_structures/src/lib.rs
+++ b/crates/oxc_data_structures/src/lib.rs
@@ -6,6 +6,9 @@ mod assert_unchecked;
 #[cfg(feature = "box_macros")]
 pub mod box_macros;
 
+#[cfg(feature = "branch_hints")]
+pub mod branch_hints;
+
 #[cfg(feature = "code_buffer")]
 pub mod code_buffer;
 


### PR DESCRIPTION
[#24359](https://github.com/oxc-project/oxc/pull/24359) bumped our MSRV to 1.95.0.

Now *at last* we have a decent way to guide branch layout: [`std::hint::cold_path`](https://doc.rust-lang.org/stable/core/hint/fn.cold_path.html). :champagne:

Add the `likely` and `unlikely` functions that Rust's docs suggest as simple ways to use this capability.