### PR TITLE
Fixing issue 24405 react compiler false positive

### DIFF
--- a/crates/oxc_linter/src/rules/react/react_compiler.rs
+++ b/crates/oxc_linter/src/rules/react/react_compiler.rs
@@ -308,6 +308,30 @@ function Component(props) {
             }",
             None,
         ),
+        // BigInt built-in should not be flagged
+        (
+            "function Component({ value }) {
+              const id = BigInt(value);
+              return <div>{id.toString()}</div>;
+        }",
+            None,
+        ),
+        // Number built-in should not be flagged
+        (
+            "function Component({ value }) {
+              const n = Number(value);
+              return <div>{n}</div>;
+        }",
+            None,
+        ),
+        // String built-in should not be flagged
+        (
+            "function Component({ value }) {
+              const s = String(value);
+              return <div>{s}</div>;
+        }",
+            None,
+        ),
     ];
 
     let fail = vec![

--- a/crates/oxc_react_compiler/src/react_compiler_hir/globals.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/globals.rs
@@ -1530,6 +1530,12 @@ const UNTYPED_GLOBALS: &[&str] = &[
     "JSON",
     "console",
     "eval",
+    "BigInt",
+    "Number",
+    "String",
+    "Boolean",
+    "Symbol",
+    "Array",
 ];
 
 /// Build the React API types (REACT_APIS from TS). Returns the list of (name, type) pairs


### PR DESCRIPTION
The problem was that the `react/react-compiler`'s `CapitalizedCalls` check was firing on built-in JavaScript globals like `BigInt()`, `Number()`, `String()` etc. because they start with a capital letter. The rule was treating them as potential React components.

The fix adds the missing built-ins to `UNTYPED_GLOBALS` in the global registry so they are recognized as known globals and excluded from the check. this fixes #24405

i also added test cases for `BigInt`, `Number` and `String` to the existing `react/react-compiler` test suite. 