### PR TITLE
refactor(react_compiler): reserve memo cache import name to remove rename pass

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/imports.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/imports.rs
@@ -45,6 +45,7 @@ pub struct ProgramContext<'a> {
     pub instrument_fn_name: Option<Ident<'a>>,
     pub instrument_gating_name: Option<Ident<'a>>,
     pub hook_guard_name: Option<Ident<'a>>,
+    pub memo_cache_name: Option<Ident<'a>>,
 
     // Internal state
     known_referenced_names: IdentHashSet<'a>,
@@ -71,6 +72,7 @@ impl<'a> ProgramContext<'a> {
             instrument_fn_name: None,
             instrument_gating_name: None,
             hook_guard_name: None,
+            memo_cache_name: None,
             known_referenced_names: IdentHashSet::default(),
             imports: FxHashMap::default(),
         }
@@ -135,10 +137,30 @@ impl<'a> ProgramContext<'a> {
         }
     }
 
-    /// Add the memo cache import (the `c` function from the compiler runtime).
-    pub fn add_memo_cache_import(&mut self) -> NonLocalImportSpecifier<'a> {
-        let module = self.react_runtime_module.clone();
-        self.add_import_specifier(&module, "c", Some("_c"))
+    /// Reserve the memo cache import's local name (`_c`, `_c2`, ...) before compilation
+    /// so codegen can emit it directly. Also avoids names only referenced as globals
+    /// (Babel's `generateUid` checks `hasGlobal`); `known_referenced_names` cannot see
+    /// globals in functions that have not compiled yet. Mirrors `new_uid("_c")`.
+    pub fn reserve_memo_cache_name(&mut self, scope: &ScopeResolver<'_, 'a>) {
+        let mut name = Ident::from("_c");
+        let mut i = 2;
+        while self.has_reference(&name) || scope.has_unresolved_reference(&name) {
+            name = format_ident!(self.allocator, "_c{i}");
+            i += 1;
+        }
+        self.known_referenced_names.insert(name);
+        self.memo_cache_name = Some(name);
+    }
+
+    /// Register the memo cache import (the `c` function from the compiler runtime) under
+    /// the local name reserved by [`Self::reserve_memo_cache_name`].
+    pub fn add_memo_cache_import(&mut self) {
+        let name = self.memo_cache_name.expect("memo cache name reserved in compile_program");
+        let binding = NonLocalImportSpecifier { name, imported: Ident::from("c") };
+        self.imports
+            .entry(self.react_runtime_module.to_string())
+            .or_default()
+            .insert("c".to_string(), binding);
     }
 
     /// Add an import specifier, reusing an existing one if it was already added.

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
@@ -149,6 +149,7 @@ fn run_pipeline<'a>(
     env.instrument_fn_name = context.instrument_fn_name;
     env.instrument_gating_name = context.instrument_gating_name;
     env.hook_guard_name = context.hook_guard_name;
+    env.memo_cache_name = context.memo_cache_name;
     env.seed_uid_known_names(context.known_referenced_names());
 
     let mut hir = lower(func, scope, &mut env)?;
@@ -362,11 +363,12 @@ fn run_pipeline<'a>(
         codegen_function(ast, &reactive_fn, &mut env, unique_identifiers, fbt_operands)?;
 
     // NOTE: we intentionally do NOT register the memo cache import here.
-    // The import is registered in apply_compiled_functions() only for functions
-    // that are actually applied to the output. Registering it here would cause
-    // a spurious `import { c as _c }` when a function compiles with memo slots
-    // but is later discarded (e.g., due to "use no memo" opt-out or errors),
-    // while other functions in the same file compile to 0 memo slots.
+    // The local name is reserved up front by `ProgramContext::reserve_memo_cache_name`,
+    // and the import itself is registered in `ox_transform_program` only when an applied
+    // function uses memo slots. Registering it here would cause a spurious
+    // `import { c as _c }` when a function compiles with memo slots but is later
+    // discarded (e.g., due to "use no memo" opt-out or errors), while other functions
+    // in the same file compile to 0 memo slots.
 
     // Stage 2 Phase 1: `validate_source_locations` operated on the Babel-shaped
     // codegen result and is disabled while the oxc emission is stubbed. It will be

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -2477,24 +2477,8 @@ impl<'a, 'b> oxc_ast_visit::VisitMut<'a> for OxcReplaceWithGatedVisitor<'a, 'b> 
     }
 }
 
