### PR TITLE
refactor(allocator): use stabilized `AtomicUsize::update`

### DIFF
--- a/crates/oxc_allocator/src/tracking.rs
+++ b/crates/oxc_allocator/src/tracking.rs
@@ -27,8 +27,7 @@ static NUM_CHUNK_ALLOC: AtomicUsize = AtomicUsize::new(0);
 pub fn record_chunk_allocation() {
     // Counter maxes out at `usize::MAX`, but if there's that many allocations,
     // the exact number is not important
-    let _ = NUM_CHUNK_ALLOC
-        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |count| Some(count.saturating_add(1)));
+    NUM_CHUNK_ALLOC.update(Ordering::Relaxed, Ordering::Relaxed, |count| count.saturating_add(1));
 }
 
 /// Counters of allocations and reallocations made in an [`Allocator`].

--- a/tasks/track_memory_allocations/src/lib.rs
+++ b/tasks/track_memory_allocations/src/lib.rs
@@ -42,8 +42,7 @@ impl AtomicCounter {
     }
 
     fn increment(&self) {
-        // Result of `fetch_update` cannot be `Err` as closure always returns `Some`
-        let _ = self.0.fetch_update(SeqCst, SeqCst, |count| Some(count.saturating_add(1)));
+        self.0.update(SeqCst, SeqCst, |count| count.saturating_add(1));
     }
 
     fn reset(&self) {


### PR DESCRIPTION
Rust 1.95 stabilized [`Atomic*::update`](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicUsize.html#method.update) (MSRV bumped in #24359), the infallible sibling of `fetch_update` for closures that always produce a new value.

Both `fetch_update` call sites (`oxc_allocator/src/tracking.rs` and `tasks/track_memory_allocations`) used an always-`Some` closure, so they gain nothing from the fallible API — switching to `update` drops the ignored `Result` (`let _ =`) and the "cannot be `Err`" comments. Same CAS-loop semantics; `saturating_add` behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)