### PR TITLE
refactor(react_compiler): replace String with arena Ident/Str in HIR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2449,6 +2449,7 @@ dependencies = [
  "oxc_parser",
  "oxc_semantic",
  "oxc_span",
+ "oxc_str",
  "oxc_syntax",
  "rustc-hash",
 ]

--- a/crates/oxc_react_compiler/Cargo.toml
+++ b/crates/oxc_react_compiler/Cargo.toml
@@ -34,6 +34,7 @@ oxc_ast_visit = { workspace = true }
 oxc_diagnostics = { workspace = true }
 oxc_semantic = { workspace = true }
 oxc_span = { workspace = true }
+oxc_str = { workspace = true }
 oxc_syntax = { workspace = true }
 
 # External crates the vendored React Compiler modules (`src/react_compiler*`) depend

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/compile_result.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/compile_result.rs
@@ -1,6 +1,7 @@
 use oxc_diagnostics::Diagnostics;
 
 use oxc_span::Span;
+use oxc_str::Ident;
 
 use crate::react_compiler_hir::ReactFunctionType;
 
@@ -32,7 +33,7 @@ pub enum CompileResult<'a> {
 pub struct CodegenFunction<'a> {
     pub span: Option<Span>,
     pub id: Option<oxc_ast::ast::BindingIdentifier<'a>>,
-    pub name_hint: Option<String>,
+    pub name_hint: Option<Ident<'a>>,
     pub params: oxc_allocator::Box<'a, oxc_ast::ast::FormalParameters<'a>>,
     pub body: oxc_allocator::Box<'a, oxc_ast::ast::FunctionBody<'a>>,
     pub generator: bool,

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/imports.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/imports.rs
@@ -4,9 +4,13 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+use std::borrow::Cow;
+
 use rustc_hash::{FxHashMap, FxHashSet};
 
+use oxc_allocator::Allocator;
 use oxc_ast::ast::{ImportDeclarationSpecifier, ModuleExportName, Program, Statement};
+use oxc_str::{Ident, IdentHashSet, format_ident};
 
 use crate::diagnostics::ErrorCategory;
 use crate::scope::ScopeResolver;
@@ -18,41 +22,44 @@ use crate::options::{CompilerTarget, PluginOptions};
 
 /// An import specifier tracked by ProgramContext.
 /// Corresponds to NonLocalImportSpecifier in the TS compiler.
-#[derive(Debug, Clone)]
-pub struct NonLocalImportSpecifier {
-    pub name: String,
-    pub imported: String,
+#[derive(Debug, Clone, Copy)]
+pub struct NonLocalImportSpecifier<'a> {
+    pub name: Ident<'a>,
+    pub imported: Ident<'a>,
 }
 
 /// Context for the program being compiled.
 /// Tracks compiled functions, generated names, and import requirements.
 /// Equivalent to ProgramContext class in Imports.ts.
-pub struct ProgramContext {
+pub struct ProgramContext<'a> {
+    allocator: &'a Allocator,
     pub opts: PluginOptions,
-    pub react_runtime_module: String,
-    pub suppressions: Vec<SuppressionRange>,
+    pub react_runtime_module: Cow<'static, str>,
+    pub suppressions: Vec<SuppressionRange<'a>>,
     pub has_module_scope_opt_out: bool,
     /// Diagnostics (errors/warnings) accumulated during compilation. Fatality is
     /// decided separately by `panicThreshold`.
     pub diagnostics: Diagnostics,
     // Pre-resolved import local names for codegen
-    pub instrument_fn_name: Option<String>,
-    pub instrument_gating_name: Option<String>,
-    pub hook_guard_name: Option<String>,
+    pub instrument_fn_name: Option<Ident<'a>>,
+    pub instrument_gating_name: Option<Ident<'a>>,
+    pub hook_guard_name: Option<Ident<'a>>,
 
     // Internal state
-    known_referenced_names: FxHashSet<String>,
-    imports: FxHashMap<String, FxHashMap<String, NonLocalImportSpecifier>>,
+    known_referenced_names: IdentHashSet<'a>,
+    imports: FxHashMap<String, FxHashMap<String, NonLocalImportSpecifier<'a>>>,
 }
 
-impl ProgramContext {
+impl<'a> ProgramContext<'a> {
     pub fn new(
+        allocator: &'a Allocator,
         opts: PluginOptions,
-        suppressions: Vec<SuppressionRange>,
+        suppressions: Vec<SuppressionRange<'a>>,
         has_module_scope_opt_out: bool,
     ) -> Self {
         let react_runtime_module = get_react_compiler_runtime_module(&opts.target);
         Self {
+            allocator,
             opts,
             react_runtime_module,
             suppressions,
@@ -61,19 +68,19 @@ impl ProgramContext {
             instrument_fn_name: None,
             instrument_gating_name: None,
             hook_guard_name: None,
-            known_referenced_names: FxHashSet::default(),
+            known_referenced_names: IdentHashSet::default(),
             imports: FxHashMap::default(),
         }
     }
 
     /// Initialize known referenced names from scope bindings.
     /// Call this after construction to seed conflict detection with program scope bindings.
-    pub fn init_from_scope(&mut self, scope: &ScopeResolver<'_, '_>) {
+    pub fn init_from_scope(&mut self, scope: &ScopeResolver<'_, 'a>) {
         // Register ALL bindings (not just program-scope) so that UID generation
         // avoids name conflicts with any binding in the file. This matches
         // Babel's generateUid() which checks all scopes.
         for symbol_id in scope.symbols() {
-            self.known_referenced_names.insert(scope.symbol_name(symbol_id).to_string());
+            self.known_referenced_names.insert(scope.symbol_ident(symbol_id));
         }
     }
 
@@ -87,40 +94,41 @@ impl ProgramContext {
     /// For hook names (use*), preserves the original name to avoid breaking
     /// hook-name-based type inference. For other names, prefixes with underscore
     /// similar to Babel's generateUid.
-    pub fn new_uid(&mut self, name: &str) -> String {
+    pub fn new_uid(&mut self, name: &str) -> Ident<'a> {
         if is_hook_name(name) {
             // Don't prefix hooks with underscore, since InferTypes might
             // type HookKind based on callee naming convention.
-            let mut uid = name.to_string();
+            let mut uid = Ident::from_str_in(name, &self.allocator);
             let mut i = 0;
             while self.has_reference(&uid) {
-                uid = format!("{}_{}", name, i);
+                uid = format_ident!(self.allocator, "{name}_{i}");
                 i += 1;
             }
-            self.known_referenced_names.insert(uid.clone());
+            self.known_referenced_names.insert(uid);
             uid
         } else if !self.has_reference(name) {
-            self.known_referenced_names.insert(name.to_string());
-            name.to_string()
+            let uid = Ident::from_str_in(name, &self.allocator);
+            self.known_referenced_names.insert(uid);
+            uid
         } else {
             // Generate unique name with underscore prefix (similar to Babel's generateUid).
             // Babel strips leading underscores before prefixing, so:
             //   generateUid("_c") → strips to "c" → generates "_c", "_c2", "_c3", ...
             //   generateUid("foo") → generates "_foo", "_foo2", "_foo3", ...
             let base = name.trim_start_matches('_');
-            let mut uid = format!("_{}", base);
+            let mut uid = format_ident!(self.allocator, "_{base}");
             let mut i = 2;
             while self.has_reference(&uid) {
-                uid = format!("_{}{}", base, i);
+                uid = format_ident!(self.allocator, "_{base}{i}");
                 i += 1;
             }
-            self.known_referenced_names.insert(uid.clone());
+            self.known_referenced_names.insert(uid);
             uid
         }
     }
 
     /// Add the memo cache import (the `c` function from the compiler runtime).
-    pub fn add_memo_cache_import(&mut self) -> NonLocalImportSpecifier {
+    pub fn add_memo_cache_import(&mut self) -> NonLocalImportSpecifier<'a> {
         let module = self.react_runtime_module.clone();
         self.add_import_specifier(&module, "c", Some("_c"))
     }
@@ -134,39 +142,39 @@ impl ProgramContext {
         module: &str,
         specifier: &str,
         name_hint: Option<&str>,
-    ) -> NonLocalImportSpecifier {
+    ) -> NonLocalImportSpecifier<'a> {
         // Check if already imported
         if let Some(module_imports) = self.imports.get(module) {
             if let Some(existing) = module_imports.get(specifier) {
-                return existing.clone();
+                return *existing;
             }
         }
 
         let name = self.new_uid(name_hint.unwrap_or(specifier));
-        let binding = NonLocalImportSpecifier { name, imported: specifier.to_string() };
+        let binding = NonLocalImportSpecifier {
+            name,
+            imported: Ident::from_str_in(specifier, &self.allocator),
+        };
 
-        self.imports
-            .entry(module.to_string())
-            .or_default()
-            .insert(specifier.to_string(), binding.clone());
+        self.imports.entry(module.to_string()).or_default().insert(specifier.to_string(), binding);
 
         binding
     }
 
     /// Register a name as referenced so future uid generation avoids it.
-    pub fn add_new_reference(&mut self, name: String) {
+    pub fn add_new_reference(&mut self, name: Ident<'a>) {
         self.known_referenced_names.insert(name);
     }
 
     /// Get the set of known referenced names for seeding per-function Environment UID generation.
-    pub fn known_referenced_names(&self) -> &FxHashSet<String> {
+    pub fn known_referenced_names(&self) -> &IdentHashSet<'a> {
         &self.known_referenced_names
     }
 
     /// Merge UID names generated during a function compilation back into the program context,
     /// so subsequent function compilations avoid collisions.
-    pub fn merge_uid_known_names(&mut self, names: &FxHashSet<String>) {
-        self.known_referenced_names.extend(names.iter().cloned());
+    pub fn merge_uid_known_names(&mut self, names: &IdentHashSet<'a>) {
+        self.known_referenced_names.extend(names.iter().copied());
     }
 
     /// Check if there are any pending imports to add to the program.
@@ -175,7 +183,7 @@ impl ProgramContext {
     }
 
     /// Get an immutable view of the generated imports.
-    pub fn imports(&self) -> &FxHashMap<String, FxHashMap<String, NonLocalImportSpecifier>> {
+    pub fn imports(&self) -> &FxHashMap<String, FxHashMap<String, NonLocalImportSpecifier<'a>>> {
         &self.imports
     }
 }
@@ -247,14 +255,14 @@ fn is_hook_name(name: &str) -> bool {
 }
 
 /// Get the runtime module name based on the compiler target.
-pub fn get_react_compiler_runtime_module(target: &CompilerTarget) -> String {
+pub fn get_react_compiler_runtime_module(target: &CompilerTarget) -> Cow<'static, str> {
     match target {
-        CompilerTarget::Version(v) if v == "19" => "react/compiler-runtime".to_string(),
+        CompilerTarget::Version(v) if v == "19" => Cow::Borrowed("react/compiler-runtime"),
         CompilerTarget::Version(v) if v == "17" || v == "18" => {
-            "react-compiler-runtime".to_string()
+            Cow::Borrowed("react-compiler-runtime")
         }
-        CompilerTarget::MetaInternal { runtime_module, .. } => runtime_module.clone(),
+        CompilerTarget::MetaInternal { runtime_module, .. } => Cow::Owned(runtime_module.clone()),
         // Default to React 19 runtime for unrecognized versions
-        CompilerTarget::Version(_) => "react/compiler-runtime".to_string(),
+        CompilerTarget::Version(_) => Cow::Borrowed("react/compiler-runtime"),
     }
 }

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
@@ -8,6 +8,7 @@
 //! Analogous to TS `Pipeline.ts` (`compileFn` → `run` → `runWithEnvironment`).
 //! Currently runs BuildHIR (lowering) and PruneMaybeThrows.
 
+use oxc_allocator::GetAllocator;
 use oxc_diagnostics::{Diagnostics, OxcDiagnostic};
 use oxc_span::Span;
 
@@ -96,12 +97,12 @@ use crate::options::CompilerOutputMode;
 #[allow(clippy::too_many_arguments)]
 pub fn compile_fn<'a>(
     ast: &oxc_ast::builder::AstBuilder<'a>,
-    func: &FunctionNode<'_>,
-    scope: &ScopeResolver<'_, '_>,
+    func: &FunctionNode<'_, 'a>,
+    scope: &ScopeResolver<'_, 'a>,
     fn_type: ReactFunctionType,
     mode: CompilerOutputMode,
     env_config: &EnvironmentConfig,
-    context: &mut ProgramContext,
+    context: &mut ProgramContext<'a>,
     fn_span: Option<Span>,
 ) -> Result<Option<CodegenFunction<'a>>, Diagnostics> {
     match run_pipeline(ast, func, scope, fn_type, mode, env_config, context) {
@@ -131,23 +132,23 @@ pub fn compile_fn<'a>(
 #[allow(clippy::too_many_arguments)]
 fn run_pipeline<'a>(
     ast: &oxc_ast::builder::AstBuilder<'a>,
-    func: &FunctionNode<'_>,
-    scope: &ScopeResolver<'_, '_>,
+    func: &FunctionNode<'_, 'a>,
+    scope: &ScopeResolver<'_, 'a>,
     fn_type: ReactFunctionType,
     mode: CompilerOutputMode,
     env_config: &EnvironmentConfig,
-    context: &mut ProgramContext,
+    context: &mut ProgramContext<'a>,
 ) -> Result<Result<Option<CodegenFunction<'a>>, Diagnostics>, OxcDiagnostic> {
-    let mut env = Environment::with_config(env_config.clone());
+    let mut env = Environment::with_config(ast.allocator(), env_config.clone());
     env.fn_type = fn_type;
     env.output_mode = match mode {
         CompilerOutputMode::Ssr => OutputMode::Ssr,
         CompilerOutputMode::Client => OutputMode::Client,
         CompilerOutputMode::Lint => OutputMode::Lint,
     };
-    env.instrument_fn_name = context.instrument_fn_name.clone();
-    env.instrument_gating_name = context.instrument_gating_name.clone();
-    env.hook_guard_name = context.hook_guard_name.clone();
+    env.instrument_fn_name = context.instrument_fn_name;
+    env.instrument_gating_name = context.instrument_gating_name;
+    env.hook_guard_name = context.hook_guard_name;
     env.seed_uid_known_names(context.known_referenced_names());
 
     let mut hir = lower(func, scope, &mut env)?;
@@ -346,7 +347,7 @@ fn run_pipeline<'a>(
     let unique_identifiers = rename_variables(&mut reactive_fn, &mut env);
 
     for name in &unique_identifiers {
-        context.add_new_reference(name.clone());
+        context.add_new_reference(*name);
     }
 
     prune_hoisted_contexts(&mut reactive_fn, &env)?;

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -41,6 +41,7 @@ use super::suppression::suppressions_to_diagnostics;
 use crate::options::{
     CompilationMode, CompilerOutputMode, GatingConfig, PanicThreshold, PluginOptions,
 };
+use oxc_str::{Ident, Str};
 
 // -----------------------------------------------------------------------
 // Constants
@@ -62,7 +63,7 @@ const OPT_OUT_DIRECTIVES: &[&str] = &["use no forget", "use no memo"];
 /// A function found in the program that should be compiled.
 ///
 /// `'a` is the arena lifetime of the discovered oxc function node.
-struct CompileSource<'a> {
+struct CompileSource<'b, 'a> {
     kind: CompileSourceKind,
     original_kind: OriginalFnKind,
     /// Byte span of the discovered function, used as the fallback labeled span in
@@ -73,9 +74,9 @@ struct CompileSource<'a> {
     fn_scope_id: ScopeId,
     fn_type: ReactFunctionType,
     /// The discovered oxc function node, handed straight to lowering.
-    fn_node: FunctionNode<'a>,
+    fn_node: FunctionNode<'b, 'a>,
     /// Directive values from the function body (for opt-in/opt-out checks)
-    body_directives: Vec<String>,
+    body_directives: Vec<Str<'a>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -92,7 +93,7 @@ enum CompileSourceKind {
 ///
 /// Also checks for dynamic gating directives (`use memo if(...)`)
 fn try_find_directive_enabling_memoization<'a>(
-    directives: &'a [String],
+    directives: &[Str<'a>],
     opts: &PluginOptions,
 ) -> Result<Option<&'a str>, Diagnostics> {
     // Check standard opt-in directives
@@ -130,7 +131,7 @@ struct DynamicGatingResult<'a> {
 /// Check for dynamic gating directives like `use memo if(identifier)`.
 /// Returns the directive and gating config if found, or an error if malformed.
 fn find_directives_dynamic_gating<'a>(
-    directives: &'a [String],
+    directives: &[Str<'a>],
     opts: &PluginOptions,
 ) -> Result<Option<DynamicGatingResult<'a>>, Diagnostics> {
     let dynamic_gating = match &opts.dynamic_gating {
@@ -952,7 +953,7 @@ fn get_react_function_type(
     name: Option<&str>,
     params: &oxc::FormalParameters,
     body: &FunctionBody,
-    body_directives: &[String],
+    body_directives: &[Str<'_>],
     is_declaration: bool,
     parent_callee_name: Option<&str>,
     opts: &PluginOptions,
@@ -1051,7 +1052,7 @@ fn get_component_or_hook_like(
 
 /// Extract the callee name from a CallExpression if it's a React API call
 /// (forwardRef, memo, React.forwardRef, React.memo).
-fn get_callee_name_if_react_api<'e>(callee: &'e oxc::Expression) -> Option<&'e str> {
+fn get_callee_name_if_react_api<'ast>(callee: &oxc::Expression<'ast>) -> Option<&'ast str> {
     match callee {
         oxc::Expression::Identifier(id) => {
             if id.name == "forwardRef" || id.name == "memo" {
@@ -1140,11 +1141,11 @@ fn handle_error<'a>(
 /// Debug log entries are accumulated on `context.debug_logs`.
 fn try_compile_function<'a>(
     ast: &AstBuilder<'a>,
-    source: &CompileSource,
-    scope: &ScopeResolver<'_, '_>,
+    source: &CompileSource<'_, 'a>,
+    scope: &ScopeResolver<'_, 'a>,
     output_mode: CompilerOutputMode,
     env_config: &EnvironmentConfig,
-    context: &mut ProgramContext,
+    context: &mut ProgramContext<'a>,
 ) -> Result<Option<CodegenFunction<'a>>, Diagnostics> {
     // Check for suppressions that affect this function. Suppression errors are
     // returned (not thrown), so they do NOT trigger CompileUnexpectedThrow.
@@ -1178,17 +1179,17 @@ fn try_compile_function<'a>(
 #[allow(clippy::result_large_err)]
 fn process_fn<'a>(
     ast: &AstBuilder<'a>,
-    source: &CompileSource,
-    scope: &ScopeResolver<'_, '_>,
+    source: &CompileSource<'_, 'a>,
+    scope: &ScopeResolver<'_, 'a>,
     output_mode: CompilerOutputMode,
     env_config: &EnvironmentConfig,
-    context: &mut ProgramContext,
+    context: &mut ProgramContext<'a>,
 ) -> Result<Option<CodegenFunction<'a>>, CompileResult<'a>> {
     // Parse directives from the function body
     let opt_in_result =
         try_find_directive_enabling_memoization(&source.body_directives, &context.opts);
     let opt_out = find_directive_disabling_memoization(
-        source.body_directives.iter().map(String::as_str),
+        source.body_directives.iter().map(Str::as_str),
         context.opts.custom_opt_out_directives.as_deref(),
     );
 
@@ -1267,8 +1268,8 @@ fn process_fn<'a>(
 
 /// Collect the directive value strings of a function body (for opt-in/opt-out
 /// checks). Matches the Babel-bridge directive values (`d.expression.value`).
-fn body_directive_values(body: &oxc::FunctionBody) -> Vec<String> {
-    body.directives.iter().map(|d| d.expression.value.to_string()).collect()
+fn body_directive_values<'a>(body: &oxc::FunctionBody<'a>) -> Vec<Str<'a>> {
+    body.directives.iter().map(|d| d.expression.value).collect()
 }
 
 /// Try to create a `CompileSource` from a discovered oxc function node.
@@ -1276,14 +1277,14 @@ fn body_directive_values(body: &oxc::FunctionBody) -> Vec<String> {
 /// `fn_node` is the oxc function node (its scope is the function's identity),
 /// `name` the inferred function name, `original_kind` the syntactic kind,
 /// and `parent_callee_name` the enclosing forwardRef/memo callee (if any).
-fn try_make_compile_source<'a>(
-    fn_node: FunctionNode<'a>,
+fn try_make_compile_source<'b, 'a>(
+    fn_node: FunctionNode<'b, 'a>,
     name: Option<&str>,
     original_kind: OriginalFnKind,
     parent_callee_name: Option<&str>,
     opts: &PluginOptions,
     already_compiled: &mut FxHashSet<ScopeId>,
-) -> Option<CompileSource<'a>> {
+) -> Option<CompileSource<'b, 'a>> {
     let (params, body, span, body_directives) = match fn_node {
         FunctionNode::Function(f) => {
             // Bodyless functions (`declare function`, overload signatures,
@@ -1374,17 +1375,17 @@ fn get_declarator_name<'ast>(decl: &oxc::VariableDeclarator<'ast>) -> Option<&'a
 /// functions are descended to find nested component/hook declarations. Classes
 /// are entered only structurally (their bodies carry no compilable functions for
 /// discovery — matching the Babel bridge, which extracted no metadata for them).
-struct DiscoveryWalker<'a, 'ast> {
+struct DiscoveryWalker<'a, 'b, 'ast> {
     opts: &'a PluginOptions,
     already_compiled: FxHashSet<ScopeId>,
-    queue: Vec<CompileSource<'ast>>,
+    queue: Vec<CompileSource<'b, 'ast>>,
     scope_stack: Vec<ScopeId>,
     loop_expression_depth: usize,
     current_declarator_name: Option<&'ast str>,
     parent_callee_stack: Vec<Option<&'ast str>>,
 }
 
-impl<'a, 'ast> DiscoveryWalker<'a, 'ast> {
+impl<'a, 'b, 'ast> DiscoveryWalker<'a, 'b, 'ast> {
     fn new(opts: &'a PluginOptions) -> Self {
         Self {
             opts,
@@ -1424,7 +1425,7 @@ impl<'a, 'ast> DiscoveryWalker<'a, 'ast> {
         self.parent_callee_stack.last().copied().flatten()
     }
 
-    fn walk_program(&mut self, program: &'ast oxc::Program<'ast>) {
+    fn walk_program(&mut self, program: &'b oxc::Program<'ast>) {
         let pushed = self.try_push_scope(program.scope_id.get());
         for stmt in &program.body {
             self.walk_statement(stmt);
@@ -1434,7 +1435,7 @@ impl<'a, 'ast> DiscoveryWalker<'a, 'ast> {
         }
     }
 
-    fn walk_block(&mut self, block: &'ast oxc::BlockStatement<'ast>) {
+    fn walk_block(&mut self, block: &'b oxc::BlockStatement<'ast>) {
         let pushed = self.try_push_scope(block.scope_id.get());
         for stmt in &block.body {
             self.walk_statement(stmt);
@@ -1444,7 +1445,7 @@ impl<'a, 'ast> DiscoveryWalker<'a, 'ast> {
         }
     }
 
-    fn walk_function_body_block(&mut self, body: &'ast oxc::FunctionBody<'ast>) {
+    fn walk_function_body_block(&mut self, body: &'b oxc::FunctionBody<'ast>) {
         // A function body BlockStatement shares the function's scope in the Babel
         // model and never gets its own scope entry, so do not push a scope here.
         for stmt in &body.statements {
@@ -1452,7 +1453,7 @@ impl<'a, 'ast> DiscoveryWalker<'a, 'ast> {
         }
     }
 
-    fn walk_statement(&mut self, stmt: &'ast oxc::Statement<'ast>) {
+    fn walk_statement(&mut self, stmt: &'b oxc::Statement<'ast>) {
         match stmt {
             oxc::Statement::BlockStatement(node) => self.walk_block(node),
             oxc::Statement::ReturnStatement(node) => {
@@ -1578,14 +1579,14 @@ impl<'a, 'ast> DiscoveryWalker<'a, 'ast> {
         }
     }
 
-    fn walk_for_left(&mut self, left: &'ast oxc::ForStatementLeft<'ast>) {
+    fn walk_for_left(&mut self, left: &'b oxc::ForStatementLeft<'ast>) {
         if let oxc::ForStatementLeft::VariableDeclaration(decl) = left {
             self.walk_variable_declaration(decl);
         }
         // Assignment-target lefts contain no functions to discover.
     }
 
-    fn walk_variable_declaration(&mut self, decl: &'ast oxc::VariableDeclaration<'ast>) {
+    fn walk_variable_declaration(&mut self, decl: &'b oxc::VariableDeclaration<'ast>) {
         for declarator in &decl.declarations {
             // Only infer the declarator name when the init is a direct function
             // expression, arrow, or call expression (for forwardRef/memo wrappers).
@@ -1604,7 +1605,7 @@ impl<'a, 'ast> DiscoveryWalker<'a, 'ast> {
         }
     }
 
-    fn walk_declaration(&mut self, decl: &'ast oxc::Declaration<'ast>) {
+    fn walk_declaration(&mut self, decl: &'b oxc::Declaration<'ast>) {
         match decl {
             oxc::Declaration::FunctionDeclaration(node) => self.walk_function(node, None),
             oxc::Declaration::VariableDeclaration(node) => self.walk_variable_declaration(node),
@@ -1613,7 +1614,7 @@ impl<'a, 'ast> DiscoveryWalker<'a, 'ast> {
         }
     }
 
-    fn walk_export_default(&mut self, decl: &'ast oxc::ExportDefaultDeclarationKind<'ast>) {
+    fn walk_export_default(&mut self, decl: &'b oxc::ExportDefaultDeclarationKind<'ast>) {
         match decl {
             oxc::ExportDefaultDeclarationKind::FunctionDeclaration(node) => {
                 self.walk_function(node, None)
@@ -1629,7 +1630,7 @@ impl<'a, 'ast> DiscoveryWalker<'a, 'ast> {
     /// Walk an oxc `Function` node (declaration or expression). `inferred_name`,
     /// when `Some`, supplies the name from the enclosing variable declarator (for
     /// function expressions); `None` means use the function's own id.
-    fn walk_function(&mut self, func: &'ast oxc::Function<'ast>, inferred_name: Option<&'ast str>) {
+    fn walk_function(&mut self, func: &'b oxc::Function<'ast>, inferred_name: Option<&'ast str>) {
         let pushed = self.try_push_scope(func.scope_id.get());
 
         let original_kind = match func.r#type {
@@ -1679,7 +1680,7 @@ impl<'a, 'ast> DiscoveryWalker<'a, 'ast> {
 
     fn walk_arrow(
         &mut self,
-        arrow: &'ast oxc::ArrowFunctionExpression<'ast>,
+        arrow: &'b oxc::ArrowFunctionExpression<'ast>,
         inferred_name: Option<&'ast str>,
     ) {
         let pushed = self.try_push_scope(arrow.scope_id.get());
@@ -1714,7 +1715,7 @@ impl<'a, 'ast> DiscoveryWalker<'a, 'ast> {
         }
     }
 
-    fn walk_expression(&mut self, expr: &'ast oxc::Expression<'ast>) {
+    fn walk_expression(&mut self, expr: &'b oxc::Expression<'ast>) {
         match expr {
             oxc::Expression::FunctionExpression(node) => {
                 // The declarator name flows into the function expression and is
@@ -1835,7 +1836,7 @@ impl<'a, 'ast> DiscoveryWalker<'a, 'ast> {
         }
     }
 
-    fn walk_argument(&mut self, arg: &'ast oxc::Argument<'ast>) {
+    fn walk_argument(&mut self, arg: &'b oxc::Argument<'ast>) {
         if let Some(expr) = arg.as_expression() {
             self.walk_expression(expr);
         } else if let oxc::Argument::SpreadElement(s) = arg {
@@ -1843,7 +1844,7 @@ impl<'a, 'ast> DiscoveryWalker<'a, 'ast> {
         }
     }
 
-    fn walk_member_expression(&mut self, member: &'ast oxc::MemberExpression<'ast>) {
+    fn walk_member_expression(&mut self, member: &'b oxc::MemberExpression<'ast>) {
         match member {
             oxc::MemberExpression::StaticMemberExpression(m) => self.walk_expression(&m.object),
             oxc::MemberExpression::ComputedMemberExpression(m) => {
@@ -1854,7 +1855,7 @@ impl<'a, 'ast> DiscoveryWalker<'a, 'ast> {
         }
     }
 
-    fn walk_chain_element(&mut self, element: &'ast oxc::ChainElement<'ast>) {
+    fn walk_chain_element(&mut self, element: &'b oxc::ChainElement<'ast>) {
         match element {
             oxc::ChainElement::CallExpression(node) => {
                 self.walk_expression(&node.callee);
@@ -1872,7 +1873,7 @@ impl<'a, 'ast> DiscoveryWalker<'a, 'ast> {
         }
     }
 
-    fn walk_object_property(&mut self, prop: &'ast oxc::ObjectPropertyKind<'ast>) {
+    fn walk_object_property(&mut self, prop: &'b oxc::ObjectPropertyKind<'ast>) {
         match prop {
             oxc::ObjectPropertyKind::SpreadProperty(s) => self.walk_expression(&s.argument),
             oxc::ObjectPropertyKind::ObjectProperty(p) => {
@@ -1901,13 +1902,13 @@ impl<'a, 'ast> DiscoveryWalker<'a, 'ast> {
         }
     }
 
-    fn walk_property_key(&mut self, key: &'ast oxc::PropertyKey<'ast>) {
+    fn walk_property_key(&mut self, key: &'b oxc::PropertyKey<'ast>) {
         if let Some(expr) = key.as_expression() {
             self.walk_expression(expr);
         }
     }
 
-    fn walk_jsx_element(&mut self, node: &'ast oxc::JSXElement<'ast>) {
+    fn walk_jsx_element(&mut self, node: &'b oxc::JSXElement<'ast>) {
         for attr in &node.opening_element.attributes {
             match attr {
                 oxc::JSXAttributeItem::Attribute(a) => {
@@ -1930,7 +1931,7 @@ impl<'a, 'ast> DiscoveryWalker<'a, 'ast> {
         self.walk_jsx_children(&node.children);
     }
 
-    fn walk_jsx_children(&mut self, children: &'ast ArenaVec<'ast, oxc::JSXChild<'ast>>) {
+    fn walk_jsx_children(&mut self, children: &'b ArenaVec<'ast, oxc::JSXChild<'ast>>) {
         for child in children {
             match child {
                 oxc::JSXChild::Element(el) => self.walk_jsx_element(el),
@@ -1942,7 +1943,7 @@ impl<'a, 'ast> DiscoveryWalker<'a, 'ast> {
         }
     }
 
-    fn walk_jsx_container(&mut self, container: &'ast oxc::JSXExpressionContainer<'ast>) {
+    fn walk_jsx_container(&mut self, container: &'b oxc::JSXExpressionContainer<'ast>) {
         if let Some(expr) = container.expression.as_expression() {
             self.walk_expression(expr);
         }
@@ -1951,10 +1952,10 @@ impl<'a, 'ast> DiscoveryWalker<'a, 'ast> {
 
 /// Find all functions in the program that should be compiled by walking the oxc
 /// `Program` directly. See [`DiscoveryWalker`] for the traversal semantics.
-fn find_functions_to_compile<'ast>(
-    program: &'ast oxc::Program<'ast>,
+fn find_functions_to_compile<'b, 'ast>(
+    program: &'b oxc::Program<'ast>,
     opts: &PluginOptions,
-) -> Vec<CompileSource<'ast>> {
+) -> Vec<CompileSource<'b, 'ast>> {
     let mut walker = DiscoveryWalker::new(opts);
     walker.walk_program(program);
     walker.queue
@@ -2102,9 +2103,9 @@ fn is_wrapper_callee(nodes: &AstNodes, node_id: NodeId) -> bool {
     get_callee_name_if_react_api(&call.callee).is_some()
 }
 
-struct CompiledFunction<'a, 'p, 's> {
+struct CompiledFunction<'a, 'b, 'p, 's> {
     kind: CompileSourceKind,
-    source: &'s CompileSource<'p>,
+    source: &'s CompileSource<'b, 'p>,
     codegen_fn: CodegenFunction<'a>,
 }
 
@@ -2283,7 +2284,7 @@ struct OxcReplaceWithGatedVisitor<'a, 'b> {
     scope_id: ScopeId,
     gating_expression: &'b oxc::Expression<'a>,
     /// Pending `export default Name;` to insert after a named export-default fn.
-    export_default_name: Option<String>,
+    export_default_name: Option<Ident<'a>>,
     done: bool,
 }
 
@@ -2317,17 +2318,17 @@ impl<'a, 'b> oxc_ast_visit::VisitMut<'a> for OxcReplaceWithGatedVisitor<'a, 'b> 
                 break;
             }
             // FunctionDeclaration → `const Foo = gating() ? ... : ...;`
-            let replace_name: Option<Option<String>> = match &stmts[i] {
+            let replace_name: Option<Option<Ident<'a>>> = match &stmts[i] {
                 oxc::Statement::FunctionDeclaration(f)
                     if f.scope_id.get() == Some(self.scope_id) =>
                 {
-                    Some(f.id.as_ref().map(|id| id.name.to_string()))
+                    Some(f.id.as_ref().map(|id| id.name))
                 }
                 oxc::Statement::ExportNamedDeclaration(e) => match &e.declaration {
                     Some(oxc::Declaration::FunctionDeclaration(f))
                         if f.scope_id.get() == Some(self.scope_id) =>
                     {
-                        Some(f.id.as_ref().map(|id| id.name.to_string()))
+                        Some(f.id.as_ref().map(|id| id.name))
                     }
                     _ => None,
                 },
@@ -2364,8 +2365,8 @@ impl<'a, 'b> oxc_ast_visit::VisitMut<'a> for OxcReplaceWithGatedVisitor<'a, 'b> 
             if let oxc::Statement::ExportDefaultDeclaration(e) = &stmts[i] {
                 if let oxc::ExportDefaultDeclarationKind::FunctionDeclaration(f) = &e.declaration {
                     if f.scope_id.get() == Some(self.scope_id) {
-                        if let Some(id) = f.id.as_ref().map(|id| id.name.to_string()) {
-                            stmts[i] = self.build_const_decl(&id);
+                        if let Some(id) = f.id.as_ref().map(|id| id.name) {
+                            stmts[i] = self.build_const_decl(id.as_str());
                             self.export_default_name = Some(id);
                         } else {
                             stmts[i] = oxc::Statement::ExportDefaultDeclaration(
@@ -2389,7 +2390,7 @@ impl<'a, 'b> oxc_ast_visit::VisitMut<'a> for OxcReplaceWithGatedVisitor<'a, 'b> 
 
         // Insert `export default Name;` right after the replaced declaration.
         if let Some(name) = self.export_default_name.take() {
-            let ident = oxc::Expression::new_identifier(SPAN, ox_atom(self.ast, &name), self.ast);
+            let ident = oxc::Expression::new_identifier(SPAN, name, self.ast);
             let export =
                 oxc::Statement::ExportDefaultDeclaration(oxc::ExportDefaultDeclaration::boxed(
                     SPAN,
@@ -2400,7 +2401,7 @@ impl<'a, 'b> oxc_ast_visit::VisitMut<'a> for OxcReplaceWithGatedVisitor<'a, 'b> 
             let pos = stmts.iter().position(|s| {
                 matches!(s, oxc::Statement::VariableDeclaration(d)
                     if d.declarations.first().is_some_and(|decl| matches!(&decl.id,
-                        oxc::BindingPattern::BindingIdentifier(b) if b.name.as_str() == name)))
+                        oxc::BindingPattern::BindingIdentifier(b) if b.name == name)))
             });
             if let Some(pos) = pos {
                 stmts.insert(pos + 1, export);
@@ -2700,11 +2701,11 @@ fn ox_add_imports_to_program<'a>(
     let imports = context.imports();
 
     // Existing non-namespaced value imports, by module name.
-    let mut existing_import_indices: FxHashMap<String, usize> = FxHashMap::default();
+    let mut existing_import_indices: FxHashMap<&str, usize> = FxHashMap::default();
     for (idx, stmt) in program.body.iter().enumerate() {
         if let oxc::Statement::ImportDeclaration(import) = stmt {
             if ox_is_non_namespaced_import(import) {
-                existing_import_indices.entry(import.source.value.to_string()).or_insert(idx);
+                existing_import_indices.entry(import.source.value.as_str()).or_insert(idx);
             }
         }
     }
@@ -2718,9 +2719,9 @@ fn ox_add_imports_to_program<'a>(
 
     for (module_name, imports_map) in sorted_modules {
         let mut sorted_imports: Vec<_> = imports_map.values().collect();
-        sorted_imports.sort_by(|a, b| a.imported.cmp(&b.imported));
+        sorted_imports.sort_by(|a, b| a.imported.as_str().cmp(b.imported.as_str()));
 
-        if let Some(&idx) = existing_import_indices.get(module_name) {
+        if let Some(&idx) = existing_import_indices.get(module_name.as_str()) {
             // Merge into the existing import declaration.
             if let oxc::Statement::ImportDeclaration(import) = &mut program.body[idx] {
                 let specifiers = import.specifiers.get_or_insert_with(|| ArenaVec::new_in(ast));
@@ -2855,10 +2856,10 @@ fn ox_is_non_namespaced_import(import: &oxc::ImportDeclaration) -> bool {
 /// - findFunctionsToCompile: traverse program to find components and hooks
 /// - processFn: per-function compilation with directive and suppression handling
 /// - applyCompiledFunctions: replace original functions with compiled versions
-pub fn compile_program<'a, 'p>(
+pub fn compile_program<'a>(
     allocator: &'a Allocator,
     semantic: &Semantic<'_>,
-    program: &'p oxc::Program<'a>,
+    program: &oxc::Program<'a>,
     options: PluginOptions,
 ) -> CompileResult<'a> {
     // Find all functions to compile. An empty queue means no work, so return
@@ -2903,12 +2904,13 @@ pub fn compile_program<'a, 'p>(
     .is_some();
 
     // Create program context
-    let mut context = ProgramContext::new(options.clone(), suppressions, has_module_scope_opt_out);
+    let mut context =
+        ProgramContext::new(allocator, options.clone(), suppressions, has_module_scope_opt_out);
 
     // The codegen back-end builds oxc nodes directly via this `AstBuilder`; `scope`
     // is a read-through view over `Semantic` for binding/reference lookups.
     let ast = AstBuilder::new(allocator);
-    let scope = ScopeResolver::new(semantic);
+    let scope = ScopeResolver::new(semantic, allocator);
 
     // Initialize known referenced names from scope bindings for UID collision detection
     context.init_from_scope(&scope);
@@ -2947,7 +2949,7 @@ pub fn compile_program<'a, 'p>(
     context.hook_guard_name = hook_guard_name;
 
     // Process each function and collect compiled results
-    let mut compiled_fns: Vec<CompiledFunction<'_, '_, '_>> = Vec::new();
+    let mut compiled_fns: Vec<CompiledFunction<'_, '_, '_, '_>> = Vec::new();
 
     for source in &queue {
         match process_fn(&ast, source, &scope, output_mode, &options.environment, &mut context) {

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/suppression.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/suppression.rs
@@ -13,8 +13,8 @@ use crate::diagnostics::ErrorCategory;
 /// labeled span on a suppression diagnostic. The former Babel front-end carried
 /// this on `CommentData`; the oxc front-end builds it directly from oxc comments.
 #[derive(Debug, Clone)]
-pub struct CommentData {
-    pub value: String,
+pub struct CommentData<'a> {
+    pub value: &'a str,
     pub start: Option<u32>,
     pub end: Option<u32>,
     pub span: Option<CommentLoc>,
@@ -39,20 +39,20 @@ pub enum SuppressionSource {
 /// The enable comment can be missing in the case where only a disable block is present,
 /// ie the rest of the file has potential React violations.
 #[derive(Debug, Clone)]
-pub struct SuppressionRange {
-    pub disable_comment: CommentData,
-    pub enable_comment: Option<CommentData>,
+pub struct SuppressionRange<'a> {
+    pub disable_comment: CommentData<'a>,
+    pub enable_comment: Option<CommentData<'a>>,
     pub source: SuppressionSource,
 }
 
 /// Build a Babel-shaped [`CommentData`] from an oxc comment, stripping the `//`
 /// or `/* */` delimiters from the value exactly as the former Babel bridge did.
-fn comment_data(comment: &oxc_ast::ast::Comment, source_text: &str) -> CommentData {
+fn comment_data<'a>(comment: &oxc_ast::ast::Comment, source_text: &'a str) -> CommentData<'a> {
     let raw = &source_text[comment.span.start as usize..comment.span.end as usize];
     let value = if matches!(comment.kind, oxc_ast::ast::CommentKind::Line) {
-        raw.strip_prefix("//").unwrap_or(raw).trim().to_string()
+        raw.strip_prefix("//").unwrap_or(raw).trim()
     } else {
-        raw.strip_prefix("/*").unwrap_or(raw).strip_suffix("*/").unwrap_or(raw).trim().to_string()
+        raw.strip_prefix("/*").unwrap_or(raw).strip_suffix("*/").unwrap_or(raw).trim()
     };
     CommentData {
         value,
@@ -134,12 +134,12 @@ fn matches_flow_suppression(value: &str) -> bool {
 
 /// Parse eslint-disable/enable and Flow suppression comments from program comments.
 /// Equivalent to findProgramSuppressions in Suppression.ts
-pub fn find_program_suppressions(
+pub fn find_program_suppressions<'a>(
     comments: &[oxc_ast::ast::Comment],
-    source_text: &str,
+    source_text: &'a str,
     rule_names: Option<&[String]>,
     flow_suppressions: bool,
-) -> Vec<SuppressionRange> {
+) -> Vec<SuppressionRange<'a>> {
     let mut suppression_ranges: Vec<SuppressionRange> = Vec::new();
     let mut disable_comment: Option<CommentData> = None;
     let mut enable_comment: Option<CommentData> = None;
@@ -157,7 +157,7 @@ pub fn find_program_suppressions(
         // Check for eslint-disable-next-line (only if not already within a block)
         if disable_comment.is_none() && has_rules {
             if let Some(names) = rule_names {
-                if matches_eslint_disable_next_line(&data.value, names) {
+                if matches_eslint_disable_next_line(data.value, names) {
                     disable_comment = Some(data.clone());
                     enable_comment = Some(data.clone());
                     source = Some(SuppressionSource::Eslint);
@@ -166,7 +166,7 @@ pub fn find_program_suppressions(
         }
 
         // Check for Flow suppression (only if not already within a block)
-        if flow_suppressions && disable_comment.is_none() && matches_flow_suppression(&data.value) {
+        if flow_suppressions && disable_comment.is_none() && matches_flow_suppression(data.value) {
             disable_comment = Some(data.clone());
             enable_comment = Some(data.clone());
             source = Some(SuppressionSource::Flow);
@@ -175,7 +175,7 @@ pub fn find_program_suppressions(
         // Check for eslint-disable (block start)
         if has_rules {
             if let Some(names) = rule_names {
-                if matches_eslint_disable(&data.value, names) {
+                if matches_eslint_disable(data.value, names) {
                     disable_comment = Some(data.clone());
                     source = Some(SuppressionSource::Eslint);
                 }
@@ -185,7 +185,7 @@ pub fn find_program_suppressions(
         // Check for eslint-enable (block end)
         if has_rules {
             if let Some(names) = rule_names {
-                if matches_eslint_enable(&data.value, names) {
+                if matches_eslint_enable(data.value, names) {
                     if matches!(source, Some(SuppressionSource::Eslint)) {
                         enable_comment = Some(data.clone());
                     }
@@ -210,11 +210,11 @@ pub fn find_program_suppressions(
 /// A suppression affects a function if:
 /// 1. The suppression is within the function's body
 /// 2. The suppression wraps the function
-pub fn filter_suppressions_that_affect_function(
-    suppressions: &[SuppressionRange],
+pub fn filter_suppressions_that_affect_function<'s, 'a>(
+    suppressions: &'s [SuppressionRange<'a>],
     fn_start: u32,
     fn_end: u32,
-) -> Vec<&SuppressionRange> {
+) -> Vec<&'s SuppressionRange<'a>> {
     let mut suppressions_in_scope: Vec<&SuppressionRange> = Vec::new();
 
     for suppression in suppressions {

--- a/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
@@ -4,7 +4,9 @@ use cow_utils::CowUtils;
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 
+use oxc_allocator::{Allocator, GetAllocator};
 use oxc_diagnostics::{Diagnostics, OxcDiagnostic};
+use oxc_str::{Ident, IdentHashMap, IdentHashSet, format_ident};
 use oxc_syntax::reference::ReferenceId;
 use oxc_syntax::symbol::SymbolId;
 
@@ -35,15 +37,20 @@ pub enum OutputMode {
 }
 
 pub struct Environment<'a> {
+    // Arena allocator for the compilation unit. HIR strings (identifier names,
+    // shape ids, property keys) live here so they can be borrowed from the
+    // source AST at lowering and emitted into the output AST without copies.
+    pub allocator: &'a Allocator,
+
     // Counters
     pub next_block_id_counter: u32,
     pub next_scope_id_counter: u32,
     next_mutable_range_id_counter: u32,
 
     // Arenas (use direct field access for sliced borrows)
-    pub identifiers: Vec<Identifier>,
-    pub types: Vec<Type>,
-    pub scopes: Vec<ReactiveScope>,
+    pub identifiers: Vec<Identifier<'a>>,
+    pub types: Vec<Type<'a>>,
+    pub scopes: Vec<ReactiveScope<'a>>,
     pub functions: Vec<HirFunction<'a>>,
 
     // Error accumulation
@@ -63,14 +70,14 @@ pub struct Environment<'a> {
 
     // Pre-resolved import local names for instrumentation/hook guards.
     // Set by the program-level code before compilation.
-    pub instrument_fn_name: Option<String>,
-    pub instrument_gating_name: Option<String>,
-    pub hook_guard_name: Option<String>,
+    pub instrument_fn_name: Option<Ident<'a>>,
+    pub instrument_gating_name: Option<Ident<'a>>,
+    pub hook_guard_name: Option<Ident<'a>>,
 
     // Renames from lowering (collision suffixes like `name_0`), recorded per
     // resolved reference so codegen can rename identifiers inside preserved TS
     // type annotations by reference identity.
-    pub renames: FxHashMap<ReferenceId, String>,
+    pub renames: FxHashMap<ReferenceId, Ident<'a>>,
 
     // Hoisted identifiers: tracks which bindings have already been hoisted
     // via DeclareContext to avoid duplicate hoisting.
@@ -82,17 +89,17 @@ pub struct Environment<'a> {
     pub enable_preserve_existing_memoization_guarantees: bool,
 
     // Type system registries
-    globals: GlobalRegistry,
-    pub shapes: ShapeRegistry,
-    module_types: FxHashMap<String, Option<Global>>,
-    module_type_errors: FxHashMap<String, Vec<String>>,
+    globals: GlobalRegistry<'a>,
+    pub shapes: ShapeRegistry<'a>,
+    module_types: IdentHashMap<'a, Option<Global<'a>>>,
+    module_type_errors: IdentHashMap<'a, Vec<String>>,
 
     // Environment configuration (feature flags, custom hooks, etc.)
     pub config: EnvironmentConfig,
 
     // Cached default hook types (lazily initialized)
-    default_nonmutating_hook: Option<Global>,
-    default_mutating_hook: Option<Global>,
+    default_nonmutating_hook: Option<Global<'a>>,
+    default_mutating_hook: Option<Global<'a>>,
 
     // Outlined functions: functions extracted from the component during outlining passes
     outlined_functions: Vec<OutlinedFunctionEntry<'a>>,
@@ -100,7 +107,7 @@ pub struct Environment<'a> {
     // Known names for collision-aware UID generation. Lazily populated from
     // identifiers on first use, then updated with each generated name.
     // Matches Babel's generateUid behavior of checking hasBinding/hasReference.
-    uid_known_names: Option<FxHashSet<String>>,
+    uid_known_names: Option<IdentHashSet<'a>>,
 }
 
 /// An outlined function entry, stored on Environment during compilation.
@@ -111,17 +118,19 @@ pub struct OutlinedFunctionEntry<'a> {
     pub fn_type: Option<ReactFunctionType>,
 }
 
-impl<'a> Environment<'a> {
-    pub fn new() -> Self {
-        Self::with_config(EnvironmentConfig::default())
+impl<'a> GetAllocator<'a> for Environment<'a> {
+    fn allocator(&self) -> &'a Allocator {
+        self.allocator
     }
+}
 
+impl<'a> Environment<'a> {
     /// Create a new Environment with the given configuration.
     ///
     /// Initializes the shape and global registries, registers custom hooks,
     /// and sets up the module type cache.
-    pub fn with_config(config: EnvironmentConfig) -> Self {
-        let mut shapes = ShapeRegistry::with_base(globals::base_shapes());
+    pub fn with_config(allocator: &'a Allocator, config: EnvironmentConfig) -> Self {
+        let mut shapes = ShapeRegistry::with_base(globals::base_shapes(), allocator);
         let mut global_registry = GlobalRegistry::with_base(globals::base_globals());
 
         // Register custom hooks from config
@@ -131,7 +140,7 @@ impl<'a> Environment<'a> {
                 continue;
             }
             let return_type = if hook.transitive_mixed_data {
-                Type::Object { shape_id: Some(BUILT_IN_MIXED_READONLY_ID.to_string()) }
+                Type::Object { shape_id: Some(BUILT_IN_MIXED_READONLY_ID) }
             } else {
                 Type::Poly
             };
@@ -147,18 +156,19 @@ impl<'a> Environment<'a> {
                 },
                 None,
             );
-            global_registry.insert(hook_name.clone(), hook_type);
+            global_registry.insert(Ident::from_str_in(hook_name, &allocator), hook_type);
         }
 
         // Register reanimated module type when enabled
-        let mut module_types: FxHashMap<String, Option<Global>> = FxHashMap::default();
+        let mut module_types: IdentHashMap<'a, Option<Global<'a>>> = IdentHashMap::default();
         if config.enable_custom_type_definition_for_reanimated {
             let reanimated_module_type = globals::get_reanimated_module_type(&mut shapes);
             module_types
-                .insert("react-native-reanimated".to_string(), Some(reanimated_module_type));
+                .insert(Ident::from("react-native-reanimated"), Some(reanimated_module_type));
         }
 
         Self {
+            allocator,
             next_block_id_counter: 0,
             next_scope_id_counter: 0,
             next_mutable_range_id_counter: 0,
@@ -183,7 +193,7 @@ impl<'a> Environment<'a> {
             globals: global_registry,
             shapes,
             module_types,
-            module_type_errors: FxHashMap::default(),
+            module_type_errors: IdentHashMap::default(),
             default_nonmutating_hook: None,
             default_mutating_hook: None,
             outlined_functions: Vec::new(),
@@ -326,7 +336,7 @@ impl<'a> Environment<'a> {
         &mut self,
         binding: &NonLocalBinding,
         span: Option<Span>,
-    ) -> Result<Option<Global>, OxcDiagnostic> {
+    ) -> Result<Option<Global<'a>>, OxcDiagnostic> {
         match binding {
             NonLocalBinding::ModuleLocal { name, .. } => {
                 if is_hook_name(name) {
@@ -446,10 +456,10 @@ impl<'a> Environment<'a> {
     /// Used internally to avoid double-borrow of `self`. Includes hook-name
     /// fallback matching TS `getPropertyType`.
     fn get_property_type_from_shapes(
-        shapes: &ShapeRegistry,
-        receiver: &Type,
+        shapes: &ShapeRegistry<'a>,
+        receiver: &Type<'a>,
         property: &str,
-    ) -> Option<Type> {
+    ) -> Option<Type<'a>> {
         let shape_id = match receiver {
             Type::Object { shape_id } | Type::Function { shape_id, .. } => shape_id.as_deref(),
             _ => None,
@@ -499,7 +509,7 @@ impl<'a> Environment<'a> {
     /// Resolve the module type provider for a given module name.
     /// Caches results. Checks pre-resolved provider results first, then falls
     /// back to `defaultModuleTypeProvider` (hardcoded).
-    fn resolve_module_type(&mut self, module_name: &str) -> Option<Global> {
+    fn resolve_module_type(&mut self, module_name: &str) -> Option<Global<'a>> {
         if let Some(cached) = self.module_types.get(module_name) {
             return cached.clone();
         }
@@ -522,11 +532,15 @@ impl<'a> Environment<'a> {
             );
             // Store errors for later reporting when the import is actually used
             for err in type_errors {
-                self.module_type_errors.entry(module_name.to_string()).or_default().push(err);
+                self.module_type_errors
+                    .entry(Ident::from_str_in(module_name, &self.allocator))
+                    .or_default()
+                    .push(err);
             }
             ty
         });
-        self.module_types.insert(module_name.to_string(), module_type.clone());
+        self.module_types
+            .insert(Ident::from_str_in(module_name, &self.allocator), module_type.clone());
         module_type
     }
 
@@ -535,7 +549,7 @@ impl<'a> Environment<'a> {
         lower == "react" || lower == "react-dom"
     }
 
-    fn get_custom_hook_type(&mut self) -> Global {
+    fn get_custom_hook_type(&mut self) -> Global<'a> {
         if self.config.enable_assume_hooks_follow_rules_of_react {
             if self.default_nonmutating_hook.is_none() {
                 self.default_nonmutating_hook = Some(default_nonmutating_hook(&mut self.shapes));
@@ -551,12 +565,12 @@ impl<'a> Environment<'a> {
 
     /// Public accessor for the custom hook type, used by InferTypes for
     /// property resolution fallback when a property name looks like a hook.
-    pub fn get_custom_hook_type_opt(&mut self) -> Option<Global> {
+    pub fn get_custom_hook_type_opt(&mut self) -> Option<Global<'a>> {
         Some(self.get_custom_hook_type())
     }
 
     /// Get a reference to the globals registry.
-    pub fn globals(&self) -> &GlobalRegistry {
+    pub fn globals(&self) -> &GlobalRegistry<'a> {
         &self.globals
     }
 
@@ -569,7 +583,7 @@ impl<'a> Environment<'a> {
     /// Like Babel's `generateUid`, checks for collisions against existing
     /// bindings (source-level identifier names) and previously generated UIDs,
     /// rather than using a blind counter.
-    pub fn generate_globally_unique_identifier_name(&mut self, name: Option<&str>) -> String {
+    pub fn generate_globally_unique_identifier_name(&mut self, name: Option<&str>) -> Ident<'a> {
         let base = name.unwrap_or("temp");
         // Apply Babel's toIdentifier sanitization:
         // 1. Replace non-identifier chars with '-'
@@ -613,10 +627,10 @@ impl<'a> Environment<'a> {
         // Lazily build the set of known names from existing identifiers.
         // This approximates Babel's hasBinding/hasGlobal/hasReference checks.
         if self.uid_known_names.is_none() {
-            let mut known = FxHashSet::default();
+            let mut known = IdentHashSet::default();
             for id in &self.identifiers {
                 if let Some(name) = &id.name {
-                    known.insert(name.value().to_string());
+                    known.insert(Ident::from(name.value()));
                 }
             }
             self.uid_known_names = Some(known);
@@ -625,8 +639,11 @@ impl<'a> Environment<'a> {
         // Find a name that doesn't collide, matching Babel's generateUid loop
         let mut i = 1u32;
         let uid = loop {
-            let candidate =
-                if i == 1 { format!("_{}", uid_base) } else { format!("_{}{}", uid_base, i) };
+            let candidate = if i == 1 {
+                format_ident!(self.allocator, "_{uid_base}")
+            } else {
+                format_ident!(self.allocator, "_{uid_base}{i}")
+            };
             i += 1;
             if !self.uid_known_names.as_ref().unwrap().contains(&candidate) {
                 break candidate;
@@ -634,7 +651,7 @@ impl<'a> Environment<'a> {
         };
 
         // Register the generated name so subsequent calls see it
-        self.uid_known_names.as_mut().unwrap().insert(uid.clone());
+        self.uid_known_names.as_mut().unwrap().insert(uid);
 
         uid
     }
@@ -642,15 +659,15 @@ impl<'a> Environment<'a> {
     /// Seed the UID known names set with external names (e.g. from ProgramContext).
     /// This ensures UID generation avoids names generated by previous function compilations,
     /// matching Babel's behavior where the program scope accumulates all generated UIDs.
-    pub fn seed_uid_known_names(&mut self, names: &FxHashSet<String>) {
+    pub fn seed_uid_known_names(&mut self, names: &IdentHashSet<'a>) {
         match &mut self.uid_known_names {
-            Some(existing) => existing.extend(names.iter().cloned()),
+            Some(existing) => existing.extend(names.iter().copied()),
             None => self.uid_known_names = Some(names.clone()),
         }
     }
 
     /// Return the UID known names accumulated during this compilation.
-    pub fn take_uid_known_names(&mut self) -> Option<FxHashSet<String>> {
+    pub fn take_uid_known_names(&mut self) -> Option<IdentHashSet<'a>> {
         self.uid_known_names.take()
     }
 
@@ -702,12 +719,6 @@ impl<'a> Environment<'a> {
     ) -> Result<Option<&HookKind>, OxcDiagnostic> {
         let ty = &self.types[self.identifiers[identifier_id.0 as usize].type_.0 as usize];
         self.get_hook_kind_for_type(ty)
-    }
-}
-
-impl Default for Environment<'_> {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/crates/oxc_react_compiler/src/react_compiler_hir/globals.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/globals.rs
@@ -8,8 +8,9 @@
 //! Provides `DEFAULT_SHAPES` (built-in object shapes) and `DEFAULT_GLOBALS`
 //! (global variable types including React hooks and JS built-ins).
 
-use rustc_hash::FxHashMap;
 use std::sync::LazyLock;
+
+use oxc_str::{Ident, IdentHashMap};
 
 use crate::react_compiler_hir::Effect;
 use crate::react_compiler_hir::Type;
@@ -27,37 +28,37 @@ use crate::react_compiler_hir::type_config::ValueReason;
 
 /// Type alias matching TS `Global = BuiltInType | PolyType`.
 /// In the Rust port, both map to our `Type` enum.
-pub type Global = Type;
+pub type Global<'a> = Type<'a>;
 
 /// Registry mapping global names to their types.
 ///
 /// Supports two modes:
-/// - **Builder mode** (`base=None`): wraps a single FxHashMap, used during
+/// - **Builder mode** (`base=None`): wraps a single map, used during
 ///   `build_default_globals` to construct the static base.
-/// - **Overlay mode** (`base=Some`): holds a `&'static FxHashMap` base plus a small
-///   extras FxHashMap. Lookups check extras first, then base. Inserts go into extras.
+/// - **Overlay mode** (`base=Some`): holds a `&'static` base map plus a small
+///   extras map. Lookups check extras first, then base. Inserts go into extras.
 ///   Cloning only copies the extras map (the base pointer is shared).
-pub struct GlobalRegistry {
-    base: Option<&'static FxHashMap<String, Global>>,
-    entries: FxHashMap<String, Global>,
+pub struct GlobalRegistry<'a> {
+    base: Option<&'static IdentHashMap<'static, Global<'static>>>,
+    entries: IdentHashMap<'a, Global<'a>>,
 }
 
-impl GlobalRegistry {
+impl<'a> GlobalRegistry<'a> {
     /// Create an empty builder-mode registry.
     pub fn new() -> Self {
-        Self { base: None, entries: FxHashMap::default() }
+        Self { base: None, entries: IdentHashMap::default() }
     }
 
     /// Create an overlay-mode registry backed by a static base.
-    pub fn with_base(base: &'static FxHashMap<String, Global>) -> Self {
-        Self { base: Some(base), entries: FxHashMap::default() }
+    pub fn with_base(base: &'static IdentHashMap<'static, Global<'static>>) -> Self {
+        Self { base: Some(base), entries: IdentHashMap::default() }
     }
 
-    pub fn get(&self, key: &str) -> Option<&Global> {
-        self.entries.get(key).or_else(|| self.base.and_then(|b| b.get(key)))
+    pub fn get(&self, key: &str) -> Option<&Global<'a>> {
+        self.entries.get(key).or_else(|| self.base.and_then(|b| b.get(key).map(shrink_global)))
     }
 
-    pub fn insert(&mut self, key: String, value: Global) {
+    pub fn insert(&mut self, key: Ident<'a>, value: Global<'a>) {
         self.entries.insert(key, value);
     }
 
@@ -73,25 +74,30 @@ impl GlobalRegistry {
             .into_iter()
             .flat_map(|b| b.keys())
             .filter(|k| !self.entries.contains_key(k.as_str()))
-            .map(String::as_str);
-        self.entries.keys().map(String::as_str).chain(base_keys)
+            .map(Ident::as_str);
+        self.entries.keys().map(Ident::as_str).chain(base_keys)
     }
 
-    /// Consume the registry and return the inner FxHashMap.
+    /// Consume the registry and return the inner map.
     /// Only valid in builder mode (no base).
-    pub fn into_inner(self) -> FxHashMap<String, Global> {
+    pub fn into_inner(self) -> IdentHashMap<'a, Global<'a>> {
         debug_assert!(self.base.is_none(), "into_inner() called on overlay-mode GlobalRegistry");
         self.entries
     }
 }
 
-impl Default for GlobalRegistry {
+/// Coerce a static global reference to the arena lifetime (covariant).
+fn shrink_global<'a, 'b>(global: &'b Global<'static>) -> &'b Global<'a> {
+    global
+}
+
+impl Default for GlobalRegistry<'_> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl Clone for GlobalRegistry {
+impl Clone for GlobalRegistry<'_> {
     fn clone(&self) -> Self {
         Self { base: self.base, entries: self.entries.clone() }
     }
@@ -102,8 +108,8 @@ impl Clone for GlobalRegistry {
 // =============================================================================
 
 struct BaseRegistries {
-    shapes: FxHashMap<String, ObjectShape>,
-    globals: FxHashMap<String, Global>,
+    shapes: IdentHashMap<'static, ObjectShape<'static>>,
+    globals: IdentHashMap<'static, Global<'static>>,
 }
 
 static BASE: LazyLock<BaseRegistries> = LazyLock::new(|| {
@@ -113,12 +119,12 @@ static BASE: LazyLock<BaseRegistries> = LazyLock::new(|| {
 });
 
 /// Get a reference to the static base shapes registry.
-pub fn base_shapes() -> &'static FxHashMap<String, ObjectShape> {
+pub fn base_shapes() -> &'static IdentHashMap<'static, ObjectShape<'static>> {
     &BASE.shapes
 }
 
 /// Get a reference to the static base globals registry.
-pub fn base_globals() -> &'static FxHashMap<String, Global> {
+pub fn base_globals() -> &'static IdentHashMap<'static, Global<'static>> {
     &BASE.globals
 }
 
@@ -127,29 +133,29 @@ pub fn base_globals() -> &'static FxHashMap<String, Global> {
 // =============================================================================
 
 /// Like `install_type_config` but collects validation errors.
-pub fn install_type_config_with_errors(
-    shapes: &mut ShapeRegistry,
+pub fn install_type_config_with_errors<'a>(
+    shapes: &mut ShapeRegistry<'a>,
     type_config: &TypeConfig,
     module_name: &str,
     errors: &mut Vec<String>,
-) -> Global {
+) -> Global<'a> {
     install_type_config_inner(shapes, type_config, module_name, &mut Some(errors))
 }
 
-fn install_type_config_inner(
-    shapes: &mut ShapeRegistry,
+fn install_type_config_inner<'a>(
+    shapes: &mut ShapeRegistry<'a>,
     type_config: &TypeConfig,
     module_name: &str,
     errors: &mut Option<&mut Vec<String>>,
-) -> Global {
+) -> Global<'a> {
     match type_config {
         TypeConfig::TypeReference(TypeReferenceConfig { name }) => match name {
-            BuiltInTypeRef::Array => Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID.to_string()) },
+            BuiltInTypeRef::Array => Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID) },
             BuiltInTypeRef::MixedReadonly => {
-                Type::Object { shape_id: Some(BUILT_IN_MIXED_READONLY_ID.to_string()) }
+                Type::Object { shape_id: Some(BUILT_IN_MIXED_READONLY_ID) }
             }
             BuiltInTypeRef::Primitive => Type::Primitive,
-            BuiltInTypeRef::Ref => Type::Object { shape_id: Some(BUILT_IN_USE_REF_ID.to_string()) },
+            BuiltInTypeRef::Ref => Type::Object { shape_id: Some(BUILT_IN_USE_REF_ID) },
             BuiltInTypeRef::Any => Type::Poly,
         },
         TypeConfig::Function(func_config) => {
@@ -170,9 +176,9 @@ fn install_type_config_inner(
                         .mutable_only_if_operands_are_mutable
                         .unwrap_or(false),
                     impure: func_config.impure.unwrap_or(false),
-                    canonical_name: func_config.canonical_name.clone(),
+                    canonical_name: func_config.canonical_name.clone().map(Into::into),
                     aliasing: func_config.aliasing.clone(),
-                    known_incompatible: func_config.known_incompatible.clone(),
+                    known_incompatible: func_config.known_incompatible.clone().map(Into::into),
                     ..Default::default()
                 },
                 None,
@@ -194,14 +200,14 @@ fn install_type_config_inner(
                     return_value_kind: hook_config.return_value_kind.unwrap_or(ValueKind::Frozen),
                     no_alias: hook_config.no_alias.unwrap_or(false),
                     aliasing: hook_config.aliasing.clone(),
-                    known_incompatible: hook_config.known_incompatible.clone(),
+                    known_incompatible: hook_config.known_incompatible.clone().map(Into::into),
                     ..Default::default()
                 },
                 None,
             )
         }
         TypeConfig::Object(obj_config) => {
-            let properties: Vec<(String, Type)> = obj_config
+            let properties: Vec<(Ident<'a>, Type<'a>)> = obj_config
                 .properties
                 .as_ref()
                 .map(|props| {
@@ -235,7 +241,7 @@ fn install_type_config_inner(
                                     ));
                                 }
                             }
-                            (key.clone(), ty)
+                            (shapes.alloc_ident(key), ty)
                         })
                         .collect()
                 })
@@ -251,14 +257,14 @@ fn install_type_config_inner(
 
 /// Build the built-in shapes registry. This corresponds to TS `BUILTIN_SHAPES`
 /// defined at module level in ObjectShape.ts.
-pub fn build_builtin_shapes() -> ShapeRegistry {
+pub fn build_builtin_shapes() -> ShapeRegistry<'static> {
     let mut shapes = ShapeRegistry::new();
 
     // BuiltInProps: { ref: UseRefType }
     add_object(
         &mut shapes,
         Some(BUILT_IN_PROPS_ID),
-        vec![("ref".to_string(), Type::Object { shape_id: Some(BUILT_IN_USE_REF_ID.to_string()) })],
+        vec![(Ident::from("ref"), Type::Object { shape_id: Some(BUILT_IN_USE_REF_ID) })],
     );
 
     build_array_shape(&mut shapes);
@@ -275,13 +281,13 @@ pub fn build_builtin_shapes() -> ShapeRegistry {
     shapes
 }
 
-fn simple_function(
-    shapes: &mut ShapeRegistry,
+fn simple_function<'a>(
+    shapes: &mut ShapeRegistry<'a>,
     positional_params: Vec<Effect>,
     rest_param: Option<Effect>,
-    return_type: Type,
+    return_type: Type<'a>,
     return_value_kind: ValueKind,
-) -> Type {
+) -> Type<'a> {
     add_function(
         shapes,
         Vec::new(),
@@ -298,7 +304,7 @@ fn simple_function(
 }
 
 /// Shorthand for a pure function returning Primitive.
-fn pure_primitive_fn(shapes: &mut ShapeRegistry) -> Type {
+fn pure_primitive_fn<'a>(shapes: &mut ShapeRegistry<'a>) -> Type<'a> {
     simple_function(shapes, Vec::new(), Some(Effect::Read), Type::Primitive, ValueKind::Primitive)
 }
 
@@ -335,7 +341,7 @@ fn build_array_shape(shapes: &mut ShapeRegistry) {
         Vec::new(),
         FunctionSignatureBuilder {
             rest_param: Some(Effect::Capture),
-            return_type: Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID.to_string()) },
+            return_type: Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID) },
             return_value_kind: ValueKind::Mutable,
             callee_effect: Effect::Capture,
             ..Default::default()
@@ -350,7 +356,7 @@ fn build_array_shape(shapes: &mut ShapeRegistry) {
         FunctionSignatureBuilder {
             rest_param: Some(Effect::Read),
             callee_effect: Effect::Capture,
-            return_type: Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID.to_string()) },
+            return_type: Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID) },
             return_value_kind: ValueKind::Mutable,
             ..Default::default()
         },
@@ -363,7 +369,7 @@ fn build_array_shape(shapes: &mut ShapeRegistry) {
         FunctionSignatureBuilder {
             rest_param: Some(Effect::ConditionallyMutate),
             callee_effect: Effect::ConditionallyMutate,
-            return_type: Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID.to_string()) },
+            return_type: Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID) },
             return_value_kind: ValueKind::Mutable,
             no_alias: true,
             mutable_only_if_operands_are_mutable: true,
@@ -425,7 +431,7 @@ fn build_array_shape(shapes: &mut ShapeRegistry) {
         FunctionSignatureBuilder {
             rest_param: Some(Effect::ConditionallyMutate),
             callee_effect: Effect::ConditionallyMutate,
-            return_type: Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID.to_string()) },
+            return_type: Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID) },
             return_value_kind: ValueKind::Mutable,
             no_alias: true,
             mutable_only_if_operands_are_mutable: true,
@@ -500,7 +506,7 @@ fn build_array_shape(shapes: &mut ShapeRegistry) {
         FunctionSignatureBuilder {
             rest_param: Some(Effect::ConditionallyMutate),
             callee_effect: Effect::ConditionallyMutate,
-            return_type: Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID.to_string()) },
+            return_type: Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID) },
             return_value_kind: ValueKind::Mutable,
             no_alias: true,
             mutable_only_if_operands_are_mutable: true,
@@ -550,22 +556,22 @@ fn build_array_shape(shapes: &mut ShapeRegistry) {
         shapes,
         Some(BUILT_IN_ARRAY_ID),
         vec![
-            ("indexOf".to_string(), index_of),
-            ("includes".to_string(), includes),
-            ("pop".to_string(), pop),
-            ("at".to_string(), at),
-            ("concat".to_string(), concat),
-            ("length".to_string(), length),
-            ("push".to_string(), push),
-            ("slice".to_string(), slice),
-            ("map".to_string(), map),
-            ("flatMap".to_string(), flat_map),
-            ("filter".to_string(), filter),
-            ("every".to_string(), every),
-            ("some".to_string(), some),
-            ("find".to_string(), find),
-            ("findIndex".to_string(), find_index),
-            ("join".to_string(), join),
+            (Ident::from("indexOf"), index_of),
+            (Ident::from("includes"), includes),
+            (Ident::from("pop"), pop),
+            (Ident::from("at"), at),
+            (Ident::from("concat"), concat),
+            (Ident::from("length"), length),
+            (Ident::from("push"), push),
+            (Ident::from("slice"), slice),
+            (Ident::from("map"), map),
+            (Ident::from("flatMap"), flat_map),
+            (Ident::from("filter"), filter),
+            (Ident::from("every"), every),
+            (Ident::from("some"), some),
+            (Ident::from("find"), find),
+            (Ident::from("findIndex"), find_index),
+            (Ident::from("join"), join),
             // TODO: rest of Array properties
         ],
     );
@@ -590,7 +596,7 @@ fn build_set_shape(shapes: &mut ShapeRegistry) {
         FunctionSignatureBuilder {
             positional_params: vec![Effect::Capture],
             callee_effect: Effect::Store,
-            return_type: Type::Object { shape_id: Some(BUILT_IN_SET_ID.to_string()) },
+            return_type: Type::Object { shape_id: Some(BUILT_IN_SET_ID) },
             return_value_kind: ValueKind::Mutable,
             aliasing: Some(AliasingSignatureConfig {
                 receiver: "@receiver".to_string(),
@@ -650,7 +656,7 @@ fn build_set_shape(shapes: &mut ShapeRegistry) {
         FunctionSignatureBuilder {
             positional_params: vec![Effect::Capture],
             callee_effect: Effect::Capture,
-            return_type: Type::Object { shape_id: Some(BUILT_IN_SET_ID.to_string()) },
+            return_type: Type::Object { shape_id: Some(BUILT_IN_SET_ID) },
             return_value_kind: ValueKind::Mutable,
             ..Default::default()
         },
@@ -663,7 +669,7 @@ fn build_set_shape(shapes: &mut ShapeRegistry) {
         FunctionSignatureBuilder {
             positional_params: vec![Effect::Capture],
             callee_effect: Effect::Capture,
-            return_type: Type::Object { shape_id: Some(BUILT_IN_SET_ID.to_string()) },
+            return_type: Type::Object { shape_id: Some(BUILT_IN_SET_ID) },
             return_value_kind: ValueKind::Mutable,
             ..Default::default()
         },
@@ -676,7 +682,7 @@ fn build_set_shape(shapes: &mut ShapeRegistry) {
         FunctionSignatureBuilder {
             positional_params: vec![Effect::Capture],
             callee_effect: Effect::Capture,
-            return_type: Type::Object { shape_id: Some(BUILT_IN_SET_ID.to_string()) },
+            return_type: Type::Object { shape_id: Some(BUILT_IN_SET_ID) },
             return_value_kind: ValueKind::Mutable,
             ..Default::default()
         },
@@ -765,20 +771,20 @@ fn build_set_shape(shapes: &mut ShapeRegistry) {
         shapes,
         Some(BUILT_IN_SET_ID),
         vec![
-            ("add".to_string(), add),
-            ("clear".to_string(), clear),
-            ("delete".to_string(), delete),
-            ("has".to_string(), has),
-            ("size".to_string(), size),
-            ("difference".to_string(), difference),
-            ("union".to_string(), union),
-            ("symmetricalDifference".to_string(), symmetrical_difference),
-            ("isSubsetOf".to_string(), is_subset_of),
-            ("isSupersetOf".to_string(), is_superset_of),
-            ("forEach".to_string(), for_each),
-            ("values".to_string(), values),
-            ("keys".to_string(), keys),
-            ("entries".to_string(), entries),
+            (Ident::from("add"), add),
+            (Ident::from("clear"), clear),
+            (Ident::from("delete"), delete),
+            (Ident::from("has"), has),
+            (Ident::from("size"), size),
+            (Ident::from("difference"), difference),
+            (Ident::from("union"), union),
+            (Ident::from("symmetricalDifference"), symmetrical_difference),
+            (Ident::from("isSubsetOf"), is_subset_of),
+            (Ident::from("isSupersetOf"), is_superset_of),
+            (Ident::from("forEach"), for_each),
+            (Ident::from("values"), values),
+            (Ident::from("keys"), keys),
+            (Ident::from("entries"), entries),
         ],
     );
 }
@@ -827,7 +833,7 @@ fn build_map_shape(shapes: &mut ShapeRegistry) {
         FunctionSignatureBuilder {
             positional_params: vec![Effect::Capture, Effect::Capture],
             callee_effect: Effect::Store,
-            return_type: Type::Object { shape_id: Some(BUILT_IN_MAP_ID.to_string()) },
+            return_type: Type::Object { shape_id: Some(BUILT_IN_MAP_ID) },
             return_value_kind: ValueKind::Mutable,
             ..Default::default()
         },
@@ -904,16 +910,16 @@ fn build_map_shape(shapes: &mut ShapeRegistry) {
         shapes,
         Some(BUILT_IN_MAP_ID),
         vec![
-            ("has".to_string(), has),
-            ("get".to_string(), get),
-            ("set".to_string(), set),
-            ("clear".to_string(), clear),
-            ("delete".to_string(), delete),
-            ("size".to_string(), size),
-            ("forEach".to_string(), for_each),
-            ("values".to_string(), values),
-            ("keys".to_string(), keys),
-            ("entries".to_string(), entries),
+            (Ident::from("has"), has),
+            (Ident::from("get"), get),
+            (Ident::from("set"), set),
+            (Ident::from("clear"), clear),
+            (Ident::from("delete"), delete),
+            (Ident::from("size"), size),
+            (Ident::from("forEach"), for_each),
+            (Ident::from("values"), values),
+            (Ident::from("keys"), keys),
+            (Ident::from("entries"), entries),
         ],
     );
 }
@@ -926,7 +932,7 @@ fn build_weak_set_shape(shapes: &mut ShapeRegistry) {
         FunctionSignatureBuilder {
             positional_params: vec![Effect::Capture],
             callee_effect: Effect::Store,
-            return_type: Type::Object { shape_id: Some(BUILT_IN_WEAK_SET_ID.to_string()) },
+            return_type: Type::Object { shape_id: Some(BUILT_IN_WEAK_SET_ID) },
             return_value_kind: ValueKind::Mutable,
             ..Default::default()
         },
@@ -950,7 +956,7 @@ fn build_weak_set_shape(shapes: &mut ShapeRegistry) {
     add_object(
         shapes,
         Some(BUILT_IN_WEAK_SET_ID),
-        vec![("has".to_string(), has), ("add".to_string(), add), ("delete".to_string(), delete)],
+        vec![(Ident::from("has"), has), (Ident::from("add"), add), (Ident::from("delete"), delete)],
     );
 }
 
@@ -975,7 +981,7 @@ fn build_weak_map_shape(shapes: &mut ShapeRegistry) {
         FunctionSignatureBuilder {
             positional_params: vec![Effect::Capture, Effect::Capture],
             callee_effect: Effect::Store,
-            return_type: Type::Object { shape_id: Some(BUILT_IN_WEAK_MAP_ID.to_string()) },
+            return_type: Type::Object { shape_id: Some(BUILT_IN_WEAK_MAP_ID) },
             return_value_kind: ValueKind::Mutable,
             ..Default::default()
         },
@@ -1000,10 +1006,10 @@ fn build_weak_map_shape(shapes: &mut ShapeRegistry) {
         shapes,
         Some(BUILT_IN_WEAK_MAP_ID),
         vec![
-            ("has".to_string(), has),
-            ("get".to_string(), get),
-            ("set".to_string(), set),
-            ("delete".to_string(), delete),
+            (Ident::from("has"), has),
+            (Ident::from("get"), get),
+            (Ident::from("set"), set),
+            (Ident::from("delete"), delete),
         ],
     );
 }
@@ -1021,7 +1027,7 @@ fn build_object_shape(shapes: &mut ShapeRegistry) {
         None,
         false,
     );
-    add_object(shapes, Some(BUILT_IN_OBJECT_ID), vec![("toString".to_string(), to_string)]);
+    add_object(shapes, Some(BUILT_IN_OBJECT_ID), vec![(Ident::from("toString"), to_string)]);
     // BuiltInFunction: empty shape
     add_object(shapes, Some(BUILT_IN_FUNCTION_ID), Vec::new());
     // BuiltInJsx: empty shape
@@ -1069,7 +1075,7 @@ fn build_object_shape(shapes: &mut ShapeRegistry) {
         Vec::new(),
         FunctionSignatureBuilder {
             positional_params: vec![Effect::Read],
-            return_type: Type::Object { shape_id: Some(BUILT_IN_MIXED_READONLY_ID.to_string()) },
+            return_type: Type::Object { shape_id: Some(BUILT_IN_MIXED_READONLY_ID) },
             callee_effect: Effect::Capture,
             return_value_kind: ValueKind::Frozen,
             ..Default::default()
@@ -1082,7 +1088,7 @@ fn build_object_shape(shapes: &mut ShapeRegistry) {
         Vec::new(),
         FunctionSignatureBuilder {
             rest_param: Some(Effect::ConditionallyMutate),
-            return_type: Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID.to_string()) },
+            return_type: Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID) },
             callee_effect: Effect::ConditionallyMutate,
             return_value_kind: ValueKind::Mutable,
             no_alias: true,
@@ -1096,7 +1102,7 @@ fn build_object_shape(shapes: &mut ShapeRegistry) {
         Vec::new(),
         FunctionSignatureBuilder {
             rest_param: Some(Effect::ConditionallyMutate),
-            return_type: Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID.to_string()) },
+            return_type: Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID) },
             callee_effect: Effect::ConditionallyMutate,
             return_value_kind: ValueKind::Mutable,
             no_alias: true,
@@ -1110,7 +1116,7 @@ fn build_object_shape(shapes: &mut ShapeRegistry) {
         Vec::new(),
         FunctionSignatureBuilder {
             rest_param: Some(Effect::ConditionallyMutate),
-            return_type: Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID.to_string()) },
+            return_type: Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID) },
             callee_effect: Effect::ConditionallyMutate,
             return_value_kind: ValueKind::Mutable,
             no_alias: true,
@@ -1124,7 +1130,7 @@ fn build_object_shape(shapes: &mut ShapeRegistry) {
         Vec::new(),
         FunctionSignatureBuilder {
             rest_param: Some(Effect::Capture),
-            return_type: Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID.to_string()) },
+            return_type: Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID) },
             callee_effect: Effect::Capture,
             return_value_kind: ValueKind::Mutable,
             ..Default::default()
@@ -1137,7 +1143,7 @@ fn build_object_shape(shapes: &mut ShapeRegistry) {
         Vec::new(),
         FunctionSignatureBuilder {
             rest_param: Some(Effect::Read),
-            return_type: Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID.to_string()) },
+            return_type: Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID) },
             callee_effect: Effect::Capture,
             return_value_kind: ValueKind::Mutable,
             ..Default::default()
@@ -1180,7 +1186,7 @@ fn build_object_shape(shapes: &mut ShapeRegistry) {
         Vec::new(),
         FunctionSignatureBuilder {
             rest_param: Some(Effect::ConditionallyMutate),
-            return_type: Type::Object { shape_id: Some(BUILT_IN_MIXED_READONLY_ID.to_string()) },
+            return_type: Type::Object { shape_id: Some(BUILT_IN_MIXED_READONLY_ID) },
             callee_effect: Effect::ConditionallyMutate,
             return_value_kind: ValueKind::Frozen,
             no_alias: true,
@@ -1217,27 +1223,25 @@ fn build_object_shape(shapes: &mut ShapeRegistry) {
         None,
         false,
     );
-    let mut mixed_props = FxHashMap::default();
-    mixed_props.insert("toString".to_string(), mixed_to_string);
-    mixed_props.insert("indexOf".to_string(), mixed_index_of);
-    mixed_props.insert("includes".to_string(), mixed_includes);
-    mixed_props.insert("at".to_string(), mixed_at);
-    mixed_props.insert("map".to_string(), mixed_map);
-    mixed_props.insert("flatMap".to_string(), mixed_flat_map);
-    mixed_props.insert("filter".to_string(), mixed_filter);
-    mixed_props.insert("concat".to_string(), mixed_concat);
-    mixed_props.insert("slice".to_string(), mixed_slice);
-    mixed_props.insert("every".to_string(), mixed_every);
-    mixed_props.insert("some".to_string(), mixed_some);
-    mixed_props.insert("find".to_string(), mixed_find);
-    mixed_props.insert("findIndex".to_string(), mixed_find_index);
-    mixed_props.insert("join".to_string(), mixed_join);
-    mixed_props.insert(
-        "*".to_string(),
-        Type::Object { shape_id: Some(BUILT_IN_MIXED_READONLY_ID.to_string()) },
-    );
+    let mut mixed_props = IdentHashMap::default();
+    mixed_props.insert(Ident::from("toString"), mixed_to_string);
+    mixed_props.insert(Ident::from("indexOf"), mixed_index_of);
+    mixed_props.insert(Ident::from("includes"), mixed_includes);
+    mixed_props.insert(Ident::from("at"), mixed_at);
+    mixed_props.insert(Ident::from("map"), mixed_map);
+    mixed_props.insert(Ident::from("flatMap"), mixed_flat_map);
+    mixed_props.insert(Ident::from("filter"), mixed_filter);
+    mixed_props.insert(Ident::from("concat"), mixed_concat);
+    mixed_props.insert(Ident::from("slice"), mixed_slice);
+    mixed_props.insert(Ident::from("every"), mixed_every);
+    mixed_props.insert(Ident::from("some"), mixed_some);
+    mixed_props.insert(Ident::from("find"), mixed_find);
+    mixed_props.insert(Ident::from("findIndex"), mixed_find_index);
+    mixed_props.insert(Ident::from("join"), mixed_join);
+    mixed_props
+        .insert(Ident::from("*"), Type::Object { shape_id: Some(BUILT_IN_MIXED_READONLY_ID) });
     shapes.insert(
-        BUILT_IN_MIXED_READONLY_ID.to_string(),
+        BUILT_IN_MIXED_READONLY_ID,
         ObjectShape { properties: mixed_props, function_type: None },
     );
 }
@@ -1247,16 +1251,13 @@ fn build_ref_shapes(shapes: &mut ShapeRegistry) {
     add_object(
         shapes,
         Some(BUILT_IN_USE_REF_ID),
-        vec![(
-            "current".to_string(),
-            Type::Object { shape_id: Some(BUILT_IN_REF_VALUE_ID.to_string()) },
-        )],
+        vec![(Ident::from("current"), Type::Object { shape_id: Some(BUILT_IN_REF_VALUE_ID) })],
     );
     // BuiltInRefValue: { *: Object { shapeId: BuiltInRefValue } } (self-referencing)
     add_object(
         shapes,
         Some(BUILT_IN_REF_VALUE_ID),
-        vec![("*".to_string(), Type::Object { shape_id: Some(BUILT_IN_REF_VALUE_ID.to_string()) })],
+        vec![(Ident::from("*"), Type::Object { shape_id: Some(BUILT_IN_REF_VALUE_ID) })],
     );
 }
 
@@ -1279,7 +1280,7 @@ fn build_state_shapes(shapes: &mut ShapeRegistry) {
     add_object(
         shapes,
         Some(BUILT_IN_USE_STATE_ID),
-        vec![("0".to_string(), Type::Poly), ("1".to_string(), set_state)],
+        vec![(Ident::from("0"), Type::Poly), (Ident::from("1"), set_state)],
     );
 
     // BuiltInSetActionState
@@ -1300,7 +1301,7 @@ fn build_state_shapes(shapes: &mut ShapeRegistry) {
     add_object(
         shapes,
         Some(BUILT_IN_USE_ACTION_STATE_ID),
-        vec![("0".to_string(), Type::Poly), ("1".to_string(), set_action_state)],
+        vec![(Ident::from("0"), Type::Poly), (Ident::from("1"), set_action_state)],
     );
 
     // BuiltInDispatch
@@ -1321,7 +1322,7 @@ fn build_state_shapes(shapes: &mut ShapeRegistry) {
     add_object(
         shapes,
         Some(BUILT_IN_USE_REDUCER_ID),
-        vec![("0".to_string(), Type::Poly), ("1".to_string(), dispatch)],
+        vec![(Ident::from("0"), Type::Poly), (Ident::from("1"), dispatch)],
     );
 
     // BuiltInStartTransition
@@ -1342,7 +1343,7 @@ fn build_state_shapes(shapes: &mut ShapeRegistry) {
     add_object(
         shapes,
         Some(BUILT_IN_USE_TRANSITION_ID),
-        vec![("0".to_string(), Type::Primitive), ("1".to_string(), start_transition)],
+        vec![(Ident::from("0"), Type::Primitive), (Ident::from("1"), start_transition)],
     );
 
     // BuiltInSetOptimistic
@@ -1363,7 +1364,7 @@ fn build_state_shapes(shapes: &mut ShapeRegistry) {
     add_object(
         shapes,
         Some(BUILT_IN_USE_OPTIMISTIC_ID),
-        vec![("0".to_string(), Type::Poly), ("1".to_string(), set_optimistic)],
+        vec![(Ident::from("0"), Type::Poly), (Ident::from("1"), set_optimistic)],
     );
 }
 
@@ -1390,8 +1391,8 @@ fn build_misc_shapes(shapes: &mut ShapeRegistry) {
 }
 
 /// Build the reanimated module type. Ported from TS `getReanimatedModuleType`.
-pub fn get_reanimated_module_type(shapes: &mut ShapeRegistry) -> Type {
-    let mut reanimated_type: Vec<(String, Type)> = Vec::new();
+pub fn get_reanimated_module_type<'a>(shapes: &mut ShapeRegistry<'a>) -> Type<'a> {
+    let mut reanimated_type: Vec<(Ident, Type)> = Vec::new();
 
     // hooks that freeze args and return frozen value
     let frozen_hooks = [
@@ -1415,7 +1416,7 @@ pub fn get_reanimated_module_type(shapes: &mut ShapeRegistry) -> Type {
             },
             None,
         );
-        reanimated_type.push((hook.to_string(), hook_type));
+        reanimated_type.push((Ident::from(*hook), hook_type));
     }
 
     // hooks that return a mutable value (modelled as shared value)
@@ -1425,9 +1426,7 @@ pub fn get_reanimated_module_type(shapes: &mut ShapeRegistry) -> Type {
             shapes,
             HookSignatureBuilder {
                 rest_param: Some(Effect::Freeze),
-                return_type: Type::Object {
-                    shape_id: Some(REANIMATED_SHARED_VALUE_ID.to_string()),
-                },
+                return_type: Type::Object { shape_id: Some(REANIMATED_SHARED_VALUE_ID) },
                 return_value_kind: ValueKind::Mutable,
                 no_alias: true,
                 hook_kind: HookKind::Custom,
@@ -1435,7 +1434,7 @@ pub fn get_reanimated_module_type(shapes: &mut ShapeRegistry) -> Type {
             },
             None,
         );
-        reanimated_type.push((hook.to_string(), hook_type));
+        reanimated_type.push((Ident::from(*hook), hook_type));
     }
 
     // functions that return mutable value
@@ -1462,7 +1461,7 @@ pub fn get_reanimated_module_type(shapes: &mut ShapeRegistry) -> Type {
             None,
             false,
         );
-        reanimated_type.push((func_name.to_string(), func_type));
+        reanimated_type.push((Ident::from(*func_name), func_type));
     }
 
     add_object(shapes, None, reanimated_type)
@@ -1476,7 +1475,7 @@ pub fn get_reanimated_module_type(shapes: &mut ShapeRegistry) -> Type {
 ///
 /// Requires a mutable reference to the shapes registry because some globals
 /// (like Object.keys, Array.isArray) register new shapes.
-pub fn build_default_globals(shapes: &mut ShapeRegistry) -> GlobalRegistry {
+pub fn build_default_globals(shapes: &mut ShapeRegistry<'static>) -> GlobalRegistry<'static> {
     let mut globals = GlobalRegistry::new();
 
     // React APIs — returns the list so we can reuse them for the React namespace
@@ -1485,7 +1484,7 @@ pub fn build_default_globals(shapes: &mut ShapeRegistry) -> GlobalRegistry {
     // Untyped globals (treated as Poly) — must come before typed globals
     // so typed definitions take priority (matching TS ordering)
     for name in UNTYPED_GLOBALS {
-        globals.insert(name.to_string(), Type::Poly);
+        globals.insert(Ident::from(*name), Type::Poly);
     }
 
     // Typed JS globals (overwrites Poly entries from UNTYPED_GLOBALS).
@@ -1495,10 +1494,13 @@ pub fn build_default_globals(shapes: &mut ShapeRegistry) -> GlobalRegistry {
     // globalThis and global — populated with all typed globals as properties
     // (matching TS: `addObject(DEFAULT_SHAPES, 'globalThis', TYPED_GLOBALS)`)
     globals.insert(
-        "globalThis".to_string(),
-        add_object(shapes, Some("globalThis"), typed_globals.clone()),
+        Ident::from("globalThis"),
+        add_object(shapes, Some(Ident::from("globalThis")), typed_globals.clone()),
     );
-    globals.insert("global".to_string(), add_object(shapes, Some("global"), typed_globals));
+    globals.insert(
+        Ident::from("global"),
+        add_object(shapes, Some(Ident::from("global")), typed_globals),
+    );
 
     globals
 }
@@ -1535,11 +1537,11 @@ const UNTYPED_GLOBALS: &[&str] = &[
 /// Build the React API types (REACT_APIS from TS). Returns the list of (name, type) pairs
 /// so they can be reused as properties of the React namespace object (matching TS behavior
 /// where the SAME type objects are used in both DEFAULT_GLOBALS and the React namespace).
-fn build_react_apis(
-    shapes: &mut ShapeRegistry,
-    globals: &mut GlobalRegistry,
-) -> Vec<(String, Type)> {
-    let mut react_apis: Vec<(String, Type)> = Vec::new();
+fn build_react_apis<'a>(
+    shapes: &mut ShapeRegistry<'a>,
+    globals: &mut GlobalRegistry<'a>,
+) -> Vec<(Ident<'a>, Type<'a>)> {
+    let mut react_apis: Vec<(Ident, Type)> = Vec::new();
 
     // useContext
     let use_context = add_hook(
@@ -1554,14 +1556,14 @@ fn build_react_apis(
         },
         Some(BUILT_IN_USE_CONTEXT_HOOK_ID),
     );
-    react_apis.push(("useContext".to_string(), use_context));
+    react_apis.push((Ident::from("useContext"), use_context));
 
     // useState
     let use_state = add_hook(
         shapes,
         HookSignatureBuilder {
             rest_param: Some(Effect::Freeze),
-            return_type: Type::Object { shape_id: Some(BUILT_IN_USE_STATE_ID.to_string()) },
+            return_type: Type::Object { shape_id: Some(BUILT_IN_USE_STATE_ID) },
             return_value_kind: ValueKind::Frozen,
             return_value_reason: Some(ValueReason::State),
             hook_kind: HookKind::UseState,
@@ -1569,14 +1571,14 @@ fn build_react_apis(
         },
         None,
     );
-    react_apis.push(("useState".to_string(), use_state));
+    react_apis.push((Ident::from("useState"), use_state));
 
     // useActionState
     let use_action_state = add_hook(
         shapes,
         HookSignatureBuilder {
             rest_param: Some(Effect::Freeze),
-            return_type: Type::Object { shape_id: Some(BUILT_IN_USE_ACTION_STATE_ID.to_string()) },
+            return_type: Type::Object { shape_id: Some(BUILT_IN_USE_ACTION_STATE_ID) },
             return_value_kind: ValueKind::Frozen,
             return_value_reason: Some(ValueReason::State),
             hook_kind: HookKind::UseActionState,
@@ -1584,14 +1586,14 @@ fn build_react_apis(
         },
         None,
     );
-    react_apis.push(("useActionState".to_string(), use_action_state));
+    react_apis.push((Ident::from("useActionState"), use_action_state));
 
     // useReducer
     let use_reducer = add_hook(
         shapes,
         HookSignatureBuilder {
             rest_param: Some(Effect::Freeze),
-            return_type: Type::Object { shape_id: Some(BUILT_IN_USE_REDUCER_ID.to_string()) },
+            return_type: Type::Object { shape_id: Some(BUILT_IN_USE_REDUCER_ID) },
             return_value_kind: ValueKind::Frozen,
             return_value_reason: Some(ValueReason::ReducerState),
             hook_kind: HookKind::UseReducer,
@@ -1599,21 +1601,21 @@ fn build_react_apis(
         },
         None,
     );
-    react_apis.push(("useReducer".to_string(), use_reducer));
+    react_apis.push((Ident::from("useReducer"), use_reducer));
 
     // useRef
     let use_ref = add_hook(
         shapes,
         HookSignatureBuilder {
             rest_param: Some(Effect::Capture),
-            return_type: Type::Object { shape_id: Some(BUILT_IN_USE_REF_ID.to_string()) },
+            return_type: Type::Object { shape_id: Some(BUILT_IN_USE_REF_ID) },
             return_value_kind: ValueKind::Mutable,
             hook_kind: HookKind::UseRef,
             ..Default::default()
         },
         None,
     );
-    react_apis.push(("useRef".to_string(), use_ref));
+    react_apis.push((Ident::from("useRef"), use_ref));
 
     // useImperativeHandle
     let use_imperative_handle = add_hook(
@@ -1627,7 +1629,7 @@ fn build_react_apis(
         },
         None,
     );
-    react_apis.push(("useImperativeHandle".to_string(), use_imperative_handle));
+    react_apis.push((Ident::from("useImperativeHandle"), use_imperative_handle));
 
     // useMemo
     let use_memo = add_hook(
@@ -1641,7 +1643,7 @@ fn build_react_apis(
         },
         None,
     );
-    react_apis.push(("useMemo".to_string(), use_memo));
+    react_apis.push((Ident::from("useMemo"), use_memo));
 
     // useCallback
     let use_callback = add_hook(
@@ -1655,7 +1657,7 @@ fn build_react_apis(
         },
         None,
     );
-    react_apis.push(("useCallback".to_string(), use_callback));
+    react_apis.push((Ident::from("useCallback"), use_callback));
 
     // useEffect (with aliasing signature)
     let use_effect = add_hook(
@@ -1696,7 +1698,7 @@ fn build_react_apis(
         },
         Some(BUILT_IN_USE_EFFECT_HOOK_ID),
     );
-    react_apis.push(("useEffect".to_string(), use_effect));
+    react_apis.push((Ident::from("useEffect"), use_effect));
 
     // useLayoutEffect
     let use_layout_effect = add_hook(
@@ -1710,7 +1712,7 @@ fn build_react_apis(
         },
         Some(BUILT_IN_USE_LAYOUT_EFFECT_HOOK_ID),
     );
-    react_apis.push(("useLayoutEffect".to_string(), use_layout_effect));
+    react_apis.push((Ident::from("useLayoutEffect"), use_layout_effect));
 
     // useInsertionEffect
     let use_insertion_effect = add_hook(
@@ -1724,28 +1726,28 @@ fn build_react_apis(
         },
         Some(BUILT_IN_USE_INSERTION_EFFECT_HOOK_ID),
     );
-    react_apis.push(("useInsertionEffect".to_string(), use_insertion_effect));
+    react_apis.push((Ident::from("useInsertionEffect"), use_insertion_effect));
 
     // useTransition
     let use_transition = add_hook(
         shapes,
         HookSignatureBuilder {
             rest_param: None,
-            return_type: Type::Object { shape_id: Some(BUILT_IN_USE_TRANSITION_ID.to_string()) },
+            return_type: Type::Object { shape_id: Some(BUILT_IN_USE_TRANSITION_ID) },
             return_value_kind: ValueKind::Frozen,
             hook_kind: HookKind::UseTransition,
             ..Default::default()
         },
         None,
     );
-    react_apis.push(("useTransition".to_string(), use_transition));
+    react_apis.push((Ident::from("useTransition"), use_transition));
 
     // useOptimistic
     let use_optimistic = add_hook(
         shapes,
         HookSignatureBuilder {
             rest_param: Some(Effect::Freeze),
-            return_type: Type::Object { shape_id: Some(BUILT_IN_USE_OPTIMISTIC_ID.to_string()) },
+            return_type: Type::Object { shape_id: Some(BUILT_IN_USE_OPTIMISTIC_ID) },
             return_value_kind: ValueKind::Frozen,
             return_value_reason: Some(ValueReason::State),
             hook_kind: HookKind::UseOptimistic,
@@ -1753,7 +1755,7 @@ fn build_react_apis(
         },
         None,
     );
-    react_apis.push(("useOptimistic".to_string(), use_optimistic));
+    react_apis.push((Ident::from("useOptimistic"), use_optimistic));
 
     // use (not a hook, it's a function)
     let use_fn = add_function(
@@ -1768,7 +1770,7 @@ fn build_react_apis(
         Some(BUILT_IN_USE_OPERATOR_ID),
         false,
     );
-    react_apis.push(("use".to_string(), use_fn));
+    react_apis.push((Ident::from("use"), use_fn));
 
     // useEffectEvent
     let use_effect_event = add_hook(
@@ -1776,7 +1778,7 @@ fn build_react_apis(
         HookSignatureBuilder {
             rest_param: Some(Effect::Freeze),
             return_type: Type::Function {
-                shape_id: Some(BUILT_IN_EFFECT_EVENT_ID.to_string()),
+                shape_id: Some(BUILT_IN_EFFECT_EVENT_ID),
                 return_type: Box::new(Type::Poly),
                 is_constructor: false,
             },
@@ -1786,30 +1788,30 @@ fn build_react_apis(
         },
         Some(BUILT_IN_USE_EFFECT_EVENT_ID),
     );
-    react_apis.push(("useEffectEvent".to_string(), use_effect_event));
+    react_apis.push((Ident::from("useEffectEvent"), use_effect_event));
 
     // Insert all React APIs as standalone globals
     for (name, ty) in &react_apis {
-        globals.insert(name.clone(), ty.clone());
+        globals.insert(*name, ty.clone());
     }
 
     react_apis
 }
 
 /// Build typed globals and return them as a list for use as globalThis/global properties.
-fn build_typed_globals(
-    shapes: &mut ShapeRegistry,
-    globals: &mut GlobalRegistry,
-    react_apis: Vec<(String, Type)>,
-) -> Vec<(String, Type)> {
-    let mut typed_globals: Vec<(String, Type)> = Vec::new();
+fn build_typed_globals<'a>(
+    shapes: &mut ShapeRegistry<'a>,
+    globals: &mut GlobalRegistry<'a>,
+    react_apis: Vec<(Ident<'a>, Type<'a>)>,
+) -> Vec<(Ident<'a>, Type<'a>)> {
+    let mut typed_globals: Vec<(Ident, Type)> = Vec::new();
     // Object
     let obj_keys = add_function(
         shapes,
         Vec::new(),
         FunctionSignatureBuilder {
             positional_params: vec![Effect::Read],
-            return_type: Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID.to_string()) },
+            return_type: Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID) },
             return_value_kind: ValueKind::Mutable,
             aliasing: Some(AliasingSignatureConfig {
                 receiver: "@receiver".to_string(),
@@ -1840,7 +1842,7 @@ fn build_typed_globals(
         Vec::new(),
         FunctionSignatureBuilder {
             positional_params: vec![Effect::ConditionallyMutate],
-            return_type: Type::Object { shape_id: Some(BUILT_IN_OBJECT_ID.to_string()) },
+            return_type: Type::Object { shape_id: Some(BUILT_IN_OBJECT_ID) },
             return_value_kind: ValueKind::Mutable,
             ..Default::default()
         },
@@ -1852,7 +1854,7 @@ fn build_typed_globals(
         Vec::new(),
         FunctionSignatureBuilder {
             positional_params: vec![Effect::Capture],
-            return_type: Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID.to_string()) },
+            return_type: Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID) },
             return_value_kind: ValueKind::Mutable,
             aliasing: Some(AliasingSignatureConfig {
                 receiver: "@receiver".to_string(),
@@ -1883,7 +1885,7 @@ fn build_typed_globals(
         Vec::new(),
         FunctionSignatureBuilder {
             positional_params: vec![Effect::Capture],
-            return_type: Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID.to_string()) },
+            return_type: Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID) },
             return_value_kind: ValueKind::Mutable,
             aliasing: Some(AliasingSignatureConfig {
                 receiver: "@receiver".to_string(),
@@ -1911,16 +1913,16 @@ fn build_typed_globals(
     );
     let object_global = add_object(
         shapes,
-        Some("Object"),
+        Some(Ident::from("Object")),
         vec![
-            ("keys".to_string(), obj_keys),
-            ("fromEntries".to_string(), obj_from_entries),
-            ("entries".to_string(), obj_entries),
-            ("values".to_string(), obj_values),
+            (Ident::from("keys"), obj_keys),
+            (Ident::from("fromEntries"), obj_from_entries),
+            (Ident::from("entries"), obj_entries),
+            (Ident::from("values"), obj_values),
         ],
     );
-    typed_globals.push(("Object".to_string(), object_global.clone()));
-    globals.insert("Object".to_string(), object_global);
+    typed_globals.push((Ident::from("Object"), object_global.clone()));
+    globals.insert(Ident::from("Object"), object_global);
 
     // Array
     let array_is_array = add_function(
@@ -1945,7 +1947,7 @@ fn build_typed_globals(
                 Effect::ConditionallyMutate,
             ],
             rest_param: Some(Effect::Read),
-            return_type: Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID.to_string()) },
+            return_type: Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID) },
             return_value_kind: ValueKind::Mutable,
             ..Default::default()
         },
@@ -1957,7 +1959,7 @@ fn build_typed_globals(
         Vec::new(),
         FunctionSignatureBuilder {
             rest_param: Some(Effect::Read),
-            return_type: Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID.to_string()) },
+            return_type: Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID) },
             return_value_kind: ValueKind::Mutable,
             ..Default::default()
         },
@@ -1966,23 +1968,23 @@ fn build_typed_globals(
     );
     let array_global = add_object(
         shapes,
-        Some("Array"),
+        Some(Ident::from("Array")),
         vec![
-            ("isArray".to_string(), array_is_array),
-            ("from".to_string(), array_from),
-            ("of".to_string(), array_of),
+            (Ident::from("isArray"), array_is_array),
+            (Ident::from("from"), array_from),
+            (Ident::from("of"), array_of),
         ],
     );
-    typed_globals.push(("Array".to_string(), array_global.clone()));
-    globals.insert("Array".to_string(), array_global);
+    typed_globals.push((Ident::from("Array"), array_global.clone()));
+    globals.insert(Ident::from("Array"), array_global);
 
     // Math
-    let math_fns: Vec<(String, Type)> = ["max", "min", "trunc", "ceil", "floor", "pow"]
+    let math_fns: Vec<(Ident, Type)> = ["max", "min", "trunc", "ceil", "floor", "pow"]
         .iter()
-        .map(|name| (name.to_string(), pure_primitive_fn(shapes)))
+        .map(|name| (Ident::from(*name), pure_primitive_fn(shapes)))
         .collect();
     let mut math_props = math_fns;
-    math_props.push(("PI".to_string(), Type::Primitive));
+    math_props.push((Ident::from("PI"), Type::Primitive));
     // Math.random is impure
     let math_random = add_function(
         shapes,
@@ -1991,16 +1993,16 @@ fn build_typed_globals(
             return_type: Type::Poly,
             return_value_kind: ValueKind::Mutable,
             impure: true,
-            canonical_name: Some("Math.random".to_string()),
+            canonical_name: Some("Math.random".into()),
             ..Default::default()
         },
         None,
         false,
     );
-    math_props.push(("random".to_string(), math_random));
-    let math_global = add_object(shapes, Some("Math"), math_props);
-    typed_globals.push(("Math".to_string(), math_global.clone()));
-    globals.insert("Math".to_string(), math_global);
+    math_props.push((Ident::from("random"), math_random));
+    let math_global = add_object(shapes, Some(Ident::from("Math")), math_props);
+    typed_globals.push((Ident::from("Math"), math_global.clone()));
+    globals.insert(Ident::from("Math"), math_global);
 
     // performance
     let perf_now = add_function(
@@ -2011,15 +2013,16 @@ fn build_typed_globals(
             return_type: Type::Poly,
             return_value_kind: ValueKind::Mutable,
             impure: true,
-            canonical_name: Some("performance.now".to_string()),
+            canonical_name: Some("performance.now".into()),
             ..Default::default()
         },
         None,
         false,
     );
-    let perf_global = add_object(shapes, Some("performance"), vec![("now".to_string(), perf_now)]);
-    typed_globals.push(("performance".to_string(), perf_global.clone()));
-    globals.insert("performance".to_string(), perf_global);
+    let perf_global =
+        add_object(shapes, Some(Ident::from("performance")), vec![(Ident::from("now"), perf_now)]);
+    typed_globals.push((Ident::from("performance"), perf_global.clone()));
+    globals.insert(Ident::from("performance"), perf_global);
 
     // Date
     let date_now = add_function(
@@ -2030,24 +2033,25 @@ fn build_typed_globals(
             return_type: Type::Poly,
             return_value_kind: ValueKind::Mutable,
             impure: true,
-            canonical_name: Some("Date.now".to_string()),
+            canonical_name: Some("Date.now".into()),
             ..Default::default()
         },
         None,
         false,
     );
-    let date_global = add_object(shapes, Some("Date"), vec![("now".to_string(), date_now)]);
-    typed_globals.push(("Date".to_string(), date_global.clone()));
-    globals.insert("Date".to_string(), date_global);
+    let date_global =
+        add_object(shapes, Some(Ident::from("Date")), vec![(Ident::from("now"), date_now)]);
+    typed_globals.push((Ident::from("Date"), date_global.clone()));
+    globals.insert(Ident::from("Date"), date_global);
 
     // console
-    let console_methods: Vec<(String, Type)> = ["error", "info", "log", "table", "trace", "warn"]
+    let console_methods: Vec<(Ident, Type)> = ["error", "info", "log", "table", "trace", "warn"]
         .iter()
-        .map(|name| (name.to_string(), pure_primitive_fn(shapes)))
+        .map(|name| (Ident::from(*name), pure_primitive_fn(shapes)))
         .collect();
-    let console_global = add_object(shapes, Some("console"), console_methods);
-    typed_globals.push(("console".to_string(), console_global.clone()));
-    globals.insert("console".to_string(), console_global);
+    let console_global = add_object(shapes, Some(Ident::from("console")), console_methods);
+    typed_globals.push((Ident::from("console"), console_global.clone()));
+    globals.insert(Ident::from("console"), console_global);
 
     // Simple global functions returning Primitive
     for name in &[
@@ -2064,15 +2068,15 @@ fn build_typed_globals(
         "decodeURIComponent",
     ] {
         let f = pure_primitive_fn(shapes);
-        typed_globals.push((name.to_string(), f.clone()));
-        globals.insert(name.to_string(), f);
+        typed_globals.push((Ident::from(*name), f.clone()));
+        globals.insert(Ident::from(*name), f);
     }
 
     // Primitive globals
-    typed_globals.push(("Infinity".to_string(), Type::Primitive));
-    globals.insert("Infinity".to_string(), Type::Primitive);
-    typed_globals.push(("NaN".to_string(), Type::Primitive));
-    globals.insert("NaN".to_string(), Type::Primitive);
+    typed_globals.push((Ident::from("Infinity"), Type::Primitive));
+    globals.insert(Ident::from("Infinity"), Type::Primitive);
+    typed_globals.push((Ident::from("NaN"), Type::Primitive));
+    globals.insert(Ident::from("NaN"), Type::Primitive);
 
     // Map, Set, WeakMap, WeakSet constructors
     let map_ctor = add_function(
@@ -2080,60 +2084,60 @@ fn build_typed_globals(
         Vec::new(),
         FunctionSignatureBuilder {
             positional_params: vec![Effect::ConditionallyMutateIterator],
-            return_type: Type::Object { shape_id: Some(BUILT_IN_MAP_ID.to_string()) },
+            return_type: Type::Object { shape_id: Some(BUILT_IN_MAP_ID) },
             return_value_kind: ValueKind::Mutable,
             ..Default::default()
         },
         None,
         true,
     );
-    typed_globals.push(("Map".to_string(), map_ctor.clone()));
-    globals.insert("Map".to_string(), map_ctor);
+    typed_globals.push((Ident::from("Map"), map_ctor.clone()));
+    globals.insert(Ident::from("Map"), map_ctor);
 
     let set_ctor = add_function(
         shapes,
         Vec::new(),
         FunctionSignatureBuilder {
             positional_params: vec![Effect::ConditionallyMutateIterator],
-            return_type: Type::Object { shape_id: Some(BUILT_IN_SET_ID.to_string()) },
+            return_type: Type::Object { shape_id: Some(BUILT_IN_SET_ID) },
             return_value_kind: ValueKind::Mutable,
             ..Default::default()
         },
         None,
         true,
     );
-    typed_globals.push(("Set".to_string(), set_ctor.clone()));
-    globals.insert("Set".to_string(), set_ctor);
+    typed_globals.push((Ident::from("Set"), set_ctor.clone()));
+    globals.insert(Ident::from("Set"), set_ctor);
 
     let weak_map_ctor = add_function(
         shapes,
         Vec::new(),
         FunctionSignatureBuilder {
             positional_params: vec![Effect::ConditionallyMutateIterator],
-            return_type: Type::Object { shape_id: Some(BUILT_IN_WEAK_MAP_ID.to_string()) },
+            return_type: Type::Object { shape_id: Some(BUILT_IN_WEAK_MAP_ID) },
             return_value_kind: ValueKind::Mutable,
             ..Default::default()
         },
         None,
         true,
     );
-    typed_globals.push(("WeakMap".to_string(), weak_map_ctor.clone()));
-    globals.insert("WeakMap".to_string(), weak_map_ctor);
+    typed_globals.push((Ident::from("WeakMap"), weak_map_ctor.clone()));
+    globals.insert(Ident::from("WeakMap"), weak_map_ctor);
 
     let weak_set_ctor = add_function(
         shapes,
         Vec::new(),
         FunctionSignatureBuilder {
             positional_params: vec![Effect::ConditionallyMutateIterator],
-            return_type: Type::Object { shape_id: Some(BUILT_IN_WEAK_SET_ID.to_string()) },
+            return_type: Type::Object { shape_id: Some(BUILT_IN_WEAK_SET_ID) },
             return_value_kind: ValueKind::Mutable,
             ..Default::default()
         },
         None,
         true,
     );
-    typed_globals.push(("WeakSet".to_string(), weak_set_ctor.clone()));
-    globals.insert("WeakSet".to_string(), weak_set_ctor);
+    typed_globals.push((Ident::from("WeakSet"), weak_set_ctor.clone()));
+    globals.insert(Ident::from("WeakSet"), weak_set_ctor);
 
     // React global object — reuses the same REACT_APIS types (matching TS behavior
     // where the same type objects are used as both standalone globals and React.* properties)
@@ -2166,7 +2170,7 @@ fn build_typed_globals(
         Vec::new(),
         FunctionSignatureBuilder {
             rest_param: Some(Effect::Capture),
-            return_type: Type::Object { shape_id: Some(BUILT_IN_USE_REF_ID.to_string()) },
+            return_type: Type::Object { shape_id: Some(BUILT_IN_USE_REF_ID) },
             return_value_kind: ValueKind::Mutable,
             ..Default::default()
         },
@@ -2175,14 +2179,14 @@ fn build_typed_globals(
     );
 
     // Build React namespace properties from react_apis + React-specific functions
-    let mut react_props: Vec<(String, Type)> = react_apis;
-    react_props.push(("createElement".to_string(), react_create_element));
-    react_props.push(("cloneElement".to_string(), react_clone_element));
-    react_props.push(("createRef".to_string(), react_create_ref));
+    let mut react_props: Vec<(Ident, Type)> = react_apis;
+    react_props.push((Ident::from("createElement"), react_create_element));
+    react_props.push((Ident::from("cloneElement"), react_clone_element));
+    react_props.push((Ident::from("createRef"), react_create_ref));
 
     let react_global = add_object(shapes, None, react_props);
-    typed_globals.push(("React".to_string(), react_global.clone()));
-    globals.insert("React".to_string(), react_global);
+    typed_globals.push((Ident::from("React"), react_global.clone()));
+    globals.insert(Ident::from("React"), react_global);
 
     // _jsx (used by JSX transform)
     let jsx_fn = add_function(
@@ -2197,8 +2201,8 @@ fn build_typed_globals(
         None,
         false,
     );
-    typed_globals.push(("_jsx".to_string(), jsx_fn.clone()));
-    globals.insert("_jsx".to_string(), jsx_fn);
+    typed_globals.push((Ident::from("_jsx"), jsx_fn.clone()));
+    globals.insert(Ident::from("_jsx"), jsx_fn);
 
     typed_globals
 }

--- a/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
@@ -14,6 +14,7 @@ use crate::react_compiler_utils::FxIndexSet;
 use oxc_ast::ast as oxc;
 use oxc_diagnostics::OxcDiagnostic;
 pub use oxc_span::Span;
+use oxc_str::{Ident, Str};
 pub use raw::RawTypeCategory;
 pub use reactive::*;
 
@@ -156,8 +157,8 @@ pub fn format_js_number(n: f64) -> String {
 #[derive(Debug, Clone)]
 pub struct HirFunction<'a> {
     pub span: Option<Span>,
-    pub id: Option<String>,
-    pub name_hint: Option<String>,
+    pub id: Option<Ident<'a>>,
+    pub name_hint: Option<Ident<'a>>,
     pub fn_type: ReactFunctionType,
     pub params: Vec<ParamPattern>,
     pub returns: Place,
@@ -166,7 +167,7 @@ pub struct HirFunction<'a> {
     pub instructions: Vec<Instruction<'a>>,
     pub generator: bool,
     pub is_async: bool,
-    pub directives: Vec<String>,
+    pub directives: Vec<Str<'a>>,
     pub aliasing_effects: Option<Vec<AliasingEffect>>,
 }
 
@@ -535,15 +536,15 @@ pub struct LValue {
 }
 
 #[derive(Debug, Clone)]
-pub struct LValuePattern {
-    pub pattern: Pattern,
+pub struct LValuePattern<'a> {
+    pub pattern: Pattern<'a>,
     pub kind: InstructionKind,
 }
 
 #[derive(Debug, Clone)]
-pub enum Pattern {
+pub enum Pattern<'a> {
     Array(ArrayPattern),
-    Object(ObjectPattern),
+    Object(ObjectPattern<'a>),
 }
 
 // =============================================================================
@@ -579,16 +580,16 @@ pub enum InstructionValue<'a> {
         span: Option<Span>,
     },
     Destructure {
-        lvalue: LValuePattern,
+        lvalue: LValuePattern<'a>,
         value: Place,
         span: Option<Span>,
     },
     Primitive {
-        value: PrimitiveValue,
+        value: PrimitiveValue<'a>,
         span: Option<Span>,
     },
     JSXText {
-        value: String,
+        value: Str<'a>,
         span: Option<Span>,
     },
     BinaryExpression {
@@ -620,7 +621,7 @@ pub enum InstructionValue<'a> {
     },
     TypeCastExpression {
         value: Place,
-        type_annotation_kind: Option<String>,
+        type_annotation_kind: Option<&'static str>,
         /// The original oxc AST type annotation subtree, preserved for codegen,
         /// which re-emits it by cloning into the output allocator (and applying any
         /// identifier renames via the environment for the rare rename case).
@@ -628,15 +629,15 @@ pub enum InstructionValue<'a> {
         span: Option<Span>,
     },
     JsxExpression {
-        tag: JsxTag,
-        props: Vec<JsxAttribute>,
+        tag: JsxTag<'a>,
+        props: Vec<JsxAttribute<'a>>,
         children: Option<Vec<Place>>,
         span: Option<Span>,
         opening_span: Option<Span>,
         closing_span: Option<Span>,
     },
     ObjectExpression {
-        properties: Vec<ObjectPropertyOrSpread>,
+        properties: Vec<ObjectPropertyOrSpread<'a>>,
         span: Option<Span>,
     },
     ObjectMethod {
@@ -652,29 +653,29 @@ pub enum InstructionValue<'a> {
         span: Option<Span>,
     },
     RegExpLiteral {
-        pattern: String,
-        flags: String,
+        pattern: Str<'a>,
+        flags: Str<'a>,
         span: Option<Span>,
     },
     MetaProperty {
-        meta: String,
-        property: String,
+        meta: Ident<'a>,
+        property: Ident<'a>,
         span: Option<Span>,
     },
     PropertyStore {
         object: Place,
-        property: PropertyLiteral,
+        property: PropertyLiteral<'a>,
         value: Place,
         span: Option<Span>,
     },
     PropertyLoad {
         object: Place,
-        property: PropertyLiteral,
+        property: PropertyLiteral<'a>,
         span: Option<Span>,
     },
     PropertyDelete {
         object: Place,
-        property: PropertyLiteral,
+        property: PropertyLiteral<'a>,
         span: Option<Span>,
     },
     ComputedStore {
@@ -694,17 +695,17 @@ pub enum InstructionValue<'a> {
         span: Option<Span>,
     },
     LoadGlobal {
-        binding: NonLocalBinding,
+        binding: NonLocalBinding<'a>,
         span: Option<Span>,
     },
     StoreGlobal {
-        name: String,
+        name: Ident<'a>,
         value: Place,
         span: Option<Span>,
     },
     FunctionExpression {
-        name: Option<String>,
-        name_hint: Option<String>,
+        name: Option<Ident<'a>>,
+        name_hint: Option<Ident<'a>>,
         lowered_func: LoweredFunction,
         expr_type: FunctionExpressionType,
         span: Option<Span>,
@@ -715,13 +716,13 @@ pub enum InstructionValue<'a> {
         // Upstream's HIR models only a single quasi with no interpolation; the
         // oxc port extends it to support `tag`-ed templates with `${...}`
         // interpolations (a deliberate divergence from the TS reference).
-        quasis: Vec<TemplateQuasi>,
+        quasis: Vec<TemplateQuasi<'a>>,
         subexprs: Vec<Place>,
         span: Option<Span>,
     },
     TemplateLiteral {
         subexprs: Vec<Place>,
-        quasis: Vec<TemplateQuasi>,
+        quasis: Vec<TemplateQuasi<'a>>,
         span: Option<Span>,
     },
     Await {
@@ -758,7 +759,7 @@ pub enum InstructionValue<'a> {
     },
     StartMemoize {
         manual_memo_id: u32,
-        deps: Option<Vec<ManualMemoDependency>>,
+        deps: Option<Vec<ManualMemoDependency<'a>>>,
         deps_span: Option<Option<Span>>,
         has_invalid_deps: bool,
         span: Option<Span>,
@@ -832,13 +833,13 @@ impl<'a> InstructionValue<'a> {
 // Supporting types
 // =============================================================================
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum PrimitiveValue {
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PrimitiveValue<'a> {
     Null,
     Undefined,
     Boolean(bool),
     Number(FloatValue),
-    String(crate::react_compiler_utils::JsString),
+    String(crate::react_compiler_utils::JsString<'a>),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -942,27 +943,27 @@ pub enum FunctionExpressionType {
 }
 
 #[derive(Debug, Clone)]
-pub struct TemplateQuasi {
-    pub raw: String,
-    pub cooked: Option<String>,
+pub struct TemplateQuasi<'a> {
+    pub raw: Str<'a>,
+    pub cooked: Option<Str<'a>>,
 }
 
 #[derive(Debug, Clone)]
-pub struct ManualMemoDependency {
-    pub root: ManualMemoDependencyRoot,
-    pub path: Vec<DependencyPathEntry>,
+pub struct ManualMemoDependency<'a> {
+    pub root: ManualMemoDependencyRoot<'a>,
+    pub path: Vec<DependencyPathEntry<'a>>,
     pub span: Option<Span>,
 }
 
 #[derive(Debug, Clone)]
-pub enum ManualMemoDependencyRoot {
+pub enum ManualMemoDependencyRoot<'a> {
     NamedLocal { value: Place, constant: bool },
-    Global { identifier_name: String },
+    Global { identifier_name: Ident<'a> },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DependencyPathEntry {
-    pub property: PropertyLiteral,
+pub struct DependencyPathEntry<'a> {
+    pub property: PropertyLiteral<'a>,
     pub optional: bool,
     pub span: Option<Span>,
 }
@@ -980,10 +981,10 @@ pub struct Place {
 }
 
 #[derive(Debug, Clone)]
-pub struct Identifier {
+pub struct Identifier<'a> {
     pub id: IdentifierId,
     pub declaration_id: DeclarationId,
-    pub name: Option<IdentifierName>,
+    pub name: Option<IdentifierName<'a>>,
     pub mutable_range: MutableRange,
     pub scope: Option<ScopeId>,
     pub type_: TypeId,
@@ -1015,16 +1016,16 @@ impl MutableRange {
     }
 }
 
-#[derive(Debug, Clone)]
-pub enum IdentifierName {
-    Named(String),
-    Promoted(String),
+#[derive(Debug, Clone, Copy)]
+pub enum IdentifierName<'a> {
+    Named(Ident<'a>),
+    Promoted(Ident<'a>),
 }
 
-impl IdentifierName {
-    pub fn value(&self) -> &str {
+impl<'a> IdentifierName<'a> {
+    pub fn value(&self) -> &'a str {
         match self {
-            IdentifierName::Named(v) | IdentifierName::Promoted(v) => v,
+            IdentifierName::Named(v) | IdentifierName::Promoted(v) => v.as_str(),
         }
     }
 }
@@ -1090,27 +1091,27 @@ pub enum ArrayPatternElement {
 }
 
 #[derive(Debug, Clone)]
-pub struct ObjectPattern {
-    pub properties: Vec<ObjectPropertyOrSpread>,
+pub struct ObjectPattern<'a> {
+    pub properties: Vec<ObjectPropertyOrSpread<'a>>,
 }
 
 #[derive(Debug, Clone)]
-pub enum ObjectPropertyOrSpread {
-    Property(ObjectProperty),
+pub enum ObjectPropertyOrSpread<'a> {
+    Property(ObjectProperty<'a>),
     Spread(SpreadPattern),
 }
 
 #[derive(Debug, Clone)]
-pub struct ObjectProperty {
-    pub key: ObjectPropertyKey,
+pub struct ObjectProperty<'a> {
+    pub key: ObjectPropertyKey<'a>,
     pub property_type: ObjectPropertyType,
     pub place: Place,
 }
 
 #[derive(Debug, Clone)]
-pub enum ObjectPropertyKey {
-    String { name: String },
-    Identifier { name: String },
+pub enum ObjectPropertyKey<'a> {
+    String { name: Ident<'a> },
+    Identifier { name: Ident<'a> },
     Computed { name: Place },
 }
 
@@ -1129,19 +1130,19 @@ impl std::fmt::Display for ObjectPropertyType {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum PropertyLiteral {
-    String(String),
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PropertyLiteral<'a> {
+    String(Ident<'a>),
     Number(FloatValue),
 }
 
-impl PropertyLiteral {
+impl PropertyLiteral<'_> {
     pub fn is_string(&self, value: &str) -> bool {
-        matches!(self, Self::String(s) if s == value)
+        matches!(self, Self::String(s) if *s == value)
     }
 }
 
-impl std::fmt::Display for PropertyLiteral {
+impl std::fmt::Display for PropertyLiteral<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             PropertyLiteral::String(s) => write!(f, "{}", s),
@@ -1169,20 +1170,20 @@ pub struct LoweredFunction {
 }
 
 #[derive(Debug, Clone)]
-pub struct BuiltinTag {
-    pub name: String,
+pub struct BuiltinTag<'a> {
+    pub name: Ident<'a>,
 }
 
 #[derive(Debug, Clone)]
-pub enum JsxTag {
+pub enum JsxTag<'a> {
     Place(Place),
-    Builtin(BuiltinTag),
+    Builtin(BuiltinTag<'a>),
 }
 
 #[derive(Debug, Clone)]
-pub enum JsxAttribute {
+pub enum JsxAttribute<'a> {
     SpreadAttribute { argument: Place },
-    Attribute { name: String, place: Place },
+    Attribute { name: Ident<'a>, place: Place },
 }
 
 // =============================================================================
@@ -1202,33 +1203,33 @@ pub enum BindingKind {
 }
 
 #[derive(Debug, Clone)]
-pub enum VariableBinding {
+pub enum VariableBinding<'a> {
     Identifier { identifier: IdentifierId, binding_kind: BindingKind },
-    Global { name: String },
-    ImportDefault { name: String, module: String },
-    ImportSpecifier { name: String, module: String, imported: String },
-    ImportNamespace { name: String, module: String },
-    ModuleLocal { name: String },
+    Global { name: Ident<'a> },
+    ImportDefault { name: Ident<'a>, module: Str<'a> },
+    ImportSpecifier { name: Ident<'a>, module: Str<'a>, imported: Ident<'a> },
+    ImportNamespace { name: Ident<'a>, module: Str<'a> },
+    ModuleLocal { name: Ident<'a> },
 }
 
 #[derive(Debug, Clone)]
-pub enum NonLocalBinding {
-    ImportDefault { name: String, module: String },
-    ImportSpecifier { name: String, module: String, imported: String },
-    ImportNamespace { name: String, module: String },
-    ModuleLocal { name: String },
-    Global { name: String },
+pub enum NonLocalBinding<'a> {
+    ImportDefault { name: Ident<'a>, module: Str<'a> },
+    ImportSpecifier { name: Ident<'a>, module: Str<'a>, imported: Ident<'a> },
+    ImportNamespace { name: Ident<'a>, module: Str<'a> },
+    ModuleLocal { name: Ident<'a> },
+    Global { name: Ident<'a> },
 }
 
-impl NonLocalBinding {
+impl<'a> NonLocalBinding<'a> {
     /// Returns the `name` field common to all variants.
-    pub fn name(&self) -> &str {
+    pub fn name(&self) -> Ident<'a> {
         match self {
             NonLocalBinding::ImportDefault { name, .. }
             | NonLocalBinding::ImportSpecifier { name, .. }
             | NonLocalBinding::ImportNamespace { name, .. }
             | NonLocalBinding::ModuleLocal { name, .. }
-            | NonLocalBinding::Global { name, .. } => name,
+            | NonLocalBinding::Global { name, .. } => *name,
         }
     }
 }
@@ -1238,15 +1239,15 @@ impl NonLocalBinding {
 // =============================================================================
 
 #[derive(Debug, Clone)]
-pub enum Type {
+pub enum Type<'a> {
     Primitive,
     Function {
-        shape_id: Option<String>,
-        return_type: Box<Type>,
+        shape_id: Option<Ident<'a>>,
+        return_type: Box<Type<'a>>,
         is_constructor: bool,
     },
     Object {
-        shape_id: Option<String>,
+        shape_id: Option<Ident<'a>>,
     },
     #[allow(clippy::enum_variant_names)]
     TypeVar {
@@ -1254,19 +1255,19 @@ pub enum Type {
     },
     Poly,
     Phi {
-        operands: Vec<Type>,
+        operands: Vec<Type<'a>>,
     },
     Property {
-        object_type: Box<Type>,
-        object_name: String,
-        property_name: PropertyNameKind,
+        object_type: Box<Type<'a>>,
+        object_name: Ident<'a>,
+        property_name: PropertyNameKind<'a>,
     },
     ObjectMethod,
 }
 
 #[derive(Debug, Clone)]
-pub enum PropertyNameKind {
-    Literal { value: PropertyLiteral },
+pub enum PropertyNameKind<'a> {
+    Literal { value: PropertyLiteral<'a> },
     Computed,
 }
 
@@ -1275,12 +1276,12 @@ pub enum PropertyNameKind {
 // =============================================================================
 
 #[derive(Debug, Clone)]
-pub struct ReactiveScope {
+pub struct ReactiveScope<'a> {
     pub id: ScopeId,
     pub range: MutableRange,
 
     /// The inputs to this reactive scope (populated by later passes)
-    pub dependencies: Vec<ReactiveScopeDependency>,
+    pub dependencies: Vec<ReactiveScopeDependency<'a>>,
 
     /// The set of values produced by this scope (populated by later passes)
     pub declarations: Vec<(IdentifierId, ReactiveScopeDeclaration)>,
@@ -1300,10 +1301,10 @@ pub struct ReactiveScope {
 
 /// A dependency of a reactive scope.
 #[derive(Debug, Clone)]
-pub struct ReactiveScopeDependency {
+pub struct ReactiveScopeDependency<'a> {
     pub identifier: IdentifierId,
     pub reactive: bool,
-    pub path: Vec<DependencyPathEntry>,
+    pub path: Vec<DependencyPathEntry<'a>>,
     pub span: Option<Span>,
 }
 
@@ -1425,27 +1426,27 @@ pub fn is_primitive_type(ty: &Type) -> bool {
 
 /// Returns true if the type is the props object.
 pub fn is_props_type(ty: &Type) -> bool {
-    matches!(ty, Type::Object { shape_id: Some(id) } if id == BUILT_IN_PROPS_ID)
+    matches!(ty, Type::Object { shape_id: Some(id) } if *id == BUILT_IN_PROPS_ID)
 }
 
 /// Returns true if the type is an array.
 pub fn is_array_type(ty: &Type) -> bool {
-    matches!(ty, Type::Object { shape_id: Some(id) } if id == BUILT_IN_ARRAY_ID)
+    matches!(ty, Type::Object { shape_id: Some(id) } if *id == BUILT_IN_ARRAY_ID)
 }
 
 /// Returns true if the type is JSX.
 pub fn is_jsx_type(ty: &Type) -> bool {
-    matches!(ty, Type::Object { shape_id: Some(id) } if id == BUILT_IN_JSX_ID)
+    matches!(ty, Type::Object { shape_id: Some(id) } if *id == BUILT_IN_JSX_ID)
 }
 
 /// Returns true if the identifier type is a ref value.
 pub fn is_ref_value_type(ty: &Type) -> bool {
-    matches!(ty, Type::Object { shape_id: Some(id) } if id == BUILT_IN_REF_VALUE_ID)
+    matches!(ty, Type::Object { shape_id: Some(id) } if *id == BUILT_IN_REF_VALUE_ID)
 }
 
 /// Returns true if the identifier type is useRef.
 pub fn is_use_ref_type(ty: &Type) -> bool {
-    matches!(ty, Type::Object { shape_id: Some(id) } if id == BUILT_IN_USE_REF_ID)
+    matches!(ty, Type::Object { shape_id: Some(id) } if *id == BUILT_IN_USE_REF_ID)
 }
 
 /// Returns true if the type is a ref or ref value.
@@ -1455,38 +1456,38 @@ pub fn is_ref_or_ref_value(ty: &Type) -> bool {
 
 /// Returns true if the type is a useState result (BuiltInUseState).
 pub fn is_use_state_type(ty: &Type) -> bool {
-    matches!(ty, Type::Object { shape_id: Some(id) } if id == object_shape::BUILT_IN_USE_STATE_ID)
+    matches!(ty, Type::Object { shape_id: Some(id) } if *id == object_shape::BUILT_IN_USE_STATE_ID)
 }
 
 /// Returns true if the type is a setState function (BuiltInSetState).
 pub fn is_set_state_type(ty: &Type) -> bool {
-    matches!(ty, Type::Function { shape_id: Some(id), .. } if id == object_shape::BUILT_IN_SET_STATE_ID)
+    matches!(ty, Type::Function { shape_id: Some(id), .. } if *id == object_shape::BUILT_IN_SET_STATE_ID)
 }
 
 /// Returns true if the type is a useEffect hook.
 pub fn is_use_effect_hook_type(ty: &Type) -> bool {
-    matches!(ty, Type::Function { shape_id: Some(id), .. } if id == object_shape::BUILT_IN_USE_EFFECT_HOOK_ID)
+    matches!(ty, Type::Function { shape_id: Some(id), .. } if *id == object_shape::BUILT_IN_USE_EFFECT_HOOK_ID)
 }
 
 /// Returns true if the type is a useLayoutEffect hook.
 pub fn is_use_layout_effect_hook_type(ty: &Type) -> bool {
-    matches!(ty, Type::Function { shape_id: Some(id), .. } if id == object_shape::BUILT_IN_USE_LAYOUT_EFFECT_HOOK_ID)
+    matches!(ty, Type::Function { shape_id: Some(id), .. } if *id == object_shape::BUILT_IN_USE_LAYOUT_EFFECT_HOOK_ID)
 }
 
 /// Returns true if the type is a useInsertionEffect hook.
 pub fn is_use_insertion_effect_hook_type(ty: &Type) -> bool {
-    matches!(ty, Type::Function { shape_id: Some(id), .. } if id == object_shape::BUILT_IN_USE_INSERTION_EFFECT_HOOK_ID)
+    matches!(ty, Type::Function { shape_id: Some(id), .. } if *id == object_shape::BUILT_IN_USE_INSERTION_EFFECT_HOOK_ID)
 }
 
 /// Returns true if the type is a useEffectEvent function.
 pub fn is_use_effect_event_type(ty: &Type) -> bool {
-    matches!(ty, Type::Function { shape_id: Some(id), .. } if id == object_shape::BUILT_IN_USE_EFFECT_EVENT_ID)
+    matches!(ty, Type::Function { shape_id: Some(id), .. } if *id == object_shape::BUILT_IN_USE_EFFECT_EVENT_ID)
 }
 
 /// Returns true if the type is a ref or ref-like mutable type (e.g. Reanimated shared values).
 pub fn is_ref_or_ref_like_mutable_type(ty: &Type) -> bool {
     matches!(ty, Type::Object { shape_id: Some(id) }
-        if id == object_shape::BUILT_IN_USE_REF_ID || id == object_shape::REANIMATED_SHARED_VALUE_ID)
+        if *id == object_shape::BUILT_IN_USE_REF_ID || *id == object_shape::REANIMATED_SHARED_VALUE_ID)
 }
 
 /// Returns true if the type is the `use()` operator (React.use).
@@ -1494,16 +1495,16 @@ pub fn is_use_operator_type(ty: &Type) -> bool {
     matches!(
         ty,
         Type::Function { shape_id: Some(id), .. }
-            if id == BUILT_IN_USE_OPERATOR_ID
+            if *id == BUILT_IN_USE_OPERATOR_ID
     )
 }
 
 /// Returns true if the type is a plain object (BuiltInObject).
 pub fn is_plain_object_type(ty: &Type) -> bool {
-    matches!(ty, Type::Object { shape_id: Some(id) } if id == object_shape::BUILT_IN_OBJECT_ID)
+    matches!(ty, Type::Object { shape_id: Some(id) } if *id == object_shape::BUILT_IN_OBJECT_ID)
 }
 
 /// Returns true if the type is a startTransition function (BuiltInStartTransition).
 pub fn is_start_transition_type(ty: &Type) -> bool {
-    matches!(ty, Type::Function { shape_id: Some(id), .. } if id == object_shape::BUILT_IN_START_TRANSITION_ID)
+    matches!(ty, Type::Function { shape_id: Some(id), .. } if *id == object_shape::BUILT_IN_START_TRANSITION_ID)
 }

--- a/crates/oxc_react_compiler/src/react_compiler_hir/object_shape.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/object_shape.rs
@@ -8,12 +8,14 @@
 //! Defines the shape registry used by Environment to resolve property types
 //! and function call signatures for built-in objects, hooks, and user-defined types.
 
+use std::borrow::Cow;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::fmt::Result as FmtResult;
 use std::sync::atomic::{AtomicU32, Ordering};
 
-use rustc_hash::FxHashMap;
+use oxc_allocator::Allocator;
+use oxc_str::{Ident, IdentHashMap, format_ident, static_ident};
 
 use crate::react_compiler_hir::Effect;
 use crate::react_compiler_hir::Type;
@@ -25,36 +27,38 @@ use crate::react_compiler_hir::type_config::{
 // Shape ID constants (matching TS ObjectShape.ts)
 // =============================================================================
 
-pub const BUILT_IN_PROPS_ID: &str = "BuiltInProps";
-pub const BUILT_IN_ARRAY_ID: &str = "BuiltInArray";
-pub const BUILT_IN_SET_ID: &str = "BuiltInSet";
-pub const BUILT_IN_MAP_ID: &str = "BuiltInMap";
-pub const BUILT_IN_WEAK_SET_ID: &str = "BuiltInWeakSet";
-pub const BUILT_IN_WEAK_MAP_ID: &str = "BuiltInWeakMap";
-pub const BUILT_IN_FUNCTION_ID: &str = "BuiltInFunction";
-pub const BUILT_IN_JSX_ID: &str = "BuiltInJsx";
-pub const BUILT_IN_OBJECT_ID: &str = "BuiltInObject";
-pub const BUILT_IN_USE_STATE_ID: &str = "BuiltInUseState";
-pub const BUILT_IN_SET_STATE_ID: &str = "BuiltInSetState";
-pub const BUILT_IN_USE_ACTION_STATE_ID: &str = "BuiltInUseActionState";
-pub const BUILT_IN_SET_ACTION_STATE_ID: &str = "BuiltInSetActionState";
-pub const BUILT_IN_USE_REF_ID: &str = "BuiltInUseRefId";
-pub const BUILT_IN_REF_VALUE_ID: &str = "BuiltInRefValue";
-pub const BUILT_IN_MIXED_READONLY_ID: &str = "BuiltInMixedReadonly";
-pub const BUILT_IN_USE_EFFECT_HOOK_ID: &str = "BuiltInUseEffectHook";
-pub const BUILT_IN_USE_LAYOUT_EFFECT_HOOK_ID: &str = "BuiltInUseLayoutEffectHook";
-pub const BUILT_IN_USE_INSERTION_EFFECT_HOOK_ID: &str = "BuiltInUseInsertionEffectHook";
-pub const BUILT_IN_USE_OPERATOR_ID: &str = "BuiltInUseOperator";
-pub const BUILT_IN_USE_REDUCER_ID: &str = "BuiltInUseReducer";
-pub const BUILT_IN_DISPATCH_ID: &str = "BuiltInDispatch";
-pub const BUILT_IN_USE_CONTEXT_HOOK_ID: &str = "BuiltInUseContextHook";
-pub const BUILT_IN_USE_TRANSITION_ID: &str = "BuiltInUseTransition";
-pub const BUILT_IN_USE_OPTIMISTIC_ID: &str = "BuiltInUseOptimistic";
-pub const BUILT_IN_SET_OPTIMISTIC_ID: &str = "BuiltInSetOptimistic";
-pub const BUILT_IN_START_TRANSITION_ID: &str = "BuiltInStartTransition";
-pub const BUILT_IN_USE_EFFECT_EVENT_ID: &str = "BuiltInUseEffectEvent";
-pub const BUILT_IN_EFFECT_EVENT_ID: &str = "BuiltInEffectEventFunction";
-pub const REANIMATED_SHARED_VALUE_ID: &str = "ReanimatedSharedValueId";
+pub const BUILT_IN_PROPS_ID: Ident<'static> = static_ident!("BuiltInProps");
+pub const BUILT_IN_ARRAY_ID: Ident<'static> = static_ident!("BuiltInArray");
+pub const BUILT_IN_SET_ID: Ident<'static> = static_ident!("BuiltInSet");
+pub const BUILT_IN_MAP_ID: Ident<'static> = static_ident!("BuiltInMap");
+pub const BUILT_IN_WEAK_SET_ID: Ident<'static> = static_ident!("BuiltInWeakSet");
+pub const BUILT_IN_WEAK_MAP_ID: Ident<'static> = static_ident!("BuiltInWeakMap");
+pub const BUILT_IN_FUNCTION_ID: Ident<'static> = static_ident!("BuiltInFunction");
+pub const BUILT_IN_JSX_ID: Ident<'static> = static_ident!("BuiltInJsx");
+pub const BUILT_IN_OBJECT_ID: Ident<'static> = static_ident!("BuiltInObject");
+pub const BUILT_IN_USE_STATE_ID: Ident<'static> = static_ident!("BuiltInUseState");
+pub const BUILT_IN_SET_STATE_ID: Ident<'static> = static_ident!("BuiltInSetState");
+pub const BUILT_IN_USE_ACTION_STATE_ID: Ident<'static> = static_ident!("BuiltInUseActionState");
+pub const BUILT_IN_SET_ACTION_STATE_ID: Ident<'static> = static_ident!("BuiltInSetActionState");
+pub const BUILT_IN_USE_REF_ID: Ident<'static> = static_ident!("BuiltInUseRefId");
+pub const BUILT_IN_REF_VALUE_ID: Ident<'static> = static_ident!("BuiltInRefValue");
+pub const BUILT_IN_MIXED_READONLY_ID: Ident<'static> = static_ident!("BuiltInMixedReadonly");
+pub const BUILT_IN_USE_EFFECT_HOOK_ID: Ident<'static> = static_ident!("BuiltInUseEffectHook");
+pub const BUILT_IN_USE_LAYOUT_EFFECT_HOOK_ID: Ident<'static> =
+    static_ident!("BuiltInUseLayoutEffectHook");
+pub const BUILT_IN_USE_INSERTION_EFFECT_HOOK_ID: Ident<'static> =
+    static_ident!("BuiltInUseInsertionEffectHook");
+pub const BUILT_IN_USE_OPERATOR_ID: Ident<'static> = static_ident!("BuiltInUseOperator");
+pub const BUILT_IN_USE_REDUCER_ID: Ident<'static> = static_ident!("BuiltInUseReducer");
+pub const BUILT_IN_DISPATCH_ID: Ident<'static> = static_ident!("BuiltInDispatch");
+pub const BUILT_IN_USE_CONTEXT_HOOK_ID: Ident<'static> = static_ident!("BuiltInUseContextHook");
+pub const BUILT_IN_USE_TRANSITION_ID: Ident<'static> = static_ident!("BuiltInUseTransition");
+pub const BUILT_IN_USE_OPTIMISTIC_ID: Ident<'static> = static_ident!("BuiltInUseOptimistic");
+pub const BUILT_IN_SET_OPTIMISTIC_ID: Ident<'static> = static_ident!("BuiltInSetOptimistic");
+pub const BUILT_IN_START_TRANSITION_ID: Ident<'static> = static_ident!("BuiltInStartTransition");
+pub const BUILT_IN_USE_EFFECT_EVENT_ID: Ident<'static> = static_ident!("BuiltInUseEffectEvent");
+pub const BUILT_IN_EFFECT_EVENT_ID: Ident<'static> = static_ident!("BuiltInEffectEventFunction");
+pub const REANIMATED_SHARED_VALUE_ID: Ident<'static> = static_ident!("ReanimatedSharedValueId");
 
 // =============================================================================
 // Core types
@@ -114,8 +118,8 @@ pub struct FunctionSignature {
     pub no_alias: bool,
     pub mutable_only_if_operands_are_mutable: bool,
     pub impure: bool,
-    pub known_incompatible: Option<String>,
-    pub canonical_name: Option<String>,
+    pub known_incompatible: Option<Cow<'static, str>>,
+    pub canonical_name: Option<Cow<'static, str>>,
     /// Aliasing signature in config form. Full parsing into AliasingSignature
     /// with Place values is deferred until the aliasing effects system is ported.
     pub aliasing: Option<AliasingSignatureConfig>,
@@ -124,73 +128,96 @@ pub struct FunctionSignature {
 /// Shape of an object or function type.
 /// Ported from TS `ObjectShape`.
 #[derive(Debug, Clone)]
-pub struct ObjectShape {
-    pub properties: FxHashMap<String, Type>,
+pub struct ObjectShape<'a> {
+    pub properties: IdentHashMap<'a, Type<'a>>,
     pub function_type: Option<FunctionSignature>,
 }
 
 /// Registry mapping shape IDs to their ObjectShape definitions.
 ///
 /// Supports two modes:
-/// - **Builder mode** (`base=None`): wraps a single FxHashMap, used during
+/// - **Builder mode** (`base=None`): wraps a single map, used during
 ///   `build_builtin_shapes` / `build_default_globals` to construct the static base.
-/// - **Overlay mode** (`base=Some`): holds a `&'static FxHashMap` base plus a small
-///   extras FxHashMap. Lookups check extras first, then base. Inserts go into extras.
+///   Anonymous shape ids minted here are leaked; they become part of the
+///   process-lifetime static tables anyway, and the build runs once.
+/// - **Overlay mode** (`base=Some`): holds a `&'static` base map plus a small
+///   extras map. Lookups check extras first, then base. Inserts go into extras,
+///   with anonymous ids allocated in the compilation arena.
 ///   Cloning only copies the extras map (the base pointer is shared).
-pub struct ShapeRegistry {
-    base: Option<&'static FxHashMap<String, ObjectShape>>,
-    entries: FxHashMap<String, ObjectShape>,
+pub struct ShapeRegistry<'a> {
+    base: Option<&'static IdentHashMap<'static, ObjectShape<'static>>>,
+    entries: IdentHashMap<'a, ObjectShape<'a>>,
+    allocator: Option<&'a Allocator>,
 }
 
-impl ShapeRegistry {
+impl<'a> ShapeRegistry<'a> {
     /// Create an empty builder-mode registry.
     pub fn new() -> Self {
-        Self { base: None, entries: FxHashMap::default() }
+        Self { base: None, entries: IdentHashMap::default(), allocator: None }
     }
 
     /// Create an overlay-mode registry backed by a static base.
-    pub fn with_base(base: &'static FxHashMap<String, ObjectShape>) -> Self {
-        Self { base: Some(base), entries: FxHashMap::default() }
+    pub fn with_base(
+        base: &'static IdentHashMap<'static, ObjectShape<'static>>,
+        allocator: &'a Allocator,
+    ) -> Self {
+        Self { base: Some(base), entries: IdentHashMap::default(), allocator: Some(allocator) }
     }
 
-    pub fn get(&self, key: &str) -> Option<&ObjectShape> {
-        self.entries.get(key).or_else(|| self.base.and_then(|b| b.get(key)))
+    pub fn get(&self, key: &str) -> Option<&ObjectShape<'a>> {
+        self.entries.get(key).or_else(|| self.base.and_then(|b| b.get(key).map(shrink_shape)))
     }
 
-    pub fn insert(&mut self, key: String, value: ObjectShape) {
+    pub fn insert(&mut self, key: Ident<'a>, value: ObjectShape<'a>) {
         self.entries.insert(key, value);
     }
 
-    /// Consume the registry and return the inner FxHashMap.
+    /// Consume the registry and return the inner map.
     /// Only valid in builder mode (no base).
-    pub fn into_inner(self) -> FxHashMap<String, ObjectShape> {
+    pub fn into_inner(self) -> IdentHashMap<'a, ObjectShape<'a>> {
         debug_assert!(self.base.is_none(), "into_inner() called on overlay-mode ShapeRegistry");
         self.entries
     }
+
+    /// Allocate an identifier with the registry's lifetime: in the compilation
+    /// arena in overlay mode, leaked in (once-per-process) builder mode.
+    pub fn alloc_ident(&self, s: &str) -> Ident<'a> {
+        match self.allocator {
+            Some(allocator) => Ident::from_str_in(s, &allocator),
+            None => Ident::from(&*s.to_string().leak()),
+        }
+    }
+
+    /// Mint a unique anonymous shape id. Mirrors TS `nextAnonId` in ObjectShape.ts.
+    /// The counter is process-global so ids stay unique across the static base
+    /// build and every per-compilation registry.
+    fn next_anon_id(&self) -> Ident<'a> {
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        match self.allocator {
+            Some(allocator) => format_ident!(allocator, "<generated_{id}>"),
+            // Builder mode runs once per process to construct the static base
+            // tables; its handful of generated ids are static data.
+            None => Ident::from(&*format!("<generated_{id}>").leak()),
+        }
+    }
 }
 
-impl Default for ShapeRegistry {
+/// Coerce a static shape reference to the arena lifetime (covariant).
+fn shrink_shape<'a, 'b>(shape: &'b ObjectShape<'static>) -> &'b ObjectShape<'a> {
+    shape
+}
+
+impl Default for ShapeRegistry<'_> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl Clone for ShapeRegistry {
+impl Clone for ShapeRegistry<'_> {
     fn clone(&self) -> Self {
-        Self { base: self.base, entries: self.entries.clone() }
+        Self { base: self.base, entries: self.entries.clone(), allocator: self.allocator }
     }
-}
-
-// =============================================================================
-// Counter for anonymous shape IDs
-// =============================================================================
-
-/// Thread-local counter for generating unique anonymous shape IDs.
-/// Mirrors TS `nextAnonId` in ObjectShape.ts.
-fn next_anon_id() -> String {
-    static COUNTER: AtomicU32 = AtomicU32::new(0);
-    let id = COUNTER.fetch_add(1, Ordering::Relaxed);
-    format!("<generated_{}>", id)
 }
 
 // =============================================================================
@@ -199,18 +226,18 @@ fn next_anon_id() -> String {
 
 /// Add a non-hook function to a ShapeRegistry.
 /// Returns a `Type::Function` representing the added function.
-pub fn add_function(
-    registry: &mut ShapeRegistry,
-    properties: Vec<(String, Type)>,
-    sig: FunctionSignatureBuilder,
-    id: Option<&str>,
+pub fn add_function<'a>(
+    registry: &mut ShapeRegistry<'a>,
+    properties: Vec<(Ident<'a>, Type<'a>)>,
+    sig: FunctionSignatureBuilder<'a>,
+    id: Option<Ident<'a>>,
     is_constructor: bool,
-) -> Type {
-    let shape_id = id.map(|s| s.to_string()).unwrap_or_else(next_anon_id);
+) -> Type<'a> {
+    let shape_id = id.unwrap_or_else(|| registry.next_anon_id());
     let return_type = sig.return_type.clone();
     add_shape(
         registry,
-        &shape_id,
+        shape_id,
         properties,
         Some(FunctionSignature {
             positional_params: sig.positional_params,
@@ -232,12 +259,16 @@ pub fn add_function(
 
 /// Add a hook to a ShapeRegistry.
 /// Returns a `Type::Function` representing the added hook.
-pub fn add_hook(registry: &mut ShapeRegistry, sig: HookSignatureBuilder, id: Option<&str>) -> Type {
-    let shape_id = id.map(|s| s.to_string()).unwrap_or_else(next_anon_id);
+pub fn add_hook<'a>(
+    registry: &mut ShapeRegistry<'a>,
+    sig: HookSignatureBuilder<'a>,
+    id: Option<Ident<'a>>,
+) -> Type<'a> {
+    let shape_id = id.unwrap_or_else(|| registry.next_anon_id());
     let return_type = sig.return_type.clone();
     add_shape(
         registry,
-        &shape_id,
+        shape_id,
         Vec::new(),
         Some(FunctionSignature {
             positional_params: sig.positional_params,
@@ -263,27 +294,27 @@ pub fn add_hook(registry: &mut ShapeRegistry, sig: HookSignatureBuilder, id: Opt
 
 /// Add an object to a ShapeRegistry.
 /// Returns a `Type::Object` representing the added object.
-pub fn add_object(
-    registry: &mut ShapeRegistry,
-    id: Option<&str>,
-    properties: Vec<(String, Type)>,
-) -> Type {
-    let shape_id = id.map(|s| s.to_string()).unwrap_or_else(next_anon_id);
-    add_shape(registry, &shape_id, properties, None);
+pub fn add_object<'a>(
+    registry: &mut ShapeRegistry<'a>,
+    id: Option<Ident<'a>>,
+    properties: Vec<(Ident<'a>, Type<'a>)>,
+) -> Type<'a> {
+    let shape_id = id.unwrap_or_else(|| registry.next_anon_id());
+    add_shape(registry, shape_id, properties, None);
     Type::Object { shape_id: Some(shape_id) }
 }
 
-fn add_shape(
-    registry: &mut ShapeRegistry,
-    id: &str,
-    properties: Vec<(String, Type)>,
+fn add_shape<'a>(
+    registry: &mut ShapeRegistry<'a>,
+    id: Ident<'a>,
+    properties: Vec<(Ident<'a>, Type<'a>)>,
     function_type: Option<FunctionSignature>,
 ) {
     let shape = ObjectShape { properties: properties.into_iter().collect(), function_type };
     // Note: TS has an invariant that the id doesn't already exist. We use
     // insert which overwrites. In practice duplicates don't occur for built-in
     // shapes, and for user configs we want last-write-wins behavior.
-    registry.insert(id.to_string(), shape);
+    registry.insert(id, shape);
 }
 
 // =============================================================================
@@ -291,22 +322,22 @@ fn add_shape(
 // =============================================================================
 
 /// Builder for non-hook function signatures.
-pub struct FunctionSignatureBuilder {
+pub struct FunctionSignatureBuilder<'a> {
     pub positional_params: Vec<Effect>,
     pub rest_param: Option<Effect>,
-    pub return_type: Type,
+    pub return_type: Type<'a>,
     pub return_value_kind: ValueKind,
     pub return_value_reason: Option<ValueReason>,
     pub callee_effect: Effect,
     pub no_alias: bool,
     pub mutable_only_if_operands_are_mutable: bool,
     pub impure: bool,
-    pub known_incompatible: Option<String>,
-    pub canonical_name: Option<String>,
+    pub known_incompatible: Option<Cow<'static, str>>,
+    pub canonical_name: Option<Cow<'static, str>>,
     pub aliasing: Option<AliasingSignatureConfig>,
 }
 
-impl Default for FunctionSignatureBuilder {
+impl Default for FunctionSignatureBuilder<'_> {
     fn default() -> Self {
         Self {
             positional_params: Vec::new(),
@@ -326,20 +357,20 @@ impl Default for FunctionSignatureBuilder {
 }
 
 /// Builder for hook signatures.
-pub struct HookSignatureBuilder {
+pub struct HookSignatureBuilder<'a> {
     pub positional_params: Vec<Effect>,
     pub rest_param: Option<Effect>,
-    pub return_type: Type,
+    pub return_type: Type<'a>,
     pub return_value_kind: ValueKind,
     pub return_value_reason: Option<ValueReason>,
     pub callee_effect: Effect,
     pub hook_kind: HookKind,
     pub no_alias: bool,
-    pub known_incompatible: Option<String>,
+    pub known_incompatible: Option<Cow<'static, str>>,
     pub aliasing: Option<AliasingSignatureConfig>,
 }
 
-impl Default for HookSignatureBuilder {
+impl Default for HookSignatureBuilder<'_> {
     fn default() -> Self {
         Self {
             positional_params: Vec::new(),
@@ -362,7 +393,7 @@ impl Default for HookSignatureBuilder {
 
 /// Default type for hooks when enableAssumeHooksFollowRulesOfReact is true.
 /// Matches TS `DefaultNonmutatingHook`.
-pub fn default_nonmutating_hook(registry: &mut ShapeRegistry) -> Type {
+pub fn default_nonmutating_hook<'a>(registry: &mut ShapeRegistry<'a>) -> Type<'a> {
     add_hook(
         registry,
         HookSignatureBuilder {
@@ -397,13 +428,13 @@ pub fn default_nonmutating_hook(registry: &mut ShapeRegistry) -> Type {
             }),
             ..Default::default()
         },
-        Some("DefaultNonmutatingHook"),
+        Some(static_ident!("DefaultNonmutatingHook")),
     )
 }
 
 /// Default type for hooks when enableAssumeHooksFollowRulesOfReact is false.
 /// Matches TS `DefaultMutatingHook`.
-pub fn default_mutating_hook(registry: &mut ShapeRegistry) -> Type {
+pub fn default_mutating_hook<'a>(registry: &mut ShapeRegistry<'a>) -> Type<'a> {
     add_hook(
         registry,
         HookSignatureBuilder {
@@ -413,6 +444,6 @@ pub fn default_mutating_hook(registry: &mut ShapeRegistry) -> Type {
             hook_kind: HookKind::Custom,
             ..Default::default()
         },
-        Some("DefaultMutatingHook"),
+        Some(static_ident!("DefaultMutatingHook")),
     )
 }

--- a/crates/oxc_react_compiler/src/react_compiler_hir/reactive.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/reactive.rs
@@ -15,6 +15,8 @@ use std::fmt::Display;
 use std::fmt::Formatter;
 use std::fmt::Result as FmtResult;
 
+use oxc_str::{Ident, Str};
+
 use crate::react_compiler_hir::{
     BlockId, EvaluationOrder, InstructionValue, LogicalOperator, ParamPattern, Place, ScopeId, Span,
 };
@@ -28,13 +30,13 @@ use crate::react_compiler_hir::{
 #[derive(Debug, Clone)]
 pub struct ReactiveFunction<'a> {
     pub span: Option<Span>,
-    pub id: Option<String>,
-    pub name_hint: Option<String>,
+    pub id: Option<Ident<'a>>,
+    pub name_hint: Option<Ident<'a>>,
     pub params: Vec<ParamPattern>,
     pub generator: bool,
     pub is_async: bool,
     pub body: ReactiveBlock<'a>,
-    pub directives: Vec<String>,
+    pub directives: Vec<Str<'a>>,
     // No env field — passed separately per established Rust convention
 }
 

--- a/crates/oxc_react_compiler/src/react_compiler_inference/analyse_functions.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/analyse_functions.rs
@@ -102,9 +102,9 @@ where
 /// Run mutation/aliasing inference on an inner function.
 ///
 /// Corresponds to TS `lowerWithMutationAliasing(fn: HIRFunction): void`.
-fn lower_with_mutation_aliasing<F>(
-    func: &mut HirFunction,
-    env: &mut Environment,
+fn lower_with_mutation_aliasing<'a, F>(
+    func: &mut HirFunction<'a>,
+    env: &mut Environment<'a>,
     debug_logger: &mut F,
 ) -> Result<(), OxcDiagnostic>
 where

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
@@ -3008,7 +3008,7 @@ fn conditionally_mutate_iterator(place: &Place, ty: &Type) -> Option<AliasingEff
 
 fn is_builtin_collection_type(ty: &Type) -> bool {
     matches!(ty, Type::Object { shape_id: Some(id) }
-        if id == BUILT_IN_ARRAY_ID || id == BUILT_IN_SET_ID || id == BUILT_IN_MAP_ID
+        if *id == BUILT_IN_ARRAY_ID || *id == BUILT_IN_SET_ID || *id == BUILT_IN_MAP_ID
     )
 }
 
@@ -3033,7 +3033,7 @@ fn get_hook_kind_for_type<'a>(
 }
 
 /// Format a Type for printPlace-style output, matching TS's `printType()`.
-fn format_type_for_print(ty: &Type) -> Cow<'_, str> {
+fn format_type_for_print<'t>(ty: &'t Type) -> Cow<'t, str> {
     match ty {
         Type::Primitive => Cow::Borrowed(""),
         Type::Function { shape_id, return_type, .. } => {
@@ -3144,7 +3144,7 @@ enum PatternItem<'a> {
     Spread(&'a Place),
 }
 
-fn each_pattern_items(pattern: &Pattern) -> Vec<PatternItem<'_>> {
+fn each_pattern_items<'p>(pattern: &'p Pattern) -> Vec<PatternItem<'p>> {
     let mut items = Vec::new();
     match pattern {
         Pattern::Array(arr) => {

--- a/crates/oxc_react_compiler/src/react_compiler_inference/memoize_fbt_and_macro_operands_in_same_scope.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/memoize_fbt_and_macro_operands_in_same_scope.rs
@@ -126,7 +126,7 @@ fn populate_macro_tags(
                 }
                 InstructionValue::LoadGlobal { binding, .. } => {
                     let name = binding.name();
-                    if let Some(macro_def) = macro_kinds.get(name) {
+                    if let Some(macro_def) = macro_kinds.get(name.as_str()) {
                         macro_tags.insert(lvalue_id, macro_def.clone());
                     }
                 }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/merge_overlapping_reactive_scopes_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/merge_overlapping_reactive_scopes_hir.rs
@@ -376,10 +376,10 @@ pub fn merge_overlapping_reactive_scopes_hir(func: &mut HirFunction, env: &mut E
 
 /// Collect operand IdentifierIds with their types from an instruction value.
 /// Used to check for Primitive type on FunctionExpression/ObjectMethod operands.
-fn each_instruction_operand_ids_with_types(
+fn each_instruction_operand_ids_with_types<'a>(
     instr: &Instruction,
-    env: &Environment,
-) -> Vec<(IdentifierId, Type)> {
+    env: &Environment<'a>,
+) -> Vec<(IdentifierId, Type<'a>)> {
     visitors::each_instruction_operand(instr, env)
         .into_iter()
         .map(|p| {

--- a/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
@@ -34,7 +34,7 @@ use crate::react_compiler_hir::{
 
 /// Main entry point: propagate scope dependencies through the HIR.
 /// Corresponds to TS `propagateScopeDependenciesHIR(fn)`.
-pub fn propagate_scope_dependencies_hir(func: &mut HirFunction, env: &mut Environment) {
+pub fn propagate_scope_dependencies_hir<'a>(func: &mut HirFunction<'a>, env: &mut Environment<'a>) {
     let used_outside_declaring_scope = find_temporaries_used_outside_declaring_scope(func, env);
     let temporaries = collect_temporaries_sidemap(func, env, &used_outside_declaring_scope);
 
@@ -218,11 +218,11 @@ fn find_temporaries_used_outside_declaring_scope(
 // =============================================================================
 
 /// Corresponds to TS `collectTemporariesSidemap`.
-fn collect_temporaries_sidemap(
-    func: &HirFunction,
-    env: &Environment,
+fn collect_temporaries_sidemap<'a>(
+    func: &HirFunction<'a>,
+    env: &Environment<'a>,
     used_outside_declaring_scope: &FxHashSet<DeclarationId>,
-) -> FxHashMap<IdentifierId, ReactiveScopeDependency> {
+) -> FxHashMap<IdentifierId, ReactiveScopeDependency<'a>> {
     let mut temporaries = FxHashMap::default();
     collect_temporaries_sidemap_impl(
         func,
@@ -260,11 +260,11 @@ fn convert_hoisted_lvalue_kind(kind: InstructionKind) -> Option<InstructionKind>
 }
 
 /// Recursive implementation. Corresponds to TS `collectTemporariesSidemapImpl`.
-fn collect_temporaries_sidemap_impl(
-    func: &HirFunction,
-    env: &Environment,
+fn collect_temporaries_sidemap_impl<'a>(
+    func: &HirFunction<'a>,
+    env: &Environment<'a>,
     used_outside_declaring_scope: &FxHashSet<DeclarationId>,
-    temporaries: &mut FxHashMap<IdentifierId, ReactiveScopeDependency>,
+    temporaries: &mut FxHashMap<IdentifierId, ReactiveScopeDependency<'a>>,
     inner_fn_context: Option<EvaluationOrder>,
 ) {
     for (_block_id, block) in &func.body.blocks {
@@ -340,17 +340,17 @@ fn collect_temporaries_sidemap_impl(
 }
 
 /// Corresponds to TS `getProperty`.
-fn get_property(
+fn get_property<'a>(
     object: &Place,
-    property_name: &PropertyLiteral,
+    property_name: &PropertyLiteral<'a>,
     optional: bool,
     span: Option<Span>,
-    temporaries: &FxHashMap<IdentifierId, ReactiveScopeDependency>,
-) -> ReactiveScopeDependency {
+    temporaries: &FxHashMap<IdentifierId, ReactiveScopeDependency<'a>>,
+) -> ReactiveScopeDependency<'a> {
     let resolved = temporaries.get(&object.identifier);
     if let Some(resolved) = resolved {
         let mut path = resolved.path.clone();
-        path.push(DependencyPathEntry { property: property_name.clone(), optional, span });
+        path.push(DependencyPathEntry { property: *property_name, optional, span });
         ReactiveScopeDependency {
             identifier: resolved.identifier,
             reactive: resolved.reactive,
@@ -361,7 +361,7 @@ fn get_property(
         ReactiveScopeDependency {
             identifier: object.identifier,
             reactive: object.reactive,
-            path: vec![DependencyPathEntry { property: property_name.clone(), optional, span }],
+            path: vec![DependencyPathEntry { property: *property_name, optional, span }],
             span,
         }
     }
@@ -371,10 +371,10 @@ fn get_property(
 // CollectOptionalChainDependencies
 // =============================================================================
 
-struct OptionalChainSidemap {
-    temporaries_read_in_optional: FxHashMap<IdentifierId, ReactiveScopeDependency>,
+struct OptionalChainSidemap<'a> {
+    temporaries_read_in_optional: FxHashMap<IdentifierId, ReactiveScopeDependency<'a>>,
     processed_instrs_in_optional: FxHashSet<ProcessedInstr>,
-    hoistable_objects: FxHashMap<BlockId, ReactiveScopeDependency>,
+    hoistable_objects: FxHashMap<BlockId, ReactiveScopeDependency<'a>>,
 }
 
 /// We track processed instructions/terminals by their lvalue IdentifierId + block id.
@@ -388,7 +388,10 @@ enum ProcessedInstr {
     Terminal(BlockId),
 }
 
-fn collect_optional_chain_sidemap(func: &HirFunction, env: &Environment) -> OptionalChainSidemap {
+fn collect_optional_chain_sidemap<'a>(
+    func: &HirFunction<'a>,
+    env: &Environment<'a>,
+) -> OptionalChainSidemap<'a> {
     let mut ctx = OptionalTraversalContext {
         seen_optionals: FxHashSet::default(),
         processed_instrs_in_optional: FxHashSet::default(),
@@ -405,17 +408,17 @@ fn collect_optional_chain_sidemap(func: &HirFunction, env: &Environment) -> Opti
     }
 }
 
-struct OptionalTraversalContext {
+struct OptionalTraversalContext<'a> {
     seen_optionals: FxHashSet<BlockId>,
     processed_instrs_in_optional: FxHashSet<ProcessedInstr>,
-    temporaries_read_in_optional: FxHashMap<IdentifierId, ReactiveScopeDependency>,
-    hoistable_objects: FxHashMap<BlockId, ReactiveScopeDependency>,
+    temporaries_read_in_optional: FxHashMap<IdentifierId, ReactiveScopeDependency<'a>>,
+    hoistable_objects: FxHashMap<BlockId, ReactiveScopeDependency<'a>>,
 }
 
-fn traverse_function_optional(
-    func: &HirFunction,
-    env: &Environment,
-    ctx: &mut OptionalTraversalContext,
+fn traverse_function_optional<'a>(
+    func: &HirFunction<'a>,
+    env: &Environment<'a>,
+    ctx: &mut OptionalTraversalContext<'a>,
 ) {
     for (_block_id, block) in &func.body.blocks {
         for &instr_id in &block.instructions {
@@ -437,16 +440,19 @@ fn traverse_function_optional(
     }
 }
 
-struct MatchConsequentResult {
+struct MatchConsequentResult<'a> {
     consequent_id: IdentifierId,
-    property: PropertyLiteral,
+    property: PropertyLiteral<'a>,
     property_id: IdentifierId,
     store_local_lvalue_id: IdentifierId,
     consequent_goto: BlockId,
     property_load_span: Option<Span>,
 }
 
-fn match_optional_test_block(test: &Terminal, func: &HirFunction) -> Option<MatchConsequentResult> {
+fn match_optional_test_block<'a>(
+    test: &Terminal,
+    func: &HirFunction<'a>,
+) -> Option<MatchConsequentResult<'a>> {
     let (test_place, consequent_block_id, alternate_block_id) = match test {
         Terminal::Branch { test, consequent, alternate, .. } => (test, *consequent, *alternate),
         _ => return None,
@@ -498,7 +504,7 @@ fn match_optional_test_block(test: &Terminal, func: &HirFunction) -> Option<Matc
 
             Some(MatchConsequentResult {
                 consequent_id: store_local_value.identifier,
-                property: property.clone(),
+                property: *property,
                 property_id: instr0.lvalue.identifier,
                 store_local_lvalue_id: instr1.lvalue.identifier,
                 consequent_goto: *goto_block,
@@ -509,10 +515,10 @@ fn match_optional_test_block(test: &Terminal, func: &HirFunction) -> Option<Matc
     }
 }
 
-fn traverse_optional_block(
+fn traverse_optional_block<'a>(
     optional_block: &BasicBlock,
-    func: &HirFunction,
-    ctx: &mut OptionalTraversalContext,
+    func: &HirFunction<'a>,
+    ctx: &mut OptionalTraversalContext<'a>,
     outer_alternate: Option<BlockId>,
 ) -> Option<IdentifierId> {
     ctx.seen_optionals.insert(optional_block.id);
@@ -549,7 +555,7 @@ fn traverse_optional_block(
                         if object.identifier == prev_instr.lvalue.identifier =>
                     {
                         path.push(DependencyPathEntry {
-                            property: property.clone(),
+                            property: *property,
                             optional: false,
                             span: *span,
                         });
@@ -648,7 +654,7 @@ fn traverse_optional_block(
         path: {
             let mut p = base_object.path;
             p.push(DependencyPathEntry {
-                property: match_result.property.clone(),
+                property: match_result.property,
                 optional: is_optional,
                 span: match_result.property_load_span,
             });
@@ -714,23 +720,23 @@ fn traverse_optional_block(
 // =============================================================================
 
 #[derive(Debug, Clone)]
-struct PropertyPathNode {
-    properties: FxHashMap<PropertyLiteral, usize>, // index into registry
-    optional_properties: FxHashMap<PropertyLiteral, usize>, // index into registry
+struct PropertyPathNode<'a> {
+    properties: FxHashMap<PropertyLiteral<'a>, usize>, // index into registry
+    optional_properties: FxHashMap<PropertyLiteral<'a>, usize>, // index into registry
     #[allow(dead_code)]
     parent: Option<usize>,
-    full_path: ReactiveScopeDependency,
+    full_path: ReactiveScopeDependency<'a>,
     has_optional: bool,
     #[allow(dead_code)]
     root: Option<IdentifierId>,
 }
 
-struct PropertyPathRegistry {
-    nodes: Vec<PropertyPathNode>,
+struct PropertyPathRegistry<'a> {
+    nodes: Vec<PropertyPathNode<'a>>,
     roots: FxHashMap<IdentifierId, usize>,
 }
 
-impl PropertyPathRegistry {
+impl<'a> PropertyPathRegistry<'a> {
     fn new() -> Self {
         Self { nodes: Vec::new(), roots: FxHashMap::default() }
     }
@@ -765,9 +771,9 @@ impl PropertyPathRegistry {
     fn get_or_create_property_entry(
         &mut self,
         parent_idx: usize,
-        entry: &DependencyPathEntry,
+        entry: &DependencyPathEntry<'a>,
     ) -> usize {
-        let map_key = entry.property.clone();
+        let map_key = entry.property;
         let existing = if entry.optional {
             self.nodes[parent_idx].optional_properties.get(&map_key).copied()
         } else {
@@ -802,7 +808,7 @@ impl PropertyPathRegistry {
         idx
     }
 
-    fn get_or_create_property(&mut self, dep: &ReactiveScopeDependency) -> usize {
+    fn get_or_create_property(&mut self, dep: &ReactiveScopeDependency<'a>) -> usize {
         let mut curr = self.get_or_create_identifier(dep.identifier, dep.reactive, dep.span);
         for entry in &dep.path {
             curr = self.get_or_create_property_entry(curr, entry);
@@ -847,7 +853,7 @@ fn reduce_maybe_optional_chains(nodes: &mut BTreeSet<usize>, registry: &mut Prop
                 // If the base is known to be non-null (in the set), replace optional with non-optional
                 let next_entry = if entry.optional && nodes.contains(&curr_node) {
                     DependencyPathEntry {
-                        property: entry.property.clone(),
+                        property: entry.property,
                         optional: false,
                         span: entry.span,
                     }
@@ -878,11 +884,11 @@ struct BlockInfo {
 }
 
 #[allow(dead_code)]
-fn collect_hoistable_property_loads(
-    func: &HirFunction,
-    env: &Environment,
-    temporaries: &FxHashMap<IdentifierId, ReactiveScopeDependency>,
-    hoistable_from_optionals: &FxHashMap<BlockId, ReactiveScopeDependency>,
+fn collect_hoistable_property_loads<'a>(
+    func: &HirFunction<'a>,
+    env: &Environment<'a>,
+    temporaries: &FxHashMap<IdentifierId, ReactiveScopeDependency<'a>>,
+    hoistable_from_optionals: &FxHashMap<BlockId, ReactiveScopeDependency<'a>>,
 ) -> FxHashMap<BlockId, BlockInfo> {
     let mut registry = PropertyPathRegistry::new();
     let known_immutable_identifiers: FxHashSet<IdentifierId> = if func.fn_type
@@ -912,12 +918,12 @@ fn collect_hoistable_property_loads(
     collect_hoistable_property_loads_impl(func, env, &ctx, &mut registry)
 }
 
-struct CollectHoistableContext<'a> {
-    temporaries: &'a FxHashMap<IdentifierId, ReactiveScopeDependency>,
-    known_immutable_identifiers: &'a FxHashSet<IdentifierId>,
-    hoistable_from_optionals: &'a FxHashMap<BlockId, ReactiveScopeDependency>,
-    nested_fn_immutable_context: Option<&'a FxHashSet<IdentifierId>>,
-    assumed_invoked_fns: &'a FxHashSet<FunctionId>,
+struct CollectHoistableContext<'a, 'e> {
+    temporaries: &'e FxHashMap<IdentifierId, ReactiveScopeDependency<'a>>,
+    known_immutable_identifiers: &'e FxHashSet<IdentifierId>,
+    hoistable_from_optionals: &'e FxHashMap<BlockId, ReactiveScopeDependency<'a>>,
+    nested_fn_immutable_context: Option<&'e FxHashSet<IdentifierId>>,
+    assumed_invoked_fns: &'e FxHashSet<FunctionId>,
 }
 
 fn is_immutable_at_instr(
@@ -944,10 +950,10 @@ fn in_range(id: EvaluationOrder, range: &MutableRange) -> bool {
     id >= range.start && id < range.end
 }
 
-fn get_maybe_non_null_in_instruction(
-    value: &InstructionValue,
-    temporaries: &FxHashMap<IdentifierId, ReactiveScopeDependency>,
-) -> Option<ReactiveScopeDependency> {
+fn get_maybe_non_null_in_instruction<'a>(
+    value: &InstructionValue<'a>,
+    temporaries: &FxHashMap<IdentifierId, ReactiveScopeDependency<'a>>,
+) -> Option<ReactiveScopeDependency<'a>> {
     match value {
         InstructionValue::PropertyLoad { object, .. } => {
             Some(temporaries.get(&object.identifier).cloned().unwrap_or_else(|| {
@@ -970,11 +976,11 @@ fn get_maybe_non_null_in_instruction(
 }
 
 #[allow(dead_code)]
-fn collect_hoistable_property_loads_impl(
-    func: &HirFunction,
-    env: &Environment,
-    ctx: &CollectHoistableContext,
-    registry: &mut PropertyPathRegistry,
+fn collect_hoistable_property_loads_impl<'a>(
+    func: &HirFunction<'a>,
+    env: &Environment<'a>,
+    ctx: &CollectHoistableContext<'a, '_>,
+    registry: &mut PropertyPathRegistry<'a>,
 ) -> FxHashMap<BlockId, BlockInfo> {
     let nodes = collect_non_nulls_in_blocks(func, env, ctx, registry);
     let working = propagate_non_null(func, &nodes, registry);
@@ -1121,11 +1127,11 @@ fn get_assumed_invoked_functions_impl(
     hoistable
 }
 
-fn collect_non_nulls_in_blocks(
-    func: &HirFunction,
-    env: &Environment,
-    ctx: &CollectHoistableContext,
-    registry: &mut PropertyPathRegistry,
+fn collect_non_nulls_in_blocks<'a>(
+    func: &HirFunction<'a>,
+    env: &Environment<'a>,
+    ctx: &CollectHoistableContext<'a, '_>,
+    registry: &mut PropertyPathRegistry<'a>,
 ) -> FxHashMap<BlockId, BlockInfo> {
     // Known non-null identifiers (e.g. component props)
     let mut known_non_null: BTreeSet<usize> = BTreeSet::new();
@@ -1384,12 +1390,12 @@ fn recursively_propagate_non_null(
     changed
 }
 
-fn collect_hoistable_and_propagate(
-    func: &HirFunction,
-    env: &Environment,
-    temporaries: &FxHashMap<IdentifierId, ReactiveScopeDependency>,
-    hoistable_from_optionals: &FxHashMap<BlockId, ReactiveScopeDependency>,
-) -> (FxHashMap<BlockId, BTreeSet<usize>>, PropertyPathRegistry) {
+fn collect_hoistable_and_propagate<'a>(
+    func: &HirFunction<'a>,
+    env: &Environment<'a>,
+    temporaries: &FxHashMap<IdentifierId, ReactiveScopeDependency<'a>>,
+    hoistable_from_optionals: &FxHashMap<BlockId, ReactiveScopeDependency<'a>>,
+) -> (FxHashMap<BlockId, BTreeSet<usize>>, PropertyPathRegistry<'a>) {
     let mut registry = PropertyPathRegistry::new();
     let assumed_invoked_fns = get_assumed_invoked_functions(func, env);
     let known_immutable_identifiers: FxHashSet<IdentifierId> = if func.fn_type
@@ -1478,33 +1484,36 @@ enum HoistableAccessType {
     NonNull,
 }
 
-struct HoistableNode {
-    properties: FxHashMap<PropertyLiteral, Box<HoistableNodeEntry>>,
+struct HoistableNode<'a> {
+    properties: FxHashMap<PropertyLiteral<'a>, Box<HoistableNodeEntry<'a>>>,
     access_type: HoistableAccessType,
 }
 
-struct HoistableNodeEntry {
-    node: HoistableNode,
+struct HoistableNodeEntry<'a> {
+    node: HoistableNode<'a>,
 }
 
-struct DependencyNode {
-    properties: FxIndexMap<PropertyLiteral, Box<DependencyNodeEntry>>,
+struct DependencyNode<'a> {
+    properties: FxIndexMap<PropertyLiteral<'a>, Box<DependencyNodeEntry<'a>>>,
     access_type: PropertyAccessType,
     span: Option<Span>,
 }
 
-struct DependencyNodeEntry {
-    node: DependencyNode,
+struct DependencyNodeEntry<'a> {
+    node: DependencyNode<'a>,
 }
 
-struct ReactiveScopeDependencyTreeHIR {
-    hoistable_roots: FxHashMap<IdentifierId, (HoistableNode, bool)>, // node + reactive
-    dep_roots: FxIndexMap<IdentifierId, (DependencyNode, bool)>, // node + reactive (preserves insertion order like JS Map)
+struct ReactiveScopeDependencyTreeHIR<'a> {
+    hoistable_roots: FxHashMap<IdentifierId, (HoistableNode<'a>, bool)>, // node + reactive
+    dep_roots: FxIndexMap<IdentifierId, (DependencyNode<'a>, bool)>, // node + reactive (preserves insertion order like JS Map)
 }
 
-impl ReactiveScopeDependencyTreeHIR {
-    fn new<'a>(hoistable_objects: impl Iterator<Item = &'a ReactiveScopeDependency>) -> Self {
-        let mut hoistable_roots: FxHashMap<IdentifierId, (HoistableNode, bool)> =
+impl<'a> ReactiveScopeDependencyTreeHIR<'a> {
+    fn new<'i>(hoistable_objects: impl Iterator<Item = &'i ReactiveScopeDependency<'a>>) -> Self
+    where
+        'a: 'i,
+    {
+        let mut hoistable_roots: FxHashMap<IdentifierId, (HoistableNode<'a>, bool)> =
             FxHashMap::default();
 
         // Sort hoistable objects so that entries with optional first path come
@@ -1536,12 +1545,11 @@ impl ReactiveScopeDependencyTreeHIR {
                 } else {
                     HoistableAccessType::NonNull
                 };
-                let entry =
-                    curr.properties.entry(dep.path[i].property.clone()).or_insert_with(|| {
-                        Box::new(HoistableNodeEntry {
-                            node: HoistableNode { properties: FxHashMap::default(), access_type },
-                        })
-                    });
+                let entry = curr.properties.entry(dep.path[i].property).or_insert_with(|| {
+                    Box::new(HoistableNodeEntry {
+                        node: HoistableNode { properties: FxHashMap::default(), access_type },
+                    })
+                });
                 curr = &mut entry.node;
             }
         }
@@ -1549,7 +1557,7 @@ impl ReactiveScopeDependencyTreeHIR {
         Self { hoistable_roots, dep_roots: FxIndexMap::default() }
     }
 
-    fn add_dependency(&mut self, dep: ReactiveScopeDependency) {
+    fn add_dependency(&mut self, dep: ReactiveScopeDependency<'a>) {
         let root = self.dep_roots.entry(dep.identifier).or_insert_with(|| {
             (
                 DependencyNode {
@@ -1578,7 +1586,7 @@ impl ReactiveScopeDependencyTreeHIR {
             };
 
             // make_or_merge_property
-            let child = dep_cursor.properties.entry(entry.property.clone()).or_insert_with(|| {
+            let child = dep_cursor.properties.entry(entry.property).or_insert_with(|| {
                 Box::new(DependencyNodeEntry {
                     node: DependencyNode {
                         properties: FxIndexMap::default(),
@@ -1598,7 +1606,7 @@ impl ReactiveScopeDependencyTreeHIR {
             merge_access(dep_cursor.access_type, PropertyAccessType::OptionalDependency);
     }
 
-    fn derive_minimal_dependencies(&self) -> Vec<ReactiveScopeDependency> {
+    fn derive_minimal_dependencies(&self) -> Vec<ReactiveScopeDependency<'a>> {
         let mut results = Vec::new();
         for (&root_id, (root_node, reactive)) in &self.dep_roots {
             collect_minimal_deps_in_subtree(root_node, *reactive, root_id, &[], &mut results);
@@ -1607,12 +1615,12 @@ impl ReactiveScopeDependencyTreeHIR {
     }
 }
 
-fn collect_minimal_deps_in_subtree(
-    node: &DependencyNode,
+fn collect_minimal_deps_in_subtree<'a>(
+    node: &DependencyNode<'a>,
     reactive: bool,
     root_id: IdentifierId,
-    path: &[DependencyPathEntry],
-    results: &mut Vec<ReactiveScopeDependency>,
+    path: &[DependencyPathEntry<'a>],
+    results: &mut Vec<ReactiveScopeDependency<'a>>,
 ) {
     if is_dependency_access(node.access_type) {
         results.push(ReactiveScopeDependency {
@@ -1625,7 +1633,7 @@ fn collect_minimal_deps_in_subtree(
         for (child_name, child_entry) in &node.properties {
             let mut new_path = path.to_vec();
             new_path.push(DependencyPathEntry {
-                property: child_name.clone(),
+                property: *child_name,
                 optional: is_optional_access(child_entry.node.access_type),
                 span: child_entry.node.span,
             });
@@ -1652,24 +1660,24 @@ struct Decl {
 }
 
 /// Context for dependency collection.
-struct DependencyCollectionContext<'a> {
+struct DependencyCollectionContext<'a, 'e> {
     declarations: FxHashMap<DeclarationId, Decl>,
     reassignments: FxHashMap<IdentifierId, Decl>,
     scope_stack: Vec<ScopeId>,
-    dep_stack: Vec<Vec<ReactiveScopeDependency>>,
-    deps: FxIndexMap<ScopeId, Vec<ReactiveScopeDependency>>,
-    temporaries: &'a FxHashMap<IdentifierId, ReactiveScopeDependency>,
+    dep_stack: Vec<Vec<ReactiveScopeDependency<'a>>>,
+    deps: FxIndexMap<ScopeId, Vec<ReactiveScopeDependency<'a>>>,
+    temporaries: &'e FxHashMap<IdentifierId, ReactiveScopeDependency<'a>>,
     #[allow(dead_code)]
-    temporaries_used_outside_scope: &'a FxHashSet<DeclarationId>,
-    processed_instrs_in_optional: &'a FxHashSet<ProcessedInstr>,
+    temporaries_used_outside_scope: &'e FxHashSet<DeclarationId>,
+    processed_instrs_in_optional: &'e FxHashSet<ProcessedInstr>,
     inner_fn_context: Option<EvaluationOrder>,
 }
 
-impl<'a> DependencyCollectionContext<'a> {
+impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
     fn new(
-        temporaries_used_outside_scope: &'a FxHashSet<DeclarationId>,
-        temporaries: &'a FxHashMap<IdentifierId, ReactiveScopeDependency>,
-        processed_instrs_in_optional: &'a FxHashSet<ProcessedInstr>,
+        temporaries_used_outside_scope: &'e FxHashSet<DeclarationId>,
+        temporaries: &'e FxHashMap<IdentifierId, ReactiveScopeDependency<'a>>,
+        processed_instrs_in_optional: &'e FxHashSet<ProcessedInstr>,
     ) -> Self {
         Self {
             declarations: FxHashMap::default(),
@@ -1767,7 +1775,7 @@ impl<'a> DependencyCollectionContext<'a> {
     fn visit_property(
         &mut self,
         object: &Place,
-        property: &PropertyLiteral,
+        property: &PropertyLiteral<'a>,
         optional: bool,
         span: Option<Span>,
         env: &mut Environment,
@@ -1776,7 +1784,7 @@ impl<'a> DependencyCollectionContext<'a> {
         self.visit_dependency(dep, env);
     }
 
-    fn visit_dependency(&mut self, dep: ReactiveScopeDependency, env: &mut Environment) {
+    fn visit_dependency(&mut self, dep: ReactiveScopeDependency<'a>, env: &mut Environment) {
         let ident = &env.identifiers[dep.identifier.0 as usize];
         let decl_id = ident.declaration_id;
 
@@ -1865,10 +1873,10 @@ impl<'a> DependencyCollectionContext<'a> {
 /// Recursively visit an inner function's blocks, processing all instructions
 /// including nested FunctionExpressions. This mirrors the TS pattern of
 /// `context.enterInnerFn(instr, () => handleFunction(innerFn))`.
-fn visit_inner_function_blocks(
+fn visit_inner_function_blocks<'a>(
     func_id: FunctionId,
-    ctx: &mut DependencyCollectionContext,
-    env: &mut Environment,
+    ctx: &mut DependencyCollectionContext<'a, '_>,
+    env: &mut Environment<'a>,
 ) {
     // Clone inner function's instructions and block structure to avoid
     // borrow conflicts when mutating env through handle_instruction.
@@ -1924,10 +1932,10 @@ fn visit_inner_function_blocks(
     }
 }
 
-fn handle_instruction(
-    instr: &Instruction,
-    ctx: &mut DependencyCollectionContext,
-    env: &mut Environment,
+fn handle_instruction<'a>(
+    instr: &Instruction<'a>,
+    ctx: &mut DependencyCollectionContext<'a, '_>,
+    env: &mut Environment<'a>,
 ) {
     let id = instr.id;
     let scope_stack_copy = ctx.scope_stack.clone();
@@ -1996,13 +2004,13 @@ fn handle_instruction(
     }
 }
 
-fn collect_dependencies(
-    func: &HirFunction,
-    env: &mut Environment,
+fn collect_dependencies<'a>(
+    func: &HirFunction<'a>,
+    env: &mut Environment<'a>,
     used_outside_declaring_scope: &FxHashSet<DeclarationId>,
-    temporaries: &FxHashMap<IdentifierId, ReactiveScopeDependency>,
+    temporaries: &FxHashMap<IdentifierId, ReactiveScopeDependency<'a>>,
     processed_instrs_in_optional: &FxHashSet<ProcessedInstr>,
-) -> FxIndexMap<ScopeId, Vec<ReactiveScopeDependency>> {
+) -> FxIndexMap<ScopeId, Vec<ReactiveScopeDependency<'a>>> {
     let mut ctx = DependencyCollectionContext::new(
         used_outside_declaring_scope,
         temporaries,
@@ -2036,10 +2044,10 @@ fn collect_dependencies(
     ctx.deps
 }
 
-fn handle_function_deps(
-    func: &HirFunction,
-    env: &mut Environment,
-    ctx: &mut DependencyCollectionContext,
+fn handle_function_deps<'a>(
+    func: &HirFunction<'a>,
+    env: &mut Environment<'a>,
+    ctx: &mut DependencyCollectionContext<'a, '_>,
     traversal: &mut ScopeBlockTraversal,
 ) {
     for (block_id, block) in &func.body.blocks {

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -1,11 +1,12 @@
+use std::borrow::Cow;
+
 use cow_utils::CowUtils;
 use rustc_hash::FxHashSet;
 
 use crate::diagnostics::ErrorCategory;
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::*;
-use crate::react_compiler_utils::FxIndexMap;
-use crate::react_compiler_utils::FxIndexSet;
+use crate::react_compiler_utils::{FxIndexMap, FxIndexSet, IdentIndexMap, JsString};
 use crate::scope::BindingKind as AstBindingKind;
 use crate::scope::DeclKind;
 use crate::scope::ScopeId;
@@ -13,9 +14,11 @@ use crate::scope::ScopeKind;
 use crate::scope::ScopeResolver;
 use crate::scope::SymbolId;
 
+use oxc_allocator::CloneIn;
 use oxc_ast::ast as oxc;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::GetSpan;
+use oxc_str::{Ident, Str, format_ident};
 
 use crate::react_compiler_lowering::FunctionNode;
 use crate::react_compiler_lowering::find_context_identifiers::find_context_identifiers;
@@ -70,7 +73,7 @@ fn promote_temporary(builder: &mut HirBuilder<'_, '_>, identifier_id: Identifier
     let env = builder.environment_mut();
     let decl_id = env.identifiers[identifier_id.0 as usize].declaration_id;
     env.identifiers[identifier_id.0 as usize].name =
-        Some(IdentifierName::Promoted(format!("#t{}", decl_id.0)));
+        Some(IdentifierName::Promoted(format_ident!(env.allocator, "#t{}", decl_id.0)));
 }
 
 fn lower_value_to_temporary<'a>(
@@ -98,7 +101,7 @@ fn lower_value_to_temporary<'a>(
 
 fn lower_expression_to_temporary<'a>(
     builder: &mut HirBuilder<'a, '_>,
-    expr: &'a oxc::Expression<'a>,
+    expr: &oxc::Expression<'a>,
 ) -> Result<Place, OxcDiagnostic> {
     let value = lower_expression(builder, expr)?;
     lower_value_to_temporary(builder, value)
@@ -189,7 +192,7 @@ fn collect_binding_names_from_pattern(
 /// block-scoped bindings and emits DeclareContext instructions to hoist them.
 fn lower_block_statement<'a>(
     builder: &mut HirBuilder<'a, '_>,
-    statements: &'a [oxc::Statement<'a>],
+    statements: &[oxc::Statement<'a>],
     block_scope: Option<ScopeId>,
     parent_scope: Option<ScopeId>,
 ) -> Result<(), OxcDiagnostic> {
@@ -199,7 +202,7 @@ fn lower_block_statement<'a>(
 
 fn lower_block_statement_with_scope<'a>(
     builder: &mut HirBuilder<'a, '_>,
-    statements: &'a [oxc::Statement<'a>],
+    statements: &[oxc::Statement<'a>],
     scope_override: ScopeId,
 ) -> Result<(), OxcDiagnostic> {
     let _ = lower_block_statement_inner(builder, statements, None, Some(scope_override), None);
@@ -208,7 +211,7 @@ fn lower_block_statement_with_scope<'a>(
 
 fn lower_block_statement_inner<'a>(
     builder: &mut HirBuilder<'a, '_>,
-    statements: &'a [oxc::Statement<'a>],
+    statements: &[oxc::Statement<'a>],
     block_scope: Option<ScopeId>,
     scope_override: Option<ScopeId>,
     parent_scope: Option<ScopeId>,
@@ -243,7 +246,7 @@ fn lower_block_statement_inner<'a>(
     // that nested block is recursively lowered. This prevents DeclareContext from
     // being emitted before an `if` terminal for variables declared within the branch.
     let scope = builder.scope();
-    let hoistable: Vec<(SymbolId, String, AstBindingKind, DeclKind, Option<u32>)> = scope
+    let hoistable: Vec<(SymbolId, Ident, AstBindingKind, DeclKind, Option<u32>)> = scope
         .bindings_with_child_blocks(scope_id)
         .into_iter()
         .filter(|&sid| {
@@ -270,7 +273,7 @@ fn lower_block_statement_inner<'a>(
         .map(|sid| {
             (
                 sid,
-                scope.symbol_name(sid).to_string(),
+                scope.symbol_ident(sid),
                 scope.binding_kind(sid),
                 scope.decl_kind(sid),
                 scope.declaration_ident(sid).map(|id| id.span.start),
@@ -311,9 +314,9 @@ fn lower_block_statement_inner<'a>(
         };
 
         // Find references to not-yet-declared hoistable bindings within this statement
-        struct HoistInfo {
+        struct HoistInfo<'a> {
             binding_id: SymbolId,
-            name: String,
+            name: Ident<'a>,
             kind: AstBindingKind,
             declaration_type: DeclKind,
             first_ref_span: Span,
@@ -406,7 +409,7 @@ fn lower_block_statement_inner<'a>(
                 };
                 will_hoist.push(HoistInfo {
                     binding_id: *binding_id,
-                    name: name.clone(),
+                    name: *name,
                     kind: *kind,
                     declaration_type: *decl_type,
                     first_ref_span,
@@ -457,7 +460,7 @@ fn lower_block_statement_inner<'a>(
             };
 
             let ref_span = Some(info.first_ref_span);
-            let identifier = builder.resolve_binding(&info.name, info.binding_id)?;
+            let identifier = builder.resolve_binding(info.name, info.binding_id)?;
             let place =
                 Place { effect: Effect::Unknown, identifier, reactive: false, span: ref_span };
             lower_value_to_temporary(
@@ -510,13 +513,13 @@ fn lower_block_statement_inner<'a>(
 // lower_statement
 // =============================================================================
 
-enum FunctionBody<'a> {
-    Block(&'a oxc::FunctionBody<'a>),
-    Expression(&'a oxc::Expression<'a>),
+enum FunctionBody<'b, 'a> {
+    Block(&'b oxc::FunctionBody<'a>),
+    Expression(&'b oxc::Expression<'a>),
 }
 
 type LowerInnerResult<'a> = Result<
-    (HirFunction<'a>, FxIndexMap<String, SymbolId>, FxIndexMap<SymbolId, IdentifierId>),
+    (HirFunction<'a>, IdentIndexMap<'a, SymbolId>, FxIndexMap<SymbolId, IdentifierId>),
     OxcDiagnostic,
 >;
 
@@ -524,7 +527,7 @@ type LowerInnerResult<'a> = Result<
 ///
 /// Receives a `FunctionNode` (discovered by the entrypoint) and lowers it to HIR.
 pub fn lower<'a>(
-    func: &'a FunctionNode<'a>,
+    func: &FunctionNode<'_, 'a>,
     scope: &ScopeResolver<'_, 'a>,
     env: &mut Environment<'a>,
 ) -> Result<HirFunction<'a>, OxcDiagnostic> {
@@ -541,7 +544,7 @@ pub fn lower<'a>(
                 f.generator,
                 f.r#async,
                 f.span,
-                f.id.as_ref().map(|id| id.name.as_str()),
+                f.id.as_ref().map(|id| id.name),
             )
         }
         FunctionNode::Arrow(arrow) => {
@@ -601,16 +604,16 @@ pub fn lower<'a>(
 /// Result of resolving an identifier for assignment.
 #[allow(clippy::too_many_arguments)]
 fn lower_inner<'a>(
-    params: &'a oxc::FormalParameters<'a>,
-    body: FunctionBody<'a>,
-    id: Option<&str>,
+    params: &oxc::FormalParameters<'a>,
+    body: FunctionBody<'_, 'a>,
+    id: Option<Ident<'a>>,
     generator: bool,
     is_async: bool,
     span: Span,
     scope: &ScopeResolver<'_, 'a>,
     env: &mut Environment<'a>,
     parent_bindings: Option<FxIndexMap<SymbolId, IdentifierId>>,
-    parent_used_names: Option<FxIndexMap<String, SymbolId>>,
+    parent_used_names: Option<IdentIndexMap<'a, SymbolId>>,
     context_map: FxIndexMap<SymbolId, Option<Span>>,
     function_scope: ScopeId,
     component_scope: ScopeId,
@@ -636,7 +639,7 @@ fn lower_inner<'a>(
     // Build context places from the captured refs
     let mut context: Vec<Place> = Vec::new();
     for (&symbol_id, ctx_span) in &context_map {
-        let identifier = builder.resolve_binding(scope.symbol_name(symbol_id), symbol_id)?;
+        let identifier = builder.resolve_binding(scope.symbol_ident(symbol_id), symbol_id)?;
         context.push(Place {
             identifier,
             effect: Effect::Unknown,
@@ -656,7 +659,7 @@ fn lower_inner<'a>(
             }
             let param_span = ident.span;
             let mut binding = builder.resolve_identifier(
-                ident.name.as_str(),
+                ident.name,
                 param_span,
                 builder.scope().resolve_binding_identifier(ident),
             )?;
@@ -669,7 +672,7 @@ fn lower_inner<'a>(
                         &builder.scope().binding_kind(symbol_id),
                     );
                     let identifier = builder.resolve_binding_with_span(
-                        ident.name.as_str(),
+                        ident.name,
                         symbol_id,
                         Some(param_span),
                     )?;
@@ -745,7 +748,7 @@ fn lower_inner<'a>(
     }
 
     // Lower the body
-    let mut directives: Vec<String> = Vec::new();
+    let mut directives: Vec<Str<'a>> = Vec::new();
     match body {
         FunctionBody::Expression(expr) => {
             let fallthrough = builder.reserve(BlockKind::Block);
@@ -762,7 +765,7 @@ fn lower_inner<'a>(
             );
         }
         FunctionBody::Block(block) => {
-            directives = block.directives.iter().map(|d| d.expression.value.to_string()).collect();
+            directives = block.directives.iter().map(|d| d.expression.value).collect();
             // A function body shares the function's scope (the scope cell lives on
             // the function node, not the block), so pass it as the scope override.
             lower_block_statement_with_scope(&mut builder, &block.statements, function_scope)?;
@@ -794,7 +797,7 @@ fn lower_inner<'a>(
     Ok((
         HirFunction {
             span: Some(span),
-            id: id.map(|s| s.to_string()),
+            id,
             name_hint: None,
             fn_type: if is_top_level { env.fn_type } else { ReactFunctionType::Other },
             params: hir_params,
@@ -826,9 +829,9 @@ fn lower_inner<'a>(
 
 /// Resolve an identifier to a Place. Local/context identifiers return a Place
 /// referencing the binding; globals/imports emit a LoadGlobal. AST-agnostic.
-fn lower_identifier(
-    builder: &mut HirBuilder<'_, '_>,
-    name: &str,
+fn lower_identifier<'a>(
+    builder: &mut HirBuilder<'a, '_>,
+    name: Ident<'a>,
     span: Span,
     symbol: Option<SymbolId>,
 ) -> Result<Place, OxcDiagnostic> {
@@ -838,7 +841,7 @@ fn lower_identifier(
             Ok(Place { identifier, effect: Effect::Unknown, reactive: false, span: Some(span) })
         }
         _ => {
-            if let VariableBinding::Global { ref name } = binding {
+            if let VariableBinding::Global { name } = binding {
                 if name == "eval" {
                     builder.record_error(
                         ErrorCategory::UnsupportedSyntax
@@ -910,14 +913,14 @@ fn convert_unary_operator(op: oxc::UnaryOperator) -> UnaryOperator {
     }
 }
 
-enum MemberProperty {
-    Literal(PropertyLiteral),
+enum MemberProperty<'a> {
+    Literal(PropertyLiteral<'a>),
     Computed(Place),
 }
 
 struct LoweredMemberExpression<'a> {
     object: Place,
-    property: MemberProperty,
+    property: MemberProperty<'a>,
     value: InstructionValue<'a>,
 }
 
@@ -925,14 +928,14 @@ struct LoweredMemberExpression<'a> {
 /// receiver place + property + load value.
 fn lower_member_expression<'a>(
     builder: &mut HirBuilder<'a, '_>,
-    member: &'a oxc::MemberExpression<'a>,
+    member: &oxc::MemberExpression<'a>,
 ) -> Result<LoweredMemberExpression<'a>, OxcDiagnostic> {
     lower_member_expression_impl(builder, member, None)
 }
 
 fn lower_member_expression_impl<'a>(
     builder: &mut HirBuilder<'a, '_>,
-    member: &'a oxc::MemberExpression<'a>,
+    member: &oxc::MemberExpression<'a>,
     lowered_object: Option<Place>,
 ) -> Result<LoweredMemberExpression<'a>, OxcDiagnostic> {
     match member {
@@ -942,10 +945,10 @@ fn lower_member_expression_impl<'a>(
                 Some(obj) => obj,
                 None => lower_expression_to_temporary(builder, &m.object)?,
             };
-            let prop_literal = PropertyLiteral::String(m.property.name.to_string());
+            let prop_literal = PropertyLiteral::String(m.property.name);
             let value = InstructionValue::PropertyLoad {
                 object: object.clone(),
-                property: prop_literal.clone(),
+                property: prop_literal,
                 span,
             };
             Ok(LoweredMemberExpression {
@@ -965,7 +968,7 @@ fn lower_member_expression_impl<'a>(
                 let prop_literal = PropertyLiteral::Number(FloatValue::new(lit.value));
                 let value = InstructionValue::PropertyLoad {
                     object: object.clone(),
-                    property: prop_literal.clone(),
+                    property: prop_literal,
                     span,
                 };
                 return Ok(LoweredMemberExpression {
@@ -1001,7 +1004,7 @@ fn lower_member_expression_impl<'a>(
             )?;
             Ok(LoweredMemberExpression {
                 object,
-                property: MemberProperty::Literal(PropertyLiteral::String(String::new())),
+                property: MemberProperty::Literal(PropertyLiteral::String(Ident::empty())),
                 value: InstructionValue::Primitive { value: PrimitiveValue::Undefined, span },
             })
         }
@@ -1009,8 +1012,8 @@ fn lower_member_expression_impl<'a>(
 }
 
 /// Build a HIR `TemplateQuasi` from an oxc `TemplateElement`.
-fn template_quasi_from_oxc(q: &oxc::TemplateElement) -> TemplateQuasi {
-    TemplateQuasi { raw: q.value.raw.to_string(), cooked: q.value.cooked.map(|c| c.to_string()) }
+fn template_quasi_from_oxc<'a>(q: &oxc::TemplateElement<'a>) -> TemplateQuasi<'a> {
+    TemplateQuasi { raw: q.value.raw, cooked: q.value.cooked }
 }
 
 /// Lower the `import` keyword callee of an `ImportExpression`. The original Babel
@@ -1075,10 +1078,10 @@ fn classify_ts_type(ty: &oxc::TSType) -> crate::react_compiler_hir::RawTypeCateg
 
 /// Lower the HIR `Type` for a TS type annotation from its coarse classification,
 /// mirroring `lower_type_annotation`.
-fn lower_ts_type(builder: &mut HirBuilder<'_, '_>, ty: &oxc::TSType) -> Type {
+fn lower_ts_type<'a>(builder: &mut HirBuilder<'a, '_>, ty: &oxc::TSType) -> Type<'a> {
     use crate::react_compiler_hir::RawTypeCategory;
     match classify_ts_type(ty) {
-        RawTypeCategory::Array => Type::Object { shape_id: Some("BuiltInArray".to_string()) },
+        RawTypeCategory::Array => Type::Object { shape_id: Some(object_shape::BUILT_IN_ARRAY_ID) },
         RawTypeCategory::Primitive => Type::Primitive,
         RawTypeCategory::Other => builder.make_type(),
     }
@@ -1092,18 +1095,23 @@ fn lower_ts_type(builder: &mut HirBuilder<'_, '_>, ty: &oxc::TSType) -> Type {
 fn lower_type_cast_expression<'a>(
     builder: &mut HirBuilder<'a, '_>,
     span: oxc_span::Span,
-    expression: &'a oxc::Expression<'a>,
-    type_annotation: &'a oxc::TSType<'a>,
-    type_annotation_kind: &str,
+    expression: &oxc::Expression<'a>,
+    type_annotation: &oxc::TSType<'a>,
+    type_annotation_kind: &'static str,
 ) -> Result<InstructionValue<'a>, OxcDiagnostic> {
     let span = Some(span);
     let value = lower_expression_to_temporary(builder, expression)?;
     // `lower_ts_type` allocates a type var (via `make_type`); keep the call for
     // behavior parity even though the resulting type is no longer stored.
     lower_ts_type(builder, type_annotation);
+    // Clone the annotation into the arena (preserving semantic id cells so
+    // codegen's rename-by-reference-identity still applies) so the HIR holds no
+    // borrows of the input `Program` reference.
+    let allocator = builder.environment().allocator;
+    let type_annotation = &*allocator.alloc(type_annotation.clone_in_with_semantic_ids(allocator));
     Ok(InstructionValue::TypeCastExpression {
         value,
-        type_annotation_kind: Some(type_annotation_kind.to_string()),
+        type_annotation_kind: Some(type_annotation_kind),
         type_annotation: Some(type_annotation),
         span,
     })
@@ -1114,16 +1122,16 @@ fn lower_type_cast_expression<'a>(
 /// mirroring `lower_member_expression_impl`.
 fn lower_member_expression_from_simple_target<'a>(
     builder: &mut HirBuilder<'a, '_>,
-    target: &'a oxc::SimpleAssignmentTarget<'a>,
+    target: &oxc::SimpleAssignmentTarget<'a>,
 ) -> Result<LoweredMemberExpression<'a>, OxcDiagnostic> {
     match target {
         oxc::SimpleAssignmentTarget::StaticMemberExpression(m) => {
             let span = Some(m.span);
             let object = lower_expression_to_temporary(builder, &m.object)?;
-            let prop_literal = PropertyLiteral::String(m.property.name.to_string());
+            let prop_literal = PropertyLiteral::String(m.property.name);
             let value = InstructionValue::PropertyLoad {
                 object: object.clone(),
-                property: prop_literal.clone(),
+                property: prop_literal,
                 span,
             };
             Ok(LoweredMemberExpression {
@@ -1139,7 +1147,7 @@ fn lower_member_expression_from_simple_target<'a>(
                 let prop_literal = PropertyLiteral::Number(FloatValue::new(lit.value));
                 let value = InstructionValue::PropertyLoad {
                     object: object.clone(),
-                    property: prop_literal.clone(),
+                    property: prop_literal,
                     span,
                 };
                 return Ok(LoweredMemberExpression {
@@ -1170,7 +1178,7 @@ fn lower_member_expression_from_simple_target<'a>(
             )?;
             Ok(LoweredMemberExpression {
                 object,
-                property: MemberProperty::Literal(PropertyLiteral::String(String::new())),
+                property: MemberProperty::Literal(PropertyLiteral::String(Ident::empty())),
                 value: InstructionValue::Primitive { value: PrimitiveValue::Undefined, span },
             })
         }
@@ -1182,7 +1190,7 @@ fn lower_member_expression_from_simple_target<'a>(
 
 fn lower_arguments<'a>(
     builder: &mut HirBuilder<'a, '_>,
-    args: &'a [oxc::Argument<'a>],
+    args: &[oxc::Argument<'a>],
 ) -> Result<Vec<PlaceOrSpread>, OxcDiagnostic> {
     let mut result = Vec::new();
     for arg in args {
@@ -1202,25 +1210,25 @@ fn lower_arguments<'a>(
 }
 
 /// Result of resolving an identifier for assignment.
-enum IdentifierForAssignment {
+enum IdentifierForAssignment<'a> {
     Place(Place),
-    Global { name: String },
+    Global { name: Ident<'a> },
 }
 
 /// Resolve an identifier as an assignment target. AST-agnostic. Returns None if
 /// the binding could not be found (error recorded).
-fn lower_identifier_for_assignment(
-    builder: &mut HirBuilder<'_, '_>,
+fn lower_identifier_for_assignment<'a>(
+    builder: &mut HirBuilder<'a, '_>,
     span: Span,
     ident_span: Span,
     kind: InstructionKind,
-    name: &str,
+    name: Ident<'a>,
     symbol: Option<SymbolId>,
-) -> Result<Option<IdentifierForAssignment>, OxcDiagnostic> {
+) -> Result<Option<IdentifierForAssignment<'a>>, OxcDiagnostic> {
     let mut binding = builder.resolve_identifier(name, ident_span, symbol)?;
     if !matches!(binding, VariableBinding::Identifier { .. }) && kind != InstructionKind::Reassign {
         if let Some(symbol_id) =
-            builder.scope().find_binding_in_descendants(name, builder.function_scope())
+            builder.scope().find_binding_in_descendants(name.as_str(), builder.function_scope())
         {
             let bk = crate::react_compiler_lowering::convert_binding_kind(
                 &builder.scope().binding_kind(symbol_id),
@@ -1265,7 +1273,7 @@ fn lower_identifier_for_assignment(
         }
         _ => {
             if kind == InstructionKind::Reassign {
-                Ok(Some(IdentifierForAssignment::Global { name: name.to_string() }))
+                Ok(Some(IdentifierForAssignment::Global { name }))
             } else {
                 builder.record_error(
                     ErrorCategory::Invariant
@@ -1298,7 +1306,7 @@ fn lower_binding_assignment<'a>(
     builder: &mut HirBuilder<'a, '_>,
     span: Span,
     kind: InstructionKind,
-    target: &'a oxc::BindingPattern<'a>,
+    target: &oxc::BindingPattern<'a>,
     value: Place,
     assignment_style: AssignmentStyle,
 ) -> Result<Option<Place>, OxcDiagnostic> {
@@ -1309,7 +1317,7 @@ fn lower_binding_assignment<'a>(
                 span,
                 id.span,
                 kind,
-                id.name.as_str(),
+                id.name,
                 builder.scope().resolve_binding_identifier(id),
             )?;
             match result {
@@ -1380,7 +1388,7 @@ fn lower_binding_assignment<'a>(
                                 id.span,
                                 id.span,
                                 kind,
-                                id.name.as_str(),
+                                id.name,
                                 builder.scope().resolve_binding_identifier(id),
                             )? {
                                 Some(IdentifierForAssignment::Place(place)) => {
@@ -1425,7 +1433,7 @@ fn lower_binding_assignment<'a>(
                                 rest.span,
                                 id.span,
                                 kind,
-                                id.name.as_str(),
+                                id.name,
                                 builder.scope().resolve_binding_identifier(id),
                             )? {
                                 Some(IdentifierForAssignment::Place(place)) => {
@@ -1513,7 +1521,7 @@ fn lower_binding_assignment<'a>(
                                 id.span,
                                 id.span,
                                 kind,
-                                id.name.as_str(),
+                                id.name,
                                 builder.scope().resolve_binding_identifier(id),
                             )? {
                                 Some(IdentifierForAssignment::Place(place)) => {
@@ -1572,7 +1580,7 @@ fn lower_binding_assignment<'a>(
                                 rest.span,
                                 id.span,
                                 kind,
-                                id.name.as_str(),
+                                id.name,
                                 builder.scope().resolve_binding_identifier(id),
                             )? {
                                 Some(IdentifierForAssignment::Place(place)) => {
@@ -1661,7 +1669,7 @@ fn lower_binding_assignment<'a>(
 fn lower_default_to_temp<'a>(
     builder: &mut HirBuilder<'a, '_>,
     pat_span: Span,
-    default: &'a oxc::Expression<'a>,
+    default: &oxc::Expression<'a>,
     value: Place,
 ) -> Result<Place, OxcDiagnostic> {
     let temp = build_temporary_place(builder, Some(pat_span));
@@ -1754,7 +1762,7 @@ fn lower_member_assignment_target<'a>(
     builder: &mut HirBuilder<'a, '_>,
     span: Span,
     kind: InstructionKind,
-    target: &'a oxc::SimpleAssignmentTarget<'a>,
+    target: &oxc::SimpleAssignmentTarget<'a>,
     value: Place,
 ) -> Result<Option<Place>, OxcDiagnostic> {
     // MemberExpression may only appear in an assignment expression (Reassign).
@@ -1773,7 +1781,7 @@ fn lower_member_assignment_target<'a>(
                 builder,
                 InstructionValue::PropertyStore {
                     object,
-                    property: PropertyLiteral::String(member.property.name.to_string()),
+                    property: PropertyLiteral::String(member.property.name),
                     value,
                     span: Some(span),
                 },
@@ -1829,9 +1837,9 @@ fn lower_member_assignment_target<'a>(
 
 /// True if `maybe` is a bare identifier assignment target that resolves to a local
 /// binding (used to compute `force_temporaries`).
-fn assignment_target_is_local_identifier(
-    builder: &mut HirBuilder<'_, '_>,
-    maybe: &oxc::AssignmentTargetMaybeDefault,
+fn assignment_target_is_local_identifier<'a>(
+    builder: &mut HirBuilder<'a, '_>,
+    maybe: &oxc::AssignmentTargetMaybeDefault<'a>,
 ) -> Result<bool, OxcDiagnostic> {
     match maybe {
         oxc::AssignmentTargetMaybeDefault::AssignmentTargetIdentifier(id) => {
@@ -1839,7 +1847,7 @@ fn assignment_target_is_local_identifier(
                 return Ok(false);
             }
             let symbol = builder.scope().resolve_reference(id);
-            match builder.resolve_identifier(id.name.as_str(), id.span, symbol)? {
+            match builder.resolve_identifier(id.name, id.span, symbol)? {
                 VariableBinding::Identifier { .. } => Ok(true),
                 _ => Ok(false),
             }
@@ -1856,7 +1864,7 @@ fn lower_assignment_target<'a>(
     builder: &mut HirBuilder<'a, '_>,
     span: Span,
     kind: InstructionKind,
-    target: &'a oxc::AssignmentTarget<'a>,
+    target: &oxc::AssignmentTarget<'a>,
     value: Place,
     assignment_style: AssignmentStyle,
 ) -> Result<Option<Place>, OxcDiagnostic> {
@@ -1867,7 +1875,7 @@ fn lower_assignment_target<'a>(
                 span,
                 id.span,
                 kind,
-                id.name.as_str(),
+                id.name,
                 builder.scope().resolve_reference(id),
             )?;
             match result {
@@ -1971,7 +1979,7 @@ fn lower_assignment_target<'a>(
                                 id.span,
                                 id.span,
                                 kind,
-                                id.name.as_str(),
+                                id.name,
                                 builder.scope().resolve_reference(id),
                             )? {
                                 Some(IdentifierForAssignment::Place(place)) => {
@@ -2023,7 +2031,7 @@ fn lower_assignment_target<'a>(
                                 rest.span,
                                 id.span,
                                 kind,
-                                id.name.as_str(),
+                                id.name,
                                 builder.scope().resolve_reference(id),
                             )? {
                                 Some(IdentifierForAssignment::Place(place)) => {
@@ -2097,7 +2105,7 @@ fn lower_assignment_target<'a>(
                                 }
                                 let symbol = builder.scope().resolve_reference(&p.binding);
                                 match builder.resolve_identifier(
-                                    p.binding.name.as_str(),
+                                    p.binding.name,
                                     p.binding.span,
                                     symbol,
                                 )? {
@@ -2125,8 +2133,7 @@ fn lower_assignment_target<'a>(
             for prop in &pattern.properties {
                 match prop {
                     oxc::AssignmentTargetProperty::AssignmentTargetPropertyIdentifier(p) => {
-                        let key =
-                            ObjectPropertyKey::Identifier { name: p.binding.name.to_string() };
+                        let key = ObjectPropertyKey::Identifier { name: p.binding.name };
                         let id = &p.binding;
                         if let Some(default) = &p.init {
                             // `{foo = d}` — Babel shorthand AssignmentPattern. Lower
@@ -2159,7 +2166,7 @@ fn lower_assignment_target<'a>(
                                 id.span,
                                 id.span,
                                 kind,
-                                id.name.as_str(),
+                                id.name,
                                 builder.scope().resolve_reference(id),
                             )? {
                                 Some(IdentifierForAssignment::Place(place)) => {
@@ -2217,7 +2224,7 @@ fn lower_assignment_target<'a>(
                                         id.span,
                                         id.span,
                                         kind,
-                                        id.name.as_str(),
+                                        id.name,
                                         builder.scope().resolve_reference(id),
                                     )? {
                                         Some(IdentifierForAssignment::Place(place)) => {
@@ -2282,7 +2289,7 @@ fn lower_assignment_target<'a>(
                                 rest.span,
                                 id.span,
                                 kind,
-                                id.name.as_str(),
+                                id.name,
                                 builder.scope().resolve_reference(id),
                             )? {
                                 Some(IdentifierForAssignment::Place(place)) => {
@@ -2360,32 +2367,32 @@ fn lower_assignment_target<'a>(
 /// A destructuring followup target: either a nested assignment target, a
 /// with-default wrapper element, or (for `{foo = d}` object shorthand) an
 /// identifier with a default expression.
-enum FollowupTarget<'a> {
-    Target(&'a oxc::AssignmentTarget<'a>),
-    MaybeDefault(&'a oxc::AssignmentTargetMaybeDefault<'a>),
+enum FollowupTarget<'b, 'a> {
+    Target(&'b oxc::AssignmentTarget<'a>),
+    MaybeDefault(&'b oxc::AssignmentTargetMaybeDefault<'a>),
     /// A bare `{foo}` shorthand object property binding that needs a promoted
     /// temporary followup (the Babel `obj_prop.value == Identifier` case).
-    Identifier(&'a oxc::IdentifierReference<'a>),
+    Identifier(&'b oxc::IdentifierReference<'a>),
     Default {
         span: oxc_span::Span,
-        default: &'a oxc::Expression<'a>,
-        binding: FollowupBinding<'a>,
+        default: &'b oxc::Expression<'a>,
+        binding: FollowupBinding<'b, 'a>,
     },
 }
 
-enum FollowupBinding<'a> {
-    Identifier(&'a oxc::IdentifierReference<'a>),
-    Target(&'a oxc::AssignmentTarget<'a>),
+enum FollowupBinding<'b, 'a> {
+    Identifier(&'b oxc::IdentifierReference<'a>),
+    Target(&'b oxc::AssignmentTarget<'a>),
 }
 
 /// Store `value` into the identifier-target `id` (a bare destructuring binding).
 /// Mirrors the `PatternLike::Identifier` followup path of the original
 /// `lower_assignment` (re-resolving the binding for the store).
-fn lower_identifier_followup_store(
-    builder: &mut HirBuilder<'_, '_>,
+fn lower_identifier_followup_store<'a>(
+    builder: &mut HirBuilder<'a, '_>,
     span: Span,
     kind: InstructionKind,
-    id: &oxc::IdentifierReference,
+    id: &oxc::IdentifierReference<'a>,
     value: Place,
 ) -> Result<Option<Place>, OxcDiagnostic> {
     let result = lower_identifier_for_assignment(
@@ -2393,7 +2400,7 @@ fn lower_identifier_followup_store(
         span,
         id.span,
         kind,
-        id.name.as_str(),
+        id.name,
         builder.scope().resolve_reference(id),
     )?;
     match result {
@@ -2436,7 +2443,7 @@ fn lower_identifier_followup_store(
 fn lower_followup_target<'a>(
     builder: &mut HirBuilder<'a, '_>,
     kind: InstructionKind,
-    target: FollowupTarget<'a>,
+    target: FollowupTarget<'_, 'a>,
     value: Place,
     assignment_style: AssignmentStyle,
 ) -> Result<Option<Place>, OxcDiagnostic> {
@@ -2468,7 +2475,7 @@ fn lower_followup_target<'a>(
 fn lower_assignment_target_maybe_default<'a>(
     builder: &mut HirBuilder<'a, '_>,
     kind: InstructionKind,
-    maybe: &'a oxc::AssignmentTargetMaybeDefault<'a>,
+    maybe: &oxc::AssignmentTargetMaybeDefault<'a>,
     value: Place,
     assignment_style: AssignmentStyle,
 ) -> Result<Option<Place>, OxcDiagnostic> {
@@ -2498,8 +2505,8 @@ fn lower_assignment_target_default<'a>(
     builder: &mut HirBuilder<'a, '_>,
     span: oxc_span::Span,
     kind: InstructionKind,
-    default: &'a oxc::Expression<'a>,
-    binding: FollowupBinding<'a>,
+    default: &oxc::Expression<'a>,
+    binding: FollowupBinding<'_, 'a>,
     value: Place,
     assignment_style: AssignmentStyle,
 ) -> Result<Option<Place>, OxcDiagnostic> {
@@ -2626,7 +2633,7 @@ fn expr_contains_optional(expr: &oxc::Expression) -> bool {
 /// HIR structure.
 fn lower_chain_expression<'a>(
     builder: &mut HirBuilder<'a, '_>,
-    chain: &'a oxc::ChainExpression<'a>,
+    chain: &oxc::ChainExpression<'a>,
 ) -> Result<InstructionValue<'a>, OxcDiagnostic> {
     match &chain.expression {
         oxc::ChainElement::CallExpression(call) => {
@@ -2659,7 +2666,7 @@ fn lower_chain_expression<'a>(
 /// to detect optional-context member/call nodes.
 fn lower_chain_subexpr<'a>(
     builder: &mut HirBuilder<'a, '_>,
-    expr: &'a oxc::Expression<'a>,
+    expr: &oxc::Expression<'a>,
 ) -> Result<InstructionValue<'a>, OxcDiagnostic> {
     match expr {
         oxc::Expression::StaticMemberExpression(_)
@@ -2685,7 +2692,7 @@ fn lower_chain_subexpr<'a>(
 /// chain only creates one alternate at the first `?.`.
 fn lower_optional_member_expression_impl<'a>(
     builder: &mut HirBuilder<'a, '_>,
-    member: &'a oxc::MemberExpression<'a>,
+    member: &oxc::MemberExpression<'a>,
     parent_alternate: Option<BlockId>,
 ) -> Result<(Place, Place), OxcDiagnostic> {
     let optional = member.optional();
@@ -2797,7 +2804,7 @@ fn lower_optional_member_expression_impl<'a>(
 /// `parent_alternate` threads the shared null/undefined block.
 fn lower_optional_call_expression_impl<'a>(
     builder: &mut HirBuilder<'a, '_>,
-    call: &'a oxc::CallExpression<'a>,
+    call: &oxc::CallExpression<'a>,
     parent_alternate: Option<BlockId>,
 ) -> Result<InstructionValue<'a>, OxcDiagnostic> {
     let span = Some(call.span);
@@ -2958,7 +2965,7 @@ fn lower_optional_call_expression_impl<'a>(
 /// Mirrors the original `lower_function_to_value`.
 fn lower_function_to_value<'a>(
     builder: &mut HirBuilder<'a, '_>,
-    func: FunctionNode<'a>,
+    func: FunctionNode<'_, 'a>,
     expr_type: FunctionExpressionType,
 ) -> Result<InstructionValue<'a>, OxcDiagnostic> {
     let span = match func {
@@ -2966,7 +2973,7 @@ fn lower_function_to_value<'a>(
         FunctionNode::Function(f) => Some(f.span),
     };
     let name = match func {
-        FunctionNode::Function(f) => f.id.as_ref().map(|id| id.name.to_string()),
+        FunctionNode::Function(f) => f.id.as_ref().map(|id| id.name),
         FunctionNode::Arrow(_) => None,
     };
     let lowered_func = lower_function(builder, func)?;
@@ -2983,7 +2990,7 @@ fn lower_function_to_value<'a>(
 /// original `lower_function`.
 fn lower_function<'a>(
     builder: &mut HirBuilder<'a, '_>,
-    func: FunctionNode<'a>,
+    func: FunctionNode<'_, 'a>,
 ) -> Result<LoweredFunction, OxcDiagnostic> {
     // Extract function parts from the AST node
     let (params, body, id, generator, is_async, func_span) = match func {
@@ -2998,14 +3005,14 @@ fn lower_function<'a>(
             } else {
                 FunctionBody::Block(arrow.body.as_ref())
             };
-            (arrow.params.as_ref(), body, None::<&str>, false, arrow.r#async, arrow.span)
+            (arrow.params.as_ref(), body, None, false, arrow.r#async, arrow.span)
         }
         FunctionNode::Function(f) => {
             let body_ref = f.body.as_deref().expect("function expression has a body");
             (
                 f.params.as_ref(),
                 FunctionBody::Block(body_ref),
-                f.id.as_ref().map(|id| id.name.as_str()),
+                f.id.as_ref().map(|id| id.name),
                 f.generator,
                 f.r#async,
                 f.span,
@@ -3065,11 +3072,11 @@ fn lower_function<'a>(
 /// Lower a function declaration statement to a FunctionExpression + StoreLocal.
 fn lower_function_declaration<'a>(
     builder: &mut HirBuilder<'a, '_>,
-    func_decl: &'a oxc::Function<'a>,
+    func_decl: &oxc::Function<'a>,
 ) -> Result<(), OxcDiagnostic> {
     let span = func_decl.span;
 
-    let func_name = func_decl.id.as_ref().map(|id| id.name.to_string());
+    let func_name = func_decl.id.as_ref().map(|id| id.name);
 
     // Find the function's scope
     let function_scope =
@@ -3100,7 +3107,7 @@ fn lower_function_declaration<'a>(
     let (hir_func, child_used_names, child_bindings) = lower_inner(
         func_decl.params.as_ref(),
         FunctionBody::Block(body_ref),
-        func_decl.id.as_ref().map(|id| id.name.as_str()),
+        func_decl.id.as_ref().map(|id| id.name),
         func_decl.generator,
         func_decl.r#async,
         span,
@@ -3124,7 +3131,7 @@ fn lower_function_declaration<'a>(
 
     // Emit FunctionExpression instruction
     let fn_value = InstructionValue::FunctionExpression {
-        name: func_name.clone(),
+        name: func_name,
         name_hint: None,
         lowered_func,
         expr_type: FunctionExpressionType::FunctionDeclaration,
@@ -3141,10 +3148,11 @@ fn lower_function_declaration<'a>(
     // todo-repro-named-function-with-shadowed-local-same-name). Fall back to
     // node-based resolution when the scope walk fails (degraded scope info,
     // e.g. synthetic scopes, or backends that split function-body scopes).
-    if let Some(ref name) = func_name {
+    if let Some(name) = func_name {
         if let Some(id_node) = &func_decl.id {
             let ident_span = id_node.span;
-            let scope_binding = builder.get_function_declaration_binding(function_scope, name);
+            let scope_binding =
+                builder.get_function_declaration_binding(function_scope, name.as_str());
             let mut is_context = false;
             let binding = match scope_binding {
                 Some(symbol_id) => {
@@ -3171,7 +3179,7 @@ fn lower_function_declaration<'a>(
                             let scope = builder.scope();
                             let scope_id =
                                 func_decl.scope_id.get().unwrap_or_else(|| scope.program_scope());
-                            scope.find_binding(scope_id, name)
+                            scope.find_binding(scope_id, name.as_str())
                         };
                         if let Some(symbol_id) = fallback {
                             let symbol =
@@ -3241,9 +3249,9 @@ fn lower_function_declaration<'a>(
 fn lower_function_for_object_method<'a>(
     builder: &mut HirBuilder<'a, '_>,
     method_span: oxc_span::Span,
-    func: &'a oxc::Function<'a>,
-    params: &'a oxc::FormalParameters<'a>,
-    body: &'a oxc::FunctionBody<'a>,
+    func: &oxc::Function<'a>,
+    params: &oxc::FormalParameters<'a>,
+    body: &oxc::FunctionBody<'a>,
     generator: bool,
     is_async: bool,
 ) -> Result<LoweredFunction, OxcDiagnostic> {
@@ -3398,13 +3406,13 @@ fn capture_scopes(
 
 fn lower_expression<'a>(
     builder: &mut HirBuilder<'a, '_>,
-    expr: &'a oxc::Expression<'a>,
+    expr: &oxc::Expression<'a>,
 ) -> Result<InstructionValue<'a>, OxcDiagnostic> {
     match expr {
         oxc::Expression::Identifier(ident) => {
             let span = Some(ident.span);
             let symbol = builder.scope().resolve_reference(ident);
-            let place = lower_identifier(builder, ident.name.as_str(), ident.span, symbol)?;
+            let place = lower_identifier(builder, ident.name, ident.span, symbol)?;
             if builder.is_context_identifier(symbol) {
                 Ok(InstructionValue::LoadContext { place, span })
             } else {
@@ -3423,12 +3431,15 @@ fn lower_expression<'a>(
             span: Some(lit.span),
         }),
         oxc::Expression::StringLiteral(lit) => Ok(InstructionValue::Primitive {
-            value: PrimitiveValue::String(lit.value.to_string().into()),
+            value: PrimitiveValue::String(lit.value.into()),
             span: Some(lit.span),
         }),
         oxc::Expression::RegExpLiteral(regexp) => Ok(InstructionValue::RegExpLiteral {
-            pattern: regexp.regex.pattern.text.as_str().to_string(),
-            flags: regexp.regex.flags.to_string(),
+            pattern: regexp.regex.pattern.text,
+            flags: Str::from_str_in(
+                &regexp.regex.flags.to_string(),
+                &builder.environment().allocator,
+            ),
             span: Some(regexp.span),
         }),
         oxc::Expression::BinaryExpression(bin) => {
@@ -3791,8 +3802,8 @@ fn lower_expression<'a>(
             let span = Some(meta.span);
             if meta.meta.name == "import" && meta.property.name == "meta" {
                 Ok(InstructionValue::MetaProperty {
-                    meta: meta.meta.name.to_string(),
-                    property: meta.property.name.to_string(),
+                    meta: meta.meta.name,
+                    property: meta.property.name,
                     span,
                 })
             } else {
@@ -3947,8 +3958,7 @@ fn lower_expression<'a>(
                     }
 
                     let ident_span = ident.span;
-                    let binding =
-                        builder.resolve_identifier(ident.name.as_str(), ident_span, symbol)?;
+                    let binding = builder.resolve_identifier(ident.name, ident_span, symbol)?;
                     if matches!(binding, VariableBinding::Global { .. }) {
                         builder.record_error(
                             ErrorCategory::Todo
@@ -3984,7 +3994,7 @@ fn lower_expression<'a>(
                     // Load the current value
                     let value = lower_identifier(
                         builder,
-                        ident.name.as_str(),
+                        ident.name,
                         ident_span,
                         builder.scope().resolve_reference(ident),
                     )?;
@@ -4143,7 +4153,7 @@ fn lower_expression<'a>(
 /// operators (`+=` etc.) handle identifier / member targets and bail on patterns.
 fn lower_assignment_expression<'a>(
     builder: &mut HirBuilder<'a, '_>,
-    assign: &'a oxc::AssignmentExpression<'a>,
+    assign: &oxc::AssignmentExpression<'a>,
 ) -> Result<InstructionValue<'a>, OxcDiagnostic> {
     let span = Some(assign.span);
 
@@ -4153,8 +4163,7 @@ fn lower_assignment_expression<'a>(
                 let symbol = builder.scope().resolve_reference(ident);
                 let right = lower_expression_to_temporary(builder, &assign.right)?;
                 let ident_span = ident.span;
-                let binding =
-                    builder.resolve_identifier(ident.name.as_str(), ident_span, symbol)?;
+                let binding = builder.resolve_identifier(ident.name, ident_span, symbol)?;
                 match binding {
                     VariableBinding::Identifier { identifier, binding_kind } => {
                         if binding_kind == BindingKind::Const {
@@ -4207,7 +4216,7 @@ fn lower_assignment_expression<'a>(
                         }
                     }
                     _ => {
-                        let name = ident.name.to_string();
+                        let name = ident.name;
                         let temp = lower_value_to_temporary(
                             builder,
                             InstructionValue::StoreGlobal {
@@ -4233,7 +4242,7 @@ fn lower_assignment_expression<'a>(
                             builder,
                             InstructionValue::PropertyStore {
                                 object,
-                                property: PropertyLiteral::String(member.property.name.to_string()),
+                                property: PropertyLiteral::String(member.property.name),
                                 value: right,
                                 span: left_span,
                             },
@@ -4344,8 +4353,7 @@ fn lower_assignment_expression<'a>(
             oxc::AssignmentTarget::AssignmentTargetIdentifier(ident) => {
                 let ident_span = ident.span;
                 let symbol = builder.scope().resolve_reference(ident);
-                let left_place =
-                    lower_identifier(builder, ident.name.as_str(), ident_span, symbol)?;
+                let left_place = lower_identifier(builder, ident.name, ident_span, symbol)?;
                 let right = lower_expression_to_temporary(builder, &assign.right)?;
                 let binary_place = lower_value_to_temporary(
                     builder,
@@ -4356,8 +4364,7 @@ fn lower_assignment_expression<'a>(
                         span,
                     },
                 )?;
-                let binding =
-                    builder.resolve_identifier(ident.name.as_str(), ident_span, symbol)?;
+                let binding = builder.resolve_identifier(ident.name, ident_span, symbol)?;
                 match binding {
                     VariableBinding::Identifier { identifier, .. } => {
                         let place = Place {
@@ -4395,7 +4402,7 @@ fn lower_assignment_expression<'a>(
                         }
                     }
                     _ => {
-                        let name = ident.name.to_string();
+                        let name = ident.name;
                         let temp = lower_value_to_temporary(
                             builder,
                             InstructionValue::StoreGlobal { name, value: binary_place, span },
@@ -4459,7 +4466,7 @@ fn lower_assignment_expression<'a>(
 /// below.
 fn lower_jsx_element_expr<'a>(
     builder: &mut HirBuilder<'a, '_>,
-    jsx_element: &'a oxc::JSXElement<'a>,
+    jsx_element: &oxc::JSXElement<'a>,
 ) -> Result<InstructionValue<'a>, OxcDiagnostic> {
     let span = Some(jsx_element.span);
     let opening_span = Some(jsx_element.opening_element.span);
@@ -4490,23 +4497,30 @@ fn lower_jsx_element_expr<'a>(
                                     )).with_label(id.span),
                             )?;
                         }
-                        name.to_string()
+                        Ident::from(name)
                     }
-                    oxc::JSXAttributeName::NamespacedName(ns) => {
-                        format!("{}:{}", ns.namespace.name, ns.name.name)
-                    }
+                    oxc::JSXAttributeName::NamespacedName(ns) => format_ident!(
+                        builder.environment().allocator,
+                        "{}:{}",
+                        ns.namespace.name,
+                        ns.name.name
+                    ),
                 };
 
                 // Get the attribute value
                 let value = match &attr.value {
                     Some(oxc::JSXAttributeValue::StringLiteral(s)) => {
                         let str_span = Some(s.span);
+                        let decoded = match decode_jsx_entities(s.value.as_str()) {
+                            Cow::Borrowed(text) => JsString::from(text),
+                            Cow::Owned(text) => {
+                                JsString::from_str_in(&text, builder.environment().allocator)
+                            }
+                        };
                         lower_value_to_temporary(
                             builder,
                             InstructionValue::Primitive {
-                                value: PrimitiveValue::String(
-                                    decode_jsx_entities(s.value.as_str()).into(),
-                                ),
+                                value: PrimitiveValue::String(decoded),
                                 span: str_span,
                             },
                         )?
@@ -4558,8 +4572,8 @@ fn lower_jsx_element_expr<'a>(
     // Matches TS: Diagnostics.invariant(tagIdentifier.kind !== 'Identifier', ...)
     if is_fbt {
         let tag_name = match &tag {
-            JsxTag::Builtin(b) => b.name.clone(),
-            _ => "fbt".to_string(),
+            JsxTag::Builtin(b) => b.name,
+            _ => Ident::from("fbt"),
         };
         // Get the opening element's name identifier and check if it's a local binding.
         let jsx_id_name = match &jsx_element.opening_element.name {
@@ -4654,7 +4668,7 @@ fn lower_jsx_element_expr<'a>(
 /// `Expression::JSXFragment` arm.
 fn lower_jsx_fragment_expr<'a>(
     builder: &mut HirBuilder<'a, '_>,
-    jsx_fragment: &'a oxc::JSXFragment<'a>,
+    jsx_fragment: &oxc::JSXFragment<'a>,
 ) -> Result<InstructionValue<'a>, OxcDiagnostic> {
     let span = Some(jsx_fragment.span);
 
@@ -4675,17 +4689,17 @@ fn lower_jsx_fragment_expr<'a>(
 /// `lower_jsx_element_name`, adapted to oxc's `JSXElementName` shape (which splits
 /// out `IdentifierReference`, `MemberExpression`, and `ThisExpression`; the latter
 /// maps to the identifier `"this"`).
-fn lower_jsx_element_name(
-    builder: &mut HirBuilder<'_, '_>,
-    name: &oxc::JSXElementName,
-) -> Result<JsxTag, OxcDiagnostic> {
+fn lower_jsx_element_name<'a>(
+    builder: &mut HirBuilder<'a, '_>,
+    name: &oxc::JSXElementName<'a>,
+) -> Result<JsxTag<'a>, OxcDiagnostic> {
     // Lower a simple JSX tag identifier (component-vs-builtin split on case).
-    fn lower_tag_identifier(
-        builder: &mut HirBuilder<'_, '_>,
-        tag: &str,
+    fn lower_tag_identifier<'a>(
+        builder: &mut HirBuilder<'a, '_>,
+        tag: Ident<'a>,
         span: oxc_span::Span,
         symbol: Option<SymbolId>,
-    ) -> Result<JsxTag, OxcDiagnostic> {
+    ) -> Result<JsxTag<'a>, OxcDiagnostic> {
         if tag.starts_with(|c: char| c.is_ascii_uppercase()) {
             // Component tag: resolve as identifier and load
             let place = lower_identifier(builder, tag, span, symbol)?;
@@ -4698,21 +4712,21 @@ fn lower_jsx_element_name(
             Ok(JsxTag::Place(temp))
         } else {
             // Builtin HTML tag
-            Ok(JsxTag::Builtin(BuiltinTag { name: tag.to_string() }))
+            Ok(JsxTag::Builtin(BuiltinTag { name: tag }))
         }
     }
 
     match name {
         oxc::JSXElementName::Identifier(id) => {
-            lower_tag_identifier(builder, id.name.as_str(), id.span, None)
+            lower_tag_identifier(builder, Ident::from(id.name.as_str()), id.span, None)
         }
         oxc::JSXElementName::IdentifierReference(id) => {
             let symbol = builder.scope().resolve_reference(id);
-            lower_tag_identifier(builder, id.name.as_str(), id.span, symbol)
+            lower_tag_identifier(builder, id.name, id.span, symbol)
         }
         oxc::JSXElementName::ThisExpression(this) => {
             // `<this.Foo />`-style `this` tag lowers as the identifier "this".
-            lower_tag_identifier(builder, "this", this.span, None)
+            lower_tag_identifier(builder, Ident::from("this"), this.span, None)
         }
         oxc::JSXElementName::MemberExpression(member) => {
             let place = lower_jsx_member_expression(builder, member)?;
@@ -4735,7 +4749,13 @@ fn lower_jsx_element_name(
             }
             let place = lower_value_to_temporary(
                 builder,
-                InstructionValue::Primitive { value: PrimitiveValue::String(tag.into()), span },
+                InstructionValue::Primitive {
+                    value: PrimitiveValue::String(JsString::from_str_in(
+                        &tag,
+                        builder.environment().allocator,
+                    )),
+                    span,
+                },
             )?;
             Ok(JsxTag::Place(place))
         }
@@ -4746,26 +4766,24 @@ fn lower_jsx_element_name(
 /// translation of the original `lower_jsx_member_expression`, adapted to oxc's
 /// `JSXMemberExpressionObject` (where the leaf object may be a `ThisExpression`,
 /// which lowers as the identifier `"this"`).
-fn lower_jsx_member_expression(
-    builder: &mut HirBuilder<'_, '_>,
-    expr: &oxc::JSXMemberExpression,
+fn lower_jsx_member_expression<'a>(
+    builder: &mut HirBuilder<'a, '_>,
+    expr: &oxc::JSXMemberExpression<'a>,
 ) -> Result<Place, OxcDiagnostic> {
     // Use the full member expression's span for instruction locs (matching TS: exprPath.node.span)
     let expr_span = Some(expr.span);
     let object = match &expr.object {
         oxc::JSXMemberExpressionObject::IdentifierReference(id) => {
             let symbol = builder.scope().resolve_reference(id);
-            lower_jsx_member_object_identifier(
-                builder,
-                id.name.as_str(),
-                id.span,
-                symbol,
-                &expr_span,
-            )?
+            lower_jsx_member_object_identifier(builder, id.name, id.span, symbol, &expr_span)?
         }
-        oxc::JSXMemberExpressionObject::ThisExpression(this) => {
-            lower_jsx_member_object_identifier(builder, "this", this.span, None, &expr_span)?
-        }
+        oxc::JSXMemberExpressionObject::ThisExpression(this) => lower_jsx_member_object_identifier(
+            builder,
+            Ident::from("this"),
+            this.span,
+            None,
+            &expr_span,
+        )?,
         oxc::JSXMemberExpressionObject::MemberExpression(inner) => {
             lower_jsx_member_expression(builder, inner)?
         }
@@ -4773,7 +4791,7 @@ fn lower_jsx_member_expression(
     let prop_name = expr.property.name.as_str();
     let value = InstructionValue::PropertyLoad {
         object,
-        property: PropertyLiteral::String(prop_name.to_string()),
+        property: PropertyLiteral::String(Ident::from(prop_name)),
         span: expr_span,
     };
     lower_value_to_temporary(builder, value)
@@ -4782,9 +4800,9 @@ fn lower_jsx_member_expression(
 /// Lower the leaf identifier of a JSX member expression object. Uses the
 /// identifier's own span for the place, but the enclosing member expression's span
 /// for the load instruction (matching TS).
-fn lower_jsx_member_object_identifier(
-    builder: &mut HirBuilder<'_, '_>,
-    name: &str,
+fn lower_jsx_member_object_identifier<'a>(
+    builder: &mut HirBuilder<'a, '_>,
+    name: Ident<'a>,
     span: oxc_span::Span,
     symbol: Option<SymbolId>,
     expr_span: &Option<Span>,
@@ -4802,7 +4820,7 @@ fn lower_jsx_member_object_identifier(
 /// original `lower_jsx_element` (the JSXChild handler), adapted to oxc's `JSXChild`.
 fn lower_jsx_element<'a>(
     builder: &mut HirBuilder<'a, '_>,
-    child: &'a oxc::JSXChild<'a>,
+    child: &oxc::JSXChild<'a>,
 ) -> Result<Option<Place>, OxcDiagnostic> {
     match child {
         oxc::JSXChild::Text(text) => {
@@ -4812,7 +4830,17 @@ fn lower_jsx_element<'a>(
             // FBT whitespace normalization differs from standard JSX.
             // Since the fbt transform runs after, preserve all whitespace
             // in FBT subtrees as is.
-            let value = if builder.fbt_depth > 0 { Some(decoded) } else { trim_jsx_text(&decoded) };
+            let value = if builder.fbt_depth > 0 {
+                Some(match decoded {
+                    Cow::Borrowed(text) => Str::from(text),
+                    Cow::Owned(ref text) => {
+                        Str::from_str_in(text, &builder.environment().allocator)
+                    }
+                })
+            } else {
+                trim_jsx_text(&decoded)
+                    .map(|text| Str::from_str_in(&text, &builder.environment().allocator))
+            };
             match value {
                 None => Ok(None),
                 Some(value) => {
@@ -5182,9 +5210,9 @@ fn trim_jsx_text(original: &str) -> Option<String> {
 /// Babel's decoded text. oxc keeps JSX text raw in the AST. Mirrors the
 /// `decode_jsx_entities` helper in `convert_ast.rs`. Unrecognized `&…;` sequences
 /// are kept verbatim.
-fn decode_jsx_entities(s: &str) -> String {
+fn decode_jsx_entities(s: &str) -> Cow<'_, str> {
     if !s.contains('&') {
-        return s.to_string();
+        return Cow::Borrowed(s);
     }
     let mut out = String::with_capacity(s.len());
     let mut chars = s.char_indices();
@@ -5227,7 +5255,7 @@ fn decode_jsx_entities(s: &str) -> String {
         }
     }
     out.push_str(&s[prev..]);
-    out
+    Cow::Owned(out)
 }
 
 /// Get the Babel-style type name of an oxc `Expression` node. Mirrors the
@@ -5290,8 +5318,8 @@ fn expression_type_name(expr: &oxc::Expression) -> &'static str {
 /// `ObjectMethod` instruction value.
 fn lower_object_method<'a>(
     builder: &mut HirBuilder<'a, '_>,
-    method: &'a oxc::ObjectProperty<'a>,
-) -> Result<Option<ObjectProperty>, OxcDiagnostic> {
+    method: &oxc::ObjectProperty<'a>,
+) -> Result<Option<ObjectProperty<'a>>, OxcDiagnostic> {
     // In oxc, a shorthand method is encoded as `kind: Init, method: true`; only
     // getters/setters carry a non-`Init` `PropertyKind`.
     let is_method = method.method && matches!(method.kind, oxc::PropertyKind::Init);
@@ -5313,7 +5341,7 @@ fn lower_object_method<'a>(
     }
 
     let key = lower_object_property_key(builder, &method.key, method.computed)?
-        .unwrap_or(ObjectPropertyKey::String { name: String::new() });
+        .unwrap_or(ObjectPropertyKey::String { name: Ident::empty() });
 
     let func = match &method.value {
         oxc::Expression::FunctionExpression(func) => func,
@@ -5340,23 +5368,23 @@ fn lower_object_method<'a>(
 /// Lower an object property key. Faithful to the original `lower_object_property_key`.
 fn lower_object_property_key<'a>(
     builder: &mut HirBuilder<'a, '_>,
-    key: &'a oxc::PropertyKey<'a>,
+    key: &oxc::PropertyKey<'a>,
     computed: bool,
-) -> Result<Option<ObjectPropertyKey>, OxcDiagnostic> {
+) -> Result<Option<ObjectPropertyKey<'a>>, OxcDiagnostic> {
     match key {
-        // Property keys stay String-typed; oxc atoms are valid UTF-8, so
-        // `to_string()` reproduces the marker wire form for non-pathological keys.
         oxc::PropertyKey::StringLiteral(lit) => {
-            Ok(Some(ObjectPropertyKey::String { name: lit.value.to_string() }))
+            Ok(Some(ObjectPropertyKey::String { name: Ident::from(lit.value.as_str()) }))
         }
         oxc::PropertyKey::StaticIdentifier(ident) if !computed => {
-            Ok(Some(ObjectPropertyKey::Identifier { name: ident.name.to_string() }))
+            Ok(Some(ObjectPropertyKey::Identifier { name: ident.name }))
         }
         oxc::PropertyKey::Identifier(ident) if !computed => {
-            Ok(Some(ObjectPropertyKey::Identifier { name: ident.name.to_string() }))
+            Ok(Some(ObjectPropertyKey::Identifier { name: ident.name }))
         }
         oxc::PropertyKey::NumericLiteral(lit) if !computed => {
-            Ok(Some(ObjectPropertyKey::Identifier { name: lit.value.to_string() }))
+            Ok(Some(ObjectPropertyKey::Identifier {
+                name: format_ident!(builder.environment().allocator, "{}", lit.value),
+            }))
         }
         _ if computed => {
             let place = lower_expression_to_temporary(builder, key.to_expression())?;
@@ -5383,7 +5411,7 @@ fn lower_object_property_key<'a>(
 /// safely reordered, then lowers it to a temporary regardless.
 fn lower_reorderable_expression<'a>(
     builder: &mut HirBuilder<'a, '_>,
-    expr: &'a oxc::Expression<'a>,
+    expr: &oxc::Expression<'a>,
 ) -> Result<Place, OxcDiagnostic> {
     if !is_reorderable_expression(builder, expr, true) {
         builder.record_error(
@@ -5553,8 +5581,8 @@ fn is_reorderable_expression(
 
 fn lower_statement<'a>(
     builder: &mut HirBuilder<'a, '_>,
-    stmt: &'a oxc::Statement<'a>,
-    label: Option<&str>,
+    stmt: &oxc::Statement<'a>,
+    label: Option<Ident<'a>>,
     parent_scope: Option<crate::scope::ScopeId>,
 ) -> Result<(), OxcDiagnostic> {
     match stmt {
@@ -5729,20 +5757,15 @@ fn lower_statement<'a>(
             let continue_target = update_block_id.unwrap_or(test_block_id);
             let body_span = Some(for_stmt.body.span());
             let body_block = builder.try_enter(BlockKind::Block, |builder, _block_id| {
-                builder.loop_scope(
-                    label.map(|s| s.to_string()),
-                    continue_target,
-                    continuation_id,
-                    |builder| {
-                        lower_statement(builder, &for_stmt.body, None, parent_scope)?;
-                        Ok(Terminal::Goto {
-                            block: continue_target,
-                            variant: GotoVariant::Continue,
-                            id: EvaluationOrder(0),
-                            span: body_span,
-                        })
-                    },
-                )
+                builder.loop_scope(label, continue_target, continuation_id, |builder| {
+                    lower_statement(builder, &for_stmt.body, None, parent_scope)?;
+                    Ok(Terminal::Goto {
+                        block: continue_target,
+                        variant: GotoVariant::Continue,
+                        id: EvaluationOrder(0),
+                        span: body_span,
+                    })
+                })
             })?;
 
             // Emit For terminal, then fill in the test block
@@ -5808,20 +5831,15 @@ fn lower_statement<'a>(
             // Loop body
             let body_span = Some(while_stmt.body.span());
             let loop_block = builder.try_enter(BlockKind::Block, |builder, _block_id| {
-                builder.loop_scope(
-                    label.map(|s| s.to_string()),
-                    conditional_id,
-                    continuation_id,
-                    |builder| {
-                        lower_statement(builder, &while_stmt.body, None, parent_scope)?;
-                        Ok(Terminal::Goto {
-                            block: conditional_id,
-                            variant: GotoVariant::Continue,
-                            id: EvaluationOrder(0),
-                            span: body_span,
-                        })
-                    },
-                )
+                builder.loop_scope(label, conditional_id, continuation_id, |builder| {
+                    lower_statement(builder, &while_stmt.body, None, parent_scope)?;
+                    Ok(Terminal::Goto {
+                        block: conditional_id,
+                        variant: GotoVariant::Continue,
+                        id: EvaluationOrder(0),
+                        span: body_span,
+                    })
+                })
             })?;
 
             // Emit While terminal, jumping to the conditional block
@@ -5862,20 +5880,15 @@ fn lower_statement<'a>(
             // Loop body, executed at least once unconditionally prior to exit
             let body_span = Some(do_while_stmt.body.span());
             let loop_block = builder.try_enter(BlockKind::Block, |builder, _block_id| {
-                builder.loop_scope(
-                    label.map(|s| s.to_string()),
-                    conditional_id,
-                    continuation_id,
-                    |builder| {
-                        lower_statement(builder, &do_while_stmt.body, None, parent_scope)?;
-                        Ok(Terminal::Goto {
-                            block: conditional_id,
-                            variant: GotoVariant::Continue,
-                            id: EvaluationOrder(0),
-                            span: body_span,
-                        })
-                    },
-                )
+                builder.loop_scope(label, conditional_id, continuation_id, |builder| {
+                    lower_statement(builder, &do_while_stmt.body, None, parent_scope)?;
+                    Ok(Terminal::Goto {
+                        block: conditional_id,
+                        variant: GotoVariant::Continue,
+                        id: EvaluationOrder(0),
+                        span: body_span,
+                    })
+                })
             })?;
 
             // Jump to the conditional block
@@ -5913,20 +5926,15 @@ fn lower_statement<'a>(
 
             let body_span = Some(for_in.body.span());
             let loop_block = builder.try_enter(BlockKind::Block, |builder, _block_id| {
-                builder.loop_scope(
-                    label.map(|s| s.to_string()),
-                    init_block_id,
-                    continuation_id,
-                    |builder| {
-                        lower_statement(builder, &for_in.body, None, parent_scope)?;
-                        Ok(Terminal::Goto {
-                            block: init_block_id,
-                            variant: GotoVariant::Continue,
-                            id: EvaluationOrder(0),
-                            span: body_span,
-                        })
-                    },
-                )
+                builder.loop_scope(label, init_block_id, continuation_id, |builder| {
+                    lower_statement(builder, &for_in.body, None, parent_scope)?;
+                    Ok(Terminal::Goto {
+                        block: init_block_id,
+                        variant: GotoVariant::Continue,
+                        id: EvaluationOrder(0),
+                        span: body_span,
+                    })
+                })
             })?;
 
             let value = lower_expression_to_temporary(builder, &for_in.right)?;
@@ -5988,20 +5996,15 @@ fn lower_statement<'a>(
 
             let body_span = Some(for_of.body.span());
             let loop_block = builder.try_enter(BlockKind::Block, |builder, _block_id| {
-                builder.loop_scope(
-                    label.map(|s| s.to_string()),
-                    init_block_id,
-                    continuation_id,
-                    |builder| {
-                        lower_statement(builder, &for_of.body, None, parent_scope)?;
-                        Ok(Terminal::Goto {
-                            block: init_block_id,
-                            variant: GotoVariant::Continue,
-                            id: EvaluationOrder(0),
-                            span: body_span,
-                        })
-                    },
-                )
+                builder.loop_scope(label, init_block_id, continuation_id, |builder| {
+                    lower_statement(builder, &for_of.body, None, parent_scope)?;
+                    Ok(Terminal::Goto {
+                        block: init_block_id,
+                        variant: GotoVariant::Continue,
+                        id: EvaluationOrder(0),
+                        span: body_span,
+                    })
+                })
             })?;
 
             let value = lower_expression_to_temporary(builder, &for_of.right)?;
@@ -6094,7 +6097,7 @@ fn lower_statement<'a>(
 
                 let fallthrough_target = fallthrough;
                 let block = builder.try_enter(BlockKind::Block, |builder, _block_id| {
-                    builder.switch_scope(label.map(|s| s.to_string()), continuation_id, |builder| {
+                    builder.switch_scope(label, continuation_id, |builder| {
                         for consequent in &case.consequent {
                             lower_statement(builder, consequent, None, parent_scope)?;
                         }
@@ -6310,7 +6313,7 @@ fn lower_statement<'a>(
             );
         }
         oxc::Statement::LabeledStatement(labeled_stmt) => {
-            let label_name = labeled_stmt.label.name.as_str();
+            let label_name = labeled_stmt.label.name;
             let span = Some(labeled_stmt.span);
 
             // Check if the body is a loop statement - if so, delegate with label
@@ -6328,10 +6331,8 @@ fn lower_statement<'a>(
                     let continuation_block = builder.reserve(BlockKind::Block);
                     let continuation_id = continuation_block.id;
                     let body_span = Some(labeled_stmt.body.span());
-                    let label_string = label_name.to_string();
-
                     let block = builder.try_enter(BlockKind::Block, |builder, _block_id| {
-                        builder.label_scope(label_string, continuation_id, |builder| {
+                        builder.label_scope(label_name, continuation_id, |builder| {
                             lower_statement(builder, &labeled_stmt.body, None, parent_scope)?;
                             Ok(())
                         })?;
@@ -6381,10 +6382,12 @@ fn lower_statement<'a>(
         }
         oxc::Statement::TSEnumDeclaration(e) => {
             // Inline TS `enum` has runtime semantics, so preserve it: emit an
-            // `UnsupportedNode` carrying the borrowed oxc statement node so the
-            // back-end can clone it verbatim into the output allocator (matching
-            // the original Babel front-end, which wrapped the enum the same way).
+            // `UnsupportedNode` carrying an arena clone of the oxc statement node
+            // so the back-end can re-emit it verbatim (matching the original Babel
+            // front-end, which wrapped the enum the same way).
             let span = Some(e.span);
+            let allocator = builder.environment().allocator;
+            let stmt = &*allocator.alloc(stmt.clone_in_with_semantic_ids(allocator));
             lower_value_to_temporary(builder, InstructionValue::UnsupportedNode { stmt, span })?;
         }
         _ => {
@@ -6403,7 +6406,7 @@ fn lower_statement<'a>(
 /// `Statement`).
 fn lower_variable_declaration<'a>(
     builder: &mut HirBuilder<'a, '_>,
-    var_decl: &'a oxc::VariableDeclaration<'a>,
+    var_decl: &oxc::VariableDeclaration<'a>,
 ) -> Result<(), OxcDiagnostic> {
     use oxc::VariableDeclarationKind as VK;
     if matches!(var_decl.kind, VK::Var) {
@@ -6447,7 +6450,7 @@ fn lower_variable_declaration<'a>(
             // No init: emit DeclareLocal or DeclareContext
             let id_span = id.span;
             let mut binding = builder.resolve_identifier(
-                id.name.as_str(),
+                id.name,
                 id_span,
                 builder.scope().resolve_binding_identifier(id),
             )?;
@@ -6461,11 +6464,8 @@ fn lower_variable_declaration<'a>(
                     let binding_kind = crate::react_compiler_lowering::convert_binding_kind(
                         &builder.scope().binding_kind(symbol_id),
                     );
-                    let identifier = builder.resolve_binding_with_span(
-                        id.name.as_str(),
-                        symbol_id,
-                        Some(id_span),
-                    )?;
+                    let identifier =
+                        builder.resolve_binding_with_span(id.name, symbol_id, Some(id_span))?;
                     binding = VariableBinding::Identifier { identifier, binding_kind };
                 }
             }
@@ -6529,7 +6529,7 @@ fn lower_variable_declaration<'a>(
 /// patterns) lowering. Mirrors the original `ForInOfLeft` match.
 fn lower_for_in_of_left<'a>(
     builder: &mut HirBuilder<'a, '_>,
-    left: &'a oxc::ForStatementLeft<'a>,
+    left: &oxc::ForStatementLeft<'a>,
     left_span: Span,
     value: Place,
 ) -> Result<Option<Place>, OxcDiagnostic> {

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/find_context_identifiers.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/find_context_identifiers.rs
@@ -423,7 +423,7 @@ fn is_captured_by_function(
 ///
 /// This is the Rust equivalent of the TypeScript `FindContextIdentifiers` pass.
 pub fn find_context_identifiers(
-    func: &FunctionNode<'_>,
+    func: &FunctionNode<'_, '_>,
     scope: &ScopeResolver<'_, '_>,
     identifier_spans: &crate::react_compiler_lowering::identifier_loc_index::IdentifierLocIndex,
 ) -> Result<FxHashSet<SymbolId>, OxcDiagnostic> {

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/hir_builder.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/hir_builder.rs
@@ -5,6 +5,7 @@ use crate::react_compiler_hir::visitors::terminal_fallthrough;
 use crate::react_compiler_hir::*;
 use crate::react_compiler_utils::FxIndexMap;
 use crate::react_compiler_utils::FxIndexSet;
+use crate::react_compiler_utils::IdentIndexMap;
 use crate::scope::DeclKind;
 use crate::scope::ImportBindingKind;
 use crate::scope::ScopeId;
@@ -13,11 +14,12 @@ use crate::scope::SymbolId;
 
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::Span;
+use oxc_str::{Ident, format_ident};
 
 use crate::react_compiler_lowering::identifier_loc_index::IdentifierLocIndex;
 
 type BuildResult<'a> = Result<
-    (HIR, Vec<Instruction<'a>>, FxIndexMap<String, SymbolId>, FxIndexMap<SymbolId, IdentifierId>),
+    (HIR, Vec<Instruction<'a>>, IdentIndexMap<'a, SymbolId>, FxIndexMap<SymbolId, IdentifierId>),
     OxcDiagnostic,
 >;
 
@@ -78,13 +80,13 @@ pub(crate) fn reserved_identifier_diagnostic(name: &str) -> OxcDiagnostic {
 // Scope types for tracking break/continue targets
 // ---------------------------------------------------------------------------
 
-enum Scope {
-    Loop { label: Option<String>, continue_block: BlockId, break_block: BlockId },
-    Label { label: String, break_block: BlockId },
-    Switch { label: Option<String>, break_block: BlockId },
+enum Scope<'a> {
+    Loop { label: Option<Ident<'a>>, continue_block: BlockId, break_block: BlockId },
+    Label { label: Ident<'a>, break_block: BlockId },
+    Switch { label: Option<Ident<'a>>, break_block: BlockId },
 }
 
-impl Scope {
+impl Scope<'_> {
     fn label(&self) -> Option<&str> {
         match self {
             Scope::Loop { label, .. } => label.as_deref(),
@@ -124,7 +126,7 @@ pub struct HirBuilder<'a, 'b> {
     completed: FxIndexMap<BlockId, BasicBlock>,
     current: WipBlock,
     entry: BlockId,
-    scopes: Vec<Scope>,
+    scopes: Vec<Scope<'a>>,
     /// Context identifiers: variables captured from an outer scope.
     /// Maps the outer scope's symbol to the source location where it was referenced.
     context: FxIndexMap<SymbolId, Option<Span>>,
@@ -132,7 +134,7 @@ pub struct HirBuilder<'a, 'b> {
     bindings: FxIndexMap<SymbolId, IdentifierId>,
     /// Names already used by bindings, for collision avoidance.
     /// Maps name string -> how many times it has been used (for appending _0, _1, ...).
-    used_names: FxIndexMap<String, SymbolId>,
+    used_names: IdentIndexMap<'a, SymbolId>,
     env: &'b mut Environment<'a>,
     scope: &'b ScopeResolver<'b, 'a>,
     exception_handler_stack: Vec<BlockId>,
@@ -176,7 +178,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
         bindings: Option<FxIndexMap<SymbolId, IdentifierId>>,
         context: Option<FxIndexMap<SymbolId, Option<Span>>>,
         entry_block_kind: Option<BlockKind>,
-        used_names: Option<FxIndexMap<String, SymbolId>>,
+        used_names: Option<IdentIndexMap<'a, SymbolId>>,
         identifier_spans: &'b IdentifierLocIndex,
     ) -> Self {
         let entry = env.next_block_id();
@@ -225,7 +227,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
 
     /// Create a new unique TypeVar type, allocated from the environment's type arena
     /// so that TypeIds are consistent with identifier type slots.
-    pub fn make_type(&mut self) -> Type {
+    pub fn make_type(&mut self) -> Type<'a> {
         let type_id = self.env.make_type();
         Type::TypeVar { id: type_id }
     }
@@ -279,13 +281,13 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
     }
 
     /// Access the used names map.
-    pub fn used_names(&self) -> &FxIndexMap<String, SymbolId> {
+    pub fn used_names(&self) -> &IdentIndexMap<'a, SymbolId> {
         &self.used_names
     }
 
     /// Merge used names from a child builder back into this builder.
     /// This ensures name deduplication works across function scopes.
-    pub fn merge_used_names(&mut self, child_used_names: FxIndexMap<String, SymbolId>) {
+    pub fn merge_used_names(&mut self, child_used_names: IdentIndexMap<'a, SymbolId>) {
         for (name, symbol_id) in child_used_names {
             self.used_names.entry(name).or_insert(symbol_id);
         }
@@ -430,12 +432,12 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
     /// Push a Loop scope, run the closure, pop and verify.
     pub fn loop_scope<T>(
         &mut self,
-        label: Option<String>,
+        label: Option<Ident<'a>>,
         continue_block: BlockId,
         break_block: BlockId,
         f: impl FnOnce(&mut Self) -> Result<T, OxcDiagnostic>,
     ) -> Result<T, OxcDiagnostic> {
-        self.scopes.push(Scope::Loop { label: label.clone(), continue_block, break_block });
+        self.scopes.push(Scope::Loop { label, continue_block, break_block });
         let value = f(self)?;
         let last = self.scopes.pop().expect("Mismatched loop scope: stack empty");
         match &last {
@@ -456,11 +458,11 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
     /// Push a Label scope, run the closure, pop and verify.
     pub fn label_scope<T>(
         &mut self,
-        label: String,
+        label: Ident<'a>,
         break_block: BlockId,
         f: impl FnOnce(&mut Self) -> Result<T, OxcDiagnostic>,
     ) -> Result<T, OxcDiagnostic> {
-        self.scopes.push(Scope::Label { label: label.clone(), break_block });
+        self.scopes.push(Scope::Label { label, break_block });
         let value = f(self)?;
         let last = self.scopes.pop().expect("Mismatched label scope: stack empty");
         match &last {
@@ -478,11 +480,11 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
     /// Push a Switch scope, run the closure, pop and verify.
     pub fn switch_scope<T>(
         &mut self,
-        label: Option<String>,
+        label: Option<Ident<'a>>,
         break_block: BlockId,
         f: impl FnOnce(&mut Self) -> Result<T, OxcDiagnostic>,
     ) -> Result<T, OxcDiagnostic> {
-        self.scopes.push(Scope::Switch { label: label.clone(), break_block });
+        self.scopes.push(Scope::Switch { label, break_block });
         let value = f(self)?;
         let last = self.scopes.pop().expect("Mismatched switch scope: stack empty");
         match &last {
@@ -637,7 +639,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
     /// Records errors for variables named 'fbt' or 'this'.
     pub fn resolve_binding(
         &mut self,
-        name: &str,
+        name: Ident<'a>,
         symbol_id: SymbolId,
     ) -> Result<IdentifierId, OxcDiagnostic> {
         self.resolve_binding_with_span(name, symbol_id, None)
@@ -646,7 +648,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
     /// Map a symbol to an HIR IdentifierId, with an optional source location.
     pub fn resolve_binding_with_span(
         &mut self,
-        name: &str,
+        name: Ident<'a>,
         symbol_id: SymbolId,
         span: Option<Span>,
     ) -> Result<IdentifierId, OxcDiagnostic> {
@@ -684,13 +686,13 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
             return Ok(identifier_id);
         }
 
-        if is_always_reserved_word(name) {
+        if is_always_reserved_word(name.as_str()) {
             // Match TS behavior: makeIdentifierName throws for reserved words.
-            return Err(reserved_identifier_diagnostic(name));
+            return Err(reserved_identifier_diagnostic(name.as_str()));
         }
 
         // Find a unique name: start with the original name, then try name_0, name_1, ...
-        let mut candidate = name.to_string();
+        let mut candidate = name;
         let mut index = 0u32;
         while let Some(&existing_symbol_id) = self.used_names.get(&candidate) {
             if existing_symbol_id == symbol_id {
@@ -698,7 +700,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
                 break;
             }
             // Name collision with a different binding, try the next suffix
-            candidate = format!("{}_{}", name, index);
+            candidate = format_ident!(self.env.allocator, "{name}_{index}");
             index += 1;
         }
 
@@ -706,14 +708,14 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
         // can rename matching identifiers inside preserved TS type annotations.
         if candidate != name {
             for &reference_id in self.scope.reference_ids(symbol_id) {
-                self.env.renames.insert(reference_id, candidate.clone());
+                self.env.renames.insert(reference_id, candidate);
             }
         }
 
         // Allocate identifier in the arena
         let id = self.env.next_identifier_id();
         // Update the name and span on the allocated identifier
-        self.env.identifiers[id.0 as usize].name = Some(IdentifierName::Named(candidate.clone()));
+        self.env.identifiers[id.0 as usize].name = Some(IdentifierName::Named(candidate));
         // Prefer the binding's declaration span over the reference span.
         // This matches TS behavior where Babel's resolveBinding returns the
         // binding identifier's original span (the declaration site).
@@ -744,13 +746,13 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
     /// - Identifier (local binding, resolved via resolve_binding)
     pub fn resolve_identifier(
         &mut self,
-        name: &str,
+        name: Ident<'a>,
         span: Span,
         symbol: Option<SymbolId>,
-    ) -> Result<VariableBinding, OxcDiagnostic> {
+    ) -> Result<VariableBinding<'a>, OxcDiagnostic> {
         let Some(symbol_id) = symbol else {
             // No binding found: this is a global
-            return Ok(VariableBinding::Global { name: name.to_string() });
+            return Ok(VariableBinding::Global { name });
         };
         // Treat type-only declarations as globals so the compiler
         // doesn't try to create/initialize HIR bindings for them.
@@ -763,31 +765,29 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
                 | DeclKind::TSEnumDeclaration
                 | DeclKind::TSModuleDeclaration
         ) {
-            return Ok(VariableBinding::Global { name: name.to_string() });
+            return Ok(VariableBinding::Global { name });
         }
         let symbol_scope = self.scope.symbol_scope(symbol_id);
         if symbol_scope == self.scope.program_scope() {
             // Module-level binding: check import info
             Ok(match self.scope.import_data(symbol_id) {
                 Some(import_info) => match import_info.kind {
-                    ImportBindingKind::Default => VariableBinding::ImportDefault {
-                        name: name.to_string(),
-                        module: import_info.source,
-                    },
+                    ImportBindingKind::Default => {
+                        VariableBinding::ImportDefault { name, module: import_info.source }
+                    }
                     ImportBindingKind::Named => VariableBinding::ImportSpecifier {
-                        name: name.to_string(),
+                        name,
                         module: import_info.source,
-                        imported: import_info.imported.unwrap_or_else(|| name.to_string()),
+                        imported: import_info.imported.unwrap_or(name),
                     },
-                    ImportBindingKind::Namespace => VariableBinding::ImportNamespace {
-                        name: name.to_string(),
-                        module: import_info.source,
-                    },
+                    ImportBindingKind::Namespace => {
+                        VariableBinding::ImportNamespace { name, module: import_info.source }
+                    }
                 },
-                None => VariableBinding::ModuleLocal { name: name.to_string() },
+                None => VariableBinding::ModuleLocal { name },
             })
         } else if !self.is_scope_within_compiled_function(symbol_scope) {
-            Ok(VariableBinding::ModuleLocal { name: name.to_string() })
+            Ok(VariableBinding::ModuleLocal { name })
         } else {
             let binding_kind = crate::react_compiler_lowering::convert_binding_kind(
                 &self.scope.binding_kind(symbol_id),

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/identifier_loc_index.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/identifier_loc_index.rs
@@ -269,7 +269,7 @@ impl<'a> Visit<'a> for IdentifierLocVisitor {
 /// Walks the function's params (`FormalParameters`) and body, mirroring the
 /// original Babel `IdentifierLocVisitor`: the function node itself is not
 /// re-entered (its own name, if any, is recorded explicitly).
-pub fn build_identifier_loc_index(func: &FunctionNode<'_>) -> IdentifierLocIndex {
+pub fn build_identifier_loc_index(func: &FunctionNode<'_, '_>) -> IdentifierLocIndex {
     let mut visitor = IdentifierLocVisitor {
         index: IdentifierLocIndex::default(),
         current_opening_element_span: None,

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/mod.rs
@@ -27,12 +27,12 @@ pub fn convert_binding_kind(kind: &crate::scope::BindingKind) -> BindingKind {
 /// oxc collapses Babel's `FunctionDeclaration`/`FunctionExpression` into one
 /// [`oxc::Function`] (discriminated by `r#type`); arrows are separate.
 #[derive(Clone, Copy)]
-pub enum FunctionNode<'a> {
-    Function(&'a oxc::Function<'a>),
-    Arrow(&'a oxc::ArrowFunctionExpression<'a>),
+pub enum FunctionNode<'b, 'a> {
+    Function(&'b oxc::Function<'a>),
+    Arrow(&'b oxc::ArrowFunctionExpression<'a>),
 }
 
-impl<'a> FunctionNode<'a> {
+impl FunctionNode<'_, '_> {
     /// The scope the function node creates (its semantic `scope_id` cell).
     pub fn scope_id(&self) -> Option<oxc_syntax::scope::ScopeId> {
         match self {

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
@@ -28,6 +28,9 @@ use std::mem::replace;
 
 use rustc_hash::FxHashMap;
 
+use oxc_allocator::Allocator;
+use oxc_str::Ident;
+
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::{
     BinaryOperator, BlockKind, FloatValue, FunctionId, GotoVariant, HirFunction, IdentifierId,
@@ -52,13 +55,13 @@ use crate::react_compiler_optimization::merge_consecutive_blocks::merge_consecut
 // =============================================================================
 
 #[derive(Debug, Clone)]
-enum Constant {
-    Primitive { value: PrimitiveValue, span: Option<Span> },
-    LoadGlobal { binding: NonLocalBinding, span: Option<Span> },
+enum Constant<'a> {
+    Primitive { value: PrimitiveValue<'a>, span: Option<Span> },
+    LoadGlobal { binding: NonLocalBinding<'a>, span: Option<Span> },
 }
 
-impl Constant {
-    fn into_instruction_value<'a>(self) -> InstructionValue<'a> {
+impl<'a> Constant<'a> {
+    fn into_instruction_value(self) -> InstructionValue<'a> {
         match self {
             Constant::Primitive { value, span } => InstructionValue::Primitive { value, span },
             Constant::LoadGlobal { binding, span } => {
@@ -70,21 +73,21 @@ impl Constant {
 
 /// Map of known constant values. Uses FxHashMap (not FxIndexMap) since iteration
 /// order does not affect correctness — this map is only used for lookups.
-type Constants = FxHashMap<IdentifierId, Constant>;
+type Constants<'a> = FxHashMap<IdentifierId, Constant<'a>>;
 
 // =============================================================================
 // Public entry point
 // =============================================================================
 
 pub fn constant_propagation<'a>(func: &mut HirFunction<'a>, env: &mut Environment<'a>) {
-    let mut constants: Constants = FxHashMap::default();
+    let mut constants: Constants<'a> = FxHashMap::default();
     constant_propagation_impl(func, env, &mut constants);
 }
 
 fn constant_propagation_impl<'a>(
     func: &mut HirFunction<'a>,
     env: &mut Environment<'a>,
-    constants: &mut Constants,
+    constants: &mut Constants<'a>,
 ) {
     loop {
         let have_terminals_changed = apply_constant_propagation(func, env, constants);
@@ -130,7 +133,7 @@ fn constant_propagation_impl<'a>(
 fn apply_constant_propagation<'a>(
     func: &mut HirFunction<'a>,
     env: &mut Environment<'a>,
-    constants: &mut Constants,
+    constants: &mut Constants<'a>,
 ) -> bool {
     let mut has_changes = false;
 
@@ -219,7 +222,7 @@ fn apply_constant_propagation<'a>(
 // Phi evaluation
 // =============================================================================
 
-fn evaluate_phi(phi: &Phi, constants: &Constants) -> Option<Constant> {
+fn evaluate_phi<'a>(phi: &Phi, constants: &Constants<'a>) -> Option<Constant<'a>> {
     let mut value: Option<Constant> = None;
     for (_pred, operand) in &phi.operands {
         let operand_value = constants.get(&operand.identifier)?;
@@ -262,15 +265,15 @@ fn evaluate_phi(phi: &Phi, constants: &Constants) -> Option<Constant> {
 // =============================================================================
 
 fn evaluate_instruction<'a>(
-    constants: &mut Constants,
+    constants: &mut Constants<'a>,
     func: &mut HirFunction<'a>,
     env: &mut Environment<'a>,
     instr_id: InstructionId,
-) -> Option<Constant> {
+) -> Option<Constant<'a>> {
     let instr = &func.instructions[instr_id.0 as usize];
     match &instr.value {
         InstructionValue::Primitive { value, span } => {
-            Some(Constant::Primitive { value: value.clone(), span: *span })
+            Some(Constant::Primitive { value: *value, span: *span })
         }
         InstructionValue::LoadGlobal { binding, span } => {
             Some(Constant::LoadGlobal { binding: binding.clone(), span: *span })
@@ -283,7 +286,7 @@ fn evaluate_instruction<'a>(
                         let object = object.clone();
                         let span = *span;
                         let new_property =
-                            PropertyLiteral::String(s.as_str().expect("guarded utf8").to_string());
+                            PropertyLiteral::String(Ident::from(s.as_str().expect("guarded utf8")));
                         func.instructions[instr_id.0 as usize].value =
                             InstructionValue::PropertyLoad { object, property: new_property, span };
                     }
@@ -311,7 +314,7 @@ fn evaluate_instruction<'a>(
                         let store_value = value.clone();
                         let span = *span;
                         let new_property =
-                            PropertyLiteral::String(s.as_str().expect("guarded utf8").to_string());
+                            PropertyLiteral::String(Ident::from(s.as_str().expect("guarded utf8")));
                         func.instructions[instr_id.0 as usize].value =
                             InstructionValue::PropertyStore {
                                 object,
@@ -434,12 +437,12 @@ fn evaluate_instruction<'a>(
                 Some(Constant::Primitive { value: rhs, .. }),
             ) = (&lhs_value, &rhs_value)
             {
-                let result = evaluate_binary_op(*operator, lhs, rhs);
-                if let Some(ref prim) = result {
+                let result = evaluate_binary_op(*operator, lhs, rhs, env.allocator);
+                if let Some(prim) = result {
                     let span = *span;
                     func.instructions[instr_id.0 as usize].value =
-                        InstructionValue::Primitive { value: prim.clone(), span };
-                    return Some(Constant::Primitive { value: prim.clone(), span });
+                        InstructionValue::Primitive { value: prim, span };
+                    return Some(Constant::Primitive { value: prim, span });
                 }
             }
             None
@@ -477,14 +480,13 @@ fn evaluate_instruction<'a>(
                     result_string.push_str(q.cooked.as_ref()?);
                 }
                 let span = *span;
-                let result = Constant::Primitive {
-                    value: PrimitiveValue::String(JsString::from_marker_string(&result_string)),
-                    span,
-                };
-                func.instructions[instr_id.0 as usize].value = InstructionValue::Primitive {
-                    value: PrimitiveValue::String(JsString::from_marker_string(&result_string)),
-                    span,
-                };
+                let value = PrimitiveValue::String(JsString::from_marker_string(
+                    &result_string,
+                    env.allocator,
+                ));
+                let result = Constant::Primitive { value, span };
+                func.instructions[instr_id.0 as usize].value =
+                    InstructionValue::Primitive { value, span };
                 return Some(result);
             }
 
@@ -497,7 +499,8 @@ fn evaluate_instruction<'a>(
             }
 
             let mut quasi_index = 0usize;
-            let mut result_string = quasis[quasi_index].cooked.as_ref().unwrap().clone();
+            let mut result_string =
+                quasis[quasi_index].cooked.as_ref().unwrap().as_str().to_string();
             quasi_index += 1;
 
             for sub_expr in subexprs {
@@ -516,7 +519,7 @@ fn evaluate_instruction<'a>(
                     PrimitiveValue::Undefined => return None,
                 };
 
-                let suffix = quasis[quasi_index].cooked.clone()?;
+                let suffix = quasis[quasi_index].cooked?;
                 quasi_index += 1;
 
                 result_string.push_str(&expression_str);
@@ -524,14 +527,11 @@ fn evaluate_instruction<'a>(
             }
 
             let span = *span;
-            let result = Constant::Primitive {
-                value: PrimitiveValue::String(JsString::from_marker_string(&result_string)),
-                span,
-            };
-            func.instructions[instr_id.0 as usize].value = InstructionValue::Primitive {
-                value: PrimitiveValue::String(JsString::from_marker_string(&result_string)),
-                span,
-            };
+            let value =
+                PrimitiveValue::String(JsString::from_marker_string(&result_string, env.allocator));
+            let result = Constant::Primitive { value, span };
+            func.instructions[instr_id.0 as usize].value =
+                InstructionValue::Primitive { value, span };
             Some(result)
         }
         InstructionValue::LoadLocal { place, .. } => {
@@ -627,7 +627,11 @@ fn evaluate_instruction<'a>(
 // Inner function processing
 // =============================================================================
 
-fn process_inner_function(func_id: FunctionId, env: &mut Environment, constants: &mut Constants) {
+fn process_inner_function<'a>(
+    func_id: FunctionId,
+    env: &mut Environment<'a>,
+    constants: &mut Constants<'a>,
+) {
     let mut inner = replace(&mut env.functions[func_id.0 as usize], placeholder_function());
     constant_propagation_impl(&mut inner, env, constants);
     env.functions[func_id.0 as usize] = inner;
@@ -637,7 +641,7 @@ fn process_inner_function(func_id: FunctionId, env: &mut Environment, constants:
 // Helper: read constant for a place
 // =============================================================================
 
-fn read(constants: &Constants, place: &Place) -> Option<Constant> {
+fn read<'a>(constants: &Constants<'a>, place: &Place) -> Option<Constant<'a>> {
     constants.get(&place.identifier).cloned()
 }
 
@@ -752,11 +756,12 @@ fn is_truthy(value: &PrimitiveValue) -> bool {
 // Binary operation evaluation
 // =============================================================================
 
-fn evaluate_binary_op(
+fn evaluate_binary_op<'a>(
     operator: BinaryOperator,
     lhs: &PrimitiveValue,
     rhs: &PrimitiveValue,
-) -> Option<PrimitiveValue> {
+    allocator: &'a Allocator,
+) -> Option<PrimitiveValue<'a>> {
     match operator {
         BinaryOperator::Add => match (lhs, rhs) {
             (PrimitiveValue::Number(l), PrimitiveValue::Number(r)) => {
@@ -767,7 +772,7 @@ fn evaluate_binary_op(
                 // halves split across the operands.
                 let mut units = l.code_units();
                 units.extend(r.code_units());
-                Some(PrimitiveValue::String(JsString::from_code_units(units)))
+                Some(PrimitiveValue::String(JsString::from_code_units(&units, allocator)))
             }
             _ => None,
         },

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/dead_code_elimination.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/dead_code_elimination.rs
@@ -11,14 +11,15 @@
 //!
 //! Ported from TypeScript `src/Optimization/DeadCodeElimination.ts`.
 
+use oxc_str::IdentHashSet;
 use rustc_hash::FxHashSet;
 
 use crate::react_compiler_hir::environment::{Environment, OutputMode};
 use crate::react_compiler_hir::object_shape::HookKind;
 use crate::react_compiler_hir::visitors;
 use crate::react_compiler_hir::{
-    ArrayPatternElement, BlockId, BlockKind, HirFunction, Identifier, IdentifierId, InstructionId,
-    InstructionKind, InstructionValue, ObjectPropertyOrSpread, Pattern,
+    ArrayPatternElement, BlockId, BlockKind, HirFunction, Identifier, IdentifierId, IdentifierName,
+    InstructionId, InstructionKind, InstructionValue, ObjectPropertyOrSpread, Pattern,
 };
 
 /// Implements dead-code elimination, eliminating instructions whose values are unused.
@@ -26,7 +27,7 @@ use crate::react_compiler_hir::{
 /// Note that unreachable blocks are already pruned during HIR construction.
 ///
 /// Corresponds to TS `deadCodeElimination(fn: HIRFunction): void`.
-pub fn dead_code_elimination(func: &mut HirFunction, env: &Environment) {
+pub fn dead_code_elimination<'a>(func: &mut HirFunction<'a>, env: &Environment<'a>) {
     // Phase 1: Find/mark all referenced identifiers
     let state = find_referenced_identifiers(func, env);
 
@@ -64,16 +65,16 @@ pub fn dead_code_elimination(func: &mut HirFunction, env: &Environment) {
 }
 
 /// State for tracking referenced identifiers during mark phase.
-struct State {
+struct State<'a> {
     /// SSA-specific usages (by IdentifierId)
     identifiers: FxHashSet<IdentifierId>,
     /// Named variable usages (any version)
-    named: FxHashSet<String>,
+    named: IdentHashSet<'a>,
 }
 
-impl State {
+impl State<'_> {
     fn new() -> Self {
-        State { identifiers: FxHashSet::default(), named: FxHashSet::default() }
+        State { identifiers: FxHashSet::default(), named: IdentHashSet::default() }
     }
 
     fn count(&self) -> usize {
@@ -82,11 +83,15 @@ impl State {
 }
 
 /// Mark an identifier as being referenced (not dead code).
-fn reference(state: &mut State, identifiers: &[Identifier], identifier_id: IdentifierId) {
+fn reference<'a>(
+    state: &mut State<'a>,
+    identifiers: &[Identifier<'a>],
+    identifier_id: IdentifierId,
+) {
     state.identifiers.insert(identifier_id);
     let ident = &identifiers[identifier_id.0 as usize];
-    if let Some(ref name) = ident.name {
-        state.named.insert(name.value().to_string());
+    if let Some(IdentifierName::Named(name) | IdentifierName::Promoted(name)) = ident.name {
+        state.named.insert(name);
     }
 }
 
@@ -110,7 +115,7 @@ fn is_id_used(state: &State, identifier_id: IdentifierId) -> bool {
 }
 
 /// Phase 1: Find all referenced identifiers via fixed-point iteration.
-fn find_referenced_identifiers(func: &HirFunction, env: &Environment) -> State {
+fn find_referenced_identifiers<'a>(func: &HirFunction<'a>, env: &Environment<'a>) -> State<'a> {
     let has_loop = has_back_edge(func);
     // Collect block ids in reverse order (postorder - successors before predecessors)
     let reversed_block_ids: Vec<BlockId> = func.body.blocks.keys().rev().copied().collect();

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/drop_manual_memoization.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/drop_manual_memoization.rs
@@ -60,7 +60,7 @@ struct ManualMemoCallee {
     load_instr_id: InstructionId,
 }
 
-struct IdentifierSidemap {
+struct IdentifierSidemap<'a> {
     /// Maps identifier id -> InstructionId of FunctionExpression instructions
     functions: FxHashSet<IdentifierId>,
     /// Maps identifier id -> ManualMemoCallee for useMemo/useCallback callees
@@ -70,7 +70,7 @@ struct IdentifierSidemap {
     /// Maps identifier id -> deps list info for array expressions
     maybe_deps_lists: FxHashMap<IdentifierId, MaybeDepsListInfo>,
     /// Maps identifier id -> ManualMemoDependency for dependency tracking
-    maybe_deps: FxHashMap<IdentifierId, ManualMemoDependency>,
+    maybe_deps: FxHashMap<IdentifierId, ManualMemoDependency<'a>>,
     /// Set of identifier ids that are results of optional chains
     optionals: FxHashSet<IdentifierId>,
 }
@@ -81,9 +81,9 @@ struct MaybeDepsListInfo {
     deps: Vec<Place>,
 }
 
-struct ExtractedMemoArgs {
+struct ExtractedMemoArgs<'a> {
     fn_place: Place,
-    deps_list: Option<Vec<ManualMemoDependency>>,
+    deps_list: Option<Vec<ManualMemoDependency<'a>>>,
     deps_span: Option<Span>,
 }
 
@@ -199,7 +199,7 @@ fn process_manual_memo_call<'a>(
     env: &mut Environment<'a>,
     instr_id: InstructionId,
     manual_memo: &ManualMemoCallee,
-    sidemap: &mut IdentifierSidemap,
+    sidemap: &mut IdentifierSidemap<'a>,
     is_validation_enabled: bool,
     next_manual_memo_id: &mut u32,
     queued_inserts: &mut FxHashMap<InstructionId, Instruction<'a>>,
@@ -266,11 +266,11 @@ fn process_manual_memo_call<'a>(
     }
 }
 
-fn collect_temporaries(
-    func: &HirFunction<'_>,
-    env: &Environment<'_>,
+fn collect_temporaries<'a>(
+    func: &HirFunction<'a>,
+    env: &Environment<'a>,
     instr_id: InstructionId,
-    sidemap: &mut IdentifierSidemap,
+    sidemap: &mut IdentifierSidemap<'a>,
 ) {
     let instr = &func.instructions[instr_id.0 as usize];
     let lvalue_id = instr.lvalue.identifier;
@@ -367,15 +367,15 @@ fn collect_temporaries(
 
 /// Collect loads from named variables and property reads into `maybe_deps`.
 /// Returns the variable + property reads represented by the instruction value.
-pub fn collect_maybe_memo_dependencies(
-    value: &InstructionValue<'_>,
-    maybe_deps: &FxHashMap<IdentifierId, ManualMemoDependency>,
+pub fn collect_maybe_memo_dependencies<'a>(
+    value: &InstructionValue<'a>,
+    maybe_deps: &FxHashMap<IdentifierId, ManualMemoDependency<'a>>,
     optional: bool,
-    env: &Environment<'_>,
-) -> Option<ManualMemoDependency> {
+    env: &Environment<'a>,
+) -> Option<ManualMemoDependency<'a>> {
     match value {
         InstructionValue::LoadGlobal { binding, span, .. } => Some(ManualMemoDependency {
-            root: ManualMemoDependencyRoot::Global { identifier_name: binding.name().to_string() },
+            root: ManualMemoDependencyRoot::Global { identifier_name: binding.name() },
             path: vec![],
             span: *span,
         }),
@@ -384,11 +384,7 @@ pub fn collect_maybe_memo_dependencies(
                 root: object_dep.root.clone(),
                 path: {
                     let mut path = object_dep.path.clone();
-                    path.push(DependencyPathEntry {
-                        property: property.clone(),
-                        optional,
-                        span: *span,
-                    });
+                    path.push(DependencyPathEntry { property: *property, optional, span: *span });
                     path
                 },
                 span: *span,
@@ -462,7 +458,7 @@ fn get_manual_memoization_replacement<'a>(
 fn make_manual_memoization_markers<'a>(
     fn_expr: &Place,
     env: &mut Environment<'a>,
-    deps_list: Option<Vec<ManualMemoDependency>>,
+    deps_list: Option<Vec<ManualMemoDependency<'a>>>,
     deps_span: Option<Span>,
     memo_decl: &Place,
     manual_memo_id: u32,
@@ -495,12 +491,12 @@ fn make_manual_memoization_markers<'a>(
     (start, finish)
 }
 
-fn extract_manual_memoization_args(
+fn extract_manual_memoization_args<'a>(
     instr: &Instruction,
     kind: ManualMemoKind,
-    sidemap: &IdentifierSidemap,
+    sidemap: &IdentifierSidemap<'a>,
     env: &mut Environment,
-) -> Option<ExtractedMemoArgs> {
+) -> Option<ExtractedMemoArgs<'a>> {
     let args: &[PlaceOrSpread] = match &instr.value {
         InstructionValue::CallExpression { args, .. } => args,
         InstructionValue::MethodCall { args, .. } => args,
@@ -573,7 +569,7 @@ fn extract_manual_memoization_args(
     }
 
     let deps_info = maybe_deps_list.unwrap();
-    let mut deps_list: Vec<ManualMemoDependency> = Vec::new();
+    let mut deps_list: Vec<ManualMemoDependency<'a>> = Vec::new();
     for dep in &deps_info.deps {
         let maybe_dep = sidemap.maybe_deps.get(&dep.identifier);
         if let Some(d) = maybe_dep {
@@ -662,7 +658,7 @@ fn is_known_react_module(module: &str) -> bool {
 /// - `ModuleLocal`: return None (same reason as above)
 /// - `ImportDefault`/`ImportNamespace` from known React module: use the local name
 /// - `ImportDefault`/`ImportNamespace` from unknown module: return None
-fn get_hook_detection_name(binding: &NonLocalBinding) -> Option<&str> {
+fn get_hook_detection_name<'a>(binding: &NonLocalBinding<'a>) -> Option<&'a str> {
     match binding {
         NonLocalBinding::Global { name } => Some(name.as_str()),
         NonLocalBinding::ImportSpecifier { imported, module, .. } => {

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/inline_iifes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/inline_iifes.rs
@@ -41,6 +41,7 @@
 //! Analogous to TS `Inference/InlineImmediatelyInvokedFunctionExpressions.ts`.
 
 use crate::react_compiler_utils::FxIndexSet;
+use oxc_str::format_ident;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::react_compiler_hir::environment::Environment;
@@ -386,5 +387,5 @@ fn declare_temporary<'a>(
 fn promote_temporary(env: &mut Environment<'_>, identifier_id: IdentifierId) {
     let decl_id = env.identifiers[identifier_id.0 as usize].declaration_id;
     env.identifiers[identifier_id.0 as usize].name =
-        Some(IdentifierName::Promoted(format!("#t{}", decl_id.0)));
+        Some(IdentifierName::Promoted(format_ident!(env.allocator, "#t{}", decl_id.0)));
 }

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/name_anonymous_functions.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/name_anonymous_functions.rs
@@ -16,6 +16,9 @@ use std::mem::take;
 
 use rustc_hash::FxHashMap;
 
+use oxc_allocator::Allocator;
+use oxc_str::{Ident, format_ident};
+
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::object_shape::HookKind;
 use crate::react_compiler_hir::{
@@ -26,18 +29,24 @@ use crate::react_compiler_hir::{
 /// Assign generated names to anonymous function expressions.
 ///
 /// Ported from TS `nameAnonymousFunctions` in `Transform/NameAnonymousFunctions.ts`.
-pub fn name_anonymous_functions(func: &mut HirFunction, env: &mut Environment) {
-    let fn_id = match &func.id {
-        Some(id) => id.clone(),
+pub fn name_anonymous_functions<'a>(func: &mut HirFunction<'a>, env: &mut Environment<'a>) {
+    let fn_id = match func.id {
+        Some(id) => id,
         None => return,
     };
 
     let nodes = name_anonymous_functions_impl(func, env);
 
-    fn visit(node: &Node, prefix: &str, updates: &mut Vec<(FunctionId, String)>) {
+    fn visit<'a>(
+        node: &Node<'a>,
+        prefix: &str,
+        updates: &mut Vec<(FunctionId, Ident<'a>)>,
+        allocator: &'a Allocator,
+    ) {
         if node.generated_name.is_some() && node.existing_name_hint.is_none() {
             // Only add the prefix to anonymous functions regardless of nesting depth
-            let name = format!("{}{}]", prefix, node.generated_name.as_ref().unwrap());
+            let name =
+                format_ident!(allocator, "{}{}]", prefix, node.generated_name.as_ref().unwrap());
             updates.push((node.function_id, name));
         }
         // Whether or not we generated a name for the function at this node,
@@ -46,25 +55,24 @@ pub fn name_anonymous_functions(func: &mut HirFunction, env: &mut Environment) {
             node.generated_name.as_deref().or(node.fn_name.as_deref()).unwrap_or("<anonymous>");
         let next_prefix = format!("{}{} > ", prefix, label);
         for inner in &node.inner {
-            visit(inner, &next_prefix, updates);
+            visit(inner, &next_prefix, updates, allocator);
         }
     }
 
-    let mut updates: Vec<(FunctionId, String)> = Vec::new();
+    let mut updates: Vec<(FunctionId, Ident<'a>)> = Vec::new();
     let prefix = format!("{}[", fn_id);
     for node in &nodes {
-        visit(node, &prefix, &mut updates);
+        visit(node, &prefix, &mut updates, env.allocator);
     }
 
     if updates.is_empty() {
         return;
     }
-    let update_map: FxHashMap<FunctionId, &str> =
-        updates.iter().map(|(fid, name)| (*fid, name.as_str())).collect();
+    let update_map: FxHashMap<FunctionId, Ident<'a>> = updates.iter().copied().collect();
 
     // Apply name updates to the inner HirFunction in the arena
     for (function_id, name) in &updates {
-        env.functions[function_id.0 as usize].name_hint = Some(name.clone());
+        env.functions[function_id.0 as usize].name_hint = Some(*name);
     }
 
     // Update name_hint on FunctionExpression instruction values in the outer function
@@ -80,41 +88,44 @@ pub fn name_anonymous_functions(func: &mut HirFunction, env: &mut Environment) {
 }
 
 /// Apply name hints to FunctionExpression instruction values.
-fn apply_name_hints_to_instructions(
-    instructions: &mut [Instruction],
-    update_map: &FxHashMap<FunctionId, &str>,
+fn apply_name_hints_to_instructions<'a>(
+    instructions: &mut [Instruction<'a>],
+    update_map: &FxHashMap<FunctionId, Ident<'a>>,
 ) {
     for instr in instructions.iter_mut() {
         if let InstructionValue::FunctionExpression { lowered_func, name_hint, .. } =
             &mut instr.value
         {
             if let Some(new_name) = update_map.get(&lowered_func.func) {
-                *name_hint = Some((*new_name).to_string());
+                *name_hint = Some(*new_name);
             }
         }
     }
 }
 
-struct Node {
+struct Node<'a> {
     /// The FunctionId for the inner function (via lowered_func.func)
     function_id: FunctionId,
     /// The generated name for this anonymous function (set based on usage context)
-    generated_name: Option<String>,
+    generated_name: Option<Ident<'a>>,
     /// The existing `name` on the FunctionExpression (non-anonymous functions have this)
-    fn_name: Option<String>,
+    fn_name: Option<Ident<'a>>,
     /// Whether the inner HirFunction already has a name_hint
-    existing_name_hint: Option<String>,
+    existing_name_hint: Option<Ident<'a>>,
     /// Nested function nodes
-    inner: Vec<Node>,
+    inner: Vec<Node<'a>>,
 }
 
-fn name_anonymous_functions_impl(func: &HirFunction, env: &Environment) -> Vec<Node> {
+fn name_anonymous_functions_impl<'a>(
+    func: &HirFunction<'a>,
+    env: &Environment<'a>,
+) -> Vec<Node<'a>> {
     // Functions that we track to generate names for
     let mut functions: FxHashMap<IdentifierId, usize> = FxHashMap::default();
     // Tracks temporaries that read from variables/globals/properties
-    let mut names: FxHashMap<IdentifierId, String> = FxHashMap::default();
+    let mut names: FxHashMap<IdentifierId, Ident<'a>> = FxHashMap::default();
     // Tracks all function nodes
-    let mut nodes: Vec<Node> = Vec::new();
+    let mut nodes: Vec<Node<'a>> = Vec::new();
 
     for block in func.body.blocks.values() {
         for instr_id in &block.instructions {
@@ -122,13 +133,13 @@ fn name_anonymous_functions_impl(func: &HirFunction, env: &Environment) -> Vec<N
             let lvalue_id = instr.lvalue.identifier;
             match &instr.value {
                 InstructionValue::LoadGlobal { binding, .. } => {
-                    names.insert(lvalue_id, binding.name().to_string());
+                    names.insert(lvalue_id, binding.name());
                 }
                 InstructionValue::LoadContext { place, .. }
                 | InstructionValue::LoadLocal { place, .. } => {
                     let ident = &env.identifiers[place.identifier.0 as usize];
-                    if let Some(IdentifierName::Named(ref name)) = ident.name {
-                        names.insert(lvalue_id, name.clone());
+                    if let Some(IdentifierName::Named(name)) = ident.name {
+                        names.insert(lvalue_id, name);
                     }
                     // If the loaded place was tracked as a function, propagate
                     if let Some(&node_idx) = functions.get(&place.identifier) {
@@ -137,7 +148,8 @@ fn name_anonymous_functions_impl(func: &HirFunction, env: &Environment) -> Vec<N
                 }
                 InstructionValue::PropertyLoad { object, property, .. } => {
                     if let Some(object_name) = names.get(&object.identifier) {
-                        names.insert(lvalue_id, format!("{}.{}", object_name, property));
+                        let name = format_ident!(env.allocator, "{}.{}", object_name, property);
+                        names.insert(lvalue_id, name);
                     }
                 }
                 InstructionValue::FunctionExpression { name, lowered_func, .. } => {
@@ -146,8 +158,8 @@ fn name_anonymous_functions_impl(func: &HirFunction, env: &Environment) -> Vec<N
                     let node = Node {
                         function_id: lowered_func.func,
                         generated_name: None,
-                        fn_name: name.clone(),
-                        existing_name_hint: inner_func.name_hint.clone(),
+                        fn_name: *name,
+                        existing_name_hint: inner_func.name_hint,
                         inner,
                     };
                     let idx = nodes.len();
@@ -163,8 +175,8 @@ fn name_anonymous_functions_impl(func: &HirFunction, env: &Environment) -> Vec<N
                         let node = &mut nodes[node_idx];
                         let var_ident = &env.identifiers[store_lvalue.place.identifier.0 as usize];
                         if node.generated_name.is_none() {
-                            if let Some(IdentifierName::Named(ref var_name)) = var_ident.name {
-                                node.generated_name = Some(var_name.clone());
+                            if let Some(IdentifierName::Named(var_name)) = var_ident.name {
+                                node.generated_name = Some(var_name);
                                 functions.remove(&value.identifier);
                             }
                         }
@@ -185,16 +197,19 @@ fn name_anonymous_functions_impl(func: &HirFunction, env: &Environment) -> Vec<N
                                     let node = &mut nodes[node_idx];
                                     if node.generated_name.is_none() {
                                         let element_name = match tag {
-                                            JsxTag::Builtin(builtin) => Some(builtin.name.clone()),
+                                            JsxTag::Builtin(builtin) => Some(builtin.name),
                                             JsxTag::Place(tag_place) => {
-                                                names.get(&tag_place.identifier).cloned()
+                                                names.get(&tag_place.identifier).copied()
                                             }
                                         };
                                         let prop_name = match element_name {
-                                            None => attr_name.clone(),
-                                            Some(ref el_name) => {
-                                                format!("<{}>.{}", el_name, attr_name)
-                                            }
+                                            None => *attr_name,
+                                            Some(el_name) => format_ident!(
+                                                env.allocator,
+                                                "<{}>.{}",
+                                                el_name,
+                                                attr_name
+                                            ),
                                         };
                                         node.generated_name = Some(prop_name);
                                         functions.remove(&place.identifier);
@@ -213,13 +228,13 @@ fn name_anonymous_functions_impl(func: &HirFunction, env: &Environment) -> Vec<N
 }
 
 /// Handle CallExpression / MethodCall to generate names for function arguments.
-fn handle_call(
-    env: &Environment,
+fn handle_call<'a>(
+    env: &Environment<'a>,
     callee_id: IdentifierId,
     args: &[PlaceOrSpread],
     functions: &mut FxHashMap<IdentifierId, usize>,
-    names: &FxHashMap<IdentifierId, String>,
-    nodes: &mut [Node],
+    names: &FxHashMap<IdentifierId, Ident<'a>>,
+    nodes: &mut [Node<'a>],
 ) {
     let callee_ident = &env.identifiers[callee_id.0 as usize];
     let callee_ty = &env.types[callee_ident.type_.0 as usize];
@@ -260,9 +275,9 @@ fn handle_call(
             let node = &mut nodes[node_idx];
             if node.generated_name.is_none() {
                 let generated_name = if fn_arg_count > 1 {
-                    format!("{}(arg{})", callee_name, i)
+                    format_ident!(env.allocator, "{}(arg{})", callee_name, i)
                 } else {
-                    format!("{}()", callee_name)
+                    format_ident!(env.allocator, "{}()", callee_name)
                 };
                 node.generated_name = Some(generated_name);
                 functions.remove(&place.identifier);

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/outline_functions.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/outline_functions.rs
@@ -15,6 +15,8 @@ use std::mem::replace;
 
 use rustc_hash::FxHashSet;
 
+use oxc_str::Ident;
+
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::{
     FunctionId, HirFunction, IdentifierId, InstructionValue, NonLocalBinding,
@@ -24,9 +26,9 @@ use crate::react_compiler_ssa::enter_ssa::placeholder_function;
 /// Outline anonymous function expressions that have no captured context variables.
 ///
 /// Ported from TS `outlineFunctions` in `Optimization/OutlineFunctions.ts`.
-pub fn outline_functions(
-    func: &mut HirFunction,
-    env: &mut Environment,
+pub fn outline_functions<'a>(
+    func: &mut HirFunction<'a>,
+    env: &mut Environment<'a>,
     fbt_operands: &FxHashSet<IdentifierId>,
 ) {
     // Collect per-instruction actions to maintain depth-first name allocation order.
@@ -93,14 +95,12 @@ pub fn outline_functions(
                 env.functions[function_id.0 as usize] = inner_func;
 
                 // Then generate the name and outline (after recursion, matching TS order)
-                let hint: Option<String> = env.functions[function_id.0 as usize]
-                    .id
-                    .clone()
-                    .or_else(|| env.functions[function_id.0 as usize].name_hint.clone());
+                let inner = &env.functions[function_id.0 as usize];
+                let hint: Option<Ident<'a>> = inner.id.or(inner.name_hint);
                 let generated_name = env.generate_globally_unique_identifier_name(hint.as_deref());
 
                 // Set the id on the inner function
-                env.functions[function_id.0 as usize].id = Some(generated_name.clone());
+                env.functions[function_id.0 as usize].id = Some(generated_name);
 
                 // Outline the function
                 let outlined_func = env.functions[function_id.0 as usize].clone();

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/outline_jsx.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/outline_jsx.rs
@@ -9,6 +9,7 @@
 //! This pass is conditional on `env.config.enable_jsx_outlining` (defaults to false).
 
 use crate::react_compiler_utils::FxIndexSet;
+use oxc_str::{Ident, IdentHashSet, format_ident};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::react_compiler_hir::Effect;
@@ -45,9 +46,9 @@ struct JsxInstrInfo {
     eval_order: EvaluationOrder,
 }
 
-struct OutlinedJsxAttribute {
-    original_name: String,
-    new_name: String,
+struct OutlinedJsxAttribute<'a> {
+    original_name: Ident<'a>,
+    new_name: Ident<'a>,
     place: Place,
 }
 
@@ -237,7 +238,7 @@ fn process_jsx_group<'a>(
     let props = collect_props(func, env, jsx_group)?;
 
     let outlined_tag = env.generate_globally_unique_identifier_name(None);
-    let new_instrs = emit_outlined_jsx(func, env, jsx_group, &props, &outlined_tag)?;
+    let new_instrs = emit_outlined_jsx(func, env, jsx_group, &props, outlined_tag)?;
     let outlined_fn = emit_outlined_fn(func, env, jsx_group, &props, globals)?;
 
     // Set the outlined function's id
@@ -251,19 +252,20 @@ fn collect_props<'a>(
     func: &HirFunction<'a>,
     env: &mut Environment<'a>,
     jsx_group: &[JsxInstrInfo],
-) -> Option<Vec<OutlinedJsxAttribute>> {
+) -> Option<Vec<OutlinedJsxAttribute<'a>>> {
     let mut id_counter = 1u32;
-    let mut seen: FxHashSet<String> = FxHashSet::default();
+    let mut seen: IdentHashSet<'a> = IdentHashSet::default();
     let mut attributes = Vec::new();
     let jsx_ids: FxHashSet<IdentifierId> = jsx_group.iter().map(|j| j.lvalue_id).collect();
 
-    let mut generate_name = |old_name: &str| -> String {
-        let mut new_name = old_name.to_string();
+    let allocator = env.allocator;
+    let mut generate_name = |old_name: Ident<'a>| -> Ident<'a> {
+        let mut new_name = old_name;
         while seen.contains(&new_name) {
-            new_name = format!("{}{}", old_name, id_counter);
+            new_name = format_ident!(allocator, "{old_name}{id_counter}");
             id_counter += 1;
         }
-        seen.insert(new_name.clone());
+        seen.insert(new_name);
         // TS: env.programContext.addNewReference(newName)
         // We don't have programContext in Rust, but this is needed for unique name tracking
         new_name
@@ -276,9 +278,9 @@ fn collect_props<'a>(
                 match attr {
                     JsxAttribute::SpreadAttribute { .. } => return None,
                     JsxAttribute::Attribute { name, place } => {
-                        let new_name = generate_name(name);
+                        let new_name = generate_name(*name);
                         attributes.push(OutlinedJsxAttribute {
-                            original_name: name.clone(),
+                            original_name: *name,
                             new_name,
                             place: place.clone(),
                         });
@@ -295,16 +297,17 @@ fn collect_props<'a>(
                     let child_id = child.identifier;
                     let decl_id = env.identifiers[child_id.0 as usize].declaration_id;
                     if env.identifiers[child_id.0 as usize].name.is_none() {
-                        env.identifiers[child_id.0 as usize].name =
-                            Some(IdentifierName::Promoted(format!("#t{}", decl_id.0)));
+                        env.identifiers[child_id.0 as usize].name = Some(IdentifierName::Promoted(
+                            format_ident!(allocator, "#t{}", decl_id.0),
+                        ));
                     }
 
-                    let child_name = match &env.identifiers[child_id.0 as usize].name {
-                        Some(IdentifierName::Named(n)) => n.clone(),
-                        Some(IdentifierName::Promoted(n)) => n.clone(),
-                        None => format!("#t{}", decl_id.0),
+                    let child_name = match env.identifiers[child_id.0 as usize].name {
+                        Some(IdentifierName::Named(n)) => n,
+                        Some(IdentifierName::Promoted(n)) => n,
+                        None => format_ident!(allocator, "#t{}", decl_id.0),
                     };
-                    let new_name = generate_name("t");
+                    let new_name = generate_name(Ident::from("t"));
                     attributes.push(OutlinedJsxAttribute {
                         original_name: child_name,
                         new_name,
@@ -322,12 +325,12 @@ fn emit_outlined_jsx<'a>(
     func: &HirFunction<'a>,
     env: &mut Environment<'a>,
     jsx_group: &[JsxInstrInfo],
-    outlined_props: &[OutlinedJsxAttribute],
-    outlined_tag: &str,
+    outlined_props: &[OutlinedJsxAttribute<'a>],
+    outlined_tag: Ident<'a>,
 ) -> Option<Vec<Instruction<'a>>> {
     let props: Vec<JsxAttribute> = outlined_props
         .iter()
-        .map(|p| JsxAttribute::Attribute { name: p.new_name.clone(), place: p.place.clone() })
+        .map(|p| JsxAttribute::Attribute { name: p.new_name, place: p.place.clone() })
         .collect();
 
     // Create LoadGlobal for the outlined component
@@ -335,7 +338,7 @@ fn emit_outlined_jsx<'a>(
     // Promote it as a JSX tag temporary
     let decl_id = env.identifiers[load_id.0 as usize].declaration_id;
     env.identifiers[load_id.0 as usize].name =
-        Some(IdentifierName::Promoted(format!("#T{}", decl_id.0)));
+        Some(IdentifierName::Promoted(format_ident!(env.allocator, "#T{}", decl_id.0)));
 
     let load_place =
         Place { identifier: load_id, effect: Effect::Unknown, reactive: false, span: None };
@@ -344,7 +347,7 @@ fn emit_outlined_jsx<'a>(
         id: EvaluationOrder(0),
         lvalue: load_place.clone(),
         value: InstructionValue::LoadGlobal {
-            binding: NonLocalBinding::ModuleLocal { name: outlined_tag.to_string() },
+            binding: NonLocalBinding::ModuleLocal { name: outlined_tag },
             span: None,
         },
         span: None,
@@ -376,7 +379,7 @@ fn emit_outlined_fn<'a>(
     func: &HirFunction<'a>,
     env: &mut Environment<'a>,
     jsx_group: &[JsxInstrInfo],
-    old_props: &[OutlinedJsxAttribute],
+    old_props: &[OutlinedJsxAttribute<'a>],
     globals: &FxHashMap<IdentifierId, usize>,
 ) -> Option<HirFunction<'a>> {
     let old_to_new_props = create_old_to_new_props_mapping(env, old_props);
@@ -385,7 +388,7 @@ fn emit_outlined_fn<'a>(
     let props_obj_id = env.next_identifier_id();
     let decl_id = env.identifiers[props_obj_id.0 as usize].declaration_id;
     env.identifiers[props_obj_id.0 as usize].name =
-        Some(IdentifierName::Promoted(format!("#t{}", decl_id.0)));
+        Some(IdentifierName::Promoted(format_ident!(env.allocator, "#t{}", decl_id.0)));
     let props_obj =
         Place { identifier: props_obj_id, effect: Effect::Unknown, reactive: false, span: None };
 
@@ -478,7 +481,7 @@ fn emit_load_globals<'a>(
 fn emit_updated_jsx<'a>(
     func: &HirFunction<'a>,
     jsx_group: &[JsxInstrInfo],
-    old_to_new_props: &FxIndexMap<IdentifierId, OutlinedJsxAttribute>,
+    old_to_new_props: &FxIndexMap<IdentifierId, OutlinedJsxAttribute<'a>>,
 ) -> Vec<Instruction<'a>> {
     let jsx_ids: FxHashSet<IdentifierId> = jsx_group.iter().map(|j| j.lvalue_id).collect();
     let mut new_instrs = Vec::new();
@@ -512,7 +515,7 @@ fn emit_updated_jsx<'a>(
                     .get(&place.identifier)
                     .expect("Expected a new property for identifier");
                 new_props.push(JsxAttribute::Attribute {
-                    name: new_prop.original_name.clone(),
+                    name: new_prop.original_name,
                     place: new_prop.place.clone(),
                 });
             }
@@ -553,10 +556,10 @@ fn emit_updated_jsx<'a>(
     new_instrs
 }
 
-fn create_old_to_new_props_mapping(
-    env: &mut Environment<'_>,
-    old_props: &[OutlinedJsxAttribute],
-) -> FxIndexMap<IdentifierId, OutlinedJsxAttribute> {
+fn create_old_to_new_props_mapping<'a>(
+    env: &mut Environment<'a>,
+    old_props: &[OutlinedJsxAttribute<'a>],
+) -> FxIndexMap<IdentifierId, OutlinedJsxAttribute<'a>> {
     let mut old_to_new = FxIndexMap::default();
 
     for old_prop in old_props {
@@ -565,8 +568,7 @@ fn create_old_to_new_props_mapping(
         }
 
         let new_id = env.next_identifier_id();
-        env.identifiers[new_id.0 as usize].name =
-            Some(IdentifierName::Named(old_prop.new_name.clone()));
+        env.identifiers[new_id.0 as usize].name = Some(IdentifierName::Named(old_prop.new_name));
 
         let new_place =
             Place { identifier: new_id, effect: Effect::Unknown, reactive: false, span: None };
@@ -574,8 +576,8 @@ fn create_old_to_new_props_mapping(
         old_to_new.insert(
             old_prop.place.identifier,
             OutlinedJsxAttribute {
-                original_name: old_prop.original_name.clone(),
-                new_name: old_prop.new_name.clone(),
+                original_name: old_prop.original_name,
+                new_name: old_prop.new_name,
                 place: new_place,
             },
         );
@@ -587,12 +589,12 @@ fn create_old_to_new_props_mapping(
 fn emit_destructure_props<'a>(
     env: &mut Environment<'a>,
     props_obj: &Place,
-    old_to_new_props: &FxIndexMap<IdentifierId, OutlinedJsxAttribute>,
+    old_to_new_props: &FxIndexMap<IdentifierId, OutlinedJsxAttribute<'a>>,
 ) -> Instruction<'a> {
     let mut properties = Vec::new();
     for prop in old_to_new_props.values() {
         properties.push(ObjectPropertyOrSpread::Property(ObjectProperty {
-            key: ObjectPropertyKey::String { name: prop.new_name.clone() },
+            key: ObjectPropertyKey::String { name: prop.new_name },
             property_type: ObjectPropertyType::Property,
             place: prop.place.clone(),
         }));

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/build_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/build_reactive_function.rs
@@ -36,8 +36,8 @@ pub fn build_reactive_function<'a>(
 
     Ok(ReactiveFunction {
         span: hir.span,
-        id: hir.id.clone(),
-        name_hint: hir.name_hint.clone(),
+        id: hir.id,
+        name_hint: hir.name_hint,
         params: hir.params.clone(),
         generator: hir.generator,
         is_async: hir.is_async,

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
@@ -10,6 +10,7 @@
 //!
 //! Corresponds to `src/ReactiveScopes/CodegenReactiveFunction.ts` in the TS compiler.
 
+use oxc_str::{Ident, IdentHashMap, IdentHashSet, format_ident};
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 
@@ -83,24 +84,24 @@ fn source_file_hash(code: &str) -> String {
 /// Top-level entry point: produces an oxc-shaped
 /// [`crate::react_compiler::entrypoint::compile_result::CodegenFunction`] from a
 /// reactive function, building oxc AST directly via [`oxc_ast::builder::AstBuilder`].
-pub fn codegen_function<'a, 'h>(
+pub fn codegen_function<'a>(
     ast: &oxc_ast::builder::AstBuilder<'a>,
-    func: &ReactiveFunction<'h>,
-    env: &mut Environment<'h>,
-    unique_identifiers: FxHashSet<String>,
+    func: &ReactiveFunction<'a>,
+    env: &mut Environment<'a>,
+    unique_identifiers: IdentHashSet<'a>,
     fbt_operands: FxHashSet<IdentifierId>,
 ) -> Result<crate::react_compiler::entrypoint::compile_result::CodegenFunction<'a>, OxcDiagnostic> {
     use crate::react_compiler::entrypoint::compile_result::CodegenFunction as OxcCodegenFunction;
     use oxc_span::SPAN;
 
-    let fn_name = func.id.as_deref().unwrap_or("[[ anonymous ]]");
+    let fn_name = func.id.unwrap_or(Ident::from("[[ anonymous ]]"));
     // Outlined functions reuse the same `fbtOperands` set as the main function
     // (see TS `codegenFunction`), so keep a copy before it is moved into the context.
     let fbt_operands_for_outlined = fbt_operands.clone();
     let mut cx = OxcContext::new(
         oxc_ast::builder::AstBuilder::new(ast.allocator()),
         env,
-        fn_name.to_string(),
+        fn_name,
         unique_identifiers,
         fbt_operands,
     );
@@ -168,10 +169,7 @@ pub fn codegen_function<'a, 'h>(
         compiled.body.statements = new_body;
     }
 
-    let id = func
-        .id
-        .as_deref()
-        .map(|name| oxc_ast::ast::BindingIdentifier::new(SPAN, ox_str(ast, name), ast));
+    let id = func.id.map(|name| oxc_ast::ast::BindingIdentifier::new(SPAN, name, ast));
 
     // Release the borrow of `env` held by `cx` so the outlined functions can be
     // compiled with fresh contexts (mirrors TS `codegenFunction`).
@@ -182,7 +180,7 @@ pub fn codegen_function<'a, 'h>(
     Ok(OxcCodegenFunction {
         span: func.span,
         id,
-        name_hint: func.name_hint.clone(),
+        name_hint: func.name_hint,
         params: compiled.params,
         body: compiled.body,
         generator: func.generator,
@@ -202,7 +200,7 @@ pub fn codegen_function<'a, 'h>(
 /// prune passes + variable renaming, then codegen it with a fresh context.
 fn ox_codegen_outlined<'a>(
     ast: &oxc_ast::builder::AstBuilder<'a>,
-    env: &mut Environment,
+    env: &mut Environment<'a>,
     fbt_operands: FxHashSet<IdentifierId>,
 ) -> Result<
     Vec<crate::react_compiler::entrypoint::compile_result::OutlinedFunction<'a>>,
@@ -273,27 +271,27 @@ fn ox_clone_temporaries<'a>(
     temp.iter().map(|(id, v)| (*id, v.as_ref().map(|v| v.clone_in(ast.allocator())))).collect()
 }
 
-struct OxcContext<'a, 'env, 'h> {
+struct OxcContext<'a, 'env> {
     ast: oxc_ast::builder::AstBuilder<'a>,
-    env: &'env mut Environment<'h>,
+    env: &'env mut Environment<'a>,
     #[allow(dead_code)]
-    fn_name: String,
+    fn_name: Ident<'a>,
     next_cache_index: u32,
     declarations: FxHashSet<DeclarationId>,
     temp: OxcTemporaries<'a>,
-    object_methods: FxHashMap<IdentifierId, (InstructionValue<'h>, Option<Span>)>,
-    unique_identifiers: FxHashSet<String>,
+    object_methods: FxHashMap<IdentifierId, (InstructionValue<'a>, Option<Span>)>,
+    unique_identifiers: IdentHashSet<'a>,
     #[allow(dead_code)]
     fbt_operands: FxHashSet<IdentifierId>,
-    synthesized_names: FxHashMap<String, String>,
+    synthesized_names: IdentHashMap<'a, Ident<'a>>,
 }
 
-impl<'a, 'env, 'h> OxcContext<'a, 'env, 'h> {
+impl<'a, 'env> OxcContext<'a, 'env> {
     fn new(
         ast: oxc_ast::builder::AstBuilder<'a>,
-        env: &'env mut Environment<'h>,
-        fn_name: String,
-        unique_identifiers: FxHashSet<String>,
+        env: &'env mut Environment<'a>,
+        fn_name: Ident<'a>,
+        unique_identifiers: IdentHashSet<'a>,
         fbt_operands: FxHashSet<IdentifierId>,
     ) -> Self {
         OxcContext {
@@ -306,7 +304,7 @@ impl<'a, 'env, 'h> OxcContext<'a, 'env, 'h> {
             object_methods: FxHashMap::default(),
             unique_identifiers,
             fbt_operands,
-            synthesized_names: FxHashMap::default(),
+            synthesized_names: IdentHashMap::default(),
         }
     }
 
@@ -326,18 +324,19 @@ impl<'a, 'env, 'h> OxcContext<'a, 'env, 'h> {
         self.declarations.contains(&ident.declaration_id)
     }
 
-    fn synthesize_name(&mut self, name: &str) -> String {
+    fn synthesize_name(&mut self, name: &str) -> Ident<'a> {
         if let Some(prev) = self.synthesized_names.get(name) {
-            return prev.clone();
+            return *prev;
         }
-        let mut validated = name.to_string();
+        let allocator = self.env.allocator;
+        let mut validated = Ident::from_str_in(name, &allocator);
         let mut index = 0u32;
         while self.unique_identifiers.contains(&validated) {
-            validated = format!("{name}{index}");
+            validated = format_ident!(allocator, "{name}{index}");
             index += 1;
         }
-        self.unique_identifiers.insert(validated.clone());
-        self.synthesized_names.insert(name.to_string(), validated.clone());
+        self.unique_identifiers.insert(validated);
+        self.synthesized_names.insert(Ident::from_str_in(name, &allocator), validated);
         validated
     }
 
@@ -371,7 +370,7 @@ const STRING_REQUIRES_EXPR_CONTAINER_CHARS: &str = "\"\\";
 /// Reference to an lvalue target during pattern codegen.
 enum LvalueRef<'a> {
     Place(&'a Place),
-    Pattern(&'a Pattern),
+    Pattern(&'a Pattern<'a>),
     // Constructed once nested spread/rest lvalue emission is ported; the match arm
     // in `ox_codegen_lvalue` already handles it.
     #[allow(dead_code)]
@@ -396,14 +395,14 @@ fn ox_str<'a>(ast: &oxc_ast::builder::AstBuilder<'a>, s: &str) -> &'a str {
 /// `typeof field` whose value binding was renamed to `field_3`), the matching
 /// references in the clone are renamed in place. The clone preserves the semantic
 /// `reference_id` cells, so renames apply by reference identity.
-fn ox_reemit_ts_type<'a>(cx: &OxcContext<'a, '_, '_>, ty: &oxc::TSType<'_>) -> oxc::TSType<'a> {
+fn ox_reemit_ts_type<'a>(cx: &OxcContext<'a, '_>, ty: &oxc::TSType<'_>) -> oxc::TSType<'a> {
     if cx.env.renames.is_empty() {
         return ty.clone_in(cx.ast.allocator());
     }
 
     struct Renamer<'a, 'env> {
         allocator: &'a oxc_allocator::Allocator,
-        renames: &'env FxHashMap<oxc_syntax::reference::ReferenceId, String>,
+        renames: &'env FxHashMap<oxc_syntax::reference::ReferenceId, Ident<'env>>,
     }
     impl<'a> oxc_ast_visit::VisitMut<'a> for Renamer<'a, '_> {
         fn visit_identifier_reference(&mut self, it: &mut oxc::IdentifierReference<'a>) {
@@ -461,9 +460,9 @@ fn ox_cache_index<'a>(
     ))
 }
 
-fn ox_codegen_reactive_function<'a, 'h>(
-    cx: &mut OxcContext<'a, '_, 'h>,
-    func: &ReactiveFunction<'h>,
+fn ox_codegen_reactive_function<'a>(
+    cx: &mut OxcContext<'a, '_>,
+    func: &ReactiveFunction<'a>,
 ) -> Result<OxcCompiledFunction<'a>, OxcDiagnostic> {
     // Register parameters
     for param in &func.params {
@@ -518,7 +517,7 @@ fn ox_codegen_reactive_function<'a, 'h>(
 }
 
 fn ox_convert_parameters<'a>(
-    cx: &mut OxcContext<'a, '_, '_>,
+    cx: &mut OxcContext<'a, '_>,
     params: &[ParamPattern],
 ) -> Result<oxc_allocator::Box<'a, oxc::FormalParameters<'a>>, OxcDiagnostic> {
     let mut items: Vec<oxc::FormalParameter<'a>> = Vec::new();
@@ -564,21 +563,21 @@ fn ox_convert_parameters<'a>(
 }
 
 fn ox_binding_for_identifier<'a>(
-    cx: &OxcContext<'a, '_, '_>,
+    cx: &OxcContext<'a, '_>,
     identifier_id: IdentifierId,
 ) -> Result<oxc::BindingPattern<'a>, OxcDiagnostic> {
     let name = ox_identifier_name(cx.env, identifier_id)?;
-    Ok(oxc_ast::ast::BindingPattern::new_binding_identifier(SPAN, ox_str(&cx.ast, &name), &cx.ast))
+    Ok(oxc_ast::ast::BindingPattern::new_binding_identifier(SPAN, name, &cx.ast))
 }
 
-fn ox_identifier_name(
-    env: &Environment,
+fn ox_identifier_name<'a>(
+    env: &Environment<'a>,
     identifier_id: IdentifierId,
-) -> Result<String, OxcDiagnostic> {
+) -> Result<Ident<'a>, OxcDiagnostic> {
     let ident = &env.identifiers[identifier_id.0 as usize];
-    match &ident.name {
-        Some(crate::react_compiler_hir::IdentifierName::Named(n)) => Ok(n.clone()),
-        Some(crate::react_compiler_hir::IdentifierName::Promoted(n)) => Ok(n.clone()),
+    match ident.name {
+        Some(crate::react_compiler_hir::IdentifierName::Named(n))
+        | Some(crate::react_compiler_hir::IdentifierName::Promoted(n)) => Ok(n),
         None => Err(invariant_err(
             "Expected temporaries to be promoted to named identifiers in an earlier pass",
             None,
@@ -590,9 +589,9 @@ fn ox_identifier_name(
 // Block codegen (oxc)
 // =============================================================================
 
-fn ox_codegen_block<'a, 'h>(
-    cx: &mut OxcContext<'a, '_, 'h>,
-    block: &ReactiveBlock<'h>,
+fn ox_codegen_block<'a>(
+    cx: &mut OxcContext<'a, '_>,
+    block: &ReactiveBlock<'a>,
 ) -> Result<oxc_allocator::Vec<'a, oxc::Statement<'a>>, OxcDiagnostic> {
     let temp_snapshot = ox_clone_temporaries(&cx.ast, &cx.temp);
     let result = ox_codegen_block_no_reset(cx, block)?;
@@ -600,9 +599,9 @@ fn ox_codegen_block<'a, 'h>(
     Ok(result)
 }
 
-fn ox_codegen_block_no_reset<'a, 'h>(
-    cx: &mut OxcContext<'a, '_, 'h>,
-    block: &ReactiveBlock<'h>,
+fn ox_codegen_block_no_reset<'a>(
+    cx: &mut OxcContext<'a, '_>,
+    block: &ReactiveBlock<'a>,
 ) -> Result<oxc_allocator::Vec<'a, oxc::Statement<'a>>, OxcDiagnostic> {
     let mut statements: oxc_allocator::Vec<'a, oxc::Statement<'a>> =
         oxc_allocator::ArenaVec::new_in(&cx.ast);
@@ -672,9 +671,9 @@ fn ox_codegen_block_no_reset<'a, 'h>(
     Ok(statements)
 }
 
-fn ox_codegen_block_statement<'a, 'h>(
-    cx: &mut OxcContext<'a, '_, 'h>,
-    block: &ReactiveBlock<'h>,
+fn ox_codegen_block_statement<'a>(
+    cx: &mut OxcContext<'a, '_>,
+    block: &ReactiveBlock<'a>,
 ) -> Result<oxc::BlockStatement<'a>, OxcDiagnostic> {
     let body = ox_codegen_block(cx, block)?;
     Ok(oxc_ast::ast::BlockStatement::new(SPAN, body, &cx.ast))
@@ -684,11 +683,11 @@ fn ox_codegen_block_statement<'a, 'h>(
 // Reactive scope codegen (memoization) (oxc)
 // =============================================================================
 
-fn ox_codegen_reactive_scope<'a, 'h>(
-    cx: &mut OxcContext<'a, '_, 'h>,
+fn ox_codegen_reactive_scope<'a>(
+    cx: &mut OxcContext<'a, '_>,
     statements: &mut oxc_allocator::Vec<'a, oxc::Statement<'a>>,
     scope_id: ScopeId,
-    block: &ReactiveBlock<'h>,
+    block: &ReactiveBlock<'a>,
 ) -> Result<(), OxcDiagnostic> {
     let scope_deps = cx.env.scopes[scope_id.0 as usize].dependencies.clone();
     let scope_decls = cx.env.scopes[scope_id.0 as usize].declarations.clone();
@@ -698,7 +697,7 @@ fn ox_codegen_reactive_scope<'a, 'h>(
         oxc_allocator::ArenaVec::new_in(&cx.ast);
     let mut cache_load_stmts: oxc_allocator::Vec<'a, oxc::Statement<'a>> =
         oxc_allocator::ArenaVec::new_in(&cx.ast);
-    let mut cache_loads: Vec<(String, u32)> = Vec::new();
+    let mut cache_loads: Vec<(Ident, u32)> = Vec::new();
     let mut change_exprs: Vec<oxc::Expression<'a>> = Vec::new();
 
     let mut deps = scope_deps;
@@ -910,9 +909,9 @@ fn ast_member_target<'a>(
 // Terminal codegen (oxc)
 // =============================================================================
 
-fn ox_codegen_terminal<'a, 'h>(
-    cx: &mut OxcContext<'a, '_, 'h>,
-    terminal: &ReactiveTerminal<'h>,
+fn ox_codegen_terminal<'a>(
+    cx: &mut OxcContext<'a, '_>,
+    terminal: &ReactiveTerminal<'a>,
 ) -> Result<Option<oxc::Statement<'a>>, OxcDiagnostic> {
     match terminal {
         ReactiveTerminal::Break { target, target_kind, .. } => {
@@ -1087,10 +1086,10 @@ fn ox_codegen_terminal<'a, 'h>(
     }
 }
 
-fn ox_codegen_for_in<'a, 'h>(
-    cx: &mut OxcContext<'a, '_, 'h>,
-    init: &ReactiveValue<'h>,
-    loop_block: &ReactiveBlock<'h>,
+fn ox_codegen_for_in<'a>(
+    cx: &mut OxcContext<'a, '_>,
+    init: &ReactiveValue<'a>,
+    loop_block: &ReactiveBlock<'a>,
     span: Option<Span>,
 ) -> Result<Option<oxc::Statement<'a>>, OxcDiagnostic> {
     let ReactiveValue::SequenceExpression { instructions, .. } = init else {
@@ -1129,11 +1128,11 @@ fn ox_codegen_for_in<'a, 'h>(
     Ok(Some(oxc_ast::ast::Statement::new_for_in_statement(SPAN, left, right, body, &cx.ast)))
 }
 
-fn ox_codegen_for_of<'a, 'h>(
-    cx: &mut OxcContext<'a, '_, 'h>,
-    init: &ReactiveValue<'h>,
-    test: &ReactiveValue<'h>,
-    loop_block: &ReactiveBlock<'h>,
+fn ox_codegen_for_of<'a>(
+    cx: &mut OxcContext<'a, '_>,
+    init: &ReactiveValue<'a>,
+    test: &ReactiveValue<'a>,
+    loop_block: &ReactiveBlock<'a>,
     span: Option<Span>,
 ) -> Result<Option<oxc::Statement<'a>>, OxcDiagnostic> {
     let ReactiveValue::SequenceExpression { instructions: init_instrs, .. } = init else {
@@ -1187,7 +1186,7 @@ fn ox_codegen_for_of<'a, 'h>(
 }
 
 fn ox_extract_for_in_of_lval<'a>(
-    cx: &mut OxcContext<'a, '_, '_>,
+    cx: &mut OxcContext<'a, '_>,
     instr_value: &InstructionValue,
     context_name: &str,
     span: Option<Span>,
@@ -1234,9 +1233,9 @@ fn ox_extract_for_in_of_lval<'a>(
     Ok((lval, var_decl_kind))
 }
 
-fn ox_codegen_for_init<'a, 'h>(
-    cx: &mut OxcContext<'a, '_, 'h>,
-    init: &ReactiveValue<'h>,
+fn ox_codegen_for_init<'a>(
+    cx: &mut OxcContext<'a, '_>,
+    init: &ReactiveValue<'a>,
 ) -> Result<Option<oxc::ForStatementInit<'a>>, OxcDiagnostic> {
     if let ReactiveValue::SequenceExpression { instructions, .. } = init {
         let block_items: Vec<ReactiveStatement> =
@@ -1331,9 +1330,9 @@ fn ox_convert_value_to_expression<'a>(
     }
 }
 
-fn ox_codegen_instruction_nullable<'a, 'h>(
-    cx: &mut OxcContext<'a, '_, 'h>,
-    instr: &ReactiveInstruction<'h>,
+fn ox_codegen_instruction_nullable<'a>(
+    cx: &mut OxcContext<'a, '_>,
+    instr: &ReactiveInstruction<'a>,
 ) -> Result<Option<oxc::Statement<'a>>, OxcDiagnostic> {
     if let ReactiveValue::Instruction(ref value) = instr.value {
         match value {
@@ -1381,9 +1380,9 @@ fn ox_codegen_instruction_nullable<'a, 'h>(
     if matches!(stmt, oxc::Statement::EmptyStatement(_)) { Ok(None) } else { Ok(Some(stmt)) }
 }
 
-fn ox_codegen_store_or_declare<'a, 'h>(
-    cx: &mut OxcContext<'a, '_, 'h>,
-    instr: &ReactiveInstruction<'h>,
+fn ox_codegen_store_or_declare<'a>(
+    cx: &mut OxcContext<'a, '_>,
+    instr: &ReactiveInstruction<'a>,
     value: &InstructionValue,
 ) -> Result<Option<oxc::Statement<'a>>, OxcDiagnostic> {
     match value {
@@ -1422,9 +1421,9 @@ fn ox_codegen_store_or_declare<'a, 'h>(
     }
 }
 
-fn ox_emit_store<'a, 'h>(
-    cx: &mut OxcContext<'a, '_, 'h>,
-    instr: &ReactiveInstruction<'h>,
+fn ox_emit_store<'a>(
+    cx: &mut OxcContext<'a, '_>,
+    instr: &ReactiveInstruction<'a>,
     kind: InstructionKind,
     lvalue: &LvalueRef,
     value: Option<oxc::Expression<'a>>,
@@ -1536,7 +1535,7 @@ fn ox_emit_store<'a, 'h>(
 
 /// Build `kind id = init;` (or `kind id;` when `init` is `None`).
 fn ox_make_var_decl<'a>(
-    cx: &OxcContext<'a, '_, '_>,
+    cx: &OxcContext<'a, '_>,
     kind: oxc::VariableDeclarationKind,
     id: oxc::BindingPattern<'a>,
     init: Option<oxc::Expression<'a>>,
@@ -1559,9 +1558,9 @@ fn ox_make_var_decl<'a>(
     ))
 }
 
-fn ox_codegen_instruction<'a, 'h>(
-    cx: &mut OxcContext<'a, '_, 'h>,
-    instr: &ReactiveInstruction<'h>,
+fn ox_codegen_instruction<'a>(
+    cx: &mut OxcContext<'a, '_>,
+    instr: &ReactiveInstruction<'a>,
     value: OxValue<'a>,
 ) -> Result<oxc::Statement<'a>, OxcDiagnostic> {
     let Some(ref lvalue) = instr.lvalue else {
@@ -1601,17 +1600,17 @@ fn ox_codegen_instruction<'a, 'h>(
 // Instruction value codegen (oxc)
 // =============================================================================
 
-fn ox_codegen_instruction_value_to_expression<'a, 'h>(
-    cx: &mut OxcContext<'a, '_, 'h>,
-    instr_value: &ReactiveValue<'h>,
+fn ox_codegen_instruction_value_to_expression<'a>(
+    cx: &mut OxcContext<'a, '_>,
+    instr_value: &ReactiveValue<'a>,
 ) -> Result<oxc::Expression<'a>, OxcDiagnostic> {
     let value = ox_codegen_instruction_value(cx, instr_value)?;
     Ok(ox_convert_value_to_expression(&cx.ast, value))
 }
 
-fn ox_codegen_instruction_value<'a, 'h>(
-    cx: &mut OxcContext<'a, '_, 'h>,
-    instr_value: &ReactiveValue<'h>,
+fn ox_codegen_instruction_value<'a>(
+    cx: &mut OxcContext<'a, '_>,
+    instr_value: &ReactiveValue<'a>,
 ) -> Result<OxValue<'a>, OxcDiagnostic> {
     match instr_value {
         ReactiveValue::Instruction(iv) => ox_codegen_base_instruction_value(cx, iv),
@@ -1721,7 +1720,7 @@ fn ox_unwrap_chain(expr: oxc::Expression<'_>) -> oxc::Expression<'_> {
 /// Re-wrap a call/member expression as an optional-chaining element, mirroring the
 /// Babel reference's `OptionalExpression` arm.
 fn ox_make_optional<'a>(
-    cx: &mut OxcContext<'a, '_, '_>,
+    cx: &mut OxcContext<'a, '_>,
     expr: oxc::Expression<'a>,
     optional: bool,
 ) -> Result<OxValue<'a>, OxcDiagnostic> {
@@ -1803,8 +1802,8 @@ fn ox_make_optional<'a>(
 }
 
 fn ox_codegen_base_instruction_value<'a>(
-    cx: &mut OxcContext<'a, '_, '_>,
-    iv: &InstructionValue,
+    cx: &mut OxcContext<'a, '_>,
+    iv: &InstructionValue<'a>,
 ) -> Result<OxValue<'a>, OxcDiagnostic> {
     match iv {
         InstructionValue::Primitive { value, .. } => {
@@ -1834,13 +1833,9 @@ fn ox_codegen_base_instruction_value<'a>(
             let expr = ox_codegen_place_to_expression(cx, place)?;
             Ok(OxValue::Expression(expr))
         }
-        InstructionValue::LoadGlobal { binding, .. } => {
-            Ok(OxValue::Expression(oxc_ast::ast::Expression::new_identifier(
-                SPAN,
-                ox_str(&cx.ast, binding.name()),
-                &cx.ast,
-            )))
-        }
+        InstructionValue::LoadGlobal { binding, .. } => Ok(OxValue::Expression(
+            oxc_ast::ast::Expression::new_identifier(SPAN, binding.name(), &cx.ast),
+        )),
         InstructionValue::CallExpression { callee, args, .. } => {
             let callee_expr = ox_codegen_place_to_expression(cx, callee)?;
             let arguments = ox_codegen_arguments(cx, args)?;
@@ -2153,7 +2148,7 @@ fn ox_codegen_base_instruction_value<'a>(
 
 /// Build `obj.prop` / `obj[prop]` member expression from a `PropertyLiteral`.
 fn ox_property_member<'a>(
-    cx: &OxcContext<'a, '_, '_>,
+    cx: &OxcContext<'a, '_>,
     object: oxc::Expression<'a>,
     property: &PropertyLiteral,
 ) -> oxc::MemberExpression<'a> {
@@ -2178,7 +2173,7 @@ fn ox_property_member<'a>(
 }
 
 fn ox_template_literal<'a>(
-    cx: &OxcContext<'a, '_, '_>,
+    cx: &OxcContext<'a, '_>,
     quasis: &[crate::react_compiler_hir::TemplateQuasi],
     expressions: oxc_allocator::Vec<'a, oxc::Expression<'a>>,
 ) -> oxc::TemplateLiteral<'a> {
@@ -2196,7 +2191,7 @@ fn ox_template_literal<'a>(
 }
 
 fn ox_codegen_arguments<'a>(
-    cx: &mut OxcContext<'a, '_, '_>,
+    cx: &mut OxcContext<'a, '_>,
     args: &[PlaceOrSpread],
 ) -> Result<oxc_allocator::Vec<'a, oxc::Argument<'a>>, OxcDiagnostic> {
     let mut out: oxc_allocator::Vec<'a, oxc::Argument<'a>> =
@@ -2208,7 +2203,7 @@ fn ox_codegen_arguments<'a>(
 }
 
 fn ox_codegen_argument<'a>(
-    cx: &mut OxcContext<'a, '_, '_>,
+    cx: &mut OxcContext<'a, '_>,
     arg: &PlaceOrSpread,
 ) -> Result<oxc::Argument<'a>, OxcDiagnostic> {
     match arg {
@@ -2246,7 +2241,7 @@ fn ox_expression_type_name(expr: &oxc::Expression) -> &'static str {
 // =============================================================================
 
 fn ox_codegen_place_to_expression<'a>(
-    cx: &mut OxcContext<'a, '_, '_>,
+    cx: &mut OxcContext<'a, '_>,
     place: &Place,
 ) -> Result<oxc::Expression<'a>, OxcDiagnostic> {
     let value = ox_codegen_place(cx, place)?;
@@ -2254,7 +2249,7 @@ fn ox_codegen_place_to_expression<'a>(
 }
 
 fn ox_codegen_place<'a>(
-    cx: &mut OxcContext<'a, '_, '_>,
+    cx: &mut OxcContext<'a, '_>,
     place: &Place,
 ) -> Result<OxValue<'a>, OxcDiagnostic> {
     let ident = &cx.env.identifiers[place.identifier.0 as usize];
@@ -2281,7 +2276,7 @@ fn ox_codegen_place<'a>(
 }
 
 fn ox_codegen_lvalue<'a>(
-    cx: &mut OxcContext<'a, '_, '_>,
+    cx: &mut OxcContext<'a, '_>,
     pattern: &LvalueRef,
 ) -> Result<oxc::BindingPattern<'a>, OxcDiagnostic> {
     match pattern {
@@ -2295,7 +2290,7 @@ fn ox_codegen_lvalue<'a>(
 }
 
 fn ox_codegen_array_pattern<'a>(
-    cx: &mut OxcContext<'a, '_, '_>,
+    cx: &mut OxcContext<'a, '_>,
     pattern: &ArrayPattern,
 ) -> Result<oxc::BindingPattern<'a>, OxcDiagnostic> {
     let mut elements: oxc_allocator::Vec<'a, Option<oxc::BindingPattern<'a>>> =
@@ -2319,7 +2314,7 @@ fn ox_codegen_array_pattern<'a>(
 }
 
 fn ox_codegen_object_pattern<'a>(
-    cx: &mut OxcContext<'a, '_, '_>,
+    cx: &mut OxcContext<'a, '_>,
     pattern: &ObjectPattern,
 ) -> Result<oxc::BindingPattern<'a>, OxcDiagnostic> {
     let mut properties: oxc_allocator::Vec<'a, oxc::BindingProperty<'a>> =
@@ -2353,7 +2348,7 @@ fn ox_codegen_object_pattern<'a>(
 
 /// Build an object pattern key, returning `(key, computed)`.
 fn ox_codegen_object_property_key<'a>(
-    cx: &mut OxcContext<'a, '_, '_>,
+    cx: &mut OxcContext<'a, '_>,
     key: &ObjectPropertyKey,
 ) -> Result<(oxc::PropertyKey<'a>, bool), OxcDiagnostic> {
     match key {
@@ -2378,7 +2373,7 @@ fn ox_codegen_object_property_key<'a>(
 }
 
 fn ox_codegen_dependency<'a>(
-    cx: &mut OxcContext<'a, '_, '_>,
+    cx: &mut OxcContext<'a, '_>,
     dep: &crate::react_compiler_hir::ReactiveScopeDependency,
 ) -> Result<oxc::Expression<'a>, OxcDiagnostic> {
     let name = ox_identifier_name(cx.env, dep.identifier)?;
@@ -2453,7 +2448,7 @@ fn ox_codegen_dependency<'a>(
 /// `ox_codegen_lvalue` into the corresponding assignment-target tree. Mirrors Babel,
 /// which reuses the same `ArrayPattern`/`ObjectPattern` nodes as assignment LHS.
 fn ox_binding_pattern_to_assignment_target<'a>(
-    cx: &OxcContext<'a, '_, '_>,
+    cx: &OxcContext<'a, '_>,
     pattern: oxc::BindingPattern<'a>,
 ) -> Result<oxc::AssignmentTarget<'a>, OxcDiagnostic> {
     match pattern {
@@ -2497,7 +2492,7 @@ fn ox_binding_pattern_to_assignment_target<'a>(
 /// Convert a `BindingPattern` element into an `AssignmentTargetMaybeDefault`, turning a
 /// nested default (`[x = 1] = arr`) into an `AssignmentTargetWithDefault`.
 fn ox_binding_pattern_to_maybe_default<'a>(
-    cx: &OxcContext<'a, '_, '_>,
+    cx: &OxcContext<'a, '_>,
     pattern: oxc::BindingPattern<'a>,
 ) -> Result<oxc::AssignmentTargetMaybeDefault<'a>, OxcDiagnostic> {
     match pattern {
@@ -2520,7 +2515,7 @@ fn ox_binding_pattern_to_maybe_default<'a>(
 /// Convert an object `BindingProperty` into an `AssignmentTargetProperty`, preserving the
 /// shorthand form (`{a}` / `{a = 1}`) vs the keyed form (`{a: b}` / `{a: b = 1}`).
 fn ox_binding_property_to_assignment_property<'a>(
-    cx: &OxcContext<'a, '_, '_>,
+    cx: &OxcContext<'a, '_>,
     prop: oxc::BindingProperty<'a>,
 ) -> Result<oxc::AssignmentTargetProperty<'a>, OxcDiagnostic> {
     if prop.shorthand {
@@ -2560,7 +2555,7 @@ fn ox_binding_property_to_assignment_property<'a>(
 
 /// Convert a binding rest element (`...x`) into an assignment-target rest.
 fn ox_binding_rest_to_assignment_rest<'a>(
-    cx: &OxcContext<'a, '_, '_>,
+    cx: &OxcContext<'a, '_>,
     rest: Option<oxc_allocator::Box<'a, oxc::BindingRestElement<'a>>>,
 ) -> Result<Option<oxc::AssignmentTargetRest<'a>>, OxcDiagnostic> {
     match rest {
@@ -2574,7 +2569,7 @@ fn ox_binding_rest_to_assignment_rest<'a>(
 
 /// Convert an expression to a `SimpleAssignmentTarget` for update expressions.
 fn ox_expression_to_simple_assignment_target<'a>(
-    cx: &OxcContext<'a, '_, '_>,
+    cx: &OxcContext<'a, '_>,
     expr: oxc::Expression<'a>,
 ) -> Result<oxc::SimpleAssignmentTarget<'a>, OxcDiagnostic> {
     match expr {
@@ -2599,9 +2594,9 @@ fn ox_expression_to_simple_assignment_target<'a>(
 // =============================================================================
 
 fn ox_codegen_function_expression<'a>(
-    cx: &mut OxcContext<'a, '_, '_>,
-    name: &Option<String>,
-    name_hint: &Option<String>,
+    cx: &mut OxcContext<'a, '_>,
+    name: &Option<Ident<'a>>,
+    name_hint: &Option<Ident<'a>>,
     lowered_func: &crate::react_compiler_hir::LoweredFunction,
     expr_type: &FunctionExpressionType,
 ) -> Result<OxValue<'a>, OxcDiagnostic> {
@@ -2672,7 +2667,7 @@ fn ox_codegen_function_expression<'a>(
 
     // enableNameAnonymousFunctions: `({ "<hint>": <fn> })["<hint>"]`
     if cx.env.config.enable_name_anonymous_functions && name.is_none() && name_hint.is_some() {
-        let hint = name_hint.as_ref().unwrap().clone();
+        let hint = *name_hint.as_ref().unwrap();
         let key = oxc::PropertyKey::from(oxc_ast::ast::Expression::new_string_literal(
             SPAN,
             ox_str(&cx.ast, &hint),
@@ -2713,7 +2708,7 @@ fn ox_codegen_function_expression<'a>(
 }
 
 fn ox_build_arrow<'a>(
-    cx: &OxcContext<'a, '_, '_>,
+    cx: &OxcContext<'a, '_>,
     params: oxc_allocator::Box<'a, oxc::FormalParameters<'a>>,
     body: oxc_allocator::Box<'a, oxc::FunctionBody<'a>>,
     is_async: bool,
@@ -2733,11 +2728,11 @@ fn ox_build_arrow<'a>(
 
 /// Run the inner-function codegen with a fresh context (mirrors the Babel reference's
 /// `Context::new` + `codegen_reactive_function` for function/object-method expressions).
-fn ox_codegen_inner_function<'a, 'h>(
-    cx: &mut OxcContext<'a, '_, 'h>,
-    reactive_fn: &ReactiveFunction<'h>,
+fn ox_codegen_inner_function<'a>(
+    cx: &mut OxcContext<'a, '_>,
+    reactive_fn: &ReactiveFunction<'a>,
 ) -> Result<OxcCompiledFunction<'a>, OxcDiagnostic> {
-    let fn_name = reactive_fn.id.as_deref().unwrap_or("[[ anonymous ]]").to_string();
+    let fn_name = reactive_fn.id.unwrap_or(Ident::from("[[ anonymous ]]"));
     let mut inner_cx = OxcContext::new(
         oxc_ast::builder::AstBuilder::new(cx.ast.allocator()),
         cx.env,
@@ -2750,7 +2745,7 @@ fn ox_codegen_inner_function<'a, 'h>(
 }
 
 fn ox_codegen_object_expression<'a>(
-    cx: &mut OxcContext<'a, '_, '_>,
+    cx: &mut OxcContext<'a, '_>,
     properties: &[ObjectPropertyOrSpread],
 ) -> Result<OxValue<'a>, OxcDiagnostic> {
     let mut props: oxc_allocator::Vec<'a, oxc::ObjectPropertyKind<'a>> =
@@ -2849,7 +2844,7 @@ fn ox_codegen_object_expression<'a>(
 // =============================================================================
 
 fn ox_codegen_jsx_expression<'a>(
-    cx: &mut OxcContext<'a, '_, '_>,
+    cx: &mut OxcContext<'a, '_>,
     tag: &JsxTag,
     props: &[JsxAttribute],
     children: &Option<Vec<Place>>,
@@ -2939,7 +2934,7 @@ fn ox_encode_jsx_text(raw: &str) -> String {
 }
 
 fn ox_codegen_jsx_attribute<'a>(
-    cx: &mut OxcContext<'a, '_, '_>,
+    cx: &mut OxcContext<'a, '_>,
     attr: &JsxAttribute,
 ) -> Result<oxc::JSXAttributeItem<'a>, OxcDiagnostic> {
     match attr {
@@ -2983,7 +2978,7 @@ fn ox_codegen_jsx_attribute<'a>(
 }
 
 fn ox_codegen_jsx_element<'a>(
-    cx: &mut OxcContext<'a, '_, '_>,
+    cx: &mut OxcContext<'a, '_>,
     place: &Place,
 ) -> Result<oxc::JSXChild<'a>, OxcDiagnostic> {
     let value = ox_codegen_place(cx, place)?;
@@ -3036,7 +3031,7 @@ fn ox_codegen_jsx_element<'a>(
 }
 
 fn ox_codegen_jsx_fbt_child_element<'a>(
-    cx: &mut OxcContext<'a, '_, '_>,
+    cx: &mut OxcContext<'a, '_>,
     place: &Place,
 ) -> Result<oxc::JSXChild<'a>, OxcDiagnostic> {
     let value = ox_codegen_place(cx, place)?;
@@ -3066,7 +3061,7 @@ fn ox_codegen_jsx_fbt_child_element<'a>(
 /// Build a `JSXElementName` from a tag expression following the TS compiler's
 /// identifier-reference rule (uppercase / contains-`.` names become references).
 fn ox_expression_to_jsx_tag<'a>(
-    cx: &OxcContext<'a, '_, '_>,
+    cx: &OxcContext<'a, '_>,
     expr: &oxc::Expression<'a>,
 ) -> Result<oxc::JSXElementName<'a>, OxcDiagnostic> {
     match expr {
@@ -3098,7 +3093,7 @@ fn ox_expression_to_jsx_tag<'a>(
 }
 
 fn ox_jsx_element_name_from_ident<'a>(
-    cx: &OxcContext<'a, '_, '_>,
+    cx: &OxcContext<'a, '_>,
     name: &str,
 ) -> oxc::JSXElementName<'a> {
     let first_char = name.chars().next().unwrap_or('a');
@@ -3112,7 +3107,7 @@ fn ox_jsx_element_name_from_ident<'a>(
 /// Convert an oxc member expression into a JSX member expression's
 /// `(object, property)` pair.
 fn ox_convert_member_expression_to_jsx<'a>(
-    cx: &OxcContext<'a, '_, '_>,
+    cx: &OxcContext<'a, '_>,
     expr: &oxc::Expression<'a>,
 ) -> Result<(oxc::JSXMemberExpressionObject<'a>, oxc::JSXIdentifier<'a>), OxcDiagnostic> {
     let oxc::Expression::StaticMemberExpression(me) = expr else {
@@ -3211,7 +3206,7 @@ fn ox_create_hook_guard<'a>(
 /// calls are wrapped in a guarded IIFE:
 /// `(function () { try { $dispatcherGuard(2); return <call>; } finally { $dispatcherGuard(3); } })()`
 fn ox_create_call_expression<'a>(
-    cx: &OxcContext<'a, '_, '_>,
+    cx: &OxcContext<'a, '_>,
     callee: oxc::Expression<'a>,
     arguments: oxc_allocator::ArenaVec<'a, oxc::Argument<'a>>,
     callee_id: IdentifierId,
@@ -3516,16 +3511,15 @@ fn dep_to_sort_key(
     env: &Environment,
 ) -> String {
     let ident = &env.identifiers[dep.identifier.0 as usize];
-    let base = match &ident.name {
-        Some(crate::react_compiler_hir::IdentifierName::Named(n)) => n.clone(),
-        Some(crate::react_compiler_hir::IdentifierName::Promoted(n)) => n.clone(),
+    let base = match ident.name {
+        Some(name) => name.value().to_string(),
         None => format!("_t{}", dep.identifier.0),
     };
     let mut parts = vec![base];
     for entry in &dep.path {
         let prefix = if entry.optional { "?" } else { "" };
         let prop = match &entry.property {
-            PropertyLiteral::String(s) => s.clone(),
+            PropertyLiteral::String(s) => s.to_string(),
             PropertyLiteral::Number(n) => format!("{}", n),
         };
         parts.push(format!("{prefix}{prop}"));
@@ -3545,9 +3539,8 @@ fn compare_scope_declaration(
 
 fn ident_sort_key(id: IdentifierId, env: &Environment) -> String {
     let ident = &env.identifiers[id.0 as usize];
-    match &ident.name {
-        Some(crate::react_compiler_hir::IdentifierName::Named(n)) => n.clone(),
-        Some(crate::react_compiler_hir::IdentifierName::Promoted(n)) => n.clone(),
+    match ident.name {
+        Some(name) => name.value().to_string(),
         None => format!("_t{}", id.0),
     }
 }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/extract_scope_declarations_from_destructuring.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/extract_scope_declarations_from_destructuring.rs
@@ -11,6 +11,7 @@
 use rustc_hash::FxHashSet;
 
 use oxc_diagnostics::OxcDiagnostic;
+use oxc_str::format_ident;
 
 use crate::react_compiler_hir::{
     DeclarationId, IdentifierId, IdentifierName, InstructionKind, InstructionValue, LValue,
@@ -134,8 +135,9 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
                     // (matches TS makeTemporaryIdentifier which receives place.span)
                     env.identifiers[temp_id.0 as usize].span = place.span;
                     // Promote the temporary
-                    env.identifiers[temp_id.0 as usize].name =
-                        Some(IdentifierName::Promoted(format!("#t{}", decl_id.0)));
+                    env.identifiers[temp_id.0 as usize].name = Some(IdentifierName::Promoted(
+                        format_ident!(env.allocator, "#t{}", decl_id.0),
+                    ));
                     let temporary = Place {
                         identifier: temp_id,
                         effect: place.effect,

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/merge_reactive_scopes_that_invalidate_together.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/merge_reactive_scopes_that_invalidate_together.rs
@@ -86,7 +86,7 @@ struct MergeTransform<'a, 'e> {
 }
 
 impl<'a, 'e> ReactiveFunctionTransform<'a> for MergeTransform<'a, 'e> {
-    type State = Option<Vec<ReactiveScopeDependency>>;
+    type State = Option<Vec<ReactiveScopeDependency<'a>>>;
 
     fn env(&self) -> &Environment<'a> {
         self.env

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/promote_used_temporaries.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/promote_used_temporaries.rs
@@ -11,6 +11,8 @@
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 
+use oxc_str::format_ident;
+
 use crate::react_compiler_hir::DeclarationId;
 use crate::react_compiler_hir::FunctionId;
 use crate::react_compiler_hir::IdentifierId;
@@ -1027,10 +1029,10 @@ fn promote_identifier(identifier_id: IdentifierId, state: &mut State, env: &mut 
     if state.tags.contains(&decl_id) {
         // JSX tag temporary: use capitalized name
         env.identifiers[identifier_id.0 as usize].name =
-            Some(IdentifierName::Promoted(format!("#T{}", decl_id.0)));
+            Some(IdentifierName::Promoted(format_ident!(env.allocator, "#T{}", decl_id.0)));
     } else {
         env.identifiers[identifier_id.0 as usize].name =
-            Some(IdentifierName::Promoted(format!("#t{}", decl_id.0)));
+            Some(IdentifierName::Promoted(format_ident!(env.allocator, "#t{}", decl_id.0)));
     }
     state.promoted.insert(decl_id);
 }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/propagate_early_returns.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/propagate_early_returns.rs
@@ -13,6 +13,7 @@
 use std::mem::take;
 
 use oxc_diagnostics::OxcDiagnostic;
+use oxc_str::{Ident, format_ident};
 
 use crate::react_compiler_hir::{
     BlockId, Effect, EvaluationOrder, IdentifierId, IdentifierName, InstructionKind,
@@ -214,7 +215,7 @@ fn apply_early_return_to_scope<'a>(
                 span: None, // GeneratedSource
             }),
             value: ReactiveValue::Instruction(InstructionValue::LoadGlobal {
-                binding: NonLocalBinding::Global { name: "Symbol".to_string() },
+                binding: NonLocalBinding::Global { name: Ident::from("Symbol") },
                 span,
             }),
             span,
@@ -235,7 +236,7 @@ fn apply_early_return_to_scope<'a>(
                     reactive: false,
                     span: None, // GeneratedSource
                 },
-                property: PropertyLiteral::String("for".to_string()),
+                property: PropertyLiteral::String(Ident::from("for")),
                 span,
             }),
             span,
@@ -335,5 +336,5 @@ fn create_temporary_place_id(env: &mut Environment, span: Option<Span>) -> Ident
 fn promote_temporary<'a>(env: &mut Environment<'a>, identifier_id: IdentifierId) {
     let decl_id = env.identifiers[identifier_id.0 as usize].declaration_id;
     env.identifiers[identifier_id.0 as usize].name =
-        Some(IdentifierName::Promoted(format!("#t{}", decl_id.0)));
+        Some(IdentifierName::Promoted(format_ident!(env.allocator, "#t{}", decl_id.0)));
 }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_reactive_dependencies.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_reactive_dependencies.rs
@@ -99,23 +99,23 @@ fn is_stable_type(ty: &Type) -> bool {
 }
 
 fn is_set_state_type(ty: &Type) -> bool {
-    matches!(ty, Type::Function { shape_id: Some(id), .. } if id == object_shape::BUILT_IN_SET_STATE_ID)
+    matches!(ty, Type::Function { shape_id: Some(id), .. } if *id == object_shape::BUILT_IN_SET_STATE_ID)
 }
 
 fn is_set_action_state_type(ty: &Type) -> bool {
-    matches!(ty, Type::Function { shape_id: Some(id), .. } if id == object_shape::BUILT_IN_SET_ACTION_STATE_ID)
+    matches!(ty, Type::Function { shape_id: Some(id), .. } if *id == object_shape::BUILT_IN_SET_ACTION_STATE_ID)
 }
 
 fn is_dispatcher_type(ty: &Type) -> bool {
-    matches!(ty, Type::Function { shape_id: Some(id), .. } if id == object_shape::BUILT_IN_DISPATCH_ID)
+    matches!(ty, Type::Function { shape_id: Some(id), .. } if *id == object_shape::BUILT_IN_DISPATCH_ID)
 }
 
 fn is_start_transition_type(ty: &Type) -> bool {
-    matches!(ty, Type::Function { shape_id: Some(id), .. } if id == object_shape::BUILT_IN_START_TRANSITION_ID)
+    matches!(ty, Type::Function { shape_id: Some(id), .. } if *id == object_shape::BUILT_IN_START_TRANSITION_ID)
 }
 
 fn is_set_optimistic_type(ty: &Type) -> bool {
-    matches!(ty, Type::Function { shape_id: Some(id), .. } if id == object_shape::BUILT_IN_SET_OPTIMISTIC_ID)
+    matches!(ty, Type::Function { shape_id: Some(id), .. } if *id == object_shape::BUILT_IN_SET_OPTIMISTIC_ID)
 }
 
 // =============================================================================

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/rename_variables.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/rename_variables.rs
@@ -9,7 +9,8 @@
 //! Corresponds to `src/ReactiveScopes/RenameVariables.ts`.
 
 use rustc_hash::FxHashMap;
-use rustc_hash::FxHashSet;
+
+use oxc_str::{Ident, IdentHashMap, IdentHashSet, format_ident};
 
 use crate::react_compiler_hir::DeclarationId;
 use crate::react_compiler_hir::EvaluationOrder;
@@ -36,27 +37,27 @@ use crate::react_compiler_reactive_scopes::visitors::ReactiveFunctionVisitor;
 // Scopes
 // =============================================================================
 
-struct Scopes {
-    seen: FxHashMap<DeclarationId, IdentifierName>,
-    stack: Vec<FxHashMap<String, DeclarationId>>,
-    globals: FxHashSet<String>,
-    names: FxHashSet<String>,
+struct Scopes<'a> {
+    seen: FxHashMap<DeclarationId, IdentifierName<'a>>,
+    stack: Vec<IdentHashMap<'a, DeclarationId>>,
+    globals: IdentHashSet<'a>,
+    names: IdentHashSet<'a>,
 }
 
-impl Scopes {
-    fn new(globals: FxHashSet<String>) -> Self {
+impl<'a> Scopes<'a> {
+    fn new(globals: IdentHashSet<'a>) -> Self {
         Self {
             seen: FxHashMap::default(),
-            stack: vec![FxHashMap::default()],
+            stack: vec![IdentHashMap::default()],
             globals,
-            names: FxHashSet::default(),
+            names: IdentHashSet::default(),
         }
     }
 
-    fn visit_identifier(&mut self, identifier_id: IdentifierId, env: &Environment) {
+    fn visit_identifier(&mut self, identifier_id: IdentifierId, env: &Environment<'a>) {
         let identifier = &env.identifiers[identifier_id.0 as usize];
         let original_name = match &identifier.name {
-            Some(name) => name.clone(),
+            Some(name) => *name,
             None => return,
         };
         let declaration_id = identifier.declaration_id;
@@ -65,39 +66,39 @@ impl Scopes {
             return;
         }
 
-        let original_value = original_name.value().to_string();
+        let original_value = original_name.value();
         let is_promoted = matches!(original_name, IdentifierName::Promoted(_));
         let is_promoted_temp = is_promoted && original_value.starts_with("#t");
         let is_promoted_jsx = is_promoted && original_value.starts_with("#T");
 
-        let mut name: String;
+        let mut name: Ident<'a>;
         let mut id: u32 = 0;
         if is_promoted_temp {
-            name = format!("t{}", id);
+            name = format_ident!(env.allocator, "t{}", id);
             id += 1;
         } else if is_promoted_jsx {
-            name = format!("T{}", id);
+            name = format_ident!(env.allocator, "T{}", id);
             id += 1;
         } else {
-            name = original_value.clone();
+            name = Ident::from(original_value);
         }
 
         while self.lookup(&name).is_some() || self.globals.contains(&name) {
             if is_promoted_temp {
-                name = format!("t{}", id);
+                name = format_ident!(env.allocator, "t{}", id);
                 id += 1;
             } else if is_promoted_jsx {
-                name = format!("T{}", id);
+                name = format_ident!(env.allocator, "T{}", id);
                 id += 1;
             } else {
-                name = format!("{}${}", original_value, id);
+                name = format_ident!(env.allocator, "{}${}", original_value, id);
                 id += 1;
             }
         }
 
-        let identifier_name = IdentifierName::Named(name.clone());
+        let identifier_name = IdentifierName::Named(name);
         self.seen.insert(declaration_id, identifier_name);
-        self.stack.last_mut().unwrap().insert(name.clone(), declaration_id);
+        self.stack.last_mut().unwrap().insert(name, declaration_id);
         self.names.insert(name);
     }
 
@@ -111,7 +112,7 @@ impl Scopes {
     }
 
     fn enter(&mut self) {
-        self.stack.push(FxHashMap::default());
+        self.stack.push(IdentHashMap::default());
     }
 
     fn leave(&mut self) {
@@ -128,29 +129,29 @@ struct Visitor<'a, 'e> {
 }
 
 impl<'a, 'e> ReactiveFunctionVisitor<'a> for Visitor<'a, 'e> {
-    type State = Scopes;
+    type State = Scopes<'a>;
 
     fn env(&self) -> &Environment<'a> {
         self.env
     }
 
     /// TS: `visitParam(place, state) { state.visit(place.identifier) }`
-    fn visit_param(&self, place: &Place, state: &mut Scopes) {
+    fn visit_param(&self, place: &Place, state: &mut Scopes<'a>) {
         state.visit_identifier(place.identifier, self.env);
     }
 
     /// TS: `visitLValue(_id, lvalue, state) { state.visit(lvalue.identifier) }`
-    fn visit_lvalue(&self, _id: EvaluationOrder, lvalue: &Place, state: &mut Scopes) {
+    fn visit_lvalue(&self, _id: EvaluationOrder, lvalue: &Place, state: &mut Scopes<'a>) {
         state.visit_identifier(lvalue.identifier, self.env);
     }
 
     /// TS: `visitPlace(_id, place, state) { state.visit(place.identifier) }`
-    fn visit_place(&self, _id: EvaluationOrder, place: &Place, state: &mut Scopes) {
+    fn visit_place(&self, _id: EvaluationOrder, place: &Place, state: &mut Scopes<'a>) {
         state.visit_identifier(place.identifier, self.env);
     }
 
     /// TS: `visitBlock(block, state) { state.enter(() => { this.traverseBlock(block, state) }) }`
-    fn visit_block(&self, block: &ReactiveBlock<'a>, state: &mut Scopes) {
+    fn visit_block(&self, block: &ReactiveBlock<'a>, state: &mut Scopes<'a>) {
         state.enter();
         self.traverse_block(block, state);
         state.leave();
@@ -159,12 +160,12 @@ impl<'a, 'e> ReactiveFunctionVisitor<'a> for Visitor<'a, 'e> {
     /// TS: `visitPrunedScope(scopeBlock, state) { this.traverseBlock(scopeBlock.instructions, state) }`
     /// No enter/leave — names assigned inside pruned scopes remain visible in
     /// the enclosing scope, preventing name reuse.
-    fn visit_pruned_scope(&self, scope: &PrunedReactiveScopeBlock<'a>, state: &mut Scopes) {
+    fn visit_pruned_scope(&self, scope: &PrunedReactiveScopeBlock<'a>, state: &mut Scopes<'a>) {
         self.traverse_block(&scope.instructions, state);
     }
 
     /// TS: `visitScope(scope, state) { for (const [_, decl] of scope.scope.declarations) state.visit(decl.identifier); this.traverseScope(scope, state) }`
-    fn visit_scope(&self, scope: &ReactiveScopeBlock<'a>, state: &mut Scopes) {
+    fn visit_scope(&self, scope: &ReactiveScopeBlock<'a>, state: &mut Scopes<'a>) {
         let scope_data = &self.env.scopes[scope.scope.0 as usize];
         let decl_ids: Vec<IdentifierId> =
             scope_data.declarations.iter().map(|(_, d)| d.identifier).collect();
@@ -175,7 +176,7 @@ impl<'a, 'e> ReactiveFunctionVisitor<'a> for Visitor<'a, 'e> {
     }
 
     /// TS: `visitValue(id, value, state) { this.traverseValue(id, value, state); if (value.kind === 'FunctionExpression' || value.kind === 'ObjectMethod') this.visitHirFunction(value.loweredFunc.func, state) }`
-    fn visit_value(&self, id: EvaluationOrder, value: &ReactiveValue<'a>, state: &mut Scopes) {
+    fn visit_value(&self, id: EvaluationOrder, value: &ReactiveValue<'a>, state: &mut Scopes<'a>) {
         self.traverse_value(id, value, state);
         if let ReactiveValue::Instruction(
             InstructionValue::FunctionExpression { lowered_func, .. }
@@ -197,15 +198,15 @@ impl<'a, 'e> ReactiveFunctionVisitor<'a> for Visitor<'a, 'e> {
 pub fn rename_variables<'a>(
     func: &mut ReactiveFunction<'a>,
     env: &mut Environment<'a>,
-) -> FxHashSet<String> {
+) -> IdentHashSet<'a> {
     rename_variables_with_parent(func, env, None)
 }
 
 fn rename_variables_with_parent<'a>(
     func: &mut ReactiveFunction<'a>,
     env: &mut Environment<'a>,
-    parent_names: Option<&FxHashSet<String>>,
-) -> FxHashSet<String> {
+    parent_names: Option<&IdentHashSet<'a>>,
+) -> IdentHashSet<'a> {
     let globals = collect_referenced_globals(&func.body, env);
 
     // Phase 1: Use ReactiveFunctionVisitor to compute the rename mapping.
@@ -218,8 +219,8 @@ fn rename_variables_with_parent<'a>(
     if let Some(parent) = parent_names {
         scopes.enter();
         for name in parent {
-            scopes.stack.last_mut().unwrap().insert(name.clone(), DeclarationId(u32::MAX));
-            scopes.names.insert(name.clone());
+            scopes.stack.last_mut().unwrap().insert(*name, DeclarationId(u32::MAX));
+            scopes.names.insert(*name);
         }
     }
     rename_variables_impl(func, &Visitor { env }, &mut scopes);
@@ -228,12 +229,12 @@ fn rename_variables_with_parent<'a>(
     for identifier in env.identifiers.iter_mut() {
         if let Some(mapped_name) = scopes.seen.get(&identifier.declaration_id) {
             if identifier.name.is_some() {
-                identifier.name = Some(mapped_name.clone());
+                identifier.name = Some(*mapped_name);
             }
         }
     }
 
-    let mut result: FxHashSet<String> = scopes.names;
+    let mut result: IdentHashSet<'a> = scopes.names;
     result.extend(globals);
     result
 }
@@ -242,7 +243,7 @@ fn rename_variables_with_parent<'a>(
 fn rename_variables_impl<'a>(
     func: &ReactiveFunction<'a>,
     visitor: &Visitor<'a, '_>,
-    scopes: &mut Scopes,
+    scopes: &mut Scopes<'a>,
 ) {
     scopes.enter();
     for param in &func.params {
@@ -265,15 +266,15 @@ fn rename_variables_impl<'a>(
 fn collect_referenced_globals<'a>(
     block: &ReactiveBlock<'a>,
     env: &Environment<'a>,
-) -> FxHashSet<String> {
-    let mut globals = FxHashSet::default();
+) -> IdentHashSet<'a> {
+    let mut globals = IdentHashSet::default();
     collect_globals_block(block, &mut globals, env);
     globals
 }
 
 fn collect_globals_block<'a>(
     block: &ReactiveBlock<'a>,
-    globals: &mut FxHashSet<String>,
+    globals: &mut IdentHashSet<'a>,
     env: &Environment<'a>,
 ) {
     for stmt in block {
@@ -296,13 +297,13 @@ fn collect_globals_block<'a>(
 
 fn collect_globals_value<'a>(
     value: &ReactiveValue<'a>,
-    globals: &mut FxHashSet<String>,
+    globals: &mut IdentHashSet<'a>,
     env: &Environment<'a>,
 ) {
     match value {
         ReactiveValue::Instruction(iv) => {
             if let InstructionValue::LoadGlobal { binding, .. } = iv {
-                globals.insert(binding.name().to_string());
+                globals.insert(binding.name());
             }
             // Visit inner functions
             match iv {
@@ -337,7 +338,7 @@ fn collect_globals_value<'a>(
 /// Recursively collects LoadGlobal names from an inner HIR function.
 fn collect_globals_hir_function<'a>(
     func_id: FunctionId,
-    globals: &mut FxHashSet<String>,
+    globals: &mut IdentHashSet<'a>,
     env: &Environment<'a>,
 ) {
     let inner_func = &env.functions[func_id.0 as usize];
@@ -348,7 +349,7 @@ fn collect_globals_hir_function<'a>(
         for instr_id in &block.instructions {
             let instr = &inner_func.instructions[instr_id.0 as usize];
             if let InstructionValue::LoadGlobal { binding, .. } = &instr.value {
-                globals.insert(binding.name().to_string());
+                globals.insert(binding.name());
             }
             // Recurse into nested function expressions
             match &instr.value {
@@ -364,7 +365,7 @@ fn collect_globals_hir_function<'a>(
 
 fn collect_globals_terminal<'a>(
     stmt: &ReactiveTerminalStatement<'a>,
-    globals: &mut FxHashSet<String>,
+    globals: &mut IdentHashSet<'a>,
     env: &Environment<'a>,
 ) {
     match &stmt.terminal {

--- a/crates/oxc_react_compiler/src/react_compiler_ssa/enter_ssa.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_ssa/enter_ssa.rs
@@ -68,7 +68,7 @@ impl SSABuilder {
         let new_id = env.next_identifier_id();
         let old = &env.identifiers[old_id.0 as usize];
         let declaration_id = old.declaration_id;
-        let name = old.name.clone();
+        let name = old.name;
         let span = old.span;
         let new_ident = &mut env.identifiers[new_id.0 as usize];
         new_ident.declaration_id = declaration_id;

--- a/crates/oxc_react_compiler/src/react_compiler_typeinference/infer_types.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_typeinference/infer_types.rs
@@ -12,7 +12,9 @@ use std::mem::replace;
 
 use rustc_hash::FxHashMap;
 
+use oxc_allocator::Allocator;
 use oxc_diagnostics::OxcDiagnostic;
+use oxc_str::{Ident, format_ident};
 
 use crate::diagnostics::ErrorCategory;
 use crate::react_compiler_hir::environment::{Environment, is_hook_name};
@@ -34,7 +36,10 @@ use crate::react_compiler_ssa::enter_ssa::placeholder_function;
 // Public API
 // =============================================================================
 
-pub fn infer_types(func: &mut HirFunction, env: &mut Environment) -> Result<(), OxcDiagnostic> {
+pub fn infer_types<'a>(
+    func: &mut HirFunction<'a>,
+    env: &mut Environment<'a>,
+) -> Result<(), OxcDiagnostic> {
     let enable_treat_ref_like_identifiers_as_refs =
         env.config.enable_treat_ref_like_identifiers_as_refs;
     let enable_treat_set_identifiers_as_state_setters =
@@ -57,24 +62,24 @@ pub fn infer_types(func: &mut HirFunction, env: &mut Environment) -> Result<(), 
 // =============================================================================
 
 /// Get the type for an identifier as a TypeVar referencing its type slot.
-fn get_type(id: IdentifierId, identifiers: &[Identifier]) -> Type {
+fn get_type<'a>(id: IdentifierId, identifiers: &[Identifier<'a>]) -> Type<'a> {
     let type_id = identifiers[id.0 as usize].type_;
     Type::TypeVar { id: type_id }
 }
 
 /// Allocate a new TypeVar in the types arena (standalone, no &mut Environment needed).
-fn make_type(types: &mut Vec<Type>) -> Type {
+fn make_type<'a>(types: &mut Vec<Type<'a>>) -> Type<'a> {
     let id = TypeId(types.len() as u32);
     types.push(Type::TypeVar { id });
     Type::TypeVar { id }
 }
 
 /// Pre-resolve LoadGlobal types for a single function's instructions.
-fn pre_resolve_globals(
-    func: &HirFunction,
+fn pre_resolve_globals<'a>(
+    func: &HirFunction<'a>,
     function_key: u32,
-    env: &mut Environment,
-    global_types: &mut FxHashMap<(u32, InstructionId), Type>,
+    env: &mut Environment<'a>,
+    global_types: &mut FxHashMap<(u32, InstructionId), Type<'a>>,
 ) {
     for &instr_id in func.body.blocks.values().flat_map(|b| &b.instructions) {
         let instr = &func.instructions[instr_id.0 as usize];
@@ -87,10 +92,10 @@ fn pre_resolve_globals(
 }
 
 /// Recursively pre-resolve LoadGlobal types for an inner function and its children.
-fn pre_resolve_globals_recursive(
+fn pre_resolve_globals_recursive<'a>(
     func_id: FunctionId,
-    env: &mut Environment,
-    global_types: &mut FxHashMap<(u32, InstructionId), Type>,
+    env: &mut Environment<'a>,
+    global_types: &mut FxHashMap<(u32, InstructionId), Type<'a>>,
 ) {
     // Collect LoadGlobal bindings and child function IDs in one pass to avoid
     // borrow conflicts (we need &env.functions to read, then &mut env for
@@ -159,12 +164,12 @@ fn is_primitive_binary_op(op: &BinaryOperator) -> bool {
 /// If `custom_hook_type` is provided and the property name looks like a hook,
 /// it will be used as a fallback when no matching property is found (matching
 /// TS `getPropertyType` behavior).
-fn resolve_property_type(
-    shapes: &ShapeRegistry,
-    resolved_object: &Type,
-    property_name: &PropertyNameKind,
-    custom_hook_type: Option<&Type>,
-) -> Option<Type> {
+fn resolve_property_type<'a>(
+    shapes: &ShapeRegistry<'a>,
+    resolved_object: &Type<'a>,
+    property_name: &PropertyNameKind<'a>,
+    custom_hook_type: Option<&Type<'a>>,
+) -> Option<Type<'a>> {
     let shape_id = match resolved_object {
         Type::Object { shape_id } | Type::Function { shape_id, .. } => shape_id.as_deref(),
         _ => {
@@ -254,14 +259,18 @@ fn type_equals(a: &Type, b: &Type) -> bool {
     }
 }
 
-fn set_name(names: &mut FxHashMap<IdentifierId, String>, id: IdentifierId, source: &Identifier) {
-    if let Some(IdentifierName::Named(ref name)) = source.name {
-        names.insert(id, name.clone());
+fn set_name<'a>(
+    names: &mut FxHashMap<IdentifierId, Ident<'a>>,
+    id: IdentifierId,
+    source: &Identifier<'a>,
+) {
+    if let Some(IdentifierName::Named(name)) = source.name {
+        names.insert(id, name);
     }
 }
 
-fn get_name(names: &FxHashMap<IdentifierId, String>, id: IdentifierId) -> String {
-    names.get(&id).cloned().unwrap_or_default()
+fn get_name<'a>(names: &FxHashMap<IdentifierId, Ident<'a>>, id: IdentifierId) -> Ident<'a> {
+    names.get(&id).copied().unwrap_or(Ident::empty())
 }
 
 // =============================================================================
@@ -274,28 +283,20 @@ fn get_name(names: &FxHashMap<IdentifierId, String>, id: IdentifierId) -> String
 /// `generate_for_function_id` with split borrows instead, because the
 /// take/replace pattern on `env.functions` requires separate `&mut` access
 /// to different fields.
-fn generate(
-    func: &HirFunction,
-    env: &mut Environment,
-    unifier: &mut Unifier,
+fn generate<'a>(
+    func: &HirFunction<'a>,
+    env: &mut Environment<'a>,
+    unifier: &mut Unifier<'a>,
 ) -> Result<(), OxcDiagnostic> {
     // Component params
     if func.fn_type == ReactFunctionType::Component {
         if let Some(ParamPattern::Place(place)) = func.params.first() {
             let ty = get_type(place.identifier, &env.identifiers);
-            unifier.unify(
-                ty,
-                Type::Object { shape_id: Some(BUILT_IN_PROPS_ID.to_string()) },
-                &env.shapes,
-            )?;
+            unifier.unify(ty, Type::Object { shape_id: Some(BUILT_IN_PROPS_ID) }, &env.shapes)?;
         }
         if let Some(ParamPattern::Place(place)) = func.params.get(1) {
             let ty = get_type(place.identifier, &env.identifiers);
-            unifier.unify(
-                ty,
-                Type::Object { shape_id: Some(BUILT_IN_USE_REF_ID.to_string()) },
-                &env.shapes,
-            )?;
+            unifier.unify(ty, Type::Object { shape_id: Some(BUILT_IN_USE_REF_ID) }, &env.shapes)?;
         }
     }
 
@@ -304,7 +305,7 @@ fn generate(
     // &mut env, but generate_instruction_types takes split borrows on env fields.
     // The key is (function_key, InstructionId) where function_key is u32::MAX
     // for the outer function and FunctionId.0 for inner functions.
-    let mut global_types: FxHashMap<(u32, InstructionId), Type> = FxHashMap::default();
+    let mut global_types: FxHashMap<(u32, InstructionId), Type<'a>> = FxHashMap::default();
     pre_resolve_globals(func, u32::MAX, env, &mut global_types);
     // Also pre-resolve inner functions recursively
     for &instr_id in func.body.blocks.values().flat_map(|b| &b.instructions) {
@@ -324,8 +325,8 @@ fn generate(
         }
     }
 
-    let mut names: FxHashMap<IdentifierId, String> = FxHashMap::default();
-    let mut return_types: Vec<Type> = Vec::new();
+    let mut names: FxHashMap<IdentifierId, Ident<'a>> = FxHashMap::default();
+    let mut return_types: Vec<Type<'a>> = Vec::new();
 
     for (_block_id, block) in &func.body.blocks {
         // Phis
@@ -351,6 +352,7 @@ fn generate(
                 &global_types,
                 &env.shapes,
                 unifier,
+                env.allocator,
             )?;
         }
 
@@ -371,14 +373,16 @@ fn generate(
 }
 
 /// Recursively generate equations for an inner function (accessed via FunctionId).
-fn generate_for_function_id(
+#[allow(clippy::too_many_arguments)]
+fn generate_for_function_id<'a>(
     func_id: FunctionId,
-    identifiers: &[Identifier],
-    types: &mut Vec<Type>,
-    functions: &mut Vec<HirFunction>,
-    global_types: &FxHashMap<(u32, InstructionId), Type>,
-    shapes: &ShapeRegistry,
-    unifier: &mut Unifier,
+    identifiers: &[Identifier<'a>],
+    types: &mut Vec<Type<'a>>,
+    functions: &mut Vec<HirFunction<'a>>,
+    global_types: &FxHashMap<(u32, InstructionId), Type<'a>>,
+    shapes: &ShapeRegistry<'a>,
+    unifier: &mut Unifier<'a>,
+    allocator: &'a Allocator,
 ) -> Result<(), OxcDiagnostic> {
     // Take the function out temporarily to avoid borrow conflicts
     let inner = replace(&mut functions[func_id.0 as usize], placeholder_function());
@@ -387,26 +391,18 @@ fn generate_for_function_id(
     if inner.fn_type == ReactFunctionType::Component {
         if let Some(ParamPattern::Place(place)) = inner.params.first() {
             let ty = get_type(place.identifier, identifiers);
-            unifier.unify(
-                ty,
-                Type::Object { shape_id: Some(BUILT_IN_PROPS_ID.to_string()) },
-                shapes,
-            )?;
+            unifier.unify(ty, Type::Object { shape_id: Some(BUILT_IN_PROPS_ID) }, shapes)?;
         }
         if let Some(ParamPattern::Place(place)) = inner.params.get(1) {
             let ty = get_type(place.identifier, identifiers);
-            unifier.unify(
-                ty,
-                Type::Object { shape_id: Some(BUILT_IN_USE_REF_ID.to_string()) },
-                shapes,
-            )?;
+            unifier.unify(ty, Type::Object { shape_id: Some(BUILT_IN_USE_REF_ID) }, shapes)?;
         }
     }
 
     // TS creates a fresh `names` Map per recursive `generate` call, so inner
     // functions don't inherit or pollute the outer function's name mappings.
-    let mut inner_names: FxHashMap<IdentifierId, String> = FxHashMap::default();
-    let mut inner_return_types: Vec<Type> = Vec::new();
+    let mut inner_names: FxHashMap<IdentifierId, Ident<'a>> = FxHashMap::default();
+    let mut inner_return_types: Vec<Type<'a>> = Vec::new();
 
     for (_block_id, block) in &inner.body.blocks {
         for phi in &block.phis {
@@ -429,6 +425,7 @@ fn generate_for_function_id(
                 global_types,
                 shapes,
                 unifier,
+                allocator,
             )?;
         }
 
@@ -450,17 +447,18 @@ fn generate_for_function_id(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn generate_instruction_types(
-    instr: &Instruction,
+fn generate_instruction_types<'a>(
+    instr: &Instruction<'a>,
     instr_id: InstructionId,
     function_key: u32,
-    identifiers: &[Identifier],
-    types: &mut Vec<Type>,
-    functions: &mut Vec<HirFunction>,
-    names: &mut FxHashMap<IdentifierId, String>,
-    global_types: &FxHashMap<(u32, InstructionId), Type>,
-    shapes: &ShapeRegistry,
-    unifier: &mut Unifier,
+    identifiers: &[Identifier<'a>],
+    types: &mut Vec<Type<'a>>,
+    functions: &mut Vec<HirFunction<'a>>,
+    names: &mut FxHashMap<IdentifierId, Ident<'a>>,
+    global_types: &FxHashMap<(u32, InstructionId), Type<'a>>,
+    shapes: &ShapeRegistry<'a>,
+    unifier: &mut Unifier<'a>,
+    allocator: &'a Allocator,
 ) -> Result<(), OxcDiagnostic> {
     let left = get_type(instr.lvalue.identifier, identifiers);
 
@@ -538,7 +536,7 @@ fn generate_instruction_types(
             let mut shape_id = None;
             if unifier.enable_treat_set_identifiers_as_state_setters {
                 if names.get(&callee.identifier).is_some_and(|name| name.starts_with("set")) {
-                    shape_id = Some(BUILT_IN_SET_STATE_ID.to_string());
+                    shape_id = Some(BUILT_IN_SET_STATE_ID);
                 }
             }
             let callee_type = get_type(callee.identifier, identifiers);
@@ -578,19 +576,11 @@ fn generate_instruction_types(
                     }
                 }
             }
-            unifier.unify(
-                left,
-                Type::Object { shape_id: Some(BUILT_IN_OBJECT_ID.to_string()) },
-                shapes,
-            )?;
+            unifier.unify(left, Type::Object { shape_id: Some(BUILT_IN_OBJECT_ID) }, shapes)?;
         }
 
         InstructionValue::ArrayExpression { .. } => {
-            unifier.unify(
-                left,
-                Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID.to_string()) },
-                shapes,
-            )?;
+            unifier.unify(left, Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID) }, shapes)?;
         }
 
         InstructionValue::PropertyLoad { object, property, .. } => {
@@ -601,7 +591,7 @@ fn generate_instruction_types(
                 Type::Property {
                     object_type: Box::new(object_type),
                     object_name,
-                    property_name: PropertyNameKind::Literal { value: property.clone() },
+                    property_name: PropertyNameKind::Literal { value: *property },
                 },
                 shapes,
             )?;
@@ -650,7 +640,9 @@ fn generate_instruction_types(
                                     object_type: Box::new(value_type),
                                     object_name,
                                     property_name: PropertyNameKind::Literal {
-                                        value: PropertyLiteral::String(i.to_string()),
+                                        value: PropertyLiteral::String(format_ident!(
+                                            allocator, "{i}"
+                                        )),
                                     },
                                 },
                                 shapes,
@@ -660,7 +652,7 @@ fn generate_instruction_types(
                             let spread_type = get_type(spread.place.identifier, identifiers);
                             unifier.unify(
                                 spread_type,
-                                Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID.to_string()) },
+                                Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID) },
                                 shapes,
                             )?;
                         }
@@ -686,7 +678,7 @@ fn generate_instruction_types(
                                         object_type: Box::new(value_type),
                                         object_name,
                                         property_name: PropertyNameKind::Literal {
-                                            value: PropertyLiteral::String(name.clone()),
+                                            value: PropertyLiteral::String(*name),
                                         },
                                     },
                                     shapes,
@@ -721,6 +713,7 @@ fn generate_instruction_types(
                 global_types,
                 shapes,
                 unifier,
+                allocator,
             )?;
             // Get the inner function's return type
             let inner_func = &functions[func_id.0 as usize];
@@ -728,7 +721,7 @@ fn generate_instruction_types(
             unifier.unify(
                 left,
                 Type::Function {
-                    shape_id: Some(BUILT_IN_FUNCTION_ID.to_string()),
+                    shape_id: Some(BUILT_IN_FUNCTION_ID),
                     return_type: Box::new(inner_return_type),
                     is_constructor: false,
                 },
@@ -751,6 +744,7 @@ fn generate_instruction_types(
                 global_types,
                 shapes,
                 unifier,
+                allocator,
             )?;
             unifier.unify(left, Type::ObjectMethod, shapes)?;
         }
@@ -763,26 +757,18 @@ fn generate_instruction_types(
                             let ref_type = get_type(place.identifier, identifiers);
                             unifier.unify(
                                 ref_type,
-                                Type::Object { shape_id: Some(BUILT_IN_USE_REF_ID.to_string()) },
+                                Type::Object { shape_id: Some(BUILT_IN_USE_REF_ID) },
                                 shapes,
                             )?;
                         }
                     }
                 }
             }
-            unifier.unify(
-                left,
-                Type::Object { shape_id: Some(BUILT_IN_JSX_ID.to_string()) },
-                shapes,
-            )?;
+            unifier.unify(left, Type::Object { shape_id: Some(BUILT_IN_JSX_ID) }, shapes)?;
         }
 
         InstructionValue::JsxFragment { .. } => {
-            unifier.unify(
-                left,
-                Type::Object { shape_id: Some(BUILT_IN_JSX_ID.to_string()) },
-                shapes,
-            )?;
+            unifier.unify(left, Type::Object { shape_id: Some(BUILT_IN_JSX_ID) }, shapes)?;
         }
 
         InstructionValue::NewExpression { callee, .. } => {
@@ -809,7 +795,7 @@ fn generate_instruction_types(
                 Type::Property {
                     object_type: Box::new(object_type),
                     object_name,
-                    property_name: PropertyNameKind::Literal { value: property.clone() },
+                    property_name: PropertyNameKind::Literal { value: *property },
                 },
                 shapes,
             )?;
@@ -839,12 +825,12 @@ fn generate_instruction_types(
 // Apply resolved types
 // =============================================================================
 
-fn apply_function(
-    func: &HirFunction,
-    functions: &[HirFunction],
-    identifiers: &mut [Identifier],
-    types: &mut [Type],
-    unifier: &Unifier,
+fn apply_function<'a>(
+    func: &HirFunction<'a>,
+    functions: &[HirFunction<'a>],
+    identifiers: &mut [Identifier<'a>],
+    types: &mut [Type<'a>],
+    unifier: &Unifier<'a>,
 ) {
     for (_block_id, block) in &func.body.blocks {
         // Phi places
@@ -891,11 +877,11 @@ fn apply_function(
     resolve_identifier(func.returns.identifier, identifiers, types, unifier);
 }
 
-fn resolve_identifier(
+fn resolve_identifier<'a>(
     id: IdentifierId,
-    identifiers: &mut [Identifier],
-    types: &mut [Type],
-    unifier: &Unifier,
+    identifiers: &mut [Identifier<'a>],
+    types: &mut [Type<'a>],
+    unifier: &Unifier<'a>,
 ) {
     let type_id = identifiers[id.0 as usize].type_;
     let current_type = types[type_id.0 as usize].clone();
@@ -904,11 +890,11 @@ fn resolve_identifier(
 }
 
 /// Resolve types for instruction lvalues (mirrors TS eachInstructionLValue).
-fn apply_instruction_lvalues(
-    value: &InstructionValue,
-    identifiers: &mut [Identifier],
-    types: &mut [Type],
-    unifier: &Unifier,
+fn apply_instruction_lvalues<'a>(
+    value: &InstructionValue<'a>,
+    identifiers: &mut [Identifier<'a>],
+    types: &mut [Type<'a>],
+    unifier: &Unifier<'a>,
 ) {
     match value {
         InstructionValue::StoreLocal { lvalue, .. }
@@ -966,11 +952,11 @@ fn apply_instruction_lvalues(
 }
 
 /// Resolve types for instruction operands (mirrors TS eachInstructionOperand).
-fn apply_instruction_operands(
-    value: &InstructionValue,
-    identifiers: &mut [Identifier],
-    types: &mut [Type],
-    unifier: &Unifier,
+fn apply_instruction_operands<'a>(
+    value: &InstructionValue<'a>,
+    identifiers: &mut [Identifier<'a>],
+    types: &mut [Type<'a>],
+    unifier: &Unifier<'a>,
 ) {
     match value {
         InstructionValue::LoadLocal { place, .. } | InstructionValue::LoadContext { place, .. } => {
@@ -1178,17 +1164,17 @@ fn apply_instruction_operands(
 // Unifier
 // =============================================================================
 
-struct Unifier {
-    substitutions: FxHashMap<TypeId, Type>,
+struct Unifier<'a> {
+    substitutions: FxHashMap<TypeId, Type<'a>>,
     enable_treat_ref_like_identifiers_as_refs: bool,
     enable_treat_set_identifiers_as_state_setters: bool,
-    custom_hook_type: Option<Type>,
+    custom_hook_type: Option<Type<'a>>,
 }
 
-impl Unifier {
+impl<'a> Unifier<'a> {
     fn new(
         enable_treat_ref_like_identifiers_as_refs: bool,
-        custom_hook_type: Option<Type>,
+        custom_hook_type: Option<Type<'a>>,
         enable_treat_set_identifiers_as_state_setters: bool,
     ) -> Self {
         Unifier {
@@ -1199,15 +1185,20 @@ impl Unifier {
         }
     }
 
-    fn unify(&mut self, t_a: Type, t_b: Type, shapes: &ShapeRegistry) -> Result<(), OxcDiagnostic> {
+    fn unify(
+        &mut self,
+        t_a: Type<'a>,
+        t_b: Type<'a>,
+        shapes: &ShapeRegistry<'a>,
+    ) -> Result<(), OxcDiagnostic> {
         self.unify_impl(t_a, t_b, shapes)
     }
 
     fn unify_impl(
         &mut self,
-        t_a: Type,
-        t_b: Type,
-        shapes: &ShapeRegistry,
+        t_a: Type<'a>,
+        t_b: Type<'a>,
+        shapes: &ShapeRegistry<'a>,
     ) -> Result<(), OxcDiagnostic> {
         // Handle Property in the RHS position
         if let Type::Property { ref object_type, ref object_name, ref property_name } = t_b {
@@ -1217,12 +1208,12 @@ impl Unifier {
             {
                 self.unify_impl(
                     *object_type.clone(),
-                    Type::Object { shape_id: Some(BUILT_IN_USE_REF_ID.to_string()) },
+                    Type::Object { shape_id: Some(BUILT_IN_USE_REF_ID) },
                     shapes,
                 )?;
                 self.unify_impl(
                     t_a,
-                    Type::Object { shape_id: Some(BUILT_IN_REF_VALUE_ID.to_string()) },
+                    Type::Object { shape_id: Some(BUILT_IN_REF_VALUE_ID) },
                     shapes,
                 )?;
                 return Ok(());
@@ -1270,9 +1261,9 @@ impl Unifier {
 
     fn bind_variable_to(
         &mut self,
-        v: Type,
-        ty: Type,
-        shapes: &ShapeRegistry,
+        v: Type<'a>,
+        ty: Type<'a>,
+        shapes: &ShapeRegistry<'a>,
     ) -> Result<(), OxcDiagnostic> {
         let v_id = match &v {
             Type::TypeVar { id } => *id,
@@ -1344,7 +1335,7 @@ impl Unifier {
         Ok(())
     }
 
-    fn try_resolve_type(&mut self, v: &Type, ty: &Type) -> Option<Type> {
+    fn try_resolve_type(&mut self, v: &Type<'a>, ty: &Type<'a>) -> Option<Type<'a>> {
         match ty {
             Type::Phi { operands } => {
                 let mut new_operands = Vec::new();
@@ -1376,7 +1367,7 @@ impl Unifier {
                 let object_type = self.try_resolve_type(v, &resolved_obj)?;
                 Some(Type::Property {
                     object_type: Box::new(object_type),
-                    object_name: object_name.clone(),
+                    object_name: *object_name,
                     property_name: property_name.clone(),
                 })
             }
@@ -1384,7 +1375,7 @@ impl Unifier {
                 let resolved_ret = self.get(return_type);
                 let return_type = self.try_resolve_type(v, &resolved_ret)?;
                 Some(Type::Function {
-                    shape_id: shape_id.clone(),
+                    shape_id: *shape_id,
                     return_type: Box::new(return_type),
                     is_constructor: *is_constructor,
                 })
@@ -1395,7 +1386,7 @@ impl Unifier {
         }
     }
 
-    fn occurs_check(&self, v: &Type, ty: &Type) -> bool {
+    fn occurs_check(&self, v: &Type<'a>, ty: &Type<'a>) -> bool {
         if type_equals(v, ty) {
             return true;
         }
@@ -1417,7 +1408,7 @@ impl Unifier {
         false
     }
 
-    fn get(&self, ty: &Type) -> Type {
+    fn get(&self, ty: &Type<'a>) -> Type<'a> {
         if let Type::TypeVar { id } = ty {
             if let Some(sub) = self.substitutions.get(id) {
                 return self.get(sub);
@@ -1431,7 +1422,7 @@ impl Unifier {
         if let Type::Function { is_constructor, shape_id, return_type } = ty {
             return Type::Function {
                 is_constructor: *is_constructor,
-                shape_id: shape_id.clone(),
+                shape_id: *shape_id,
                 return_type: Box::new(self.get(return_type)),
             };
         }
@@ -1444,11 +1435,11 @@ impl Unifier {
 // Union types helper
 // =============================================================================
 
-fn try_union_types(ty1: &Type, ty2: &Type) -> Option<Type> {
-    let (readonly_type, other_type) = if matches!(ty1, Type::Object { shape_id } if shape_id.as_deref() == Some(BUILT_IN_MIXED_READONLY_ID))
+fn try_union_types<'a>(ty1: &Type<'a>, ty2: &Type<'a>) -> Option<Type<'a>> {
+    let (readonly_type, other_type) = if matches!(ty1, Type::Object { shape_id: Some(id) } if *id == BUILT_IN_MIXED_READONLY_ID)
     {
         (ty1, ty2)
-    } else if matches!(ty2, Type::Object { shape_id } if shape_id.as_deref() == Some(BUILT_IN_MIXED_READONLY_ID))
+    } else if matches!(ty2, Type::Object { shape_id: Some(id) } if *id == BUILT_IN_MIXED_READONLY_ID)
     {
         (ty2, ty1)
     } else {
@@ -1458,7 +1449,7 @@ fn try_union_types(ty1: &Type, ty2: &Type) -> Option<Type> {
     if matches!(other_type, Type::Primitive) {
         // Union(Primitive | MixedReadonly) = MixedReadonly
         return Some(readonly_type.clone());
-    } else if matches!(other_type, Type::Object { shape_id } if shape_id.as_deref() == Some(BUILT_IN_ARRAY_ID))
+    } else if matches!(other_type, Type::Object { shape_id: Some(id) } if *id == BUILT_IN_ARRAY_ID)
     {
         // Union(Array | MixedReadonly) = Array
         return Some(other_type.clone());

--- a/crates/oxc_react_compiler/src/react_compiler_utils/js_string.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_utils/js_string.rs
@@ -1,9 +1,13 @@
 //! A JavaScript string value. JS strings are sequences of UTF-16 code units
 //! with no validity requirement, so a value can contain unpaired surrogate
-//! halves that Rust's `String` cannot represent. `JsString` keeps the common
+//! halves that Rust's `str` cannot represent. `JsString` keeps the common
 //! valid case as UTF-8 and falls back to code units only when the value is
 //! ill-formed, so the compiler computes on true program values instead of
 //! replacement characters or escape hatches.
+//!
+//! Both representations borrow from the compilation arena, so `JsString` is
+//! `Copy`: string literals borrow the AST's arena text directly, and computed
+//! values (constant folding, entity decoding) are allocated once.
 //!
 //! Wire format: the babel bridge transports lone surrogates as
 //! `__SURROGATE_XXXX__` markers (see `sanitizeJsonSurrogates` in bridge.ts),
@@ -13,58 +17,66 @@
 
 use std::fmt;
 
+use oxc_allocator::Allocator;
+use oxc_str::Str;
+
 /// Invariant: `Repr::Utf8` holds every well-formed value and `Repr::Wtf16`
 /// only ill-formed ones (at least one unpaired surrogate). The derived
 /// `PartialEq`/`Hash` are only sound under this invariant: a well-formed
 /// value smuggled into `Wtf16` would compare unequal to its `Utf8` twin.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct JsString(Repr);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct JsString<'a>(Repr<'a>);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-enum Repr {
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum Repr<'a> {
     /// A well-formed string (no unpaired surrogates), stored as UTF-8.
-    Utf8(String),
+    Utf8(Str<'a>),
     /// An ill-formed string, stored as UTF-16 code units.
-    Wtf16(Vec<u16>),
+    Wtf16(&'a [u16]),
 }
 
-impl JsString {
+impl<'a> JsString<'a> {
+    /// Allocate a computed string into the arena.
+    pub fn from_str_in(s: &str, allocator: &'a Allocator) -> Self {
+        JsString(Repr::Utf8(Str::from(allocator.alloc_str(s))))
+    }
+
     /// Build from UTF-16 code units, normalizing to UTF-8 when well-formed.
-    pub fn from_code_units(units: Vec<u16>) -> Self {
-        match String::from_utf16(&units) {
-            Ok(s) => JsString(Repr::Utf8(s)),
-            Err(_) => JsString(Repr::Wtf16(units)),
+    pub fn from_code_units(units: &[u16], allocator: &'a Allocator) -> Self {
+        match String::from_utf16(units) {
+            Ok(s) => Self::from_str_in(&s, allocator),
+            Err(_) => JsString(Repr::Wtf16(allocator.alloc_slice_copy(units))),
         }
     }
 
     /// The UTF-8 view, when the value is well-formed.
-    pub fn as_str(&self) -> Option<&str> {
-        match &self.0 {
-            Repr::Utf8(s) => Some(s),
+    pub fn as_str(self) -> Option<&'a str> {
+        match self.0 {
+            Repr::Utf8(s) => Some(s.as_str()),
             Repr::Wtf16(_) => None,
         }
     }
 
-    pub fn code_units(&self) -> Vec<u16> {
-        match &self.0 {
-            Repr::Utf8(s) => s.encode_utf16().collect(),
-            Repr::Wtf16(units) => units.clone(),
+    pub fn code_units(self) -> Vec<u16> {
+        match self.0 {
+            Repr::Utf8(s) => s.as_str().encode_utf16().collect(),
+            Repr::Wtf16(units) => units.to_vec(),
         }
     }
 
     /// Length in UTF-16 code units (JS `String.prototype.length`).
-    pub fn len_utf16(&self) -> usize {
-        match &self.0 {
-            Repr::Utf8(s) => s.encode_utf16().count(),
+    pub fn len_utf16(self) -> usize {
+        match self.0 {
+            Repr::Utf8(s) => s.as_str().encode_utf16().count(),
             Repr::Wtf16(units) => units.len(),
         }
     }
 
     /// The value with unpaired surrogates replaced by U+FFFD, for consumers
     /// whose string type cannot represent ill-formed values.
-    pub fn to_string_lossy(&self) -> String {
-        match &self.0 {
-            Repr::Utf8(s) => s.clone(),
+    pub fn to_string_lossy(self) -> String {
+        match self.0 {
+            Repr::Utf8(s) => s.as_str().to_string(),
             Repr::Wtf16(units) => String::from_utf16_lossy(units),
         }
     }
@@ -76,11 +88,11 @@ impl JsString {
     /// All scanning is byte-wise: a marker is 18 ASCII bytes, so byte-slice
     /// comparisons cannot land on a UTF-8 char boundary the way `str` range
     /// indexing can when multibyte text follows the prefix.
-    pub fn from_marker_string(s: &str) -> Self {
+    pub fn from_marker_string(s: &str, allocator: &'a Allocator) -> Self {
         const PREFIX: &[u8] = b"__SURROGATE_";
         const MARKER_LEN: usize = 18;
         if !s.contains("__SURROGATE_") {
-            return JsString(Repr::Utf8(s.to_string()));
+            return Self::from_str_in(s, allocator);
         }
         let bytes = s.as_bytes();
         let mut units: Vec<u16> = Vec::with_capacity(s.len());
@@ -109,13 +121,13 @@ impl JsString {
             }
         }
         units.extend(s[segment_start..].encode_utf16());
-        JsString::from_code_units(units)
+        JsString::from_code_units(&units, allocator)
     }
 
     /// Encode to the bridge wire form (markers for unpaired surrogates).
-    pub fn to_marker_string(&self) -> String {
-        match &self.0 {
-            Repr::Utf8(s) => s.clone(),
+    pub fn to_marker_string(self) -> String {
+        match self.0 {
+            Repr::Utf8(s) => s.as_str().to_string(),
             Repr::Wtf16(units) => {
                 let mut out = String::with_capacity(units.len() * 2);
                 let mut iter = units.iter().copied().peekable();
@@ -152,9 +164,9 @@ impl JsString {
     /// Render as JS-source-style escaped text, matching the form TS's debug
     /// printer produces via JSON.stringify: unpaired surrogates print as
     /// lowercase `\udXXX` escapes inside the otherwise UTF-8 text.
-    pub fn to_escaped_string(&self) -> String {
-        match &self.0 {
-            Repr::Utf8(s) => s.clone(),
+    pub fn to_escaped_string(self) -> String {
+        match self.0 {
+            Repr::Utf8(s) => s.as_str().to_string(),
             Repr::Wtf16(units) => {
                 let mut out = String::with_capacity(units.len() * 2);
                 let mut iter = units.iter().copied().peekable();
@@ -189,33 +201,34 @@ impl JsString {
     }
 }
 
-impl From<String> for JsString {
-    fn from(s: String) -> Self {
-        // A Rust String is valid UTF-8 and so cannot contain an unpaired
-        // surrogate; constructing Utf8 directly preserves the invariant.
+impl<'a> From<&'a str> for JsString<'a> {
+    /// Borrow an arena (or `'static`) string directly. A `&str` is valid UTF-8
+    /// and so cannot contain an unpaired surrogate; constructing `Utf8`
+    /// directly preserves the invariant.
+    fn from(s: &'a str) -> Self {
+        JsString(Repr::Utf8(Str::from(s)))
+    }
+}
+
+impl<'a> From<Str<'a>> for JsString<'a> {
+    fn from(s: Str<'a>) -> Self {
         JsString(Repr::Utf8(s))
     }
 }
 
-impl From<&str> for JsString {
-    fn from(s: &str) -> Self {
-        JsString(Repr::Utf8(s.to_string()))
-    }
-}
-
-impl PartialEq<str> for JsString {
+impl PartialEq<str> for JsString<'_> {
     fn eq(&self, other: &str) -> bool {
         self.as_str() == Some(other)
     }
 }
 
-impl PartialEq<&str> for JsString {
+impl PartialEq<&str> for JsString<'_> {
     fn eq(&self, other: &&str) -> bool {
         self.as_str() == Some(*other)
     }
 }
 
-impl fmt::Display for JsString {
+impl fmt::Display for JsString<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.to_escaped_string())
     }

--- a/crates/oxc_react_compiler/src/react_compiler_utils/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_utils/mod.rs
@@ -11,3 +11,5 @@ pub use js_string::JsString;
 pub type FxIndexMap<K, V> = IndexMap<K, V, FxBuildHasher>;
 /// `IndexSet` keyed with the fast `FxHasher` (rustc-hash) instead of the default SipHash.
 pub type FxIndexSet<T> = IndexSet<T, FxBuildHasher>;
+/// `IndexMap` keyed by [`oxc_str::Ident`], reusing its precomputed hash.
+pub type IdentIndexMap<'a, V> = IndexMap<oxc_str::Ident<'a>, V, oxc_allocator::IdentBuildHasher>;

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_exhaustive_dependencies.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_exhaustive_dependencies.rs
@@ -4,6 +4,7 @@ use std::mem::{replace, take};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use oxc_diagnostics::OxcDiagnostic;
+use oxc_str::Ident;
 
 use crate::diagnostics::ErrorCategory;
 use crate::react_compiler_hir::environment::Environment;
@@ -100,9 +101,9 @@ pub fn validate_exhaustive_dependencies(
 // =============================================================================
 
 /// Info extracted from a StartMemoize instruction
-struct StartMemoInfo {
+struct StartMemoInfo<'a> {
     manual_memo_id: u32,
-    deps: Option<Vec<ManualMemoDependency>>,
+    deps: Option<Vec<ManualMemoDependency<'a>>>,
     deps_span: Option<Option<Span>>,
     #[allow(dead_code)]
     span: Option<Span>,
@@ -110,51 +111,51 @@ struct StartMemoInfo {
 
 /// A temporary value tracked during dependency collection
 #[derive(Debug, Clone)]
-enum Temporary {
+enum Temporary<'a> {
     Local {
         identifier: IdentifierId,
-        path: Vec<DependencyPathEntry>,
+        path: Vec<DependencyPathEntry<'a>>,
         context: bool,
         span: Option<Span>,
     },
     Global {
-        binding: NonLocalBinding,
+        binding: NonLocalBinding<'a>,
     },
     Aggregate {
-        dependencies: Vec<InferredDependency>,
+        dependencies: Vec<InferredDependency<'a>>,
         span: Option<Span>,
     },
 }
 
 /// An inferred dependency (Local or Global)
 #[derive(Debug, Clone)]
-enum InferredDependency {
+enum InferredDependency<'a> {
     Local {
         identifier: IdentifierId,
-        path: Vec<DependencyPathEntry>,
+        path: Vec<DependencyPathEntry<'a>>,
         #[allow(dead_code)]
         context: bool,
         span: Option<Span>,
     },
     Global {
-        binding: NonLocalBinding,
+        binding: NonLocalBinding<'a>,
     },
 }
 
 /// Hashable key for deduplicating inferred dependencies in a Set
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-enum InferredDependencyKey {
+enum InferredDependencyKey<'a> {
     Local { identifier: IdentifierId, path_key: String },
-    Global { name: String },
+    Global { name: Ident<'a> },
 }
 
-fn dep_to_key(dep: &InferredDependency) -> InferredDependencyKey {
+fn dep_to_key<'a>(dep: &InferredDependency<'a>) -> InferredDependencyKey<'a> {
     match dep {
         InferredDependency::Local { identifier, path, .. } => {
             InferredDependencyKey::Local { identifier: *identifier, path_key: path_to_string(path) }
         }
         InferredDependency::Global { binding } => {
-            InferredDependencyKey::Global { name: binding.name().to_string() }
+            InferredDependencyKey::Global { name: binding.name() }
         }
     }
 }
@@ -167,13 +168,13 @@ fn path_to_string(path: &[DependencyPathEntry]) -> String {
 }
 
 /// Callbacks for StartMemoize/FinishMemoize/Effect events
-struct Callbacks<'a> {
-    start_memo: &'a mut Option<StartMemoInfo>,
+struct Callbacks<'s, 'a> {
+    start_memo: &'s mut Option<StartMemoInfo<'a>>,
     #[allow(dead_code)]
-    memo_locals: &'a mut FxHashSet<IdentifierId>,
+    memo_locals: &'s mut FxHashSet<IdentifierId>,
     validate_memo: bool,
     validate_effect: ExhaustiveEffectDepsMode,
-    reactive: &'a FxHashSet<IdentifierId>,
+    reactive: &'s FxHashSet<IdentifierId>,
     diagnostics: Vec<OxcDiagnostic>,
     /// manual_memo_ids that had validation errors (to set has_invalid_deps)
     invalid_memo_ids: FxHashSet<u32>,
@@ -220,14 +221,14 @@ fn is_use_ref_type(ty: &Type) -> bool {
 
 fn get_identifier_type<'a>(
     id: IdentifierId,
-    identifiers: &'a [Identifier],
-    types: &'a [Type],
-) -> &'a Type {
+    identifiers: &'a [Identifier<'a>],
+    types: &'a [Type<'a>],
+) -> &'a Type<'a> {
     let ident = &identifiers[id.0 as usize];
     &types[ident.type_.0 as usize]
 }
 
-fn get_identifier_name(id: IdentifierId, identifiers: &[Identifier]) -> Option<&str> {
+fn get_identifier_name<'a>(id: IdentifierId, identifiers: &[Identifier<'a>]) -> Option<&'a str> {
     identifiers[id.0 as usize].name.as_ref().map(IdentifierName::value)
 }
 
@@ -378,10 +379,10 @@ fn find_optional_places(func: &HirFunction) -> FxHashMap<IdentifierId, bool> {
 // Dependency collection
 // =============================================================================
 
-fn add_dependency(
-    dep: &Temporary,
-    dependencies: &mut Vec<InferredDependency>,
-    dep_keys: &mut FxHashSet<InferredDependencyKey>,
+fn add_dependency<'a>(
+    dep: &Temporary<'a>,
+    dependencies: &mut Vec<InferredDependency<'a>>,
+    dep_keys: &mut FxHashSet<InferredDependencyKey<'a>>,
     locals: &FxHashSet<IdentifierId>,
 ) {
     match dep {
@@ -414,10 +415,10 @@ fn add_dependency(
     }
 }
 
-fn add_dependency_inferred(
-    dep: &InferredDependency,
-    dependencies: &mut Vec<InferredDependency>,
-    dep_keys: &mut FxHashSet<InferredDependencyKey>,
+fn add_dependency_inferred<'a>(
+    dep: &InferredDependency<'a>,
+    dependencies: &mut Vec<InferredDependency<'a>>,
+    dep_keys: &mut FxHashSet<InferredDependencyKey<'a>>,
     locals: &FxHashSet<IdentifierId>,
 ) {
     match dep {
@@ -438,11 +439,11 @@ fn add_dependency_inferred(
     }
 }
 
-fn visit_candidate_dependency(
+fn visit_candidate_dependency<'a>(
     place: &Place,
-    temporaries: &FxHashMap<IdentifierId, Temporary>,
-    dependencies: &mut Vec<InferredDependency>,
-    dep_keys: &mut FxHashSet<InferredDependencyKey>,
+    temporaries: &FxHashMap<IdentifierId, Temporary<'a>>,
+    dependencies: &mut Vec<InferredDependency<'a>>,
+    dep_keys: &mut FxHashSet<InferredDependencyKey<'a>>,
     locals: &FxHashSet<IdentifierId>,
 ) {
     if let Some(dep) = temporaries.get(&place.identifier) {
@@ -450,15 +451,15 @@ fn visit_candidate_dependency(
     }
 }
 
-fn collect_dependencies(
-    func: &HirFunction,
-    identifiers: &[Identifier],
-    types: &[Type],
-    functions: &[HirFunction],
-    temporaries: &mut FxHashMap<IdentifierId, Temporary>,
-    callbacks: &mut Option<&mut Callbacks<'_>>,
+fn collect_dependencies<'a>(
+    func: &HirFunction<'a>,
+    identifiers: &[Identifier<'a>],
+    types: &[Type<'a>],
+    functions: &[HirFunction<'a>],
+    temporaries: &mut FxHashMap<IdentifierId, Temporary<'a>>,
+    callbacks: &mut Option<&mut Callbacks<'_, 'a>>,
     is_function_expression: bool,
-) -> Result<Temporary, OxcDiagnostic> {
+) -> Result<Temporary<'a>, OxcDiagnostic> {
     let optionals = find_optional_places(func);
     let mut locals: FxHashSet<IdentifierId> = FxHashSet::default();
 
@@ -689,7 +690,7 @@ fn collect_dependencies(
                             let mut new_path = path.clone();
                             new_path.push(DependencyPathEntry {
                                 optional,
-                                property: property.clone(),
+                                property: *property,
                                 span: instr.value.span().copied(),
                             });
                             temporaries.insert(
@@ -900,9 +901,7 @@ fn collect_dependencies(
                                                         ManualMemoDependency {
                                                             root:
                                                                 ManualMemoDependencyRoot::Global {
-                                                                    identifier_name: binding
-                                                                        .name()
-                                                                        .to_string(),
+                                                                    identifier_name: binding.name(),
                                                                 },
                                                             path: Vec::new(),
                                                             span: None,
@@ -1009,9 +1008,7 @@ fn collect_dependencies(
                                                         ManualMemoDependency {
                                                             root:
                                                                 ManualMemoDependencyRoot::Global {
-                                                                    identifier_name: binding
-                                                                        .name()
-                                                                        .to_string(),
+                                                                    identifier_name: binding.name(),
                                                                 },
                                                             path: Vec::new(),
                                                             span: None,
@@ -1107,14 +1104,14 @@ fn collect_dependencies(
 
 #[allow(clippy::too_many_arguments)]
 fn validate_dependencies(
-    mut inferred: Vec<InferredDependency>,
-    manual_dependencies: &[ManualMemoDependency],
+    mut inferred: Vec<InferredDependency<'_>>,
+    manual_dependencies: &[ManualMemoDependency<'_>],
     reactive: &FxHashSet<IdentifierId>,
     manual_memo_span: Option<Span>,
     category: ErrorCategory,
     exhaustive_deps_report_mode: &str,
-    identifiers: &[Identifier],
-    types: &[Type],
+    identifiers: &[Identifier<'_>],
+    types: &[Type<'_>],
 ) -> Result<Option<OxcDiagnostic>, OxcDiagnostic> {
     // Sort dependencies by name and path
     inferred.sort_by(|a, b| {
@@ -1122,7 +1119,7 @@ fn validate_dependencies(
             (
                 InferredDependency::Global { binding: ab },
                 InferredDependency::Global { binding: bb },
-            ) => ab.name().cmp(bb.name()),
+            ) => ab.name().as_str().cmp(bb.name().as_str()),
             (
                 InferredDependency::Local { identifier: a_id, path: a_path, .. },
                 InferredDependency::Local { identifier: b_id, path: b_path, .. },
@@ -1162,7 +1159,7 @@ fn validate_dependencies(
                 let a_name = ab.name();
                 let b_name = get_identifier_name(*b_id, identifiers);
                 match b_name {
-                    Some(bn) => a_name.cmp(bn),
+                    Some(bn) => a_name.as_str().cmp(bn),
                     None => Ordering::Equal,
                 }
             }
@@ -1173,7 +1170,7 @@ fn validate_dependencies(
                 let a_name = get_identifier_name(*a_id, identifiers);
                 let b_name = bb.name();
                 match a_name {
-                    Some(an) => an.cmp(b_name),
+                    Some(an) => an.cmp(b_name.as_str()),
                     None => Ordering::Equal,
                 }
             }
@@ -1235,7 +1232,7 @@ fn validate_dependencies(
             InferredDependency::Global { binding } => {
                 for (i, manual_dep) in manual_dependencies.iter().enumerate() {
                     if let ManualMemoDependencyRoot::Global { identifier_name } = &manual_dep.root {
-                        if identifier_name == binding.name() {
+                        if *identifier_name == binding.name() {
                             matched.insert(i);
                             extra.push(manual_dep);
                         }

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_capitalized_calls.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_capitalized_calls.rs
@@ -2,6 +2,7 @@ use cow_utils::CowUtils;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use oxc_diagnostics::OxcDiagnostic;
+use oxc_str::Ident;
 
 use crate::diagnostics::ErrorCategory;
 use crate::react_compiler_hir::environment::Environment;
@@ -22,8 +23,8 @@ pub fn validate_no_capitalized_calls(
         }
     }
 
-    let mut capital_load_globals: FxHashMap<IdentifierId, String> = FxHashMap::default();
-    let mut capitalized_properties: FxHashMap<IdentifierId, String> = FxHashMap::default();
+    let mut capital_load_globals: FxHashMap<IdentifierId, Ident> = FxHashMap::default();
+    let mut capitalized_properties: FxHashMap<IdentifierId, Ident> = FxHashMap::default();
 
     let reason = "Capitalized functions are reserved for components, which must be invoked with JSX. If this is a component, render it with JSX. Otherwise, ensure that it has no hook calls and rename it to begin with a lowercase letter. Alternatively, if you know for a fact that this function is not a component, you can allowlist it via the compiler config";
 
@@ -39,10 +40,10 @@ pub fn validate_no_capitalized_calls(
                     if !name.is_empty()
                         && name.starts_with(|c: char| c.is_ascii_uppercase())
                         // We don't want to flag CONSTANTS()
-                        && name != name.cow_to_uppercase()
-                        && !allow_list.contains(name)
+                        && name.as_str() != name.cow_to_uppercase()
+                        && !allow_list.contains(name.as_str())
                     {
-                        capital_load_globals.insert(lvalue_id, name.to_string());
+                        capital_load_globals.insert(lvalue_id, name);
                     }
                 }
                 InstructionValue::CallExpression { callee, span, .. } => {
@@ -62,7 +63,7 @@ pub fn validate_no_capitalized_calls(
                     ..
                 } => {
                     if prop_name.starts_with(|c: char| c.is_ascii_uppercase()) {
-                        capitalized_properties.insert(lvalue_id, prop_name.clone());
+                        capitalized_properties.insert(lvalue_id, *prop_name);
                     }
                 }
                 InstructionValue::MethodCall { property, span, .. } => {

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_derived_computations_in_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_derived_computations_in_effects.rs
@@ -10,10 +10,12 @@
 //!
 //! Port of ValidateNoDerivedComputationsInEffects_exp.ts.
 
-use crate::react_compiler_utils::{FxIndexMap, FxIndexSet};
+use crate::react_compiler_utils::{FxIndexSet, IdentIndexMap};
 use rustc_hash::{FxHashMap, FxHashSet};
 
+use oxc_allocator::IdentBuildHasher;
 use oxc_diagnostics::{Diagnostics, OxcDiagnostic};
+use oxc_str::{Ident, IdentHashSet};
 
 use crate::diagnostics::ErrorCategory;
 use crate::react_compiler_hir::BasicBlock;
@@ -32,6 +34,9 @@ use crate::react_compiler_hir::{
 
 const MAX_FIXPOINT_ITERATIONS: usize = 100;
 
+/// `IndexSet` keyed by [`Ident`], reusing its precomputed hash.
+type IdentIndexSet<'a> = indexmap::IndexSet<Ident<'a>, IdentBuildHasher>;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum TypeOfValue {
     Ignored,
@@ -41,10 +46,10 @@ enum TypeOfValue {
 }
 
 #[derive(Debug, Clone)]
-struct DerivationMetadata {
+struct DerivationMetadata<'a> {
     type_of_value: TypeOfValue,
     place_identifier: IdentifierId,
-    place_name: Option<IdentifierName>,
+    place_name: Option<IdentifierName<'a>>,
     source_ids: FxIndexSet<IdentifierId>,
     is_state_source: bool,
 }
@@ -61,25 +66,25 @@ struct DepElement {
     span: Option<Span>,
 }
 
-struct ValidationContext {
+struct ValidationContext<'a> {
     /// Map from lvalue identifier to the FunctionId of function expressions
     functions: FxHashMap<IdentifierId, FunctionId>,
     /// Map from lvalue identifier to ArrayExpression elements (candidate deps)
     candidate_dependencies: FxHashMap<IdentifierId, Vec<DepElement>>,
-    derivation_cache: DerivationCache,
+    derivation_cache: DerivationCache<'a>,
     effects_cache: FxHashMap<IdentifierId, EffectMetadata>,
     set_state_loads: FxHashMap<IdentifierId, Option<IdentifierId>>,
     set_state_usages: FxHashMap<IdentifierId, FxHashSet<Span>>,
 }
 
 #[derive(Debug, Clone)]
-struct DerivationCache {
+struct DerivationCache<'a> {
     has_changes: bool,
-    cache: FxHashMap<IdentifierId, DerivationMetadata>,
-    previous_cache: Option<FxHashMap<IdentifierId, DerivationMetadata>>,
+    cache: FxHashMap<IdentifierId, DerivationMetadata<'a>>,
+    previous_cache: Option<FxHashMap<IdentifierId, DerivationMetadata<'a>>>,
 }
 
-impl DerivationCache {
+impl<'a> DerivationCache<'a> {
     fn new() -> Self {
         DerivationCache { has_changes: false, cache: FxHashMap::default(), previous_cache: None }
     }
@@ -91,7 +96,7 @@ impl DerivationCache {
                 *key,
                 DerivationMetadata {
                     place_identifier: value.place_identifier,
-                    place_name: value.place_name.clone(),
+                    place_name: value.place_name,
                     source_ids: value.source_ids.clone(),
                     type_of_value: value.type_of_value,
                     is_state_source: value.is_state_source,
@@ -140,7 +145,7 @@ impl DerivationCache {
     fn add_derivation_entry(
         &mut self,
         derived_id: IdentifierId,
-        derived_name: Option<IdentifierName>,
+        derived_name: Option<IdentifierName<'a>>,
         source_ids: FxIndexSet<IdentifierId>,
         type_of_value: TypeOfValue,
         is_state_source: bool,
@@ -172,7 +177,7 @@ impl DerivationCache {
     }
 }
 
-fn is_derivation_equal(a: &DerivationMetadata, b: &DerivationMetadata) -> bool {
+fn is_derivation_equal(a: &DerivationMetadata<'_>, b: &DerivationMetadata<'_>) -> bool {
     if a.type_of_value != b.type_of_value {
         return false;
     }
@@ -269,8 +274,8 @@ fn is_mutable_at(
 }
 
 pub fn validate_no_derived_computations_in_effects_exp(
-    func: &HirFunction,
-    env: &Environment,
+    func: &HirFunction<'_>,
+    env: &Environment<'_>,
 ) -> Result<Diagnostics, OxcDiagnostic> {
     let identifiers = &env.identifiers;
 
@@ -287,7 +292,7 @@ pub fn validate_no_derived_computations_in_effects_exp(
     if func.fn_type == ReactFunctionType::Hook {
         for param in &func.params {
             if let ParamPattern::Place(place) = param {
-                let name = identifiers[place.identifier.0 as usize].name.clone();
+                let name = identifiers[place.identifier.0 as usize].name;
                 context.derivation_cache.cache.insert(
                     place.identifier,
                     DerivationMetadata {
@@ -302,7 +307,7 @@ pub fn validate_no_derived_computations_in_effects_exp(
         }
     } else if func.fn_type == ReactFunctionType::Component {
         if let Some(ParamPattern::Place(place)) = func.params.first() {
-            let name = identifiers[place.identifier.0 as usize].name.clone();
+            let name = identifiers[place.identifier.0 as usize].name;
             context.derivation_cache.cache.insert(
                 place.identifier,
                 DerivationMetadata {
@@ -358,7 +363,11 @@ pub fn validate_no_derived_computations_in_effects_exp(
     Ok(errors)
 }
 
-fn record_phi_derivations(block: &BasicBlock, context: &mut ValidationContext, env: &Environment) {
+fn record_phi_derivations<'a>(
+    block: &BasicBlock,
+    context: &mut ValidationContext<'a>,
+    env: &Environment<'a>,
+) {
     let identifiers = &env.identifiers;
     for phi in &block.phis {
         let mut type_of_value = TypeOfValue::Ignored;
@@ -373,7 +382,7 @@ fn record_phi_derivations(block: &BasicBlock, context: &mut ValidationContext, e
         }
 
         if type_of_value != TypeOfValue::Ignored {
-            let name = identifiers[phi.place.identifier.0 as usize].name.clone();
+            let name = identifiers[phi.place.identifier.0 as usize].name;
             context.derivation_cache.add_derivation_entry(
                 phi.place.identifier,
                 name,
@@ -386,11 +395,11 @@ fn record_phi_derivations(block: &BasicBlock, context: &mut ValidationContext, e
 }
 
 #[allow(clippy::only_used_in_recursion)]
-fn record_instruction_derivations(
+fn record_instruction_derivations<'a>(
     instr: &Instruction,
-    context: &mut ValidationContext,
+    context: &mut ValidationContext<'a>,
     is_first_pass: bool,
-    env: &Environment,
+    env: &Environment<'a>,
 ) -> Result<(), OxcDiagnostic> {
     let identifiers = &env.identifiers;
     let types = &env.types;
@@ -442,7 +451,7 @@ fn record_instruction_derivations(
             // Check if lvalue is useState type
             let lvalue_type = &types[identifiers[lvalue_id.0 as usize].type_.0 as usize];
             if is_use_state_type(lvalue_type) {
-                let name = identifiers[lvalue_id.0 as usize].name.clone();
+                let name = identifiers[lvalue_id.0 as usize].name;
                 context.derivation_cache.add_derivation_entry(
                     lvalue_id,
                     name,
@@ -473,7 +482,7 @@ fn record_instruction_derivations(
             // Check if lvalue is useState type
             let lvalue_type = &types[identifiers[lvalue_id.0 as usize].type_.0 as usize];
             if is_use_state_type(lvalue_type) {
-                let name = identifiers[lvalue_id.0 as usize].name.clone();
+                let name = identifiers[lvalue_id.0 as usize].name;
                 context.derivation_cache.add_derivation_entry(
                     lvalue_id,
                     name,
@@ -524,7 +533,7 @@ fn record_instruction_derivations(
 
     // Record derivation for ALL lvalue places (including destructured variables)
     for &lv_id in &each_instruction_lvalue_ids(instr) {
-        let name = identifiers[lv_id.0 as usize].name.clone();
+        let name = identifiers[lv_id.0 as usize].name;
         context.derivation_cache.add_derivation_entry(
             lv_id,
             name,
@@ -546,7 +555,7 @@ fn record_instruction_derivations(
                 if let Some(existing) = context.derivation_cache.cache.get_mut(&operand.id) {
                     existing.type_of_value = join_value(type_of_value, existing.type_of_value);
                 } else {
-                    let name = identifiers[operand.id.0 as usize].name.clone();
+                    let name = identifiers[operand.id.0 as usize].name;
                     context.derivation_cache.add_derivation_entry(
                         operand.id,
                         name,
@@ -597,18 +606,18 @@ fn each_instruction_operand_with_effect(
 // Tree building and rendering (for error messages)
 // =============================================================================
 
-struct TreeNode {
-    name: String,
+struct TreeNode<'a> {
+    name: Ident<'a>,
     type_of_value: TypeOfValue,
     is_source: bool,
-    children: Vec<TreeNode>,
+    children: Vec<TreeNode<'a>>,
 }
 
-fn build_tree_node(
+fn build_tree_node<'a>(
     source_id: IdentifierId,
-    context: &ValidationContext,
-    visited: &FxHashSet<String>,
-) -> Vec<TreeNode> {
+    context: &ValidationContext<'a>,
+    visited: &IdentHashSet<'a>,
+) -> Vec<TreeNode<'a>> {
     let source_metadata = match context.derivation_cache.cache.get(&source_id) {
         Some(m) => m,
         None => return Vec::new(),
@@ -617,7 +626,7 @@ fn build_tree_node(
     if source_metadata.is_state_source {
         if let Some(IdentifierName::Named(name)) = &source_metadata.place_name {
             return vec![TreeNode {
-                name: name.clone(),
+                name: *name,
                 type_of_value: source_metadata.type_of_value,
                 is_source: true,
                 children: Vec::new(),
@@ -626,7 +635,7 @@ fn build_tree_node(
     }
 
     let mut children: Vec<TreeNode> = Vec::new();
-    let mut named_siblings: FxIndexSet<String> = FxIndexSet::default();
+    let mut named_siblings: IdentIndexSet = IdentIndexSet::default();
 
     for child_id in &source_metadata.source_ids {
         assert_ne!(
@@ -636,13 +645,13 @@ fn build_tree_node(
 
         let mut new_visited = visited.clone();
         if let Some(IdentifierName::Named(name)) = &source_metadata.place_name {
-            new_visited.insert(name.clone());
+            new_visited.insert(*name);
         }
 
         let child_nodes = build_tree_node(*child_id, context, &new_visited);
         for child_node in child_nodes {
             if !named_siblings.contains(&child_node.name) {
-                named_siblings.insert(child_node.name.clone());
+                named_siblings.insert(child_node.name);
                 children.push(child_node);
             }
         }
@@ -651,7 +660,7 @@ fn build_tree_node(
     if let Some(IdentifierName::Named(name)) = &source_metadata.place_name {
         if !visited.contains(name) {
             return vec![TreeNode {
-                name: name.clone(),
+                name: *name,
                 type_of_value: source_metadata.type_of_value,
                 is_source: source_metadata.is_state_source,
                 children,
@@ -662,12 +671,12 @@ fn build_tree_node(
     children
 }
 
-fn render_tree(
-    node: &TreeNode,
+fn render_tree<'a>(
+    node: &TreeNode<'a>,
     indent: &str,
     is_last: bool,
-    props_set: &mut FxIndexSet<String>,
-    state_set: &mut FxIndexSet<String>,
+    props_set: &mut IdentIndexSet<'a>,
+    state_set: &mut IdentIndexSet<'a>,
 ) -> String {
     let prefix = format!(
         "{}{}",
@@ -681,16 +690,16 @@ fn render_tree(
     if node.is_source {
         let type_label = match node.type_of_value {
             TypeOfValue::FromProps => {
-                props_set.insert(node.name.clone());
+                props_set.insert(node.name);
                 "Prop"
             }
             TypeOfValue::FromState => {
-                state_set.insert(node.name.clone());
+                state_set.insert(node.name);
                 "State"
             }
             _ => {
-                props_set.insert(node.name.clone());
-                state_set.insert(node.name.clone());
+                props_set.insert(node.name);
+                state_set.insert(node.name);
                 "Prop and State"
             }
         };
@@ -731,11 +740,11 @@ fn get_fn_local_deps(
     Some(deps)
 }
 
-fn validate_effect(
+fn validate_effect<'a>(
     effect_func_id: FunctionId,
     dependencies: &[DepElement],
-    context: &mut ValidationContext,
-    env: &Environment,
+    context: &mut ValidationContext<'a>,
+    env: &Environment<'a>,
     errors: &mut Diagnostics,
 ) {
     let identifiers = &env.identifiers;
@@ -889,15 +898,15 @@ fn validate_effect(
                 && context.set_state_usages.contains_key(&root_id)
                 && effect_usage_count == total_usage_count - 1
             {
-                let mut props_set: FxIndexSet<String> = FxIndexSet::default();
-                let mut state_set: FxIndexSet<String> = FxIndexSet::default();
+                let mut props_set: IdentIndexSet = IdentIndexSet::default();
+                let mut state_set: IdentIndexSet = IdentIndexSet::default();
 
-                let mut root_nodes_map: FxIndexMap<String, TreeNode> = FxIndexMap::default();
+                let mut root_nodes_map: IdentIndexMap<TreeNode> = IdentIndexMap::default();
                 for id in &derived.source_ids {
-                    let nodes = build_tree_node(*id, context, &FxHashSet::default());
+                    let nodes = build_tree_node(*id, context, &IdentHashSet::default());
                     for node in nodes {
                         if !root_nodes_map.contains_key(&node.name) {
-                            root_nodes_map.insert(node.name.clone(), node);
+                            root_nodes_map.insert(node.name, node);
                         }
                     }
                 }

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_preserved_manual_memoization.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_preserved_manual_memoization.rs
@@ -25,7 +25,7 @@ use crate::react_compiler_hir::{
 };
 
 /// State tracked during manual memo validation within a StartMemoize..FinishMemoize range.
-struct ManualMemoBlockState {
+struct ManualMemoBlockState<'h> {
     /// Reassigned temporaries (declaration_id -> set of identifier ids that were reassigned to it).
     reassignments: FxHashMap<DeclarationId, FxHashSet<IdentifierId>>,
     /// Source location of the StartMemoize instruction.
@@ -33,7 +33,7 @@ struct ManualMemoBlockState {
     /// Declarations produced within this manual memo block.
     decls: FxHashSet<DeclarationId>,
     /// Normalized deps from source (useMemo/useCallback dep array).
-    deps_from_source: Option<Vec<ManualMemoDependency>>,
+    deps_from_source: Option<Vec<ManualMemoDependency<'h>>>,
     /// Manual memo id from StartMemoize.
     manual_memo_id: u32,
 }
@@ -41,13 +41,13 @@ struct ManualMemoBlockState {
 /// Top-level visitor state.
 struct VisitorState<'a, 'h> {
     env: &'a mut Environment<'h>,
-    manual_memo_state: Option<ManualMemoBlockState>,
+    manual_memo_state: Option<ManualMemoBlockState<'h>>,
     /// Completed (non-pruned) scope IDs.
     scopes: FxHashSet<ScopeId>,
     /// Completed pruned scope IDs.
     pruned_scopes: FxHashSet<ScopeId>,
     /// Map from identifier ID to its normalized manual memo dependency.
-    temporaries: FxHashMap<IdentifierId, ManualMemoDependency>,
+    temporaries: FxHashMap<IdentifierId, ManualMemoDependency<'h>>,
 }
 
 /// Validate that manual memoization (useMemo/useCallback) is preserved.
@@ -57,9 +57,9 @@ struct VisitorState<'a, 'h> {
 /// 1. Dependencies' scopes have completed before the memo block starts
 /// 2. Memoized values are actually within scopes (not unmemoized)
 /// 3. Inferred scope dependencies match the source dependencies
-pub fn validate_preserved_manual_memoization(
-    func: &ReactiveFunction<'_>,
-    env: &mut Environment<'_>,
+pub fn validate_preserved_manual_memoization<'h>(
+    func: &ReactiveFunction<'h>,
+    env: &mut Environment<'h>,
 ) {
     let mut state = VisitorState {
         env,
@@ -75,13 +75,13 @@ fn is_named(ident: &Identifier) -> bool {
     matches!(ident.name, Some(IdentifierName::Named(_)))
 }
 
-fn visit_block(block: &ReactiveBlock, state: &mut VisitorState<'_, '_>) {
+fn visit_block<'h>(block: &ReactiveBlock<'h>, state: &mut VisitorState<'_, 'h>) {
     for stmt in block {
         visit_statement(stmt, state);
     }
 }
 
-fn visit_statement(stmt: &ReactiveStatement, state: &mut VisitorState<'_, '_>) {
+fn visit_statement<'h>(stmt: &ReactiveStatement<'h>, state: &mut VisitorState<'_, 'h>) {
     match stmt {
         ReactiveStatement::Instruction(instr) => {
             visit_instruction(instr, state);
@@ -98,7 +98,7 @@ fn visit_statement(stmt: &ReactiveStatement, state: &mut VisitorState<'_, '_>) {
     }
 }
 
-fn visit_terminal(terminal: &ReactiveTerminalStatement, state: &mut VisitorState) {
+fn visit_terminal<'h>(terminal: &ReactiveTerminalStatement<'h>, state: &mut VisitorState<'_, 'h>) {
     match &terminal.terminal {
         ReactiveTerminal::If { consequent, alternate, .. } => {
             visit_block(consequent, state);
@@ -131,7 +131,7 @@ fn visit_terminal(terminal: &ReactiveTerminalStatement, state: &mut VisitorState
     }
 }
 
-fn visit_scope(scope_block: &ReactiveScopeBlock, state: &mut VisitorState<'_, '_>) {
+fn visit_scope<'h>(scope_block: &ReactiveScopeBlock<'h>, state: &mut VisitorState<'_, 'h>) {
     // Traverse the scope's instructions first
     visit_block(&scope_block.instructions, state);
 
@@ -167,12 +167,12 @@ fn visit_scope(scope_block: &ReactiveScopeBlock, state: &mut VisitorState<'_, '_
     }
 }
 
-fn visit_pruned_scope(pruned: &PrunedReactiveScopeBlock, state: &mut VisitorState) {
+fn visit_pruned_scope<'h>(pruned: &PrunedReactiveScopeBlock<'h>, state: &mut VisitorState<'_, 'h>) {
     visit_block(&pruned.instructions, state);
     state.pruned_scopes.insert(pruned.scope);
 }
 
-fn visit_instruction(instr: &ReactiveInstruction, state: &mut VisitorState<'_, '_>) {
+fn visit_instruction<'h>(instr: &ReactiveInstruction<'h>, state: &mut VisitorState<'_, 'h>) {
     // Record temporaries and deps in the instruction's value
     record_temporaries(instr, state);
 
@@ -313,7 +313,7 @@ fn record_unmemoized_error(span: Option<Span>, env: &mut Environment) {
 
 /// Record temporaries from an instruction.
 /// TS: `recordTemporaries`
-fn record_temporaries(instr: &ReactiveInstruction, state: &mut VisitorState<'_, '_>) {
+fn record_temporaries<'h>(instr: &ReactiveInstruction<'h>, state: &mut VisitorState<'_, 'h>) {
     let lvalue = &instr.lvalue;
     let lv_id = lvalue.as_ref().map(|lv| lv.identifier);
     if let Some(id) = lv_id {
@@ -350,7 +350,7 @@ fn record_temporaries(instr: &ReactiveInstruction, state: &mut VisitorState<'_, 
 
 /// Record dependencies from a reactive value.
 /// TS: `recordDepsInValue`
-fn record_deps_in_value(value: &ReactiveValue, state: &mut VisitorState<'_, '_>) {
+fn record_deps_in_value<'h>(value: &ReactiveValue<'h>, state: &mut VisitorState<'_, 'h>) {
     match value {
         ReactiveValue::SequenceExpression { instructions, value, .. } => {
             for instr in instructions {
@@ -442,7 +442,7 @@ fn start_memoize_operands(deps: &Option<Vec<ManualMemoDependency>>) -> Vec<Place
 }
 
 /// Get lvalue places from a Destructure pattern.
-fn destructure_lvalue_places(pattern: &Pattern) -> Vec<&Place> {
+fn destructure_lvalue_places<'p>(pattern: &'p Pattern<'_>) -> Vec<&'p Place> {
     let mut result = Vec::new();
     match pattern {
         Pattern::Array(arr) => {
@@ -613,12 +613,12 @@ fn get_compare_dependency_result_description(result: CompareDependencyResult) ->
 
 /// Validate that an inferred dependency matches a source dependency or was produced
 /// within the manual memo block.
-fn validate_inferred_dep(
+fn validate_inferred_dep<'h>(
     dep_id: IdentifierId,
-    dep_path: &[DependencyPathEntry],
-    temporaries: &FxHashMap<IdentifierId, ManualMemoDependency>,
+    dep_path: &[DependencyPathEntry<'h>],
+    temporaries: &FxHashMap<IdentifierId, ManualMemoDependency<'h>>,
     decls_within_memo_block: &FxHashSet<DeclarationId>,
-    valid_deps_in_memo_block: &[ManualMemoDependency],
+    valid_deps_in_memo_block: &[ManualMemoDependency<'h>],
     env: &mut Environment,
     memo_location: Option<Span>,
 ) {

--- a/crates/oxc_react_compiler/src/scope.rs
+++ b/crates/oxc_react_compiler/src/scope.rs
@@ -1,3 +1,4 @@
+use oxc_allocator::Allocator;
 use oxc_ast::AstKind;
 use oxc_ast::ast::{
     BindingIdentifier, BindingPattern, IdentifierReference, ImportDeclaration, ModuleExportName,
@@ -5,6 +6,7 @@ use oxc_ast::ast::{
 };
 use oxc_semantic::{AstNodes, NodeId, Scoping, Semantic};
 use oxc_span::GetSpan;
+use oxc_str::{Ident, Str};
 use oxc_syntax::scope::ScopeFlags;
 use oxc_syntax::symbol::SymbolFlags;
 use rustc_hash::FxHashSet;
@@ -86,13 +88,13 @@ impl DeclKind {
 }
 
 #[derive(Debug, Clone)]
-pub struct ImportBindingData {
+pub struct ImportBindingData<'a> {
     /// The module specifier string (e.g., "react" in `import {useState} from 'react'`).
-    pub source: String,
+    pub source: Str<'a>,
     pub kind: ImportBindingKind,
     /// For named imports: the imported name (e.g., "bar" in `import {bar as baz} from 'foo'`).
     /// None for default and namespace imports.
-    pub imported: Option<String>,
+    pub imported: Option<Ident<'a>>,
 }
 
 #[derive(Debug, Clone)]
@@ -108,7 +110,8 @@ pub enum ImportBindingKind {
 /// is derived from `Scoping` on demand.
 pub struct ScopeResolver<'s, 'a> {
     scoping: &'s Scoping,
-    nodes: &'s AstNodes<'a>,
+    nodes: &'s AstNodes<'s>,
+    allocator: &'a Allocator,
     /// All Function-kind scopes, in scope-tree order.
     function_scopes: Vec<ScopeId>,
     /// `(start, end)` source windows of Function-kind scopes, used by the
@@ -119,12 +122,19 @@ pub struct ScopeResolver<'s, 'a> {
 }
 
 impl<'s, 'a> ScopeResolver<'s, 'a> {
-    pub fn new(semantic: &'s Semantic<'a>) -> Self {
+    pub fn new<'ast>(semantic: &'s Semantic<'ast>, allocator: &'a Allocator) -> Self {
         let scoping = semantic.scoping();
-        let nodes = semantic.nodes();
+        // `AstNodes` is covariant in its lifetime; shrink the AST references to
+        // the `Semantic` borrow so the resolver needs no third lifetime.
+        let nodes: &'s AstNodes<'s> = semantic.nodes();
 
-        let mut resolver =
-            Self { scoping, nodes, function_scopes: Vec::new(), function_scope_ranges: Vec::new() };
+        let mut resolver = Self {
+            scoping,
+            nodes,
+            allocator,
+            function_scopes: Vec::new(),
+            function_scope_ranges: Vec::new(),
+        };
 
         for scope_id in scoping.scope_descendants_from_root() {
             if resolver.scope_kind(scope_id) != ScopeKind::Function {
@@ -184,6 +194,13 @@ impl<'s, 'a> ScopeResolver<'s, 'a> {
 
     pub fn symbol_name(&self, symbol_id: SymbolId) -> &'s str {
         self.scoping().symbol_name(symbol_id)
+    }
+
+    /// The symbol's name as an arena-lifetime `Ident`, copied into the arena.
+    /// The name in `Scoping` lives in the `Semantic` borrow, not the arena, so
+    /// a copy decouples the compiled output from that borrow.
+    pub fn symbol_ident(&self, symbol_id: SymbolId) -> Ident<'a> {
+        Ident::from_str_in(self.symbol_name(symbol_id), &self.allocator)
     }
 
     /// The scope a symbol is declared in.
@@ -308,19 +325,19 @@ impl<'s, 'a> ScopeResolver<'s, 'a> {
     /// The symbol's declaration identifier (the first declaration for
     /// redeclared symbols). `None` for declaration kinds the old conversion
     /// did not map (e.g. interfaces).
-    pub fn declaration_ident(&self, symbol_id: SymbolId) -> Option<&'a BindingIdentifier<'a>> {
+    pub fn declaration_ident(&self, symbol_id: SymbolId) -> Option<&'s BindingIdentifier<'s>> {
         let decl_node = self.nodes.get_node(self.scoping.symbol_declaration(symbol_id));
         find_binding_identifier(decl_node.kind(), self.symbol_name(symbol_id))
     }
 
     /// For import bindings: the source module and import details.
-    pub fn import_data(&self, symbol_id: SymbolId) -> Option<ImportBindingData> {
+    pub fn import_data(&self, symbol_id: SymbolId) -> Option<ImportBindingData<'a>> {
         let decl_node = self.nodes.get_node(self.scoping.symbol_declaration(symbol_id));
         match decl_node.kind() {
             AstKind::ImportDefaultSpecifier(_) => {
                 let import_decl = self.find_import_declaration(decl_node.id())?;
                 Some(ImportBindingData {
-                    source: import_decl.source.value.to_string(),
+                    source: Str::from_str_in(import_decl.source.value.as_str(), &self.allocator),
                     kind: ImportBindingKind::Default,
                     imported: None,
                 })
@@ -328,7 +345,7 @@ impl<'s, 'a> ScopeResolver<'s, 'a> {
             AstKind::ImportNamespaceSpecifier(_) => {
                 let import_decl = self.find_import_declaration(decl_node.id())?;
                 Some(ImportBindingData {
-                    source: import_decl.source.value.to_string(),
+                    source: Str::from_str_in(import_decl.source.value.as_str(), &self.allocator),
                     kind: ImportBindingKind::Namespace,
                     imported: None,
                 })
@@ -336,14 +353,14 @@ impl<'s, 'a> ScopeResolver<'s, 'a> {
             AstKind::ImportSpecifier(spec) => {
                 let import_decl = self.find_import_declaration(decl_node.id())?;
                 let imported_name = match &spec.imported {
-                    ModuleExportName::IdentifierName(ident) => ident.name.to_string(),
-                    ModuleExportName::IdentifierReference(ident) => ident.name.to_string(),
-                    ModuleExportName::StringLiteral(lit) => lit.value.to_string(),
+                    ModuleExportName::IdentifierName(ident) => ident.name.as_str(),
+                    ModuleExportName::IdentifierReference(ident) => ident.name.as_str(),
+                    ModuleExportName::StringLiteral(lit) => lit.value.as_str(),
                 };
                 Some(ImportBindingData {
-                    source: import_decl.source.value.to_string(),
+                    source: Str::from_str_in(import_decl.source.value.as_str(), &self.allocator),
                     kind: ImportBindingKind::Named,
-                    imported: Some(imported_name),
+                    imported: Some(Ident::from_str_in(imported_name, &self.allocator)),
                 })
             }
             _ => None,
@@ -354,7 +371,7 @@ impl<'s, 'a> ScopeResolver<'s, 'a> {
     fn find_import_declaration(
         &self,
         specifier_node_id: NodeId,
-    ) -> Option<&'s ImportDeclaration<'a>> {
+    ) -> Option<&'s ImportDeclaration<'s>> {
         let mut current_id = specifier_node_id;
         // Walk up the parent chain (max 10 levels to avoid infinite loop)
         for _ in 0..10 {


### PR DESCRIPTION
Converts `oxc_react_compiler` HIR strings from owned `String` to arena types from `oxc_str`, mirroring the `oxc_ast` conventions. Output is byte-identical over the 1806-fixture snapshot corpus, and the public `transform`/`lint` API is unchanged.

## Type mapping

- Identifier-ish names → `Ident<'a>` (Copy, precomputed hash): `IdentifierName`, `PropertyLiteral`, `ObjectPropertyKey`, `NonLocalBinding`/`VariableBinding` names, JSX attribute/tag names, `StoreGlobal`, `MetaProperty`, function ids/name-hints, `Type::shape_id`/`object_name`
- Text values → `Str<'a>`: directives, `JSXText`, template quasis, regex pattern/flags, import module specifiers
- `JsString` is now Copy with `Utf8(Str<'a>) | Wtf16(&'a [u16])` — string literals borrow AST arena text directly; constant-folding results allocate once into the arena
- Name-keyed maps → `IdentHashMap`/`IdentHashSet`/`IdentIndexMap` (str lookups keep working via `Equivalent` with the precomputed hash)
- `type_annotation_kind` → `Option<&'static str>` (`"as"`/`"satisfies"`)

## Where names come from

- AST names are copied out of node fields as `Ident<'a>` values (free); binding names resolved through `Scoping` are arena-copied once by `ScopeResolver::symbol_ident()` (the `Scoping` name storage lives in the `Semantic` borrow, not the arena)
- `Environment<'a>` now carries `allocator: &'a Allocator`; synthesized names (`#t{n}` temporaries, `name_{i}` collision suffixes, `_temp{i}` uids, `$` cache vars, outlined-component names) build with `format_ident!`
- `BUILT_IN_*` shape ids are `Ident<'static>` consts (`static_ident!`), so shape-id comparisons take the len+hash fast path; the static globals/shapes base tables are `IdentHashMap<'static, _>` built with zero startup `String` allocations (the handful of `<generated_N>` anon ids minted during the once-per-process static build are leaked as static data; per-compilation ids go in the arena)

## Structural payoff

Codegen previously kept the HIR at a separate lifetime `'h` and re-allocated every identifier into the output arena via `ox_str`. Input AST, HIR, and output AST share one allocator, so the lifetimes are unified: a name flows from source text through lowering, SSA versioning, and renaming into the output AST without a single copy. Per-operand `Constant` clones in constant propagation and per-version name clones in `enter_ssa` are now 16-byte copies.

To keep the public API borrow-free (`&Program<'a>`, `&Semantic<'_>`, unchanged from before), the HIR holds no references into the input `Program`: the two AST nodes it used to keep verbatim — `TypeCastExpression` type annotations and `UnsupportedNode` statements (inline TS `enum`) — are cloned into the arena at lowering with `clone_in_with_semantic_ids` (preserving the semantic id cells codegen's rename-by-reference-identity relies on). `FunctionNode` and the discovery/lowering paths carry the node borrow and the arena lifetime separately.

## Deliberately still `String`

- Config API (`options.rs`, `environment_config.rs`, `type_config.rs`) — created before the arena exists; converted at the `with_config` boundary
- `Cow<'static, str>` where values are static-or-config-owned: `FunctionSignature::canonical_name`/`known_incompatible`, `get_react_compiler_runtime_module`
- Suppression comment values are now `&'a str` source subslices; `decode_jsx_entities` returns `Cow` (borrows when no entity)
- Diagnostics/debug text (`format_place`, dependency printers, sort keys, `format_js_number`) and aliasing-config placeholder names (`"@rest"`, …)

## Verification

- `cargo test -p oxc_react_compiler`: 1806-fixture snapshot suite unchanged, 15 integration tests pass (tests/example untouched from main)
- `oxc_linter` / `oxc_transformer` (+tests) / benchmark build clean; transformer integration tests pass
- clippy (CI profile), typos, shear, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)