### PR TITLE
feat(linter/typescript): implement prefer-destructuring rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -328,6 +328,7 @@ export type AllowConstantLoopConditionsMode = "never" | "always" | "only-allowed
 export type Modifier =
   "private" | "private readonly" | "protected" | "protected readonly" | "public" | "public readonly" | "readonly";
 export type Prefer2 = "class-property" | "parameter-property";
+export type PreferDestructuringOption2 = PreferDestructuringTargetOption2 | PreferDestructuringAssignmentConfig2;
 /**
  * Represents the different ways `ignorePrimitives` can be specified in JSON.
  * Can be:
@@ -1455,7 +1456,10 @@ export interface DummyRuleMap {
   "typescript/only-throw-error"?: RuleNoConfig | [AllowWarnDeny, OnlyThrowErrorConfig];
   "typescript/parameter-properties"?: RuleNoConfig | [AllowWarnDeny, ParameterPropertiesConfig];
   "typescript/prefer-as-const"?: RuleNoConfig;
-  "typescript/prefer-destructuring"?: RuleNoConfig;
+  "typescript/prefer-destructuring"?:
+    | RuleNoConfig
+    | [AllowWarnDeny, PreferDestructuringOption2]
+    | [AllowWarnDeny, PreferDestructuringOption2, PreferDestructuringEnforcementConfig];
   "typescript/prefer-enum-initializers"?: RuleNoConfig;
   "typescript/prefer-find"?: RuleNoConfig;
   "typescript/prefer-for-of"?: RuleNoConfig;
@@ -5594,6 +5598,24 @@ export interface ParameterPropertiesConfig {
    * Whether to prefer parameter properties or class properties.
    */
   prefer?: Prefer2;
