### PR TITLE
refactor(react_compiler): use semantic IDs instead of spans to locate AST nodes

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
@@ -150,8 +150,6 @@ fn run_pipeline<'a>(
     env.hook_guard_name = context.hook_guard_name.clone();
     env.seed_uid_known_names(context.known_referenced_names());
 
-    env.reference_node_ids = scope.all_reference_positions().clone();
-
     let mut hir = lower(func, scope, &mut env)?;
 
     // Check for Invariant errors after lowering, before logging HIR.

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -17,7 +17,7 @@ use oxc_ast::AstKind;
 use oxc_ast::ast as oxc;
 use oxc_ast::builder::AstBuilder;
 use oxc_diagnostics::{Diagnostics, OxcDiagnostic};
-use oxc_span::{GetSpan, SPAN, Span};
+use oxc_span::{SPAN, Span};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::diagnostics::{ErrorCategory, has_critical_errors, with_fallback_label};
@@ -25,7 +25,7 @@ use crate::react_compiler_hir::ReactFunctionType;
 use crate::react_compiler_hir::environment_config::EnvironmentConfig;
 use crate::react_compiler_lowering::FunctionNode;
 use crate::scope::ScopeResolver;
-use oxc_allocator::{Allocator, ArenaBox, ArenaVec, CloneIn, GetAllocator};
+use oxc_allocator::{Allocator, ArenaBox, ArenaVec, CloneIn, GetAddress, GetAllocator};
 use oxc_semantic::{AstNodes, NodeId, Scoping, Semantic};
 use oxc_syntax::scope::ScopeId;
 use oxc_syntax::symbol::SymbolId;
@@ -70,7 +70,7 @@ struct CompileSource<'a> {
     fn_ast_span: Option<Span>,
     fn_start: Option<u32>,
     fn_end: Option<u32>,
-    fn_node_id: Option<u32>,
+    fn_scope_id: ScopeId,
     fn_type: ReactFunctionType,
     /// The discovered oxc function node, handed straight to lowering.
     fn_node: FunctionNode<'a>,
@@ -1273,8 +1273,8 @@ fn body_directive_values(body: &oxc::FunctionBody) -> Vec<String> {
 
 /// Try to create a `CompileSource` from a discovered oxc function node.
 ///
-/// `fn_node` is the oxc function node, `span` its byte range (`span.start` is the
-/// node id), `name` the inferred function name, `original_kind` the syntactic kind,
+/// `fn_node` is the oxc function node (its scope is the function's identity),
+/// `name` the inferred function name, `original_kind` the syntactic kind,
 /// and `parent_callee_name` the enclosing forwardRef/memo callee (if any).
 fn try_make_compile_source<'a>(
     fn_node: FunctionNode<'a>,
@@ -1282,7 +1282,7 @@ fn try_make_compile_source<'a>(
     original_kind: OriginalFnKind,
     parent_callee_name: Option<&str>,
     opts: &PluginOptions,
-    already_compiled: &mut FxHashSet<u32>,
+    already_compiled: &mut FxHashSet<ScopeId>,
 ) -> Option<CompileSource<'a>> {
     let (params, body, span, body_directives) = match fn_node {
         FunctionNode::Function(f) => {
@@ -1305,11 +1305,11 @@ fn try_make_compile_source<'a>(
         }
     };
 
-    let node_id = span.start;
+    let fn_scope_id = fn_node.scope_id()?;
 
-    // Skip if already compiled (identified by node_id). This is a workaround for
-    // Babel not consistently respecting skip().
-    if already_compiled.contains(&node_id) {
+    // Skip if already compiled (identified by the function's scope). This is a
+    // workaround for Babel not consistently respecting skip().
+    if already_compiled.contains(&fn_scope_id) {
         return None;
     }
 
@@ -1326,7 +1326,7 @@ fn try_make_compile_source<'a>(
         false,
     )?;
 
-    already_compiled.insert(node_id);
+    already_compiled.insert(fn_scope_id);
 
     Some(CompileSource {
         kind: CompileSourceKind::Original,
@@ -1337,7 +1337,7 @@ fn try_make_compile_source<'a>(
         fn_ast_span: Some(span),
         fn_start: Some(span.start),
         fn_end: Some(span.end),
-        fn_node_id: Some(node_id),
+        fn_scope_id,
         fn_type,
         fn_node,
         body_directives,
@@ -1376,7 +1376,7 @@ fn get_declarator_name<'ast>(decl: &oxc::VariableDeclarator<'ast>) -> Option<&'a
 /// discovery — matching the Babel bridge, which extracted no metadata for them).
 struct DiscoveryWalker<'a, 'ast> {
     opts: &'a PluginOptions,
-    already_compiled: FxHashSet<u32>,
+    already_compiled: FxHashSet<ScopeId>,
     queue: Vec<CompileSource<'ast>>,
     scope_stack: Vec<ScopeId>,
     loop_expression_depth: usize,
@@ -2021,10 +2021,9 @@ fn may_have_functions_to_compile(semantic: &Semantic, opts: &PluginOptions) -> b
                         get_function_name_from_id(func.id.as_ref()),
                         OriginalFnKind::FunctionDeclaration,
                     ),
-                    _ => (
-                        declarator_name_for(nodes, node.id(), func.span),
-                        OriginalFnKind::FunctionExpression,
-                    ),
+                    _ => {
+                        (declarator_name_for(nodes, node.id()), OriginalFnKind::FunctionExpression)
+                    }
                 };
                 // A nameless function without directives can never classify.
                 if name.is_none()
@@ -2035,7 +2034,7 @@ fn may_have_functions_to_compile(semantic: &Semantic, opts: &PluginOptions) -> b
                 (FunctionNode::Function(func), name, original_kind)
             }
             AstKind::ArrowFunctionExpression(arrow) => {
-                let name = declarator_name_for(nodes, node.id(), arrow.span);
+                let name = declarator_name_for(nodes, node.id());
                 if name.is_none() && arrow.body.directives.is_empty() {
                     continue;
                 }
@@ -2074,14 +2073,12 @@ fn has_wrapper_callee_reference(scoping: &Scoping, nodes: &AstNodes, symbol_id: 
 
 /// The `const Foo = <fn>` name for a function/arrow node, iff the declarator's
 /// init is directly this node — the same direct-init rule the discovery walker
-/// applies (wrappers like parens or TS casts break the inference there too).
-fn declarator_name_for<'a>(nodes: &AstNodes<'a>, node_id: NodeId, span: Span) -> Option<&'a str> {
+/// applies. A function whose direct parent is the declarator can only be its
+/// init (wrappers like parens or TS casts introduce an intermediate parent and
+/// break the inference there too).
+fn declarator_name_for<'a>(nodes: &AstNodes<'a>, node_id: NodeId) -> Option<&'a str> {
     match nodes.parent_kind(node_id) {
-        AstKind::VariableDeclarator(decl)
-            if decl.init.as_ref().is_some_and(|init| init.span() == span) =>
-        {
-            get_declarator_name(decl)
-        }
+        AstKind::VariableDeclarator(decl) => get_declarator_name(decl),
         _ => None,
     }
 }
