### PR TITLE
feat(lexer): add scalar lexer and close the remaining pathological regex vs division cases.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_lexer"
-version = "0.139.0"
+version = "0.138.0"
 dependencies = [
  "memchr",
  "oxc_ast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_lexer"
-version = "0.138.0"
+version = "0.139.0"
 dependencies = [
  "memchr",
  "oxc_ast",

--- a/crates/oxc_lexer/Cargo.toml
+++ b/crates/oxc_lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_lexer"
-version = "0.138.0"
+version = "0.139.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_lexer/Cargo.toml
+++ b/crates/oxc_lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_lexer"
-version = "0.139.0"
+version = "0.138.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_lexer/README.md
+++ b/crates/oxc_lexer/README.md
@@ -1,18 +1,11 @@
 # Oxc Lexer
 
-A spec compliant standalone lexer for JS/JSX/TS on x86_64; Other platforms coming soon.
+A spec compliant standalone lexer for JS/JSX/TS.
 
 ## Overview
 
 - Test262 compliant.
 - TS/JSX Working
 - UTF-8 validation costs 0.15CPB (Cycles per byte), optional parameter.
-
-## Building
-
-Requires static AVX2/BMI2 (x86_64). Without the flags the crate compiles to an
-empty stub so workspace-wide builds still pass on any platform:
-
-```sh
-RUSTFLAGS="-C target-feature=+avx2,+bmi2" cargo test -p oxc_lexer --all-features
-```
+- SIMD in x86_64 AVX2, Scalar for every other platform currently (in progress).
+- Regex vs Division cases should be handled even in pathological cases.

--- a/crates/oxc_lexer/src/diagnostics.rs
+++ b/crates/oxc_lexer/src/diagnostics.rs
@@ -412,6 +412,9 @@ pub fn to_oxc_diagnostic(d: &Diagnostic, source: &str) -> OxcDiagnostic {
             diag(sev, format!("Invalid Character `{}`", offending_char(source, d))).with_label(span)
         }
         Code::INVALID_REGEXP_GRAMMAR => diag(sev, "Invalid regular expression").with_label(span),
+        Code::HTML_COMMENT_IN_MODULE => {
+            diag(sev, "HTML comments are not allowed in modules").with_label(span)
+        }
         Code::ORACLE_DEPTH_EXCEEDED => diag(sev, "Nesting depth limit exceeded").with_label(span),
         Code::ALLOCATION_LIMIT_EXCEEDED => diag(sev, "Source length exceeds 4 GiB limit"),
 

--- a/crates/oxc_lexer/src/error.rs
+++ b/crates/oxc_lexer/src/error.rs
@@ -19,6 +19,7 @@ pub mod diag_code {
     pub const ALLOCATION_LIMIT_EXCEEDED: u16 = 17;
     pub const UNEXPECTED_CHARACTER: u16 = 18;
     pub const LINE_TERMINATOR_IN_STRING: u16 = 19;
+    pub const HTML_COMMENT_IN_MODULE: u16 = 20;
 }
 
 pub mod diag_severity {

--- a/crates/oxc_lexer/src/lanes.rs
+++ b/crates/oxc_lexer/src/lanes.rs
@@ -8,7 +8,7 @@
     clippy::collapsible_match
 )]
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
 use core::arch::x86_64::*;
 
 use crate::error::{Diagnostic, diag_code, diag_severity};
@@ -34,6 +34,7 @@ pub struct Lanes {
     /// code-level survivors pay the identifier-char check. Empty for
     /// pure-ASCII input.
     pub unicode_leads: Vec<u32>,
+    pub module: bool,
 }
 
 impl Lanes {
@@ -481,7 +482,7 @@ static KEEP: [u64; 9] = [
     0xffff_ffff_ffff_ffff,
 ];
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
 #[inline]
 fn cook_short<const EMIT: bool, const CRLF: bool>(
     src: &[u8],
@@ -507,7 +508,7 @@ fn cook_short<const EMIT: bool, const CRLF: bool>(
     }
 }
 
-#[cfg(not(target_arch = "x86_64"))]
+#[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
 #[inline]
 fn cook_short<const EMIT: bool, const CRLF: bool>(
     src: &[u8],
@@ -538,7 +539,7 @@ fn cook_short<const EMIT: bool, const CRLF: bool>(
     }
 }
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
 #[inline]
 fn span_has_bs(src: &[u8], bs: usize, be: usize) -> bool {
     let mut i = bs;
@@ -560,14 +561,14 @@ fn span_has_bs(src: &[u8], bs: usize, be: usize) -> bool {
     false
 }
 
-#[cfg(not(target_arch = "x86_64"))]
+#[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
 #[inline]
 fn span_has_bs(src: &[u8], bs: usize, be: usize) -> bool {
     memchr::memchr(b'\\', &src[bs..be]).is_some()
 }
 
 /// Template variant of [`span_has_bs`]: a raw CR also forces the decode path.
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
 #[inline]
 fn span_has_bs_or_cr(src: &[u8], bs: usize, be: usize) -> bool {
     let mut i = bs;
@@ -593,7 +594,7 @@ fn span_has_bs_or_cr(src: &[u8], bs: usize, be: usize) -> bool {
     false
 }
 
-#[cfg(not(target_arch = "x86_64"))]
+#[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
 #[inline]
 fn span_has_bs_or_cr(src: &[u8], bs: usize, be: usize) -> bool {
     memchr::memchr2(b'\\', b'\r', &src[bs..be]).is_some()

--- a/crates/oxc_lexer/src/lib.rs
+++ b/crates/oxc_lexer/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
+#![cfg(target_endian = "little")]
 #![allow(unsafe_code)]
 
 pub mod arena;
@@ -24,7 +24,6 @@ pub use token::{
 
 use core::cell::RefCell;
 
-/// Zero-byte padding required past the lexed length `n`: the SIMD scanners over-read (but never act on) up to this many bytes.
 pub const PAD: usize = 64;
 
 thread_local! {
@@ -87,6 +86,7 @@ fn lex_into_arena(src: &[u8], len: u32, options: LexOptions, arena: &mut Arena) 
                 arena.tok_starts,
                 options.jsx,
                 options.ts,
+                options.source_type_module,
                 options.validate_utf8,
             )
         };

--- a/crates/oxc_lexer/src/pipeline/bitmap.rs
+++ b/crates/oxc_lexer/src/pipeline/bitmap.rs
@@ -1,3 +1,4 @@
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
 use core::arch::x86_64::*;
 
 #[inline(always)]
@@ -81,12 +82,31 @@ pub(super) unsafe fn bm_clear_range(bm: *mut u64, a: usize, b: usize) {
     }
     *bm.add(wb) &= !hi;
 }
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
 #[inline]
 pub(super) unsafe fn bm_any(bm: *const u64, nw: usize) -> bool {
     let mut w = 0usize;
     while w + 4 <= nw {
         let v = _mm256_loadu_si256(bm.add(w) as *const __m256i);
         if _mm256_testz_si256(v, v) == 0 {
+            return true;
+        }
+        w += 4;
+    }
+    while w < nw {
+        if *bm.add(w) != 0 {
+            return true;
+        }
+        w += 1;
+    }
+    false
+}
+#[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
+#[inline]
+pub(super) unsafe fn bm_any(bm: *const u64, nw: usize) -> bool {
+    let mut w = 0usize;
+    while w + 4 <= nw {
+        if (*bm.add(w) | *bm.add(w + 1) | *bm.add(w + 2) | *bm.add(w + 3)) != 0 {
             return true;
         }
         w += 4;

--- a/crates/oxc_lexer/src/pipeline/carve.rs
+++ b/crates/oxc_lexer/src/pipeline/carve.rs
@@ -329,7 +329,7 @@ unsafe fn lex_slash(
         lex_line_comment(src, srcs, n, st, kind, s, lanes)
     } else if d == b'*' {
         lex_block_comment(src, srcs, n, st, kind, s, lanes)
-    } else if prev_is_regex(t, src, st, kind, word, digit, n, s, ts) {
+    } else if prev_is_regex(t, src, st, kind, word, digit, n, s, ts, lanes.module) {
         lex_regex(src, srcs, n, st, kind, word, s, lanes)
     } else if s + 1 < n && *src.add(s + 1) == b'=' {
         // `/=`: absorb the `=`.
@@ -488,7 +488,18 @@ pub(super) unsafe fn carve_jsx(
                         } else if c1 == b'=' || is_digit(c1) {
                             // `<=` / `a<5`: leave for coalesce.
                             i = s + 1;
-                        } else if prev_is_regex(t, src, st, kind, word, digit, n, s, ts) {
+                        } else if prev_is_regex(
+                            t,
+                            src,
+                            st,
+                            kind,
+                            word,
+                            digit,
+                            n,
+                            s,
+                            ts,
+                            lanes.module,
+                        ) {
                             // Operand position: candidate JSX.
                             let mut tpos = s + 1;
                             while tpos < n && is_ws(*src.add(tpos)) {
@@ -784,13 +795,14 @@ pub(super) unsafe fn carve(
                 i = lex_slash(t, src, srcs, n, st, kind, opch, word, digit, ts, s, lanes);
             }
             b'<' => {
-                // Annex B B.1.3: `<!--` begins a line comment, valid anywhere.
-                // A bare `<` falls through as an operator.
-                if s + 3 < n
+                let html = s + 3 < n
                     && *src.add(s + 1) == b'!'
                     && *src.add(s + 2) == b'-'
-                    && *src.add(s + 3) == b'-'
-                {
+                    && *src.add(s + 3) == b'-';
+                if html && (!lanes.module || html_close_at_line_start(srcs, s)) {
+                    if lanes.module {
+                        lanes.push_diag(s as u32, 4, diag_code::HTML_COMMENT_IN_MODULE);
+                    }
                     let end = find_line_terminator(src, n, s + 4);
                     *kind.add(s) = LCOM;
                     if end > s + 1 {
@@ -819,10 +831,10 @@ pub(super) unsafe fn carve(
             }
             b'>' => {
                 // Annex B B.1.3: `-->` begins a line comment, but only at
-                // line start. `s` is the `>`; the `-->` starts at s - 2.
                 if s >= 2
                     && *src.add(s - 1) == b'-'
                     && *src.add(s - 2) == b'-'
+                    && !lanes.module
                     && html_close_at_line_start(srcs, s - 2)
                 {
                     let start = s - 2;

--- a/crates/oxc_lexer/src/pipeline/classify.rs
+++ b/crates/oxc_lexer/src/pipeline/classify.rs
@@ -1,14 +1,24 @@
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
 use core::arch::x86_64::*;
 
 use crate::error::diag_code;
 use crate::lanes::Lanes;
 use crate::opmap::{KW_KIND_BASE, PUNCT1_KIND_UNKNOWN};
-use crate::tables::{PH_A, PH_B, PH_T0, PH_T1, Tables, is_digit, is_id_start, is_op_char, is_word};
+#[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
+use crate::opmap::{PUNCT1, PUNCT1_NKNOWN};
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
+use crate::tables::{PH_A, PH_B, PH_T0, PH_T1};
+use crate::tables::{Tables, is_digit, is_id_start, is_op_char, is_word};
+#[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
+use crate::tables::{is_kw_init, is_kw_init_ts, is_ws};
 
 use super::bitmap::{bm_clear_range, bm_next0, bm_prev1, bm_set1};
-use super::find::{load256, mm, scan_ident_esc, veq};
+use super::find::scan_ident_esc;
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
+use super::find::{load256, mm, veq};
 use super::{IDENT, IDENT_ESC, NUM, PRIV_IDENT, PRIV_IDENT_ESC, WS};
 
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
 #[inline(always)]
 unsafe fn vpunct1(
     v: __m256i,
@@ -26,6 +36,7 @@ unsafe fn vpunct1(
     let ctl = _mm256_cmpgt_epi8(_mm256_set1_epi8(0x20), v);
     _mm256_blendv_epi8(ord, v96, ctl)
 }
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
 pub(super) unsafe fn classify(
     t: &Tables,
     ts: bool,
@@ -168,6 +179,175 @@ pub(super) unsafe fn classify(
             *kind.add(i + kk) = kd;
             prev_word = isw as u64;
             prev_ws = isws as u64;
+        }
+        *word.add(b) = w;
+        *st.add(b) = stw;
+        *kwinit.add(b) = kwi;
+        *opch.add(b) = opw;
+        *digit.add(b) = dgw;
+        *dot.add(b) = dtw;
+        *misc.add(b) = msw;
+    }
+}
+
+#[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
+const FL_WORD: u32 = 0;
+#[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
+const FL_WS: u32 = 1;
+#[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
+const FL_DIGIT: u32 = 2;
+#[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
+const FL_DOT: u32 = 3;
+#[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
+const FL_OPCH: u32 = 4;
+#[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
+const FL_KWINIT: u32 = 5;
+#[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
+const FL_MISC: u32 = 6;
+
+#[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
+const fn cls_table(ts: bool) -> [u16; 256] {
+    let mut punct = [PUNCT1_KIND_UNKNOWN; 256];
+    let mut i = 0;
+    while i < PUNCT1_NKNOWN {
+        punct[PUNCT1[i].0 as usize] = PUNCT1[i].1;
+        i += 1;
+    }
+    let mut t = [0u16; 256];
+    let mut c = 0usize;
+    while c < 256 {
+        let b = c as u8;
+        let mut f = 0u16;
+        if is_word(b) {
+            f |= 1 << FL_WORD;
+        }
+        if is_ws(b) {
+            f |= 1 << FL_WS;
+        }
+        if is_digit(b) {
+            f |= 1 << FL_DIGIT;
+        }
+        if b == b'.' {
+            f |= 1 << FL_DOT;
+        }
+        if is_op_char(b) {
+            f |= 1 << FL_OPCH;
+        }
+        if (ts && is_kw_init_ts(b)) || (!ts && is_kw_init(b)) {
+            f |= 1 << FL_KWINIT;
+        }
+        if b == b'#' || b == b'\\' || b >= 0x80 {
+            f |= 1 << FL_MISC;
+        }
+        let kd = if is_ws(b) {
+            WS
+        } else if is_word(b) {
+            if is_digit(b) { NUM } else { IDENT }
+        } else {
+            punct[c]
+        };
+        t[c] = (f << 8) | kd as u16;
+        c += 1;
+    }
+    t
+}
+#[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
+static CLS_JS: [u16; 256] = cls_table(false);
+#[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
+static CLS_TS: [u16; 256] = cls_table(true);
+
+#[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
+#[inline(always)]
+fn pk(fw: u64, bit: u32) -> u64 {
+    (((fw >> bit) & 0x0101_0101_0101_0101).wrapping_mul(0x0102_0408_1020_4080)) >> 56
+}
+
+#[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
+pub(super) unsafe fn classify(
+    _t: &Tables,
+    ts: bool,
+    src: *const u8,
+    n: usize,
+    word: *mut u64,
+    st: *mut u64,
+    kwinit: *mut u64,
+    opch: *mut u64,
+    digit: *mut u64,
+    dot: *mut u64,
+    misc: *mut u64,
+    kind: *mut u8,
+) {
+    let t16: &[u16; 256] = if ts { &CLS_TS } else { &CLS_JS };
+    let mut cw: u64 = 0;
+    let mut cs: u64 = 0;
+    let nbf = n / 64;
+    for b in 0..nbf {
+        let base = b * 64;
+        let (mut mw, mut ms, mut mdg, mut mdt, mut mop, mut mkw, mut mmi) =
+            (0u64, 0u64, 0u64, 0u64, 0u64, 0u64, 0u64);
+        let mut g = 0usize;
+        while g < 8 {
+            let p = base + g * 8;
+            let mut fw = 0u64;
+            let mut kw = 0u64;
+            let mut j = 0usize;
+            while j < 8 {
+                let v = t16[*src.add(p + j) as usize] as u64;
+                fw |= (v >> 8) << (j * 8);
+                kw |= (v & 0xff) << (j * 8);
+                j += 1;
+            }
+            core::ptr::write_unaligned(kind.add(p) as *mut u64, kw);
+            let sh = (g * 8) as u32;
+            mw |= pk(fw, FL_WORD) << sh;
+            ms |= pk(fw, FL_WS) << sh;
+            mdg |= pk(fw, FL_DIGIT) << sh;
+            mdt |= pk(fw, FL_DOT) << sh;
+            mop |= pk(fw, FL_OPCH) << sh;
+            mkw |= pk(fw, FL_KWINIT) << sh;
+            mmi |= pk(fw, FL_MISC) << sh;
+            g += 1;
+        }
+        let wprev = (mw << 1) | cw;
+        let sprev = (ms << 1) | cs;
+        *st.add(b) = (ms & !sprev) | (mw & !wprev) | (!ms & !mw);
+        cw = mw >> 63;
+        cs = ms >> 63;
+        *word.add(b) = mw;
+        *kwinit.add(b) = mkw;
+        *opch.add(b) = mop;
+        *digit.add(b) = mdg;
+        *dot.add(b) = mdt;
+        *misc.add(b) = mmi;
+    }
+    let i = nbf * 64;
+    if i < n {
+        let b = nbf;
+        let tail = n - i;
+        let (mut w, mut stw, mut kwi, mut opw, mut dgw, mut dtw, mut msw) =
+            (0u64, 0u64, 0u64, 0u64, 0u64, 0u64, 0u64);
+        let mut prev_word = cw & 1;
+        let mut prev_ws = cs & 1;
+        for kk in 0..tail {
+            let v = t16[*src.add(i + kk) as usize];
+            let f = (v >> 8) as u64;
+            w |= ((f >> FL_WORD) & 1) << kk;
+            kwi |= ((f >> FL_KWINIT) & 1) << kk;
+            opw |= ((f >> FL_OPCH) & 1) << kk;
+            dgw |= ((f >> FL_DIGIT) & 1) << kk;
+            dtw |= ((f >> FL_DOT) & 1) << kk;
+            msw |= ((f >> FL_MISC) & 1) << kk;
+            let isw = (f >> FL_WORD) & 1;
+            let isws = (f >> FL_WS) & 1;
+            let start = (isws != 0 && prev_ws == 0)
+                || (isw != 0 && prev_word == 0)
+                || (isws == 0 && isw == 0);
+            if start {
+                stw |= 1u64 << kk;
+            }
+            *kind.add(i + kk) = (v & 0xff) as u8;
+            prev_word = isw;
+            prev_ws = isws;
         }
         *word.add(b) = w;
         *st.add(b) = stw;

--- a/crates/oxc_lexer/src/pipeline/coalesce.rs
+++ b/crates/oxc_lexer/src/pipeline/coalesce.rs
@@ -1,5 +1,3 @@
-use core::arch::x86_64::{_MM_HINT_T0, _mm_prefetch};
-
 use crate::error::diag_code;
 use crate::lanes::Lanes;
 use crate::opmap::{KwSet, OP_QDOT};
@@ -9,6 +7,15 @@ use super::NUM;
 use super::bitmap::{bm_clear_range, bm_next0, bm_set1};
 use super::find::scan_number;
 use super::keywords::{KWB, kw_verify_batch};
+
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
+#[inline(always)]
+fn prefetch(p: *const u8) {
+    unsafe { core::arch::x86_64::_mm_prefetch(p as *const i8, core::arch::x86_64::_MM_HINT_T0) }
+}
+#[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
+#[inline(always)]
+fn prefetch(_p: *const u8) {}
 
 unsafe fn munch_walk(
     t: &Tables,
@@ -203,8 +210,8 @@ pub(super) unsafe fn coalesce(
         if kwc != 0 {
             let base = (w << 6) as u32;
             let cnt = kwc.count_ones() as usize;
-            _mm_prefetch(src.add(base as usize) as *const i8, _MM_HINT_T0);
-            _mm_prefetch(kind.add(base as usize) as *const i8, _MM_HINT_T0);
+            prefetch(src.add(base as usize));
+            prefetch(kind.add(base as usize) as *const u8);
             *kwpos.add(k) = base + kwc.trailing_zeros();
             kwc &= kwc.wrapping_sub(1);
             *kwpos.add(k + 1) = base + kwc.trailing_zeros();

--- a/crates/oxc_lexer/src/pipeline/compress.rs
+++ b/crates/oxc_lexer/src/pipeline/compress.rs
@@ -1,11 +1,15 @@
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
 use core::arch::x86_64::*;
 
 use crate::error::diag_code;
 use crate::lanes::Lanes;
 use crate::tables::Tables;
 
+#[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
+use super::find::{eqm, load8};
 use super::{BIGINT, IDENT_ESC, NUM, PRIV_IDENT_ESC};
 
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
 pub(super) unsafe fn compress(
     t: &Tables,
     st: *const u64,
@@ -54,6 +58,94 @@ pub(super) unsafe fn compress(
     }
     m
 }
+#[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
+pub(super) unsafe fn compress(
+    _t: &Tables,
+    st: *const u64,
+    kind: *const u8,
+    nb: usize,
+    starts: *mut u32,
+    kinds: *mut u8,
+) -> usize {
+    let mut m = 0usize;
+    for b in 0..nb {
+        let mut w = *st.add(b);
+        if w == 0 {
+            continue;
+        }
+        let base = (b * 64) as u32;
+        while w != 0 {
+            let bit = w.trailing_zeros();
+            w &= w - 1;
+            *starts.add(m) = base + bit;
+            *kinds.add(m) = *kind.add((base + bit) as usize);
+            m += 1;
+        }
+    }
+    m
+}
+#[inline(always)]
+unsafe fn emit_value(
+    src: &[u8],
+    out_kinds: *const u8,
+    out_starts: *const u32,
+    j: usize,
+    lanes: &mut Lanes,
+) {
+    let s = *out_starts.add(j) as usize;
+    let e = *out_starts.add(j + 1) as usize;
+    let k = *out_kinds.add(j);
+    if k < IDENT_ESC {
+        lanes.push_number_swar(src, s, e);
+    } else if k == IDENT_ESC {
+        lanes.push_atom(src, s, e);
+    } else {
+        lanes.push_atom(src, s + 1, e);
+    }
+}
+#[cold]
+unsafe fn invalid_diags(
+    src: &[u8],
+    out_kinds: *const u8,
+    out_starts: *const u32,
+    m: usize,
+    lanes: &mut Lanes,
+) {
+    let nn = *out_starts.add(m);
+    let char_after = |cs: u32| -> u32 {
+        if cs >= nn {
+            return 0;
+        }
+        let b = src[cs as usize];
+        let l: u32 = if b < 0x80 {
+            1
+        } else if b >= 0xF0 {
+            4
+        } else if b >= 0xE0 {
+            3
+        } else if b >= 0xC0 {
+            2
+        } else {
+            1
+        };
+        l.min(nn - cs)
+    };
+    for j in 0..m {
+        if *out_kinds.add(j) == 255 {
+            let s = *out_starts.add(j);
+            let e = *out_starts.add(j + 1);
+            let b0 = src[s as usize];
+            if b0 == b'\\' {
+                lanes.push_diag(s + 1, char_after(s + 1), diag_code::INVALID_IDENTIFIER_ESCAPE);
+            } else if b0 == b'#' {
+                lanes.push_diag(s + 1, char_after(s + 1), diag_code::UNEXPECTED_CHARACTER);
+            } else {
+                lanes.push_diag(s, e - s, diag_code::UNEXPECTED_CHARACTER);
+            }
+        }
+    }
+}
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
 pub(super) unsafe fn lanes_post(
     src: &[u8],
     out_kinds: *const u8,
@@ -74,21 +166,6 @@ pub(super) unsafe fn lanes_post(
             )
         }};
     }
-    macro_rules! emit {
-        ($j:expr) => {{
-            let j = $j;
-            let s = *out_starts.add(j) as usize;
-            let e = *out_starts.add(j + 1) as usize;
-            let k = *out_kinds.add(j);
-            if k < IDENT_ESC {
-                lanes.push_number_swar(src, s, e);
-            } else if k == IDENT_ESC {
-                lanes.push_atom(src, s, e);
-            } else {
-                lanes.push_atom(src, s + 1, e);
-            }
-        }};
-    }
     // 255 (INVALID) is the byte-class default for stray/control bytes and
     // reaches the output as a 1-byte token. Track "any seen" alongside the
     // value sweep; localize cold.
@@ -107,7 +184,7 @@ pub(super) unsafe fn lanes_post(
         let mut mask = (_mm256_movemask_epi8(h0) as u32 as u64)
             | ((_mm256_movemask_epi8(h1) as u32 as u64) << 32);
         while mask != 0 {
-            emit!(i + mask.trailing_zeros() as usize);
+            emit_value(src, out_kinds, out_starts, i + mask.trailing_zeros() as usize, lanes);
             mask &= mask - 1;
         }
         i += 64;
@@ -125,53 +202,51 @@ pub(super) unsafe fn lanes_post(
         }
         inv_dirty |= invm != 0;
         while mask != 0 {
-            emit!(i + mask.trailing_zeros() as usize);
+            emit_value(src, out_kinds, out_starts, i + mask.trailing_zeros() as usize, lanes);
             mask &= mask - 1;
         }
         i += 32;
     }
-    // Cold, invalid input only: each 255 token is itself the bad byte.
     if inv_dirty {
-        let nn = *out_starts.add(m); // EOF sentinel == n
-        // Span of the one char at `cs` (utf8 length, clamped, empty at EOF):
-        // `\` and `#` errors blame the char after them, like oxc_parser.
-        let char_after = |cs: u32| -> u32 {
-            if cs >= nn {
-                return 0;
-            }
-            let b = src[cs as usize];
-            let l: u32 = if b < 0x80 {
-                1
-            } else if b >= 0xF0 {
-                4
-            } else if b >= 0xE0 {
-                3
-            } else if b >= 0xC0 {
-                2
-            } else {
-                1 // continuation/invalid byte: code 6 fires alongside
-            };
-            l.min(nn - cs)
-        };
-        for j in 0..m {
-            if *out_kinds.add(j) == 255 {
-                let s = *out_starts.add(j);
-                let e = *out_starts.add(j + 1);
-                let b0 = src[s as usize];
-                if b0 == b'\\' {
-                    // Bare code-level `\` (`x = \A`): literal-interior
-                    // backslashes never survive carve, so this is a real
-                    // identifier-escape error. The parser spans the one char
-                    // after the `\`.
-                    lanes.push_diag(s + 1, char_after(s + 1), diag_code::INVALID_IDENTIFIER_ESCAPE);
-                } else if b0 == b'#' {
-                    // Misplaced `#` (including `#!` past offset 0): the
-                    // parser consumes the char after `#` and reports on it.
-                    lanes.push_diag(s + 1, char_after(s + 1), diag_code::UNEXPECTED_CHARACTER);
-                } else {
-                    lanes.push_diag(s, e - s, diag_code::UNEXPECTED_CHARACTER);
-                }
-            }
+        invalid_diags(src, out_kinds, out_starts, m, lanes);
+    }
+}
+#[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
+pub(super) unsafe fn lanes_post(
+    src: &[u8],
+    out_kinds: *const u8,
+    out_starts: *const u32,
+    m: usize,
+    lanes: &mut Lanes,
+) {
+    let mut inv = 0u64;
+    let mut i = 0usize;
+    while i + 8 <= m {
+        let x = load8(out_kinds, i);
+        let mut hits = eqm(x, NUM) | eqm(x, BIGINT) | eqm(x, IDENT_ESC) | eqm(x, PRIV_IDENT_ESC);
+        inv |= eqm(x, 255);
+        while hits != 0 {
+            emit_value(
+                src,
+                out_kinds,
+                out_starts,
+                i + (hits.trailing_zeros() >> 3) as usize,
+                lanes,
+            );
+            hits &= hits - 1;
         }
+        i += 8;
+    }
+    let mut inv_dirty = inv != 0;
+    while i < m {
+        let k = *out_kinds.add(i);
+        if k == NUM || k == BIGINT || k == IDENT_ESC || k == PRIV_IDENT_ESC {
+            emit_value(src, out_kinds, out_starts, i, lanes);
+        }
+        inv_dirty |= k == 255;
+        i += 1;
+    }
+    if inv_dirty {
+        invalid_diags(src, out_kinds, out_starts, m, lanes);
     }
 }

--- a/crates/oxc_lexer/src/pipeline/find.rs
+++ b/crates/oxc_lexer/src/pipeline/find.rs
@@ -1,19 +1,38 @@
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
 use core::arch::x86_64::*;
 
 use crate::tables::{hex_val, is_digit, is_word};
 
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
 #[inline(always)]
 pub(super) unsafe fn veq(v: __m256i, c: u8) -> __m256i {
     _mm256_cmpeq_epi8(v, _mm256_set1_epi8(c as i8))
 }
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
 #[inline(always)]
 pub(super) unsafe fn mm(v: __m256i) -> u32 {
     _mm256_movemask_epi8(v) as u32
 }
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
 #[inline(always)]
 pub(super) unsafe fn load256(src: *const u8, i: usize) -> __m256i {
     _mm256_loadu_si256(src.add(i) as *const __m256i)
 }
+
+#[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
+#[inline(always)]
+pub(super) unsafe fn load8(src: *const u8, i: usize) -> u64 {
+    core::ptr::read_unaligned(src.add(i) as *const u64)
+}
+#[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
+#[inline(always)]
+pub(super) fn eqm(x: u64, b: u8) -> u64 {
+    let lo = 0x0101_0101_0101_0101u64;
+    let y = x ^ lo.wrapping_mul(b as u64);
+    y.wrapping_sub(lo) & !y & 0x8080_8080_8080_8080
+}
+
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
 #[inline]
 pub(super) unsafe fn find1(src: *const u8, n: usize, mut i: usize, a: u8) -> usize {
     while i + 32 <= n {
@@ -31,6 +50,25 @@ pub(super) unsafe fn find1(src: *const u8, n: usize, mut i: usize, a: u8) -> usi
     }
     n
 }
+#[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
+#[inline]
+pub(super) unsafe fn find1(src: *const u8, n: usize, mut i: usize, a: u8) -> usize {
+    while i + 8 <= n {
+        let m = eqm(load8(src, i), a);
+        if m != 0 {
+            return i + (m.trailing_zeros() >> 3) as usize;
+        }
+        i += 8;
+    }
+    while i < n {
+        if *src.add(i) == a {
+            return i;
+        }
+        i += 1;
+    }
+    n
+}
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
 #[inline]
 pub(super) unsafe fn find2(src: *const u8, n: usize, mut i: usize, a: u8, b: u8) -> usize {
     while i + 32 <= n {
@@ -50,6 +88,27 @@ pub(super) unsafe fn find2(src: *const u8, n: usize, mut i: usize, a: u8, b: u8)
     }
     n
 }
+#[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
+#[inline]
+pub(super) unsafe fn find2(src: *const u8, n: usize, mut i: usize, a: u8, b: u8) -> usize {
+    while i + 8 <= n {
+        let x = load8(src, i);
+        let m = eqm(x, a) | eqm(x, b);
+        if m != 0 {
+            return i + (m.trailing_zeros() >> 3) as usize;
+        }
+        i += 8;
+    }
+    while i < n {
+        let c = *src.add(i);
+        if c == a || c == b {
+            return i;
+        }
+        i += 1;
+    }
+    n
+}
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
 #[inline]
 unsafe fn find3(src: *const u8, n: usize, mut i: usize, a: u8, b: u8, c: u8) -> usize {
     while i + 32 <= n {
@@ -69,6 +128,27 @@ unsafe fn find3(src: *const u8, n: usize, mut i: usize, a: u8, b: u8, c: u8) -> 
     }
     n
 }
+#[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
+#[inline]
+unsafe fn find3(src: *const u8, n: usize, mut i: usize, a: u8, b: u8, c: u8) -> usize {
+    while i + 8 <= n {
+        let x = load8(src, i);
+        let m = eqm(x, a) | eqm(x, b) | eqm(x, c);
+        if m != 0 {
+            return i + (m.trailing_zeros() >> 3) as usize;
+        }
+        i += 8;
+    }
+    while i < n {
+        let ch = *src.add(i);
+        if ch == a || ch == b || ch == c {
+            return i;
+        }
+        i += 1;
+    }
+    n
+}
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
 #[inline]
 unsafe fn find4(src: *const u8, n: usize, mut i: usize, a: u8, b: u8, c: u8, d: u8) -> usize {
     while i + 32 <= n {
@@ -81,6 +161,26 @@ unsafe fn find4(src: *const u8, n: usize, mut i: usize, a: u8, b: u8, c: u8, d: 
             return i + m.trailing_zeros() as usize;
         }
         i += 32;
+    }
+    while i < n {
+        let x = *src.add(i);
+        if x == a || x == b || x == c || x == d {
+            return i;
+        }
+        i += 1;
+    }
+    n
+}
+#[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
+#[inline]
+unsafe fn find4(src: *const u8, n: usize, mut i: usize, a: u8, b: u8, c: u8, d: u8) -> usize {
+    while i + 8 <= n {
+        let x = load8(src, i);
+        let m = eqm(x, a) | eqm(x, b) | eqm(x, c) | eqm(x, d);
+        if m != 0 {
+            return i + (m.trailing_zeros() >> 3) as usize;
+        }
+        i += 8;
     }
     while i < n {
         let x = *src.add(i);
@@ -112,6 +212,7 @@ pub(super) unsafe fn find_line_terminator(src: *const u8, n: usize, mut i: usize
     }
 }
 /// OR-fold of `vpcmpeqb` results, associated as a tree.
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
 macro_rules! vor {
     ($a:expr) => { $a };
     ($a:expr, $b:expr) => { _mm256_or_si256($a, $b) };
@@ -120,11 +221,10 @@ macro_rules! vor {
     };
 }
 
-/// Define a fixed-needle SIMD finder: `$name(src, n, i)` returns the index
-/// of the first byte in `src[i..n]` matching any needle, or `n`.
-macro_rules! simd_finder {
+macro_rules! finder {
     ($(#[$attr:meta])* $name:ident: $($needle:expr),+ $(,)?) => {
         $(#[$attr])*
+        #[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
         #[inline]
         pub(super) unsafe fn $name(src: *const u8, n: usize, mut i: usize) -> usize {
             while i + 32 <= n {
@@ -144,48 +244,69 @@ macro_rules! simd_finder {
             }
             n
         }
+        $(#[$attr])*
+        #[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
+        #[inline]
+        pub(super) unsafe fn $name(src: *const u8, n: usize, mut i: usize) -> usize {
+            while i + 8 <= n {
+                let x = load8(src, i);
+                let m = $(eqm(x, $needle))|+;
+                if m != 0 {
+                    return i + (m.trailing_zeros() >> 3) as usize;
+                }
+                i += 8;
+            }
+            while i < n {
+                let c = *src.add(i);
+                if $(c == $needle)||+ {
+                    return i;
+                }
+                i += 1;
+            }
+            n
+        }
     };
 }
 
-simd_finder!(
+finder!(
     /// JS-mode top-level scan: string/template/regex-or-comment openers plus
     /// the Annex B `<!--` / `-->` trigger bytes.
     find_opener: b'"', b'\'', b'`', b'/', b'<', b'>'
 );
-simd_finder!(
+finder!(
     /// [`find_opener`] widened with `{` / `}` — used inside template
     /// substitutions, where braces drive the nesting depth.
     find_opener6: b'"', b'\'', b'`', b'/', b'{', b'}', b'<', b'>'
 );
-simd_finder!(
+finder!(
     /// [`find_opener`] shape for `carve_jsx` JS mode at top level: `<` (the
     /// JSX-start byte) instead of the Annex B `<` / `>` pair.
     find_opener_jsx5: b'"', b'\'', b'`', b'/', b'<'
 );
-simd_finder!(
+finder!(
     /// [`find_opener_jsx5`] widened with `{` / `}`. Used by `carve_jsx` JS
     /// mode inside a template substitution or JSX expression container.
     find_opener_jsx7: b'"', b'\'', b'`', b'/', b'{', b'}', b'<'
 );
-simd_finder!(
+finder!(
     /// TAG-mode scan: the bytes that matter inside an opening `<...>` tag.
     find_jsx_tag: b'"', b'\'', b'{', b'/', b'>'
 );
-simd_finder!(
+finder!(
     /// [`find_jsx_tag`] widened with `<` (`.tsx` only), so `carve_jsx` can
     /// spot and skip a type-argument list inside the opening tag.
     find_jsx_tag_ts: b'"', b'\'', b'{', b'/', b'>', b'<'
 );
-simd_finder!(
+finder!(
     /// TEXT-mode scan (strict): JSX child text ends at any of `< { > }`.
     find_jsx_text: b'<', b'{', b'>', b'}'
 );
-simd_finder!(
+finder!(
     /// Template-body scan: terminator, escape lead, or `$` (`${` starts a
     /// substitution).
     find_tmpl: b'`', b'\\', b'$'
 );
-simd_finder!(
+finder!(
     /// Regex-body scan. LF/CR and the 0xE2 lead (LS/PS) are watched so
     /// line terminators in the body can be diagnosed.
     find_regex: b'/', b'\\', b'[', b']', b'\n', b'\r', 0xE2
@@ -228,6 +349,7 @@ unsafe fn lic_verify_at(src: *const u8, q: usize) -> bool {
     (c1 == b'l' && core::slice::from_raw_parts(src.add(q + 2), 6) == b"icense")
         || (c1 == b'p' && core::slice::from_raw_parts(src.add(q + 2), 7) == b"reserve")
 }
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
 #[inline(always)]
 unsafe fn lic_first(src: *const u8, base: usize, mut am: u32) -> i64 {
     while am != 0 {
@@ -239,6 +361,19 @@ unsafe fn lic_first(src: *const u8, base: usize, mut am: u32) -> i64 {
     }
     -1
 }
+#[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
+#[inline(always)]
+unsafe fn lic_first8(src: *const u8, base: usize, mut am: u64) -> i64 {
+    while am != 0 {
+        let q = base + (am.trailing_zeros() >> 3) as usize;
+        am &= am - 1;
+        if lic_verify_at(src, q) {
+            return q as i64;
+        }
+    }
+    -1
+}
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
 pub(super) unsafe fn scan_block_comment(
     src: *const u8,
     n: usize,
@@ -285,11 +420,59 @@ pub(super) unsafe fn scan_block_comment(
     }
     (n, saw_nl, lic_q)
 }
+#[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
+pub(super) unsafe fn scan_block_comment(
+    src: *const u8,
+    n: usize,
+    mut i: usize,
+) -> (usize, bool, i64) {
+    let mut saw_nl = false;
+    let mut lic_q: i64 = -1;
+    while i + 8 <= n {
+        let x = load8(src, i);
+        let y = load8(src, i + 1);
+        let term = eqm(x, b'*') & eqm(y, b'/');
+        let nl = eqm(x, b'\n') | eqm(x, b'\r');
+        let at = eqm(x, b'@');
+        if term != 0 {
+            let j = (term.trailing_zeros() >> 3) as usize;
+            let bodymask: u64 = if j > 0 { (1u64 << (j * 8)) - 1 } else { 0 };
+            saw_nl |= (nl & bodymask) != 0;
+            if lic_q < 0 {
+                let am = at & bodymask;
+                if am != 0 {
+                    lic_q = lic_first8(src, i, am);
+                }
+            }
+            return (i + j + 1, saw_nl, lic_q);
+        }
+        saw_nl |= nl != 0;
+        if lic_q < 0 && at != 0 {
+            lic_q = lic_first8(src, i, at);
+        }
+        i += 8;
+    }
+    while i + 1 < n {
+        let c = *src.add(i);
+        if c == b'*' && *src.add(i + 1) == b'/' {
+            return (i + 1, saw_nl, lic_q);
+        }
+        if c == b'\n' || c == b'\r' {
+            saw_nl = true;
+        }
+        if c == b'@' && lic_q < 0 && lic_verify_at(src, i) {
+            lic_q = i as i64;
+        }
+        i += 1;
+    }
+    (n, saw_nl, lic_q)
+}
 /// Scan a `//` line comment to its LineTerminator (LF, CR, or LS/PS),
 /// tracking the first `@license` / `@preserve` position for comment
 /// metadata. A 0xE2 that isn't LS/PS (typographic punctuation in prose) is
 /// cleared from the mask and the scan continues; the LS/PS confirm can read
 /// the pad, which never matches 0x80.
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
 pub(super) unsafe fn scan_line_comment(src: *const u8, n: usize, mut i: usize) -> (usize, i64) {
     let mut lic_q: i64 = -1;
     while i + 32 <= n {
@@ -319,6 +502,54 @@ pub(super) unsafe fn scan_line_comment(src: *const u8, n: usize, mut i: usize) -
             lic_q = lic_first(src, i, at);
         }
         i += 32;
+    }
+    while i < n {
+        let c = *src.add(i);
+        if c == b'\n' || c == b'\r' {
+            return (i, lic_q);
+        }
+        if c == 0xE2
+            && *src.add(i + 1) == 0x80
+            && (*src.add(i + 2) == 0xA8 || *src.add(i + 2) == 0xA9)
+        {
+            return (i, lic_q);
+        }
+        if c == b'@' && lic_q < 0 && lic_verify_at(src, i) {
+            lic_q = i as i64;
+        }
+        i += 1;
+    }
+    (n, lic_q)
+}
+#[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
+pub(super) unsafe fn scan_line_comment(src: *const u8, n: usize, mut i: usize) -> (usize, i64) {
+    let mut lic_q: i64 = -1;
+    while i + 8 <= n {
+        let x = load8(src, i);
+        let mut term = eqm(x, b'\n') | eqm(x, b'\r') | eqm(x, 0xE2);
+        let at = eqm(x, b'@');
+        while term != 0 {
+            let t = (term.trailing_zeros() >> 3) as usize;
+            let c = *src.add(i + t);
+            if c == 0xE2
+                && !(*src.add(i + t + 1) == 0x80
+                    && (*src.add(i + t + 2) == 0xA8 || *src.add(i + t + 2) == 0xA9))
+            {
+                term &= term - 1;
+                continue;
+            }
+            if lic_q < 0 {
+                let am = at & if t > 0 { (1u64 << (t * 8)) - 1 } else { 0 };
+                if am != 0 {
+                    lic_q = lic_first8(src, i, am);
+                }
+            }
+            return (i + t, lic_q);
+        }
+        if lic_q < 0 && at != 0 {
+            lic_q = lic_first8(src, i, at);
+        }
+        i += 8;
     }
     while i < n {
         let c = *src.add(i);

--- a/crates/oxc_lexer/src/pipeline/keywords.rs
+++ b/crates/oxc_lexer/src/pipeline/keywords.rs
@@ -1,10 +1,18 @@
-use core::arch::x86_64::*;
-
 use crate::opmap::KwSet;
 
 use super::IDENT;
 
 pub(super) const KWB: usize = 64;
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
+#[inline(always)]
+fn bzhi(x: u64, n: u32) -> u64 {
+    unsafe { core::arch::x86_64::_bzhi_u64(x, n) }
+}
+#[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
+#[inline(always)]
+fn bzhi(x: u64, n: u32) -> u64 {
+    x & (u64::MAX >> (64 - n))
+}
 /// Resolve a batch of keyword candidates (positions collected by
 /// `coalesce`): exact match against the perfect-hash tables, patching
 /// `kind` from IDENT to the keyword kind on hit. `TS_KEY` selects the
@@ -34,7 +42,7 @@ pub(super) unsafe fn kw_verify_batch<const TS_KEY: bool>(
             continue;
         }
         let w8 = core::ptr::read_unaligned(src.add(p) as *const u64);
-        let z = _bzhi_u64(w8, (len << 3) as u32);
+        let z = bzhi(w8, (len << 3) as u32);
         let key = if TS_KEY {
             // Last char comes off the bzhi'd word: bits above len*8 are
             // already zero, so the shift leaves exactly that byte.

--- a/crates/oxc_lexer/src/pipeline/mod.rs
+++ b/crates/oxc_lexer/src/pipeline/mod.rs
@@ -18,6 +18,7 @@ mod compress;
 mod find;
 mod keywords;
 mod regex_div;
+mod replay;
 
 use crate::PAD;
 use crate::lanes::Lanes;
@@ -148,11 +149,13 @@ impl Lexer {
         out_starts: *mut u32,
         jsx: bool,
         ts: bool,
+        module: bool,
         vutf8: bool,
     ) -> usize {
         debug_assert!(src.len() >= n + PAD, "source must extend PAD zeroed bytes past n");
         self.ensure(n);
         self.lanes.clear();
+        self.lanes.module = module;
         if n == 0 {
             *out_kinds = EOF;
             *out_starts = 0;
@@ -227,7 +230,16 @@ impl Lexer {
         let kinds = self.kinds.as_mut_ptr();
         let starts = self.starts.as_mut_ptr();
         unsafe {
-            self.lex_raw(src, n, kinds, starts, options.jsx, options.ts, options.validate_utf8)
+            self.lex_raw(
+                src,
+                n,
+                kinds,
+                starts,
+                options.jsx,
+                options.ts,
+                options.source_type_module,
+                options.validate_utf8,
+            )
         }
     }
 }

--- a/crates/oxc_lexer/src/pipeline/regex_div.rs
+++ b/crates/oxc_lexer/src/pipeline/regex_div.rs
@@ -4,8 +4,8 @@ use crate::tables::{Tables, is_digit, is_glue_join, is_word, is_ws};
 use super::bitmap::{bm_next0, bm_next1, bm_prev1};
 use super::find::scan_number;
 use super::{
-    BCOM, HASHBANG, IDENT, IDENT_ESC, JEND, JSX_LT, LCOM, NUM, PRIV_IDENT, PRIV_IDENT_ESC, REGEX,
-    STR, TMPL_HEAD, TMPL_MIDDLE, TMPL_NOSUB, TMPL_TAIL, WS,
+    BCOM, BIGINT, HASHBANG, IDENT, IDENT_ESC, JEND, JSX_LT, LCOM, NUM, PRIV_IDENT, PRIV_IDENT_ESC,
+    REGEX, STR, TMPL_HEAD, TMPL_MIDDLE, TMPL_NOSUB, TMPL_TAIL, WS,
 };
 
 #[inline]
@@ -23,37 +23,91 @@ unsafe fn glue_anchor(src: *const u8, st: *const u64, qi: usize) -> usize {
     }
     a
 }
-unsafe fn prev_regex_sim(t: &Tables, src: *const u8, n: usize, a: usize, p: usize) -> bool {
+#[inline]
+pub(super) unsafe fn prop_name(src: *const u8, pos: usize) -> bool {
+    pos > 0 && *src.add(pos - 1) == b'.' && (pos < 2 || *src.add(pos - 2) != b'.')
+}
+enum RunEnd {
+    Seg(usize, usize, bool),
+    Blank(bool),
+}
+
+unsafe fn word_run_end(src: *const u8, s: usize, e: usize) -> RunEnd {
+    let mut i = s;
+    let mut seg: Option<(usize, usize)> = None;
+    let mut nl_after = false;
+    let mut any_nl = false;
+    while i < e {
+        let b = *src.add(i);
+        let mut trivia: Option<(bool, usize)> = None;
+        if b >= 0x80 {
+            let b1 = *src.add(i + 1);
+            let b2 = *src.add(i + 2);
+            trivia = match b {
+                0xc2 if b1 == 0xa0 => Some((false, 2)),
+                0xe1 if b1 == 0x9a && b2 == 0x80 => Some((false, 3)),
+                0xe2 if b1 == 0x80 && ((0x80..=0x8a).contains(&b2) || b2 == 0xaf) => {
+                    Some((false, 3))
+                }
+                0xe2 if b1 == 0x80 && (b2 == 0xa8 || b2 == 0xa9) => Some((true, 3)),
+                0xe2 if b1 == 0x81 && b2 == 0x9f => Some((false, 3)),
+                0xe3 if b1 == 0x80 && b2 == 0x80 => Some((false, 3)),
+                0xef if b1 == 0xbb && b2 == 0xbf => Some((false, 3)),
+                _ => None,
+            };
+        }
+        if let Some((nl, w)) = trivia {
+            if nl {
+                nl_after = true;
+                any_nl = true;
+            }
+            i += w;
+        } else {
+            match &mut seg {
+                Some((_, se)) if *se == i => *se = i + 1,
+                _ => {
+                    seg = Some((i, i + 1));
+                    nl_after = false;
+                }
+            }
+            i += 1;
+        }
+    }
+    match seg {
+        Some((ss, se)) => RunEnd::Seg(ss, se, nl_after),
+        None => RunEnd::Blank(any_nl),
+    }
+}
+unsafe fn prev_regex_sim(
+    t: &Tables,
+    src: *const u8,
+    n: usize,
+    a: usize,
+    p: usize,
+    seed_tail: bool,
+) -> bool {
     let mut lastk: i32 = -1;
     let mut ls = 0usize;
     let mut le = 0usize;
+    let mut prevk: i32 = -1;
+    let mut pls = 0usize;
+    let mut ple = 0usize;
     let mut pos = a;
     while pos < p {
         let c = *src.add(pos);
-        if c == b'.' && pos + 1 < n && is_digit(*src.add(pos + 1)) {
-            ls = pos;
-            pos = scan_number(src, n, pos);
-            le = pos;
-            lastk = NUM as i32;
-            continue;
-        }
-        if is_digit(c) {
-            ls = pos;
-            pos = scan_number(src, n, pos);
-            le = pos;
-            lastk = NUM as i32;
-            continue;
-        }
-        if is_word(c) {
-            ls = pos;
-            while pos < n && is_word(*src.add(pos)) {
-                pos += 1;
+        let e: usize;
+        let nk: i32;
+        if is_digit(c) || (c == b'.' && pos + 1 < n && is_digit(*src.add(pos + 1))) {
+            e = scan_number(src, n, pos);
+            nk = NUM as i32;
+        } else if is_word(c) {
+            let mut w = pos;
+            while w < n && is_word(*src.add(w)) {
+                w += 1;
             }
-            le = pos;
-            lastk = IDENT as i32;
-            continue;
-        }
-        if c == b'.' || c == b'+' || c == b'-' || c == b'?' {
+            e = w;
+            nk = IDENT as i32;
+        } else if c == b'.' || c == b'+' || c == b'-' || c == b'?' {
             let b1 = *src.add(pos + 1);
             let b2 = *src.add(pos + 2);
             let b3 = *src.add(pos + 3);
@@ -72,13 +126,18 @@ unsafe fn prev_regex_sim(t: &Tables, src: *const u8, n: usize, a: usize, p: usiz
                 opl = l as usize;
                 break;
             }
-            ls = pos;
-            le = pos + opl;
-            lastk = 1000;
-            pos += opl;
-            continue;
+            e = pos + opl;
+            nk = 1000;
+        } else {
+            break;
         }
-        break;
+        prevk = lastk;
+        pls = ls;
+        ple = le;
+        ls = pos;
+        le = e;
+        lastk = nk;
+        pos = e;
     }
     if lastk == -1 {
         return true;
@@ -87,12 +146,102 @@ unsafe fn prev_regex_sim(t: &Tables, src: *const u8, n: usize, a: usize, p: usiz
         return false;
     }
     if lastk == IDENT as i32 {
-        if ls > 0 && *src.add(ls - 1) == b'.' && (ls < 2 || *src.add(ls - 2) != b'.') {
+        if prop_name(src, ls) {
             return false;
         }
-        return t.is_regex_keyword(src.add(ls), le - ls);
+        return match word_run_end(src, ls, le) {
+            RunEnd::Seg(ss, se, _) => t.is_regex_keyword(src.add(ss), se - ss),
+            RunEnd::Blank(_) => !seed_tail,
+        };
+    }
+    if le - ls == 2
+        && *src.add(ls + 1) == *src.add(ls)
+        && (*src.add(ls) == b'+' || *src.add(ls) == b'-')
+    {
+        let tail = if prevk == NUM as i32 {
+            true
+        } else if prevk == IDENT as i32 {
+            match word_run_end(src, pls, ple) {
+                RunEnd::Seg(ss, se, false) => {
+                    prop_name(src, pls)
+                        || prop_name(src, ss)
+                        || !t.is_regex_keyword(src.add(ss), se - ss)
+                }
+                RunEnd::Seg(_, _, true) => false,
+                RunEnd::Blank(true) => false,
+                RunEnd::Blank(false) => seed_tail,
+            }
+        } else if prevk == -1 {
+            seed_tail
+        } else {
+            false
+        };
+        return !tail;
     }
     !(*src.add(le - 1) == b')' || *src.add(le - 1) == b']')
+}
+unsafe fn anchor_seed_tail(
+    t: &Tables,
+    src: *const u8,
+    st: *const u64,
+    kind: *const u8,
+    n: usize,
+    anchor: usize,
+) -> bool {
+    let q = bm_prev_sig(st, kind, anchor);
+    if q < 0 {
+        return false;
+    }
+    let mut sp = q as usize;
+    {
+        let te = bm_next1(st, sp + 1, n);
+        if lt_in_range(src, te, anchor) {
+            return false;
+        }
+    }
+    for _ in 0..8 {
+        let kk = *kind.add(sp);
+        if kk >= OP_KIND_BASE {
+            let ch = *src.add(sp);
+            return ch == b')' || ch == b']';
+        }
+        if kk == IDENT
+            || kk == IDENT_ESC
+            || kk == PRIV_IDENT
+            || kk == PRIV_IDENT_ESC
+            || kk == NUM
+            || kk == BIGINT
+        {
+            let e = bm_next1(st, sp + 1, n);
+            match word_run_end(src, sp, e) {
+                RunEnd::Seg(_, _, true) => return false,
+                RunEnd::Seg(ss, se, false) => {
+                    if kk == NUM || kk == BIGINT {
+                        return true;
+                    }
+                    if prop_name(src, sp) || prop_name(src, ss) {
+                        return true;
+                    }
+                    return !t.is_regex_keyword(src.add(ss), se - ss);
+                }
+                RunEnd::Blank(true) => return false,
+                RunEnd::Blank(false) => {
+                    let q2 = bm_prev_sig(st, kind, sp);
+                    if q2 < 0 {
+                        return false;
+                    }
+                    let t2 = bm_next1(st, q2 as usize + 1, n);
+                    if lt_in_range(src, t2, sp) {
+                        return false;
+                    }
+                    sp = q2 as usize;
+                    continue;
+                }
+            }
+        }
+        return matches!(kk, STR | REGEX | TMPL_NOSUB | TMPL_TAIL | JEND);
+    }
+    false
 }
 /// Distance cap (in token starts) for the backward delimiter matches below;
 /// past it we fall back to the safe legacy "`}` means regex" answer. Only
@@ -101,7 +250,7 @@ const BRACE_MATCH_CAP: u32 = 1024;
 /// Previous significant token start before `pos` (skipping trivia), or -1 at
 /// start of input.
 #[inline]
-unsafe fn bm_prev_sig(st: *const u64, kind: *const u8, pos: usize) -> i64 {
+pub(super) unsafe fn bm_prev_sig(st: *const u64, kind: *const u8, pos: usize) -> i64 {
     let mut q = bm_prev1(st, pos);
     while q >= 0 {
         let k = *kind.add(q as usize);
@@ -138,29 +287,210 @@ fn is_operand_punct(ch: u8) -> bool {
             | b'<'
     )
 }
+pub(super) unsafe fn lt_in_range(src: *const u8, a: usize, b: usize) -> bool {
+    let mut i = a;
+    while i < b {
+        let c = *src.add(i);
+        if c == b'\n' || c == b'\r' {
+            return true;
+        }
+        if c == 0xe2
+            && *src.add(i + 1) == 0x80
+            && (*src.add(i + 2) == 0xa8 || *src.add(i + 2) == 0xa9)
+        {
+            return true;
+        }
+        i += 1;
+    }
+    false
+}
 /// Is the token at `pos` in operand (expression-only) position? Strict
 /// whitelist; anything else returns false. Deliberately not `prev_is_regex`:
 /// a regex may follow `;`/`:`/`else`, but a `{` there is a block, so reusing
 /// it would be unsound. Complement of acorn's `braceIsBlock`.
 #[inline]
-unsafe fn operand_position(src: *const u8, st: *const u64, kind: *const u8, pos: usize) -> bool {
+pub(super) unsafe fn operand_position(
+    t: &Tables,
+    src: *const u8,
+    st: *const u64,
+    kind: *const u8,
+    n: usize,
+    pos: usize,
+    ts: bool,
+    depth: u32,
+) -> bool {
+    operand_position_at(t, src, st, kind, n, pos, ts, depth, 0)
+}
+unsafe fn operand_position_at(
+    t: &Tables,
+    src: *const u8,
+    st: *const u64,
+    kind: *const u8,
+    n: usize,
+    pos: usize,
+    ts: bool,
+    depth: u32,
+    hops: u32,
+) -> bool {
+    if hops > 8 || depth > 8 {
+        return false;
+    }
     let q = bm_prev_sig(st, kind, pos);
     if q < 0 {
         return false; // start of input => statement position
     }
     let p = q as usize;
     if *kind.add(p) < OP_KIND_BASE {
-        // Of the value kinds, only a template substitution (`${ {..} }`)
-        // puts what follows in operand position.
         let k = *kind.add(p);
-        return k == TMPL_HEAD || k == TMPL_MIDDLE;
+        if k == TMPL_HEAD || k == TMPL_MIDDLE {
+            return true;
+        }
+        if k == IDENT && !prop_name(src, p) {
+            if ident_is(src, p, b"new")
+                || ident_is(src, p, b"typeof")
+                || ident_is(src, p, b"void")
+                || ident_is(src, p, b"delete")
+                || ident_is(src, p, b"in")
+                || ident_is(src, p, b"instanceof")
+                || ident_is(src, p, b"case")
+            {
+                return true;
+            }
+            if ident_is(src, p, b"return")
+                || ident_is(src, p, b"throw")
+                || ident_is(src, p, b"yield")
+                || ident_is(src, p, b"await")
+            {
+                let e = bm_next1(st, p + 1, n);
+                return !lt_in_range(src, e, pos);
+            }
+            if ident_is(src, p, b"async") && ident_is(src, pos, b"function") {
+                let e = bm_next1(st, p + 1, n);
+                if !lt_in_range(src, e, pos) {
+                    return operand_position_at(t, src, st, kind, n, p, ts, depth, hops + 1);
+                }
+                return false;
+            }
+        }
+        if let Some(at) = decorator_start(src, st, kind, p) {
+            return operand_position_at(t, src, st, kind, n, at, ts, depth, hops + 1);
+        }
+        return false;
     }
-    is_operand_punct(*src.add(p))
+    let ch = *src.add(p);
+    if is_operand_punct(ch) {
+        return true;
+    }
+    if ch == b':' {
+        return colon_marks_value(t, src, st, kind, n, p, ts, depth);
+    }
+    if ch == b')' {
+        if let Some(at) = decorator_start(src, st, kind, p) {
+            return operand_position_at(t, src, st, kind, n, at, ts, depth, hops + 1);
+        }
+    }
+    false
+}
+unsafe fn colon_marks_value(
+    t: &Tables,
+    src: *const u8,
+    st: *const u64,
+    kind: *const u8,
+    n: usize,
+    colon: usize,
+    ts: bool,
+    depth: u32,
+) -> bool {
+    if depth > 8 {
+        return false;
+    }
+    let mut debt: u32 = 0;
+    let mut steps: u32 = 0;
+    let mut q = bm_prev_sig(st, kind, colon);
+    while q >= 0 {
+        steps += 1;
+        if steps > BRACE_MATCH_CAP {
+            return false;
+        }
+        let w = q as usize;
+        if *kind.add(w) >= OP_KIND_BASE {
+            match *src.add(w) {
+                c @ (b')' | b']' | b'}') => {
+                    let open = match c {
+                        b')' => b'(',
+                        b']' => b'[',
+                        _ => b'{',
+                    };
+                    match match_delim_back(src, st, kind, w, open, c) {
+                        Some(op) => {
+                            q = bm_prev_sig(st, kind, op);
+                            continue;
+                        }
+                        None => return false,
+                    }
+                }
+                b'{' => {
+                    return brace_opens_value(t, src, st, kind, n, w, ts, depth + 1);
+                }
+                b'(' | b'[' | b';' => return false,
+                b':' => debt += 1,
+                b'?' => {
+                    if *src.add(w + 1) != b'?'
+                        && *src.add(w + 1) != b'.'
+                        && (w == 0 || *src.add(w - 1) != b'?')
+                    {
+                        if debt == 0 {
+                            return true;
+                        }
+                        debt -= 1;
+                    }
+                }
+                _ => {}
+            }
+        }
+        q = bm_prev_sig(st, kind, w);
+    }
+    false
+}
+unsafe fn decorator_start(
+    src: *const u8,
+    st: *const u64,
+    kind: *const u8,
+    p: usize,
+) -> Option<usize> {
+    let mut q = p as i64;
+    let mut steps: u32 = 0;
+    while q >= 0 {
+        steps += 1;
+        if steps > 32 {
+            return None;
+        }
+        let w = q as usize;
+        let kk = *kind.add(w);
+        if kk >= OP_KIND_BASE {
+            let c = *src.add(w);
+            if c == b'@' {
+                return Some(w);
+            }
+            if c == b')' {
+                let lp = match_delim_back(src, st, kind, w, b'(', b')')?;
+                q = bm_prev_sig(st, kind, lp);
+                continue;
+            }
+            if c != b'.' {
+                return None;
+            }
+        } else if kk != IDENT {
+            return None;
+        }
+        q = bm_prev_sig(st, kind, w);
+    }
+    None
 }
 /// Does the identifier at `pos` equal exactly `kw`? The following-byte check
 /// rejects longer identifiers (the source pad makes it safe at EOF).
 #[inline]
-unsafe fn ident_is(src: *const u8, pos: usize, kw: &[u8]) -> bool {
+pub(super) unsafe fn ident_is(src: *const u8, pos: usize, kw: &[u8]) -> bool {
     let mut i = 0;
     while i < kw.len() {
         if *src.add(pos + i) != kw[i] {
@@ -170,11 +500,117 @@ unsafe fn ident_is(src: *const u8, pos: usize, kw: &[u8]) -> bool {
     }
     !is_word(*src.add(pos + kw.len()))
 }
+enum AngleMatch {
+    Found(usize),
+    NotType,
+    Unknown,
+}
+unsafe fn angle_match_back(
+    src: *const u8,
+    st: *const u64,
+    kind: *const u8,
+    gt: usize,
+) -> AngleMatch {
+    let mut depth: i32 = 1;
+    let mut tmpl: i32 = 0;
+    let mut steps: u32 = 0;
+    let mut q = bm_prev_sig(st, kind, gt);
+    while q >= 0 {
+        steps += 1;
+        if steps > 128 {
+            return AngleMatch::Unknown;
+        }
+        let w = q as usize;
+        let kk = *kind.add(w);
+        if tmpl > 0 {
+            if kk == TMPL_TAIL {
+                tmpl += 1;
+            } else if kk == TMPL_HEAD {
+                tmpl -= 1;
+            }
+            q = bm_prev_sig(st, kind, w);
+            continue;
+        }
+        if kk == TMPL_TAIL {
+            tmpl = 1;
+            q = bm_prev_sig(st, kind, w);
+            continue;
+        }
+        if kk >= OP_KIND_BASE {
+            let c = *src.add(w);
+            match c {
+                b'>' => {
+                    if !(w > 0 && *src.add(w - 1) == b'=') {
+                        depth += 1;
+                    }
+                }
+                b'<' => {
+                    if *src.add(w + 1) == b'=' {
+                        return AngleMatch::NotType;
+                    }
+                    depth -= 1;
+                    if depth == 0 {
+                        return AngleMatch::Found(w);
+                    }
+                }
+                b')' | b']' | b'}' => {
+                    let open = match c {
+                        b')' => b'(',
+                        b']' => b'[',
+                        _ => b'{',
+                    };
+                    match match_delim_back(src, st, kind, w, open, c) {
+                        Some(op) => {
+                            q = bm_prev_sig(st, kind, op);
+                            continue;
+                        }
+                        None => return AngleMatch::Unknown,
+                    }
+                }
+                b'(' | b'[' | b'{' | b';' => return AngleMatch::NotType,
+                b'.' | b',' | b'|' | b'&' | b'?' | b':' | b'=' | b'+' | b'-' => {}
+                _ => return AngleMatch::NotType,
+            }
+        } else if !matches!(kk, IDENT | IDENT_ESC | NUM | BIGINT | STR | TMPL_NOSUB) {
+            if kk == TMPL_HEAD || kk == TMPL_MIDDLE {
+                return AngleMatch::Unknown;
+            }
+            return AngleMatch::NotType;
+        }
+        q = bm_prev_sig(st, kind, w);
+    }
+    AngleMatch::NotType
+}
+unsafe fn chain_head(
+    src: *const u8,
+    st: *const u64,
+    kind: *const u8,
+    from: usize,
+) -> Option<usize> {
+    let mut head = from;
+    let mut steps: u32 = 0;
+    while prop_name(src, head) {
+        steps += 1;
+        if steps > 32 {
+            return None;
+        }
+        let d = bm_prev_sig(st, kind, head);
+        if d < 0 {
+            return None;
+        }
+        let o = bm_prev_sig(st, kind, d as usize);
+        if o < 0 || *kind.add(o as usize) != IDENT {
+            return None;
+        }
+        head = o as usize;
+    }
+    Some(head)
+}
 /// Match the close punctuator at `from` back to its opener, counting only
 /// punctuator delimiters — template-closing `}`s and cleared literal
 /// interiors are invisible. None if unbalanced or past the cap.
 #[inline]
-unsafe fn match_delim_back(
+pub(super) unsafe fn match_delim_back(
     src: *const u8,
     st: *const u64,
     kind: *const u8,
@@ -206,54 +642,460 @@ unsafe fn match_delim_back(
     }
     None
 }
-/// Does the `{` at `brace` open a value (object literal or function-
-/// expression body) rather than a block? Class expressions and TS `as {..}`
-/// are not handled; they fall back to regex, same as legacy.
 #[inline]
-unsafe fn brace_opens_value(src: *const u8, st: *const u64, kind: *const u8, brace: usize) -> bool {
+unsafe fn brace_opens_value(
+    t: &Tables,
+    src: *const u8,
+    st: *const u64,
+    kind: *const u8,
+    n: usize,
+    brace: usize,
+    ts: bool,
+    depth: u32,
+) -> bool {
+    if depth > 8 {
+        return false;
+    }
+    if operand_position(t, src, st, kind, n, brace, ts, depth) {
+        return true;
+    }
     let q = bm_prev_sig(st, kind, brace);
     if q < 0 {
         return false; // start of input => block
     }
     let p = q as usize;
-    if *kind.add(p) < OP_KIND_BASE {
-        let k = *kind.add(p);
-        return k == TMPL_HEAD || k == TMPL_MIDDLE; // `${ {..} }`
-    }
-    let ch = *src.add(p);
-    if is_operand_punct(ch) {
-        return true; // object literal in operand position
-    }
-    // `{` preceded by `)` may be a function-expression body:
-    // `function (..) { } /`. Match the `)` to its `(`; if an anonymous
-    // `function` sits before the `(` in operand position, the `{}` is a
-    // value and the `/` is division.
-    if ch == b')' {
-        if let Some(lp) = match_delim_back(src, st, kind, p, b'(', b')') {
-            let w = bm_prev_sig(st, kind, lp);
-            if w >= 0 {
-                let wp = w as usize;
-                if *kind.add(wp) < OP_KIND_BASE
-                    && ident_is(src, wp, b"function")
-                    && operand_position(src, st, kind, wp)
-                {
-                    return true;
+    if *kind.add(p) >= OP_KIND_BASE {
+        let ch = *src.add(p);
+        if ch == b'>' {
+            if p > 0 && *src.add(p - 1) == b'=' {
+                return false;
+            }
+            if !ts {
+                return true;
+            }
+            return ts_gt_brace_value(t, src, st, kind, n, p, depth);
+        }
+        if ch == b')' {
+            if let Some(lp) = match_delim_back(src, st, kind, p, b'(', b')') {
+                let w = bm_prev_sig(st, kind, lp);
+                if w >= 0 {
+                    let wp = w as usize;
+                    if *kind.add(wp) < OP_KIND_BASE
+                        && ident_is(src, wp, b"function")
+                        && operand_position(t, src, st, kind, n, wp, ts, depth)
+                    {
+                        return true;
+                    }
                 }
             }
         }
     }
+    if ts
+        && *kind.add(p) == IDENT
+        && !prop_name(src, p)
+        && (ident_is(src, p, b"as") || ident_is(src, p, b"satisfies"))
+        && tail_or_brace_before(t, src, st, kind, n, p)
+    {
+        return true;
+    }
+    class_brace_is_value(t, src, st, kind, n, brace, ts, depth)
+}
+const CLASS_WALK_CAP: u32 = 64;
+unsafe fn class_brace_is_value(
+    t: &Tables,
+    src: *const u8,
+    st: *const u64,
+    kind: *const u8,
+    n: usize,
+    brace: usize,
+    ts: bool,
+    depth: u32,
+) -> bool {
+    class_walk_from(t, src, st, kind, n, bm_prev_sig(st, kind, brace), ts, depth)
+}
+unsafe fn class_walk_from(
+    t: &Tables,
+    src: *const u8,
+    st: *const u64,
+    kind: *const u8,
+    n: usize,
+    start: i64,
+    ts: bool,
+    depth: u32,
+) -> bool {
+    let mut q = start;
+    let mut steps: u32 = 0;
+    let mut crossed_obj = false;
+    let mut pending_comma = false;
+    while q >= 0 {
+        steps += 1;
+        if steps > CLASS_WALK_CAP {
+            return false;
+        }
+        let w = q as usize;
+        let kk = *kind.add(w);
+        if kk >= OP_KIND_BASE {
+            let c = *src.add(w);
+            if c == b')' || c == b']' {
+                let open = if c == b')' { b'(' } else { b'[' };
+                match match_delim_back(src, st, kind, w, open, c) {
+                    Some(op) => {
+                        q = bm_prev_sig(st, kind, op);
+                        continue;
+                    }
+                    None => return false,
+                }
+            }
+            if c == b'}' {
+                if crossed_obj {
+                    return false;
+                }
+                let Some(ob) = match_delim_back(src, st, kind, w, b'{', b'}') else {
+                    return false;
+                };
+                let nx = bm_prev_sig(st, kind, ob);
+                if nx < 0 {
+                    return false;
+                }
+                let np = nx as usize;
+                if *kind.add(np) != IDENT || prop_name(src, np) || !ident_is(src, np, b"extends") {
+                    return false;
+                }
+                crossed_obj = true;
+                q = nx;
+                continue;
+            }
+            if ts && c == b',' {
+                pending_comma = true;
+                q = bm_prev_sig(st, kind, w);
+                continue;
+            }
+            if c == b':' {
+                return colon_return_type_value(t, src, st, kind, n, w, ts, depth)
+                    || colon_marks_value(t, src, st, kind, n, w, ts, depth);
+            }
+            if ts && c == b'>' && !(w > 0 && *src.add(w - 1) == b'=') {
+                match angle_match_back(src, st, kind, w) {
+                    AngleMatch::Found(lt) => {
+                        q = bm_prev_sig(st, kind, lt);
+                        continue;
+                    }
+                    _ => return false,
+                }
+            }
+            if c != b'.' && c != b'?' {
+                return false;
+            }
+        } else if kk == IDENT {
+            if !prop_name(src, w) {
+                if ident_is(src, w, b"class") {
+                    if pending_comma {
+                        return false;
+                    }
+                    return operand_position(t, src, st, kind, n, w, ts, depth);
+                }
+                if ts && ident_is(src, w, b"implements") {
+                    pending_comma = false;
+                }
+            }
+        } else if !matches!(kk, NUM | BIGINT | STR | REGEX | TMPL_NOSUB) {
+            return false;
+        }
+        q = bm_prev_sig(st, kind, w);
+    }
     false
+}
+unsafe fn of_is_forof_keyword(
+    t: &Tables,
+    src: *const u8,
+    st: *const u64,
+    kind: *const u8,
+    n: usize,
+    qi: usize,
+) -> bool {
+    let q = bm_prev_sig(st, kind, qi);
+    if q < 0 {
+        return false;
+    }
+    let tp = q as usize;
+    let tk = *kind.add(tp);
+    if tk == IDENT {
+        let e = bm_next1(st, tp + 1, n);
+        if !prop_name(src, tp) && t.is_regex_keyword(src.add(tp), e - tp) {
+            return false;
+        }
+    } else if tk >= OP_KIND_BASE {
+        let c = *src.add(tp);
+        if c != b']' && c != b'}' && c != b')' {
+            return false;
+        }
+    } else {
+        return false;
+    }
+    let mut par: i32 = 0;
+    let mut brk: i32 = 0;
+    let mut brc: i32 = 0;
+    let mut steps: u32 = 0;
+    let mut w = q;
+    while w >= 0 {
+        steps += 1;
+        if steps > BRACE_MATCH_CAP {
+            return false;
+        }
+        let p = w as usize;
+        let kk = *kind.add(p);
+        if kk >= OP_KIND_BASE {
+            match *src.add(p) {
+                b')' => par += 1,
+                b']' => brk += 1,
+                b'}' => brc += 1,
+                b'(' => {
+                    if par == 0 && brk == 0 && brc == 0 {
+                        let h = bm_prev_sig(st, kind, p);
+                        if h < 0 || *kind.add(h as usize) != IDENT {
+                            return false;
+                        }
+                        let mut hp = h as usize;
+                        if ident_is(src, hp, b"await") {
+                            let h2 = bm_prev_sig(st, kind, hp);
+                            if h2 < 0 || *kind.add(h2 as usize) != IDENT {
+                                return false;
+                            }
+                            hp = h2 as usize;
+                        }
+                        return !prop_name(src, hp) && ident_is(src, hp, b"for");
+                    }
+                    par -= 1;
+                }
+                b'[' => {
+                    if brk == 0 && par == 0 && brc == 0 {
+                        return false;
+                    }
+                    brk -= 1;
+                }
+                b'{' => {
+                    if brc == 0 && par == 0 && brk == 0 {
+                        return false;
+                    }
+                    brc -= 1;
+                }
+                _ => {}
+            }
+        } else if kk == IDENT
+            && par == 0
+            && brk == 0
+            && brc == 0
+            && !prop_name(src, p)
+            && ident_is(src, p, b"of")
+        {
+            let b = bm_prev_sig(st, kind, p);
+            if b >= 0 {
+                let bp = b as usize;
+                let bk = *kind.add(bp);
+                let tail = if bk == IDENT {
+                    let be = bm_next1(st, bp + 1, n);
+                    prop_name(src, bp) || !t.is_regex_keyword(src.add(bp), be - bp)
+                } else {
+                    bk >= OP_KIND_BASE && matches!(*src.add(bp), b']' | b'}' | b')')
+                };
+                if tail {
+                    return false;
+                }
+            }
+        }
+        w = bm_prev_sig(st, kind, p);
+    }
+    false
+}
+unsafe fn colon_return_type_value(
+    t: &Tables,
+    src: *const u8,
+    st: *const u64,
+    kind: *const u8,
+    n: usize,
+    colon: usize,
+    ts: bool,
+    depth: u32,
+) -> bool {
+    let q = bm_prev_sig(st, kind, colon);
+    if q < 0 || *kind.add(q as usize) < OP_KIND_BASE || *src.add(q as usize) != b')' {
+        return false;
+    }
+    let Some(lp) = match_delim_back(src, st, kind, q as usize, b'(', b')') else {
+        return false;
+    };
+    let w = bm_prev_sig(st, kind, lp);
+    if w < 0 {
+        return false;
+    }
+    let wp = w as usize;
+    *kind.add(wp) < OP_KIND_BASE
+        && !prop_name(src, wp)
+        && ident_is(src, wp, b"function")
+        && operand_position(t, src, st, kind, n, wp, ts, depth)
+}
+pub(super) unsafe fn tail_before(
+    t: &Tables,
+    src: *const u8,
+    st: *const u64,
+    kind: *const u8,
+    n: usize,
+    pos: usize,
+) -> bool {
+    let s = bm_prev_sig(st, kind, pos);
+    if s < 0 {
+        return false;
+    }
+    let sp = s as usize;
+    let sk = *kind.add(sp);
+    if sk >= OP_KIND_BASE {
+        return matches!(*src.add(sp), b')' | b']');
+    }
+    if sk == IDENT {
+        let e = bm_next1(st, sp + 1, n);
+        return prop_name(src, sp) || !t.is_regex_keyword(src.add(sp), e - sp);
+    }
+    matches!(sk, NUM | BIGINT | STR | TMPL_NOSUB | TMPL_TAIL | REGEX | PRIV_IDENT)
+}
+unsafe fn tail_or_brace_before(
+    t: &Tables,
+    src: *const u8,
+    st: *const u64,
+    kind: *const u8,
+    n: usize,
+    pos: usize,
+) -> bool {
+    if tail_before(t, src, st, kind, n, pos) {
+        return true;
+    }
+    let s = bm_prev_sig(st, kind, pos);
+    s >= 0 && *kind.add(s as usize) >= OP_KIND_BASE && *src.add(s as usize) == b'}'
+}
+unsafe fn as_gated_type_ref(
+    t: &Tables,
+    src: *const u8,
+    st: *const u64,
+    kind: *const u8,
+    n: usize,
+    lt: usize,
+) -> bool {
+    let b = bm_prev_sig(st, kind, lt);
+    if b < 0 || *kind.add(b as usize) != IDENT {
+        return false;
+    }
+    let Some(head) = chain_head(src, st, kind, b as usize) else {
+        return false;
+    };
+    let a = bm_prev_sig(st, kind, head);
+    if a < 0 {
+        return false;
+    }
+    let ap = a as usize;
+    if *kind.add(ap) != IDENT
+        || prop_name(src, ap)
+        || !(ident_is(src, ap, b"as") || ident_is(src, ap, b"satisfies"))
+    {
+        return false;
+    }
+    tail_or_brace_before(t, src, st, kind, n, ap)
+}
+unsafe fn ts_gt_brace_value(
+    t: &Tables,
+    src: *const u8,
+    st: *const u64,
+    kind: *const u8,
+    n: usize,
+    gt: usize,
+    depth: u32,
+) -> bool {
+    let lt = match angle_match_back(src, st, kind, gt) {
+        AngleMatch::Found(lt) => lt,
+        AngleMatch::NotType => return true,
+        AngleMatch::Unknown => return false,
+    };
+    let b = bm_prev_sig(st, kind, lt);
+    if b < 0 {
+        return true;
+    }
+    let bp = b as usize;
+    if *kind.add(bp) != IDENT {
+        return true;
+    }
+    let Some(head) = chain_head(src, st, kind, bp) else {
+        return false;
+    };
+    let tq = bm_prev_sig(st, kind, head);
+    if tq < 0 {
+        return true;
+    }
+    let tp = tq as usize;
+    let tk = *kind.add(tp);
+    if tk == IDENT && !prop_name(src, tp) {
+        if ident_is(src, tp, b"class") {
+            return operand_position(t, src, st, kind, n, tp, true, depth);
+        }
+        if ident_is(src, tp, b"interface") {
+            return false;
+        }
+        if ident_is(src, tp, b"extends") || ident_is(src, tp, b"implements") {
+            return class_walk_from(t, src, st, kind, n, tq, true, depth);
+        }
+        let e = bm_next1(st, tp + 1, n);
+        if t.is_regex_keyword(src.add(tp), e - tp) {
+            return true;
+        }
+        return false;
+    }
+    if tk >= OP_KIND_BASE && *src.add(tp) == b':' {
+        return colon_return_type_value(t, src, st, kind, n, tp, true, depth);
+    }
+    true
+}
+unsafe fn paren_close_is_regex(src: *const u8, st: *const u64, kind: *const u8, qi: usize) -> bool {
+    let Some(lp) = match_delim_back(src, st, kind, qi, b'(', b')') else {
+        return false;
+    };
+    let q = bm_prev_sig(st, kind, lp);
+    if q < 0 {
+        return false;
+    }
+    let mut w = q as usize;
+    if *kind.add(w) != IDENT {
+        return false;
+    }
+    if ident_is(src, w, b"await") {
+        let q2 = bm_prev_sig(st, kind, w);
+        if q2 < 0 || *kind.add(q2 as usize) != IDENT {
+            return false;
+        }
+        w = q2 as usize;
+        return !prop_name(src, w) && ident_is(src, w, b"for");
+    }
+    !prop_name(src, w)
+        && (ident_is(src, w, b"if")
+            || ident_is(src, w, b"while")
+            || ident_is(src, w, b"for")
+            || ident_is(src, w, b"with"))
 }
 /// A `/` right after `}`: regex if the `}` closed a block, division if it
 /// closed a value. Cold; any uncertainty falls back to regex (the legacy
 /// answer), which can never introduce a stream-swallowing regex.
 #[inline]
-unsafe fn brace_close_is_regex(src: *const u8, st: *const u64, kind: *const u8, qi: usize) -> bool {
+unsafe fn brace_close_is_regex(
+    t: &Tables,
+    src: *const u8,
+    st: *const u64,
+    kind: *const u8,
+    n: usize,
+    qi: usize,
+    ts: bool,
+) -> bool {
     match match_delim_back(src, st, kind, qi, b'{', b'}') {
-        Some(brace) => !brace_opens_value(src, st, kind, brace),
+        Some(brace) => !brace_opens_value(t, src, st, kind, n, brace, ts, 0),
         None => true, // unbalanced / cap => fallback regex
     }
 }
+
 pub(super) unsafe fn prev_is_regex(
     t: &Tables,
     src: *const u8,
@@ -264,6 +1106,7 @@ pub(super) unsafe fn prev_is_regex(
     n: usize,
     p: usize,
     ts: bool,
+    module: bool,
 ) -> bool {
     let mut q = bm_prev1(st, p);
     while q >= 0 {
@@ -294,14 +1137,38 @@ pub(super) unsafe fn prev_is_regex(
             if de >= we {
                 return false;
             }
-            return prev_regex_sim(t, src, n, glue_anchor(src, st, qi), p);
+            let a = glue_anchor(src, st, qi);
+            return prev_regex_sim(t, src, n, a, p, anchor_seed_tail(t, src, st, kind, n, a));
         }
         if k == IDENT {
-            if qi > 0 && *src.add(qi - 1) == b'.' && (qi < 2 || *src.add(qi - 2) != b'.') {
+            if prop_name(src, qi) {
                 return false;
             }
             let e = bm_next1(st, qi + 1, n);
-            return t.is_regex_keyword(src.add(qi), e - qi);
+            let (ws, we) = match word_run_end(src, qi, e) {
+                RunEnd::Seg(ss, se, _) => (ss, se),
+                RunEnd::Blank(_) => {
+                    q = bm_prev1(st, qi);
+                    continue;
+                }
+            };
+            if t.is_regex_keyword(src.add(ws), we - ws) {
+                if !module && we - ws == 5 {
+                    if ident_is(src, ws, b"yield") {
+                        return super::replay::replay_is_keyword(
+                            t, src, st, kind, n, qi, ts, false,
+                        );
+                    }
+                    if ident_is(src, ws, b"await") {
+                        return super::replay::replay_is_keyword(t, src, st, kind, n, qi, ts, true);
+                    }
+                }
+                return true;
+            }
+            if we - ws == 2 && *src.add(ws) == b'o' && *src.add(ws + 1) == b'f' {
+                return of_is_forof_keyword(t, src, st, kind, n, qi);
+            }
+            return false;
         }
         if k >= OP_KIND_BASE {
             let ch = *src.add(qi);
@@ -324,15 +1191,451 @@ pub(super) unsafe fn prev_is_regex(
                 continue;
             }
             if ch == b'.' || ch == b'+' || ch == b'-' {
-                return prev_regex_sim(t, src, n, glue_anchor(src, st, qi), p);
+                let a = glue_anchor(src, st, qi);
+                return prev_regex_sim(t, src, n, a, p, anchor_seed_tail(t, src, st, kind, n, a));
             }
             // `}` closed either a block (regex follows) or a value (division).
             if ch == b'}' {
-                return brace_close_is_regex(src, st, kind, qi);
+                return brace_close_is_regex(t, src, st, kind, n, qi, ts);
             }
-            return !(ch == b')' || ch == b']');
+            if ch == b')' {
+                return paren_close_is_regex(src, st, kind, qi);
+            }
+            if ts && ch == b'>' && !(qi > 0 && *src.add(qi - 1) == b'=') {
+                if let AngleMatch::Found(lt) = angle_match_back(src, st, kind, qi) {
+                    if as_gated_type_ref(t, src, st, kind, n, lt) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            return ch != b']';
         }
         return true;
     }
     true
+}
+#[cfg(test)]
+mod tests {
+    use crate::options::default_options;
+    use crate::token::token_kind as k;
+    use crate::{Lexer, PAD};
+
+    fn kinds_of(code: &str, ts: bool, jsx: bool) -> Vec<u8> {
+        let mut buf = code.as_bytes().to_vec();
+        let n = buf.len();
+        buf.resize(n + PAD, 0);
+        let mut opts = default_options();
+        opts.ts = ts;
+        opts.jsx = jsx;
+        let mut lx = Lexer::new();
+        let count = lx.lex(&buf, n, opts);
+        lx.kinds[..count - 1].iter().copied().filter(|&kk| !crate::is_trivia(kk)).collect()
+    }
+
+    #[track_caller]
+    fn regex(code: &str, ts: bool) {
+        let ks = kinds_of(code, ts, false);
+        assert!(ks.contains(&k::REGEXP), "expected regex in {code:?}: kinds {ks:?}");
+    }
+
+    #[track_caller]
+    fn division(code: &str, ts: bool) {
+        let ks = kinds_of(code, ts, false);
+        assert!(!ks.contains(&k::REGEXP), "expected division in {code:?}: kinds {ks:?}");
+        assert!(ks.contains(&k::SLASH), "expected a `/` in {code:?}: kinds {ks:?}");
+    }
+
+    #[track_caller]
+    fn assert_regex(code: &str) {
+        regex(code, false);
+    }
+
+    #[track_caller]
+    fn assert_division(code: &str) {
+        division(code, false);
+    }
+
+    #[test]
+    fn debugger_precedes_regex() {
+        regex("debugger\n/re/.test(x);", false);
+        division("x.debugger / 2;", false);
+    }
+
+    #[test]
+    fn for_of_head_precedes_regex() {
+        regex("for (x of /re/) ;", false);
+        regex("for ([a, b] of /re/) ;", false);
+        regex("for ({a} of /re/) ;", false);
+        regex("for (const x of /re/) ;", false);
+        regex("for await (x of /re/) ;", false);
+        regex("for ([a, of] of /re/) ;", false);
+        division("var of = 1; of / 2;", false);
+        division("instance/of/g;", false);
+        division("for (of / 2;;) ;", false);
+        division("for (of of of / 2) ;", false);
+        division("f(x, of / 2);", false);
+    }
+
+    #[test]
+    fn unicode_ident_postfix_is_division() {
+        division("\u{53d8}\u{91cf}++ / b;", false);
+        division("\u{53d8}\u{91cf} ++ / b;", false);
+        regex("a\u{2028}++/re/.lastIndex;", false);
+        regex("a\u{2029}++/re/.lastIndex;", false);
+        division("a\u{00a0}++ / b;", false);
+        division("a\u{200a}++ / b;", false);
+        division("a\u{feff}++ / b;", false);
+        division("a\u{200d}b++ / 2;", false);
+    }
+
+    #[test]
+    fn operand_keywords_before_value_braces() {
+        division("x = typeof {} / 2;", false);
+        division("x = void {} / 2;", false);
+        division("f(new class {} / 2);", false);
+        division("return function(){} / 2;", false);
+        division("throw {} / 2;", false);
+        division("if (k in {} / 2) ;", false);
+        division("switch (x) { case class {} / 2: break; }", false);
+        regex("return\nclass C {} /re/.test(x);", false);
+        regex("export default class C {} /re/.test(x);", false);
+    }
+
+    #[test]
+    fn object_literal_heritage() {
+        division("(class C extends {valueOf(){}} {} / 2);", false);
+        division("(class extends {a:1}.constructor {} / 2);", false);
+        regex("x = class {}\n{} /re/.test(s);", false);
+        regex("x = class C extends {a:1} {}\n{} /re/.test(s);", false);
+    }
+
+    #[test]
+    fn ts_implements_heritage() {
+        division("(class C implements I, J {} / 2);", true);
+        division("(class C extends B implements I, J {} / 2);", true);
+        regex("class C implements I, J {} /re/.test(x);", true);
+        regex("x = class A {}, y\n{} /re/.test(s);", true);
+    }
+
+    #[test]
+    fn decorated_class_expression() {
+        division("x = @dec class {} / 2;", true);
+        division("x = @ns.dec() class {} / 2;", true);
+        division("f(@a @b(1) class {} / 2);", true);
+        regex("@dec class C {} /re/.test(x);", true);
+    }
+
+    #[test]
+    fn ts_angle_before_brace() {
+        division("(class C<T> {} / 2);", true);
+        division("(class C extends B<T> {} / 2);", true);
+        division("(class C<T extends {a: 1}> {} / 2);", true);
+        division("(class C<T = X> {} / 2);", true);
+        division("x = f < T > {} / re / g;", true);
+        division("x = a < b + c > {} / 2;", true);
+        division("(a > {} / 2);", true);
+        regex("class C<T> {} /re/.test(x);", true);
+        regex("interface I<T> {} /re/.test(x);", true);
+        regex("declare class C<T> {} /re/.test(x);", true);
+        regex("class C extends B<T> {}\n/re/.test(x);", true);
+    }
+
+    #[test]
+    fn brace_tail_before_as() {
+        division("let v = {a: 1} as T / y;", true);
+        division("let v = {} as A<B> / y;", true);
+        division("let v = {} satisfies T / y;", true);
+        division("let v = ({} as T) / y;", true);
+    }
+
+    #[test]
+    fn template_literal_types_cross() {
+        division("(class C<T extends `a${X}`> {} / 2);", true);
+        division("(class C<T extends `a${`b${Y}`}`> {} / 2);", true);
+        division("let v = x as A<`a${B}`> / y;", true);
+        regex("class C<T extends `a${X}`> {} /re/.test(x);", true);
+    }
+
+    #[test]
+    fn hidden_trivia_segments() {
+        division("a\u{00a0}++ / b;", false);
+        division("a\u{200a}++ / b;", false);
+        division("a\u{feff}++ / b;", false);
+        division("x = a \u{00a0}++ / b;", false);
+        regex("return\u{00a0}++/re/.lastIndex;", false);
+        division("x.\u{00a0}return++ / 2;", false);
+        regex("a\u{2028}++/re/.lastIndex;", false);
+        regex("f(a,\u{00a0}++/re/.lastIndex);", false);
+    }
+
+    #[test]
+    fn ts_as_type_brace() {
+        division("let v = x as {} / y;", true);
+        division("let v = x as {a: 1} / y;", true);
+        division("let v = f() as {} / y;", true);
+        division("let v = x satisfies {} / y;", true);
+        regex("f();\nas: {} /re/.test(s);", true);
+    }
+
+    #[test]
+    fn ts_as_angle_form() {
+        division("let v = x as A<B> / y;", true);
+        division("let v = x as a.b.C<D> / y;", true);
+        division("let v = f() as A<B<C>> / y;", true);
+        division("let v = x satisfies A<B> / y;", true);
+        regex("let q = a > /re/.source.length;", true);
+        regex("let q = (x < y) > /re/.source;", true);
+        regex("g(x => /re/.test(x));", true);
+    }
+
+    #[test]
+    fn ts_return_type_function_expr() {
+        division("x = function(): T {} / 2;", true);
+        division("x = function(): a.b.T {} / 2;", true);
+        division("x = function(): Map<A, B> {} / 2;", true);
+        division("x = async function(): T {} / 2;", true);
+        regex("function f(): T {} /re/.test(x);", true);
+        regex("function f(): Map<A, B> {} /re/.test(x);", true);
+        regex("L: {} /re/.test(x);", true);
+        regex("switch (x) { case f(y): {} /re/.test(s); }", true);
+    }
+
+    #[test]
+    fn async_function_expression_value() {
+        division("x = async function(){} / 2;", false);
+        regex("async function f(){} /re/.test(x);", false);
+    }
+
+    #[test]
+    fn slash_dense_chains() {
+        let count = |code: &str, want_re: usize, want_slash: usize| {
+            let ks = kinds_of(code, false, false);
+            let re = ks.iter().filter(|&&kk| kk == k::REGEXP).count();
+            let sl = ks.iter().filter(|&&kk| kk == k::SLASH).count();
+            assert_eq!(
+                (re, sl),
+                (want_re, want_slash),
+                "{code:?}: kinds {ks:?} (regexps, slashes)"
+            );
+        };
+        count("x = /a/g / /b/g;", 2, 1);
+        count("x = /a/ / /b/;", 2, 1);
+        count("x = a / /b/ / c;", 1, 2);
+        count("x = /a/ / b / c;", 1, 2);
+        count("x = /a/.lastIndex / 2;", 1, 1);
+        count("x /= /re/.source.length;", 1, 0);
+        count("x = /a/ instanceof /b/ ? 1 : 2;", 2, 0);
+        count("x = /a/ in /b/ ? 1 : 2;", 2, 0);
+        count("f(/a/, /b/, a / b);", 2, 1);
+        count("x = [/a/, /b/][i] / 2;", 2, 1);
+        count("x = `${/a/.source}` / 2;", 1, 1);
+    }
+
+    #[test]
+    fn colon_member_and_ternary_values() {
+        division("({a: function(){} / 2, b: 1});", false);
+        division("({a: {} / 2});", false);
+        division("({a: {b: {} / 2}});", false);
+        division("({a: class {} / 2});", false);
+        division("x = c ? y : {} / 2;", false);
+        division("x = c ? d ? a : b : {} / 2;", false);
+        regex("L: {} /re/.test(x);", false);
+        regex("{ L: function f(){} /re/ }", false);
+        regex("switch (x) { case a: function f(){} /re/ }", false);
+        regex("switch (x) { case f(y), z: {} /re/.test(s); }", false);
+        regex("c ? a : b\nL: {} /re/.test(s);", false);
+        regex("if (c) {} L: {} /re/.test(s);", false);
+    }
+
+    #[test]
+    fn postfix_incdec_then_slash_is_division() {
+        assert_division("a++ / b;");
+        assert_division("a-- / b;");
+        assert_division("a ++ / b;");
+        assert_division("x[i]++ / n;");
+        assert_division("f(x)++ / n;");
+        assert_division("a.return++ / 2;");
+        assert_division("obj.#f++ / 2;");
+        assert_division("a = b++/c/g;");
+        assert_division("a++\n/ b / c;");
+    }
+
+    #[test]
+    fn prefix_incdec_then_slash_is_regex() {
+        assert_regex("++/re/.lastIndex;");
+        assert_regex("x = ++/re/.lastIndex;");
+        assert_regex("(a, ++/re/.lastIndex);");
+        assert_regex("f(++/re/.lastIndex);");
+        assert_regex("return++/re/.lastIndex;");
+        assert_regex("a + ++/re/.lastIndex;");
+        assert_regex("a ** ++/re/.lastIndex;");
+    }
+
+    #[test]
+    fn line_terminator_forces_prefix() {
+        assert_regex("a\n++/re/.lastIndex;");
+        assert_regex("a\r\n++/re/.lastIndex;");
+        assert_regex("a\u{2028}++/re/.lastIndex;");
+        assert_regex("a\u{2029}++/re/.lastIndex;");
+        assert_regex("a /* x\ny */ ++/re/.lastIndex;");
+        assert_division("a /* xy */ ++ / b;");
+    }
+
+    #[test]
+    fn incdec_runs_keep_maximal_munch() {
+        assert_regex("a+++/re/;");
+        assert_regex("a---/re/;");
+        assert_division("a++/b/;");
+    }
+
+    #[test]
+    fn default_and_extends_precede_regex() {
+        assert_regex("export default /^x$/;");
+        assert_regex("export default /re/.source;");
+        assert_regex("class C extends /re/.constructor {}");
+        assert_division("x.default / 2;");
+        assert_division("x.extends / 2;");
+    }
+
+    #[test]
+    fn statement_head_paren_then_regex() {
+        assert_regex("if (x) /re/.test(y);");
+        assert_regex("if (f(x)) /re/.test(y);");
+        assert_regex("while (x) /re/.exec(y);");
+        assert_regex("for (;;) /re/.test(x);");
+        assert_regex("with (o) /re/.test(x);");
+        assert_regex("for await (x of y) /re/.test(x);");
+        assert_regex("do x; while (y) /re/.test(z);");
+        assert_regex("if (a) while (b) /re/.test(c);");
+    }
+
+    #[test]
+    fn value_paren_then_slash_stays_division() {
+        assert_division("f(x) / 2;");
+        assert_division("(a + b) / 2;");
+        assert_division("x.if(a) / 2;");
+        assert_division("x?.while(a) / 2;");
+        assert_division("if (a) (b) / c / d;");
+        assert_division("await (x) / 2;");
+    }
+
+    #[test]
+    fn class_expression_brace_then_slash_is_division() {
+        assert_division("(class {} / 2);");
+        assert_division("(class C {} / 2);");
+        assert_division("(class extends B {} / 2);");
+        assert_division("(class C extends B {} / 2);");
+        assert_division("(class C extends f(B) {} / 2);");
+        assert_division("(class C extends a.b[0] {} / 2);");
+        assert_division("x = class {} / 2;");
+        assert_division("f(class {m(){}} / 2);");
+        assert_division("`${class {} / 2}`;");
+    }
+
+    #[test]
+    fn class_declaration_brace_then_slash_is_regex() {
+        assert_regex("class C {} /re/.test(x);");
+        assert_regex("class C extends B {}\n/re/.test(x);");
+        assert_regex("{ class C {} } /re/.test(x);");
+    }
+
+    #[test]
+    fn block_braces_keep_the_regex_answer() {
+        assert_regex("{} /re/.test(x);");
+        assert_regex(";{} /re/.test(x);");
+        assert_regex("L: {} /re/.test(x);");
+        assert_regex("if(a){}else{} /'/.test(s);\nconst t='x';");
+        assert_regex("x = () => {}\n/re/.test(s);");
+    }
+
+    #[test]
+    fn value_braces_keep_the_division_answer() {
+        assert_division("f({} / 2);");
+        assert_division("x = function(){} / 2;");
+    }
+
+    #[test]
+    fn plain_contexts_unchanged() {
+        assert_division("a / b;");
+        assert_division("1n / 2;");
+        assert_regex("a + /re/g;");
+        assert_regex("x = /re/;");
+        assert_regex("f(/re/);");
+    }
+
+    #[test]
+    fn ts_postfix_bang_unchanged() {
+        let ks = kinds_of("x! / 2;", true, false);
+        assert!(!ks.contains(&k::REGEXP), "x! / 2 must stay division: {ks:?}");
+    }
+
+    #[test]
+    fn bare_gt_object_rhs_is_division() {
+        assert_division("x = f < T > {} / re / g;");
+        assert_division("x = a > {} / 2;");
+        assert_division("x = a >> {} / 2;");
+        assert_division("x = a >>> {} / 2;");
+        assert_division("x = a-- > {} / 2;");
+        assert_division("x = a >\n{} / 2;");
+    }
+
+    #[test]
+    fn arrow_block_bodies_still_regex() {
+        assert_regex("x = y => {}\n/re/.test(s);");
+        assert_regex("x = async () => {}\n/re/.test(s);");
+    }
+
+    #[test]
+    fn ts_angle_close_resolved() {
+        let ks = kinds_of("class C<T> {} /re/.test(x);", true, false);
+        assert!(ks.contains(&k::REGEXP), "TS class decl with type params: {ks:?}");
+        let ks = kinds_of("x = f < T > {} / re / g;", true, false);
+        assert!(!ks.contains(&k::REGEXP), "TS relational re-read must divide: {ks:?}");
+    }
+
+    #[test]
+    fn unicode_ident_tail_resolved() {
+        assert_division("\u{53d8}\u{91cf}++ / b;");
+        assert_regex("a\u{2028}++/re/.lastIndex;");
+    }
+
+    #[test]
+    fn of_trade_resolved() {
+        assert_regex("for (x of /re/) ;");
+        assert_division("var of = 1; of / 2;");
+        assert_division("instance/of/g;");
+    }
+
+    #[test]
+    fn jsx_operand_positions() {
+        let jsx = |code: &str| kinds_of(code, false, true);
+        let ks = jsx("export default <App/>;");
+        assert!(ks.contains(&k::JSX_LT), "export default <App/> must open JSX: {ks:?}");
+        let ks = jsx("if (x) <App/>;");
+        assert!(ks.contains(&k::JSX_LT), "if (x) <App/> must open JSX: {ks:?}");
+        let ks = jsx("x = a < b;");
+        assert!(!ks.contains(&k::JSX_LT), "a < b is a comparison: {ks:?}");
+        let ks = jsx("f(x) < y;");
+        assert!(!ks.contains(&k::JSX_LT), "f(x) < y is a comparison: {ks:?}");
+        let ks = jsx("a++ < b;");
+        assert!(!ks.contains(&k::JSX_LT), "a++ < b is a comparison: {ks:?}");
+        let ks = jsx("x = a > {} < b;");
+        assert!(!ks.contains(&k::JSX_LT), "a > {{}} < b is a comparison chain: {ks:?}");
+    }
+
+    #[test]
+    fn jsx_replay_oracle() {
+        let jsx = |code: &str| kinds_of(code, false, true);
+        let ks = jsx("function* items(d) { for (const x of d) yield <li id={x}/>; }");
+        assert!(ks.contains(&k::JSX_LT), "yielded JSX element must frame: {ks:?}");
+        let ks = jsx("var await = 1, max = 10;\nif (await < max) done();");
+        assert!(!ks.contains(&k::JSX_LT), "await < max is a comparison: {ks:?}");
+        assert!(ks.contains(&k::LT), "expected a plain `<`: {ks:?}");
+        let ks = jsx("async function f() { return await <Spinner/>; }");
+        assert!(ks.contains(&k::JSX_LT), "awaited JSX element must frame: {ks:?}");
+        let ks =
+            jsx("var await = 1, g = 2;\nvar el = <a b={async () => await 1} c={await /2/g}/>;");
+        assert!(!ks.contains(&k::REGEXP), "container leak, expected division: {ks:?}");
+    }
 }

--- a/crates/oxc_lexer/src/pipeline/replay.rs
+++ b/crates/oxc_lexer/src/pipeline/replay.rs
@@ -1,0 +1,913 @@
+use crate::tables::Tables;
+
+use super::bitmap::bm_next1;
+use super::regex_div::{
+    bm_prev_sig, ident_is, lt_in_range, match_delim_back, operand_position, prop_name, tail_before,
+};
+use super::{
+    BCOM, HASHBANG, IDENT, IDENT_ESC, LCOM, NUM, PRIV_IDENT, PRIV_IDENT_ESC, STR, TMPL_HEAD,
+    TMPL_MIDDLE, TMPL_NOSUB, TMPL_TAIL, WS,
+};
+use crate::opmap::OP_KIND_BASE;
+
+const POP_BRACE: u8 = 0;
+const POP_PAREN: u8 = 1;
+const POP_CONCISE: u8 = 2;
+const MAX_SCOPES: usize = 512;
+
+#[derive(Clone, Copy)]
+struct Scope {
+    is_gen: bool,
+    asyn: bool,
+    strict: bool,
+    reserved: bool,
+    is_class: bool,
+    is_obj: bool,
+    pop: u8,
+    par: i32,
+    brk: i32,
+    brc: i32,
+    tdep: i32,
+    qdebt: u32,
+}
+
+impl Scope {
+    fn child(&self) -> Scope {
+        Scope { is_class: false, is_obj: false, pop: POP_BRACE, qdebt: 0, ..*self }
+    }
+}
+
+unsafe fn async_modifier(
+    src: *const u8,
+    st: *const u64,
+    kind: *const u8,
+    n: usize,
+    pos: usize,
+    next: usize,
+) -> bool {
+    if *kind.add(pos) != IDENT || prop_name(src, pos) || !ident_is(src, pos, b"async") {
+        return false;
+    }
+    let e = bm_next1(st, pos + 1, n);
+    !lt_in_range(src, e, next)
+}
+
+unsafe fn header_kind(
+    src: *const u8,
+    st: *const u64,
+    kind: *const u8,
+    n: usize,
+    lp: usize,
+    in_class: bool,
+    in_obj: bool,
+) -> Option<(bool, bool)> {
+    let w = bm_prev_sig(st, kind, lp);
+    if w < 0 {
+        return None;
+    }
+    let mut p = w as usize;
+    if *kind.add(p) >= OP_KIND_BASE && *src.add(p) == b'*' {
+        let f = bm_prev_sig(st, kind, p);
+        if f >= 0 && *kind.add(f as usize) == IDENT && ident_is(src, f as usize, b"function") {
+            let a = bm_prev_sig(st, kind, f as usize);
+            let asyn = a >= 0 && async_modifier(src, st, kind, n, a as usize, f as usize);
+            return Some((true, asyn));
+        }
+        return None;
+    }
+    let named = if *kind.add(p) >= OP_KIND_BASE {
+        if *src.add(p) == b']' {
+            let Some(lb) = match_delim_back(src, st, kind, p, b'[', b']') else {
+                return None;
+            };
+            p = lb;
+            true
+        } else {
+            return None;
+        }
+    } else if *kind.add(p) == IDENT {
+        if ident_is(src, p, b"function") && !prop_name(src, p) && !(in_class || in_obj) {
+            let a = bm_prev_sig(st, kind, p);
+            let asyn = a >= 0 && async_modifier(src, st, kind, n, a as usize, p);
+            return Some((false, asyn));
+        }
+        let f = bm_prev_sig(st, kind, p);
+        if f >= 0 {
+            let fp = f as usize;
+            if *kind.add(fp) == IDENT && !prop_name(src, fp) && ident_is(src, fp, b"function") {
+                let a = bm_prev_sig(st, kind, fp);
+                let asyn = a >= 0 && async_modifier(src, st, kind, n, a as usize, fp);
+                return Some((false, asyn));
+            }
+            if *kind.add(fp) >= OP_KIND_BASE && *src.add(fp) == b'*' {
+                let g = bm_prev_sig(st, kind, fp);
+                if g >= 0
+                    && *kind.add(g as usize) == IDENT
+                    && ident_is(src, g as usize, b"function")
+                {
+                    let a = bm_prev_sig(st, kind, g as usize);
+                    let asyn = a >= 0 && async_modifier(src, st, kind, n, a as usize, g as usize);
+                    return Some((true, asyn));
+                }
+            }
+        }
+        true
+    } else {
+        matches!(*kind.add(p), STR | NUM | PRIV_IDENT | IDENT_ESC | PRIV_IDENT_ESC)
+    };
+    if !named || !(in_class || in_obj) {
+        return None;
+    }
+    let mut is_gen = false;
+    let mut asyn = false;
+    let mut cur = p;
+    for _ in 0..4 {
+        let m = bm_prev_sig(st, kind, cur);
+        if m < 0 {
+            break;
+        }
+        let mp = m as usize;
+        if *kind.add(mp) >= OP_KIND_BASE {
+            if *src.add(mp) == b'*' && !is_gen {
+                is_gen = true;
+                cur = mp;
+                continue;
+            }
+            break;
+        }
+        if *kind.add(mp) == IDENT && !prop_name(src, mp) {
+            if !asyn && async_modifier(src, st, kind, n, mp, cur) {
+                asyn = true;
+                cur = mp;
+                continue;
+            }
+            if ident_is(src, mp, b"get") || ident_is(src, mp, b"set") {
+                cur = mp;
+                continue;
+            }
+            if ident_is(src, mp, b"static") {
+                cur = mp;
+                continue;
+            }
+        }
+        break;
+    }
+    if is_gen || asyn {
+        let cpq = bm_prev_sig(st, kind, cur);
+        let mut method_pos = false;
+        if cpq >= 0 {
+            let cp = cpq as usize;
+            if *kind.add(cp) >= OP_KIND_BASE {
+                let c = *src.add(cp);
+                method_pos = c == b'{' || c == b',' || c == b';' || (c == b'}' && in_class);
+            }
+            if !method_pos && in_class {
+                let ce = bm_next1(st, cp + 1, n);
+                method_pos = lt_in_range(src, ce, cur);
+            }
+        }
+        if !method_pos {
+            if *kind.add(p) == IDENT && !prop_name(src, p) && ident_is(src, p, b"function") {
+                let a = bm_prev_sig(st, kind, p);
+                let asy = a >= 0 && async_modifier(src, st, kind, n, a as usize, p);
+                return Some((false, asy));
+            }
+            return None;
+        }
+    }
+    Some((is_gen, asyn))
+}
+
+unsafe fn continues_expression(src: *const u8, kind: *const u8, pos: usize, ts: bool) -> bool {
+    let k = *kind.add(pos);
+    if k >= OP_KIND_BASE {
+        let c = *src.add(pos);
+        if (c == b'+' || c == b'-') && *src.add(pos + 1) == c {
+            return false;
+        }
+        return matches!(
+            c,
+            b'+' | b'-'
+                | b'*'
+                | b'/'
+                | b'%'
+                | b'&'
+                | b'|'
+                | b'^'
+                | b'<'
+                | b'>'
+                | b'='
+                | b'?'
+                | b'.'
+                | b','
+                | b'('
+                | b'['
+                | b':'
+                | b')'
+                | b']'
+                | b'}'
+        );
+    }
+    if k == IDENT {
+        return ident_is(src, pos, b"in")
+            || ident_is(src, pos, b"instanceof")
+            || (ts && (ident_is(src, pos, b"as") || ident_is(src, pos, b"satisfies")));
+    }
+    matches!(k, TMPL_HEAD | TMPL_NOSUB)
+}
+
+unsafe fn asi_tail_before(
+    t: &Tables,
+    src: *const u8,
+    st: *const u64,
+    kind: *const u8,
+    n: usize,
+    pos: usize,
+) -> bool {
+    if tail_before(t, src, st, kind, n, pos) {
+        return true;
+    }
+    let q = bm_prev_sig(st, kind, pos);
+    if q < 0 {
+        return false;
+    }
+    let p = q as usize;
+    if *kind.add(p) < OP_KIND_BASE {
+        return false;
+    }
+    let c = *src.add(p);
+    if c == b'}' {
+        return true;
+    }
+    if (c == b'+' || c == b'-') && p > 0 && *src.add(p - 1) == c && (p < 2 || *src.add(p - 2) != c)
+    {
+        let f = p - 1;
+        if tail_before(t, src, st, kind, n, f) {
+            return true;
+        }
+        let b = bm_prev_sig(st, kind, f);
+        return b >= 0 && *kind.add(b as usize) >= OP_KIND_BASE && *src.add(b as usize) == b'}';
+    }
+    false
+}
+
+#[expect(clippy::too_many_arguments, reason = "cold walker plumbing")]
+unsafe fn asi_pop_concise(
+    t: &Tables,
+    scopes: &mut Vec<Scope>,
+    src: *const u8,
+    st: *const u64,
+    kind: *const u8,
+    n: usize,
+    prev_end: usize,
+    pos: usize,
+    par: i32,
+    brk: i32,
+    brc: i32,
+    tdepth: i32,
+    ts: bool,
+) {
+    if scopes.last().is_none_or(|s| s.pop != POP_CONCISE) {
+        return;
+    }
+    if !lt_in_range(src, prev_end, pos)
+        || continues_expression(src, kind, pos, ts)
+        || !asi_tail_before(t, src, st, kind, n, pos)
+    {
+        return;
+    }
+    while scopes.len() > 1 {
+        let top = *scopes.last().unwrap();
+        if top.pop == POP_CONCISE
+            && top.par == par
+            && top.brk == brk
+            && top.brc == brc
+            && top.tdep == tdepth
+        {
+            scopes.pop();
+            continue;
+        }
+        break;
+    }
+}
+
+unsafe fn arrow_is_async(
+    src: *const u8,
+    st: *const u64,
+    kind: *const u8,
+    n: usize,
+    gt: usize,
+) -> bool {
+    let h = bm_prev_sig(st, kind, gt.saturating_sub(1));
+    if h < 0 {
+        return false;
+    }
+    let hp = h as usize;
+    if *kind.add(hp) == IDENT {
+        let a = bm_prev_sig(st, kind, hp);
+        return a >= 0 && async_modifier(src, st, kind, n, a as usize, hp);
+    }
+    if *kind.add(hp) >= OP_KIND_BASE && *src.add(hp) == b')' {
+        if let Some(lp) = match_delim_back(src, st, kind, hp, b'(', b')') {
+            let a = bm_prev_sig(st, kind, lp);
+            return a >= 0 && async_modifier(src, st, kind, n, a as usize, lp);
+        }
+    }
+    false
+}
+
+pub(super) unsafe fn replay_is_keyword(
+    t: &Tables,
+    src: *const u8,
+    st: *const u64,
+    kind: *const u8,
+    n: usize,
+    site: usize,
+    ts: bool,
+    is_await: bool,
+) -> bool {
+    let mut scopes: Vec<Scope> = Vec::with_capacity(16);
+    scopes.push(Scope {
+        is_gen: false,
+        asyn: false,
+        strict: false,
+        reserved: false,
+        is_class: false,
+        is_obj: false,
+        pop: POP_BRACE,
+        par: 0,
+        brk: 0,
+        brc: 0,
+        tdep: 0,
+        qdebt: 0,
+    });
+    let mut par: i32 = 0;
+    let mut brk: i32 = 0;
+    let mut brc: i32 = 0;
+    let mut tdepth: i32 = 0;
+    let mut pending_class: Vec<(i32, i32, i32)> = Vec::new();
+    let mut prologue: u8 = 1;
+    let mut prev_end: usize = 0;
+
+    let mut i = 0usize;
+    loop {
+        loop {
+            i = bm_next1(st, i, n);
+            if i >= site {
+                asi_pop_concise(
+                    t,
+                    &mut scopes,
+                    src,
+                    st,
+                    kind,
+                    n,
+                    prev_end,
+                    site,
+                    par,
+                    brk,
+                    brc,
+                    tdepth,
+                    ts,
+                );
+                let top = *scopes.last().unwrap();
+                return if is_await {
+                    top.asyn || top.reserved
+                } else {
+                    top.is_gen || top.strict || top.reserved
+                };
+            }
+            let k = *kind.add(i);
+            if k == WS || k == LCOM || k == BCOM || k == HASHBANG {
+                i += 1;
+                continue;
+            }
+            break;
+        }
+        let pos = i;
+        let k = *kind.add(pos);
+        i = pos + 1;
+        asi_pop_concise(t, &mut scopes, src, st, kind, n, prev_end, pos, par, brk, brc, tdepth, ts);
+        prev_end = bm_next1(st, pos + 1, n);
+
+        if prologue != 0 {
+            if k == STR {
+                let e = bm_next1(st, pos + 1, n).min(site);
+                let mut j = e;
+                let confirmed;
+                loop {
+                    j = bm_next1(st, j, n);
+                    if j >= site {
+                        confirmed = true;
+                        break;
+                    }
+                    let jk = *kind.add(j);
+                    if jk == WS || jk == LCOM || jk == BCOM {
+                        j += 1;
+                        continue;
+                    }
+                    confirmed = (jk >= OP_KIND_BASE
+                        && (*src.add(j) == b';' || *src.add(j) == b'}'))
+                        || (lt_in_range(src, e, j) && !continues_expression(src, kind, j, ts));
+                    break;
+                }
+                if confirmed {
+                    if e - pos == 12
+                        && (ident_is(src, pos + 1, b"use strict"))
+                        && (*src.add(pos) == b'"' || *src.add(pos) == b'\'')
+                        && *src.add(e - 1) == *src.add(pos)
+                    {
+                        scopes.last_mut().unwrap().strict = true;
+                    }
+                    prologue = 2;
+                } else {
+                    prologue = 0;
+                }
+                continue;
+            }
+            if k >= OP_KIND_BASE && *src.add(pos) == b';' {
+                prologue = if prologue == 2 { 1 } else { 0 };
+            } else {
+                prologue = 0;
+            }
+        }
+
+        if k < OP_KIND_BASE {
+            if k == IDENT && !prop_name(src, pos) && ident_is(src, pos, b"class") {
+                pending_class.push((par, brk, brc));
+            } else if k == TMPL_HEAD {
+                tdepth += 1;
+            } else if k == TMPL_MIDDLE || k == TMPL_TAIL {
+                while scopes.len() > 1 {
+                    let top = *scopes.last().unwrap();
+                    if top.pop == POP_CONCISE && top.tdep == tdepth {
+                        scopes.pop();
+                        continue;
+                    }
+                    break;
+                }
+                if k == TMPL_TAIL {
+                    tdepth -= 1;
+                }
+            }
+            continue;
+        }
+        match *src.add(pos) {
+            b'(' => {
+                par += 1;
+                let enc = *scopes.last().unwrap();
+                if let Some((g, a)) = header_kind(src, st, kind, n, pos, enc.is_class, enc.is_obj) {
+                    if scopes.len() >= MAX_SCOPES {
+                        return true;
+                    }
+                    let mut s = enc.child();
+                    s.is_gen = g;
+                    s.asyn = a;
+                    s.reserved = false;
+                    s.pop = POP_PAREN;
+                    s.par = par;
+                    s.brk = brk;
+                    s.brc = brc;
+                    s.tdep = tdepth;
+                    scopes.push(s);
+                }
+            }
+            b')' => {
+                while scopes.len() > 1 {
+                    let top = *scopes.last().unwrap();
+                    if (top.pop == POP_CONCISE && par - 1 < top.par)
+                        || (top.pop == POP_PAREN && top.par == par)
+                    {
+                        scopes.pop();
+                        continue;
+                    }
+                    break;
+                }
+                par -= 1;
+            }
+            b'[' => brk += 1,
+            b']' => {
+                while scopes.len() > 1 {
+                    let top = *scopes.last().unwrap();
+                    if top.pop == POP_CONCISE && brk - 1 < top.brk {
+                        scopes.pop();
+                        continue;
+                    }
+                    break;
+                }
+                brk -= 1;
+            }
+            b'{' => {
+                brc += 1;
+                if scopes.len() >= MAX_SCOPES {
+                    return true;
+                }
+                let enc = *scopes.last().unwrap();
+                let q = bm_prev_sig(st, kind, pos);
+                let mut s = enc.child();
+                s.par = par;
+                s.brk = brk;
+                s.brc = brc;
+                s.tdep = tdepth;
+                let mut opened_body = false;
+                if q >= 0 {
+                    let p = q as usize;
+                    let pk = *kind.add(p);
+                    if pk >= OP_KIND_BASE {
+                        let pb = *src.add(p);
+                        if pb == b'>' && p > 0 && *src.add(p - 1) == b'=' {
+                            s.is_gen = false;
+                            s.asyn = arrow_is_async(src, st, kind, n, p);
+                            s.reserved = false;
+                            opened_body = true;
+                        } else if pb == b')' {
+                            if let Some(lp) = match_delim_back(src, st, kind, p, b'(', b')') {
+                                if let Some((g, a)) =
+                                    header_kind(src, st, kind, n, lp, enc.is_class, enc.is_obj)
+                                {
+                                    s.is_gen = g;
+                                    s.asyn = a;
+                                    s.reserved = false;
+                                    opened_body = true;
+                                }
+                            }
+                        }
+                    }
+                    if !opened_body
+                        && pk == IDENT
+                        && enc.is_class
+                        && !prop_name(src, p)
+                        && ident_is(src, p, b"static")
+                    {
+                        s.reserved = true;
+                        s.strict = true;
+                        opened_body = true;
+                    }
+                    if !opened_body
+                        && !pending_class.is_empty()
+                        && pk == IDENT
+                        && !prop_name(src, p)
+                        && ident_is(src, p, b"extends")
+                    {
+                        s.is_obj = true;
+                        opened_body = true;
+                    }
+                }
+                if !opened_body && !pending_class.is_empty() {
+                    pending_class.pop();
+                    s.strict = true;
+                    s.is_class = true;
+                    s.reserved = false;
+                    opened_body = true;
+                }
+                if !opened_body && operand_position(t, src, st, kind, n, pos, ts, 0) {
+                    s.is_obj = true;
+                    opened_body = true;
+                }
+                let is_scope_start = opened_body && !s.is_obj && !s.is_class;
+                scopes.push(s);
+                if is_scope_start {
+                    prologue = 1;
+                }
+            }
+            b'}' => {
+                while scopes.len() > 1 {
+                    let top = *scopes.last().unwrap();
+                    if top.pop == POP_CONCISE && brc - 1 < top.brc {
+                        scopes.pop();
+                        continue;
+                    }
+                    break;
+                }
+                if scopes.len() <= 1 {
+                    return true;
+                }
+                scopes.pop();
+                brc -= 1;
+            }
+            b'>' if pos > 0 && *src.add(pos - 1) == b'=' => {
+                let mut j = pos + 1;
+                let mut concise = true;
+                loop {
+                    j = bm_next1(st, j, n);
+                    if j >= site.min(n) {
+                        break;
+                    }
+                    let jk = *kind.add(j);
+                    if jk == WS || jk == LCOM || jk == BCOM {
+                        j += 1;
+                        continue;
+                    }
+                    concise = !(jk >= OP_KIND_BASE && *src.add(j) == b'{');
+                    break;
+                }
+                if concise {
+                    if scopes.len() >= MAX_SCOPES {
+                        return true;
+                    }
+                    let enc = *scopes.last().unwrap();
+                    let mut s = enc.child();
+                    s.is_gen = false;
+                    s.asyn = arrow_is_async(src, st, kind, n, pos);
+                    s.reserved = false;
+                    s.pop = POP_CONCISE;
+                    s.par = par;
+                    s.brk = brk;
+                    s.brc = brc;
+                    s.tdep = tdepth;
+                    scopes.push(s);
+                }
+            }
+            b'?' => {
+                if *src.add(pos + 1) != b'?'
+                    && *src.add(pos + 1) != b'.'
+                    && (pos == 0 || *src.add(pos - 1) != b'?')
+                {
+                    if let Some(top) = scopes.last_mut() {
+                        if top.pop == POP_CONCISE
+                            && top.par == par
+                            && top.brk == brk
+                            && top.brc == brc
+                            && top.tdep == tdepth
+                        {
+                            top.qdebt += 1;
+                        }
+                    }
+                }
+            }
+            b',' | b';' | b':' => {
+                let is_colon = *src.add(pos) == b':';
+                while scopes.len() > 1 {
+                    let top = *scopes.last().unwrap();
+                    if top.pop == POP_CONCISE && top.par == par && top.brk == brk && top.brc == brc
+                    {
+                        if is_colon && top.qdebt > 0 {
+                            scopes.last_mut().unwrap().qdebt -= 1;
+                            break;
+                        }
+                        scopes.pop();
+                        continue;
+                    }
+                    break;
+                }
+                while let Some(&(cp, ck, cb)) = pending_class.last() {
+                    if cp == par && ck == brk && cb == brc {
+                        pending_class.pop();
+                        continue;
+                    }
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::options::default_options;
+    use crate::token::token_kind as k;
+    use crate::{Lexer, PAD};
+
+    fn kinds_of(code: &str, module: bool) -> Vec<u8> {
+        let mut buf = code.as_bytes().to_vec();
+        let n = buf.len();
+        buf.resize(n + PAD, 0);
+        let mut opts = default_options();
+        opts.source_type_module = module;
+        let mut lx = Lexer::new();
+        let count = lx.lex(&buf, n, opts);
+        lx.kinds[..count - 1].iter().copied().filter(|&kk| !crate::is_trivia(kk)).collect()
+    }
+
+    #[track_caller]
+    fn regex(code: &str) {
+        let ks = kinds_of(code, false);
+        assert!(ks.contains(&k::REGEXP), "expected regex in {code:?}: kinds {ks:?}");
+    }
+
+    #[track_caller]
+    fn division(code: &str) {
+        let ks = kinds_of(code, false);
+        assert!(!ks.contains(&k::REGEXP), "expected division in {code:?}: kinds {ks:?}");
+        assert!(ks.contains(&k::SLASH), "expected a `/` in {code:?}: kinds {ks:?}");
+    }
+
+    #[test]
+    fn yield_identifier_divides() {
+        division("var yield = 1; var r = yield /2/g;");
+        division("function f() { var yield = 1; return yield /2/g; }");
+        division("function* g() { function h() { var yield = 1; return yield /2/g; } }");
+        division("function* g() { const a = () => { var yield = 1; return yield /2/g; }; }");
+        division("({ get m() { var yield = 1; return yield /2/g; } });");
+    }
+
+    #[test]
+    fn yield_keyword_stays_regex() {
+        regex("function* g() { yield /re/; }");
+        regex("function* g() { if (x) { while (y) { yield /re/; } } }");
+        regex("function* g() { const o = { a: yield /re/ }; }");
+        regex("class C { *m() { yield /re/; } }");
+        regex("({ *m() { yield /re/ } });");
+        regex("async function* ag() { yield /re/; }");
+        regex("function* g() { const c = class { [yield /re/](){} }; }");
+    }
+
+    #[test]
+    fn strict_yield_stays_regex() {
+        regex("\"use strict\"; var r = yield /2/g;");
+        regex("'use strict'\nvar r = yield /2/g;");
+        regex("function f() { \"use strict\"; return yield /2/g; }");
+        regex("class C { m() { return yield /2/g; } }");
+        division("var s = \"use strict\"; var yield = 1; var r = yield /2/g;");
+    }
+
+    #[test]
+    fn await_identifier_divides() {
+        division("var await = 1; var r = await /2/g;");
+        division("\"use strict\"; var await = 1; var r = await /2/g;");
+        division("async function f() { function g() { var await = 1; return await /2/g; } }");
+        division("async function f() { const g = () => { var await = 1; return await /2/g; }; }");
+        division("function f() { var await = 1; return await /2/g; }");
+    }
+
+    #[test]
+    fn await_keyword_stays_regex() {
+        regex("async function f() { await /re/; }");
+        regex("async function f() { if (x) { await /re/; } }");
+        regex("({ async m() { await /re/ } });");
+        regex("class C { async m() { await /re/ } }");
+        regex("const f = async () => { await /re/ };");
+        regex("const f = async x => { await /re/ };");
+        regex("x = async () => await /re/.test(s);");
+        regex("f(1, async () => await /re/.test(s), 2);");
+        regex("class C { static { await /re/ } }");
+    }
+
+    #[test]
+    fn concise_bodies_pop() {
+        division("var await = 1; const g = [async () => await 1, await /2/g];");
+        division("var await = 1; const h = (async () => await 1, await /2/g);");
+        division("var await = 1; const t = c ? async () => await 1 : await /2/g;");
+    }
+
+    #[test]
+    fn params_take_their_functions_kind() {
+        division("function* g() { function h(a = yield /2/g) {} }");
+        division("async function f() { function h(a = await /2/g) {} }");
+    }
+
+    #[test]
+    fn module_gate_skips_replay() {
+        let ks = kinds_of("var r = await /re/.test(x);", true);
+        assert!(ks.contains(&k::REGEXP), "module keeps await reserved: {ks:?}");
+        let ks = kinds_of("var r = yield /re/;", true);
+        assert!(ks.contains(&k::REGEXP), "module keeps yield reserved: {ks:?}");
+    }
+
+    #[test]
+    fn property_spellings_unaffected() {
+        division("x.yield / 2;");
+        division("x.await / 2;");
+    }
+
+    #[test]
+    fn fake_directive_expression_continuation() {
+        division("\"use strict\"\n+ 1; var yield = 1; var r = yield /2/g;");
+        division("\"use strict\"\n.length; var yield = 1; var r = yield /2/g;");
+    }
+
+    #[test]
+    fn leading_semicolon_ends_prologue() {
+        division("; \"use strict\"; var yield = 1; var r = yield /2/g;");
+    }
+
+    #[test]
+    fn concise_body_ends_by_asi() {
+        division("var await = 1; var f = async () => 0\nvar r = await /2/g;");
+    }
+
+    #[test]
+    fn concise_body_asi_generator_side() {
+        regex("function* gen() { const f = () => 0\nyield /re/ }");
+    }
+
+    #[test]
+    fn concise_body_ternary_colon_does_not_pop() {
+        regex("var await = 1; x = async () => c ? a : await /re/;");
+    }
+
+    #[test]
+    fn no_asi_pop_after_operator() {
+        regex("var f = async () => x +\nawait /2/g;");
+    }
+
+    #[test]
+    fn template_substitution_pops_concise() {
+        division("var await = 1, g = 2; x = `${async () => await 1}${await /2/g}`;");
+    }
+
+    #[test]
+    fn template_substitution_generator_side() {
+        regex("function* g() { var x = `${() => 1}${yield /re/}`; }");
+        regex("var f = async () => `${await 1}` + await /re/;");
+    }
+
+    #[test]
+    fn asi_pop_after_brace_tail() {
+        division("var await = 1; var f = async () => y = {a: 1}\nvar r = await /2/g;");
+        division("var await = 1; var f = async () => y = function(){}\nvar r = await /2/g;");
+        regex("function* gen() { const f = () => o = {a: 1}\nyield /re/ }");
+    }
+
+    #[test]
+    fn asi_pop_after_postfix_tail() {
+        division("var await = 1; var f = async () => x++\nvar r = await /2/g;");
+        division("var await = 1; var f = async () => x--\nvar r = await /2/g;");
+    }
+
+    #[test]
+    fn asi_pop_postfix_only() {
+        regex(
+            "function* g() { const f = () => o = {a: 1}
+yield /re/ }",
+        );
+        division(
+            "function* g() { const f = () => ++
+yield /2/g; }",
+        );
+    }
+
+    #[test]
+    fn asi_pop_across_absorbed_ls() {
+        division("var await = 1; var f = async () => x\u{2028}var r = await /2/g;");
+    }
+
+    #[test]
+    fn asi_pop_spaced_prefix_pair() {
+        division("var yield = 4, g = 2;\nfunction* gen() { const f = () => 1 + ++\nyield /2/g; }");
+    }
+
+    #[test]
+    fn method_named_function_keeps_modifiers() {
+        regex("var o = { *function() { yield /re/ } };");
+        regex("var o = { async function() { await /re/ } };");
+    }
+
+    #[test]
+    fn computed_method_modifiers() {
+        regex("var o = { *['m']() { yield /re/ } };");
+        regex("var await = 1; var o = { async ['m']() { await /re/ } };");
+        regex("var await = 1; class C { async ['m']() { await /re/ } }");
+        regex("var await = 1; class C { static async ['m']() { await /re/ } }");
+    }
+
+    #[test]
+    fn method_header_matrix() {
+        for code in [
+            "({ *m() { yield /re/ } });",
+            "({ *['m']() { yield /re/ } });",
+            "({ *[k]() { yield /re/ } });",
+            "({ *'m'() { yield /re/ } });",
+            "({ *42() { yield /re/ } });",
+            "({ *function() { yield /re/ } });",
+            "({ async m() { await /re/ } });",
+            "({ async ['m']() { await /re/ } });",
+            "({ async function() { await /re/ } });",
+            "({ async *m() { await /re/ } });",
+            "({ async *[k]() { yield /re/ } });",
+            "class C { *m() { yield /re/ } }",
+            "class C { *['m']() { yield /re/ } }",
+            "class C { static *m() { yield /re/ } }",
+            "class C { static async *[k]() { await /re/ } }",
+            "class C { async [k]() { await /re/ } }",
+            "class C { async #p() { await /re/ } }",
+        ] {
+            regex(code);
+        }
+        regex("({ *\\u0066oo() { yield /re/ } });");
+        regex("class C { async *#\\u0066() { await /re/ } }");
+        regex(
+            "class C { x = 1
+async *m() { await /re/ } }",
+        );
+        division("({ a: b * function() { var yield = 1; return yield /2/g; } });");
+        division("({ a: b * async function() { var yield = 1; return yield /2/g; } });");
+        division("({ get m() { var yield = 1; return yield /2/g; } });");
+        division("({ ['m']() { var yield = 1; return yield /2/g; } });");
+        division("class C { ['m']() { var await = 1; return await /2/g; } }");
+        division("({ a: function() { var yield = 1; return yield /2/g; } });");
+        regex("({ a: async function() { await /re/ } });");
+    }
+
+    #[test]
+    fn mult_star_is_not_a_modifier() {
+        division("var o = { a: b * function() { var yield = 1; return yield /2/g; } };");
+        division("var o = { a: b * async function() { var yield = 1; return yield /2/g; } };");
+    }
+
+    #[test]
+    fn bigint_and_escaped_method_names() {
+        regex("var o = { *1n() { yield /re/ } };");
+        regex("var o = { *\\u0066oo() { yield /re/ } };");
+    }
+}

--- a/crates/oxc_lexer/src/tables.rs
+++ b/crates/oxc_lexer/src/tables.rs
@@ -14,19 +14,19 @@ use crate::opmap::{
 };
 
 #[inline(always)]
-pub fn is_ws(c: u8) -> bool {
+pub const fn is_ws(c: u8) -> bool {
     c == b' ' || c == b'\t' || c == b'\n' || c == b'\r' || c == 0x0c || c == 0x0b
 }
 #[inline(always)]
-pub fn is_digit(c: u8) -> bool {
+pub const fn is_digit(c: u8) -> bool {
     c >= b'0' && c <= b'9'
 }
 #[inline(always)]
-pub fn is_id_start(c: u8) -> bool {
+pub const fn is_id_start(c: u8) -> bool {
     (c >= b'a' && c <= b'z') || (c >= b'A' && c <= b'Z') || c == b'_' || c == b'$' || c >= 0x80
 }
 #[inline(always)]
-pub fn is_word(c: u8) -> bool {
+pub const fn is_word(c: u8) -> bool {
     is_id_start(c) || is_digit(c)
 }
 #[inline(always)]
@@ -48,20 +48,20 @@ pub fn is_glue_join(c: u8) -> bool {
 pub const KWINIT_LO: [u8; 16] = [0, 1, 3, 3, 3, 1, 3, 3, 0, 3, 0, 0, 1, 0, 1, 1];
 pub const KWINIT_HI: [u8; 16] = [0, 0, 0, 0, 0, 0, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0];
 #[inline(always)]
-pub fn is_kw_init(c: u8) -> bool {
+pub const fn is_kw_init(c: u8) -> bool {
     (KWINIT_LO[(c & 15) as usize] & KWINIT_HI[(c >> 4) as usize]) != 0
 }
 /// TS-mode variant: the JS set plus `k`/`m`/`p`/`u` (keyof, module, the
 /// p-words, unique/unknown/undefined/using). Same hi-nibble rows.
 pub const KWINIT_TS_LO: [u8; 16] = [2, 1, 3, 3, 3, 3, 3, 3, 0, 3, 0, 1, 1, 1, 1, 1];
 #[inline(always)]
-pub fn is_kw_init_ts(c: u8) -> bool {
+pub const fn is_kw_init_ts(c: u8) -> bool {
     (KWINIT_TS_LO[(c & 15) as usize] & KWINIT_HI[(c >> 4) as usize]) != 0
 }
 pub const OPCH_LO: [u8; 16] = [0, 1, 0, 0, 0, 1, 1, 0, 0, 0, 1, 1, 10, 3, 7, 2];
 pub const OPCH_HI: [u8; 16] = [0, 0, 1, 2, 0, 4, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0];
 #[inline(always)]
-pub fn is_op_char(c: u8) -> bool {
+pub const fn is_op_char(c: u8) -> bool {
     (OPCH_LO[(c & 15) as usize] & OPCH_HI[(c >> 4) as usize]) != 0
 }
 pub const PH_A: [u8; 16] = [4, 13, 19, 20, 0, 14, 7, 8, 10, 26, 22, 0, 29, 23, 3, 2];
@@ -141,7 +141,7 @@ impl Tables {
         // `of` is deliberately absent: it precedes a regex only in a for-of
         // head (never written — a RegExp isn't iterable), while `instance/of/g`
         // style division is real code. Matches es-module-lexer/SWC/RESS.
-        const RX: [&str; 13] = [
+        const RX: [&str; 16] = [
             "in",
             "do",
             "new",
@@ -154,9 +154,11 @@ impl Tables {
             "return",
             "typeof",
             "delete",
+            "default",
+            "extends",
+            "debugger",
             "instanceof",
         ];
-        // Indexed by kind offset from KW_BASE (all 13 sit in the JS kind
         // block, offsets < 64), so the mask is set-independent.
         let mut mask = 0u64;
         for r in RX.iter() {

--- a/crates/oxc_lexer/tests/diagnostics.rs
+++ b/crates/oxc_lexer/tests/diagnostics.rs
@@ -1,6 +1,6 @@
 //! Diagnostic coverage for every code class. Each positive test has a
 //! `*_never_flagged` counterpart: valid input must emit nothing.
-#![cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
+#![cfg(target_endian = "little")]
 #![expect(
     clippy::cast_possible_truncation,
     clippy::unreadable_literal,

--- a/crates/oxc_lexer/tests/module_goal.rs
+++ b/crates/oxc_lexer/tests/module_goal.rs
@@ -1,0 +1,72 @@
+#![cfg(target_endian = "little")]
+#![expect(clippy::cast_possible_truncation, reason = "test helpers: lengths fit u32")]
+
+use oxc_lexer::{Lexer, PAD, default_options, diag_code, lex_utf8, token_kind as k};
+
+fn kinds_of(code: &str, module: bool) -> Vec<u8> {
+    let mut buf = code.as_bytes().to_vec();
+    let n = buf.len();
+    buf.resize(n + PAD, 0);
+    let mut opts = default_options();
+    opts.source_type_module = module;
+    let mut lx = Lexer::new();
+    let count = lx.lex(&buf, n, opts);
+    lx.kinds[..count - 1].iter().copied().filter(|&kk| !oxc_lexer::is_trivia(kk)).collect()
+}
+
+fn diag_codes(code: &str, module: bool) -> Vec<u16> {
+    let mut buf = code.as_bytes().to_vec();
+    let n = buf.len() as u32;
+    buf.resize(buf.len() + PAD, 0);
+    let mut opts = default_options();
+    opts.source_type_module = module;
+    let (res, _arena) = lex_utf8(&buf, n, opts);
+    res.diagnostics().iter().map(|d| d.code).collect()
+}
+
+#[test]
+fn script_html_open_comment_anywhere() {
+    let ks = kinds_of("x <!-- y\nz;", false);
+    assert!(!ks.contains(&k::LT) && !ks.contains(&k::BANG), "script comment: {ks:?}");
+    assert!(diag_codes("x <!-- y\nz;", false).is_empty());
+}
+
+#[test]
+fn module_html_open_comment_mid_expression_is_lt() {
+    let ks = kinds_of("x <!-- y;", true);
+    assert!(ks.contains(&k::LT), "expected `<` operator: {ks:?}");
+    assert!(ks.contains(&k::BANG), "expected `!` operator: {ks:?}");
+    assert!(ks.contains(&k::MINUS_MINUS), "expected `--` operator: {ks:?}");
+    assert!(diag_codes("x <!-- y;", true).is_empty());
+}
+
+#[test]
+fn module_html_open_comment_at_line_start_diagnosed() {
+    let src = "<!-- c\nx;";
+    let ks = kinds_of(src, true);
+    assert!(!ks.contains(&k::LT), "line-start form stays a comment: {ks:?}");
+    assert_eq!(diag_codes(src, true), vec![diag_code::HTML_COMMENT_IN_MODULE]);
+    let src = "x;\n<!-- c\ny;";
+    assert_eq!(diag_codes(src, true), vec![diag_code::HTML_COMMENT_IN_MODULE]);
+    assert!(diag_codes(src, false).is_empty(), "script form is silent");
+}
+
+#[test]
+fn module_html_close_comment_is_operators() {
+    let src = "a;\n--> b;";
+    let script = kinds_of(src, false);
+    assert!(!script.contains(&k::MINUS_MINUS), "script comment: {script:?}");
+    let module = kinds_of(src, true);
+    assert!(module.contains(&k::MINUS_MINUS), "expected `--`: {module:?}");
+    assert!(module.contains(&k::GT), "expected `>`: {module:?}");
+    assert!(diag_codes(src, true).is_empty());
+}
+
+#[test]
+fn mid_line_close_comment_unchanged() {
+    for module in [false, true] {
+        let ks = kinds_of("a --> b;", module);
+        assert!(ks.contains(&k::MINUS_MINUS), "module={module}: {ks:?}");
+        assert!(ks.contains(&k::GT), "module={module}: {ks:?}");
+    }
+}

--- a/crates/oxc_lexer/tests/regex_div.rs
+++ b/crates/oxc_lexer/tests/regex_div.rs
@@ -1,0 +1,57 @@
+#![cfg(target_endian = "little")]
+#![expect(
+    clippy::cast_possible_truncation,
+    clippy::naive_bytecount,
+    reason = "test helpers: lengths fit u32; counting a tiny kind buffer"
+)]
+
+use oxc_lexer::{Lexer, PAD, default_options, lex_utf8, token_kind as k};
+
+fn kinds_of(code: &str, ts: bool, jsx: bool) -> Vec<u8> {
+    let mut buf = code.as_bytes().to_vec();
+    let n = buf.len();
+    buf.resize(n + PAD, 0);
+    let mut opts = default_options();
+    opts.ts = ts;
+    opts.jsx = jsx;
+    let mut lx = Lexer::new();
+    let count = lx.lex(&buf, n, opts);
+    lx.kinds[..count - 1].iter().copied().filter(|&kk| !oxc_lexer::is_trivia(kk)).collect()
+}
+
+#[test]
+fn one_probe_per_family() {
+    let ks = kinds_of("a++ / b;", false, false);
+    assert!(!ks.contains(&k::REGEXP) && ks.contains(&k::SLASH), "{ks:?}");
+    let ks = kinds_of("x = ++/re/.lastIndex;", false, false);
+    assert!(ks.contains(&k::REGEXP), "{ks:?}");
+    let ks = kinds_of("export default /^x$/;", false, false);
+    assert!(ks.contains(&k::REGEXP), "{ks:?}");
+    let ks = kinds_of("if (x) /re/.test(y);", false, false);
+    assert!(ks.contains(&k::REGEXP), "{ks:?}");
+    let ks = kinds_of("(a + b) / 2;", false, false);
+    assert!(!ks.contains(&k::REGEXP), "{ks:?}");
+    let ks = kinds_of("(class {} / 2);", false, false);
+    assert!(!ks.contains(&k::REGEXP), "{ks:?}");
+    let ks = kinds_of("var yield = 1; var r = yield /2/g;", false, false);
+    assert!(!ks.contains(&k::REGEXP), "{ks:?}");
+    let ks = kinds_of("function* g() { yield /re/; }", false, false);
+    assert!(ks.contains(&k::REGEXP), "{ks:?}");
+    let ks = kinds_of("export default <App/>;", false, true);
+    assert!(ks.contains(&k::JSX_LT), "{ks:?}");
+}
+
+#[test]
+fn arena_api_matches_and_stays_clean() {
+    let code = "x = /a/g / /b/g; if (y) /re/.test(z); var yield = 1; var r = yield /2/g;";
+    let mut buf = code.as_bytes().to_vec();
+    let n = buf.len() as u32;
+    buf.resize(buf.len() + PAD, 0);
+    let (res, arena) = lex_utf8(&buf, n, default_options());
+    assert!(res.diagnostics().is_empty(), "{:?}", res.diagnostics());
+    let count = res.token_count as usize;
+    // SAFETY: `arena.tok_kinds` points to `token_count` kinds written by `lex_utf8`.
+    let kinds = unsafe { core::slice::from_raw_parts(arena.tok_kinds, count) }.to_vec();
+    let re = kinds.iter().filter(|&&kk| kk == k::REGEXP).count();
+    assert_eq!(re, 3, "two regex literals and one regex argument: {kinds:?}");
+}

--- a/crates/oxc_lexer/tests/ts_keywords.rs
+++ b/crates/oxc_lexer/tests/ts_keywords.rs
@@ -1,7 +1,7 @@
 //! TS-mode keyword recognition: the TS set is active only under
 //! `LexOptions::ts`, JS mode must be unaffected, and the wider TS hash key
 //! must separate the pairs the JS key cannot.
-#![cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
+#![cfg(target_endian = "little")]
 
 use oxc_lexer::{Lexer, PAD, default_options, token_kind as k};
 


### PR DESCRIPTION
- Adds scalar fallback to oxc_lexer.
- Closes the Regex vs Division mislex gaps (without parser feedback).
- Adds a swathe of aggressive regex vs division test cases. 
- Adds `replay.rs` which kicks in for cases that will not appear in real source but closes out the remaining spec compliance gaps for `await` and `yield` and regex.
- All regex vs division gaps filled now falls into `zero cost` or `pay when occurs` permafrost cold path.