### PR TITLE
perf(linter/typescript/prefer-ts-expect-error): avoid String clone per comment

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/prefer_ts_expect_error.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_ts_expect_error.rs
@@ -97,18 +97,18 @@ impl Rule for PreferTsExpectError {
     }
 }
 
-fn get_last_comment_line(comment: Comment, raw: &str) -> String {
+fn get_last_comment_line<'a>(comment: Comment, raw: &'a str) -> &'a str {
     if comment.is_line() {
-        return String::from(raw);
+        return raw;
     }
 
-    String::from(raw.lines().last().unwrap_or(raw))
+    raw.lines().last().unwrap_or(raw)
 }
 
 fn is_valid_ts_ignore_present(comment: Comment, raw: &str) -> bool {
     let line = get_last_comment_line(comment, raw);
 
-    if comment.is_line() { test_single_line_comment(&line) } else { test_multi_line_comment(&line) }
+    if comment.is_line() { test_single_line_comment(line) } else { test_multi_line_comment(line) }
 }
 
 fn test_single_line_comment(line: &str) -> bool {

--- a/crates/oxc_linter/src/rules/typescript/prefer_ts_expect_error.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_ts_expect_error.rs
@@ -97,7 +97,7 @@ impl Rule for PreferTsExpectError {
     }
 }
 
-fn get_last_comment_line<'a>(comment: Comment, raw: &'a str) -> &'a str {
+fn get_last_comment_line(comment: Comment, raw: &str) -> &str {
     if comment.is_line() {
         return raw;
     }


### PR DESCRIPTION
## What

`get_last_comment_line` in the `typescript/prefer-ts-expect-error` rule heap-allocated a
`String` (`String::from(raw)` / `String::from(raw.lines().last()...)`) for **every comment in the
file**. It is called unconditionally from `is_valid_ts_ignore_present`, which `run_once` invokes on
every comment *before* any `@ts-ignore` match — so the allocation happens once per comment even in
files with zero violations. The returned value is only ever read as `&str`
(`test_single_line_comment` / `test_multi_line_comment`), never mutated or stored. `raw` is
`ctx.source_range(...)` → `&'a str` tied to the arena, and `str::lines().last()` yields a borrowed
slice of it, so the heap copy is pure waste.

## Change

Return a borrowed `&'a str` instead of an owned `String`:

```diff
-fn get_last_comment_line(comment: Comment, raw: &str) -> String {
+fn get_last_comment_line<'a>(comment: Comment, raw: &'a str) -> &'a str {
     if comment.is_line() {
-        return String::from(raw);
+        return raw;
     }
-
-    String::from(raw.lines().last().unwrap_or(raw))
+    raw.lines().last().unwrap_or(raw)
 }
```

(The caller's `test_*` calls take `&str`, so `&line` becomes `line`.)

## Impact

One heap allocation removed per comment. Measured on a synthetic 11k-line TS file with 4,000
comments (`typescript/prefer-ts-expect-error` as the only enabled rule), counting system-allocator
activity during `Linter::run` only:

| metric      |   baseline |  this branch |        Δ |
|-------------|-----------:|-------------:|---------:|
| allocs/iter |     12,006 |        8,006 | **−4,000 (−33%)** |
| bytes/iter  |  1,479,224 |    1,377,057 | −102,167 |

The −4,000 allocs/iter exactly equals the comment count (one `String::from` per comment).

### Wall clock

This is a memory/allocation optimization, not a speed one — same class as #23751 (whose own
wall-clock delta was only −0.7% to −4%). In an isolated single-rule Criterion benchmark
(release build, `tasks/benchmark`, the repo's deterministic `NeverGrowInPlace` allocator),
the change trends slightly faster (~−4% median over 40 paired runs, fixed faster in 57%), but the effect is small and near the noise floor of a shared
machine, so no end-to-end speedup should be assumed. The reliable, deterministic win is the
reduced allocation count above (production uses mimalloc, where these small allocations are
cheap).

## Verification

- `cargo test -p oxc_linter --lib prefer_ts_expect_error` passes.

This PR was assisted by Claude Code.
