### PR TITLE
refactor(react_compiler): split public API into compile + in-place CompileOutput::transform

### DIFF
--- a/crates/oxc_react_compiler/examples/react_compiler.rs
+++ b/crates/oxc_react_compiler/examples/react_compiler.rs
@@ -20,7 +20,7 @@ use oxc_parser::Parser;
 use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
 
-use oxc_react_compiler::{PluginOptions, transform};
+use oxc_react_compiler::{PluginOptions, compile};
 
 /// Compile a React component with the Rust React Compiler and print the result.
 fn main() {
@@ -39,26 +39,27 @@ fn main() {
     let allocator = Allocator::default();
     let mut program = Parser::new(&allocator, &source_text, source_type).parse().program;
 
-    let mut result = {
+    let (output, diagnostics) = {
         let semantic = SemanticBuilder::new().with_build_nodes(true).build(&program).semantic;
-        transform(&program, &semantic, &allocator, PluginOptions::default())
+        compile(&program, &semantic, &allocator, PluginOptions::default())
     };
-    if let Some(compiled) = result.program.take() {
-        program = compiled;
+    let changed = output.is_some();
+    if let Some(output) = output {
+        output.transform(&mut program);
     }
 
-    if !result.diagnostics.is_empty() {
+    if !diagnostics.is_empty() {
         println!("Diagnostics:\n");
-        for diagnostic in &result.diagnostics {
+        for diagnostic in &diagnostics {
             println!("{diagnostic:?}");
         }
         println!();
     }
 
-    if result.changed {
-        let output = Codegen::new().build(&program).code;
+    if changed {
+        let code = Codegen::new().build(&program).code;
         println!("Compiled:\n");
-        println!("{output}");
+        println!("{code}");
     } else {
         println!("No changes: no React component or hook found (or compilation bailed out).");
     }

--- a/crates/oxc_react_compiler/src/lib.rs
+++ b/crates/oxc_react_compiler/src/lib.rs
@@ -21,6 +21,8 @@ use crate::react_compiler::entrypoint::imports::{
 };
 use crate::react_compiler::entrypoint::program::compile_program;
 
+pub use crate::react_compiler::entrypoint::program::CompileOutput;
+
 // Re-exported so integrations needn't depend on the upstream `react_compiler` crates.
 pub use crate::options::{
     CompilationMode, CompilerOutputMode, CompilerTarget, DynamicGatingConfig, GatingConfig,
@@ -40,76 +42,40 @@ pub use crate::react_compiler_utils::FxIndexMap;
 use oxc_ast::ast::Program;
 use oxc_diagnostics::Diagnostics;
 use oxc_semantic::Semantic;
-use oxc_span::GetSpan;
-use rustc_hash::FxHashSet;
-
-#[derive(Default)]
-pub struct TransformResult<'a> {
-    /// The rewritten program, when the compiler memoized something.
-    ///
-    /// Callers that want in-place behavior should replace their original
-    /// `Program` with this value after the borrowed `Semantic` has gone out of
-    /// scope.
-    pub program: Option<Program<'a>>,
-    /// Whether `program` contains a rewritten program. `false` means the
-    /// compiler made no changes — no React-like functions, a bail-out, or
-    /// nothing to memoize.
-    pub changed: bool,
-    /// Errors and warnings produced by the compile. Errors (e.g. Rules of Hooks
-    /// violations) are hard problems in the source; the program is still left
-    /// valid. Warnings include bail-outs where the compiler declined to optimize.
-    pub diagnostics: Diagnostics,
-}
 
 pub struct LintResult {
     /// Errors and warnings produced by the compile.
     pub diagnostics: Diagnostics,
 }
 
-/// Run the React Compiler on a pre-parsed program, returning a rewritten
-/// program when it memoizes something.
+/// Run the React Compiler on a pre-parsed program.
+///
+/// Returns the compiled output — `None` when the compiler has nothing to change
+/// (no React-like functions, a bail-out, nothing to memoize, or a fatal error) —
+/// together with the diagnostics. Errors (e.g. Rules of Hooks violations) are
+/// hard problems in the source; the program is still left valid. Warnings
+/// include bail-outs where the compiler declined to optimize.
 ///
 /// Must run **first**, on the pristine AST, before any other transform. The
 /// borrowed `semantic` must have been built from that same pristine AST with
-/// `SemanticBuilder::with_build_nodes(true)`.
-pub fn transform<'a>(
-    program: &Program<'a>,
-    semantic: &Semantic<'_>,
-    allocator: &'a Allocator,
-    options: PluginOptions,
-) -> TransformResult<'a> {
-    let (program, diagnostics) = compile(program, semantic, allocator, options);
-    let changed = program.is_some();
-    TransformResult { program, changed, diagnostics }
-}
-
-/// Lint a pre-parsed program — like [`transform`] but read-only: it collects
-/// diagnostics without rewriting the program.
+/// `SemanticBuilder::with_build_nodes(true)`. Rewrite the program by applying
+/// the output with [`CompileOutput::transform`] once `semantic` is dropped:
 ///
-/// The borrowed `semantic` must have been built from `program` with
-/// `SemanticBuilder::with_build_nodes(true)`.
-pub fn lint<'a>(
+/// ```ignore
+/// let (output, diagnostics) = {
+///     let semantic = SemanticBuilder::new().with_build_nodes(true).build(&program).semantic;
+///     compile(&program, &semantic, &allocator, options)
+/// }; // `semantic`'s borrow of `program` ends here
+/// if let Some(output) = output {
+///     output.transform(&mut program);
+/// }
+/// ```
+pub fn compile<'a>(
     program: &Program<'a>,
     semantic: &Semantic<'_>,
     allocator: &'a Allocator,
     options: PluginOptions,
-) -> LintResult {
-    let mut options = options;
-    options.no_emit = true;
-
-    let (_program, diagnostics) = compile(program, semantic, allocator, options);
-    LintResult { diagnostics }
-}
-
-/// Shared compile pipeline behind [`transform`] and [`lint`]. Borrows `program`
-/// (so `lint` can stay read-only) and returns the compiled OXC program — `None`
-/// when nothing was compiled — together with diagnostics and logger events.
-fn compile<'a>(
-    program: &Program<'a>,
-    semantic: &Semantic<'_>,
-    allocator: &'a Allocator,
-    options: PluginOptions,
-) -> (Option<Program<'a>>, Diagnostics) {
+) -> (Option<CompileOutput<'a>>, Diagnostics) {
     // Check for existing runtime imports (file already compiled).
     if has_memo_cache_function_import(program, &get_react_compiler_runtime_module(&options.target))
     {
@@ -123,41 +89,26 @@ fn compile<'a>(
         return (None, diagnostics);
     }
 
-    let result = compile_program(allocator, semantic, program, options);
-
-    let (program_ast, diagnostics) = match result {
-        CompileResult::Success { ast, diagnostics, .. } => (ast, diagnostics),
-        CompileResult::Error { diagnostics, .. } => (None, diagnostics),
-    };
-
-    let compiled = program_ast.map(|mut compiled: Program<'a>| {
-        compiled.source_type = program.source_type;
-        prune_inner_comments(&mut compiled);
-        compiled
-    });
-
-    (compiled, diagnostics)
+    match compile_program(allocator, semantic, program, options) {
+        CompileResult::Success { output, diagnostics } => (output, diagnostics),
+        CompileResult::Error { diagnostics } => (None, diagnostics),
+    }
 }
 
-/// Drop comments left dangling by compilation.
+/// Lint a pre-parsed program — like [`compile`] but read-only: it collects
+/// diagnostics without producing a rewrite.
 ///
-/// `ox_splice_program` clones the source program — `comments` and `source_text`
-/// included — so `compiled` already carries every original comment. The compiled
-/// functions were rebuilt with fresh spans, though, so a comment that pointed
-/// inside one no longer lines up with any statement and codegen would re-emit it
-/// at a stale position. Keep only the comments still anchored to a top-level
-/// statement.
-fn prune_inner_comments(compiled: &mut Program<'_>) {
-    if compiled.comments.is_empty() {
-        return;
-    }
-    let mut top_level_starts = FxHashSet::default();
-    top_level_starts.insert(0u32);
-    for stmt in &compiled.body {
-        let start = stmt.span().start;
-        if start > 0 {
-            top_level_starts.insert(start);
-        }
-    }
-    compiled.comments.retain(|comment| top_level_starts.contains(&comment.attached_to));
+/// The borrowed `semantic` must have been built from `program` with
+/// `SemanticBuilder::with_build_nodes(true)`.
+pub fn lint<'a>(
+    program: &Program<'a>,
+    semantic: &Semantic<'_>,
+    allocator: &'a Allocator,
+    options: PluginOptions,
+) -> LintResult {
+    let mut options = options;
+    options.no_emit = true;
+
+    let (_output, diagnostics) = compile(program, semantic, allocator, options);
+    LintResult { diagnostics }
 }

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/compile_result.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/compile_result.rs
@@ -5,17 +5,16 @@ use oxc_str::Ident;
 
 use crate::react_compiler_hir::ReactFunctionType;
 
+use super::program::CompileOutput;
+
 /// Main result type returned by the compile function.
-///
-/// Stage 2: the compiled program is an arena-allocated oxc
-/// [`oxc_ast::ast::Program`] (lifetime `'a` of the arena), built directly by the
-/// codegen back-end (see `compile_program`) instead of the former Babel `File`.
-#[derive(Debug)]
+#[allow(clippy::large_enum_variant)] // built once per compile; `ProgramContext` carries the options
 pub enum CompileResult<'a> {
     /// Compilation succeeded (or no functions needed compilation).
-    /// `ast` is None if no changes were made to the program.
+    /// `output` is None if no changes are to be made to the program — always so
+    /// in lint output mode.
     Success {
-        ast: Option<oxc_ast::ast::Program<'a>>,
+        output: Option<CompileOutput<'a>>,
         /// Errors and warnings accumulated during compilation.
         diagnostics: Diagnostics,
     },

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/imports.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/imports.rs
@@ -87,6 +87,11 @@ impl<'a> ProgramContext<'a> {
         }
     }
 
+    /// The arena the compiled nodes were allocated in.
+    pub fn allocator(&self) -> &'a Allocator {
+        self.allocator
+    }
+
     /// Check if a name conflicts with known references.
     pub fn has_reference(&self, name: &str) -> bool {
         self.known_referenced_names.contains(name)

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -17,7 +17,7 @@ use oxc_ast::AstKind;
 use oxc_ast::ast as oxc;
 use oxc_ast::builder::AstBuilder;
 use oxc_diagnostics::{Diagnostics, OxcDiagnostic};
-use oxc_span::{SPAN, Span};
+use oxc_span::{GetSpan, SPAN, Span};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::diagnostics::{ErrorCategory, has_critical_errors, with_fallback_label};
@@ -2117,19 +2117,69 @@ enum OriginalFnKind {
 }
 
 // =============================================================================
-// oxc splice
+// oxc transform
 //
-// Builds the final oxc `Program` by substituting each compiled oxc function (from
-// codegen) for its original — matched by the original function's scope — applying
-// gating, inserting outlined functions, and adding the memo-cache / gating imports.
+// Rewrites the oxc `Program` in place by substituting each compiled oxc function
+// (from codegen) for its original — matched by the original function's scope —
+// applying gating, inserting outlined functions, and adding the memo-cache /
+// gating imports.
 // =============================================================================
 
-/// An owned, oxc-shaped compiled function ready to splice into the program.
+/// An owned, oxc-shaped compiled function ready to substitute into the program.
 struct OxcReplacement<'a> {
     fn_scope_id: ScopeId,
     original_kind: OriginalFnKind,
     codegen_fn: CodegenFunction<'a>,
     gating: Option<GatingConfig>,
+}
+
+/// The owned output of a [`compile`](crate::compile) that produced changes:
+/// everything the transform phase needs, carrying only the arena lifetime — no
+/// borrows of the input `Program` or `Semantic` — so the caller can drop its
+/// `Semantic` (and with it the shared borrow of the program) before mutating.
+pub struct CompileOutput<'a> {
+    replacements: Vec<OxcReplacement<'a>>,
+    context: ProgramContext<'a>,
+}
+
+impl<'a> CompileOutput<'a> {
+    /// Rewrite `program` in place: substitute each original function with its
+    /// memoized version (matched by the `scope_id` cells populated when the
+    /// caller built `Semantic`), insert outlined declarations, add the required
+    /// imports, and drop comments left dangling inside replaced functions.
+    ///
+    /// `program` must be the same, unmodified program [`compile`](crate::compile)
+    /// saw. Afterwards any previously computed `Semantic`/`Scoping` is stale.
+    pub fn transform(self, program: &mut oxc::Program<'a>) {
+        let CompileOutput { replacements, mut context } = self;
+        let ast = AstBuilder::new(context.allocator());
+        ox_transform_program(&ast, program, &replacements, &mut context);
+        // Diagnostics were extracted at the end of compilation; nothing in the
+        // transform phase may add more.
+        debug_assert!(context.diagnostics.is_empty());
+        prune_inner_comments(program);
+    }
+}
+
+/// Drop comments left dangling by compilation.
+///
+/// The compiled functions were rebuilt with fresh spans, so a comment that
+/// pointed inside one no longer lines up with any statement and codegen would
+/// re-emit it at a stale position. Keep only the comments still anchored to a
+/// top-level statement.
+fn prune_inner_comments(program: &mut oxc::Program<'_>) {
+    if program.comments.is_empty() {
+        return;
+    }
+    let mut top_level_starts = FxHashSet::default();
+    top_level_starts.insert(0u32);
+    for stmt in &program.body {
+        let start = stmt.span().start;
+        if start > 0 {
+            top_level_starts.insert(start);
+        }
+    }
+    program.comments.retain(|comment| top_level_starts.contains(&comment.attached_to));
 }
 
 /// Copy the TS metadata (type annotation, decorators, optional/modifier flags)
