### PR TITLE
refactor(allocator): remove `Layout::repeat` polyfill

### DIFF
--- a/crates/oxc_allocator/src/arena/bumpalo_alloc.rs
+++ b/crates/oxc_allocator/src/arena/bumpalo_alloc.rs
@@ -8,76 +8,18 @@
 // This file may not be copied, modified, or distributed except according to those terms.
 
 #![expect(clippy::undocumented_unsafe_blocks)]
-#![allow(unstable_name_collisions)]
 #![allow(dead_code)]
 
 use std::{
-    alloc::{Layout, LayoutError},
+    alloc::Layout,
     cmp, fmt, mem,
     ptr::{self, NonNull},
 };
 
 #[cold]
-fn new_layout_err() -> LayoutError {
-    Layout::from_size_align(1, 3).unwrap_err()
-}
-
-#[cold]
 #[inline(never)]
 pub fn handle_alloc_error(layout: Layout) -> ! {
     panic!("encountered allocation error: {layout:?}")
-}
-
-// TODO: `Layout::repeat` was stabilized in Rust 1.95. Remove this trait and use the
-// standard library method directly once MSRV reaches 1.95.
-pub trait UnstableLayoutMethods {
-    fn padding_needed_for(&self, align: usize) -> usize;
-    fn repeat(&self, n: usize) -> Result<(Layout, usize), LayoutError>;
-    fn array<T>(n: usize) -> Result<Layout, LayoutError>;
-}
-
-impl UnstableLayoutMethods for Layout {
-    fn padding_needed_for(&self, align: usize) -> usize {
-        let len = self.size();
-
-        // Rounded up value is:
-        //   len_rounded_up = (len + align - 1) & !(align - 1);
-        // and then we return the padding difference: `len_rounded_up - len`.
-        //
-        // We use modular arithmetic throughout:
-        //
-        // 1. align is guaranteed to be > 0, so align - 1 is always valid
-        //
-        // 2. `len + align - 1` can overflow by at most `align - 1`, so the &-mask with `!(align - 1)` will
-        //    ensure that in the case of overflow, `len_rounded_up` will itself be 0. Thus the returned
-        //    padding, when added to `len`, yields 0, which trivially satisfies the alignment `align`.
-        //
-        // (Of course, attempts to allocate blocks of memory whose size and padding overflow in the above
-        // manner should cause the allocator to yield an error anyway.)
-
-        let len_rounded_up = len.wrapping_add(align).wrapping_sub(1) & !align.wrapping_sub(1);
-        len_rounded_up.wrapping_sub(len)
-    }
-
-    fn repeat(&self, n: usize) -> Result<(Layout, usize), LayoutError> {
-        let padded_size = self
-            .size()
-            .checked_add(self.padding_needed_for(self.align()))
-            .ok_or_else(new_layout_err)?;
-        let alloc_size = padded_size.checked_mul(n).ok_or_else(new_layout_err)?;
-
-        unsafe {
-            // self.align is already known to be valid and alloc_size has been padded already
-            Ok((Layout::from_size_align_unchecked(alloc_size, self.align()), padded_size))
-        }
-    }
-
-    fn array<T>(n: usize) -> Result<Layout, LayoutError> {
-        UnstableLayoutMethods::repeat(&Layout::new::<T>(), n).map(|(k, offs)| {
-            debug_assert_eq!(offs, mem::size_of::<T>());
-            k
-        })
-    }
 }
 
 /// Represents the combination of a starting address and a total capacity of the returned block.

--- a/crates/oxc_allocator/src/vec2/raw_vec.rs
+++ b/crates/oxc_allocator/src/vec2/raw_vec.rs
@@ -21,7 +21,6 @@
     clippy::needless_pass_by_value,
     clippy::inline_always
 )]
-#![allow(unstable_name_collisions)]
 #![allow(dead_code)]
 
 use std::{


### PR DESCRIPTION
Rust 1.95 stabilized [`Layout::repeat`](https://doc.rust-lang.org/std/alloc/struct.Layout.html#method.repeat) (MSRV bumped in #24359), which the `UnstableLayoutMethods` polyfill trait in `bumpalo_alloc.rs` was waiting on (per its TODO comment).

It turns out the whole trait is deletable rather than just replaceable:

- The only `.repeat()` call outside the trait itself (`vec2/raw_vec.rs`) is inside a commented-out block.
- The live `Layout::array::<T>(n)` calls already resolve to the inherent std method (stable since 1.44), not the trait method.
- `padding_needed_for` was only used by the trait's own `repeat` impl.

Also drops the two `#![allow(unstable_name_collisions)]` attributes, which only existed because the trait methods collided with the then-unstable std inherent methods.

Net: -59 lines, no behavior change. `cargo check/clippy/test -p oxc_allocator` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)