### PR TITLE
refactor(react_compiler): remove UnsupportedNode and align TypeCastExpression with oxc AST

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
@@ -621,11 +621,7 @@ pub enum InstructionValue<'a> {
     },
     TypeCastExpression {
         value: Place,
-        type_annotation_kind: Option<&'static str>,
-        /// The original oxc AST type annotation subtree, preserved for codegen,
-        /// which re-emits it by cloning into the output allocator (and applying any
-        /// identifier renames via the environment for the rare rename case).
-        type_annotation: Option<&'a oxc::TSType<'a>>,
+        cast: TypeCast<'a>,
         span: Option<Span>,
     },
     JsxExpression {
@@ -770,13 +766,17 @@ pub enum InstructionValue<'a> {
         pruned: bool,
         span: Option<Span>,
     },
-    UnsupportedNode {
-        /// The borrowed oxc statement node preserved verbatim, so codegen can clone
-        /// it into the output allocator and re-emit it (e.g. an inline TS `enum`,
-        /// which has runtime semantics but no HIR representation).
-        stmt: &'a oxc::Statement<'a>,
-        span: Option<Span>,
-    },
+}
+
+/// A preserved TS type-cast wrapper, aligned with the oxc AST node it was
+/// lowered from. The type subtree is an arena clone made at lowering; codegen
+/// re-emits it, applying identifier renames via semantic reference ids.
+#[derive(Debug, Clone, Copy)]
+pub enum TypeCast<'a> {
+    /// `expr as T` (`TSAsExpression`) and `<T>expr` (`TSTypeAssertion`)
+    As(&'a oxc::TSType<'a>),
+    /// `expr satisfies T` (`TSSatisfiesExpression`)
+    Satisfies(&'a oxc::TSType<'a>),
 }
 
 impl<'a> InstructionValue<'a> {
@@ -823,8 +823,7 @@ impl<'a> InstructionValue<'a> {
             | InstructionValue::PostfixUpdate { span, .. }
             | InstructionValue::Debugger { span, .. }
             | InstructionValue::StartMemoize { span, .. }
-            | InstructionValue::FinishMemoize { span, .. }
-            | InstructionValue::UnsupportedNode { span, .. } => span.as_ref(),
+            | InstructionValue::FinishMemoize { span, .. } => span.as_ref(),
         }
     }
 }

--- a/crates/oxc_react_compiler/src/react_compiler_hir/visitors.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/visitors.rs
@@ -79,8 +79,7 @@ pub fn each_instruction_value_lvalue(value: &InstructionValue) -> Vec<Place> {
         | InstructionValue::NextPropertyOf { .. }
         | InstructionValue::Debugger { .. }
         | InstructionValue::StartMemoize { .. }
-        | InstructionValue::FinishMemoize { .. }
-        | InstructionValue::UnsupportedNode { .. } => {}
+        | InstructionValue::FinishMemoize { .. } => {}
     }
     result
 }
