### PR TITLE
perf(linter/jest/valid-title): compile disallowedWords regex once

### DIFF
--- a/crates/oxc_linter/src/rules/shared/jest_vitest/valid_title.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/valid_title.rs
@@ -120,8 +120,9 @@ pub struct ValidTitleConfig {
     ignore_type_of_describe_name: bool,
     /// Whether to allow arguments as titles.
     allow_arguments: bool,
-    /// A list of disallowed words, which will not be allowed in titles.
-    disallowed_words: Vec<CompactStr>,
+    /// Matcher for disallowed words, which will not be allowed in titles.
+    /// `None` when no disallowed words are configured.
+    disallowed_words_reg: Option<Regex>,
     /// Whether to ignore leading and trailing spaces in titles.
     ignore_spaces: bool,
     /// Patterns for titles that must not match.
@@ -147,11 +148,17 @@ impl ValidTitleConfig {
         let ignore_type_of_describe_name = get_as_bool("ignoreTypeOfDescribeName");
         let allow_arguments = get_as_bool("allowArguments");
         let ignore_spaces = get_as_bool("ignoreSpaces");
-        let disallowed_words = config
+        let disallowed_words: Vec<&str> = config
             .and_then(|v| v.get("disallowedWords"))
             .and_then(|v| v.as_array())
-            .map(|v| v.iter().filter_map(|v| v.as_str().map(CompactStr::from)).collect())
+            .map(|v| v.iter().filter_map(|v| v.as_str()).collect())
             .unwrap_or_default();
+        let disallowed_words_reg = (!disallowed_words.is_empty()).then(|| {
+            let disallowed_words_pattern =
+                disallowed_words.iter().map(|word| regex::escape(word)).join("|");
+            Regex::new(&format!(r"(?iu)\b(?:{disallowed_words_pattern})\b"))
+                .expect("escaped disallowed words should form a valid regex")
+        });
         let must_not_match_patterns = config
             .and_then(|v| v.get("mustNotMatch"))
             .and_then(compile_matcher_patterns)
@@ -165,7 +172,7 @@ impl ValidTitleConfig {
             ignore_type_of_test_name,
             ignore_type_of_describe_name,
             allow_arguments,
-            disallowed_words,
+            disallowed_words_reg,
             ignore_spaces,
             must_not_match_patterns,
             must_match_patterns,
@@ -407,12 +414,7 @@ fn validate_title(
         return;
     }
 
-    if !config.disallowed_words.is_empty() {
-        let disallowed_words_pattern =
-            config.disallowed_words.iter().map(|word| regex::escape(word)).join("|");
-        let disallowed_words_reg = Regex::new(&format!(r"(?iu)\b(?:{disallowed_words_pattern})\b"))
-            .expect("escaped disallowed words should form a valid regex");
-
+    if let Some(disallowed_words_reg) = &config.disallowed_words_reg {
         if let Some(matched) = disallowed_words_reg.find(title) {
             ctx.diagnostic(disallowed_word_diagnostic(matched.as_str(), span));
         }


### PR DESCRIPTION
The `disallowedWords` regex in `jest/valid-title` (shared with `vitest/valid-title`) was escaped, joined, and recompiled for every `test`/`describe` title checked. This moves the compilation into `from_configuration`, storing a compiled `Option<Regex>` on the config.

### Benchmark

**Fixture:** a generated `spec.test.js` containing 30,000 one-line test cases of the form

```js
test("does thing number 12345 correctly", () => { expect(12345).toBe(12345); });
```

None of the titles contain a disallowed word, so the fixture measures the pure per-title overhead of the rule (the common case in a real suite); output parity on the reporting path was verified separately with a canary file whose titles do contain disallowed words.

**Config:** a single-rule `.oxlintrc.json` so nothing else contributes to the timing:

```json
{
  "plugins": ["jest"],
  "categories": { "correctness": "off" },
  "rules": { "jest/valid-title": ["warn", { "disallowedWords": ["forbidden", "banned", "xyzzy"] }] }
}
```

**Method:** two release binaries (baseline from `main`, this branch), run interleaved in alternating order for 40 paired samples (plus 5 warmup runs each) with `--silent`, timed with `time.monotonic_ns()`. A parse-only config (`"rules": {}`) run on the same fixture showed no difference between the binaries (0.995×, t=-0.9), so the delta is attributable to the rule and not binary-layout noise.

| | mean |
|---|---|
| before | 2161.19 ms |
| after | 28.89 ms |

**74.8× faster** (paired t=651, 40/40 wins). The magnitude scales with title count × number of disallowed words; suites that don't set `disallowedWords` are unaffected (the rule already early-returns). `--format=json` output is byte-identical between the two binaries on the fixture and canaries.

### Disclosure

This change was implemented and benchmarked with AI assistance (Claude Code), and has been reviewed by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)