### PR TITLE
refactor(parser): use `cold_path` for pure branch-layout hints

### DIFF
--- a/crates/oxc_parser/Cargo.toml
+++ b/crates/oxc_parser/Cargo.toml
@@ -21,7 +21,11 @@ workspace = true
 [dependencies]
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
-oxc_data_structures = { workspace = true, features = ["assert_unchecked", "fieldless_enum"] }
+oxc_data_structures = { workspace = true, features = [
+  "assert_unchecked",
+  "branch_hints",
+  "fieldless_enum",
+] }
 oxc_diagnostics = { workspace = true }
 oxc_ecmascript = { workspace = true }
 oxc_regular_expression = { workspace = true, optional = true }

--- a/crates/oxc_parser/src/lexer/comment.rs
+++ b/crates/oxc_parser/src/lexer/comment.rs
@@ -1,12 +1,13 @@
 use memchr::memmem::Finder;
 
 use oxc_ast::CommentKind;
+use oxc_data_structures::branch_hints::cold_path;
 use oxc_syntax::line_terminator::is_line_terminator;
 
 use crate::{config::LexerConfig as Config, diagnostics};
 
 use super::{
-    Kind, Lexer, cold_branch,
+    Kind, Lexer,
     search::{SafeByteMatchTable, byte_search, safe_byte_match_table},
     source::SourcePosition,
 };