@@ -2090,19 +2087,19 @@ fn declarator_name_for<'a>(nodes: &AstNodes<'a>, node_id: NodeId, span: Span) ->
 /// [`get_callee_name_if_react_api`] recognizes — directly (`memo(...)`) or as
 /// the object of a called member (`React.memo(...)`).
 fn is_wrapper_callee(nodes: &AstNodes, node_id: NodeId) -> bool {
-    let span = nodes.get_node(node_id).kind().span();
+    let node_address = nodes.get_node(node_id).address();
     let parent = nodes.parent_node(node_id);
-    let (call, callee_span) = match parent.kind() {
-        AstKind::CallExpression(call) => (call, span),
-        AstKind::StaticMemberExpression(member) if member.object.span() == span => {
+    let call = match parent.kind() {
+        AstKind::CallExpression(call) if call.callee.address() == node_address => call,
+        AstKind::StaticMemberExpression(member) if member.object.address() == node_address => {
             match nodes.parent_kind(parent.id()) {
-                AstKind::CallExpression(call) => (call, member.span),
+                AstKind::CallExpression(call) if call.callee.address() == parent.address() => call,
                 _ => return false,
             }
         }
         _ => return false,
     };
-    call.callee.span() == callee_span && get_callee_name_if_react_api(&call.callee).is_some()
+    get_callee_name_if_react_api(&call.callee).is_some()
 }
 
 struct CompiledFunction<'a, 'p, 's> {
@@ -2124,13 +2121,13 @@ enum OriginalFnKind {
 // oxc splice
 //
 // Builds the final oxc `Program` by substituting each compiled oxc function (from
-// codegen) for its original — matched by `span.start == fn_node_id` — applying
+// codegen) for its original — matched by the original function's scope — applying
 // gating, inserting outlined functions, and adding the memo-cache / gating imports.
 // =============================================================================
 
 /// An owned, oxc-shaped compiled function ready to splice into the program.
 struct OxcReplacement<'a> {
-    fn_node_id: Option<u32>,
+    fn_scope_id: ScopeId,
     original_kind: OriginalFnKind,
     codegen_fn: CodegenFunction<'a>,
     gating: Option<GatingConfig>,
@@ -2211,11 +2208,11 @@ fn ox_build_compiled_expression<'a>(
     }
 }
 
-/// Visitor that replaces a compiled function in the oxc AST by matching `span.start`.
-/// Mirrors the Babel `ReplaceFnVisitor`.
+/// Visitor that replaces a compiled function in the oxc AST by matching the
+/// original function's scope. Mirrors the Babel `ReplaceFnVisitor`.
 struct OxcReplaceFnVisitor<'a, 'b> {
     ast: &'b AstBuilder<'a>,
-    node_id: u32,
+    scope_id: ScopeId,
     codegen: &'b CodegenFunction<'a>,
     done: bool,
 }
@@ -2229,7 +2226,7 @@ impl<'a, 'b> oxc_ast_visit::VisitMut<'a> for OxcReplaceFnVisitor<'a, 'b> {
         if self.done {
             return;
         }
-        if func.span.start == self.node_id {
+        if func.scope_id.get() == Some(self.scope_id) {
             // When the compiled function does not initialize a memo cache, the body is
             // left essentially intact, so the original TS signature (type parameters,
             // `this` parameter, return type, and per-parameter type annotations) is
@@ -2259,7 +2256,7 @@ impl<'a, 'b> oxc_ast_visit::VisitMut<'a> for OxcReplaceFnVisitor<'a, 'b> {
         if self.done {
             return;
         }
-        if arrow.span.start == self.node_id {
+        if arrow.scope_id.get() == Some(self.scope_id) {
             let keep_types = self.codegen.memo_slots_used == 0;
             let mut params = self.codegen.params.clone_in(self.ast.allocator());
             if keep_types {
@@ -2279,11 +2276,11 @@ impl<'a, 'b> oxc_ast_visit::VisitMut<'a> for OxcReplaceFnVisitor<'a, 'b> {
     }
 }
 
-/// Visitor that replaces a function (matched by `span.start`) with a gated
+/// Visitor that replaces a function (matched by its scope) with a gated
 /// conditional expression. Mirrors the Babel `ReplaceWithGatedVisitor`.
 struct OxcReplaceWithGatedVisitor<'a, 'b> {
     ast: &'b AstBuilder<'a>,
-    node_id: u32,
+    scope_id: ScopeId,
     gating_expression: &'b oxc::Expression<'a>,
     /// Pending `export default Name;` to insert after a named export-default fn.
     export_default_name: Option<String>,
@@ -2321,12 +2318,14 @@ impl<'a, 'b> oxc_ast_visit::VisitMut<'a> for OxcReplaceWithGatedVisitor<'a, 'b> 
             }
             // FunctionDeclaration → `const Foo = gating() ? ... : ...;`
             let replace_name: Option<Option<String>> = match &stmts[i] {
-                oxc::Statement::FunctionDeclaration(f) if f.span.start == self.node_id => {
+                oxc::Statement::FunctionDeclaration(f)
+                    if f.scope_id.get() == Some(self.scope_id) =>
+                {
                     Some(f.id.as_ref().map(|id| id.name.to_string()))
                 }
                 oxc::Statement::ExportNamedDeclaration(e) => match &e.declaration {
                     Some(oxc::Declaration::FunctionDeclaration(f))
-                        if f.span.start == self.node_id =>
+                        if f.scope_id.get() == Some(self.scope_id) =>
                     {
                         Some(f.id.as_ref().map(|id| id.name.to_string()))
                     }
@@ -2364,7 +2363,7 @@ impl<'a, 'b> oxc_ast_visit::VisitMut<'a> for OxcReplaceWithGatedVisitor<'a, 'b> 
             // ExportDefaultDeclaration with FunctionDeclaration
             if let oxc::Statement::ExportDefaultDeclaration(e) = &stmts[i] {
                 if let oxc::ExportDefaultDeclarationKind::FunctionDeclaration(f) = &e.declaration {
-                    if f.span.start == self.node_id {
+                    if f.scope_id.get() == Some(self.scope_id) {
                         if let Some(id) = f.id.as_ref().map(|id| id.name.to_string()) {
                             stmts[i] = self.build_const_decl(&id);
                             self.export_default_name = Some(id);
@@ -2416,8 +2415,8 @@ impl<'a, 'b> oxc_ast_visit::VisitMut<'a> for OxcReplaceWithGatedVisitor<'a, 'b> 
             return;
         }
         let matched = match expr {
-            oxc::Expression::FunctionExpression(f) => f.span.start == self.node_id,
-            oxc::Expression::ArrowFunctionExpression(f) => f.span.start == self.node_id,
+            oxc::Expression::FunctionExpression(f) => f.scope_id.get() == Some(self.scope_id),
+            oxc::Expression::ArrowFunctionExpression(f) => f.scope_id.get() == Some(self.scope_id),
             _ => false,
         };
         if matched {
@@ -2472,10 +2471,7 @@ fn ox_apply_gated_conditional<'a>(
     gating_config: &GatingConfig,
     context: &mut ProgramContext,
 ) {
-    let node_id = match replacement.fn_node_id {
-        Some(nid) => nid,
-        None => return,
-    };
+    let scope_id = replacement.fn_scope_id;
 
     let gating_import = context.add_import_specifier(
         &gating_config.source,
@@ -2483,9 +2479,9 @@ fn ox_apply_gated_conditional<'a>(
         None,
     );
 
-    // Clone the original function (matched by node_id) as the fallback expression
-    // BEFORE replacing it.
-    let original_expr = ox_clone_original_fn_as_expression(ast, program, node_id);
+    // Clone the original function (matched by its scope) as the fallback
+    // expression BEFORE replacing it.
+    let original_expr = ox_clone_original_fn_as_expression(ast, program, scope_id);
     let original_expr = match original_expr {
         Some(e) => e,
         None => return,
@@ -2505,7 +2501,7 @@ fn ox_apply_gated_conditional<'a>(
 
     let mut visitor = OxcReplaceWithGatedVisitor {
         ast,
-        node_id,
+        scope_id,
         gating_expression: &gating_expression,
         export_default_name: None,
         done: false,
@@ -2513,16 +2509,17 @@ fn ox_apply_gated_conditional<'a>(
     oxc_ast_visit::VisitMut::visit_program(&mut visitor, program);
 }
 
-/// Clone the original function at `node_id` as an `Expression` (FunctionDeclaration
-/// becomes a FunctionExpression). Mirrors `clone_original_fn_as_expression`.
+/// Clone the original function with scope `scope_id` as an `Expression`
+/// (FunctionDeclaration becomes a FunctionExpression). Mirrors
+/// `clone_original_fn_as_expression`.
 fn ox_clone_original_fn_as_expression<'a>(
     ast: &AstBuilder<'a>,
     program: &oxc::Program<'a>,
-    node_id: u32,
+    scope_id: ScopeId,
 ) -> Option<oxc::Expression<'a>> {
     struct Finder<'a, 'b> {
         ast: &'b AstBuilder<'a>,
-        node_id: u32,
+        scope_id: ScopeId,
         found: Option<oxc::Expression<'a>>,
     }
     impl<'a, 'b> oxc_ast_visit::Visit<'a> for Finder<'a, 'b> {
@@ -2534,7 +2531,7 @@ fn ox_clone_original_fn_as_expression<'a>(
             if self.found.is_some() {
                 return;
             }
-            if func.span.start == self.node_id {
+            if func.scope_id.get() == Some(self.scope_id) {
                 let f = oxc::Function::boxed(
                     SPAN,
                     oxc::FunctionType::FunctionExpression,
@@ -2558,7 +2555,7 @@ fn ox_clone_original_fn_as_expression<'a>(
             if self.found.is_some() {
                 return;
             }
-            if arrow.span.start == self.node_id {
+            if arrow.scope_id.get() == Some(self.scope_id) {
                 self.found = Some(oxc::Expression::ArrowFunctionExpression(ArenaBox::new_in(
                     arrow.clone_in(self.ast.allocator()),
                     self.ast,
@@ -2568,7 +2565,7 @@ fn ox_clone_original_fn_as_expression<'a>(
             oxc_ast_visit::walk::walk_arrow_function_expression(self, arrow);
         }
     }
-    let mut finder = Finder { ast, node_id, found: None };
+    let mut finder = Finder { ast, scope_id, found: None };
     oxc_ast_visit::Visit::visit_program(&mut finder, program);
     finder.found.map(|e| e.clone_in(ast.allocator()))
 }
@@ -2581,7 +2578,10 @@ fn ox_splice_program<'a>(
     replacements: &[OxcReplacement<'a>],
     context: &mut ProgramContext,
 ) -> oxc::Program<'a> {
-    let mut program = program.clone_in(ast.allocator());
+    // Preserve the semantic id cells: the replacement visitors match original
+    // functions by their `scope_id`, and codegen-built nodes carry no cells, so
+    // they can never be spuriously matched.
+    let mut program = program.clone_in_with_semantic_ids(ast.allocator());
 
     // Outlined function declarations are placed differently depending on the
     // original function's syntactic kind, mirroring `insertNewOutlinedFunctionNode`
@@ -2609,16 +2609,18 @@ fn ox_splice_program<'a>(
 
         if let Some(ref gating_config) = replacement.gating {
             ox_apply_gated_conditional(ast, &mut program, replacement, gating_config, context);
-        } else if let Some(node_id) = replacement.fn_node_id {
-            let mut visitor =
-                OxcReplaceFnVisitor { ast, node_id, codegen: &replacement.codegen_fn, done: false };
+        } else {
+            let mut visitor = OxcReplaceFnVisitor {
+                ast,
+                scope_id: replacement.fn_scope_id,
+                codegen: &replacement.codegen_fn,
+                done: false,
+            };
             oxc_ast_visit::VisitMut::visit_program(&mut visitor, &mut program);
         }
 
         if !sibling_outlined_decls.is_empty() {
-            if let Some(node_id) = replacement.fn_node_id {
-                ox_insert_outlined_after(&mut program, node_id, sibling_outlined_decls);
-            }
+            ox_insert_outlined_after(&mut program, replacement.fn_scope_id, sibling_outlined_decls);
         }
     }
 
@@ -2644,22 +2646,23 @@ fn ox_splice_program<'a>(
 }
 
 /// Insert outlined function declarations immediately after the top-level statement
-/// that declares the function identified by `node_id`. Mirrors Babel's
+/// that declares the function with scope `scope_id`. Mirrors Babel's
 /// `originalFn.insertAfter(...)` for `FunctionDeclaration` originals. The statement
 /// may be a bare `FunctionDeclaration` or one wrapped in an `export`.
 fn ox_insert_outlined_after<'a>(
     program: &mut oxc::Program<'a>,
-    node_id: u32,
+    scope_id: ScopeId,
     outlined_decls: Vec<oxc::Statement<'a>>,
 ) {
     let matches = |stmt: &oxc::Statement<'a>| -> bool {
+        let is_target = |f: &oxc::Function<'a>| -> bool { f.scope_id.get() == Some(scope_id) };
         match stmt {
-            oxc::Statement::FunctionDeclaration(f) => f.span.start == node_id,
+            oxc::Statement::FunctionDeclaration(f) => is_target(f),
             oxc::Statement::ExportNamedDeclaration(e) => {
-                matches!(&e.declaration, Some(oxc::Declaration::FunctionDeclaration(f)) if f.span.start == node_id)
+                matches!(&e.declaration, Some(oxc::Declaration::FunctionDeclaration(f)) if is_target(f))
             }
             oxc::Statement::ExportDefaultDeclaration(e) => {
-                matches!(&e.declaration, oxc::ExportDefaultDeclarationKind::FunctionDeclaration(f) if f.span.start == node_id)
+                matches!(&e.declaration, oxc::ExportDefaultDeclarationKind::FunctionDeclaration(f) if is_target(f))
             }
             _ => false,
         }
@@ -2905,7 +2908,7 @@ pub fn compile_program<'a, 'p>(
     // The codegen back-end builds oxc nodes directly via this `AstBuilder`; `scope`
     // is a read-through view over `Semantic` for binding/reference lookups.
     let ast = AstBuilder::new(allocator);
-    let scope = ScopeResolver::new(semantic, program);
+    let scope = ScopeResolver::new(semantic);
 
     // Initialize known referenced names from scope bindings for UID collision detection
     context.init_from_scope(&scope);
@@ -2991,7 +2994,7 @@ pub fn compile_program<'a, 'p>(
                 None
             };
             OxcReplacement {
-                fn_node_id: cf.source.fn_node_id,
+                fn_scope_id: cf.source.fn_scope_id,
                 original_kind: cf.source.original_kind,
                 codegen_fn: cf.codegen_fn,
                 gating,
@@ -3004,8 +3007,8 @@ pub fn compile_program<'a, 'p>(
 
     // `ast` is `None` when nothing was compiled — always so in lint mode, which
     // applies nothing — skipping `ox_splice_program`'s whole-program clone. Splicing
-    // each compiled function in for its original (matched by `span.start ==
-    // fn_node_id`) is also what inserts the memo-cache / gating imports, so (matching
+    // each compiled function in for its original (matched by the function's scope)
+    // is also what inserts the memo-cache / gating imports, so (matching
     // TS `addImportsToProgram`) they're added only when there are replacements.
     CompileResult::Success {
         ast: (!replacements.is_empty())

--- a/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
@@ -5,6 +5,8 @@ use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 
 use oxc_diagnostics::{Diagnostics, OxcDiagnostic};
+use oxc_syntax::reference::ReferenceId;
+use oxc_syntax::symbol::SymbolId;
 
 use crate::diagnostics::ErrorCategory;
 
@@ -22,15 +24,6 @@ use crate::react_compiler_hir::object_shape::add_hook;
 use crate::react_compiler_hir::object_shape::default_mutating_hook;
 use crate::react_compiler_hir::object_shape::default_nonmutating_hook;
 use crate::react_compiler_hir::*;
-
-/// A variable rename from lowering: the binding at `declaration_start` position
-/// was renamed from `original` to `renamed`.
-#[derive(Debug, Clone)]
-pub struct BindingRename {
-    pub original: String,
-    pub renamed: String,
-    pub declaration_start: u32,
-}
 
 /// Output mode for the compiler, mirrored from the entrypoint's CompilerOutputMode.
 /// Stored on Environment so pipeline passes can access it.
@@ -74,20 +67,14 @@ pub struct Environment<'a> {
     pub instrument_gating_name: Option<String>,
     pub hook_guard_name: Option<String>,
 
-    // Renames: tracks variable renames from lowering (original_name → new_name)
-    // keyed by binding declaration position, for applying back to the Babel AST.
-    pub renames: Vec<BindingRename>,
-
-    // Node IDs of identifiers that are actual references to bindings.
-    // Used by codegen to filter type annotation renames — only rename identifiers
-    // whose node_id is in this set (type labels like ObjectTypeIndexer params
-    // are NOT in this set and should keep their original names).
-    pub reference_node_ids: FxHashSet<u32>,
+    // Renames from lowering (collision suffixes like `name_0`), recorded per
+    // resolved reference so codegen can rename identifiers inside preserved TS
+    // type annotations by reference identity.
+    pub renames: FxHashMap<ReferenceId, String>,
 
     // Hoisted identifiers: tracks which bindings have already been hoisted
     // via DeclareContext to avoid duplicate hoisting.
-    // Uses u32 to avoid depending on react_compiler_ast types.
-    hoisted_identifiers: FxHashSet<u32>,
+    hoisted_identifiers: FxHashSet<SymbolId>,
 
     // Config flags for validation passes (kept for backwards compat with existing pipeline code)
     pub validate_preserve_existing_memoization_guarantees: bool,
@@ -186,8 +173,7 @@ impl<'a> Environment<'a> {
             instrument_fn_name: None,
             instrument_gating_name: None,
             hook_guard_name: None,
-            renames: Vec::new(),
-            reference_node_ids: FxHashSet::default(),
+            renames: FxHashMap::default(),
             hoisted_identifiers: FxHashSet::default(),
             validate_preserve_existing_memoization_guarantees: config
                 .validate_preserve_existing_memoization_guarantees,
@@ -319,12 +305,12 @@ impl<'a> Environment<'a> {
     }
 
     /// Check if a binding has been hoisted (via DeclareContext) already.
-    pub fn is_hoisted_identifier(&self, binding_id: u32) -> bool {
+    pub fn is_hoisted_identifier(&self, binding_id: SymbolId) -> bool {
         self.hoisted_identifiers.contains(&binding_id)
     }
 
     /// Mark a binding as hoisted.
-    pub fn add_hoisted_identifier(&mut self, binding_id: u32) {
+    pub fn add_hoisted_identifier(&mut self, binding_id: SymbolId) {
         self.hoisted_identifiers.insert(binding_id);
     }
 

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -42,16 +42,12 @@ fn is_class_scope_descendant(scope: &ScopeResolver<'_, '_>, scope_id: ScopeId) -
     scope.ancestors(scope_id).skip(1).any(|s| scope.scope_kind(s) == ScopeKind::Class)
 }
 
-fn validate_ts_this_parameters_in_function_range(
+fn validate_ts_this_parameters_within(
     scope: &ScopeResolver<'_, '_>,
-    start: u32,
-    end: u32,
+    function_scope: ScopeId,
 ) -> Result<(), OxcDiagnostic> {
-    if start >= end {
-        return Ok(());
-    }
-    for &(node_start, _, scope_id) in scope.function_scope_ranges() {
-        if node_start < start || node_start >= end {
+    for scope_id in scope.function_scopes() {
+        if !scope.ancestors(scope_id).any(|s| s == function_scope) {
             continue;
         }
         if is_class_scope_descendant(scope, scope_id) {
@@ -277,7 +273,7 @@ fn lower_block_statement_inner<'a>(
                 scope.symbol_name(sid).to_string(),
                 scope.binding_kind(sid),
                 scope.decl_kind(sid),
-                scope.declaration_start(sid),
+                scope.declaration_ident(sid).map(|id| id.span.start),
             )
         })
         .collect();
@@ -309,8 +305,8 @@ fn lower_block_statement_inner<'a>(
                 .scope()
                 .function_scope_ranges()
                 .iter()
-                .filter(|&&(pos, _, _)| pos > stmt_start && pos < stmt_end)
-                .map(|&(pos, end, _)| (pos, end))
+                .copied()
+                .filter(|&(pos, _)| pos > stmt_start && pos < stmt_end)
                 .collect()
         };
 
@@ -320,8 +316,7 @@ fn lower_block_statement_inner<'a>(
             name: String,
             kind: AstBindingKind,
             declaration_type: DeclKind,
-            first_ref_pos: u32,
-            first_ref_nid: u32,
+            first_ref_span: Span,
         }
         let mut will_hoist: Vec<HoistInfo> = Vec::new();
 
@@ -330,58 +325,58 @@ fn lower_block_statement_inner<'a>(
                 continue;
             }
 
-            // Find the first reference (not declaration) to this binding in the statement's range.
+            // Find the first reference to this binding in the statement's range.
             // Exclude JSX identifier references: while Babel's scope system links JSX
             // tag names to local bindings (and the context capture pass includes them),
             // the TS hoisting analysis does NOT traverse JSX elements. This mismatch
             // is intentional — it matches the TS behavior where <colgroup> adds
             // "colgroup" to the context but does NOT trigger hoisting, causing
             // EnterSSA to error with "Expected identifier to be defined before use".
-            //
-            // The decl_start filter excludes the binding's own declaration position from
-            // counting as a reference. For hoisted bindings (function declarations), this
-            // filter is only applied when the current statement IS a FunctionDeclaration,
-            // since that's the only statement type where decl_start is a declaration, not
-            // a reference.
-            let apply_decl_filter = !matches!(kind, AstBindingKind::Hoisted) || is_function_decl;
-            let refs_in_stmt: Vec<(u32, u32)> = scope
-                .reference_positions(*binding_id)
-                .chain(decl_start.iter().copied())
-                .filter_map(|ref_nid| {
-                    let entry = builder.identifier_spans().get(&ref_nid)?;
-                    let ref_start = entry.start;
+            let mut refs_in_stmt: Vec<Span> = scope
+                .reference_ids(*binding_id)
+                .iter()
+                .filter_map(|&ref_id| {
+                    let entry = builder.identifier_spans().reference(ref_id)?;
+                    let ref_start = entry.span.start;
                     if ref_start < stmt_start || ref_start >= stmt_end {
                         return None;
                     }
-                    if apply_decl_filter && *decl_start == Some(ref_nid) {
+                    if entry.is_jsx() {
                         return None;
                     }
-                    if entry.is_jsx {
-                        return None;
-                    }
-                    Some((ref_start, ref_nid))
+                    Some(entry.span)
                 })
                 .collect();
+            // For hoisted bindings (function declarations) outside their own
+            // declaration statement, the declaration site itself counts as a
+            // reference (Babel's binding references include the declaration).
+            let decl_counts_as_ref = matches!(kind, AstBindingKind::Hoisted) && !is_function_decl;
+            if decl_counts_as_ref {
+                if let Some(decl_span) = builder.identifier_spans().declaration_span(*binding_id) {
+                    if decl_span.start >= stmt_start && decl_span.start < stmt_end {
+                        refs_in_stmt.push(decl_span);
+                    }
+                }
+            }
 
             if refs_in_stmt.is_empty() {
                 continue;
             }
 
-            let (first_ref_pos, first_ref_nid) =
-                *refs_in_stmt.iter().min_by_key(|(pos, _)| *pos).unwrap();
+            let first_ref_span = *refs_in_stmt.iter().min_by_key(|s| s.start).unwrap();
 
             // Hoist if: (1) binding is "hoisted" kind (function declaration), or
             // (2) any reference to this binding is inside a nested function scope.
             // Check per-reference rather than per-statement to correctly handle
             // statements that contain both nested functions and top-level code.
             let is_hoisted_kind = matches!(kind, AstBindingKind::Hoisted);
-            let refs_in_nested_fn: Vec<(u32, u32)> = refs_in_stmt
+            let refs_in_nested_fn: Vec<Span> = refs_in_stmt
                 .iter()
                 .copied()
-                .filter(|&(ref_pos, _)| {
+                .filter(|s| {
                     nested_function_ranges
                         .iter()
-                        .any(|&(fn_start, fn_end)| ref_pos >= fn_start && ref_pos < fn_end)
+                        .any(|&(fn_start, fn_end)| s.start >= fn_start && s.start < fn_end)
                 })
                 .collect();
             let should_hoist = is_hoisted_kind || !refs_in_nested_fn.is_empty();
@@ -404,28 +399,27 @@ fn lower_block_statement_inner<'a>(
                 // For hoisted bindings (function declarations), use the first reference
                 // overall. For non-hoisted bindings, use the first reference inside a
                 // nested function.
-                let (hoist_ref_pos, hoist_ref_nid) = if is_hoisted_kind {
-                    (first_ref_pos, first_ref_nid)
+                let first_ref_span = if is_hoisted_kind {
+                    first_ref_span
                 } else {
-                    *refs_in_nested_fn.iter().min_by_key(|(pos, _)| *pos).unwrap()
+                    *refs_in_nested_fn.iter().min_by_key(|s| s.start).unwrap()
                 };
                 will_hoist.push(HoistInfo {
                     binding_id: *binding_id,
                     name: name.clone(),
                     kind: *kind,
                     declaration_type: *decl_type,
-                    first_ref_pos: hoist_ref_pos,
-                    first_ref_nid: hoist_ref_nid,
+                    first_ref_span,
                 });
             }
         }
 
         // Sort by first reference position to match TS traversal order
-        will_hoist.sort_by_key(|h| h.first_ref_pos);
+        will_hoist.sort_by_key(|h| h.first_ref_span.start);
 
         // Emit DeclareContext for hoisted bindings
         for info in &will_hoist {
-            if builder.environment().is_hoisted_identifier(info.binding_id.index() as u32) {
+            if builder.environment().is_hoisted_identifier(info.binding_id) {
                 continue;
             }
 
@@ -462,8 +456,7 @@ fn lower_block_statement_inner<'a>(
                 }
             };
 
-            // Look up the reference location for the DeclareContext instruction.
-            let ref_span = builder.identifier_spans().get(&info.first_ref_nid).map(|e| e.span);
+            let ref_span = Some(info.first_ref_span);
             let identifier = builder.resolve_binding(&info.name, info.binding_id)?;
             let place =
                 Place { effect: Effect::Unknown, identifier, reactive: false, span: ref_span };
@@ -474,7 +467,7 @@ fn lower_block_statement_inner<'a>(
                     span: ref_span,
                 },
             )?;
-            builder.environment_mut().add_hoisted_identifier(info.binding_id.index() as u32);
+            builder.environment_mut().add_hoisted_identifier(info.binding_id);
             // Hoisted identifiers also become context identifiers (matching TS addHoistedIdentifier)
             builder.add_context_identifier(info.binding_id);
         }
@@ -539,7 +532,7 @@ pub fn lower<'a>(
     // Note: `id` param may include inferred names (e.g., from `const Foo = () => {}`),
     // but the HIR function's `id` field should only include the function's own AST id
     // (FunctionDeclaration.id or FunctionExpression.id, NOT arrow functions).
-    let (params, body, generator, is_async, span, start, end, ast_id) = match func {
+    let (params, body, generator, is_async, span, ast_id) = match func {
         FunctionNode::Function(f) => {
             let body_ref = f.body.as_deref().expect("component function has a body");
             (
@@ -548,8 +541,6 @@ pub fn lower<'a>(
                 f.generator,
                 f.r#async,
                 f.span,
-                f.span.start,
-                f.span.end,
                 f.id.as_ref().map(|id| id.name.as_str()),
             )
         }
@@ -564,22 +555,13 @@ pub fn lower<'a>(
             } else {
                 FunctionBody::Block(arrow.body.as_ref())
             };
-            (
-                arrow.params.as_ref(),
-                body,
-                false,
-                arrow.r#async,
-                arrow.span,
-                arrow.span.start,
-                arrow.span.end,
-                None,
-            )
+            (arrow.params.as_ref(), body, false, arrow.r#async, arrow.span, None)
         }
     };
 
     let scope_id = func.scope_id().unwrap_or_else(|| scope.program_scope());
 
-    validate_ts_this_parameters_in_function_range(scope, start, end)?;
+    validate_ts_this_parameters_within(scope, scope_id)?;
 
     // Build identifier location index from the AST (replaces serialized referenceLocs/jsxReferencePositions)
     let identifier_spans = build_identifier_loc_index(func);
@@ -1345,7 +1327,7 @@ fn lower_binding_assignment<'a>(
                         let is_hoisted = builder
                             .scope()
                             .resolve_binding_identifier(id)
-                            .map(|s| builder.environment().is_hoisted_identifier(s.index() as u32))
+                            .map(|s| builder.environment().is_hoisted_identifier(s))
                             .unwrap_or(false);
                         if kind == InstructionKind::Const && !is_hoisted {
                             builder.record_error(
@@ -1902,7 +1884,7 @@ fn lower_assignment_target<'a>(
                         let is_hoisted = builder
                             .scope()
                             .resolve_reference(id)
-                            .map(|s| builder.environment().is_hoisted_identifier(s.index() as u32))
+                            .map(|s| builder.environment().is_hoisted_identifier(s))
                             .unwrap_or(false);
                         if kind == InstructionKind::Const && !is_hoisted {
                             builder.record_error(
@@ -3004,7 +2986,7 @@ fn lower_function<'a>(
     func: FunctionNode<'a>,
 ) -> Result<LoweredFunction, OxcDiagnostic> {
     // Extract function parts from the AST node
-    let (params, body, id, generator, is_async, func_start, func_end, func_span) = match func {
+    let (params, body, id, generator, is_async, func_span) = match func {
         FunctionNode::Arrow(arrow) => {
             let body = if arrow.expression {
                 match arrow.body.statements.first() {
@@ -3016,16 +2998,7 @@ fn lower_function<'a>(
             } else {
                 FunctionBody::Block(arrow.body.as_ref())
             };
-            (
-                arrow.params.as_ref(),
-                body,
-                None::<&str>,
-                false,
-                arrow.r#async,
-                arrow.span.start,
-                arrow.span.end,
-                arrow.span,
-            )
+            (arrow.params.as_ref(), body, None::<&str>, false, arrow.r#async, arrow.span)
         }
         FunctionNode::Function(f) => {
             let body_ref = f.body.as_deref().expect("function expression has a body");
@@ -3035,8 +3008,6 @@ fn lower_function<'a>(
                 f.id.as_ref().map(|id| id.name.as_str()),
                 f.generator,
                 f.r#async,
-                f.span.start,
-                f.span.end,
                 f.span,
             )
         }
@@ -3053,14 +3024,8 @@ fn lower_function<'a>(
     let ident_spans = builder.identifier_spans();
 
     // Gather captured context
-    let captured_context = gather_captured_context(
-        scope,
-        function_scope,
-        component_scope,
-        func_start,
-        func_end,
-        ident_spans,
-    );
+    let captured_context =
+        gather_captured_context(scope, function_scope, component_scope, ident_spans);
     let merged_context: FxIndexMap<SymbolId, Option<Span>> = {
         let parent_context = builder.context().clone();
         let mut merged = parent_context;
@@ -3103,8 +3068,6 @@ fn lower_function_declaration<'a>(
     func_decl: &'a oxc::Function<'a>,
 ) -> Result<(), OxcDiagnostic> {
     let span = func_decl.span;
-    let func_start = func_decl.span.start;
-    let func_end = func_decl.span.end;
 
     let func_name = func_decl.id.as_ref().map(|id| id.name.to_string());
 
@@ -3121,14 +3084,8 @@ fn lower_function_declaration<'a>(
     let ident_spans = builder.identifier_spans();
 
     // Gather captured context
-    let captured_context = gather_captured_context(
-        scope,
-        function_scope,
-        component_scope,
-        func_start,
-        func_end,
-        ident_spans,
-    );
+    let captured_context =
+        gather_captured_context(scope, function_scope, component_scope, ident_spans);
     let merged_context: FxIndexMap<SymbolId, Option<Span>> = {
         let parent_context = builder.context().clone();
         let mut merged = parent_context;
@@ -3218,7 +3175,7 @@ fn lower_function_declaration<'a>(
                         };
                         if let Some(symbol_id) = fallback {
                             let symbol =
-                                builder.scope().declaration_start(symbol_id).map(|_| symbol_id);
+                                builder.scope().declaration_ident(symbol_id).map(|_| symbol_id);
                             binding = builder.resolve_identifier(name, ident_span, symbol)?;
                         }
                     }
@@ -3290,8 +3247,6 @@ fn lower_function_for_object_method<'a>(
     generator: bool,
     is_async: bool,
 ) -> Result<LoweredFunction, OxcDiagnostic> {
-    let func_start = method_span.start;
-    let func_end = method_span.end;
     let func_span = method_span;
 
     let function_scope = func.scope_id.get().unwrap_or_else(|| builder.scope().program_scope());
@@ -3304,14 +3259,8 @@ fn lower_function_for_object_method<'a>(
     let context_ids = builder.context_identifiers().clone();
     let ident_spans = builder.identifier_spans();
 
-    let captured_context = gather_captured_context(
-        scope,
-        function_scope,
-        component_scope,
-        func_start,
-        func_end,
-        ident_spans,
-    );
+    let captured_context =
+        gather_captured_context(scope, function_scope, component_scope, ident_spans);
     let merged_context: FxIndexMap<SymbolId, Option<Span>> = {
         let parent_context = builder.context().clone();
         let mut merged = parent_context;
@@ -3352,10 +3301,9 @@ fn gather_captured_context(
     scope: &ScopeResolver<'_, '_>,
     function_scope: ScopeId,
     component_scope: ScopeId,
-    func_start: u32,
-    func_end: u32,
     identifier_spans: &IdentifierLocIndex,
 ) -> FxIndexMap<SymbolId, Option<Span>> {
+    let root_node = scope.capture_root_node(function_scope);
     let parent_scope = scope.scope_parent(function_scope);
     let pure_scopes = match parent_scope {
         Some(parent) => capture_scopes(scope, parent, component_scope),
@@ -3382,27 +3330,22 @@ fn gather_captured_context(
         if !pure_scopes.contains(&scope.symbol_scope(symbol_id)) {
             continue;
         }
-        let declaration_start = scope.declaration_start(symbol_id);
-        for ref_nid in scope.reference_positions(symbol_id) {
-            // Range check: use the position stored in identifier_spans
-            let ref_start = identifier_spans.get(&ref_nid).map(|e| e.start).unwrap_or(0);
-            if ref_start < func_start || ref_start >= func_end {
-                continue;
-            }
-            // Skip references that are actually the binding's own declaration site
-            if declaration_start == Some(ref_nid) {
-                continue;
-            }
-            // Skip function/class declaration names that are not expression references.
+        let declaration_start = scope.declaration_ident(symbol_id).map(|id| id.span.start);
+        for &ref_id in scope.reference_ids(symbol_id) {
+            // Only references the identifier walk recorded participate; the walk
+            // covers exactly the compiled function's subtree.
+            let Some(entry) = identifier_spans.reference(ref_id) else { continue };
+            let ref_start = entry.span.start;
             // Skip type-annotation references: TS's gatherCapturedContext traverse
             // skips TypeAnnotation/TSTypeAnnotation/TypeAlias/TSTypeAliasDeclaration
             // subtrees, so identifiers there never become captures (they DO still
             // feed FindContextIdentifiers and the hoisting analysis, which have no
             // such skip in TS).
-            if let Some(entry) = identifier_spans.get(&ref_nid) {
-                if entry.is_declaration_name || entry.in_type_annotation {
-                    continue;
-                }
+            if entry.in_type_annotation {
+                continue;
+            }
+            if !scope.node_within(scope.reference_node_id(ref_id), root_node) {
+                continue;
             }
             // Skip references whose start offset aliases the binding's own
             // declaration offset. Hermes desugars (component syntax) reuse the
@@ -3415,9 +3358,7 @@ fn gather_captured_context(
             if declaration_start == Some(ref_start) {
                 continue;
             }
-            let span = identifier_spans.get(&ref_nid).map(|entry| {
-                if let Some(oe_span) = &entry.opening_element_span { *oe_span } else { entry.span }
-            });
+            let span = Some(entry.opening_element_span.unwrap_or(entry.span));
             captured
                 .entry(symbol_id)
                 .and_modify(|(min_pos, existing_span)| {

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/find_context_identifiers.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/find_context_identifiers.rs
@@ -476,8 +476,7 @@ pub fn find_context_identifiers(
     // resolved references (including ones inside type annotations) sit within a
     // nested function scope.
     //
-    // Declaration sites are excluded: they are not references. The function
-    // windows include the object-method alias windows, matching the old map.
+    // Declaration sites are excluded structurally: they are not references.
     let candidates: Vec<SymbolId> = visitor
         .binding_info
         .iter()
@@ -486,21 +485,17 @@ pub fn find_context_identifiers(
         .collect();
     for symbol_id in candidates {
         let binding_scope = scope.symbol_scope(symbol_id);
-        let declaration_start = scope.declaration_start(symbol_id);
-        'refs: for ref_nid in scope.reference_positions(symbol_id) {
-            if declaration_start == Some(ref_nid) {
+        'refs: for &ref_id in scope.reference_ids(symbol_id) {
+            // Only references recorded by the identifier walk participate (the
+            // walk covers exactly the compiled function's subtree).
+            if identifier_spans.reference(ref_id).is_none() {
                 continue;
             }
-            let ref_pos = match identifier_spans.get(&ref_nid) {
-                Some(entry) => entry.start,
-                None => continue,
-            };
-            // Check if ref_pos is inside a nested function scope
-            for &(fn_start, fn_end, fn_scope) in scope.function_scope_ranges() {
-                if fn_start <= ref_pos
-                    && ref_pos < fn_end
-                    && is_captured_by_function(scope, binding_scope, fn_scope)
-                {
+            // Check whether the reference sits inside a nested function that
+            // captures the binding.
+            let ref_node = scope.reference_node_id(ref_id);
+            for fn_scope in scope.containing_function_scopes(ref_node) {
+                if is_captured_by_function(scope, binding_scope, fn_scope) {
                     visitor.binding_info.get_mut(&symbol_id).unwrap().referenced_by_inner_fn = true;
                     break 'refs;
                 }

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/hir_builder.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/hir_builder.rs
@@ -236,9 +236,10 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
         self.scope
     }
 
-    /// Look up the source location of an identifier by its node_id.
-    pub fn get_identifier_span(&self, node_id: u32) -> Option<Span> {
-        self.identifier_spans.get(&node_id).map(|entry| entry.span)
+    /// The declaration identifier's span, when the declaration was recorded
+    /// in the compiled function's identifier index.
+    pub fn declaration_span(&self, symbol_id: SymbolId) -> Option<Span> {
+        self.identifier_spans.declaration_span(symbol_id)
     }
 
     /// Access the function scope (the scope of the function being compiled).
@@ -668,11 +669,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
                     true
                 };
             if should_record_fbt_error {
-                let error_span = self
-                    .scope
-                    .declaration_start(symbol_id)
-                    .and_then(|nid| self.get_identifier_span(nid))
-                    .or(span);
+                let error_span = self.declaration_span(symbol_id).or(span);
                 self.env.record_error(
                     ErrorCategory::Todo
                         .diagnostic("Support local variables named `fbt`")
@@ -705,14 +702,11 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
             index += 1;
         }
 
-        // Record rename if the candidate differs from the original name
+        // Record the rename on each resolved reference of the binding, so codegen
+        // can rename matching identifiers inside preserved TS type annotations.
         if candidate != name {
-            if let Some(decl_start) = self.scope.declaration_start(symbol_id) {
-                self.env.renames.push(crate::react_compiler_hir::environment::BindingRename {
-                    original: name.to_string(),
-                    renamed: candidate.clone(),
-                    declaration_start: decl_start,
-                });
+            for &reference_id in self.scope.reference_ids(symbol_id) {
+                self.env.renames.insert(reference_id, candidate.clone());
             }
         }
 
@@ -723,8 +717,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
         // Prefer the binding's declaration span over the reference span.
         // This matches TS behavior where Babel's resolveBinding returns the
         // binding identifier's original span (the declaration site).
-        let decl_span =
-            self.scope.declaration_start(symbol_id).and_then(|nid| self.get_identifier_span(nid));
+        let decl_span = self.declaration_span(symbol_id);
         if let Some(ref dl) = decl_span {
             self.env.identifiers[id.0 as usize].span = Some(*dl);
         } else if let Some(ref span) = span {

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/identifier_loc_index.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/identifier_loc_index.rs
@@ -1,10 +1,8 @@
-//! Builds an index mapping identifier node-IDs to source locations.
+//! Builds an index mapping identifier references and declarations to source
+//! locations, keyed by semantic `ReferenceId` / `SymbolId`.
 //!
-//! Walks the function's oxc AST to collect an [`IdentifierLocEntry`] for every
-//! Identifier / JSXIdentifier node (and for identifiers inside TS type
-//! annotations). Keyed by node_id (== `span.start`) for identity lookups; each
-//! entry also stores `start` (byte offset) for range-containment checks in
-//! `gather_captured_context`.
+//! Walks the function's oxc AST to collect resolved identifier references and
+//! binding declarations (including identifiers inside TS type annotations).
 //!
 //! This is a translation of the original immutable `IdentifierLocVisitor`, which
 //! was driven by the in-tree `AstWalker`/`Visitor`
@@ -15,9 +13,9 @@
 //! oxc walk to match those positions instead of relying on oxc's default
 //! full-AST traversal. The traversal records:
 //!
-//! * every reference / binding identifier → `is_jsx = false`
-//! * function / class declaration & expression names → `is_declaration_name = true`
-//! * JSX element-name identifiers → `is_jsx = true` plus the enclosing
+//! * every identifier reference and (declaration-map) binding identifier
+//! * function / class declaration & expression names, into the declaration map
+//! * JSX element-name identifier references, carrying the enclosing
 //!   `JSXOpeningElement`'s span as `opening_element_span`
 //! * identifiers inside TS type subtrees → `in_type_annotation = true`
 //!
@@ -37,25 +35,16 @@ use oxc_ast::ast as oxc;
 use oxc_ast_visit::Visit;
 
 use crate::react_compiler_hir::Span;
+use crate::scope::{ReferenceId, SymbolId};
 
 use crate::react_compiler_lowering::FunctionNode;
 
-/// Source location and whether the identifier is a JSXIdentifier.
+/// Source location data for a resolved identifier reference.
 pub struct IdentifierLocEntry {
-    /// The byte offset of the identifier (base.start). Stored here so that
-    /// callers iterating by node_id can still do position-range containment
-    /// checks without a separate bridge map.
-    pub start: u32,
     pub span: Span,
-    pub is_jsx: bool,
-    /// For JSX identifiers that are the root name of a JSXOpeningElement,
-    /// stores the JSXOpeningElement's span (which spans the full tag).
+    /// For JSX element-name identifiers, the enclosing `JSXOpeningElement`'s
+    /// span (which spans the full tag).
     pub opening_element_span: Option<Span>,
-    /// True if this identifier is the name of a function/class declaration
-    /// (not an expression reference). Used by `gather_captured_context` to
-    /// skip non-expression positions, matching the TS behavior where the
-    /// Expression visitor doesn't visit declaration names.
-    pub is_declaration_name: bool,
     /// True if this identifier sits inside a type annotation subtree
     /// (TypeAnnotation/TSTypeAnnotation/TypeAlias/TSTypeAliasDeclaration).
     /// `gather_captured_context` skips these to match the TS
@@ -64,9 +53,38 @@ pub struct IdentifierLocEntry {
     pub in_type_annotation: bool,
 }
 
-/// Index mapping node_id → IdentifierLocEntry for all Identifier
-/// and JSXIdentifier nodes in a function's AST.
-pub type IdentifierLocIndex = FxHashMap<u32, IdentifierLocEntry>;
+impl IdentifierLocEntry {
+    /// True for JSX element-name identifiers. The TS hoisting analysis does
+    /// not traverse JSX elements, so hoisting skips these references.
+    pub fn is_jsx(&self) -> bool {
+        self.opening_element_span.is_some()
+    }
+}
+
+/// Identifier locations for a function's AST, keyed by semantic identity.
+///
+/// Only identifiers the original Babel walker visited are recorded, so
+/// membership in these maps is itself meaningful: a symbol has a declaration
+/// span here iff its declaration identifier sits in a position the walker
+/// recorded (inside the compiled function, outside type subtrees).
+#[derive(Default)]
+pub struct IdentifierLocIndex {
+    /// Resolved identifier references, keyed by their `reference_id` cell.
+    refs: FxHashMap<ReferenceId, IdentifierLocEntry>,
+    /// Declaration (binding) identifier spans, keyed by their `symbol_id` cell.
+    /// First declaration wins for redeclared symbols.
+    decl_spans: FxHashMap<SymbolId, Span>,
+}
+
+impl IdentifierLocIndex {
+    pub fn reference(&self, reference_id: ReferenceId) -> Option<&IdentifierLocEntry> {
+        self.refs.get(&reference_id)
+    }
+
+    pub fn declaration_span(&self, symbol_id: SymbolId) -> Option<Span> {
+        self.decl_spans.get(&symbol_id).copied()
+    }
+}
 
 struct IdentifierLocVisitor {
     index: IdentifierLocIndex,
@@ -78,57 +96,53 @@ struct IdentifierLocVisitor {
 }
 
 impl IdentifierLocVisitor {
-    fn record(&mut self, span: oxc_span::Span, is_jsx: bool, is_declaration_name: bool) {
-        let opening_element_span = if is_jsx { self.current_opening_element_span } else { None };
-        // `or_insert` keeps the richer entry already recorded for a node_id.
-        // Function/class names are recorded as declaration names *before* the
-        // generic binding-identifier walk re-visits them, so the declaration
-        // entry wins, matching the original visitor.
-        self.index.entry(span.start).or_insert(IdentifierLocEntry {
-            start: span.start,
-            span,
-            is_jsx,
-            opening_element_span,
-            is_declaration_name,
+    /// `current_opening_element_span` is set only while walking a JSX
+    /// element name, so it doubles as the is-JSX signal.
+    fn record_reference(&mut self, ident: &oxc::IdentifierReference<'_>) {
+        let Some(reference_id) = ident.reference_id.get() else { return };
+        self.index.refs.entry(reference_id).or_insert(IdentifierLocEntry {
+            span: ident.span,
+            opening_element_span: self.current_opening_element_span,
             in_type_annotation: self.type_depth > 0,
         });
     }
 
+    fn record_declaration(&mut self, ident: &oxc::BindingIdentifier<'_>) {
+        let Some(symbol_id) = ident.symbol_id.get() else { return };
+        self.index.decl_spans.entry(symbol_id).or_insert(ident.span);
+    }
+
     /// Record the JSX element name identifiers (and only those) while the
     /// `current_opening_element_span` is set, mirroring the original
-    /// `walk_jsx_element_name` / `walk_jsx_member_expression`.
+    /// `walk_jsx_element_name` / `walk_jsx_member_expression`. Lowercase tag
+    /// names, `this`, and member-property parts carry no reference and are
+    /// never looked up, so only `IdentifierReference` names are recorded.
     fn record_jsx_element_name<'a>(&mut self, name: &oxc::JSXElementName<'a>) {
         match name {
-            oxc::JSXElementName::Identifier(id) => self.record(id.span, true, false),
-            oxc::JSXElementName::IdentifierReference(id) => self.record(id.span, true, false),
-            oxc::JSXElementName::ThisExpression(t) => self.record(t.span, true, false),
+            oxc::JSXElementName::IdentifierReference(id) => self.record_reference(id),
             oxc::JSXElementName::MemberExpression(m) => self.record_jsx_member_expression(m),
-            // JSXNamespacedName identifiers are not visited by the original walker.
-            oxc::JSXElementName::NamespacedName(_) => {}
+            oxc::JSXElementName::Identifier(_)
+            | oxc::JSXElementName::ThisExpression(_)
+            | oxc::JSXElementName::NamespacedName(_) => {}
         }
     }
 
     fn record_jsx_member_expression<'a>(&mut self, expr: &oxc::JSXMemberExpression<'a>) {
         match &expr.object {
             oxc::JSXMemberExpressionObject::IdentifierReference(id) => {
-                self.record(id.span, true, false);
+                self.record_reference(id);
             }
-            oxc::JSXMemberExpressionObject::ThisExpression(t) => self.record(t.span, true, false),
+            oxc::JSXMemberExpressionObject::ThisExpression(_) => {}
             oxc::JSXMemberExpressionObject::MemberExpression(inner) => {
                 self.record_jsx_member_expression(inner);
             }
         }
-        self.record(expr.property.span, true, false);
     }
 }
 
 impl<'a> Visit<'a> for IdentifierLocVisitor {
     fn visit_identifier_reference(&mut self, it: &oxc::IdentifierReference<'a>) {
-        self.record(it.span, false, false);
-    }
-
-    fn visit_identifier_name(&mut self, it: &oxc::IdentifierName<'a>) {
-        self.record(it.span, false, false);
+        self.record_reference(it);
     }
 
     fn visit_binding_identifier(&mut self, it: &oxc::BindingIdentifier<'a>) {
@@ -138,21 +152,7 @@ impl<'a> Visit<'a> for IdentifierLocVisitor {
         if self.type_depth > 0 {
             return;
         }
-        self.record(it.span, false, false);
-    }
-
-    fn visit_jsx_identifier(&mut self, it: &oxc::JSXIdentifier<'a>) {
-        self.record(it.span, true, false);
-    }
-
-    fn visit_function(&mut self, it: &oxc::Function<'a>, flags: oxc_syntax::scope::ScopeFlags) {
-        // The function's own name is a declaration name, not an expression
-        // reference. Record it first so the generic binding-identifier walk
-        // (via the default traversal below) does not overwrite the flag.
-        if let Some(id) = &it.id {
-            self.record(id.span, false, true);
-        }
-        oxc_ast_visit::walk::walk_function(self, it, flags);
+        self.record_declaration(it);
     }
 
     fn visit_class(&mut self, it: &oxc::Class<'a>) {
@@ -161,7 +161,7 @@ impl<'a> Visit<'a> for IdentifierLocVisitor {
         // RawNodes (type idents only). It did NOT walk `super_class` (the extends
         // clause) nor the class body's method/property members.
         if let Some(id) = &it.id {
-            self.record(id.span, false, true);
+            self.record_declaration(id);
         }
         if let Some(type_parameters) = &it.type_parameters {
             self.visit_ts_type_parameter_declaration(type_parameters);
@@ -194,10 +194,10 @@ impl<'a> Visit<'a> for IdentifierLocVisitor {
         // before attributes and children.
         self.current_opening_element_span = Some(it.opening_element.span);
         self.record_jsx_element_name(&it.opening_element.name);
+        self.current_opening_element_span = None;
         if let Some(type_args) = &it.opening_element.type_arguments {
             self.visit_ts_type_parameter_instantiation(type_args);
         }
-        self.current_opening_element_span = None;
 
         // The original walker visited only attribute VALUES and spread arguments,
         // never attribute names, and had no closing-element handling.
@@ -263,14 +263,15 @@ impl<'a> Visit<'a> for IdentifierLocVisitor {
     fn visit_ts_module_declaration(&mut self, _it: &oxc::TSModuleDeclaration<'a>) {}
 }
 
-/// Build an index of all Identifier and JSXIdentifier positions in a function's AST.
+/// Build an index of the resolved identifier references and binding
+/// declarations in a function's AST.
 ///
 /// Walks the function's params (`FormalParameters`) and body, mirroring the
 /// original Babel `IdentifierLocVisitor`: the function node itself is not
 /// re-entered (its own name, if any, is recorded explicitly).
 pub fn build_identifier_loc_index(func: &FunctionNode<'_>) -> IdentifierLocIndex {
     let mut visitor = IdentifierLocVisitor {
-        index: FxHashMap::default(),
+        index: IdentifierLocIndex::default(),
         current_opening_element_span: None,
         type_depth: 0,
     };
@@ -279,7 +280,7 @@ pub fn build_identifier_loc_index(func: &FunctionNode<'_>) -> IdentifierLocIndex
         FunctionNode::Function(f) => {
             // The function's own name is a declaration name.
             if let Some(id) = &f.id {
-                visitor.record(id.span, false, true);
+                visitor.record_declaration(id);
             }
             if let Some(type_parameters) = &f.type_parameters {
                 visitor.visit_ts_type_parameter_declaration(type_parameters);

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
@@ -394,77 +394,26 @@ fn ox_str<'a>(ast: &oxc_ast::builder::AstBuilder<'a>, s: &str) -> &'a str {
 ///
 /// When some identifier reference inside the type has a binding rename (e.g. a
 /// `typeof field` whose value binding was renamed to `field_3`), the matching
-/// references in the clone are renamed in place. `clone_in` preserves spans, so the
-/// renames are keyed by source offset, exactly like the reference set that selects
-/// them.
+/// references in the clone are renamed in place. The clone preserves the semantic
+/// `reference_id` cells, so renames apply by reference identity.
 fn ox_reemit_ts_type<'a>(cx: &OxcContext<'a, '_, '_>, ty: &oxc::TSType<'_>) -> oxc::TSType<'a> {
-    // Which identifier references inside the type get a binding rename, keyed by
-    // absolute source offset. An ident is renamed only if it is an actual reference
-    // (its offset is in `reference_node_ids`, excluding type labels / property keys)
-    // and a binding rename applies for the nearest enclosing declaration. Without
-    // this, a `typeof field` keeps the pre-rename name while the value binding was
-    // renamed to `field_3`.
-    let renames_by_offset: FxHashMap<u32, String> = if cx.env.renames.is_empty() {
-        FxHashMap::default()
-    } else {
-        struct Collector {
-            out: Vec<(u32, String)>,
-        }
-        impl<'v> oxc_ast_visit::Visit<'v> for Collector {
-            fn visit_identifier_reference(&mut self, it: &oxc::IdentifierReference<'v>) {
-                self.out.push((it.span.start, it.name.to_string()));
-            }
-            fn visit_identifier_name(&mut self, it: &oxc::IdentifierName<'v>) {
-                self.out.push((it.span.start, it.name.to_string()));
-            }
-        }
-        let mut collector = Collector { out: Vec::new() };
-        oxc_ast_visit::Visit::visit_ts_type(&mut collector, ty);
-
-        let mut renames = FxHashMap::default();
-        for (offset, name) in &collector.out {
-            if *offset == 0 || !cx.env.reference_node_ids.contains(offset) {
-                continue;
-            }
-            if let Some(rename) = cx
-                .env
-                .renames
-                .iter()
-                .filter(|r| &r.original == name && r.declaration_start <= *offset)
-                .max_by_key(|r| r.declaration_start)
-            {
-                renames.insert(*offset, rename.renamed.clone());
-            }
-        }
-        renames
-    };
-
-    // Clone the stored type into the output allocator. Common case: no renames apply,
-    // so the clone is the whole answer.
-    let mut cloned = ty.clone_in(cx.ast.allocator());
-    if renames_by_offset.is_empty() {
-        return cloned;
+    if cx.env.renames.is_empty() {
+        return ty.clone_in(cx.ast.allocator());
     }
 
-    // Rename case: rewrite the matching identifier references in the clone, keyed by
-    // the preserved source offset.
-    struct Renamer<'a> {
+    struct Renamer<'a, 'env> {
         allocator: &'a oxc_allocator::Allocator,
-        renames_by_offset: FxHashMap<u32, String>,
+        renames: &'env FxHashMap<oxc_syntax::reference::ReferenceId, String>,
     }
-    impl<'a> oxc_ast_visit::VisitMut<'a> for Renamer<'a> {
+    impl<'a> oxc_ast_visit::VisitMut<'a> for Renamer<'a, '_> {
         fn visit_identifier_reference(&mut self, it: &mut oxc::IdentifierReference<'a>) {
-            if let Some(renamed) = self.renames_by_offset.get(&it.span.start) {
-                it.name = renamed.as_str().into_in(self.allocator);
-            }
-        }
-        fn visit_identifier_name(&mut self, it: &mut oxc::IdentifierName<'a>) {
-            if let Some(renamed) = self.renames_by_offset.get(&it.span.start) {
+            if let Some(renamed) = it.reference_id.get().and_then(|id| self.renames.get(&id)) {
                 it.name = renamed.as_str().into_in(self.allocator);
             }
         }
     }
-    let mut renamer = Renamer { allocator: cx.ast.allocator(), renames_by_offset };
+    let mut cloned = ty.clone_in_with_semantic_ids(cx.ast.allocator());
+    let mut renamer = Renamer { allocator: cx.ast.allocator(), renames: &cx.env.renames };
     oxc_ast_visit::VisitMut::visit_ts_type(&mut renamer, &mut cloned);
     cloned
 }

--- a/crates/oxc_react_compiler/src/scope.rs
+++ b/crates/oxc_react_compiler/src/scope.rs
@@ -1,7 +1,7 @@
 use oxc_ast::AstKind;
 use oxc_ast::ast::{
-    BindingIdentifier, BindingPattern, ExportDefaultDeclarationKind, IdentifierReference,
-    ImportDeclaration, ModuleExportName, Program, PropertyKind, Statement, TSModuleDeclarationName,
+    BindingIdentifier, BindingPattern, IdentifierReference, ImportDeclaration, ModuleExportName,
+    PropertyKind, TSModuleDeclarationName,
 };
 use oxc_semantic::{AstNodes, NodeId, Scoping, Semantic};
 use oxc_span::GetSpan;
@@ -9,6 +9,7 @@ use oxc_syntax::scope::ScopeFlags;
 use oxc_syntax::symbol::SymbolFlags;
 use rustc_hash::FxHashSet;
 
+pub use oxc_syntax::reference::ReferenceId;
 pub use oxc_syntax::scope::ScopeId;
 pub use oxc_syntax::symbol::SymbolId;
 
@@ -108,60 +109,32 @@ pub enum ImportBindingKind {
 pub struct ScopeResolver<'s, 'a> {
     scoping: &'s Scoping,
     nodes: &'s AstNodes<'a>,
-    /// Positions of resolved identifier references, declaration identifiers, and
-    /// `export default function` exports (Babel counts the export statement as a
-    /// reference to the function's binding).
-    reference_positions: FxHashSet<u32>,
-    /// `(start, end, scope_id)` source windows of Function-kind scopes, used for
-    /// position-range containment checks. Object methods get an extra window
+    /// All Function-kind scopes, in scope-tree order.
+    function_scopes: Vec<ScopeId>,
+    /// `(start, end)` source windows of Function-kind scopes, used by the
+    /// hoisting analysis's position checks. Object methods get an extra window
     /// starting at the enclosing ObjectProperty (Babel's ObjectMethod spans the
     /// whole property, including `get `/`set ` prefixes and computed keys).
-    function_scope_ranges: Vec<(u32, u32, ScopeId)>,
+    function_scope_ranges: Vec<(u32, u32)>,
 }
 
 impl<'s, 'a> ScopeResolver<'s, 'a> {
-    pub fn new(semantic: &'s Semantic<'a>, program: &Program<'_>) -> Self {
+    pub fn new(semantic: &'s Semantic<'a>) -> Self {
         let scoping = semantic.scoping();
         let nodes = semantic.nodes();
 
-        let mut reference_positions = FxHashSet::default();
-        for symbol_id in scoping.symbol_ids() {
-            for &ref_id in scoping.get_resolved_reference_ids(symbol_id) {
-                let reference = scoping.get_reference(ref_id);
-                reference_positions.insert(nodes.get_node(reference.node_id()).kind().span().start);
-            }
-            let decl_node = nodes.get_node(scoping.symbol_declaration(symbol_id));
-            let name = scoping.symbol_name(symbol_id);
-            if let Some(start) = find_binding_identifier_start(decl_node.kind(), name) {
-                reference_positions.insert(start);
-            }
-        }
-        for stmt in &program.body {
-            let Statement::ExportDefaultDeclaration(export) = stmt else { continue };
-            let ExportDefaultDeclarationKind::FunctionDeclaration(func) = &export.declaration
-            else {
-                continue;
-            };
-            let Some(id) = &func.id else { continue };
-            if id.symbol_id.get().is_some()
-                || scoping.symbol_ids().any(|s| scoping.symbol_name(s) == id.name.as_str())
-            {
-                reference_positions.insert(export.span.start);
-            }
-        }
-
         let mut resolver =
-            Self { scoping, nodes, reference_positions, function_scope_ranges: Vec::new() };
+            Self { scoping, nodes, function_scopes: Vec::new(), function_scope_ranges: Vec::new() };
 
-        let mut function_scope_ranges = Vec::new();
         for scope_id in scoping.scope_descendants_from_root() {
             if resolver.scope_kind(scope_id) != ScopeKind::Function {
                 continue;
             }
+            resolver.function_scopes.push(scope_id);
             let node = nodes.get_node(scoping.get_node_id(scope_id));
             let span = node.kind().span();
             if span.end > span.start {
-                function_scope_ranges.push((span.start, span.end, scope_id));
+                resolver.function_scope_ranges.push((span.start, span.end));
             }
             // For function scopes inside object methods, also record a window from
             // the parent ObjectProperty's start, so range checks match Babel's
@@ -169,16 +142,15 @@ impl<'s, 'a> ScopeResolver<'s, 'a> {
             if let AstKind::Function(_) = node.kind() {
                 let parent = nodes.parent_node(node.id());
                 if let AstKind::ObjectProperty(prop) = parent.kind() {
-                    if prop.method || matches!(prop.kind, PropertyKind::Get | PropertyKind::Set) {
+                    if is_object_method_property(prop) {
                         let prop_start = parent.kind().span().start;
                         if prop_start != span.start {
-                            function_scope_ranges.push((prop_start, span.end, scope_id));
+                            resolver.function_scope_ranges.push((prop_start, span.end));
                         }
                     }
                 }
             }
         }
-        resolver.function_scope_ranges = function_scope_ranges;
 
         resolver
     }
@@ -200,7 +172,9 @@ impl<'s, 'a> ScopeResolver<'s, 'a> {
     /// only the first declaration's position was mapped.
     pub fn resolve_binding_identifier(&self, ident: &BindingIdentifier) -> Option<SymbolId> {
         let symbol_id = ident.symbol_id.get()?;
-        (self.declaration_start(symbol_id) == Some(ident.span.start)).then_some(symbol_id)
+        self.declaration_ident(symbol_id)
+            .is_some_and(|decl| std::ptr::eq(decl, ident))
+            .then_some(symbol_id)
     }
 
     /// All symbols in the program, in symbol-table order.
@@ -331,12 +305,12 @@ impl<'s, 'a> ScopeResolver<'s, 'a> {
         }
     }
 
-    /// The start offset of the symbol's declaration identifier (the first
-    /// declaration for redeclared symbols). `None` for declaration kinds the
-    /// old conversion did not map (e.g. interfaces).
-    pub fn declaration_start(&self, symbol_id: SymbolId) -> Option<u32> {
+    /// The symbol's declaration identifier (the first declaration for
+    /// redeclared symbols). `None` for declaration kinds the old conversion
+    /// did not map (e.g. interfaces).
+    pub fn declaration_ident(&self, symbol_id: SymbolId) -> Option<&'a BindingIdentifier<'a>> {
         let decl_node = self.nodes.get_node(self.scoping.symbol_declaration(symbol_id));
-        find_binding_identifier_start(decl_node.kind(), self.symbol_name(symbol_id))
+        find_binding_identifier(decl_node.kind(), self.symbol_name(symbol_id))
     }
 
     /// For import bindings: the source module and import details.
@@ -397,19 +371,9 @@ impl<'s, 'a> ScopeResolver<'s, 'a> {
         None
     }
 
-    /// Positions of the symbol's resolved references (including TS type references).
-    pub fn reference_positions(&self, symbol_id: SymbolId) -> impl Iterator<Item = u32> + '_ {
-        let nodes = self.nodes;
-        self.scoping().get_resolved_reference_ids(symbol_id).iter().map(move |&ref_id| {
-            let reference = self.scoping().get_reference(ref_id);
-            nodes.get_node(reference.node_id()).kind().span().start
-        })
-    }
-
-    /// The positions of every resolved reference, declaration identifier, and
-    /// export-default pseudo-reference. Feeds `Environment::reference_node_ids`.
-    pub fn all_reference_positions(&self) -> &FxHashSet<u32> {
-        &self.reference_positions
+    /// The symbol's resolved reference IDs (including TS type references).
+    pub fn reference_ids(&self, symbol_id: SymbolId) -> &'s [ReferenceId] {
+        self.scoping().get_resolved_reference_ids(symbol_id)
     }
 
     /// The program-level (module) scope.
@@ -486,10 +450,61 @@ impl<'s, 'a> ScopeResolver<'s, 'a> {
         symbols
     }
 
-    /// `(start, end, scope_id)` windows of Function-kind scopes, for
-    /// position-range containment checks.
-    pub fn function_scope_ranges(&self) -> &[(u32, u32, ScopeId)] {
+    /// `(start, end)` source windows of Function-kind scopes, for the hoisting
+    /// analysis's position checks.
+    pub fn function_scope_ranges(&self) -> &[(u32, u32)] {
         &self.function_scope_ranges
+    }
+
+    /// All Function-kind scopes, in scope-tree order.
+    pub fn function_scopes(&self) -> impl Iterator<Item = ScopeId> + '_ {
+        self.function_scopes.iter().copied()
+    }
+
+    /// The AST node a reference sits on.
+    pub fn reference_node_id(&self, reference_id: ReferenceId) -> NodeId {
+        self.scoping().get_reference(reference_id).node_id()
+    }
+
+    /// The subtree root for capture analysis of a function scope: the function
+    /// node itself, widened to the enclosing ObjectProperty for object methods
+    /// and accessors (Babel's ObjectMethod node spans the whole property,
+    /// including `get `/`set ` prefixes and computed keys).
+    pub fn capture_root_node(&self, function_scope: ScopeId) -> NodeId {
+        let node_id = self.scoping().get_node_id(function_scope);
+        let node = self.nodes.get_node(node_id);
+        if let AstKind::Function(_) = node.kind() {
+            let parent = self.nodes.parent_node(node_id);
+            if let AstKind::ObjectProperty(prop) = parent.kind() {
+                if is_object_method_property(prop) {
+                    return parent.id();
+                }
+            }
+        }
+        node_id
+    }
+
+    /// Whether `node_id` is `root` or one of its descendants.
+    pub fn node_within(&self, node_id: NodeId, root: NodeId) -> bool {
+        node_id == root || self.nodes.ancestor_ids(node_id).any(|id| id == root)
+    }
+
+    /// Scopes of the functions lexically containing `node_id`, innermost first.
+    /// Mirrors Babel's ObjectMethod extent: a node inside a method property's
+    /// computed key or accessor prefix counts as inside that method's function.
+    pub fn containing_function_scopes(
+        &self,
+        node_id: NodeId,
+    ) -> impl Iterator<Item = ScopeId> + '_ {
+        self.nodes.ancestor_kinds(node_id).filter_map(|kind| match kind {
+            AstKind::Function(func) => func.scope_id.get(),
+            AstKind::ArrowFunctionExpression(arrow) => arrow.scope_id.get(),
+            AstKind::ObjectProperty(prop) if is_object_method_property(prop) => match &prop.value {
+                oxc_ast::ast::Expression::FunctionExpression(func) => func.scope_id.get(),
+                _ => None,
+            },
+            _ => None,
+        })
     }
 
     /// Find a binding by name within the descendants of a given scope
@@ -530,56 +545,34 @@ impl<'s, 'a> ScopeResolver<'s, 'a> {
     }
 }
 
-/// Find the binding identifier's start position within a declaration AST node.
-fn find_binding_identifier_start(kind: AstKind, name: &str) -> Option<u32> {
+/// Whether an object property is what Babel models as an `ObjectMethod`
+/// (a method or a `get`/`set` accessor), whose node spans the whole property.
+fn is_object_method_property(prop: &oxc_ast::ast::ObjectProperty) -> bool {
+    prop.method || matches!(prop.kind, PropertyKind::Get | PropertyKind::Set)
+}
+
+/// Find the binding identifier with the given name within a declaration AST node.
+fn find_binding_identifier<'a>(kind: AstKind<'a>, name: &str) -> Option<&'a BindingIdentifier<'a>> {
     match kind {
-        AstKind::BindingIdentifier(ident) => {
-            if ident.name.as_str() == name {
-                Some(ident.span.start)
-            } else {
-                None
-            }
-        }
+        AstKind::BindingIdentifier(ident) => (ident.name.as_str() == name).then_some(ident),
         AstKind::VariableDeclarator(decl) => find_identifier_in_pattern(&decl.id, name),
-        AstKind::Function(func) => func
-            .id
-            .as_ref()
-            .and_then(|id| if id.name.as_str() == name { Some(id.span.start) } else { None }),
-        AstKind::Class(class) => class
-            .id
-            .as_ref()
-            .and_then(|id| if id.name.as_str() == name { Some(id.span.start) } else { None }),
+        AstKind::Function(func) => func.id.as_ref().filter(|id| id.name.as_str() == name),
+        AstKind::Class(class) => class.id.as_ref().filter(|id| id.name.as_str() == name),
         AstKind::FormalParameter(param) => find_identifier_in_pattern(&param.pattern, name),
         AstKind::FormalParameterRest(rest) => find_identifier_in_pattern(&rest.rest.argument, name),
-        AstKind::ImportSpecifier(spec) => Some(spec.local.span.start),
-        AstKind::ImportDefaultSpecifier(spec) => Some(spec.local.span.start),
-        AstKind::ImportNamespaceSpecifier(spec) => Some(spec.local.span.start),
+        AstKind::ImportSpecifier(spec) => Some(&spec.local),
+        AstKind::ImportDefaultSpecifier(spec) => Some(&spec.local),
+        AstKind::ImportNamespaceSpecifier(spec) => Some(&spec.local),
         AstKind::CatchClause(catch) => {
             catch.param.as_ref().and_then(|p| find_identifier_in_pattern(&p.pattern, name))
         }
         AstKind::CatchParameter(param) => find_identifier_in_pattern(&param.pattern, name),
         AstKind::TSTypeAliasDeclaration(decl) => {
-            if decl.id.name.as_str() == name {
-                Some(decl.id.span.start)
-            } else {
-                None
-            }
+            (decl.id.name.as_str() == name).then_some(&decl.id)
         }
-        AstKind::TSEnumDeclaration(decl) => {
-            if decl.id.name.as_str() == name {
-                Some(decl.id.span.start)
-            } else {
-                None
-            }
-        }
+        AstKind::TSEnumDeclaration(decl) => (decl.id.name.as_str() == name).then_some(&decl.id),
         AstKind::TSModuleDeclaration(decl) => match &decl.id {
-            TSModuleDeclarationName::Identifier(id) => {
-                if id.name.as_str() == name {
-                    Some(id.span.start)
-                } else {
-                    None
-                }
-            }
+            TSModuleDeclarationName::Identifier(id) => (id.name.as_str() == name).then_some(id),
             _ => None,
         },
         _ => None,
@@ -587,41 +580,27 @@ fn find_binding_identifier_start(kind: AstKind, name: &str) -> Option<u32> {
 }
 
 /// Recursively find a binding identifier within a binding pattern.
-fn find_identifier_in_pattern(pattern: &BindingPattern, name: &str) -> Option<u32> {
+fn find_identifier_in_pattern<'a>(
+    pattern: &'a BindingPattern<'a>,
+    name: &str,
+) -> Option<&'a BindingIdentifier<'a>> {
     match pattern {
-        BindingPattern::BindingIdentifier(ident) => {
-            if ident.name.as_str() == name {
-                Some(ident.span.start)
-            } else {
-                None
-            }
-        }
-        BindingPattern::ObjectPattern(obj) => {
-            for prop in &obj.properties {
-                if let Some(start) = find_identifier_in_pattern(&prop.value, name) {
-                    return Some(start);
-                }
-            }
-            if let Some(rest) = &obj.rest {
-                if let Some(start) = find_identifier_in_pattern(&rest.argument, name) {
-                    return Some(start);
-                }
-            }
-            None
-        }
-        BindingPattern::ArrayPattern(arr) => {
-            for element in arr.elements.iter().flatten() {
-                if let Some(start) = find_identifier_in_pattern(element, name) {
-                    return Some(start);
-                }
-            }
-            if let Some(rest) = &arr.rest {
-                if let Some(start) = find_identifier_in_pattern(&rest.argument, name) {
-                    return Some(start);
-                }
-            }
-            None
-        }
+        BindingPattern::BindingIdentifier(ident) => (ident.name.as_str() == name).then_some(ident),
+        BindingPattern::ObjectPattern(obj) => obj
+            .properties
+            .iter()
+            .find_map(|prop| find_identifier_in_pattern(&prop.value, name))
+            .or_else(|| {
+                obj.rest.as_ref().and_then(|rest| find_identifier_in_pattern(&rest.argument, name))
+            }),
+        BindingPattern::ArrayPattern(arr) => arr
+            .elements
+            .iter()
+            .flatten()
+            .find_map(|element| find_identifier_in_pattern(element, name))
+            .or_else(|| {
+                arr.rest.as_ref().and_then(|rest| find_identifier_in_pattern(&rest.argument, name))
+            }),
         BindingPattern::AssignmentPattern(assign) => find_identifier_in_pattern(&assign.left, name),
     }
 }


### PR DESCRIPTION
The crate inherited Babel's `node.start`-as-node-ID convention: spans were used as lookup keys and node identity throughout. This converts every such mechanism to semantic IDs (`ReferenceId` / `SymbolId` / `ScopeId` / `NodeId`, plus node pointer identity), staged as four commits, each byte-identical over the fixture corpus.

**1. Type-annotation renames** — `Environment::renames` was `Vec<{original, renamed, declaration_start}>`, matched in codegen by name + nearest-preceding-declaration offset, filtered through `reference_node_ids` (a program-wide `FxHashSet<u32>` of reference offsets). Now `FxHashMap<ReferenceId, String>`, recorded per resolved reference at rename time and applied in `ox_reemit_ts_type` via the `reference_id` cells on a `clone_in_with_semantic_ids` clone. Deletes `reference_node_ids`, the export-default pseudo-reference block, and `ScopeResolver`'s position-set construction.

**2. Identifier-loc index + declaration identity** — `IdentifierLocIndex` was `FxHashMap<u32 /* span.start */, Entry>`; now `refs: FxHashMap<ReferenceId, Entry>` + `decl_spans: FxHashMap<SymbolId, Span>`, read off the semantic cells during the walk. `resolve_binding_identifier` compared `declaration_start(symbol) == ident.span.start`; now the declaration identifier is found as a node and compared by `ptr::eq` (`declaration_ident` replaces `declaration_start`). The hoisting analysis, `gather_captured_context`, and `find_context_identifiers` iterate `reference_ids()` instead of reference positions; identity-aliasing skips that ID iteration makes structurally impossible are dropped.

**3. Structural containment** — "is this reference inside this function" checks moved from byte-range windows to structure: `gather_captured_context` tests AST-subtree membership against `capture_root_node(function_scope)` (the function node, widened to the enclosing `ObjectProperty` for methods/accessors, mirroring Babel's `ObjectMethod` extent — this also removes the `func_start`/`func_end`/`method_span` plumbing through the lowering entry points); the `find_context_identifiers` supplement walks the reference node's containing functions; `validate_ts_this_parameters` uses scope ancestry.

**4. Function identity in the entrypoint** — `CompileSource::fn_node_id`/`already_compiled` and the whole splice machinery (`OxcReplaceFnVisitor`, gated replacement, outlined-decl insertion, original-fn cloning) matched functions by `span.start == fn_node_id`; now by the function's `ScopeId` cell. This requires `ox_splice_program` to clone the program with `clone_in_with_semantic_ids` (a plain `clone_in` resets the cells; codegen-built nodes carry no cells, so they can never be spuriously matched, whereas the old span matching could in principle re-match a span-preserving clone). `is_wrapper_callee` same-node span comparisons became pointer identity, `declarator_name_for` needs only the parent edge, and `hoisted_identifiers` is typed `FxHashSet<SymbolId>` instead of raw `u32`.

Spans remain only as **values**: diagnostic labels, output ordering (source-position sort of captures/hoists, matching Babel's position-ordered traversal), hoisting's statement-range attribution, suppression-comment overlap (comments have no IDs), and `fn_start`/`fn_end` metadata.

One behavioral note: positional-aliasing defenses that existed for Hermes-desugared component syntax (generated nodes reusing source offsets) are now mostly structural — the gather-side alias filter is kept, but the ID-based iteration no longer needs the declaration-site offset skips. The fixture corpus has no Hermes cases; the ecosystem differential is the place to watch.

Verified: all four stages individually byte-identical over the 1288-fixture snapshot corpus; clippy clean with `--all-features`.
