### PR TITLE
docs(ast_tools): correct comments concerning enum inheritance

### DIFF
--- a/tasks/ast_tools/src/derives/clone_in.rs
+++ b/tasks/ast_tools/src/derives/clone_in.rs
@@ -168,15 +168,13 @@ fn derive_enum(enum_def: &EnumDef, schema: &Schema) -> TokenStream {
 
 /// Generate the `match` body for an enum's `clone_in` / `clone_in_with_semantic_ids` method.
 ///
-/// Own variants are cloned arm-by-arm. Variants inherited via `inherit_variants!` are *not*
-/// expanded individually. Instead they are delegated to the inherited enum's own `CloneIn` impl,
-/// using the `to_*` reference cast (narrow `&Self` to `&Inherited`) and the generated `From` impl
-/// (widen the cloned `Inherited` back to `Self`). Both casts are zero-cost because the inherited
-/// variants share discriminants and layout with the parent enum.
+/// Own variants are cloned arm-by-arm. Variants inherited via `INHERIT` are *not* expanded individually.
+/// Instead they are delegated to the inherited enum's own `CloneIn` impl, using `to_*` reference cast
+/// (narrow `&Self` to `&Inherited`), and the generated `From` impl (widen the clone back to `Self`).
+/// Both casts are zero-cost because the inherited variants share discriminants and layout with the parent enum.
 ///
 /// This avoids re-emitting the parent enum's variant arms (e.g. all of `Expression`'s ~30 variants)
-/// in every inheriting enum (`Argument`, `PropertyKey`, ...), which is a large source of binary
-/// bloat, and is behaviour-identical to expanding the arms inline.
+/// in every inheriting enum (`Argument`, `PropertyKey`, ...), which is a large source of binary bloat.
 fn derive_enum_body(
     enum_def: &EnumDef,
     type_ident: &Ident,
@@ -197,10 +195,12 @@ fn derive_enum_body(
 
     let inherited_arms = enum_def.inherits.iter().map(|&inherits_id| {
         let inherited = schema.enum_def(inherits_id);
+
         let patterns = inherited.all_variants(schema).map(|variant| {
             let ident = variant.ident();
             if variant.is_fieldless() { quote!( Self::#ident ) } else { quote!( Self::#ident(_) ) }
         });
+
         let to_inherited = create_ident(&format!("to_{}", inherited.snake_name()));
         quote! {
             #(#patterns)|* => {

--- a/tasks/ast_tools/src/derives/estree.rs
+++ b/tasks/ast_tools/src/derives/estree.rs
@@ -605,13 +605,14 @@ fn generate_body_for_enum(enum_def: &EnumDef, schema: &Schema) -> TokenStream {
         }
     });
 
-    // Variants inherited via `inherit_variants!` are delegated to the inherited enum's `ESTree`
-    // impl through the generated `to_*` reference cast, instead of re-emitting an arm for each.
-    // Inherited variants carry the parent's serialization config, so this is byte-identical, and
-    // it avoids duplicating the parent enum's arms (e.g. all of `Expression`'s variants) in every
-    // inheriting enum (`Argument`, `PropertyKey`, ...).
+    // Variants inherited via `INHERIT` are delegated to the inherited enum's `ESTree` impl
+    // through the generated `to_*` reference cast, instead of re-emitting an arm for each.
+    // This avoids duplicating the inherited enum's arms e.g. all of `Expression`'s variants
+    // in every enum that inherits `Expression` (`Argument`, `PropertyKey` etc),
+    // which reduces binary size.
     let inherited_branches = enum_def.inherits.iter().map(|&inherits_id| {
         let inherited = schema.enum_def(inherits_id);
+
         let patterns = inherited.all_variants(schema).map(|variant| {
             let variant_ident = variant.ident();
             if variant.is_fieldless() {
@@ -620,6 +621,7 @@ fn generate_body_for_enum(enum_def: &EnumDef, schema: &Schema) -> TokenStream {
                 quote!( Self::#variant_ident(_) )
             }
         });
+
         let to_inherited = create_ident(&format!("to_{}", inherited.snake_name()));
         quote! {
             #(#patterns)|* => self.#to_inherited().serialize(serializer),


### PR DESCRIPTION
Follow-on after #23555.

Since that PR was written, the `inherit_variants!` macro was removed, so some of the comments were out of date.

Bring those comments up to date. Also shorten the comments a bit and reformat them.