@@ -2569,19 +2619,18 @@ fn ox_clone_original_fn_as_expression<'a>(
     finder.found.map(|e| e.clone_in(ast.allocator()))
 }
 
-/// Splice every compiled oxc function into a clone of the original oxc program and
-/// add the required imports. Returns the final memoized program.
-fn ox_splice_program<'a>(
+/// Substitute every compiled oxc function into the program in place and add the
+/// required imports.
+///
+/// The replacement visitors match original functions by their `scope_id` cells
+/// (populated by the caller's semantic build); codegen-built nodes carry no
+/// cells, so they can never be spuriously matched.
+fn ox_transform_program<'a>(
     ast: &AstBuilder<'a>,
-    program: &oxc::Program<'a>,
+    program: &mut oxc::Program<'a>,
     replacements: &[OxcReplacement<'a>],
     context: &mut ProgramContext,
-) -> oxc::Program<'a> {
-    // Preserve the semantic id cells: the replacement visitors match original
-    // functions by their `scope_id`, and codegen-built nodes carry no cells, so
-    // they can never be spuriously matched.
-    let mut program = program.clone_in_with_semantic_ids(ast.allocator());
-
+) {
     // Outlined function declarations are placed differently depending on the
     // original function's syntactic kind, mirroring `insertNewOutlinedFunctionNode`
     // in TS `Program.ts`:
@@ -2607,7 +2656,7 @@ fn ox_splice_program<'a>(
         }
 
         if let Some(ref gating_config) = replacement.gating {
-            ox_apply_gated_conditional(ast, &mut program, replacement, gating_config, context);
+            ox_apply_gated_conditional(ast, program, replacement, gating_config, context);
         } else {
             let mut visitor = OxcReplaceFnVisitor {
                 ast,
@@ -2615,11 +2664,11 @@ fn ox_splice_program<'a>(
                 codegen: &replacement.codegen_fn,
                 done: false,
             };
-            oxc_ast_visit::VisitMut::visit_program(&mut visitor, &mut program);
+            oxc_ast_visit::VisitMut::visit_program(&mut visitor, program);
         }
 
         if !sibling_outlined_decls.is_empty() {
-            ox_insert_outlined_after(&mut program, replacement.fn_scope_id, sibling_outlined_decls);
+            ox_insert_outlined_after(program, replacement.fn_scope_id, sibling_outlined_decls);
         }
     }
 
