### PR TITLE
perf(linter/typescript/consistent-type-imports): remove redundant Vec per violation

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
@@ -281,13 +281,11 @@ impl Rule for ConsistentTypeImports {
                 {
                     let type_names = type_references_without_type_qualifier
                         .iter()
-                        .map(|specifier| specifier.name())
+                        .map(|specifier| specifier.local().name.as_str())
                         .collect::<Vec<_>>();
 
                     // ['foo', 'bar', 'baz' ] => "foo, bar, and baz".
                     let type_imports = format_word_list(&type_names);
-                    let type_names =
-                        type_names.iter().map(std::convert::AsRef::as_ref).collect::<Vec<_>>();
 
                     let fixer_fn = |fixer: RuleFixer<'_, 'a>| {
                         let fix_options = FixOptions {
@@ -341,10 +339,10 @@ impl Rule for ConsistentTypeImports {
 // the `and` clause inserted before the last item.
 //
 // Example: ['foo', 'bar', 'baz' ] returns the string "foo, bar, and baz".
-fn format_word_list<'a>(words: &[Cow<'a, str>]) -> Cow<'a, str> {
+fn format_word_list<'a>(words: &[&'a str]) -> Cow<'a, str> {
     match words.len() {
         0 => Cow::Borrowed(""),
-        1 => words[0].clone(),
+        1 => Cow::Borrowed(words[0]),
         2 => Cow::Owned(format!("{} and {}", words[0], words[1])),
         _ => {
             let mut result = String::with_capacity(words.len() * 2);


### PR DESCRIPTION
## What

When `typescript/consistent-type-imports` reports an import whose specifiers are only used as
types, `run` built **two** `Vec`s per violation:

```rust
let type_names = type_references_without_type_qualifier
    .iter()
    .map(|specifier| specifier.name())          // Vec<Cow<'a, str>>
    .collect::<Vec<_>>();

let type_imports = format_word_list(&type_names);
let type_names =
    type_names.iter().map(std::convert::AsRef::as_ref).collect::<Vec<_>>();  // Vec<&str>
```

`ImportDeclarationSpecifier::name()` always returns `Cow::Borrowed(self.local().name.as_str())`, so
the first `Vec<Cow>` is never anything but borrowed data, and the second `collect` allocates an
entire additional `Vec` on every violation just to convert `Cow → &str` for the fixer. Both the
message builder (`format_word_list`) and the fixer only need `&str`.

## Change

Collect a single `Vec<&str>` directly from the arena-backed names and drop the second `collect`;
`format_word_list` takes `&[&str]`:

```diff
     let type_names = type_references_without_type_qualifier
         .iter()
-        .map(|specifier| specifier.name())
+        .map(|specifier| specifier.local().name.as_str())
         .collect::<Vec<_>>();

     let type_imports = format_word_list(&type_names);
-    let type_names =
-        type_names.iter().map(std::convert::AsRef::as_ref).collect::<Vec<_>>();
```
```diff
-fn format_word_list<'a>(words: &[Cow<'a, str>]) -> Cow<'a, str> {
+fn format_word_list<'a>(words: &[&'a str]) -> Cow<'a, str> {
     match words.len() {
         0 => Cow::Borrowed(""),
-        1 => words[0].clone(),
+        1 => Cow::Borrowed(words[0]),
         2 => Cow::Owned(format!("{} and {}", words[0], words[1])),
```

## Impact

One `Vec` allocation removed per reported import, and the remaining `Vec` shrinks from
`Cow<str>` (24 B/elem) to `&str` (16 B/elem). Measured on a synthetic 9k-line TS file with 3,000
type-only import declarations (`typescript/consistent-type-imports` as the only enabled rule),
counting system-allocator activity during `Linter::run` only:

| metric      |   baseline |  this branch |        Δ |
|-------------|-----------:|-------------:|---------:|
| allocs/iter |     21,006 |       18,006 | **−3,000 (−14%)** |
| bytes/iter  |  2,555,972 |    2,339,972 | −216,000 |

The −3,000 allocs/iter exactly equals the number of reported imports (one redundant `Vec` each).

### Wall clock

This is a memory/allocation optimization, not a speed one — same class as #23751 (whose own
wall-clock delta was only −0.7% to −4%). In an isolated single-rule Criterion benchmark
(release build, `tasks/benchmark`, the repo's deterministic `NeverGrowInPlace` allocator),
the change trends slightly faster (~−5% median over 40 paired runs, fixed faster in 57%), but the effect is small and near the noise floor of a shared
machine, so no end-to-end speedup should be assumed. The reliable, deterministic win is the
reduced allocation count above (production uses mimalloc, where these small allocations are
cheap).

## Verification

- `cargo test -p oxc_linter --lib consistent_type_imports` passes.

This PR was assisted by Claude Code.
