### PR TITLE
refactor(linter): remove dead code

### DIFF
--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -16,7 +16,6 @@ use crate::{
     config::{
         ESLintRule, OxlintOverrides, OxlintRules,
         external_plugins::ExternalPluginEntry,
-        overrides::OxlintOverride,
         plugins::{LintPlugins, is_normal_plugin_name, normalize_plugin_name},
         rules::OverrideRulesError,
     },
@@ -341,11 +340,6 @@ impl ConfigStoreBuilder {
         self
     }
 
-    pub fn with_categories(mut self, categories: OxlintCategories) -> Self {
-        self.categories = categories;
-        self
-    }
-
     /// Enable or disable a set of plugins, leaving unrelated plugins alone.
     ///
     /// See [`ConfigStoreBuilder::with_builtin_plugins`] for details on how plugin configuration affects your
@@ -389,12 +383,6 @@ impl ConfigStoreBuilder {
     #[cfg(test)]
     pub(crate) fn with_rule(mut self, rule: RuleEnum, severity: AllowWarnDeny) -> Self {
         self.rules.insert(rule, severity);
-        self
-    }
-
-    /// Appends an override to the end of the current list of overrides.
-    pub fn with_overrides<O: IntoIterator<Item = OxlintOverride>>(mut self, overrides: O) -> Self {
-        self.overrides.extend(overrides);
         self
     }
 

--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -14,8 +14,7 @@ use oxc_span::Span;
 #[cfg(debug_assertions)]
 use crate::rule::RuleFixMeta;
 use crate::{
-    AllowWarnDeny, FrameworkFlags, ModuleRecord, OxlintEnv, OxlintGlobals, OxlintSettings,
-    WEBSITE_BASE_RULES_URL,
+    FrameworkFlags, ModuleRecord, OxlintEnv, OxlintGlobals, OxlintSettings, WEBSITE_BASE_RULES_URL,
     config::GlobalValue,
     disable_directives::DisableDirectives,
     fixer::{Fix, FixKind, Message, MessageRule, PossibleFixes, RuleFix, RuleFixer},
@@ -72,34 +71,6 @@ impl<'a> Deref for LintContext<'a> {
 }
 
 impl<'a> LintContext<'a> {
-    /// Set the plugin name for the current rule.
-    pub fn with_plugin_name(mut self, plugin: &'static str) -> Self {
-        self.current_plugin_name = plugin;
-        self.current_plugin_display_name = plugin_display_name(plugin);
-        self
-    }
-
-    /// Set the current rule name. Name should be kebab-cased like: `no-unused-vars` or `no-undef`.
-    pub fn with_rule_name(mut self, name: &'static str) -> Self {
-        self.current_rule_name = name;
-        self
-    }
-
-    /// Set the current rule fix capabilities. See [`RuleFixMeta`] for more information.
-    #[cfg(debug_assertions)]
-    pub fn with_rule_fix_capabilities(mut self, capabilities: RuleFixMeta) -> Self {
-        self.current_rule_fix_capabilities = capabilities;
-        self
-    }
-
-    /// Update the severity of diagnostics reported by the rule this context is
-    /// associated with.
-    #[inline]
-    pub fn with_severity(mut self, severity: AllowWarnDeny) -> Self {
-        self.severity = Severity::from(severity);
-        self
-    }
-
     /// Get information such as the control flow graph, bound symbols, AST, etc.
     /// for the file being linted.
     ///

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -563,11 +563,6 @@ impl RuleFixMeta {
         matches!(self, Self::Fixable(_) | Self::Conditional(_))
     }
 
-    #[inline]
-    pub fn is_pending(self) -> bool {
-        matches!(self, Self::FixPending)
-    }
-
     pub fn supports_fix(self, kind: FixKind) -> bool {
         matches!(self, Self::Fixable(fix_kind) | Self::Conditional(fix_kind) if fix_kind.can_apply(kind))
     }

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/options.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/options.rs
@@ -416,11 +416,6 @@ pub enum ArgsOption {
 }
 impl ArgsOption {
     #[inline]
-    pub const fn is_after_used(&self) -> bool {
-        matches!(self, Self::AfterUsed)
-    }
-
-    #[inline]
     pub const fn is_all(&self) -> bool {
         matches!(self, Self::All)
     }


### PR DESCRIPTION
AI Disclosure: This was generated with Claude Code, reviewed by me for correctness and to ensure none of this was code that has been modified recently and is in the middle of being modified (none of it is).

Removes 8 functions in `oxc_linter` that no longer have any callers and haven't been touched in >6 months.

- **`LintContext::with_plugin_name` / `with_rule_name` / `with_rule_fix_capabilities` / `with_severity`** — `ContextHost::spawn` and `spawn_for_test` construct `LintContext` with struct literals and set every one of these fields directly, so the builder methods are never called.
- **`ConfigStoreBuilder::with_categories` / `with_overrides`** — the `categories` and `overrides` fields are populated through other paths.
- **`RuleFixMeta::is_pending`**.
- **`ArgsOption::is_after_used`** — its siblings `is_all` and `is_none` are both live in `allowed.rs`, but the `AfterUsed` case is handled there with a `debug_assert_eq!` against the variant instead, so this accessor never got a caller.

Also drops two imports that became unused.

This is arguably a breaking change as all of these are public methods? I'm not sure if that was the reason for us keeping them around or if these were all mistakenly left behind. And I don't believe we encourage usage of/publish the linter to crates.io anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)