@@ -2636,12 +2685,10 @@ fn ox_splice_program<'a>(
             old_name: "useMemoCache",
             new_name: &import_spec.name,
         };
-        oxc_ast_visit::VisitMut::visit_program(&mut visitor, &mut program);
+        oxc_ast_visit::VisitMut::visit_program(&mut visitor, program);
     }
 
-    ox_add_imports_to_program(ast, &mut program, context);
-
-    program
+    ox_add_imports_to_program(ast, program, context);
 }
 
 /// Insert outlined function declarations immediately after the top-level statement
@@ -2846,8 +2893,8 @@ fn ox_is_non_namespaced_import(import: &oxc::ImportDeclaration) -> bool {
 /// Main entry point for the React Compiler.
 ///
 /// Receives the arena allocator, semantic model, the full program AST, and
-/// resolved options. Returns a CompileResult indicating whether the AST was
-/// modified, along with any logger events.
+/// resolved options. Returns a CompileResult carrying the compiled output to
+/// apply — `None` when nothing changed — along with any diagnostics.
 ///
 /// This function implements the logic from the TS entrypoint (Program.ts):
 /// - findProgramSuppressions: find eslint/flow suppression comments
@@ -2864,11 +2911,11 @@ pub fn compile_program<'a>(
     // before all the setup below, which only compilation needs. The pre-check
     // decides emptiness from semantic data without walking the AST.
     if !may_have_functions_to_compile(semantic, &options) {
-        return CompileResult::Success { ast: None, diagnostics: Diagnostics::new() };
+        return CompileResult::Success { output: None, diagnostics: Diagnostics::new() };
     }
     let queue = find_functions_to_compile(program, &options);
     if queue.is_empty() {
-        return CompileResult::Success { ast: None, diagnostics: Diagnostics::new() };
+        return CompileResult::Success { output: None, diagnostics: Diagnostics::new() };
     }
 
     // Compute output mode once, up front
@@ -2977,7 +3024,7 @@ pub fn compile_program<'a>(
                 ));
             handle_error(&err, None, context.opts.panic_threshold, &mut context.diagnostics);
         }