+}
+export interface PreferDestructuringTargetOption2 {
+  array?: boolean;
+  object?: boolean;
+}
+export interface PreferDestructuringAssignmentConfig2 {
+  AssignmentExpression?: PreferDestructuringTargetOption2;
+  VariableDeclarator?: PreferDestructuringTargetOption2;
+}
+export interface PreferDestructuringEnforcementConfig {
+  /**
+   * Whether to enforce destructuring on variable declarations with type annotations.
+   */
+  enforceForDeclarationWithTypeAnnotation?: boolean;
+  /**
+   * Whether to enforce destructuring that uses a different variable name than the property name.
+   */
+  enforceForRenamedProperties?: boolean;
 }
 export interface PreferLiteralEnumMember {
   /**

--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1455,6 +1455,7 @@ export interface DummyRuleMap {
   "typescript/only-throw-error"?: RuleNoConfig | [AllowWarnDeny, OnlyThrowErrorConfig];
   "typescript/parameter-properties"?: RuleNoConfig | [AllowWarnDeny, ParameterPropertiesConfig];
   "typescript/prefer-as-const"?: RuleNoConfig;
+  "typescript/prefer-destructuring"?: RuleNoConfig;
   "typescript/prefer-enum-initializers"?: RuleNoConfig;
   "typescript/prefer-find"?: RuleNoConfig;
   "typescript/prefer-for-of"?: RuleNoConfig;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -1480,11 +1480,6 @@ impl RuleRunner for crate::rules::eslint::yoda::Yoda {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
-impl RuleRunner for crate::rules::typescript::prefer_destructuring::PreferDestructuring {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
-    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
-}
-
 impl RuleRunner
     for crate::rules::typescript::adjacent_overload_signatures::AdjacentOverloadSignatures
 {
@@ -2027,6 +2022,14 @@ impl RuleRunner for crate::rules::typescript::prefer_as_const::PreferAsConst {
     const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
         AstType::PropertyDefinition,
         AstType::TSAsExpression,
+        AstType::VariableDeclarator,
+    ]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::typescript::prefer_destructuring::PreferDestructuring {
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::AssignmentExpression,
         AstType::VariableDeclarator,
     ]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -1480,6 +1480,11 @@ impl RuleRunner for crate::rules::eslint::yoda::Yoda {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::typescript::prefer_destructuring::PreferDestructuring {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner
     for crate::rules::typescript::adjacent_overload_signatures::AdjacentOverloadSignatures
 {

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -564,6 +564,7 @@ pub use crate::rules::typescript::non_nullable_type_assertion_style::NonNullable
 pub use crate::rules::typescript::only_throw_error::OnlyThrowError as TypescriptOnlyThrowError;
 pub use crate::rules::typescript::parameter_properties::ParameterProperties as TypescriptParameterProperties;
 pub use crate::rules::typescript::prefer_as_const::PreferAsConst as TypescriptPreferAsConst;
+pub use crate::rules::typescript::prefer_destructuring::PreferDestructuring as TypescriptPreferDestructuring;
 pub use crate::rules::typescript::prefer_enum_initializers::PreferEnumInitializers as TypescriptPreferEnumInitializers;
 pub use crate::rules::typescript::prefer_find::PreferFind as TypescriptPreferFind;
 pub use crate::rules::typescript::prefer_for_of::PreferForOf as TypescriptPreferForOf;
@@ -1079,6 +1080,7 @@ pub enum RuleEnum {
     EslintValidTypeof(EslintValidTypeof),
     EslintVarsOnTop(EslintVarsOnTop),
     EslintYoda(EslintYoda),
+    TypescriptPreferDestructuring(TypescriptPreferDestructuring),
     TypescriptAdjacentOverloadSignatures(TypescriptAdjacentOverloadSignatures),
     TypescriptArrayType(TypescriptArrayType),
     TypescriptAwaitThenable(TypescriptAwaitThenable),
@@ -1930,7 +1932,9 @@ const ESLINT_USE_ISNAN_ID: usize = ESLINT_UNICODE_BOM_ID + 1usize;
 const ESLINT_VALID_TYPEOF_ID: usize = ESLINT_USE_ISNAN_ID + 1usize;
 const ESLINT_VARS_ON_TOP_ID: usize = ESLINT_VALID_TYPEOF_ID + 1usize;
 const ESLINT_YODA_ID: usize = ESLINT_VARS_ON_TOP_ID + 1usize;
-const TYPESCRIPT_ADJACENT_OVERLOAD_SIGNATURES_ID: usize = ESLINT_YODA_ID + 1usize;
+const TYPESCRIPT_PREFER_DESTRUCTURING_ID: usize = ESLINT_YODA_ID + 1usize;
+const TYPESCRIPT_ADJACENT_OVERLOAD_SIGNATURES_ID: usize =
+    TYPESCRIPT_PREFER_DESTRUCTURING_ID + 1usize;
 const TYPESCRIPT_ARRAY_TYPE_ID: usize = TYPESCRIPT_ADJACENT_OVERLOAD_SIGNATURES_ID + 1usize;
 const TYPESCRIPT_AWAIT_THENABLE_ID: usize = TYPESCRIPT_ARRAY_TYPE_ID + 1usize;
 const TYPESCRIPT_BAN_TS_COMMENT_ID: usize = TYPESCRIPT_AWAIT_THENABLE_ID + 1usize;
@@ -2883,6 +2887,7 @@ impl RuleEnum {
             Self::EslintValidTypeof(_) => ESLINT_VALID_TYPEOF_ID,
             Self::EslintVarsOnTop(_) => ESLINT_VARS_ON_TOP_ID,
             Self::EslintYoda(_) => ESLINT_YODA_ID,
+            Self::TypescriptPreferDestructuring(_) => TYPESCRIPT_PREFER_DESTRUCTURING_ID,
             Self::TypescriptAdjacentOverloadSignatures(_) => {
                 TYPESCRIPT_ADJACENT_OVERLOAD_SIGNATURES_ID
             }
@@ -3856,6 +3861,7 @@ impl RuleEnum {
             Self::EslintValidTypeof(_) => EslintValidTypeof::NAME,
             Self::EslintVarsOnTop(_) => EslintVarsOnTop::NAME,
             Self::EslintYoda(_) => EslintYoda::NAME,
+            Self::TypescriptPreferDestructuring(_) => TypescriptPreferDestructuring::NAME,
             Self::TypescriptAdjacentOverloadSignatures(_) => {
                 TypescriptAdjacentOverloadSignatures::NAME
             }
@@ -4821,6 +4827,7 @@ impl RuleEnum {
             Self::EslintValidTypeof(_) => EslintValidTypeof::CATEGORY,
             Self::EslintVarsOnTop(_) => EslintVarsOnTop::CATEGORY,
             Self::EslintYoda(_) => EslintYoda::CATEGORY,
+            Self::TypescriptPreferDestructuring(_) => TypescriptPreferDestructuring::CATEGORY,
             Self::TypescriptAdjacentOverloadSignatures(_) => {
                 TypescriptAdjacentOverloadSignatures::CATEGORY
             }
@@ -5833,6 +5840,7 @@ impl RuleEnum {
             Self::EslintValidTypeof(_) => EslintValidTypeof::FIX,
             Self::EslintVarsOnTop(_) => EslintVarsOnTop::FIX,
             Self::EslintYoda(_) => EslintYoda::FIX,
+            Self::TypescriptPreferDestructuring(_) => TypescriptPreferDestructuring::FIX,
             Self::TypescriptAdjacentOverloadSignatures(_) => {
                 TypescriptAdjacentOverloadSignatures::FIX
             }
@@ -6827,6 +6835,9 @@ impl RuleEnum {
             Self::EslintValidTypeof(_) => EslintValidTypeof::documentation(),
             Self::EslintVarsOnTop(_) => EslintVarsOnTop::documentation(),
             Self::EslintYoda(_) => EslintYoda::documentation(),
+            Self::TypescriptPreferDestructuring(_) => {
+                TypescriptPreferDestructuring::documentation()
+            }
             Self::TypescriptAdjacentOverloadSignatures(_) => {
                 TypescriptAdjacentOverloadSignatures::documentation()
             }
@@ -8356,6 +8367,10 @@ impl RuleEnum {
                 .or_else(|| EslintVarsOnTop::schema(generator)),
             Self::EslintYoda(_) => {
                 EslintYoda::config_schema(generator).or_else(|| EslintYoda::schema(generator))
+            }
+            Self::TypescriptPreferDestructuring(_) => {
+                TypescriptPreferDestructuring::config_schema(generator)
+                    .or_else(|| TypescriptPreferDestructuring::schema(generator))
             }
             Self::TypescriptAdjacentOverloadSignatures(_) => {
                 TypescriptAdjacentOverloadSignatures::config_schema(generator)
@@ -10439,6 +10454,7 @@ impl RuleEnum {
             Self::EslintValidTypeof(_) => "eslint",
             Self::EslintVarsOnTop(_) => "eslint",
             Self::EslintYoda(_) => "eslint",
+            Self::TypescriptPreferDestructuring(_) => "typescript",
             Self::TypescriptAdjacentOverloadSignatures(_) => "typescript",
             Self::TypescriptArrayType(_) => "typescript",
             Self::TypescriptAwaitThenable(_) => "typescript",
@@ -11719,6 +11735,9 @@ impl RuleEnum {
                 Ok(Self::EslintVarsOnTop(EslintVarsOnTop::from_configuration(value)?))
             }
             Self::EslintYoda(_) => Ok(Self::EslintYoda(EslintYoda::from_configuration(value)?)),
+            Self::TypescriptPreferDestructuring(_) => Ok(Self::TypescriptPreferDestructuring(
+                TypescriptPreferDestructuring::from_configuration(value)?,
+            )),
             Self::TypescriptAdjacentOverloadSignatures(_) => {
                 Ok(Self::TypescriptAdjacentOverloadSignatures(
                     TypescriptAdjacentOverloadSignatures::from_configuration(value)?,
@@ -13998,6 +14017,7 @@ impl RuleEnum {
             Self::EslintValidTypeof(rule) => rule.to_configuration(),
             Self::EslintVarsOnTop(rule) => rule.to_configuration(),
             Self::EslintYoda(rule) => rule.to_configuration(),
+            Self::TypescriptPreferDestructuring(rule) => rule.to_configuration(),
             Self::TypescriptAdjacentOverloadSignatures(rule) => rule.to_configuration(),
             Self::TypescriptArrayType(rule) => rule.to_configuration(),
             Self::TypescriptAwaitThenable(rule) => rule.to_configuration(),
@@ -14848,6 +14868,7 @@ impl RuleEnum {
             Self::EslintValidTypeof(rule) => rule.run(node, ctx),
             Self::EslintVarsOnTop(rule) => rule.run(node, ctx),
             Self::EslintYoda(rule) => rule.run(node, ctx),
+            Self::TypescriptPreferDestructuring(rule) => rule.run(node, ctx),
             Self::TypescriptAdjacentOverloadSignatures(rule) => rule.run(node, ctx),
             Self::TypescriptArrayType(rule) => rule.run(node, ctx),
             Self::TypescriptAwaitThenable(rule) => rule.run(node, ctx),
@@ -15706,6 +15727,7 @@ impl RuleEnum {
             Self::EslintValidTypeof(rule) => rule.run_once(ctx),
             Self::EslintVarsOnTop(rule) => rule.run_once(ctx),
             Self::EslintYoda(rule) => rule.run_once(ctx),
+            Self::TypescriptPreferDestructuring(rule) => rule.run_once(ctx),
             Self::TypescriptAdjacentOverloadSignatures(rule) => rule.run_once(ctx),
             Self::TypescriptArrayType(rule) => rule.run_once(ctx),
             Self::TypescriptAwaitThenable(rule) => rule.run_once(ctx),
@@ -16567,6 +16589,7 @@ impl RuleEnum {
             Self::EslintValidTypeof(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintVarsOnTop(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintYoda(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::TypescriptPreferDestructuring(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::TypescriptAdjacentOverloadSignatures(rule) => {
                 rule.run_on_jest_node(jest_node, ctx)
             }
@@ -17540,6 +17563,7 @@ impl RuleEnum {
             Self::EslintValidTypeof(rule) => rule.should_run(ctx),
             Self::EslintVarsOnTop(rule) => rule.should_run(ctx),
             Self::EslintYoda(rule) => rule.should_run(ctx),
+            Self::TypescriptPreferDestructuring(rule) => rule.should_run(ctx),
             Self::TypescriptAdjacentOverloadSignatures(rule) => rule.should_run(ctx),
             Self::TypescriptArrayType(rule) => rule.should_run(ctx),
             Self::TypescriptAwaitThenable(rule) => rule.should_run(ctx),
@@ -18419,6 +18443,9 @@ impl RuleEnum {
             Self::EslintValidTypeof(_) => EslintValidTypeof::IS_TSGOLINT_RULE,
             Self::EslintVarsOnTop(_) => EslintVarsOnTop::IS_TSGOLINT_RULE,
             Self::EslintYoda(_) => EslintYoda::IS_TSGOLINT_RULE,
+            Self::TypescriptPreferDestructuring(_) => {
+                TypescriptPreferDestructuring::IS_TSGOLINT_RULE
+            }
             Self::TypescriptAdjacentOverloadSignatures(_) => {
                 TypescriptAdjacentOverloadSignatures::IS_TSGOLINT_RULE
             }
@@ -19616,6 +19643,7 @@ impl RuleEnum {
             Self::EslintValidTypeof(_) => EslintValidTypeof::VERSION,
             Self::EslintVarsOnTop(_) => EslintVarsOnTop::VERSION,
             Self::EslintYoda(_) => EslintYoda::VERSION,
+            Self::TypescriptPreferDestructuring(_) => TypescriptPreferDestructuring::VERSION,
             Self::TypescriptAdjacentOverloadSignatures(_) => {
                 TypescriptAdjacentOverloadSignatures::VERSION
             }
@@ -20640,6 +20668,7 @@ impl RuleEnum {
             Self::EslintValidTypeof(_) => EslintValidTypeof::HAS_CONFIG,
             Self::EslintVarsOnTop(_) => EslintVarsOnTop::HAS_CONFIG,
             Self::EslintYoda(_) => EslintYoda::HAS_CONFIG,
+            Self::TypescriptPreferDestructuring(_) => TypescriptPreferDestructuring::HAS_CONFIG,
             Self::TypescriptAdjacentOverloadSignatures(_) => {
                 TypescriptAdjacentOverloadSignatures::HAS_CONFIG
             }
@@ -21685,6 +21714,7 @@ impl RuleEnum {
             Self::EslintValidTypeof(_) => EslintValidTypeof::INFO,
             Self::EslintVarsOnTop(_) => EslintVarsOnTop::INFO,
             Self::EslintYoda(_) => EslintYoda::INFO,
+            Self::TypescriptPreferDestructuring(_) => TypescriptPreferDestructuring::INFO,
             Self::TypescriptAdjacentOverloadSignatures(_) => {
                 TypescriptAdjacentOverloadSignatures::INFO
             }
@@ -22649,6 +22679,7 @@ impl RuleEnum {
             Self::EslintValidTypeof(rule) => rule.types_info(),
             Self::EslintVarsOnTop(rule) => rule.types_info(),
             Self::EslintYoda(rule) => rule.types_info(),
+            Self::TypescriptPreferDestructuring(rule) => rule.types_info(),
             Self::TypescriptAdjacentOverloadSignatures(rule) => rule.types_info(),
             Self::TypescriptArrayType(rule) => rule.types_info(),
             Self::TypescriptAwaitThenable(rule) => rule.types_info(),
@@ -23494,6 +23525,7 @@ impl RuleEnum {
             Self::EslintValidTypeof(rule) => rule.run_info(),
             Self::EslintVarsOnTop(rule) => rule.run_info(),
             Self::EslintYoda(rule) => rule.run_info(),
+            Self::TypescriptPreferDestructuring(rule) => rule.run_info(),
             Self::TypescriptAdjacentOverloadSignatures(rule) => rule.run_info(),
             Self::TypescriptArrayType(rule) => rule.run_info(),
             Self::TypescriptAwaitThenable(rule) => rule.run_info(),
@@ -24361,6 +24393,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::EslintValidTypeof(EslintValidTypeof::default()),
         RuleEnum::EslintVarsOnTop(EslintVarsOnTop::default()),
         RuleEnum::EslintYoda(EslintYoda::default()),
+        RuleEnum::TypescriptPreferDestructuring(TypescriptPreferDestructuring::default()),
         RuleEnum::TypescriptAdjacentOverloadSignatures(
             TypescriptAdjacentOverloadSignatures::default(),
         ),

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -1080,7 +1080,6 @@ pub enum RuleEnum {
     EslintValidTypeof(EslintValidTypeof),
     EslintVarsOnTop(EslintVarsOnTop),
     EslintYoda(EslintYoda),
-    TypescriptPreferDestructuring(TypescriptPreferDestructuring),
     TypescriptAdjacentOverloadSignatures(TypescriptAdjacentOverloadSignatures),
     TypescriptArrayType(TypescriptArrayType),
     TypescriptAwaitThenable(TypescriptAwaitThenable),
@@ -1162,6 +1161,7 @@ pub enum RuleEnum {
     TypescriptOnlyThrowError(TypescriptOnlyThrowError),
     TypescriptParameterProperties(TypescriptParameterProperties),
     TypescriptPreferAsConst(TypescriptPreferAsConst),
+    TypescriptPreferDestructuring(TypescriptPreferDestructuring),
     TypescriptPreferEnumInitializers(TypescriptPreferEnumInitializers),
     TypescriptPreferFind(TypescriptPreferFind),
     TypescriptPreferForOf(TypescriptPreferForOf),
@@ -1932,9 +1932,7 @@ const ESLINT_USE_ISNAN_ID: usize = ESLINT_UNICODE_BOM_ID + 1usize;
 const ESLINT_VALID_TYPEOF_ID: usize = ESLINT_USE_ISNAN_ID + 1usize;
 const ESLINT_VARS_ON_TOP_ID: usize = ESLINT_VALID_TYPEOF_ID + 1usize;
 const ESLINT_YODA_ID: usize = ESLINT_VARS_ON_TOP_ID + 1usize;
-const TYPESCRIPT_PREFER_DESTRUCTURING_ID: usize = ESLINT_YODA_ID + 1usize;
-const TYPESCRIPT_ADJACENT_OVERLOAD_SIGNATURES_ID: usize =
-    TYPESCRIPT_PREFER_DESTRUCTURING_ID + 1usize;
+const TYPESCRIPT_ADJACENT_OVERLOAD_SIGNATURES_ID: usize = ESLINT_YODA_ID + 1usize;
 const TYPESCRIPT_ARRAY_TYPE_ID: usize = TYPESCRIPT_ADJACENT_OVERLOAD_SIGNATURES_ID + 1usize;
 const TYPESCRIPT_AWAIT_THENABLE_ID: usize = TYPESCRIPT_ARRAY_TYPE_ID + 1usize;
 const TYPESCRIPT_BAN_TS_COMMENT_ID: usize = TYPESCRIPT_AWAIT_THENABLE_ID + 1usize;
@@ -2048,7 +2046,8 @@ const TYPESCRIPT_ONLY_THROW_ERROR_ID: usize =
     TYPESCRIPT_NON_NULLABLE_TYPE_ASSERTION_STYLE_ID + 1usize;
 const TYPESCRIPT_PARAMETER_PROPERTIES_ID: usize = TYPESCRIPT_ONLY_THROW_ERROR_ID + 1usize;
 const TYPESCRIPT_PREFER_AS_CONST_ID: usize = TYPESCRIPT_PARAMETER_PROPERTIES_ID + 1usize;
-const TYPESCRIPT_PREFER_ENUM_INITIALIZERS_ID: usize = TYPESCRIPT_PREFER_AS_CONST_ID + 1usize;
+const TYPESCRIPT_PREFER_DESTRUCTURING_ID: usize = TYPESCRIPT_PREFER_AS_CONST_ID + 1usize;
+const TYPESCRIPT_PREFER_ENUM_INITIALIZERS_ID: usize = TYPESCRIPT_PREFER_DESTRUCTURING_ID + 1usize;
 const TYPESCRIPT_PREFER_FIND_ID: usize = TYPESCRIPT_PREFER_ENUM_INITIALIZERS_ID + 1usize;
 const TYPESCRIPT_PREFER_FOR_OF_ID: usize = TYPESCRIPT_PREFER_FIND_ID + 1usize;
 const TYPESCRIPT_PREFER_FUNCTION_TYPE_ID: usize = TYPESCRIPT_PREFER_FOR_OF_ID + 1usize;
@@ -2887,7 +2886,6 @@ impl RuleEnum {
             Self::EslintValidTypeof(_) => ESLINT_VALID_TYPEOF_ID,
             Self::EslintVarsOnTop(_) => ESLINT_VARS_ON_TOP_ID,
             Self::EslintYoda(_) => ESLINT_YODA_ID,
-            Self::TypescriptPreferDestructuring(_) => TYPESCRIPT_PREFER_DESTRUCTURING_ID,
             Self::TypescriptAdjacentOverloadSignatures(_) => {
                 TYPESCRIPT_ADJACENT_OVERLOAD_SIGNATURES_ID
             }
@@ -3019,6 +3017,7 @@ impl RuleEnum {
             Self::TypescriptOnlyThrowError(_) => TYPESCRIPT_ONLY_THROW_ERROR_ID,
             Self::TypescriptParameterProperties(_) => TYPESCRIPT_PARAMETER_PROPERTIES_ID,
             Self::TypescriptPreferAsConst(_) => TYPESCRIPT_PREFER_AS_CONST_ID,
+            Self::TypescriptPreferDestructuring(_) => TYPESCRIPT_PREFER_DESTRUCTURING_ID,
             Self::TypescriptPreferEnumInitializers(_) => TYPESCRIPT_PREFER_ENUM_INITIALIZERS_ID,
             Self::TypescriptPreferFind(_) => TYPESCRIPT_PREFER_FIND_ID,
             Self::TypescriptPreferForOf(_) => TYPESCRIPT_PREFER_FOR_OF_ID,
@@ -3861,7 +3860,6 @@ impl RuleEnum {
             Self::EslintValidTypeof(_) => EslintValidTypeof::NAME,
             Self::EslintVarsOnTop(_) => EslintVarsOnTop::NAME,
             Self::EslintYoda(_) => EslintYoda::NAME,
-            Self::TypescriptPreferDestructuring(_) => TypescriptPreferDestructuring::NAME,
             Self::TypescriptAdjacentOverloadSignatures(_) => {
                 TypescriptAdjacentOverloadSignatures::NAME
             }
@@ -3993,6 +3991,7 @@ impl RuleEnum {
             Self::TypescriptOnlyThrowError(_) => TypescriptOnlyThrowError::NAME,
             Self::TypescriptParameterProperties(_) => TypescriptParameterProperties::NAME,
             Self::TypescriptPreferAsConst(_) => TypescriptPreferAsConst::NAME,
+            Self::TypescriptPreferDestructuring(_) => TypescriptPreferDestructuring::NAME,
             Self::TypescriptPreferEnumInitializers(_) => TypescriptPreferEnumInitializers::NAME,
             Self::TypescriptPreferFind(_) => TypescriptPreferFind::NAME,
             Self::TypescriptPreferForOf(_) => TypescriptPreferForOf::NAME,
@@ -4827,7 +4826,6 @@ impl RuleEnum {
             Self::EslintValidTypeof(_) => EslintValidTypeof::CATEGORY,
             Self::EslintVarsOnTop(_) => EslintVarsOnTop::CATEGORY,
             Self::EslintYoda(_) => EslintYoda::CATEGORY,
-            Self::TypescriptPreferDestructuring(_) => TypescriptPreferDestructuring::CATEGORY,
             Self::TypescriptAdjacentOverloadSignatures(_) => {
                 TypescriptAdjacentOverloadSignatures::CATEGORY
             }
@@ -4965,6 +4963,7 @@ impl RuleEnum {
             Self::TypescriptOnlyThrowError(_) => TypescriptOnlyThrowError::CATEGORY,
             Self::TypescriptParameterProperties(_) => TypescriptParameterProperties::CATEGORY,
             Self::TypescriptPreferAsConst(_) => TypescriptPreferAsConst::CATEGORY,
+            Self::TypescriptPreferDestructuring(_) => TypescriptPreferDestructuring::CATEGORY,
             Self::TypescriptPreferEnumInitializers(_) => TypescriptPreferEnumInitializers::CATEGORY,
             Self::TypescriptPreferFind(_) => TypescriptPreferFind::CATEGORY,
             Self::TypescriptPreferForOf(_) => TypescriptPreferForOf::CATEGORY,
@@ -5840,7 +5839,6 @@ impl RuleEnum {
             Self::EslintValidTypeof(_) => EslintValidTypeof::FIX,
             Self::EslintVarsOnTop(_) => EslintVarsOnTop::FIX,
             Self::EslintYoda(_) => EslintYoda::FIX,
-            Self::TypescriptPreferDestructuring(_) => TypescriptPreferDestructuring::FIX,
             Self::TypescriptAdjacentOverloadSignatures(_) => {
                 TypescriptAdjacentOverloadSignatures::FIX
             }
@@ -5972,6 +5970,7 @@ impl RuleEnum {
             Self::TypescriptOnlyThrowError(_) => TypescriptOnlyThrowError::FIX,
             Self::TypescriptParameterProperties(_) => TypescriptParameterProperties::FIX,
             Self::TypescriptPreferAsConst(_) => TypescriptPreferAsConst::FIX,
+            Self::TypescriptPreferDestructuring(_) => TypescriptPreferDestructuring::FIX,
             Self::TypescriptPreferEnumInitializers(_) => TypescriptPreferEnumInitializers::FIX,
             Self::TypescriptPreferFind(_) => TypescriptPreferFind::FIX,
             Self::TypescriptPreferForOf(_) => TypescriptPreferForOf::FIX,
@@ -6835,9 +6834,6 @@ impl RuleEnum {
             Self::EslintValidTypeof(_) => EslintValidTypeof::documentation(),
             Self::EslintVarsOnTop(_) => EslintVarsOnTop::documentation(),
             Self::EslintYoda(_) => EslintYoda::documentation(),
-            Self::TypescriptPreferDestructuring(_) => {
-                TypescriptPreferDestructuring::documentation()
-            }
             Self::TypescriptAdjacentOverloadSignatures(_) => {
                 TypescriptAdjacentOverloadSignatures::documentation()
             }
@@ -7001,6 +6997,9 @@ impl RuleEnum {
                 TypescriptParameterProperties::documentation()
             }
             Self::TypescriptPreferAsConst(_) => TypescriptPreferAsConst::documentation(),
+            Self::TypescriptPreferDestructuring(_) => {
+                TypescriptPreferDestructuring::documentation()
+            }
             Self::TypescriptPreferEnumInitializers(_) => {
                 TypescriptPreferEnumInitializers::documentation()
             }
@@ -8368,10 +8367,6 @@ impl RuleEnum {
             Self::EslintYoda(_) => {
                 EslintYoda::config_schema(generator).or_else(|| EslintYoda::schema(generator))
             }
-            Self::TypescriptPreferDestructuring(_) => {
-                TypescriptPreferDestructuring::config_schema(generator)
-                    .or_else(|| TypescriptPreferDestructuring::schema(generator))
-            }
             Self::TypescriptAdjacentOverloadSignatures(_) => {
                 TypescriptAdjacentOverloadSignatures::config_schema(generator)
                     .or_else(|| TypescriptAdjacentOverloadSignatures::schema(generator))
@@ -8650,6 +8645,10 @@ impl RuleEnum {
             }
             Self::TypescriptPreferAsConst(_) => TypescriptPreferAsConst::config_schema(generator)
                 .or_else(|| TypescriptPreferAsConst::schema(generator)),
+            Self::TypescriptPreferDestructuring(_) => {
+                TypescriptPreferDestructuring::config_schema(generator)
+                    .or_else(|| TypescriptPreferDestructuring::schema(generator))
+            }
             Self::TypescriptPreferEnumInitializers(_) => {
                 TypescriptPreferEnumInitializers::config_schema(generator)
                     .or_else(|| TypescriptPreferEnumInitializers::schema(generator))
@@ -10454,7 +10453,6 @@ impl RuleEnum {
             Self::EslintValidTypeof(_) => "eslint",
             Self::EslintVarsOnTop(_) => "eslint",
             Self::EslintYoda(_) => "eslint",
-            Self::TypescriptPreferDestructuring(_) => "typescript",
             Self::TypescriptAdjacentOverloadSignatures(_) => "typescript",
             Self::TypescriptArrayType(_) => "typescript",
             Self::TypescriptAwaitThenable(_) => "typescript",
@@ -10534,6 +10532,7 @@ impl RuleEnum {
             Self::TypescriptOnlyThrowError(_) => "typescript",
             Self::TypescriptParameterProperties(_) => "typescript",
             Self::TypescriptPreferAsConst(_) => "typescript",
+            Self::TypescriptPreferDestructuring(_) => "typescript",
             Self::TypescriptPreferEnumInitializers(_) => "typescript",
             Self::TypescriptPreferFind(_) => "typescript",
             Self::TypescriptPreferForOf(_) => "typescript",
@@ -11735,9 +11734,6 @@ impl RuleEnum {
                 Ok(Self::EslintVarsOnTop(EslintVarsOnTop::from_configuration(value)?))
             }
             Self::EslintYoda(_) => Ok(Self::EslintYoda(EslintYoda::from_configuration(value)?)),
-            Self::TypescriptPreferDestructuring(_) => Ok(Self::TypescriptPreferDestructuring(
-                TypescriptPreferDestructuring::from_configuration(value)?,
-            )),
             Self::TypescriptAdjacentOverloadSignatures(_) => {
                 Ok(Self::TypescriptAdjacentOverloadSignatures(
                     TypescriptAdjacentOverloadSignatures::from_configuration(value)?,
@@ -12038,6 +12034,9 @@ impl RuleEnum {
             )),
             Self::TypescriptPreferAsConst(_) => Ok(Self::TypescriptPreferAsConst(
                 TypescriptPreferAsConst::from_configuration(value)?,
+            )),
+            Self::TypescriptPreferDestructuring(_) => Ok(Self::TypescriptPreferDestructuring(
+                TypescriptPreferDestructuring::from_configuration(value)?,
             )),
             Self::TypescriptPreferEnumInitializers(_) => {
                 Ok(Self::TypescriptPreferEnumInitializers(
@@ -14017,7 +14016,6 @@ impl RuleEnum {
             Self::EslintValidTypeof(rule) => rule.to_configuration(),
             Self::EslintVarsOnTop(rule) => rule.to_configuration(),
             Self::EslintYoda(rule) => rule.to_configuration(),
-            Self::TypescriptPreferDestructuring(rule) => rule.to_configuration(),
             Self::TypescriptAdjacentOverloadSignatures(rule) => rule.to_configuration(),
             Self::TypescriptArrayType(rule) => rule.to_configuration(),
             Self::TypescriptAwaitThenable(rule) => rule.to_configuration(),
@@ -14099,6 +14097,7 @@ impl RuleEnum {
             Self::TypescriptOnlyThrowError(rule) => rule.to_configuration(),
             Self::TypescriptParameterProperties(rule) => rule.to_configuration(),
             Self::TypescriptPreferAsConst(rule) => rule.to_configuration(),
+            Self::TypescriptPreferDestructuring(rule) => rule.to_configuration(),
             Self::TypescriptPreferEnumInitializers(rule) => rule.to_configuration(),
             Self::TypescriptPreferFind(rule) => rule.to_configuration(),
             Self::TypescriptPreferForOf(rule) => rule.to_configuration(),
@@ -14868,7 +14867,6 @@ impl RuleEnum {
             Self::EslintValidTypeof(rule) => rule.run(node, ctx),
             Self::EslintVarsOnTop(rule) => rule.run(node, ctx),
             Self::EslintYoda(rule) => rule.run(node, ctx),
-            Self::TypescriptPreferDestructuring(rule) => rule.run(node, ctx),
             Self::TypescriptAdjacentOverloadSignatures(rule) => rule.run(node, ctx),
             Self::TypescriptArrayType(rule) => rule.run(node, ctx),
             Self::TypescriptAwaitThenable(rule) => rule.run(node, ctx),
@@ -14948,6 +14946,7 @@ impl RuleEnum {
             Self::TypescriptOnlyThrowError(rule) => rule.run(node, ctx),
             Self::TypescriptParameterProperties(rule) => rule.run(node, ctx),
             Self::TypescriptPreferAsConst(rule) => rule.run(node, ctx),
+            Self::TypescriptPreferDestructuring(rule) => rule.run(node, ctx),
             Self::TypescriptPreferEnumInitializers(rule) => rule.run(node, ctx),
             Self::TypescriptPreferFind(rule) => rule.run(node, ctx),
             Self::TypescriptPreferForOf(rule) => rule.run(node, ctx),
@@ -15727,7 +15726,6 @@ impl RuleEnum {
             Self::EslintValidTypeof(rule) => rule.run_once(ctx),
             Self::EslintVarsOnTop(rule) => rule.run_once(ctx),
             Self::EslintYoda(rule) => rule.run_once(ctx),
-            Self::TypescriptPreferDestructuring(rule) => rule.run_once(ctx),
             Self::TypescriptAdjacentOverloadSignatures(rule) => rule.run_once(ctx),
             Self::TypescriptArrayType(rule) => rule.run_once(ctx),
             Self::TypescriptAwaitThenable(rule) => rule.run_once(ctx),
@@ -15807,6 +15805,7 @@ impl RuleEnum {
             Self::TypescriptOnlyThrowError(rule) => rule.run_once(ctx),
             Self::TypescriptParameterProperties(rule) => rule.run_once(ctx),
             Self::TypescriptPreferAsConst(rule) => rule.run_once(ctx),
+            Self::TypescriptPreferDestructuring(rule) => rule.run_once(ctx),
             Self::TypescriptPreferEnumInitializers(rule) => rule.run_once(ctx),
             Self::TypescriptPreferFind(rule) => rule.run_once(ctx),
             Self::TypescriptPreferForOf(rule) => rule.run_once(ctx),
@@ -16589,7 +16588,6 @@ impl RuleEnum {
             Self::EslintValidTypeof(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintVarsOnTop(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintYoda(rule) => rule.run_on_jest_node(jest_node, ctx),
-            Self::TypescriptPreferDestructuring(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::TypescriptAdjacentOverloadSignatures(rule) => {
                 rule.run_on_jest_node(jest_node, ctx)
             }
@@ -16721,6 +16719,7 @@ impl RuleEnum {
             Self::TypescriptOnlyThrowError(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::TypescriptParameterProperties(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::TypescriptPreferAsConst(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::TypescriptPreferDestructuring(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::TypescriptPreferEnumInitializers(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::TypescriptPreferFind(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::TypescriptPreferForOf(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -17563,7 +17562,6 @@ impl RuleEnum {
             Self::EslintValidTypeof(rule) => rule.should_run(ctx),
             Self::EslintVarsOnTop(rule) => rule.should_run(ctx),
             Self::EslintYoda(rule) => rule.should_run(ctx),
-            Self::TypescriptPreferDestructuring(rule) => rule.should_run(ctx),
             Self::TypescriptAdjacentOverloadSignatures(rule) => rule.should_run(ctx),
             Self::TypescriptArrayType(rule) => rule.should_run(ctx),
             Self::TypescriptAwaitThenable(rule) => rule.should_run(ctx),
@@ -17643,6 +17641,7 @@ impl RuleEnum {
             Self::TypescriptOnlyThrowError(rule) => rule.should_run(ctx),
             Self::TypescriptParameterProperties(rule) => rule.should_run(ctx),
             Self::TypescriptPreferAsConst(rule) => rule.should_run(ctx),
+            Self::TypescriptPreferDestructuring(rule) => rule.should_run(ctx),
             Self::TypescriptPreferEnumInitializers(rule) => rule.should_run(ctx),
             Self::TypescriptPreferFind(rule) => rule.should_run(ctx),
             Self::TypescriptPreferForOf(rule) => rule.should_run(ctx),
@@ -18443,9 +18442,6 @@ impl RuleEnum {
             Self::EslintValidTypeof(_) => EslintValidTypeof::IS_TSGOLINT_RULE,
             Self::EslintVarsOnTop(_) => EslintVarsOnTop::IS_TSGOLINT_RULE,
             Self::EslintYoda(_) => EslintYoda::IS_TSGOLINT_RULE,
-            Self::TypescriptPreferDestructuring(_) => {
-                TypescriptPreferDestructuring::IS_TSGOLINT_RULE
-            }
             Self::TypescriptAdjacentOverloadSignatures(_) => {
                 TypescriptAdjacentOverloadSignatures::IS_TSGOLINT_RULE
             }
@@ -18609,6 +18605,9 @@ impl RuleEnum {
                 TypescriptParameterProperties::IS_TSGOLINT_RULE
             }
             Self::TypescriptPreferAsConst(_) => TypescriptPreferAsConst::IS_TSGOLINT_RULE,
+            Self::TypescriptPreferDestructuring(_) => {
+                TypescriptPreferDestructuring::IS_TSGOLINT_RULE
+            }
             Self::TypescriptPreferEnumInitializers(_) => {
                 TypescriptPreferEnumInitializers::IS_TSGOLINT_RULE
             }
@@ -19643,7 +19642,6 @@ impl RuleEnum {
             Self::EslintValidTypeof(_) => EslintValidTypeof::VERSION,
             Self::EslintVarsOnTop(_) => EslintVarsOnTop::VERSION,
             Self::EslintYoda(_) => EslintYoda::VERSION,
-            Self::TypescriptPreferDestructuring(_) => TypescriptPreferDestructuring::VERSION,
             Self::TypescriptAdjacentOverloadSignatures(_) => {
                 TypescriptAdjacentOverloadSignatures::VERSION
             }
@@ -19781,6 +19779,7 @@ impl RuleEnum {
             Self::TypescriptOnlyThrowError(_) => TypescriptOnlyThrowError::VERSION,
             Self::TypescriptParameterProperties(_) => TypescriptParameterProperties::VERSION,
             Self::TypescriptPreferAsConst(_) => TypescriptPreferAsConst::VERSION,
+            Self::TypescriptPreferDestructuring(_) => TypescriptPreferDestructuring::VERSION,
             Self::TypescriptPreferEnumInitializers(_) => TypescriptPreferEnumInitializers::VERSION,
             Self::TypescriptPreferFind(_) => TypescriptPreferFind::VERSION,
             Self::TypescriptPreferForOf(_) => TypescriptPreferForOf::VERSION,
@@ -20668,7 +20667,6 @@ impl RuleEnum {
             Self::EslintValidTypeof(_) => EslintValidTypeof::HAS_CONFIG,
             Self::EslintVarsOnTop(_) => EslintVarsOnTop::HAS_CONFIG,
             Self::EslintYoda(_) => EslintYoda::HAS_CONFIG,
-            Self::TypescriptPreferDestructuring(_) => TypescriptPreferDestructuring::HAS_CONFIG,
             Self::TypescriptAdjacentOverloadSignatures(_) => {
                 TypescriptAdjacentOverloadSignatures::HAS_CONFIG
             }
@@ -20812,6 +20810,7 @@ impl RuleEnum {
             Self::TypescriptOnlyThrowError(_) => TypescriptOnlyThrowError::HAS_CONFIG,
             Self::TypescriptParameterProperties(_) => TypescriptParameterProperties::HAS_CONFIG,
             Self::TypescriptPreferAsConst(_) => TypescriptPreferAsConst::HAS_CONFIG,
+            Self::TypescriptPreferDestructuring(_) => TypescriptPreferDestructuring::HAS_CONFIG,
             Self::TypescriptPreferEnumInitializers(_) => {
                 TypescriptPreferEnumInitializers::HAS_CONFIG
             }
@@ -21714,7 +21713,6 @@ impl RuleEnum {
             Self::EslintValidTypeof(_) => EslintValidTypeof::INFO,
             Self::EslintVarsOnTop(_) => EslintVarsOnTop::INFO,
             Self::EslintYoda(_) => EslintYoda::INFO,
-            Self::TypescriptPreferDestructuring(_) => TypescriptPreferDestructuring::INFO,
             Self::TypescriptAdjacentOverloadSignatures(_) => {
                 TypescriptAdjacentOverloadSignatures::INFO
             }
@@ -21846,6 +21844,7 @@ impl RuleEnum {
             Self::TypescriptOnlyThrowError(_) => TypescriptOnlyThrowError::INFO,
             Self::TypescriptParameterProperties(_) => TypescriptParameterProperties::INFO,
             Self::TypescriptPreferAsConst(_) => TypescriptPreferAsConst::INFO,
+            Self::TypescriptPreferDestructuring(_) => TypescriptPreferDestructuring::INFO,
             Self::TypescriptPreferEnumInitializers(_) => TypescriptPreferEnumInitializers::INFO,
             Self::TypescriptPreferFind(_) => TypescriptPreferFind::INFO,
             Self::TypescriptPreferForOf(_) => TypescriptPreferForOf::INFO,
@@ -22679,7 +22678,6 @@ impl RuleEnum {
             Self::EslintValidTypeof(rule) => rule.types_info(),
             Self::EslintVarsOnTop(rule) => rule.types_info(),
             Self::EslintYoda(rule) => rule.types_info(),
-            Self::TypescriptPreferDestructuring(rule) => rule.types_info(),
             Self::TypescriptAdjacentOverloadSignatures(rule) => rule.types_info(),
             Self::TypescriptArrayType(rule) => rule.types_info(),
             Self::TypescriptAwaitThenable(rule) => rule.types_info(),
@@ -22759,6 +22757,7 @@ impl RuleEnum {
             Self::TypescriptOnlyThrowError(rule) => rule.types_info(),
             Self::TypescriptParameterProperties(rule) => rule.types_info(),
             Self::TypescriptPreferAsConst(rule) => rule.types_info(),
+            Self::TypescriptPreferDestructuring(rule) => rule.types_info(),
             Self::TypescriptPreferEnumInitializers(rule) => rule.types_info(),
             Self::TypescriptPreferFind(rule) => rule.types_info(),
             Self::TypescriptPreferForOf(rule) => rule.types_info(),
@@ -23525,7 +23524,6 @@ impl RuleEnum {
             Self::EslintValidTypeof(rule) => rule.run_info(),
             Self::EslintVarsOnTop(rule) => rule.run_info(),
             Self::EslintYoda(rule) => rule.run_info(),
-            Self::TypescriptPreferDestructuring(rule) => rule.run_info(),
             Self::TypescriptAdjacentOverloadSignatures(rule) => rule.run_info(),
             Self::TypescriptArrayType(rule) => rule.run_info(),
             Self::TypescriptAwaitThenable(rule) => rule.run_info(),
@@ -23605,6 +23603,7 @@ impl RuleEnum {
             Self::TypescriptOnlyThrowError(rule) => rule.run_info(),
             Self::TypescriptParameterProperties(rule) => rule.run_info(),
             Self::TypescriptPreferAsConst(rule) => rule.run_info(),
+            Self::TypescriptPreferDestructuring(rule) => rule.run_info(),
             Self::TypescriptPreferEnumInitializers(rule) => rule.run_info(),
             Self::TypescriptPreferFind(rule) => rule.run_info(),
             Self::TypescriptPreferForOf(rule) => rule.run_info(),
@@ -24393,7 +24392,6 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::EslintValidTypeof(EslintValidTypeof::default()),
         RuleEnum::EslintVarsOnTop(EslintVarsOnTop::default()),
         RuleEnum::EslintYoda(EslintYoda::default()),
-        RuleEnum::TypescriptPreferDestructuring(TypescriptPreferDestructuring::default()),
         RuleEnum::TypescriptAdjacentOverloadSignatures(
             TypescriptAdjacentOverloadSignatures::default(),
         ),
@@ -24525,6 +24523,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::TypescriptOnlyThrowError(TypescriptOnlyThrowError::default()),
         RuleEnum::TypescriptParameterProperties(TypescriptParameterProperties::default()),
         RuleEnum::TypescriptPreferAsConst(TypescriptPreferAsConst::default()),
+        RuleEnum::TypescriptPreferDestructuring(TypescriptPreferDestructuring::default()),
         RuleEnum::TypescriptPreferEnumInitializers(TypescriptPreferEnumInitializers::default()),
         RuleEnum::TypescriptPreferFind(TypescriptPreferFind::default()),
         RuleEnum::TypescriptPreferForOf(TypescriptPreferForOf::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -310,6 +310,7 @@ pub(crate) mod typescript {
     pub mod only_throw_error;
     pub mod parameter_properties;
     pub mod prefer_as_const;
+    pub mod prefer_destructuring;
     pub mod prefer_enum_initializers;
     pub mod prefer_find;
     pub mod prefer_for_of;

--- a/crates/oxc_linter/src/rules/typescript/prefer_destructuring.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_destructuring.rs
@@ -1,58 +1,462 @@
+use oxc_ast::{
+    AstKind,
+    ast::{
+        AssignmentOperator, AssignmentTarget, BindingPattern, Expression, MemberExpression,
+        PropertyKey, TSSignature, TSType, VariableDeclarationKind,
+    },
+};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::Span;
+use oxc_semantic::ScopeId;
+use oxc_span::{GetSpan, Span};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     AstNode,
     context::LintContext,
-    fixer::{RuleFix, RuleFixer},
-    rule::Rule,
+    rule::{Rule, TupleRuleConfig},
 };
 
-fn prefer_destructuring_diagnostic(span: Span) -> OxcDiagnostic {
-    // See <https://oxc.rs/docs/contribute/linter/adding-rules.html#diagnostics> for details
-    OxcDiagnostic::warn("Should be an imperative statement about what is wrong.")
-        .with_help("Should be a command-like statement that tells the user how to fix the issue.")
+fn prefer_object_destructuring(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Use Object destructuring.")
+        .with_help("Use object destructuring rather than direct member access.")
         .with_label(span)
 }
 
-#[derive(Debug, Default, Clone)]
-pub struct PreferDestructuring;
+fn prefer_array_destructuring(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Use Array destructuring.")
+        .with_help("Use array destructuring rather than direct member access.")
+        .with_label(span)
+}
 
-// See <https://github.com/oxc-project/oxc/issues/6050> for documentation details.
+#[derive(Debug, Clone, JsonSchema, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+struct PreferDestructuringTargetConfig {
+    array: bool,
+    object: bool,
+}
+
+impl Default for PreferDestructuringTargetConfig {
+    fn default() -> Self {
+        Self { array: true, object: true }
+    }
+}
+
+impl PreferDestructuringTargetConfig {
+    fn disabled() -> Self {
+        Self { array: false, object: false }
+    }
+}
+
+#[derive(Debug, Default, Clone, JsonSchema, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct PreferDestructuringTargetOption {
+    array: Option<bool>,
+    object: Option<bool>,
+}
+
+impl PreferDestructuringTargetOption {
+    fn enabled_by_default() -> Self {
+        Self { array: Some(true), object: Some(true) }
+    }
+
+    fn into_config(self) -> PreferDestructuringTargetConfig {
+        PreferDestructuringTargetConfig {
+            array: self.array.unwrap_or(false),
+            object: self.object.unwrap_or(false),
+        }
+    }
+}
+
+#[derive(Debug, Clone, JsonSchema, Deserialize, Serialize)]
+#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+struct PreferDestructuringAssignmentConfig {
+    variable_declarator: Option<PreferDestructuringTargetOption>,
+    assignment_expression: Option<PreferDestructuringTargetOption>,
+}
+
+impl PreferDestructuringAssignmentConfig {
+    fn into_configs(self) -> (PreferDestructuringTargetConfig, PreferDestructuringTargetConfig) {
+        let variable_declarator = self.variable_declarator.map_or_else(
+            PreferDestructuringTargetConfig::disabled,
+            PreferDestructuringTargetOption::into_config,
+        );
+        let assignment_expression = self.assignment_expression.map_or_else(
+            PreferDestructuringTargetConfig::disabled,
+            PreferDestructuringTargetOption::into_config,
+        );
+
+        (variable_declarator, assignment_expression)
+    }
+}
+
+#[derive(Debug, Clone, JsonSchema, Deserialize, Serialize)]
+#[serde(untagged)]
+enum PreferDestructuringOption {
+    Target(PreferDestructuringTargetOption),
+    Assignment(PreferDestructuringAssignmentConfig),
+}
+
+impl Default for PreferDestructuringOption {
+    fn default() -> Self {
+        Self::Target(PreferDestructuringTargetOption::enabled_by_default())
+    }
+}
+
+impl PreferDestructuringOption {
+    fn into_configs(self) -> (PreferDestructuringTargetConfig, PreferDestructuringTargetConfig) {
+        match self {
+            Self::Target(config) => {
+                let config = config.into_config();
+                (config.clone(), config)
+            }
+            Self::Assignment(config) => config.into_configs(),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, JsonSchema, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+struct PreferDestructuringEnforcementConfig {
+    /// Whether to enforce destructuring on variable declarations with type annotations.
+    enforce_for_declaration_with_type_annotation: bool,
+    /// Whether to enforce destructuring that uses a different variable name than the property name.
+    enforce_for_renamed_properties: bool,
+}
+
+#[derive(Debug, Default, Clone, JsonSchema, Deserialize, Serialize)]
+#[serde(default)]
+struct PreferDestructuringConfig(PreferDestructuringOption, PreferDestructuringEnforcementConfig);
+
+impl PreferDestructuringConfig {
+    fn into_rule(self) -> PreferDestructuring {
+        let (variable_declarator, assignment_expression) = self.0.into_configs();
+
+        PreferDestructuring {
+            variable_declarator,
+            assignment_expression,
+            enforce_for_renamed_properties: self.1.enforce_for_renamed_properties,
+            enforce_for_declaration_with_type_annotation: self
+                .1
+                .enforce_for_declaration_with_type_annotation,
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PreferDestructuring {
+    variable_declarator: PreferDestructuringTargetConfig,
+    assignment_expression: PreferDestructuringTargetConfig,
+    enforce_for_renamed_properties: bool,
+    enforce_for_declaration_with_type_annotation: bool,
+}
+
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// FIXME: Briefly describe the rule's purpose.
+    /// Requires destructuring from arrays and/or objects. This is the
+    /// TypeScript-aware version of the [`prefer-destructuring`](https://eslint.org/docs/latest/rules/prefer-destructuring)
+    /// ESLint rule.
     ///
     /// ### Why is this bad?
     ///
-    /// FIXME: Explain why violating this rule is problematic.
+    /// The plain ESLint rule treats any numeric member access such as `x[0]`
+    /// as array-like, and reports it as an opportunity for array destructuring.
+    /// That is incorrect when the object being indexed is not actually an array
+    /// or iterable — for example `let x: { 0: unknown }; let y = x[0];`, where
+    /// `x[0]` is really an object property access. This rule uses the available
+    /// type annotations to distinguish array/iterable access from object
+    /// property access, and only reports the appropriate destructuring form.
+    ///
+    /// It also adds the `enforceForDeclarationWithTypeAnnotation` option, which
+    /// controls whether declarations that carry an explicit type annotation are
+    /// reported (they are skipped by default, since destructuring them requires
+    /// rewriting the annotation).
     ///
     /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```ts
-    /// FIXME: Add at least one example of code that violates the rule.
+    /// let x: { [Symbol.iterator]: unknown };
+    /// let y = x[0];
+    ///
+    /// let obj = { foo: 'bar' };
+    /// const foo = obj.foo;
     /// ```
     ///
     /// Examples of **correct** code for this rule:
     /// ```ts
-    /// FIXME: Add at least one example of code that is allowed with the rule.
+    /// declare const object: { foo: string };
+    /// var foo: string = object.foo;
+    ///
+    /// let x: { 0: unknown };
+    /// let y = x[0];
     /// ```
     PreferDestructuring,
     typescript,
-    nursery, // TODO: change category to `correctness`, `suspicious`, `pedantic`, `perf`, `restriction`, or `style`
-             // See <https://oxc.rs/docs/contribute/linter.html#rule-category> for details
-    pending, // TODO: describe fix capabilities. Remove or set to `none` if no fix can be done,
-             // keep at 'pending' if you think one could be added but don't know how.
-             // Options are 'fix', 'fix_dangerous', 'suggestion', and 'conditional_fix_suggestion'
+    style,
+    conditional_fix,
+    config = PreferDestructuringConfig,
     version = "next",
-    short_description = "FIXME: One-sentence description of the rule.",
+    short_description = "Require destructuring from arrays and/or objects.",
 );
 
 impl Rule for PreferDestructuring {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {}
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<TupleRuleConfig<PreferDestructuringConfig>>(value)
+            .map(|config| config.into_inner().into_rule())
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::AssignmentExpression(assign_expr)
+                if assign_expr.operator == AssignmentOperator::Assign =>
+            {
+                let AssignmentTarget::AssignmentTargetIdentifier(target) = &assign_expr.left else {
+                    return;
+                };
+                let Some(member) = assign_expr.right.without_parentheses().as_member_expression()
+                else {
+                    return;
+                };
+                self.check(
+                    member,
+                    Some(target.name.as_str()),
+                    assign_expr.span,
+                    None,
+                    &self.assignment_expression,
+                    node.scope_id(),
+                    ctx,
+                );
+            }
+            AstKind::VariableDeclarator(declarator) => {
+                // Skip `using` and `await using` declarations - destructuring doesn't apply to them.
+                if matches!(
+                    declarator.kind,
+                    VariableDeclarationKind::Using | VariableDeclarationKind::AwaitUsing
+                ) {
+                    return;
+                }
+                let Some(init) = &declarator.init else {
+                    return;
+                };
+                let Some(member) = init.without_parentheses().as_member_expression() else {
+                    return;
+                };
+                let BindingPattern::BindingIdentifier(ident) = &declarator.id else {
+                    // Already destructured (array/object pattern) - nothing to report.
+                    return;
+                };
+
+                // `enforceForDeclarationWithTypeAnnotation`: declarations with an
+                // explicit type annotation are skipped unless the option is enabled.
+                // When enabled, we still report but suppress the autofix, because
+                // destructuring the binding would require rewriting the annotation.
+                let has_type_annotation = declarator.type_annotation.is_some();
+                if has_type_annotation && !self.enforce_for_declaration_with_type_annotation {
+                    return;
+                }
+
+                self.check(
+                    member,
+                    Some(ident.name.as_str()),
+                    init.span(),
+                    if has_type_annotation { None } else { Some(declarator.span()) },
+                    &self.variable_declarator,
+                    node.scope_id(),
+                    ctx,
+                );
+            }
+            _ => {}
+        }
+    }
+}
+
+impl PreferDestructuring {
+    /// `target_name` is the name of the binding/assignment target (e.g. `foo` in
+    /// `var foo = obj.foo`), used to decide whether a property access is
+    /// "renamed". `fix_span`, when `Some`, is the span to replace when applying
+    /// an object-destructuring autofix (only available for plain declarations
+    /// without a type annotation).
+    #[expect(clippy::too_many_arguments)]
+    fn check<'a>(
+        &self,
+        member: &MemberExpression<'a>,
+        target_name: Option<&str>,
+        report_span: Span,
+        fix_span: Option<Span>,
+        config: &PreferDestructuringTargetConfig,
+        scope_id: ScopeId,
+        ctx: &LintContext<'a>,
+    ) {
+        // Access on `super` or a private field cannot be destructured.
+        if matches!(member, MemberExpression::PrivateFieldExpression(_))
+            || matches!(member.object(), Expression::Super(_))
+        {
+            return;
+        }
+        // Optional chaining member access is not reported.
+        if member.optional() {
+            return;
+        }
+
+        match member {
+            MemberExpression::ComputedMemberExpression(computed) => {
+                // Template-literal keys are never reported.
+                if matches!(computed.expression, Expression::TemplateLiteral(_)) {
+                    return;
+                }
+
+                if let Expression::NumericLiteral(_) = &computed.expression {
+                    // `x[0]`: use the type of `x` to decide array vs object.
+                    if is_iterable_or_any(member.object(), scope_id, ctx) {
+                        // Iterable/any -> array destructuring.
+                        if config.array {
+                            ctx.diagnostic(prefer_array_destructuring(report_span));
+                        }
+                    } else {
+                        // Object-like -> only report as object destructuring when
+                        // renamed properties are enforced and object is enabled.
+                        if self.enforce_for_renamed_properties && config.object {
+                            ctx.diagnostic(prefer_object_destructuring(report_span));
+                        }
+                    }
+                    return;
+                }
+
+                // Non-numeric, non-template computed access (`x[i]`, `obj['foo']`, `obj[key]`).
+                if !config.object {
+                    return;
+                }
+                if let Expression::StringLiteral(string_literal) = &computed.expression {
+                    if self.enforce_for_renamed_properties
+                        || target_name.is_some_and(|name| name == string_literal.value.as_str())
+                    {
+                        ctx.diagnostic(prefer_object_destructuring(report_span));
+                    }
+                } else if self.enforce_for_renamed_properties {
+                    ctx.diagnostic(prefer_object_destructuring(report_span));
+                }
+            }
+            MemberExpression::StaticMemberExpression(static_expr) => {
+                if !config.object {
+                    return;
+                }
+                let names_match =
+                    target_name.is_some_and(|name| name == static_expr.property.name.as_str());
+                if !self.enforce_for_renamed_properties && !names_match {
+                    return;
+                }
+
+                if names_match && let Some(fix_span) = fix_span {
+                    ctx.diagnostic_with_fix(prefer_object_destructuring(report_span), |fixer| {
+                        let prop = fixer.source_range(static_expr.property.span);
+                        let object_text = fixer.source_range(
+                            get_object_span_without_redundant_parentheses(&static_expr.object),
+                        );
+                        fixer.replace(fix_span, format!("{{{prop}}} = {object_text}"))
+                    });
+                } else {
+                    ctx.diagnostic(prefer_object_destructuring(report_span));
+                }
+            }
+            MemberExpression::PrivateFieldExpression(_) => unreachable!(),
+        }
+    }
+}
+
+/// Syntactically approximate TypeScript's `isTypeAnyOrIterableType`: resolve
+/// the object identifier to its declaration and classify the declared type.
+/// A call expression whose callee is a generator is treated as iterable.
+/// Anything whose type cannot be resolved falls back to `true` (array-like),
+/// matching the base ESLint rule's behavior of treating `x[0]` as array access.
+fn is_iterable_or_any<'a>(
+    object: &Expression<'a>,
+    scope_id: ScopeId,
+    ctx: &LintContext<'a>,
+) -> bool {
+    match object.without_parentheses() {
+        Expression::Identifier(ident) => {
+            let Some(symbol_id) = ctx.scoping().get_binding(scope_id, ident.name) else {
+                // Unresolved (e.g. `declare`d elsewhere / global) -> treat as array-like.
+                return true;
+            };
+            let decl = ctx.semantic().symbol_declaration(symbol_id);
+            let Some(ts_type) = declared_type_of(decl) else {
+                // No annotation available -> treat as array-like.
+                return true;
+            };
+            is_iterable_type(ts_type)
+        }
+        Expression::CallExpression(call) => {
+            // `it()[0]` where `it` is a generator is iterable.
+            if let Expression::Identifier(ident) = &call.callee
+                && let Some(symbol_id) = ctx.scoping().get_binding(scope_id, ident.name)
+            {
+                let decl = ctx.semantic().symbol_declaration(symbol_id);
+                if let AstKind::Function(func) = decl.kind() {
+                    return func.generator;
+                }
+            }
+            true
+        }
+        // Any other object expression: fall back to array-like handling.
+        _ => true,
+    }
+}
+
+/// Extract the declared `TSType` of a binding declaration node, if present.
+fn declared_type_of<'a>(node: &AstNode<'a>) -> Option<&'a TSType<'a>> {
+    match node.kind() {
+        AstKind::VariableDeclarator(declarator) => {
+            declarator.type_annotation.as_ref().map(|annotation| &annotation.type_annotation)
+        }
+        _ => None,
+    }
+}
+
+/// Syntactic approximation of "is this type any or iterable?".
+fn is_iterable_type(ts_type: &TSType) -> bool {
+    match ts_type {
+        // `any` is treated as iterable by the reference rule; `T[]` and tuples are iterable too.
+        TSType::TSAnyKeyword(_) | TSType::TSArrayType(_) | TSType::TSTupleType(_) => true,
+        // A union is iterable only if *every* member is iterable.
+        TSType::TSUnionType(union) => union.types.iter().all(is_iterable_type),
+        // An intersection is iterable if *any* member is iterable.
+        TSType::TSIntersectionType(intersection) => intersection.types.iter().any(is_iterable_type),
+        // `{ [Symbol.iterator]: ... }` is iterable; other object literals are not.
+        TSType::TSTypeLiteral(literal) => literal.members.iter().any(|member| {
+            matches!(member, TSSignature::TSPropertySignature(prop)
+                if prop.computed && is_symbol_iterator_key(&prop.key))
+        }),
+        // `unknown`, `object`, `Record<...>`, and everything else are object-like.
+        _ => false,
+    }
+}
+
+/// Whether a computed property key is `[Symbol.iterator]`.
+fn is_symbol_iterator_key(key: &PropertyKey) -> bool {
+    if let PropertyKey::StaticMemberExpression(member) = key
+        && let Expression::Identifier(object) = &member.object
+    {
+        return object.name == "Symbol" && member.property.name == "iterator";
+    }
+    false
+}
+
+/// Returns the span of the object expression, stripping redundant parentheses for expressions
+/// where they are unnecessary in the `{ ... } = <object>` destructuring context.
+///
+/// A `SequenceExpression` (`(a, b)`) must keep its parentheses, otherwise
+/// `var {foo} = a, b` would parse as two declarators. Other parenthesized
+/// expressions such as arrow functions (`(() => null)`) and assignments
+/// (`(a = obj)`) do not need the parentheses in this position.
+fn get_object_span_without_redundant_parentheses(object: &Expression) -> Span {
+    match object.without_parentheses() {
+        Expression::SequenceExpression(_) => object.span(),
+        inner => inner.span(),
+    }
 }
 
 #[test]
@@ -142,7 +546,7 @@ fn test() {
                     declare class Foo {
                       foo: string;
                     }
-            
+
                     class Bar extends Foo {
                       static foo() {
                         var foo: any = super.foo;
@@ -491,7 +895,7 @@ fn test() {
             "
                   class C {
                     #foo: string;
-            
+
                     method() {
                       const foo: unknown = this.#foo;
                     }
@@ -503,7 +907,7 @@ fn test() {
             "
                   class C {
                     #foo: string;
-            
+
                     method() {
                       let foo: unknown;
                       foo = this.#foo;
@@ -516,7 +920,7 @@ fn test() {
             "
                     class C {
                       #foo: string;
-            
+
                       method() {
                         const bar: unknown = this.#foo;
                       }
@@ -530,7 +934,7 @@ fn test() {
             "
                     class C {
                       #foo: string;
-            
+
                       method(another: C) {
                         let bar: unknown;
                         bar: unknown = another.#foo;
@@ -545,7 +949,7 @@ fn test() {
             "
                     class C {
                       #foo: string;
-            
+
                       method() {
                         const foo: unknown = this.#foo;
                       }

--- a/crates/oxc_linter/src/rules/typescript/prefer_destructuring.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_destructuring.rs
@@ -1,0 +1,906 @@
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    fixer::{RuleFix, RuleFixer},
+    rule::Rule,
+};
+
+fn prefer_destructuring_diagnostic(span: Span) -> OxcDiagnostic {
+    // See <https://oxc.rs/docs/contribute/linter/adding-rules.html#diagnostics> for details
+    OxcDiagnostic::warn("Should be an imperative statement about what is wrong.")
+        .with_help("Should be a command-like statement that tells the user how to fix the issue.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PreferDestructuring;
+
+// See <https://github.com/oxc-project/oxc/issues/6050> for documentation details.
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// FIXME: Briefly describe the rule's purpose.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// FIXME: Explain why violating this rule is problematic.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```ts
+    /// FIXME: Add at least one example of code that violates the rule.
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```ts
+    /// FIXME: Add at least one example of code that is allowed with the rule.
+    /// ```
+    PreferDestructuring,
+    typescript,
+    nursery, // TODO: change category to `correctness`, `suspicious`, `pedantic`, `perf`, `restriction`, or `style`
+             // See <https://oxc.rs/docs/contribute/linter.html#rule-category> for details
+    pending, // TODO: describe fix capabilities. Remove or set to `none` if no fix can be done,
+             // keep at 'pending' if you think one could be added but don't know how.
+             // Options are 'fix', 'fix_dangerous', 'suggestion', and 'conditional_fix_suggestion'
+    version = "next",
+    short_description = "FIXME: One-sentence description of the rule.",
+);
+
+impl Rule for PreferDestructuring {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {}
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (
+            "
+                  declare const object: { foo: string };
+                  var foo: string = object.foo;
+                ",
+            None,
+        ),
+        (
+            "
+                  declare const array: number[];
+                  const bar: number = array[0];
+                ",
+            None,
+        ),
+        (
+            "
+                    declare const object: { foo: string };
+                    var { foo } = object;
+                  ",
+            Some(
+                serde_json::json!([ { "object": true }, { "enforceForDeclarationWithTypeAnnotation": true }, ]),
+            ),
+        ),
+        (
+            "
+                    declare const object: { foo: string };
+                    var { foo }: { foo: number } = object;
+                  ",
+            Some(
+                serde_json::json!([ { "object": true }, { "enforceForDeclarationWithTypeAnnotation": true }, ]),
+            ),
+        ),
+        (
+            "
+                    declare const array: number[];
+                    var [foo] = array;
+                  ",
+            Some(
+                serde_json::json!([ { "array": true }, { "enforceForDeclarationWithTypeAnnotation": true }, ]),
+            ),
+        ),
+        (
+            "
+                    declare const array: number[];
+                    var [foo]: [foo: number] = array;
+                  ",
+            Some(
+                serde_json::json!([ { "object": true }, { "enforceForDeclarationWithTypeAnnotation": true }, ]),
+            ),
+        ),
+        (
+            "
+                    declare const object: { bar: string };
+                    var foo: unknown = object.bar;
+                  ",
+            Some(
+                serde_json::json!([ { "object": true }, { "enforceForDeclarationWithTypeAnnotation": true }, ]),
+            ),
+        ),
+        (
+            "
+                    declare const object: { foo: string };
+                    var { foo: bar } = object;
+                  ",
+            Some(
+                serde_json::json!([ { "object": true }, { "enforceForDeclarationWithTypeAnnotation": true }, ]),
+            ),
+        ),
+        (
+            "
+                    declare const object: { foo: boolean };
+                    var { foo: bar }: { foo: boolean } = object;
+                  ",
+            Some(
+                serde_json::json!([ { "object": true }, { "enforceForDeclarationWithTypeAnnotation": true }, ]),
+            ),
+        ),
+        (
+            "
+                    declare class Foo {
+                      foo: string;
+                    }
+            
+                    class Bar extends Foo {
+                      static foo() {
+                        var foo: any = super.foo;
+                      }
+                    }
+                  ",
+            Some(
+                serde_json::json!([ { "object": true }, { "enforceForDeclarationWithTypeAnnotation": true }, ]),
+            ),
+        ),
+        (
+            "
+                  let x: { 0: unknown };
+                  let y = x[0];
+                ",
+            None,
+        ),
+        (
+            "
+                  let x: { 0: unknown };
+                  y = x[0];
+                ",
+            None,
+        ),
+        (
+            "
+                  let x: unknown;
+                  let y = x[0];
+                ",
+            None,
+        ),
+        (
+            "
+                  let x: unknown;
+                  y = x[0];
+                ",
+            None,
+        ),
+        (
+            "
+                  let x: { 0: unknown } | unknown[];
+                  let y = x[0];
+                ",
+            None,
+        ),
+        (
+            "
+                  let x: { 0: unknown } | unknown[];
+                  y = x[0];
+                ",
+            None,
+        ),
+        (
+            "
+                  let x: { 0: unknown } & (() => void);
+                  let y = x[0];
+                ",
+            None,
+        ),
+        (
+            "
+                  let x: { 0: unknown } & (() => void);
+                  y = x[0];
+                ",
+            None,
+        ),
+        (
+            "
+                  let x: Record<number, unknown>;
+                  let y = x[0];
+                ",
+            None,
+        ),
+        (
+            "
+                  let x: Record<number, unknown>;
+                  y = x[0];
+                ",
+            None,
+        ),
+        (
+            "
+                    let x: { 0: unknown };
+                    let { 0: y } = x;
+                  ",
+            Some(
+                serde_json::json!([ { "array": true, "object": true }, { "enforceForRenamedProperties": true }, ]),
+            ),
+        ),
+        (
+            "
+                    let x: { 0: unknown };
+                    ({ 0: y } = x);
+                  ",
+            Some(
+                serde_json::json!([ { "array": true, "object": true }, { "enforceForRenamedProperties": true }, ]),
+            ),
+        ),
+        (
+            "
+                    let x: { 0: unknown };
+                    let y = x[0];
+                  ",
+            Some(serde_json::json!([{ "array": true }, { "enforceForRenamedProperties": true }])),
+        ),
+        (
+            "
+                    let x: { 0: unknown };
+                    y = x[0];
+                  ",
+            Some(serde_json::json!([{ "array": true }, { "enforceForRenamedProperties": true }])),
+        ),
+        (
+            "
+                    let x: { 0: unknown };
+                    let y = x[0];
+                  ",
+            Some(
+                serde_json::json!([ { "AssignmentExpression": { "array": true, "object": true }, "VariableDeclarator": { "array": true, "object": false }, }, { "enforceForRenamedProperties": true }, ]),
+            ),
+        ),
+        (
+            "
+                    let x: { 0: unknown };
+                    y = x[0];
+                  ",
+            Some(
+                serde_json::json!([ { "AssignmentExpression": { "array": true, "object": false }, "VariableDeclarator": { "array": true, "object": true }, }, { "enforceForRenamedProperties": true }, ]),
+            ),
+        ),
+        (
+            "
+                    let x: Record<number, unknown>;
+                    let i: number = 0;
+                    y = x[i];
+                  ",
+            Some(
+                serde_json::json!([ { "array": true, "object": false }, { "enforceForRenamedProperties": true }, ]),
+            ),
+        ),
+        (
+            "
+                    let x: Record<number, unknown>;
+                    let i: 0 = 0;
+                    y = x[i];
+                  ",
+            Some(
+                serde_json::json!([ { "array": true, "object": false }, { "enforceForRenamedProperties": true }, ]),
+            ),
+        ),
+        (
+            "
+                    let x: Record<number, unknown>;
+                    let i: 0 | 1 | 2 = 0;
+                    y = x[i];
+                  ",
+            Some(
+                serde_json::json!([ { "array": true, "object": false }, { "enforceForRenamedProperties": true }, ]),
+            ),
+        ),
+        (
+            "
+                    let x: unknown[];
+                    let i: number = 0;
+                    y = x[i];
+                  ",
+            Some(
+                serde_json::json!([ { "array": true, "object": false }, { "enforceForRenamedProperties": true }, ]),
+            ),
+        ),
+        (
+            "
+                    let x: unknown[];
+                    let i: 0 = 0;
+                    y = x[i];
+                  ",
+            Some(
+                serde_json::json!([ { "array": true, "object": false }, { "enforceForRenamedProperties": true }, ]),
+            ),
+        ),
+        (
+            "
+                    let x: unknown[];
+                    let i: 0 | 1 | 2 = 0;
+                    y = x[i];
+                  ",
+            Some(
+                serde_json::json!([ { "array": true, "object": false }, { "enforceForRenamedProperties": true }, ]),
+            ),
+        ),
+        (
+            "
+                    let x: unknown[];
+                    let i: number = 0;
+                    y = x[i];
+                  ",
+            Some(
+                serde_json::json!([ { "array": true, "object": true }, { "enforceForRenamedProperties": false }, ]),
+            ),
+        ),
+        (
+            "
+                    let x: { 0: unknown };
+                    y += x[0];
+                  ",
+            Some(
+                serde_json::json!([ { "array": true, "object": true }, { "enforceForRenamedProperties": true }, ]),
+            ),
+        ),
+        (
+            "
+                    class Bar {
+                      public [0]: unknown;
+                    }
+                    class Foo extends Bar {
+                      static foo() {
+                        let y = super[0];
+                      }
+                    }
+                  ",
+            Some(
+                serde_json::json!([ { "array": true, "object": true }, { "enforceForRenamedProperties": true }, ]),
+            ),
+        ),
+        (
+            "
+                    class Bar {
+                      public [0]: unknown;
+                    }
+                    class Foo extends Bar {
+                      static foo() {
+                        y = super[0];
+                      }
+                    }
+                  ",
+            Some(
+                serde_json::json!([ { "array": true, "object": true }, { "enforceForRenamedProperties": true }, ]),
+            ),
+        ),
+        (
+            "
+                  let xs: unknown[] = [1];
+                  let [x] = xs;
+                ",
+            None,
+        ),
+        (
+            "
+                  const obj: { x: unknown } = { x: 1 };
+                  const { x } = obj;
+                ",
+            None,
+        ),
+        (
+            "
+                  var obj: { x: unknown } = { x: 1 };
+                  var { x: y } = obj;
+                ",
+            None,
+        ),
+        (
+            "
+                  let obj: { x: unknown } = { x: 1 };
+                  let key: 'x' = 'x';
+                  let { [key]: foo } = obj;
+                ",
+            None,
+        ),
+        (
+            "
+                  const obj: { x: unknown } = { x: 1 };
+                  let x: unknown;
+                  ({ x } = obj);
+                ",
+            None,
+        ),
+        (
+            "
+                  let obj: { x: unknown } = { x: 1 };
+                  let y = obj.x;
+                ",
+            None,
+        ),
+        (
+            "
+                  var obj: { x: unknown } = { x: 1 };
+                  var y: unknown;
+                  y = obj.x;
+                ",
+            None,
+        ),
+        (
+            "
+                  const obj: { x: unknown } = { x: 1 };
+                  const y = obj['x'];
+                ",
+            None,
+        ),
+        (
+            "
+                  let obj: Record<string, unknown> = {};
+                  let key = 'abc';
+                  var y = obj[key];
+                ",
+            None,
+        ),
+        (
+            "
+                  let obj: { x: number } = { x: 1 };
+                  let x = 10;
+                  x += obj.x;
+                ",
+            None,
+        ),
+        (
+            "
+                  let obj: { x: boolean } = { x: false };
+                  let x = true;
+                  x ||= obj.x;
+                ",
+            None,
+        ),
+        (
+            "
+                  const xs: number[] = [1];
+                  let x = 3;
+                  x *= xs[0];
+                ",
+            None,
+        ),
+        (
+            "
+                  let xs: unknown[] | undefined;
+                  let x = xs?.[0];
+                ",
+            None,
+        ),
+        (
+            "
+                  let obj: Record<string, unknown> | undefined;
+                  let x = obj?.x;
+                ",
+            None,
+        ),
+        (
+            "
+                  class C {
+                    #foo: string;
+            
+                    method() {
+                      const foo: unknown = this.#foo;
+                    }
+                  }
+                ",
+            None,
+        ),
+        (
+            "
+                  class C {
+                    #foo: string;
+            
+                    method() {
+                      let foo: unknown;
+                      foo = this.#foo;
+                    }
+                  }
+                ",
+            None,
+        ),
+        (
+            "
+                    class C {
+                      #foo: string;
+            
+                      method() {
+                        const bar: unknown = this.#foo;
+                      }
+                    }
+                  ",
+            Some(
+                serde_json::json!([ { "array": true, "object": true }, { "enforceForDeclarationWithTypeAnnotation": true }, ]),
+            ),
+        ),
+        (
+            "
+                    class C {
+                      #foo: string;
+            
+                      method(another: C) {
+                        let bar: unknown;
+                        bar: unknown = another.#foo;
+                      }
+                    }
+                  ",
+            Some(
+                serde_json::json!([ { "array": true, "object": true }, { "enforceForDeclarationWithTypeAnnotation": true }, ]),
+            ),
+        ),
+        (
+            "
+                    class C {
+                      #foo: string;
+            
+                      method() {
+                        const foo: unknown = this.#foo;
+                      }
+                    }
+                  ",
+            Some(
+                serde_json::json!([ { "array": true, "object": true }, { "enforceForDeclarationWithTypeAnnotation": true }, ]),
+            ),
+        ),
+    ];
+
+    let fail = vec![
+        (
+            "var foo: string = object.foo;",
+            Some(
+                serde_json::json!([ { "object": true }, { "enforceForDeclarationWithTypeAnnotation": true }, ]),
+            ),
+        ),
+        (
+            "var foo: string = array[0];",
+            Some(
+                serde_json::json!([ { "array": true }, { "enforceForDeclarationWithTypeAnnotation": true }, ]),
+            ),
+        ),
+        (
+            "var foo: unknown = object.bar;",
+            Some(
+                serde_json::json!([ { "object": true }, { "enforceForDeclarationWithTypeAnnotation": true, "enforceForRenamedProperties": true, }, ]),
+            ),
+        ),
+        (
+            "
+                    let x: { [Symbol.iterator]: unknown };
+                    let y = x[0];
+                  ",
+            None,
+        ),
+        (
+            "
+                    let x: { [Symbol.iterator]: unknown };
+                    y = x[0];
+                  ",
+            None,
+        ),
+        (
+            "
+                    let x: [1, 2, 3];
+                    let y = x[0];
+                  ",
+            None,
+        ),
+        (
+            "
+                    let x: [1, 2, 3];
+                    y = x[0];
+                  ",
+            None,
+        ),
+        (
+            "
+                    function* it() {
+                      yield 1;
+                    }
+                    let y = it()[0];
+                  ",
+            None,
+        ),
+        (
+            "
+                    function* it() {
+                      yield 1;
+                    }
+                    y = it()[0];
+                  ",
+            None,
+        ),
+        (
+            "
+                    let x: any;
+                    let y = x[0];
+                  ",
+            None,
+        ),
+        (
+            "
+                    let x: any;
+                    y = x[0];
+                  ",
+            None,
+        ),
+        (
+            "
+                    let x: string[] | { [Symbol.iterator]: unknown };
+                    let y = x[0];
+                  ",
+            None,
+        ),
+        (
+            "
+                    let x: string[] | { [Symbol.iterator]: unknown };
+                    y = x[0];
+                  ",
+            None,
+        ),
+        (
+            "
+                    let x: object & unknown[];
+                    let y = x[0];
+                  ",
+            None,
+        ),
+        (
+            "
+                    let x: object & unknown[];
+                    y = x[0];
+                  ",
+            None,
+        ),
+        (
+            "
+                    let x: { 0: string };
+                    let y = x[0];
+                  ",
+            Some(serde_json::json!([{ "object": true }, { "enforceForRenamedProperties": true }])),
+        ),
+        (
+            "
+                    let x: { 0: string };
+                    y = x[0];
+                  ",
+            Some(serde_json::json!([{ "object": true }, { "enforceForRenamedProperties": true }])),
+        ),
+        (
+            "
+                    let x: { 0: string };
+                    let y = x[0];
+                  ",
+            Some(
+                serde_json::json!([ { "AssignmentExpression": { "array": false, "object": false }, "VariableDeclarator": { "array": false, "object": true }, }, { "enforceForRenamedProperties": true }, ]),
+            ),
+        ),
+        (
+            "
+                    let x: { 0: string };
+                    y = x[0];
+                  ",
+            Some(
+                serde_json::json!([ { "AssignmentExpression": { "array": false, "object": true }, "VariableDeclarator": { "array": false, "object": false }, }, { "enforceForRenamedProperties": true }, ]),
+            ),
+        ),
+        (
+            "
+                    let x: Record<number, unknown>;
+                    let i: number = 0;
+                    y = x[i];
+                  ",
+            Some(
+                serde_json::json!([ { "array": true, "object": true }, { "enforceForRenamedProperties": true }, ]),
+            ),
+        ),
+        (
+            "
+                    let x: Record<number, unknown>;
+                    let i: 0 = 0;
+                    y = x[i];
+                  ",
+            Some(
+                serde_json::json!([ { "array": true, "object": true }, { "enforceForRenamedProperties": true }, ]),
+            ),
+        ),
+        (
+            "
+                    let x: Record<number, unknown>;
+                    let i: 0 | 1 | 2 = 0;
+                    y = x[i];
+                  ",
+            Some(
+                serde_json::json!([ { "array": true, "object": true }, { "enforceForRenamedProperties": true }, ]),
+            ),
+        ),
+        (
+            "
+                    let x: unknown[];
+                    let i: number = 0;
+                    y = x[i];
+                  ",
+            Some(
+                serde_json::json!([ { "array": true, "object": true }, { "enforceForRenamedProperties": true }, ]),
+            ),
+        ),
+        (
+            "
+                    let x: unknown[];
+                    let i: 0 = 0;
+                    y = x[i];
+                  ",
+            Some(
+                serde_json::json!([ { "array": true, "object": true }, { "enforceForRenamedProperties": true }, ]),
+            ),
+        ),
+        (
+            "
+                    let x: unknown[];
+                    let i: 0 | 1 | 2 = 0;
+                    y = x[i];
+                  ",
+            Some(
+                serde_json::json!([ { "array": true, "object": true }, { "enforceForRenamedProperties": true }, ]),
+            ),
+        ),
+        (
+            "
+                    let x: { 0: unknown } | unknown[];
+                    let y = x[0];
+                  ",
+            Some(serde_json::json!([{ "object": true }, { "enforceForRenamedProperties": true }])),
+        ),
+        (
+            "
+                    let x: { 0: unknown } | unknown[];
+                    y = x[0];
+                  ",
+            Some(serde_json::json!([{ "object": true }, { "enforceForRenamedProperties": true }])),
+        ),
+        (
+            "
+                    let obj = { foo: 'bar' };
+                    const foo = obj.foo;
+                  ",
+            None,
+        ),
+        (
+            "
+                    let obj = { foo: 'bar' };
+                    var x: null = null;
+                    const foo = (x, obj).foo;
+                  ",
+            None,
+        ),
+        ("const call = (() => null).call;", None),
+        (
+            "
+                    const obj = { foo: 'bar' };
+                    let a: any;
+                    var foo = (a = obj).foo;
+                  ",
+            None,
+        ),
+        (
+            "
+                    const obj = { asdf: { qwer: null } };
+                    const qwer = obj.asdf.qwer;
+                  ",
+            None,
+        ),
+        (
+            "
+                    const obj = { foo: 100 };
+                    const /* comment */ foo = obj.foo;
+                  ",
+            None,
+        ),
+        (
+            "
+                    let obj = { foo: 'bar' };
+                    const x = obj.foo;
+                  ",
+            Some(serde_json::json!([{ "object": true }, { "enforceForRenamedProperties": true }])),
+        ),
+        (
+            "
+                    let obj = { foo: 'bar' };
+                    let x: unknown;
+                    x = obj.foo;
+                  ",
+            Some(serde_json::json!([{ "object": true }, { "enforceForRenamedProperties": true }])),
+        ),
+        (
+            "
+                    let obj: Record<string, unknown>;
+                    let key = 'abc';
+                    const x = obj[key];
+                  ",
+            Some(serde_json::json!([{ "object": true }, { "enforceForRenamedProperties": true }])),
+        ),
+        (
+            "
+                    let obj: Record<string, unknown>;
+                    let key = 'abc';
+                    let x: unknown;
+                    x = obj[key];
+                  ",
+            Some(serde_json::json!([{ "object": true }, { "enforceForRenamedProperties": true }])),
+        ),
+    ];
+
+    let fix = vec![
+        (
+            "
+                    let obj = { foo: 'bar' };
+                    const foo = obj.foo;
+                  ",
+            "
+                    let obj = { foo: 'bar' };
+                    const {foo} = obj;
+                  ",
+        ),
+        (
+            "
+                    let obj = { foo: 'bar' };
+                    var x: null = null;
+                    const foo = (x, obj).foo;
+                  ",
+            "
+                    let obj = { foo: 'bar' };
+                    var x: null = null;
+                    const {foo} = (x, obj);
+                  ",
+        ),
+        ("const call = (() => null).call;", "const {call} = () => null;"),
+        (
+            "
+                    const obj = { foo: 'bar' };
+                    let a: any;
+                    var foo = (a = obj).foo;
+                  ",
+            "
+                    const obj = { foo: 'bar' };
+                    let a: any;
+                    var {foo} = a = obj;
+                  ",
+        ),
+        (
+            "
+                    const obj = { asdf: { qwer: null } };
+                    const qwer = obj.asdf.qwer;
+                  ",
+            "
+                    const obj = { asdf: { qwer: null } };
+                    const {qwer} = obj.asdf;
+                  ",
+        ),
+        (
+            "
+                    const obj = { foo: 100 };
+                    const /* comment */ foo = obj.foo;
+                  ",
+            "
+                    const obj = { foo: 100 };
+                    const /* comment */ {foo} = obj;
+                  ",
+        ),
+    ];
+
+    Tester::new(PreferDestructuring::NAME, PreferDestructuring::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/typescript_prefer_destructuring.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_prefer_destructuring.snap
@@ -1,0 +1,328 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ typescript(prefer-destructuring): Use Object destructuring.
+   ╭─[prefer_destructuring.tsx:1:19]
+ 1 │ var foo: string = object.foo;
+   ·                   ──────────
+   ╰────
+  help: Use object destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Array destructuring.
+   ╭─[prefer_destructuring.tsx:1:19]
+ 1 │ var foo: string = array[0];
+   ·                   ────────
+   ╰────
+  help: Use array destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Object destructuring.
+   ╭─[prefer_destructuring.tsx:1:20]
+ 1 │ var foo: unknown = object.bar;
+   ·                    ──────────
+   ╰────
+  help: Use object destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Array destructuring.
+   ╭─[prefer_destructuring.tsx:3:29]
+ 2 │                     let x: { [Symbol.iterator]: unknown };
+ 3 │                     let y = x[0];
+   ·                             ────
+ 4 │                   
+   ╰────
+  help: Use array destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Array destructuring.
+   ╭─[prefer_destructuring.tsx:3:21]
+ 2 │                     let x: { [Symbol.iterator]: unknown };
+ 3 │                     y = x[0];
+   ·                     ────────
+ 4 │                   
+   ╰────
+  help: Use array destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Array destructuring.
+   ╭─[prefer_destructuring.tsx:3:29]
+ 2 │                     let x: [1, 2, 3];
+ 3 │                     let y = x[0];
+   ·                             ────
+ 4 │                   
+   ╰────
+  help: Use array destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Array destructuring.
+   ╭─[prefer_destructuring.tsx:3:21]
+ 2 │                     let x: [1, 2, 3];
+ 3 │                     y = x[0];
+   ·                     ────────
+ 4 │                   
+   ╰────
+  help: Use array destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Array destructuring.
+   ╭─[prefer_destructuring.tsx:5:29]
+ 4 │                     }
+ 5 │                     let y = it()[0];
+   ·                             ───────
+ 6 │                   
+   ╰────
+  help: Use array destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Array destructuring.
+   ╭─[prefer_destructuring.tsx:5:21]
+ 4 │                     }
+ 5 │                     y = it()[0];
+   ·                     ───────────
+ 6 │                   
+   ╰────
+  help: Use array destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Array destructuring.
+   ╭─[prefer_destructuring.tsx:3:29]
+ 2 │                     let x: any;
+ 3 │                     let y = x[0];
+   ·                             ────
+ 4 │                   
+   ╰────
+  help: Use array destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Array destructuring.
+   ╭─[prefer_destructuring.tsx:3:21]
+ 2 │                     let x: any;
+ 3 │                     y = x[0];
+   ·                     ────────
+ 4 │                   
+   ╰────
+  help: Use array destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Array destructuring.
+   ╭─[prefer_destructuring.tsx:3:29]
+ 2 │                     let x: string[] | { [Symbol.iterator]: unknown };
+ 3 │                     let y = x[0];
+   ·                             ────
+ 4 │                   
+   ╰────
+  help: Use array destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Array destructuring.
+   ╭─[prefer_destructuring.tsx:3:21]
+ 2 │                     let x: string[] | { [Symbol.iterator]: unknown };
+ 3 │                     y = x[0];
+   ·                     ────────
+ 4 │                   
+   ╰────
+  help: Use array destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Array destructuring.
+   ╭─[prefer_destructuring.tsx:3:29]
+ 2 │                     let x: object & unknown[];
+ 3 │                     let y = x[0];
+   ·                             ────
+ 4 │                   
+   ╰────
+  help: Use array destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Array destructuring.
+   ╭─[prefer_destructuring.tsx:3:21]
+ 2 │                     let x: object & unknown[];
+ 3 │                     y = x[0];
+   ·                     ────────
+ 4 │                   
+   ╰────
+  help: Use array destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Object destructuring.
+   ╭─[prefer_destructuring.tsx:3:29]
+ 2 │                     let x: { 0: string };
+ 3 │                     let y = x[0];
+   ·                             ────
+ 4 │                   
+   ╰────
+  help: Use object destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Object destructuring.
+   ╭─[prefer_destructuring.tsx:3:21]
+ 2 │                     let x: { 0: string };
+ 3 │                     y = x[0];
+   ·                     ────────
+ 4 │                   
+   ╰────
+  help: Use object destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Object destructuring.
+   ╭─[prefer_destructuring.tsx:3:29]
+ 2 │                     let x: { 0: string };
+ 3 │                     let y = x[0];
+   ·                             ────
+ 4 │                   
+   ╰────
+  help: Use object destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Object destructuring.
+   ╭─[prefer_destructuring.tsx:3:21]
+ 2 │                     let x: { 0: string };
+ 3 │                     y = x[0];
+   ·                     ────────
+ 4 │                   
+   ╰────
+  help: Use object destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Object destructuring.
+   ╭─[prefer_destructuring.tsx:4:21]
+ 3 │                     let i: number = 0;
+ 4 │                     y = x[i];
+   ·                     ────────
+ 5 │                   
+   ╰────
+  help: Use object destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Object destructuring.
+   ╭─[prefer_destructuring.tsx:4:21]
+ 3 │                     let i: 0 = 0;
+ 4 │                     y = x[i];
+   ·                     ────────
+ 5 │                   
+   ╰────
+  help: Use object destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Object destructuring.
+   ╭─[prefer_destructuring.tsx:4:21]
+ 3 │                     let i: 0 | 1 | 2 = 0;
+ 4 │                     y = x[i];
+   ·                     ────────
+ 5 │                   
+   ╰────
+  help: Use object destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Object destructuring.
+   ╭─[prefer_destructuring.tsx:4:21]
+ 3 │                     let i: number = 0;
+ 4 │                     y = x[i];
+   ·                     ────────
+ 5 │                   
+   ╰────
+  help: Use object destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Object destructuring.
+   ╭─[prefer_destructuring.tsx:4:21]
+ 3 │                     let i: 0 = 0;
+ 4 │                     y = x[i];
+   ·                     ────────
+ 5 │                   
+   ╰────
+  help: Use object destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Object destructuring.
+   ╭─[prefer_destructuring.tsx:4:21]
+ 3 │                     let i: 0 | 1 | 2 = 0;
+ 4 │                     y = x[i];
+   ·                     ────────
+ 5 │                   
+   ╰────
+  help: Use object destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Object destructuring.
+   ╭─[prefer_destructuring.tsx:3:29]
+ 2 │                     let x: { 0: unknown } | unknown[];
+ 3 │                     let y = x[0];
+   ·                             ────
+ 4 │                   
+   ╰────
+  help: Use object destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Object destructuring.
+   ╭─[prefer_destructuring.tsx:3:21]
+ 2 │                     let x: { 0: unknown } | unknown[];
+ 3 │                     y = x[0];
+   ·                     ────────
+ 4 │                   
+   ╰────
+  help: Use object destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Object destructuring.
+   ╭─[prefer_destructuring.tsx:3:33]
+ 2 │                     let obj = { foo: 'bar' };
+ 3 │                     const foo = obj.foo;
+   ·                                 ───────
+ 4 │                   
+   ╰────
+  help: Use object destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Object destructuring.
+   ╭─[prefer_destructuring.tsx:4:33]
+ 3 │                     var x: null = null;
+ 4 │                     const foo = (x, obj).foo;
+   ·                                 ────────────
+ 5 │                   
+   ╰────
+  help: Use object destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Object destructuring.
+   ╭─[prefer_destructuring.tsx:1:14]
+ 1 │ const call = (() => null).call;
+   ·              ─────────────────
+   ╰────
+  help: Use object destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Object destructuring.
+   ╭─[prefer_destructuring.tsx:4:31]
+ 3 │                     let a: any;
+ 4 │                     var foo = (a = obj).foo;
+   ·                               ─────────────
+ 5 │                   
+   ╰────
+  help: Use object destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Object destructuring.
+   ╭─[prefer_destructuring.tsx:3:34]
+ 2 │                     const obj = { asdf: { qwer: null } };
+ 3 │                     const qwer = obj.asdf.qwer;
+   ·                                  ─────────────
+ 4 │                   
+   ╰────
+  help: Use object destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Object destructuring.
+   ╭─[prefer_destructuring.tsx:3:47]
+ 2 │                     const obj = { foo: 100 };
+ 3 │                     const /* comment */ foo = obj.foo;
+   ·                                               ───────
+ 4 │                   
+   ╰────
+  help: Use object destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Object destructuring.
+   ╭─[prefer_destructuring.tsx:3:31]
+ 2 │                     let obj = { foo: 'bar' };
+ 3 │                     const x = obj.foo;
+   ·                               ───────
+ 4 │                   
+   ╰────
+  help: Use object destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Object destructuring.
+   ╭─[prefer_destructuring.tsx:4:21]
+ 3 │                     let x: unknown;
+ 4 │                     x = obj.foo;
+   ·                     ───────────
+ 5 │                   
+   ╰────
+  help: Use object destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Object destructuring.
+   ╭─[prefer_destructuring.tsx:4:31]
+ 3 │                     let key = 'abc';
+ 4 │                     const x = obj[key];
+   ·                               ────────
+ 5 │                   
+   ╰────
+  help: Use object destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Object destructuring.
+   ╭─[prefer_destructuring.tsx:5:21]
+ 4 │                     let x: unknown;
+ 5 │                     x = obj[key];
+   ·                     ────────────
+ 6 │                   
+   ╰────
+  help: Use object destructuring rather than direct member access.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -8166,7 +8166,27 @@
           "$ref": "#/definitions/RuleNoConfig"
         },
         "typescript/prefer-destructuring": {
-          "$ref": "#/definitions/RuleNoConfig"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleNoConfig"
+            },
+            {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/AllowWarnDeny"
+                },
+                {
+                  "$ref": "#/definitions/PreferDestructuringOption2"
+                },
+                {
+                  "$ref": "#/definitions/PreferDestructuringEnforcementConfig"
+                }
+              ],
+              "maxItems": 3,
+              "minItems": 2
+            }
+          ]
         },
         "typescript/prefer-enum-initializers": {
           "$ref": "#/definitions/RuleNoConfig"
@@ -16888,6 +16908,18 @@
       },
       "additionalProperties": false
     },
