### PR TITLE
refactor(ast): move `AstKind::ty` out of generated code

### DIFF
--- a/crates/oxc_ast/src/ast_kind_impl.rs
+++ b/crates/oxc_ast/src/ast_kind_impl.rs
@@ -3,13 +3,25 @@
 //! This module provides methods and utilities for working with [`AstKind`],
 //! including type checking, conversions, and tree traversal helpers.
 
+use std::ptr::NonNull;
+
 use oxc_allocator::{Address, GetAddress, UnstableAddress};
 use oxc_span::GetSpan;
 use oxc_str::{Ident, Str};
 
-use super::{AstKind, ast::*};
+use super::{AstKind, AstType, ast::*};
 
 impl<'a> AstKind<'a> {
+    /// Get the [`AstType`] of an [`AstKind`].
+    #[inline]
+    pub fn ty(&self) -> AstType {
+        // SAFETY: `AstKind` is `#[repr(C, u8)]`, so discriminant is stored in first byte,
+        // and it's valid to read it.
+        // `AstType` is also `#[repr(u8)]` and `AstKind` and `AstType` both have the same
+        // discriminants, so it's valid to read `AstKind`'s discriminant as `AstType`.
+        unsafe { *NonNull::from_ref(self).cast::<AstType>().as_ref() }
+    }
+
     /// Check if this AST node is a statement
     ///
     /// Returns `true` for all statement types including iteration statements,

--- a/crates/oxc_ast/src/generated/ast_kind.rs
+++ b/crates/oxc_ast/src/generated/ast_kind.rs
@@ -1,8 +1,6 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/ast_kind.rs`.
 
-use std::ptr::NonNull;
-
 use oxc_allocator::{Address, GetAddress, UnstableAddress};
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::node::NodeId;
@@ -418,16 +416,6 @@ pub enum AstKind<'a> {
 }
 
 impl AstKind<'_> {
-    /// Get the [`AstType`] of an [`AstKind`].
-    #[inline]
-    pub fn ty(&self) -> AstType {
-        // SAFETY: `AstKind` is `#[repr(C, u8)]`, so discriminant is stored in first byte,
-        // and it's valid to read it.
-        // `AstType` is also `#[repr(u8)]` and `AstKind` and `AstType` both have the same
-        // discriminants, so it's valid to read `AstKind`'s discriminant as `AstType`.
-        unsafe { *NonNull::from_ref(self).cast::<AstType>().as_ref() }
-    }
-
     /// Get [`NodeId`] of an [`AstKind`].
     // `node_id` field is in consistent position in all AST structs, so this boils down to 1 instruction.
     #[inline]

--- a/tasks/ast_tools/src/generators/ast_kind.rs
+++ b/tasks/ast_tools/src/generators/ast_kind.rs
@@ -99,9 +99,6 @@ impl Generator for AstKindGenerator {
 
         let output = quote! {
             ///@@line_break
-            use std::ptr::NonNull;
-
-            ///@@line_break
             use oxc_allocator::{Address, GetAddress, UnstableAddress};
             use oxc_span::{GetSpan, Span};
             use oxc_syntax::node::NodeId;
@@ -130,16 +127,6 @@ impl Generator for AstKindGenerator {
 
             ///@@line_break
             impl AstKind<'_> {
-                /// Get the [`AstType`] of an [`AstKind`].
-                #[inline]
-                pub fn ty(&self) -> AstType {
-                    ///@ SAFETY: `AstKind` is `#[repr(C, u8)]`, so discriminant is stored in first byte,
-                    ///@ and it's valid to read it.
-                    ///@ `AstType` is also `#[repr(u8)]` and `AstKind` and `AstType` both have the same
-                    ///@ discriminants, so it's valid to read `AstKind`'s discriminant as `AstType`.
-                    unsafe { *NonNull::from_ref(self).cast::<AstType>().as_ref() }
-                }
-
                 ///@@line_break
                 /// Get [`NodeId`] of an [`AstKind`].
                 ///@ `node_id` field is in consistent position in all AST structs, so this boils down to 1 instruction.


### PR DESCRIPTION
Follow-on after #24381. `AstKind::ty` is pure static code. It doesn't need to be generated. Move it out of the generated code.