-        return CompileResult::Success { ast: None, diagnostics: context.diagnostics };
+        return CompileResult::Success { output: None, diagnostics: context.diagnostics };
     }
 
     // Convert compiled functions to owned oxc replacements (dropping the borrows of
@@ -3010,14 +3057,13 @@ pub fn compile_program<'a>(
     // Drop the discovery results (and their borrows of `file.program`).
     drop(queue);
 
-    // `ast` is `None` when nothing was compiled — always so in lint mode, which
-    // applies nothing — skipping `ox_splice_program`'s whole-program clone. Splicing
-    // each compiled function in for its original (matched by the function's scope)
-    // is also what inserts the memo-cache / gating imports, so (matching
-    // TS `addImportsToProgram`) they're added only when there are replacements.
-    CompileResult::Success {
-        ast: (!replacements.is_empty())
-            .then(|| ox_splice_program(&ast, program, &replacements, &mut context)),
-        diagnostics: context.diagnostics,
-    }
+    // `output` is `None` when nothing was compiled — always so in lint mode, which
+    // applies nothing. Substituting each compiled function for its original
+    // (matched by the function's scope) is also what inserts the memo-cache /
+    // gating imports, so (matching TS `addImportsToProgram`) they're added only
+    // when there are replacements.
+    let diagnostics = std::mem::take(&mut context.diagnostics);
+    let output =
+        if replacements.is_empty() { None } else { Some(CompileOutput { replacements, context }) };
+    CompileResult::Success { output, diagnostics }
 }