+    "PreferDestructuringAssignmentConfig2": {
+      "type": "object",
+      "properties": {
+        "AssignmentExpression": {
+          "$ref": "#/definitions/PreferDestructuringTargetOption2"
+        },
+        "VariableDeclarator": {
+          "$ref": "#/definitions/PreferDestructuringTargetOption2"
+        }
+      },
+      "additionalProperties": false
+    },
     "PreferDestructuringConfig": {
       "type": "array",
       "items": [
@@ -16901,6 +16933,37 @@
       "maxItems": 2,
       "minItems": 2
     },
+    "PreferDestructuringConfig2": {
+      "type": "array",
+      "items": [
+        {
+          "$ref": "#/definitions/PreferDestructuringOption2"
+        },
+        {
+          "$ref": "#/definitions/PreferDestructuringEnforcementConfig"
+        }
+      ],
+      "maxItems": 2,
+      "minItems": 2
+    },
+    "PreferDestructuringEnforcementConfig": {
+      "type": "object",
+      "properties": {
+        "enforceForDeclarationWithTypeAnnotation": {
+          "description": "Whether to enforce destructuring on variable declarations with type annotations.",
+          "default": false,
+          "type": "boolean",
+          "markdownDescription": "Whether to enforce destructuring on variable declarations with type annotations."
+        },
+        "enforceForRenamedProperties": {
+          "description": "Whether to enforce destructuring that uses a different variable name than the property name.",
+          "default": false,
+          "type": "boolean",
+          "markdownDescription": "Whether to enforce destructuring that uses a different variable name than the property name."
+        }
+      },
+      "additionalProperties": false
+    },
     "PreferDestructuringOption": {
       "anyOf": [
         {
@@ -16908,6 +16971,16 @@
         },
         {
           "$ref": "#/definitions/PreferDestructuringAssignmentConfig"
+        }
+      ]
+    },
+    "PreferDestructuringOption2": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/PreferDestructuringTargetOption2"
+        },
+        {
+          "$ref": "#/definitions/PreferDestructuringAssignmentConfig2"
         }
       ]
     },