@@ -271,7 +270,6 @@ pub fn each_instruction_value_operand_with_functions(
         | InstructionValue::RegExpLiteral { .. }
         | InstructionValue::MetaProperty { .. }
         | InstructionValue::LoadGlobal { .. }
-        | InstructionValue::UnsupportedNode { .. }
         | InstructionValue::Primitive { .. }
         | InstructionValue::JSXText { .. } => {
             // no operands
@@ -1018,7 +1016,6 @@ pub fn for_each_instruction_value_operand_mut(
         | InstructionValue::RegExpLiteral { .. }
         | InstructionValue::MetaProperty { .. }
         | InstructionValue::LoadGlobal { .. }
-        | InstructionValue::UnsupportedNode { .. }
         | InstructionValue::Primitive { .. }
         | InstructionValue::JSXText { .. } => {}
     }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
@@ -2213,8 +2213,7 @@ fn compute_signature_for_instruction(
         | InstructionValue::Primitive { .. }
         | InstructionValue::RegExpLiteral { .. }
         | InstructionValue::TemplateLiteral { .. }
-        | InstructionValue::UnaryExpression { .. }
-        | InstructionValue::UnsupportedNode { .. } => {
+        | InstructionValue::UnaryExpression { .. } => {
             effects.push(AliasingEffect::Create {
                 into: lvalue.clone(),
                 value: ValueKind::Primitive,

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_scope_variables.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_scope_variables.rs
@@ -199,7 +199,6 @@ fn may_allocate(value: &InstructionValue, lvalue_type_is_primitive: bool) -> boo
         | InstructionValue::JsxFragment { .. }
         | InstructionValue::NewExpression { .. }
         | InstructionValue::ObjectExpression { .. }
-        | InstructionValue::UnsupportedNode { .. }
         | InstructionValue::ObjectMethod { .. }
         | InstructionValue::FunctionExpression { .. } => true,
     }

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -1097,7 +1097,7 @@ fn lower_type_cast_expression<'a>(
     span: oxc_span::Span,
     expression: &oxc::Expression<'a>,
     type_annotation: &oxc::TSType<'a>,
-    type_annotation_kind: &'static str,
+    cast: fn(&'a oxc::TSType<'a>) -> TypeCast<'a>,
 ) -> Result<InstructionValue<'a>, OxcDiagnostic> {
     let span = Some(span);
     let value = lower_expression_to_temporary(builder, expression)?;
@@ -1109,12 +1109,7 @@ fn lower_type_cast_expression<'a>(
     // borrows of the input `Program` reference.
     let allocator = builder.environment().allocator;
     let type_annotation = &*allocator.alloc(type_annotation.clone_in_with_semantic_ids(allocator));
-    Ok(InstructionValue::TypeCastExpression {
-        value,
-        type_annotation_kind: Some(type_annotation_kind),
-        type_annotation: Some(type_annotation),
-        span,
-    })
+    Ok(InstructionValue::TypeCastExpression { value, cast: cast(type_annotation), span })
 }
 
 /// Lower a member-expression update target (oxc's member variants of
@@ -4033,19 +4028,27 @@ fn lower_expression<'a>(
         // `x as T` / `x satisfies T` / `<T>x` lower the inner expression to a
         // temporary and emit a `TypeCastExpression` carrying the type metadata,
         // mirroring the original Babel logic.
-        oxc::Expression::TSAsExpression(ts) => {
-            lower_type_cast_expression(builder, ts.span, &ts.expression, &ts.type_annotation, "as")
-        }
+        oxc::Expression::TSAsExpression(ts) => lower_type_cast_expression(
+            builder,
+            ts.span,
+            &ts.expression,
+            &ts.type_annotation,
+            TypeCast::As,
+        ),
         oxc::Expression::TSSatisfiesExpression(ts) => lower_type_cast_expression(
             builder,
             ts.span,
             &ts.expression,
             &ts.type_annotation,
-            "satisfies",
+            TypeCast::Satisfies,
         ),
-        oxc::Expression::TSTypeAssertion(ts) => {
-            lower_type_cast_expression(builder, ts.span, &ts.expression, &ts.type_annotation, "as")
-        }
+        oxc::Expression::TSTypeAssertion(ts) => lower_type_cast_expression(
+            builder,
+            ts.span,
+            &ts.expression,
+            &ts.type_annotation,
+            TypeCast::As,
+        ),
         // `x!` and `x<T>` unwrap to their inner expression (the original also just
         // unwraps these).
         oxc::Expression::TSNonNullExpression(ts) => lower_expression(builder, &ts.expression),
@@ -6380,15 +6383,12 @@ fn lower_statement<'a>(
                     .diagnostic("JavaScript `import` and `export` statements may only appear at the top level of a module").with_label(stmt.span()),
             )?;
         }
-        oxc::Statement::TSEnumDeclaration(e) => {
-            // Inline TS `enum` has runtime semantics, so preserve it: emit an
-            // `UnsupportedNode` carrying an arena clone of the oxc statement node
-            // so the back-end can re-emit it verbatim (matching the original Babel
-            // front-end, which wrapped the enum the same way).
-            let span = Some(e.span);
-            let allocator = builder.environment().allocator;
-            let stmt = &*allocator.alloc(stmt.clone_in_with_semantic_ids(allocator));
-            lower_value_to_temporary(builder, InstructionValue::UnsupportedNode { stmt, span })?;
+        oxc::Statement::TSEnumDeclaration(_) => {
+            // Inline TS `enum` has runtime semantics but no HIR representation, and
+            // the compiled body is rebuilt from HIR. Flag the function to be skipped
+            // (silently, no diagnostic) once lowering finishes, rather than dropping
+            // the enum from the output. Other functions in the file are unaffected.
+            builder.environment_mut().skip_compilation = true;
         }
         _ => {
             // Remaining statements are skipped: bodyless FunctionDeclaration

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/hir_builder.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/hir_builder.rs
@@ -756,9 +756,9 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
         };
         // Treat type-only declarations as globals so the compiler
         // doesn't try to create/initialize HIR bindings for them.
-        // TSEnumDeclaration is included because enums inside function
-        // bodies are lowered as UnsupportedNode and their binding
-        // is never initialized in HIR.
+        // TSEnumDeclaration is included because a function with an inline
+        // enum is skipped (`skip_compilation`) and the enum binding is
+        // never initialized in HIR.
         if matches!(
             self.scope.decl_kind(symbol_id),
             DeclKind::TSTypeAliasDeclaration

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
@@ -618,8 +618,7 @@ fn evaluate_instruction<'a>(
         | InstructionValue::IteratorNext { .. }
         | InstructionValue::NextPropertyOf { .. }
         | InstructionValue::Debugger { .. }
-        | InstructionValue::FinishMemoize { .. }
-        | InstructionValue::UnsupportedNode { .. } => None,
+        | InstructionValue::FinishMemoize { .. } => None,
     }
 }
 

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/dead_code_elimination.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/dead_code_elimination.rs
@@ -340,7 +340,6 @@ fn pruneable_value(value: &InstructionValue, state: &State, env: &Environment) -
             false
         }
         InstructionValue::NewExpression { .. }
-        | InstructionValue::UnsupportedNode { .. }
         | InstructionValue::TaggedTemplateExpression { .. } => {
             // Potentially safe to prune, but we conservatively keep them
             false

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
@@ -38,6 +38,7 @@ use crate::react_compiler_hir::PrimitiveValue;
 use crate::react_compiler_hir::PropertyLiteral;
 use crate::react_compiler_hir::ScopeId;
 use crate::react_compiler_hir::SpreadPattern;
+use crate::react_compiler_hir::TypeCast;
 use crate::react_compiler_hir::environment::{Environment, OutputMode};
 use crate::react_compiler_hir::reactive::PrunedReactiveScopeBlock;
 use crate::react_compiler_hir::reactive::ReactiveBlock;
@@ -1365,13 +1366,6 @@ fn ox_codegen_instruction_nullable<'a>(
                 cx.object_methods.insert(lvalue.identifier, (value.clone(), *span));
                 return Ok(None);
             }
-            InstructionValue::UnsupportedNode { stmt, .. } => {
-                // Statement-position unsupported node (e.g. an inline TS `enum`
-                // declaration): re-emit it verbatim by cloning the borrowed oxc
-                // statement into the output allocator, mirroring the Babel path's
-                // `return node` for non-expression original nodes.
-                return Ok(Some(stmt.clone_in(cx.ast.allocator())));
-            }
             _ => {}
         }
     }