--- a/crates/oxc_react_compiler/tests/snapshot.rs
+++ b/crates/oxc_react_compiler/tests/snapshot.rs
@@ -2,7 +2,7 @@
 //!
 //! Each input under `fixtures/` (copied from upstream
 //! `babel-plugin-react-compiler/src/__tests__/fixtures/compiler`) is parsed,
-//! analysed, and run through [`oxc_react_compiler::transform`]; the compiled output
+//! analysed, and run through [`oxc_react_compiler::compile`]; the compiled output
 //! plus diagnostics are snapshotted with `insta` into `tests/snapshots/`.
 //!
 //! Per-fixture options come from the first-line `// @directive` pragmas, mirroring
@@ -29,7 +29,7 @@ use oxc_react_compiler::{
     BuiltInTypeRef, CompilationMode, CompilerOutputMode, DynamicGatingConfig, Effect,
     EnvironmentConfig, ExhaustiveEffectDepsMode, ExternalFunctionConfig, FunctionTypeConfig,
     FxIndexMap, GatingConfig, HookTypeConfig, InstrumentationConfig, ObjectTypeConfig,
-    PanicThreshold, PluginOptions, TypeConfig, TypeReferenceConfig, ValueKind, lint, transform,
+    PanicThreshold, PluginOptions, TypeConfig, TypeReferenceConfig, ValueKind, compile, lint,
 };
 use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
