### PR TITLE
fix(semantic): respect implicit arguments bindings

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -657,12 +657,39 @@ impl<'a> SemanticBuilder<'a> {
     #[expect(clippy::inline_always, reason = "Hot path — called for every reference resolution")]
     #[inline(always)]
     fn walk_up_resolve_reference(&mut self, name: Ident<'a>, reference_id: ReferenceId) -> bool {
+        let is_arguments_value_reference = name == "arguments" && {
+            let flags = self.scoping.references[reference_id].flags();
+            flags.is_value() || flags.is_value_as_type()
+        };
         let mut scope_id = Some(self.scoping.references[reference_id].scope_id());
         while let Some(sid) = scope_id {
-            if let Some(symbol_id) = self.scoping.get_binding(sid, name)
-                && self.try_resolve_reference(reference_id, symbol_id)
-            {
-                return true;
+            let is_implicit_arguments_boundary = is_arguments_value_reference && {
+                let flags = self.scoping.scope_flags(sid);
+                flags.is_function() && !flags.is_arrow()
+            };
+
+            if let Some(symbol_id) = self.scoping.get_binding(sid, name) {
+                // The name of a named function expression is in an environment outside the
+                // function's implicit `arguments` binding, even though Oxc represents both with
+                // the same scope. Parameters and local declarations still take precedence.
+                let is_function_expression_name = is_implicit_arguments_boundary
+                    && self
+                        .scoping
+                        .symbol_flags(symbol_id)
+                        .contains(SymbolFlags::FunctionExpression);
+                if !is_function_expression_name
+                    && self.try_resolve_reference(reference_id, symbol_id)
+                {
+                    return true;
+                }
+            }
+
+            // Non-arrow functions implicitly bind `arguments` in value space. Oxc does not
+            // represent that implicit binding as a symbol, so stop before an outer declaration
+            // with the same name can capture the reference. Arrow functions inherit `arguments`
+            // and therefore do not form a boundary here.
+            if is_implicit_arguments_boundary {
+                return false;
             }
             scope_id = self.scoping.scope_parent_id(sid);
         }

--- a/crates/oxc_semantic/tests/fixtures/oxc/js/functions/arguments-shadowed.js
+++ b/crates/oxc_semantic/tests/fixtures/oxc/js/functions/arguments-shadowed.js
@@ -1,0 +1,20 @@
+const arguments = {};
+
+function ordinary() {
+  arguments;
+  () => arguments;
+
+  function nested() {
+    arguments;
+  }
+}
+
+const arrow = () => arguments;
+
+const named = function arguments() {
+  arguments;
+};
+
+function explicitlyShadowed(arguments) {
+  arguments;
+}

--- a/crates/oxc_semantic/tests/fixtures/oxc/js/functions/arguments-shadowed.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/js/functions/arguments-shadowed.snap
@@ -1,0 +1,133 @@
+---
+source: crates/oxc_semantic/tests/main.rs
+input_file: crates/oxc_semantic/tests/fixtures/oxc/js/functions/arguments-shadowed.js
+---
+[
+  {
+    "children": [
+      {
+        "children": [
+          {
+            "children": [],
+            "flags": "ScopeFlags(Function | Arrow)",
+            "id": 2,
+            "node": "ArrowFunctionExpression",
+            "symbols": []
+          },
+          {
+            "children": [],
+            "flags": "ScopeFlags(Function)",
+            "id": 3,
+            "node": "Function(nested)",
+            "symbols": []
+          }
+        ],
+        "flags": "ScopeFlags(Function)",
+        "id": 1,
+        "node": "Function(ordinary)",
+        "symbols": [
+          {
+            "flags": "SymbolFlags(Function)",
+            "id": 2,
+            "name": "nested",
+            "node": "Function(nested)",
+            "references": []
+          }
+        ]
+      },
+      {
+        "children": [],
+        "flags": "ScopeFlags(Function | Arrow)",
+        "id": 4,
+        "node": "ArrowFunctionExpression",
+        "symbols": []
+      },
+      {
+        "children": [],
+        "flags": "ScopeFlags(Function)",
+        "id": 5,
+        "node": "Function(arguments)",
+        "symbols": [
+          {
+            "flags": "SymbolFlags(Function | FunctionExpression)",
+            "id": 5,
+            "name": "arguments",
+            "node": "Function(arguments)",
+            "references": []
+          }
+        ]
+      },
+      {
+        "children": [],
+        "flags": "ScopeFlags(Function)",
+        "id": 6,
+        "node": "Function(explicitlyShadowed)",
+        "symbols": [
+          {
+            "flags": "SymbolFlags(FunctionScopedVariable)",
+            "id": 7,
+            "name": "arguments",
+            "node": "FormalParameter(arguments)",
+            "references": [
+              {
+                "flags": "ReferenceFlags(Read)",
+                "id": 5,
+                "name": "arguments",
+                "node_id": 47,
+                "scope_id": 6
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "flags": "ScopeFlags(Top)",
+    "id": 0,
+    "node": "Program",
+    "symbols": [
+      {
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "id": 0,
+        "name": "arguments",
+        "node": "VariableDeclarator(arguments)",
+        "references": [
+          {
+            "flags": "ReferenceFlags(Read)",
+            "id": 3,
+            "name": "arguments",
+            "node_id": 30,
+            "scope_id": 4
+          }
+        ]
+      },
+      {
+        "flags": "SymbolFlags(Function)",
+        "id": 1,
+        "name": "ordinary",
+        "node": "Function(ordinary)",
+        "references": []
+      },
+      {
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "id": 3,
+        "name": "arrow",
+        "node": "VariableDeclarator(arrow)",
+        "references": []
+      },
+      {
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "id": 4,
+        "name": "named",
+        "node": "VariableDeclarator(named)",
+        "references": []
+      },
+      {
+        "flags": "SymbolFlags(Function)",
+        "id": 6,
+        "name": "explicitlyShadowed",
+        "node": "Function(explicitlyShadowed)",
+        "references": []
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary

- stop value-space `arguments` references from walking past a non-arrow function's implicit arguments binding
- preserve lexical capture through arrow functions and precedence for explicit parameters or local declarations
- handle named function expressions whose name binding is represented in the same Oxc scope but is outside the runtime arguments environment
- add a semantic scope snapshot covering ordinary, arrow, nested, named, and explicitly shadowed functions

## Root cause

Oxc intentionally represents the implicit arguments object as an unresolved reference instead of creating a synthetic symbol. The walk-up resolver did not treat non-arrow function scopes as a boundary, so it could incorrectly attach an inner `arguments` reference to an outer declaration with the same name.

## Validation

- `env -u NO_COLOR just ready`
- `cargo test -p oxc_semantic --all-features`
- `cargo clippy -p oxc_semantic --all-targets --all-features -- -D warnings`
- focused downstream tests for `prefer-rest-params`, `no-undef`, and `object-shorthand`

Closes #23844.

## AI assistance

This change was developed with assistance from OpenAI Codex. The implementation and regression coverage were validated with the repository's full prescribed `just ready` workflow.