@@ -16922,6 +16995,18 @@
       "additionalProperties": false
     },
     "PreferDestructuringTargetOption": {
+      "type": "object",
+      "properties": {
+        "array": {
+          "type": "boolean"
+        },
+        "object": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "PreferDestructuringTargetOption2": {
       "type": "object",
       "properties": {
         "array": {

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -8165,6 +8165,9 @@
         "typescript/prefer-as-const": {
           "$ref": "#/definitions/RuleNoConfig"
         },
+        "typescript/prefer-destructuring": {
+          "$ref": "#/definitions/RuleNoConfig"
+        },
         "typescript/prefer-enum-initializers": {
           "$ref": "#/definitions/RuleNoConfig"
         },

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -511,6 +511,7 @@ typescript/no-var-requires                                 |  24652
 typescript/no-wrapper-object-types                         |  13199
 typescript/parameter-properties                            |   1070
 typescript/prefer-as-const                                 |  12866
+typescript/prefer-destructuring                            |  50504
 typescript/prefer-enum-initializers                        |     23
 typescript/prefer-for-of                                   |    557
 typescript/prefer-function-type                            |  14798


### PR DESCRIPTION
Implements the [prefer-destructuring](https://typescript-eslint.io/rules/prefer-destructuring/) rule.

Full disclosure: My initial implementation was done with Claude Code, but the code was reviewed by me and I feel confident that this is ready for review.

All tests pass and all options are supported.