@@ -52,7 +52,7 @@ fn normalize_newlines(source: &str) -> String {
 }
 
 /// Parse, analyse, compile, and render the compiled program + diagnostics, plus any
-/// divergence between the read-only `lint` entry point and `transform`.
+/// divergence between the read-only `lint` entry point and `compile`.
 fn run_fixture(source: &str) -> String {
     let (source_type, options) = parse_pragma(source);
     // In lint output mode the compiler validates without rewriting the program, so
@@ -70,22 +70,23 @@ fn run_fixture(source: &str) -> String {
     // Surface parse failures rather than silently compiling a recovered/dummy AST.
     push_diagnostics(&mut out, "Parse errors", parsed.diagnostics.as_slice());
 
-    // `transform` and `lint` both borrow a `Semantic` built from the pristine program;
-    // scope the borrow so it ends before we swap in the compiled program. `transform`
+    // `compile` and `lint` both borrow a `Semantic` built from the pristine program;
+    // scope the borrow so it ends before the output rewrites the program. `compile`
     // runs first on the untouched allocator so its output stays byte-identical to a
-    // transform-only run; `lint` then re-runs the shared `compile` pipeline read-only so
-    // we can cross-check its diagnostics against `transform`'s below.
-    let (mut result, lint_diagnostics) = {
+    // compile-only run; `lint` then re-runs the same pipeline read-only so we can
+    // cross-check its diagnostics against `compile`'s below.
+    let (output, diagnostics, lint_diagnostics) = {
         let semantic = SemanticBuilder::new().with_build_nodes(true).build(&program).semantic;
-        let result = transform(&program, &semantic, &allocator, options.clone());
+        let (output, diagnostics) = compile(&program, &semantic, &allocator, options.clone());
         let lint_diagnostics = lint(&program, &semantic, &allocator, options).diagnostics;
-        (result, lint_diagnostics)
+        (output, diagnostics, lint_diagnostics)
     };
-    if let Some(compiled) = result.program.take() {
-        program = compiled;
+    let changed = output.is_some();
+    if let Some(output) = output {
+        output.transform(&mut program);
     }
 
-    push_diagnostics(&mut out, "Diagnostics", result.diagnostics.as_slice());
+    push_diagnostics(&mut out, "Diagnostics", diagnostics.as_slice());
     // Mirror the upstream `snap` runner, which always re-emits the program as
     // `## Code` unless a hard error turns the output into `## Error`. So when the
     // compiler cleanly declines to change anything (e.g. `@expectNothingCompiled`,
@@ -94,22 +95,22 @@ fn run_fixture(source: &str) -> String {
     // the `No changes.` marker. The marker is kept only when a non-lint run reports
     // an error (parse failure or compile diagnostic), where upstream emits no code —
     // and echoing a parse-recovered AST would be misleading.
-    let clean = parsed.diagnostics.is_empty() && result.diagnostics.as_slice().is_empty();
-    if result.changed || clean || lint_mode {
+    let clean = parsed.diagnostics.is_empty() && diagnostics.as_slice().is_empty();
+    if changed || clean || lint_mode {
         out.push_str(&Codegen::new().build(&program).code);
     } else {
         out.push_str("No changes.");
     }
 
-    // Cross-check the read-only `lint` entry point against `transform`. Both funnel
-    // through the same `compile` pipeline, so their diagnostics are identical for almost
+    // Cross-check the read-only `lint` entry point against `compile`. Both funnel
+    // through the same pipeline, so their diagnostics are identical for almost
     // every fixture. They diverge only where the pipeline gates a validation on lint
     // output mode: `@validateNoSetStateInEffects` / `@validateNoJSXInTryStatements` /
     // `@validateStaticComponents` / `@validateNoDerivedComputationsInEffectsExp` fixtures
     // gain lint-only findings, while `@enableEmitHookGuards` conversely errors only when
     // emitting. Surface any divergence in the snapshot so it stays reviewed rather than
     // drifting silently.
-    let transform_body = diagnostics_body(result.diagnostics.as_slice());
+    let transform_body = diagnostics_body(diagnostics.as_slice());
     let lint_body = diagnostics_body(lint_diagnostics.as_slice());
     if lint_body != transform_body {
         out.push_str("\n\nLint-mode diagnostics (differ from transform):\n\n");

--- a/crates/oxc_react_compiler/tests/transform.rs
+++ b/crates/oxc_react_compiler/tests/transform.rs
@@ -3,14 +3,20 @@
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{ModuleExportName, Program, Statement};
 use oxc_codegen::Codegen;
+use oxc_diagnostics::Diagnostics;
 use oxc_parser::Parser;
 use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
 
-use oxc_react_compiler::{PluginOptions, TransformResult, transform};
+use oxc_react_compiler::{PluginOptions, compile};
 
 fn options() -> PluginOptions {
     PluginOptions::default()
+}
+
+struct TransformResult {
+    changed: bool,
+    diagnostics: Diagnostics,
 }
 
 /// Parse `source_text` then run the compiler in place, returning the
@@ -20,16 +26,17 @@ fn transform_source<'a>(
     source_type: SourceType,
     allocator: &'a Allocator,
     options: PluginOptions,
-) -> (Program<'a>, TransformResult<'a>) {
+) -> (Program<'a>, TransformResult) {
     let mut program = Parser::new(allocator, source_text, source_type).parse().program;
-    let mut result = {
+    let (output, diagnostics) = {
         let semantic = SemanticBuilder::new().with_build_nodes(true).build(&program).semantic;
-        transform(&program, &semantic, allocator, options)
+        compile(&program, &semantic, allocator, options)
     };
-    if let Some(compiled) = result.program.take() {
-        program = compiled;
+    let changed = output.is_some();
+    if let Some(output) = output {
+        output.transform(&mut program);
     }
-    (program, result)
+    (program, TransformResult { changed, diagnostics })
 }
 
 #[test]
@@ -403,9 +410,9 @@ fn diagnostics_preserve_compiler_severity() {
     );
 }
 
-/// Compilation clones the source program, so top-level comments survive; comments
-/// inside a compiled function are pruned because their anchor no longer resolves to
-/// a statement (see `prune_inner_comments`).
+/// The transform only rewrites the compiled functions, so top-level comments
+/// survive; comments inside a compiled function are pruned because their anchor no
+/// longer resolves to a statement (see `prune_inner_comments`).
 #[test]
 fn top_level_comments_are_preserved() {
     let source = "\

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -11,7 +11,7 @@ use oxc_allocator::{Allocator, ArenaVec, ReplaceWith};
 use oxc_ast::{ast::*, builder::AstBuilder};
 use oxc_diagnostics::Diagnostics;
 #[cfg(feature = "react_compiler")]
-use oxc_react_compiler::{PluginOptions, transform as react_compiler_transform};
+use oxc_react_compiler::{PluginOptions, compile as react_compiler_compile};
 use oxc_semantic::Scoping;
 #[cfg(feature = "react_compiler")]
 use oxc_semantic::SemanticBuilder;
@@ -228,17 +228,17 @@ impl<'a> Transformer<'a> {
         let Some(options) = self.react_compiler.take() else {
             return (scoping, Diagnostics::new());
         };
-        let mut result = {
+        let (output, diagnostics) = {
             let semantic = SemanticBuilder::new().with_build_nodes(true).build(program).semantic;
-            react_compiler_transform(program, &semantic, self.allocator, options)
+            react_compiler_compile(program, &semantic, self.allocator, options)
         };
-        if !result.changed {
-            return (scoping, result.diagnostics);
-        }
-        *program = result.program.take().expect("changed result should include a program");
+        let Some(output) = output else {
+            return (scoping, diagnostics);
+        };
+        output.transform(program);
         let scoping =
             SemanticBuilder::new().with_enum_eval(true).build(program).semantic.into_scoping();
-        (scoping, result.diagnostics)
+        (scoping, diagnostics)
     }
 }
 

--- a/tasks/benchmark/benches/react_compiler.rs
+++ b/tasks/benchmark/benches/react_compiler.rs
@@ -1,7 +1,7 @@
 use oxc_allocator::Allocator;
 use oxc_benchmark::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use oxc_parser::{Parser, ParserReturn};
-use oxc_react_compiler::{PluginOptions, transform};
+use oxc_react_compiler::{PluginOptions, compile};
 use oxc_semantic::SemanticBuilder;
 use oxc_tasks_common::TestFiles;
 
@@ -30,15 +30,15 @@ fn bench_react_compiler(criterion: &mut Criterion) {
                     Parser::new(&allocator, source_text, source_type).parse();
 
                 runner.run(|| {
-                    let mut result = {
+                    let (output, diagnostics) = {
                         let semantic =
                             SemanticBuilder::new().with_build_nodes(true).build(&program).semantic;
-                        transform(&program, &semantic, &allocator, options.clone())
+                        compile(&program, &semantic, &allocator, options.clone())
                     };
-                    if let Some(compiled) = result.program.take() {
-                        program = compiled;
+                    if let Some(output) = output {
+                        output.transform(&mut program);
                     }
-                    result
+                    diagnostics
                 });
             });
         });


### PR DESCRIPTION
Splits `oxc_react_compiler`'s public API into two phases so the transform rewrites the caller's program in place instead of returning a whole-program clone:

- `compile(&Program, &Semantic, &Allocator, PluginOptions) -> (Option<CompileOutput>, Diagnostics)` — read-only; `None` means no changes (or error / lint output mode).
- `CompileOutput::transform(self, &mut Program, &Allocator)` — substitutes the compiled functions into the program in place. `CompileOutput` owns only arena data (replacements + `ProgramContext`), so the caller drops its `Semantic` between the two calls, releasing the shared borrow that previously forced `ox_splice_program` to `clone_in_with_semantic_ids` the entire program.
- `lint` is unchanged and structurally never runs the transform phase; the oxlint rule needed no changes.

The old `transform` free function and `TransformResult` are removed; `oxc_transformer` no longer does the `*program = result.program.take()` swap and just applies the output to its `&mut Program`.

The 1806-fixture snapshot corpus is byte-identical, and the transform path drops one whole-program clone per compiled file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)