@@ -2082,32 +2076,24 @@ fn ox_codegen_base_instruction_value<'a>(
                 oxc_allocator::ArenaBox::new_in(template, &cx.ast),
             )))
         }
-        InstructionValue::TypeCastExpression {
-            value,
-            type_annotation_kind,
-            type_annotation,
-            ..
-        } => {
+        InstructionValue::TypeCastExpression { value, cast, .. } => {
             let expr = ox_codegen_place_to_expression(cx, value)?;
             // Re-emit the stored TS type into the output allocator (a `clone_in`, with
             // any binding renames applied to identifier references inside the type) and
             // re-wrap the inner expression, matching the baseline output.
-            let wrapped = match (type_annotation_kind.as_deref(), type_annotation) {
-                (Some("satisfies"), Some(ta)) => {
-                    oxc_ast::ast::Expression::new_ts_satisfies_expression(
-                        SPAN,
-                        expr,
-                        ox_reemit_ts_type(cx, ta),
-                        &cx.ast,
-                    )
-                }
-                (Some("as"), Some(ta)) => oxc_ast::ast::Expression::new_ts_as_expression(
+            let wrapped = match cast {
+                TypeCast::Satisfies(ta) => oxc_ast::ast::Expression::new_ts_satisfies_expression(
                     SPAN,
                     expr,
                     ox_reemit_ts_type(cx, ta),
                     &cx.ast,
                 ),
-                _ => expr,
+                TypeCast::As(ta) => oxc_ast::ast::Expression::new_ts_as_expression(
+                    SPAN,
+                    expr,
+                    ox_reemit_ts_type(cx, ta),
+                    &cx.ast,
+                ),
             };
             Ok(OxValue::Expression(wrapped))
         }
@@ -2138,8 +2124,7 @@ fn ox_codegen_base_instruction_value<'a>(
         | InstructionValue::DeclareContext { .. }
         | InstructionValue::Destructure { .. }
         | InstructionValue::ObjectMethod { .. }
-        | InstructionValue::StoreContext { .. }
-        | InstructionValue::UnsupportedNode { .. } => Err(invariant_err(
+        | InstructionValue::StoreContext { .. } => Err(invariant_err(
             &format!("Unexpected {:?} in codegenInstructionValue", std::mem::discriminant(iv)),
             None,
         )),

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_escaping_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_escaping_scopes.rs
@@ -772,14 +772,6 @@ impl<'a, 'e> CollectDependenciesVisitor<'a, 'e> {
                     operands.iter().map(|p| (p.identifier, id)).collect();
                 (lvalues, rvalues)
             }
-            InstructionValue::UnsupportedNode { .. } => {
-                let lvalues = if let Some(lv) = lvalue {
-                    vec![LValueMemoization { place_identifier: lv, level: MemoizationLevel::Never }]
-                } else {
-                    vec![]
-                };
-                (lvalues, vec![])
-            }
         }
     }
 

--- a/crates/oxc_react_compiler/src/react_compiler_typeinference/infer_types.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_typeinference/infer_types.rs
@@ -808,7 +808,6 @@ fn generate_instruction_types<'a>(
         | InstructionValue::Await { .. }
         | InstructionValue::GetIterator { .. }
         | InstructionValue::IteratorNext { .. }
-        | InstructionValue::UnsupportedNode { .. }
         | InstructionValue::Debugger { .. }
         | InstructionValue::FinishMemoize { .. } => {
             // No type equations for these
@@ -1153,8 +1152,7 @@ fn apply_instruction_operands<'a>(
         | InstructionValue::DeclareContext { .. }
         | InstructionValue::RegExpLiteral { .. }
         | InstructionValue::MetaProperty { .. }
-        | InstructionValue::Debugger { .. }
-        | InstructionValue::UnsupportedNode { .. } => {
+        | InstructionValue::Debugger { .. } => {
             // No operand places
         }
     }

--- a/crates/oxc_react_compiler/tests/snapshots/ts-enum-inline.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/ts-enum-inline.snap
@@ -2,26 +2,16 @@
 source: crates/oxc_react_compiler/tests/snapshot.rs
 input_file: crates/oxc_react_compiler/fixtures/ts-enum-inline.tsx
 ---
-import { c as _c } from "react/compiler-runtime";
 function Component(props) {
-	const $ = _c(2);
 	enum Bool {
 		True = "true",
 		False = "false"
 	}
-	let bool = Bool.False;
+	let bool: Bool = Bool.False;
 	if (props.value) {
 		bool = Bool.True;
 	}
-	let t0;
-	if ($[0] !== bool) {
-		t0 = <div>{bool}</div>;
-		$[0] = bool;
-		$[1] = t0;
-	} else {
-		t0 = $[1];
-	}
-	return t0;
+	return <div>{bool}</div>;
 }
 export const FIXTURE_ENTRYPOINT = {
 	fn: Component,


### PR DESCRIPTION
Follow-up to #24393, removing preserved-AST baggage from the HIR:

## Remove `UnsupportedNode`

Its only producer was the inline TS `enum` statement — upstream's single *silent* `UnsupportedNode` case (every other upstream site records an error first, so the function fails compilation anyway; this port already expresses those without the wrapper). Instead of carrying an AST statement through the whole pipeline just to re-emit it at codegen, inline enums now take the same path as `using` declarations: lowering sets `skip_compilation`, the function is left uncompiled — silently, no diagnostic — and the rest of the file compiles as usual.

One intended snapshot change: `ts-enum-inline.tsx` is no longer memoized and round-trips unchanged. (Top-level enums are unaffected — only compiled function bodies are rebuilt.)

## Align `TypeCastExpression` with the oxc AST

The stringly `(type_annotation_kind: Option<&'static str>, type_annotation: Option<&TSType>)` pair becomes a `TypeCast<'a>` enum mirroring the oxc wrapper nodes it lowers from — `TSAsExpression`/`TSTypeAssertion` → `TypeCast::As`, `TSSatisfiesExpression` → `TypeCast::Satisfies` — removing the invalid `None`/`Some` combinations and codegen's dead fallback arm. This leaves the cast annotation as the only borrowed AST kept in the HIR (an arena clone made at lowering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)