### PR TITLE
refactor(semantic, transformer, react_compiler): use if-let match guards

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_preserved_manual_memoization.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_preserved_manual_memoization.rs
@@ -274,30 +274,22 @@ fn visit_instruction(instr: &ReactiveInstruction, state: &mut VisitorState<'_, '
         }
         ReactiveValue::Instruction(InstructionValue::StoreLocal { lvalue, value, .. }) => {
             // Track reassignments from inlining of manual memo
-            if state.manual_memo_state.is_some() && lvalue.kind == InstructionKind::Reassign {
+            if let Some(memo_state) = &mut state.manual_memo_state
+                && lvalue.kind == InstructionKind::Reassign
+            {
                 let decl_id =
                     state.env.identifiers[lvalue.place.identifier.0 as usize].declaration_id;
-                state
-                    .manual_memo_state
-                    .as_mut()
-                    .unwrap()
-                    .reassignments
-                    .entry(decl_id)
-                    .or_default()
-                    .insert(value.identifier);
+                memo_state.reassignments.entry(decl_id).or_default().insert(value.identifier);
             }
         }
         ReactiveValue::Instruction(InstructionValue::LoadLocal { place, .. })
-            if state.manual_memo_state.is_some() =>
+            if let Some(memo_state) = &mut state.manual_memo_state =>
         {
             let place_ident = &state.env.identifiers[place.identifier.0 as usize];
             if let Some(ref lvalue) = instr.lvalue {
                 let lvalue_ident = &state.env.identifiers[lvalue.identifier.0 as usize];
                 if place_ident.scope.is_some() && lvalue_ident.scope.is_none() {
-                    state
-                        .manual_memo_state
-                        .as_mut()
-                        .unwrap()
+                    memo_state
                         .reassignments
                         .entry(lvalue_ident.declaration_id)
                         .or_default()

--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -572,8 +572,8 @@ fn get_module_instance_state_for_statement<'a, 'b>(
                     ModuleInstanceState::Instantiated
                 }
             }
-            Statement::ExportNamedDeclaration(export_decl) if export_decl.declaration.is_some() => {
-                match export_decl.declaration.as_ref().unwrap() {
+            Statement::ExportNamedDeclaration(export_decl) if let Some(declaration) = &export_decl.declaration => {
+                match declaration {
                     Declaration::TSModuleDeclaration(module_decl) => {
                         get_module_instance_state_impl(builder, module_decl, current_node_id, module_declaration_stmts)
                     }

--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -61,8 +61,10 @@ impl<'a> Traverse<'a, TransformState<'a>> for TypeScriptAnnotations<'a> {
 
         program.body.retain_mut(|stmt| {
             let need_retain = match stmt {
-                Statement::ExportNamedDeclaration(decl) if decl.declaration.is_some() => {
-                    decl.declaration.as_ref().is_some_and(|decl| !decl.is_typescript_syntax())
+                Statement::ExportNamedDeclaration(decl)
+                    if let Some(declaration) = &decl.declaration =>
+                {
+                    !declaration.is_typescript_syntax()
                 }
                 Statement::ExportNamedDeclaration(decl) => {
                     if decl.export_kind.is_type() {


### PR DESCRIPTION
Rust 1.95 stabilized if-let guards in match arms (MSRV bumped in #24359). This converts the three places which guard on `is_some()` and then re-extract the same value in the body — the guard now binds the value directly:

- `oxc_semantic` `binder.rs` — `export_decl.declaration.is_some()` guard followed by `.as_ref().unwrap()`.
- `oxc_transformer` `typescript/annotations.rs` — `decl.declaration.is_some()` guard followed by an `is_some_and` re-check.
- `oxc_react_compiler` `validate_preserved_manual_memoization.rs` — `state.manual_memo_state.is_some()` guard followed by `.as_mut().unwrap()`; the guard now binds `&mut` directly. The sibling `StoreLocal` arm used the same unwrap idiom in a body `if`, converted to a let chain for consistency.

I audited the other ~15 `is_some()` match guards in the workspace: they only test the value without extracting it in the body, so they stay as plain guards.

Verified: crate tests pass, semantic coverage suites and Babel transform conformance produce **zero snapshot diffs**, clippy clean for the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)