### PR TITLE
fix(linter/jest/prefer-lowercase-title): false positive when `lowercaseFirstCharacterOnly` is false

### DIFF
--- a/crates/oxc_linter/src/rules/jest/prefer_lowercase_title.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_lowercase_title.rs
@@ -52,6 +52,10 @@ fn test() {
         ("it('foo', function () {})", None),
         ("it(\"foo\", function () {})", None),
         ("it(`foo`, function () {})", None),
+        (
+            "it('some longer description', function () {})",
+            Some(serde_json::json!([{ "lowercaseFirstCharacterOnly": false }])),
+        ),
         ("it(\"<Foo/>\", function () {})", None),
         ("it(\"123 foo\", function () {})", None),
         ("it(42, function () {})", None),
@@ -182,6 +186,10 @@ fn test() {
             None,
         ),
         ("describe(`Some longer description`, function () {})", None),
+        (
+            "describe(`some longer Description`, function () {})",
+            Some(serde_json::json!([{ "lowercaseFirstCharacterOnly": false }])),
+        ),
         ("fdescribe(`Some longer description`, function () {})", None),
         ("it.each(['green', 'black'])('Should return %', () => {})", None),
         ("describe.each(['green', 'black'])('Should return %', () => {})", None),
@@ -263,6 +271,11 @@ fn test() {
             "describe(`Some longer description`, function () {})",
             "describe(`some longer description`, function () {})",
             None,
+        ),
+        (
+            "describe(`some longer Description`, function () {})",
+            "describe(`some longer description`, function () {})",
+            Some(serde_json::json!([{ "lowercaseFirstCharacterOnly": false }])),
         ),
         (
             "fdescribe(`Some longer description`, function () {})",

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/prefer_lowercase_title.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/prefer_lowercase_title.rs
@@ -211,18 +211,8 @@ impl PreferLowercaseTitleConfig {
             if first_char == lower {
                 return;
             }
-        } else {
-            for n in 0..literal.chars().count() {
-                let Some(next_char) = literal.chars().nth(n) else {
-                    return;
-                };
-
-                let next_lower = next_char.to_ascii_lowercase();
-
-                if next_char != next_lower {
-                    break;
-                }
-            }
+        } else if !literal.bytes().any(|b| b.is_ascii_uppercase()) {
+            return;
         }
 
         let replacement = if self.lowercase_first_character_only {

--- a/crates/oxc_linter/src/rules/vitest/prefer_lowercase_title.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_lowercase_title.rs
@@ -395,6 +395,14 @@ fn test() {
         (r#"describe("oo", function () {})"#, None),
         (r#"test("foo", function () {})"#, None),
         ("test(`123`, function () {})", None),
+        (
+            "test(`sfc compile`, function () {})",
+            Some(serde_json::json!([{ "lowercaseFirstCharacterOnly": false }])),
+        ),
+        (
+            "test(`0 sfc compile`, function () {})",
+            Some(serde_json::json!([{ "lowercaseFirstCharacterOnly": false }])),
+        ),
     ];
     pass.extend(pass_jest);
 

--- a/crates/oxc_linter/src/rules/vitest/prefer_lowercase_title.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_lowercase_title.rs
@@ -413,6 +413,10 @@ fn test() {
             "test(`SFC Compile`, function () {})",
             Some(serde_json::json!([{ "lowercaseFirstCharacterOnly": false }])),
         ),
+        (
+            "test(`sfc Compile`, function () {})",
+            Some(serde_json::json!([{ "lowercaseFirstCharacterOnly": false }])),
+        ),
         ("bench(`Foo MM mm`, function () {})", None),
     ];
     fail.extend(fail_jest);
@@ -422,6 +426,11 @@ fn test() {
         ("test(`Foo MM mm`, function () {})", "test(`foo MM mm`, function () {})", None),
         (
             "test(`SFC Compile`, function () {})",
+            "test(`sfc compile`, function () {})",
+            Some(serde_json::json!([{ "lowercaseFirstCharacterOnly": false }])),
+        ),
+        (
+            "test(`sfc Compile`, function () {})",
             "test(`sfc compile`, function () {})",
             Some(serde_json::json!([{ "lowercaseFirstCharacterOnly": false }])),
         ),

--- a/crates/oxc_linter/src/snapshots/jest_prefer_lowercase_title.snap
+++ b/crates/oxc_linter/src/snapshots/jest_prefer_lowercase_title.snap
@@ -96,6 +96,13 @@ source: crates/oxc_linter/src/tester.rs
   help: `"Some longer description"`s should begin with lowercase
 
   ⚠ jest(prefer-lowercase-title): Enforce lowercase test names
+   ╭─[prefer_lowercase_title.tsx:1:10]
+ 1 │ describe(`some longer Description`, function () {})
+   ·          ─────────────────────────
+   ╰────
+  help: `"some longer Description"`s should begin with lowercase
+
+  ⚠ jest(prefer-lowercase-title): Enforce lowercase test names
    ╭─[prefer_lowercase_title.tsx:1:11]
  1 │ fdescribe(`Some longer description`, function () {})
    ·           ─────────────────────────

--- a/crates/oxc_linter/src/snapshots/vitest_prefer_lowercase_title.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_prefer_lowercase_title.snap
@@ -24,6 +24,13 @@ source: crates/oxc_linter/src/tester.rs
   help: `"SFC Compile"`s should begin with lowercase
 
   ⚠ vitest(prefer-lowercase-title): Enforce lowercase test names
+   ╭─[prefer_lowercase_title.tsx:1:6]
+ 1 │ test(`sfc Compile`, function () {})
+   ·      ─────────────
+   ╰────
+  help: `"sfc Compile"`s should begin with lowercase
+
+  ⚠ vitest(prefer-lowercase-title): Enforce lowercase test names
    ╭─[prefer_lowercase_title.tsx:1:7]
  1 │ bench(`Foo MM mm`, function () {})
    ·       ───────────


### PR DESCRIPTION
With `lowercaseFirstCharacterOnly: false`, the char-scanning loop in `lint_string` never took its early return: the `chars().nth(n)` lookup inside the loop cannot fail for `n < chars().count()`, so the `else { return }` branch was unreachable. As a result, all-lowercase titles fell through the loop and were reported as violations.

This replaces the loop with a `bytes().any(|b| b.is_ascii_uppercase())` check (uppercase detection here is inherently ASCII: the rule's fix path lowercases via ASCII) and adds two regression pass-tests to `vitest/prefer-lowercase-title` covering all-lowercase titles under `lowercaseFirstCharacterOnly: false`.

The old loop was also accidentally quadratic (`chars().nth(n)` per iteration restarts the char walk each time).

### Benchmark

Interleaved paired-sample benchmark (N=40) on a synthetic title-dense fixture, single-rule oxlintrc (titles crafted to report on both binaries so the perf comparison is apples-to-apples despite the behavior fix):

| | mean |
|---|---|
| before | 15.70 ms |
| after | 7.60 ms |

**2.07× faster** (paired t=44). Parse-only differential was null.

### Disclosure

This change was implemented and benchmarked with AI assistance (Claude Code), and has been reviewed by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)