### PR TITLE
refactor(ast): return `Ident` from `ImportDeclarationSpecifier::name`

### DIFF
--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -1942,8 +1942,8 @@ impl<'a> ImportDeclarationSpecifier<'a> {
     /// - `import { foo } from "lib"` => `"foo"`
     /// - `import * as foo from "lib"` => `"foo"`
     /// - `import foo from "lib"` => `"foo"`
-    pub fn name(&self) -> Cow<'a, str> {
-        Cow::Borrowed(self.local().name.as_str())
+    pub fn name(&self) -> Ident<'a> {
+        self.local().name
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/sort_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/sort_imports.rs
@@ -1,7 +1,4 @@
-use std::{
-    borrow::Cow,
-    fmt::{Display, Write},
-};
+use std::fmt::{Display, Write};
 
 use cow_utils::CowUtils;
 use itertools::Itertools;
@@ -9,6 +6,7 @@ use oxc_ast::ast::{ImportDeclaration, ImportDeclarationSpecifier, Statement};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
+use oxc_str::Ident;
 use rustc_hash::FxHashSet;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -172,15 +170,8 @@ impl SortImports {
         let previous_member_syntax_group_index =
             self.member_syntax_sort_order.get_group_index_by_import_decl(previous);
 
-        let mut current_local_member_name = get_first_local_member_name(current);
-        let mut previous_local_member_name = get_first_local_member_name(previous);
-
-        if self.ignore_case {
-            current_local_member_name = current_local_member_name
-                .map(|name| Cow::Owned(name.cow_to_ascii_lowercase().into_owned()));
-            previous_local_member_name = previous_local_member_name
-                .map(|name| Cow::Owned(name.cow_to_ascii_lowercase().into_owned()));
-        }
+        let current_local_member_name = get_first_local_member_name(current);
+        let previous_local_member_name = get_first_local_member_name(previous);
 
         // "memberSyntaxSortOrder": ["none", "all", "multiple", "single"]
         // ```js
@@ -208,7 +199,12 @@ impl SortImports {
                 // ```
                 if let Some((current_name, previous_name)) =
                     current_local_member_name.zip(previous_local_member_name)
-                    && current_name < previous_name
+                    && if self.ignore_case {
+                        current_name.as_str().cow_to_ascii_lowercase()
+                            < previous_name.as_str().cow_to_ascii_lowercase()
+                    } else {
+                        current_name.as_str() < previous_name.as_str()
+                    }
                 {
                     ctx.diagnostic(sort_imports_alphabetically_diagnostic(current.span));
                 }
@@ -422,7 +418,7 @@ impl Display for ImportKind {
     }
 }
 
-fn get_first_local_member_name<'a>(decl: &ImportDeclaration<'a>) -> Option<Cow<'a, str>> {
+fn get_first_local_member_name<'a>(decl: &ImportDeclaration<'a>) -> Option<Ident<'a>> {
     let specifiers = decl.specifiers.as_ref()?;
     specifiers.first().map(ImportDeclarationSpecifier::name)
 }


### PR DESCRIPTION
## Summary

- return oxc_str::Ident directly from ImportDeclarationSpecifier::name. It currently doesn't make sense to return a `Cow` when we could just return an `Ident` directly, and avoid some needless conversions, if callers need `Cow`s they can convert at the usage sites.

## History

- f6d9ca6e4795674b4404afa35f5530be1cc72aab introduced the method returning CompactStr for eslint/sort-imports
- a1b2d83ea9c1157cf71a4b88857918d90074f0e6 moved the implementation into ast_impl/js.rs without a semantic change
- b257d531510a591aeb9acd40b2e0488f4a5f1091 introduced local() and rewrote name() to delegate through it
- a207923af1b87953e89ecbf0fe272cf7134b71ef changed CompactStr to Cow to avoid allocation
- 1bed5ce2a5fc89b3aa89fdf5e92ad8abc089e4a9 made formatting-only changes
- a7dd5aa3eefa4263c23f58d4c1b5900100564063 added the temporary missing-docs allowance
- c63291a8ea96920d15c19b52660757b956a207bf added the current documentation and examples

The Cow conversion had no owned-string branch. Returning the existing Copy Ident preserves the zero-allocation behavior and retains its precomputed hash.
