### PR TITLE
perf(linter): compute comment fix span only for directive comments

### DIFF
--- a/crates/oxc_linter/src/disable_directives.rs
+++ b/crates/oxc_linter/src/disable_directives.rs
@@ -546,10 +546,6 @@ impl DisableDirectivesBuilder {
             // `comment.span` is the full outer span (including `//` or `/* */` delimiters).
             // It is used as the diagnostic span.
             let outer_span = comment.span;
-            // Pre-compute the fix span for this comment:
-            // - whole line (incl. leading whitespace + newline) if the comment is alone on the line
-            // - outer comment span (incl. `//` / `/* */` delimiters) otherwise
-            let comment_fix_span = Self::compute_comment_fix_span(comment, source_text);
             let text_source = comment_span.source_text(source_text);
             let text = text_source.trim_start();
             let Some((directive_prefix, directive_kind, rule_list_text)) =
@@ -557,6 +553,11 @@ impl DisableDirectivesBuilder {
             else {
                 continue;
             };
+
+            // Pre-compute the fix span for this directive comment:
+            // - whole line (incl. leading whitespace + newline) if the comment is alone on the line
+            // - outer comment span (incl. `//` / `/* */` delimiters) otherwise
+            let comment_fix_span = Self::compute_comment_fix_span(comment, source_text);
 
             let rule_names = Self::collect_rule_names(rule_list_text);
             let rule_list_start = comment_span.end - rule_list_text.len() as u32;


### PR DESCRIPTION
This is a micro-optimization but in a repo with 10k+ files with 10k+ comments, this would have some (very minor) impact that is worth doing, given that the change is so small.

## What this does

`DisableDirectivesBuilder::build_impl` pre-computed the fix span for every comment in the file — before `match_directive` filters out non-directive comments, which is the overwhelming majority. The fix span is only consumed after that filter (all uses sit below the early `continue`), so for ordinary comments the computation was pure waste. This PR moves the computation below the directive check. 5 insertions, 4 deletions, no logic change.

## Benchmark

Interleaved paired samples (N=40 pairs, warmup, `time.monotonic_ns()`), single rule enabled (`eslint/no-debugger`, zero diagnostics on the fixtures so the common non-reporting path is measured), baseline binary built from pristine `main`:

| Fixture | Baseline | Optimized | Speedup |
|---|---|---|---|
| Single-line file, 10k inline `/* */` comments (~318 KB) | 91.96 ms | 8.90 ms | **10.3×** (t=297.6, 40/0 wins) |
| 30k short `//` comment lines | 12.15 ms | 11.74 ms | 1.04× (t=2.7, 29/11) |
| Control: comment-free 30k-line file, all rules off | 13.11 ms | 13.32 ms | 0.98× (t=-1.0, noise) |

The adversarial single-line case is where the quadratic bites (minified bundles, generated code). Typical multi-line code sees a small win proportional to comment density. The comment-free control shows the deltas aren't binary-layout noise. (A rules-off "parse-only" run on the comment fixture shows the same ~10× — the directives builder runs regardless of rule config, which is exactly why this path is worth trimming.)

## Correctness

- All 1169 `oxc_linter` lib tests pass, including the `fix_span_*` unit tests covering `compute_comment_fix_span`.
- Diagnostics parity (`--format=json`, diagnostics array compared) is exact between baseline and optimized binaries on both fixtures and on a canary exercising `eslint-disable-line`, `eslint-disable-next-line`, block `eslint-disable`/`eslint-enable`, an unused directive, and comments sharing lines with code.
- `--fix --fix-suggestions --fix-dangerously` output is byte-identical between the two binaries on that canary.
- The reorder computes the same value from the same inputs for every comment that reaches a use; only the timing moves.

## AI disclosure

This change was implemented with Claude Code. Reviewed by me manually to confirm the fix is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)