### PR TITLE
refactor(rust): use stabilized `ptr::as_ref_unchecked`

### DIFF
--- a/crates/oxc_ast/src/generated/ast_kind.rs
+++ b/crates/oxc_ast/src/generated/ast_kind.rs
@@ -425,7 +425,7 @@ impl AstKind<'_> {
         // and it's valid to read it.
         // `AstType` is also `#[repr(u8)]` and `AstKind` and `AstType` both have the same
         // discriminants, so it's valid to read `AstKind`'s discriminant as `AstType`.
-        unsafe { *ptr::from_ref(self).cast::<AstType>().as_ref().unwrap_unchecked() }
+        unsafe { *ptr::from_ref(self).cast::<AstType>().as_ref_unchecked() }
     }
 
     /// Get [`NodeId`] of an [`AstKind`].

--- a/crates/oxc_ast_visit/src/utf8_to_utf16/translation.rs
+++ b/crates/oxc_ast_visit/src/utf8_to_utf16/translation.rs
@@ -151,7 +151,7 @@ pub fn build_translations(source_text: &str, translations: &mut Vec<Translation>
         // so `ptr` remains always aligned for `CHUNK_ALIGNMENT`.
         // `ptr < body_end_ptr` check ensures it's valid to read `CHUNK_SIZE` bytes starting at `ptr`.
         #[expect(clippy::cast_ptr_alignment)]
-        let chunk = unsafe { ptr.cast::<AlignedChunk>().as_ref().unwrap_unchecked() };
+        let chunk = unsafe { ptr.cast::<AlignedChunk>().as_ref_unchecked() };
         if chunk.contains_unicode() {
             // SAFETY: `ptr` is equal to or after `start_ptr`. Both are within bounds of `bytes`.
             // `ptr` is derived from `start_ptr`.

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -329,7 +329,7 @@ impl<'a> Codegen<'a> {
             loop {
                 // SAFETY: `ptr` is always less than or equal to `last_ptr`.
                 // `last_ptr` is within bounds of `bytes`, so safe to read a byte at `ptr`.
-                let byte = unsafe { *ptr.as_ref().unwrap_unchecked() };
+                let byte = unsafe { *ptr.as_ref_unchecked() };
                 if byte == b'<' {
                     // SAFETY: `ptr <= last_ptr`, and `last_ptr` points to no later than
                     // 8 bytes before end of string, so safe to read 8 bytes from `ptr`

--- a/crates/oxc_parser/src/lexer/source.rs
+++ b/crates/oxc_parser/src/lexer/source.rs
@@ -729,12 +729,12 @@ impl<'a> SourcePosition<'a> {
     ///
     /// # Implementation details
     ///
-    /// Using `as_ref()` for reading is copied from `core::slice::iter::next`.
+    /// Using a reference for reading is copied from `core::slice::iter::next`.
     ///
-    /// Using `ptr.as_ref().unwrap_unchecked()` instead of `*ptr` or `ptr.read()` produces
+    /// Using `ptr.as_ref_unchecked()` instead of `*ptr` or `ptr.read()` produces
     /// a 7% speed-up on Lexer benchmarks.
     ///
-    /// The likely explanation is that going through `as_ref()` + `unwrap_unchecked()` produces a `&u8`,
+    /// The likely explanation is that going through `as_ref_unchecked()` produces a `&u8`,
     /// which carries `nonnull` and `dereferenceable` metadata in LLVM IR that a raw `*const u8` dereference does not.
     /// This may allow LLVM to better optimize the surrounding control flow in the lexer's hot loops
     /// (e.g. eliminating dead paths, speculative loads).
@@ -750,7 +750,7 @@ impl<'a> SourcePosition<'a> {
         // to the same memory can exist, as that would violate Rust's aliasing rules.
         // Pointer is "dereferenceable" by definition as a `u8` is 1 byte and cannot span multiple objects.
         // Alignment is not relevant as `u8` is aligned on 1 (i.e. no alignment requirements).
-        unsafe { *self.ptr.as_ref().unwrap_unchecked() }
+        unsafe { *self.ptr.as_ref_unchecked() }
     }
 
     /// Read 2 bytes from this `SourcePosition`.
@@ -770,7 +770,7 @@ impl<'a> SourcePosition<'a> {
         // Alignment is not relevant as `u8` is aligned on 1 (i.e. no alignment requirements).
         unsafe {
             let p = self.ptr.cast::<[u8; 2]>();
-            *p.as_ref().unwrap_unchecked()
+            *p.as_ref_unchecked()
         }
     }
 

--- a/tasks/ast_tools/src/generators/ast_kind.rs
+++ b/tasks/ast_tools/src/generators/ast_kind.rs
@@ -137,7 +137,7 @@ impl Generator for AstKindGenerator {
                     ///@ and it's valid to read it.
                     ///@ `AstType` is also `#[repr(u8)]` and `AstKind` and `AstType` both have the same
                     ///@ discriminants, so it's valid to read `AstKind`'s discriminant as `AstType`.
-                    unsafe { *ptr::from_ref(self).cast::<AstType>().as_ref().unwrap_unchecked() }
+                    unsafe { *ptr::from_ref(self).cast::<AstType>().as_ref_unchecked() }
                 }
 
                 ///@@line_break


### PR DESCRIPTION
Rust 1.95 stabilized [`<*const T>::as_ref_unchecked`](https://doc.rust-lang.org/std/primitive.pointer.html#method.as_ref_unchecked) (MSRV bumped in #24359). This replaces the `ptr.as_ref().unwrap_unchecked()` idiom at its 5 call sites:

- `oxc_parser` `lexer/source.rs` `read()`/`read2()` — the doc comment there explains the idiom exists because producing a `&u8` carries `nonnull`/`dereferenceable` LLVM metadata that a raw deref does not (7% lexer speedup). `as_ref_unchecked` is implemented as exactly that reference production (`&*self`), so codegen is unchanged — it just skips the `Option` detour. Comment updated to name the new method.
- `oxc_codegen` `lib.rs` — `</script` search loop.
- `oxc_ast_visit` `utf8_to_utf16/translation.rs` — chunk read.
- `oxc_ast` `generated/ast_kind.rs` `AstKind::ty` — changed via its generator in `tasks/ast_tools`, regenerated with `just ast`.

Verified: `cargo test` for the touched crates, and parser/semantic/codegen conformance (test262 / babel / typescript / misc) with **zero snapshot diffs**. CodSpeed should show this perf-neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)