### PR TITLE
refactor(ast): use `NonNull` for ref casting

### DIFF
--- a/crates/oxc_ast/src/generated/ast_kind.rs
+++ b/crates/oxc_ast/src/generated/ast_kind.rs
@@ -1,7 +1,7 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/ast_kind.rs`.
 
-use std::ptr;
+use std::ptr::NonNull;
 
 use oxc_allocator::{Address, GetAddress, UnstableAddress};
 use oxc_span::{GetSpan, Span};
@@ -425,7 +425,7 @@ impl AstKind<'_> {
         // and it's valid to read it.
         // `AstType` is also `#[repr(u8)]` and `AstKind` and `AstType` both have the same
         // discriminants, so it's valid to read `AstKind`'s discriminant as `AstType`.
-        unsafe { *ptr::from_ref(self).cast::<AstType>().as_ref_unchecked() }
+        unsafe { *NonNull::from_ref(self).cast::<AstType>().as_ref() }
     }
 
     /// Get [`NodeId`] of an [`AstKind`].

--- a/tasks/ast_tools/src/generators/ast_kind.rs
+++ b/tasks/ast_tools/src/generators/ast_kind.rs
@@ -99,7 +99,7 @@ impl Generator for AstKindGenerator {
 
         let output = quote! {
             ///@@line_break
-            use std::ptr;
+            use std::ptr::NonNull;
 
             ///@@line_break
             use oxc_allocator::{Address, GetAddress, UnstableAddress};
@@ -137,7 +137,7 @@ impl Generator for AstKindGenerator {
                     ///@ and it's valid to read it.
                     ///@ `AstType` is also `#[repr(u8)]` and `AstKind` and `AstType` both have the same
                     ///@ discriminants, so it's valid to read `AstKind`'s discriminant as `AstType`.
-                    unsafe { *ptr::from_ref(self).cast::<AstType>().as_ref_unchecked() }
+                    unsafe { *NonNull::from_ref(self).cast::<AstType>().as_ref() }
                 }
 
                 ///@@line_break


### PR DESCRIPTION
Follow-on after #24381. When casting a `&` reference, it's preferable to use `NonNull` - that safely gains the "pointer is not null" fact, rather than unsafely promising it with `as_ref_unchecked` on a raw pointer.