-/// Visitor that renames every identifier reference matching `old_name` to `new_name`.
-/// Mirrors the Babel `RenameIdentifierVisitor` (used to rename `useMemoCache`).
-struct OxcRenameIdentifierVisitor<'a, 'b> {
-    ast: &'b AstBuilder<'a>,
-    old_name: &'b str,
-    new_name: &'b str,
-}
-
-impl<'a, 'b> oxc_ast_visit::VisitMut<'a> for OxcRenameIdentifierVisitor<'a, 'b> {
-    fn visit_identifier_reference(&mut self, ident: &mut oxc::IdentifierReference<'a>) {
-        if ident.name == self.old_name {
-            ident.name = ox_atom(self.ast, self.new_name).into();
-        }
-    }
-}
-
 /// Allocate a `&'a str` in the arena (satisfies the builders' `Into<Ident>` /
-/// `IntoIn` slots; convert to `Atom` via `.into()` where a bare `Atom` is needed).
+/// `IntoIn` slots).
 fn ox_atom<'a>(ast: &AstBuilder<'a>, s: &str) -> &'a str {
     oxc_allocator::StringBuilder::from_str_in(s, ast.allocator()).into_str()
 }
@@ -2676,16 +2660,9 @@ fn ox_transform_program<'a>(
     // the top level.
     program.body.extend(appended_outlined_decls);
 