@@ -45,29 +46,28 @@ impl<'a, C: Config> Lexer<'a, C> {
                 } else {
                     // `0xE2`. Could be first byte of LS/PS, or could be some other Unicode char.
                     // Either way, Unicode is uncommon, so make this a cold branch.
-                    cold_branch(|| {
-                        // SAFETY: Next byte is `0xE2` which is always 1st byte of a 3-byte UTF-8 char.
-                        // So safe to advance `pos` by 1 and read 2 bytes.
-                        let next2 = unsafe { pos.add(1).read2() };
-                        if matches!(next2, LS_BYTES_2_AND_3 | PS_BYTES_2_AND_3) {
-                            // Irregular line break
-                            self.trivia_builder
-                                .add_line_comment(self.token.start(), self.source.offset_of(pos), self.source.whole());
-                            // Advance `pos` to after this char.
-                            // SAFETY: `0xE2` is always 1st byte of a 3-byte UTF-8 char,
-                            // so consuming 3 bytes will place `pos` on next UTF-8 char boundary.
-                            pos = unsafe { pos.add(3) };
-                            // We've found the end. Do not continue searching.
-                            false
-                        } else {
-                            // Some other Unicode char beginning with `0xE2`.
-                            // Skip 3 bytes (macro skips 1 already, so skip 2 here), and continue searching.
-                            // SAFETY: `0xE2` is always 1st byte of a 3-byte UTF-8 char,
-                            // so consuming 3 bytes will place `pos` on next UTF-8 char boundary.
-                            pos = unsafe { pos.add(2) };
-                            true
-                        }
-                    })
+                    cold_path();
+                    // SAFETY: Next byte is `0xE2` which is always 1st byte of a 3-byte UTF-8 char.
+                    // So safe to advance `pos` by 1 and read 2 bytes.
+                    let next2 = unsafe { pos.add(1).read2() };
+                    if matches!(next2, LS_BYTES_2_AND_3 | PS_BYTES_2_AND_3) {
+                        // Irregular line break
+                        self.trivia_builder
+                            .add_line_comment(self.token.start(), self.source.offset_of(pos), self.source.whole());
+                        // Advance `pos` to after this char.
+                        // SAFETY: `0xE2` is always 1st byte of a 3-byte UTF-8 char,
+                        // so consuming 3 bytes will place `pos` on next UTF-8 char boundary.
+                        pos = unsafe { pos.add(3) };
+                        // We've found the end. Do not continue searching.
+                        false
+                    } else {
+                        // Some other Unicode char beginning with `0xE2`.
+                        // Skip 3 bytes (macro skips 1 already, so skip 2 here), and continue searching.
+                        // SAFETY: `0xE2` is always 1st byte of a 3-byte UTF-8 char,
+                        // so consuming 3 bytes will place `pos` on next UTF-8 char boundary.
+                        pos = unsafe { pos.add(2) };
+                        true
+                    }
                 }
             },
             handle_eof: {
@@ -113,29 +113,28 @@ impl<'a, C: Config> Lexer<'a, C> {
                     } else {
                         // This is last byte in file. Continue to `handle_eof`.
                         // This is illegal in valid JS, so mark this branch cold.
-                        cold_branch(|| true)
+                        cold_path();
+                        true
                     }
                 } else if next_byte == LS_OR_PS_FIRST {
                     // `0xE2`. Could be first byte of LS/PS, or could be some other Unicode char.
                     // Either way, Unicode is uncommon, so make this a cold branch.
-                    cold_branch(|| {
-                        // SAFETY: Next byte is `0xE2` which is always 1st byte of a 3-byte UTF-8 char.
-                        // So safe to advance `pos` by 1 and read 2 bytes.
-                        let next2 = unsafe { pos.add(1).read2() };
-                        if matches!(next2, LS_BYTES_2_AND_3 | PS_BYTES_2_AND_3) {
-                            // Irregular line break
-                            self.token.set_is_on_new_line(true);
-                            // Ideally we'd go on to `skip_multi_line_comment_after_line_break` here
-                            // but can't do that easily because can't use `return` in a closure.
-                            // But irregular line breaks are rare anyway.
-                        }
-                        // Either way, continue searching.
-                        // Skip 3 bytes (macro skips 1 already, so skip 2 here), and continue searching.
-                        // SAFETY: `0xE2` is always 1st byte of a 3-byte UTF-8 char,
-                        // so consuming 3 bytes will place `pos` on next UTF-8 char boundary.
-                        pos = unsafe { pos.add(2) };
-                        true
-                    })
+                    cold_path();
+                    // SAFETY: Next byte is `0xE2` which is always 1st byte of a 3-byte UTF-8 char.
+                    // So safe to advance `pos` by 1 and read 2 bytes.
+                    let next2 = unsafe { pos.add(1).read2() };
+                    if matches!(next2, LS_BYTES_2_AND_3 | PS_BYTES_2_AND_3) {
+                        // Irregular line break
+                        self.token.set_is_on_new_line(true);
+                        // Ideally we'd go on to `skip_multi_line_comment_after_line_break` here,
+                        // but irregular line breaks are rare anyway.
+                    }
+                    // Either way, continue searching.
+                    // Skip 3 bytes (macro skips 1 already, so skip 2 here), and continue searching.
+                    // SAFETY: `0xE2` is always 1st byte of a 3-byte UTF-8 char,
+                    // so consuming 3 bytes will place `pos` on next UTF-8 char boundary.
+                    pos = unsafe { pos.add(2) };
+                    true
                 } else {
                     // Regular line break.
                     // No need to look for more line breaks, so switch to faster search just for `*/`.

--- a/crates/oxc_parser/src/lexer/identifier.rs
+++ b/crates/oxc_parser/src/lexer/identifier.rs
@@ -1,6 +1,7 @@
 use std::cmp::max;
 
 use oxc_allocator::ArenaStringBuilder;
+use oxc_data_structures::branch_hints::cold_path;
 use oxc_span::Span;
 use oxc_syntax::identifier::{
     is_identifier_part, is_identifier_part_unicode, is_identifier_start_unicode,
@@ -70,20 +71,18 @@ impl<'a, C: Config> Lexer<'a, C> {
         // Handle uncommon cases in cold branches to keep the common ASCII path
         // as fast as possible.
         if !next_byte.is_ascii() {
-            return cold_branch(|| {
-                // SAFETY: `after_first` is position after consuming 1 byte, so subtracting 1
-                // makes `start_pos` `source`'s position as it was at start of this function
-                let start_pos = unsafe { after_first.sub(1) };
-                &self.identifier_tail_unicode(start_pos)[1..]
-            });
+            cold_path();
+            // SAFETY: `after_first` is position after consuming 1 byte, so subtracting 1
+            // makes `start_pos` `source`'s position as it was at start of this function
+            let start_pos = unsafe { after_first.sub(1) };
+            return &self.identifier_tail_unicode(start_pos)[1..];
         }
         if next_byte == b'\\' {
-            return cold_branch(|| {
-                // SAFETY: `after_first` is position after consuming 1 byte, so subtracting 1
-                // makes `start_pos` `source`'s position as it was at start of this function
-                let start_pos = unsafe { after_first.sub(1) };
-                &self.identifier_backslash(start_pos, false)[1..]
-            });
+            cold_path();
+            // SAFETY: `after_first` is position after consuming 1 byte, so subtracting 1
+            // makes `start_pos` `source`'s position as it was at start of this function
+            let start_pos = unsafe { after_first.sub(1) };
+            return &self.identifier_backslash(start_pos, false)[1..];
         }
 
         // Return identifier minus its first char.
@@ -122,7 +121,8 @@ impl<'a, C: Config> Lexer<'a, C> {
                 self.consume_char();
             } else if c == '\\' {
                 // This branch marked cold as escapes are uncommon
-                return cold_branch(|| self.identifier_backslash(start_pos, false));
+                cold_path();
+                return self.identifier_backslash(start_pos, false);
             } else {
                 break;
             }
@@ -252,22 +252,20 @@ impl<'a, C: Config> Lexer<'a, C> {
         // Handle uncommon cases in cold branches to keep the common ASCII path
         // as fast as possible.
         if !next_byte.is_ascii() {
-            return cold_branch(|| {
-                // SAFETY: `after_first` is position after consuming 1 byte, so subtracting 1
-                // makes `start_pos` `source`'s position as it was at start of this function
-                let start_pos = unsafe { after_first.sub(1) };
-                self.identifier_tail_unicode(start_pos);
-                Kind::PrivateIdentifier
-            });
+            cold_path();
+            // SAFETY: `after_first` is position after consuming 1 byte, so subtracting 1
+            // makes `start_pos` `source`'s position as it was at start of this function
+            let start_pos = unsafe { after_first.sub(1) };
+            self.identifier_tail_unicode(start_pos);
+            return Kind::PrivateIdentifier;
         }
         if next_byte == b'\\' {
-            return cold_branch(|| {
-                // SAFETY: `after_first` is position after consuming 1 byte, so subtracting 1
-                // makes `start_pos` `source`'s position as it was at start of this function
-                let start_pos = unsafe { after_first.sub(1) };
-                self.identifier_backslash(start_pos, false);
-                Kind::PrivateIdentifier
-            });
+            cold_path();
+            // SAFETY: `after_first` is position after consuming 1 byte, so subtracting 1
+            // makes `start_pos` `source`'s position as it was at start of this function
+            let start_pos = unsafe { after_first.sub(1) };
+            self.identifier_backslash(start_pos, false);
+            return Kind::PrivateIdentifier;
         }
 
         Kind::PrivateIdentifier
@@ -287,10 +285,9 @@ impl<'a, C: Config> Lexer<'a, C> {
             }
         } else if b == b'\\' {
             // Assume Unicode characters are more common than `\` escapes, so this branch as cold
-            return cold_branch(|| {
-                self.identifier_backslash_handler();
-                Kind::PrivateIdentifier
-            });
+            cold_path();
+            self.identifier_backslash_handler();
+            return Kind::PrivateIdentifier;
         }
 
         // No identifier found

--- a/crates/oxc_parser/src/lexer/jsx.rs
+++ b/crates/oxc_parser/src/lexer/jsx.rs
@@ -1,5 +1,6 @@
 use memchr::memchr;
 
+use oxc_data_structures::branch_hints::cold_path;
 use oxc_span::Span;
 use oxc_syntax::identifier::is_identifier_part;
 
@@ -131,15 +132,14 @@ impl<C: Config> Lexer<'_, C> {
         if !next_byte.is_ascii() {
             // Unicode chars are rare in identifiers, so cold branch to keep common path for ASCII
             // as fast as possible
-            cold_branch(|| {
-                while let Some(c) = self.peek_char() {
-                    if c == '-' || is_identifier_part(c) {
-                        self.consume_char();
-                    } else {
-                        break;
-                    }
+            cold_path();
+            while let Some(c) = self.peek_char() {
+                if c == '-' || is_identifier_part(c) {
+                    self.consume_char();
+                } else {
+                    break;
                 }
-            });
+            }
         }
 
         Some(self.finish_next_retokenized(Kind::Ident))

--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -607,8 +607,16 @@ impl<'a, C: Config> Lexer<'a, C> {
 
 /// Call a closure while hinting to compiler that this branch is rarely taken.
 ///
+/// Unlike [`cold_path`], which only guides branch layout, this `#[cold]` trampoline also moves
+/// the closure's code and stack usage out of the caller's frame (unless compiler chooses to
+/// inline it). Use `cold_path` for pure branch hints. Use `cold_branch` where keeping large
+/// stack objects (e.g. an `OxcDiagnostic` return buffer) out of the hot function's stack frame
+/// is the aim.
+///
 /// "Cold trampoline function", suggested in:
 /// <https://users.rust-lang.org/t/is-cold-the-only-reliable-way-to-hint-to-branch-predictor/106509/2>
+///
+/// [`cold_path`]: oxc_data_structures::branch_hints::cold_path
 #[cold]
 pub fn cold_branch<F: FnOnce() -> T, T>(f: F) -> T {
     f()

--- a/crates/oxc_parser/src/lexer/string.rs
+++ b/crates/oxc_parser/src/lexer/string.rs
@@ -1,6 +1,7 @@
 use std::cmp::max;
 
 use oxc_allocator::ArenaStringBuilder;
+use oxc_data_structures::branch_hints::cold_path;
 
 use crate::{config::LexerConfig as Config, diagnostics};
 
@@ -156,12 +157,13 @@ macro_rules! handle_string_literal_escape {
                         str.push_str(chunk);
                         continue 'outer;
                     }
-                    LOSSY_REPLACEMENT_CHAR_FIRST_BYTE => cold_branch(|| {
+                    LOSSY_REPLACEMENT_CHAR_FIRST_BYTE => {
                         // If the string contains lone surrogates, the lossy replacement character (U+FFFD)
                         // is used as start of an escape sequence.
                         // So an actual lossy escape character has to be escaped too.
                         // Output it as `\u{FFFD}fffd`.
                         // Cold branch because this should be very rare in real-world code.
+                        cold_path();
 
                         // SAFETY: A byte is available, as we just peeked it, and it's 0xEF.
                         // 0xEF is always 1st byte of a 3-byte Unicode sequence, so safe to consume 3 bytes.
@@ -176,7 +178,7 @@ macro_rules! handle_string_literal_escape {
                             str.push_str("fffd");
                             chunk_start = $lexer.source.position();
                         }
-                    }),
+                    }
                     _ => {
                         // Line break. This is impossible in valid JS, so cold path.
                         return cold_branch(|| {

--- a/crates/oxc_parser/src/lexer/template.rs
+++ b/crates/oxc_parser/src/lexer/template.rs
@@ -1,6 +1,7 @@
 use std::{cmp::max, str};
 
 use oxc_allocator::ArenaStringBuilder;
+use oxc_data_structures::branch_hints::cold_path;
 
 use crate::{config::LexerConfig as Config, diagnostics};
 
@@ -66,7 +67,8 @@ impl<'a, C: Config> Lexer<'a, C> {
                         } else {
                             // This is last byte in file. Continue to `handle_eof`.
                             // This is illegal in valid JS, so mark this branch cold.
-                            cold_branch(|| true)
+                            cold_path();
+                            true
                         }
                     },
                     b'`' => {
@@ -256,7 +258,8 @@ impl<'a, C: Config> Lexer<'a, C> {
                     } else {
                         // This is last byte in file. Continue to `handle_eof`.
                         // This is illegal in valid JS, so mark this branch cold.
-                        cold_branch(|| true)
+                        cold_path();
+                        true
                     }
                 } else {
                     // Next byte is '`', `\r`, `\`, or first byte of lossy replacement character.
@@ -309,7 +312,7 @@ impl<'a, C: Config> Lexer<'a, C> {
                             } else {
                                 // This is last byte in file. Continue to `handle_eof`.
                                 // This is illegal in valid JS, so mark this branch cold.
-                                cold_branch(|| {});
+                                cold_path();
                             }
 
                             // Continue searching


### PR DESCRIPTION
Rust 1.95 stabilized [`std::hint::cold_path`](https://doc.rust-lang.org/std/hint/fn.cold_path.html), re-exported via `oxc_data_structures::branch_hints` in #24368. This replaces the `cold_branch` closure trampoline with `cold_path()` at the **14 call sites where the hint only guides branch layout** — straight-line code instead of closure ceremony.

The other **10 sites keep `cold_branch` deliberately**: they build diagnostics, and several document (e.g. `cursor.rs` `asi()`, `punctuation.rs` `<!--`, `string.rs`, `numeric.rs`) that the `#[cold]` trampoline exists to keep the ~232-byte `OxcDiagnostic` return buffer out of the hot function's stack frame. `cold_path` only sets branch weights — it does not outline code or stack usage — so replacing those sites would regress that. `cold_branch`'s doc comment now explains when to use which.

One small unlock while here: the comment in `skip_multi_line_comment` saying we "can't use `return` in a closure" to jump to the faster post-line-break search — that limitation is gone now the closure is gone; left as a possible follow-up since it's a behavior change.

Verified:
- `cargo test -p oxc_parser` and clippy clean.
- Parser conformance (test262 / babel / typescript / misc): **zero snapshot diffs**.
- Codegen-wise the replaced sites were tiny closures that inlined into the trampoline anyway; CodSpeed on this PR is the final perf gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)