### PR TITLE
perf(linter/eslint/no-underscore-dangle): avoid String clone per identifier

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_underscore_dangle.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_underscore_dangle.rs
@@ -156,7 +156,7 @@ enum BindingContext {
 
 impl NoUnderscoreDangle {
     fn is_allowed(&self, name: &str) -> bool {
-        is_always_allowed(name) || self.allow.contains(&name.to_string())
+        is_always_allowed(name) || self.allow.iter().any(|allowed| allowed == name)
     }
 
     fn report(&self, ctx: &LintContext, span: Span, name: &str) {


### PR DESCRIPTION
## What

`NoUnderscoreDangle::is_allowed` heap-allocated a `String` (`name.to_string()`) on every call, only
to feed `Vec::contains` for a membership test:

```rust
fn is_allowed(&self, name: &str) -> bool {
    is_always_allowed(name) || self.allow.contains(&name.to_string())
}
```

`is_allowed` runs from `report`, which fires for every checked identifier (bindings, members,
private fields, function/method/property names). `self.allow` is a `Vec<String>` and `name` is
already `&str`, so the `to_string()` allocates a throwaway `String` purely to compare it, then drops
it — once per identifier the rule inspects.

## Change

Compare against the existing `String`s by reference; no allocation:

```diff
-    is_always_allowed(name) || self.allow.contains(&name.to_string())
+    is_always_allowed(name) || self.allow.iter().any(|allowed| allowed == name)
```

## Impact

One heap allocation removed per checked identifier. Measured on a synthetic 8k-line TS file with
8,000 dangling-underscore identifiers (`eslint/no-underscore-dangle` as the only enabled rule),
counting system-allocator activity during `Linter::run` only:

| metric      |   baseline |  this branch |        Δ |
|-------------|-----------:|-------------:|---------:|
| allocs/iter |     32,006 |       24,006 | **−8,000 (−25%)** |
| bytes/iter  |  5,236,309 |    5,174,529 |  −61,780 |

The −8,000 allocs/iter exactly equals the number of identifiers checked (one `to_string` each).

### Wall clock

This is a memory/allocation optimization, not a speed one — same class as #23751 (whose own
wall-clock delta was only −0.7% to −4%). In an isolated single-rule Criterion benchmark
(release build, `tasks/benchmark`, the repo's deterministic `NeverGrowInPlace` allocator),
the change trends flat (fixed faster in only 20/40 paired runs — no measurable wall-clock change; the removed `String` is dwarfed by the rule's unavoidable per-diagnostic message allocations), but the effect is small and near the noise floor of a shared
machine, so no end-to-end speedup should be assumed. The reliable, deterministic win is the
reduced allocation count above (production uses mimalloc, where these small allocations are
cheap).

## Verification

- `cargo test -p oxc_linter --lib no_underscore_dangle` passes.

This PR was assisted by Claude Code.