-    // Register the memo cache import and rename `useMemoCache` references.
-    let needs_memo_import = replacements.iter().any(|r| r.codegen_fn.memo_slots_used > 0);
-    if needs_memo_import {
-        let import_spec = context.add_memo_cache_import();
-        let mut visitor = OxcRenameIdentifierVisitor {
-            ast,
-            old_name: "useMemoCache",
-            new_name: &import_spec.name,
-        };
-        oxc_ast_visit::VisitMut::visit_program(&mut visitor, program);
+    // Register the memo cache import; codegen emitted its pre-reserved local name.
+    if replacements.iter().any(|r| r.codegen_fn.memo_slots_used > 0) {
+        context.add_memo_cache_import();
     }
 
     ox_add_imports_to_program(ast, program, context);
@@ -2997,6 +2974,11 @@ pub fn compile_program<'a>(
     context.instrument_fn_name = instrument_fn_name;
     context.instrument_gating_name = instrument_gating_name;
     context.hook_guard_name = hook_guard_name;
+
+    // Reserve the memo-cache import's local name (`_c`, `_c2`, ...) up front so codegen
+    // can emit it directly; the import itself is registered in `ox_transform_program`,
+    // and only when an applied function uses memo slots.
+    context.reserve_memo_cache_name(&scope);
 
     // Process each function and collect compiled results
     let mut compiled_fns: Vec<CompiledFunction<'_, '_, '_, '_>> = Vec::new();

--- a/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
@@ -68,11 +68,12 @@ pub struct Environment<'a> {
     // Output mode (Client, Ssr, Lint)
     pub output_mode: OutputMode,
 
-    // Pre-resolved import local names for instrumentation/hook guards.
+    // Pre-resolved import local names for instrumentation/hook guards/memo cache.
     // Set by the program-level code before compilation.
     pub instrument_fn_name: Option<Ident<'a>>,
     pub instrument_gating_name: Option<Ident<'a>>,
     pub hook_guard_name: Option<Ident<'a>>,
+    pub memo_cache_name: Option<Ident<'a>>,
 
     // Renames from lowering (collision suffixes like `name_0`), recorded per
     // resolved reference so codegen can rename identifiers inside preserved TS
@@ -183,6 +184,7 @@ impl<'a> Environment<'a> {
             instrument_fn_name: None,
             instrument_gating_name: None,
             hook_guard_name: None,
+            memo_cache_name: None,
             renames: FxHashMap::default(),
             hoisted_identifiers: FxHashSet::default(),
             validate_preserve_existing_memoization_guarantees: config

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
@@ -4,7 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 //! Code generation pass: converts a `ReactiveFunction` tree back into a Babel-compatible
-//! AST with memoization (useMemoCache) wired in.
+//! AST with memoization (the memo-cache import) wired in.
 //!
 //! This is the final pass in the compilation pipeline.
 //!
@@ -130,10 +130,12 @@ pub fn codegen_function<'a>(
     let cache_count = compiled.memo_slots_used;
     if cache_count != 0 {
         let cache_name = cx.synthesize_name("$");
-        // const $ = useMemoCache(N)
+        let memo_cache_name =
+            cx.env.memo_cache_name.expect("memo cache name reserved in compile_program");
+        // const $ = _c(N)
         let use_memo_cache = oxc_ast::ast::Expression::new_call_expression(
             SPAN,
-            oxc_ast::ast::Expression::new_identifier(SPAN, "useMemoCache", ast),
+            oxc_ast::ast::Expression::new_identifier(SPAN, memo_cache_name, ast),
             None::<oxc_allocator::Box<oxc_ast::ast::TSTypeParameterInstantiation>>,
             oxc_allocator::ArenaVec::from_value_in(
                 oxc_ast::ast::Argument::from(ox_number(ast, cache_count as f64)),

--- a/crates/oxc_react_compiler/src/scope.rs
+++ b/crates/oxc_react_compiler/src/scope.rs
@@ -444,6 +444,11 @@ impl<'s, 'a> ScopeResolver<'s, 'a> {
         self.scoping().find_binding(scope_id, name.into())
     }
 
+    /// Whether `name` is referenced as a global (unresolved reference) anywhere in the file.
+    pub fn has_unresolved_reference(&self, name: &str) -> bool {
+        self.scoping().root_unresolved_references().contains_key(name)
+    }
+
     /// Bindings declared directly in a scope.
     pub fn bindings_in(&self, scope_id: ScopeId) -> impl Iterator<Item = SymbolId> + '_ {
         self.scoping().iter_bindings_in(scope_id)


### PR DESCRIPTION
## What

Removes `OxcRenameIdentifierVisitor` — the whole-program pass that patched a `useMemoCache` placeholder callee into the real memo-cache import local (`_c`) after codegen.

Codegen used to emit `const $ = useMemoCache(N)` with a placeholder, and `ox_transform_program` minted the real name at splice time and walked the entire program renaming it (mirroring the Babel plugin's placeholder-then-rename dance).

Instead, the name is now **reserved up front**:

- `ProgramContext::reserve_memo_cache_name` mints `_c`/`_c2`/… before compilation, next to the existing instrument/hook-guard pre-resolved names.
- It flows into each per-function `Environment::memo_cache_name`, and codegen emits it directly at the `const $ = _c(N)` preface.
- The import itself stays **deferred** — registered in `ox_transform_program` only when an applied function actually uses memo slots (unchanged gate), so no spurious imports.

## Why the collision behavior is preserved

The old late mint saw globals referenced *inside* compiled functions (via `rename_variables`' returned set), so a file referencing a global literally named `_c` correctly picked `_c2`. An up-front mint can't see those yet, so `reserve_memo_cache_name` also checks the file's `root_unresolved_references` — a superset — keeping the name choice byte-identical, and as a bonus avoiding a shadowed module-level `_c` (closer to Babel's `generateUid` `hasGlobal` check).

## Result

Byte-identical output across the full 1806-fixture snapshot corpus (`cargo test -p oxc_react_compiler`, zero `.snap` changes). Clippy (`CARGO_BUILD_WARNINGS=deny`) and rustdoc (`-D warnings`) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)