### PR TITLE
refactor(ast_tools): clarify inlining in `CloneIn` generator

### DIFF
--- a/tasks/ast_tools/src/derives/clone_in.rs
+++ b/tasks/ast_tools/src/derives/clone_in.rs
@@ -156,13 +156,15 @@ fn derive_enum(enum_def: &EnumDef, schema: &Schema) -> TokenStream {
         )
     };
 
-    // Note: Add `#[inline(always)]` to methods for fieldless enums, because they're no-ops
+    // Add `#[inline(always)]` to methods for fieldless enums, because they're no-ops
+    let inline_always = enum_def.is_fieldless();
+
     generate_impl(
         &type_ident,
         &clone_in_body,
         &clone_in_with_semantic_ids_body,
         enum_def.has_lifetime,
-        enum_def.is_fieldless(),
+        inline_always,
     )
 }
 


### PR DESCRIPTION
Tiny refactor to `CloneIn` generator. Clarify the logic about which `clone_in` methods get an `#[inline(always)]` attribute.