### PR TITLE
refactor(allocator, ast_tools): generate a single CloneIn traversal via a runtime flag

### DIFF
--- a/crates/oxc_allocator/src/bitset.rs
+++ b/crates/oxc_allocator/src/bitset.rs
@@ -175,7 +175,11 @@ impl Debug for BitSet<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for BitSet<'_> {
     type Cloned = BitSet<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> BitSet<'new_alloc> {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> BitSet<'new_alloc> {
         let slice = self.entries.as_ref();
 
         // SAFETY: `slice` already exists, so its layout must be valid

--- a/crates/oxc_allocator/src/clone_in.rs
+++ b/crates/oxc_allocator/src/clone_in.rs
@@ -19,8 +19,15 @@ use crate::{Allocator, Box, HashMap, Vec};
 ///
 /// impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for Struct<'old_alloc> {
 ///     type Cloned = Struct<'new_alloc>;
-///     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-///         Struct { a: self.a.clone_in(allocator), b: self.b.clone_in(allocator) }
+///     fn clone_in_impl(
+///         &self,
+///         with_semantic_ids: bool,
+///         allocator: &'new_alloc Allocator,
+///     ) -> Self::Cloned {
+///         Struct {
+///             a: self.a.clone_in_impl(with_semantic_ids, allocator),
+///             b: self.b.clone_in_impl(with_semantic_ids, allocator),
+///         }
 ///     }
 /// }
 /// ```
@@ -36,14 +43,40 @@ pub trait CloneIn<'new_alloc>: Sized {
 
     /// Clone `self` into the given `allocator`. `allocator` may be the same one
     /// that `self` is already in.
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned;
+    // `#[inline(always)]` because it just delegates to `clone_in_impl`.
+    #[expect(clippy::inline_always)]
+    #[inline(always)]
+    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+        self.clone_in_impl(false, allocator)
+    }
 
     /// Almost identical as `clone_in`, but for some special type, it will also clone the semantic ids.
     /// Please use this method only if you make sure semantic info is synced with the ast node.
-    #[inline]
+    // `#[inline(always)]` because it just delegates to `clone_in_impl`.
+    #[expect(clippy::inline_always)]
+    #[inline(always)]
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        self.clone_in(allocator)
+        self.clone_in_impl(true, allocator)
     }
+
+    /// Clone `self` into `allocator`, threading whether semantic ids should be preserved as a
+    /// runtime `with_semantic_ids` flag rather than as two separate methods. This is the method
+    /// that implementors provide; `clone_in` and `clone_in_with_semantic_ids` are thin wrappers
+    /// around it.
+    ///
+    /// It exists so the `CloneIn` derive can emit a *single* recursive traversal that serves both
+    /// `clone_in` (`with_semantic_ids == false`) and `clone_in_with_semantic_ids`
+    /// (`with_semantic_ids == true`), instead of monomorphizing two near-identical traversals over
+    /// the whole AST. Id fields recurse when `with_semantic_ids` is `true` and reset to their
+    /// default when it is `false`.
+    ///
+    /// Prefer calling `clone_in` or `clone_in_with_semantic_ids` at call sites — they name the
+    /// intent and delegate here.
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned;
 }
 
 impl<'alloc, T, C> CloneIn<'alloc> for Option<T>
@@ -52,12 +85,9 @@ where
 {
     type Cloned = Option<C>;
 
-    fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        self.as_ref().map(|it| it.clone_in(allocator))
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        self.as_ref().map(|it| it.clone_in_with_semantic_ids(allocator))
+    #[inline]
+    fn clone_in_impl(&self, with_semantic_ids: bool, allocator: &'alloc Allocator) -> Self::Cloned {
+        self.as_ref().map(|it| it.clone_in_impl(with_semantic_ids, allocator))
     }
 }
 
@@ -67,12 +97,13 @@ where
 {
     type Cloned = Box<'new_alloc, C>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        Box::new_in(self.as_ref().clone_in(allocator), &allocator)
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        Box::new_in(self.as_ref().clone_in_with_semantic_ids(allocator), &allocator)
+    #[inline]
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
+        Box::new_in(self.as_ref().clone_in_impl(with_semantic_ids, allocator), &allocator)
     }
 }
 
@@ -82,7 +113,11 @@ where
 {
     type Cloned = Box<'new_alloc, [C]>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         let slice = self.as_ref();
 
         // Compile-time check that `T` and `C` have identical size and alignment - which they always will
@@ -106,43 +141,7 @@ where
         unsafe {
             let mut ptr = dst_ptr;
             for item in slice {
-                ptr.write(item.clone_in(allocator));
-                ptr = ptr.add(1);
-            }
-        }
-
-        // SAFETY: We just initialized `slice.len()` x `C`s, starting at `dst_ptr`
-        let new_slice = unsafe { slice::from_raw_parts_mut(dst_ptr.as_ptr(), slice.len()) };
-        // SAFETY: `NonNull::from(new_slice)` produces a valid pointer. The data is in the arena.
-        // Lifetime of returned `Box` matches the `Allocator` the data was allocated in.
-        unsafe { Box::from_non_null(NonNull::from(new_slice)) }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        let slice = self.as_ref();
-
-        // Compile-time check that `T` and `C` have identical size and alignment - which they always will
-        // with intended usage that `T` and `C` are same types, just with different lifetimes.
-        // This guarantees that layout of clone is same as layout of `slice`,
-        // so we can create `Layout` with `for_value`, which has no runtime checks.
-        const {
-            assert!(
-                size_of::<C>() == size_of::<T>() && align_of::<C>() == align_of::<T>(),
-                "Size and alignment of `T` and `<T as CloneIn>::Cloned` must be the same"
-            );
-        }
-        let layout = Layout::for_value(slice);
-
-        let dst_ptr = allocator.alloc_layout(layout).cast::<C>();
-
-        // SAFETY: We allocated space for `slice.len()` items of type `C`, starting at `dst_ptr`.
-        // Therefore, writing `slice.len()` elements to that memory region is safe.
-        // `C` isn't `Drop`, and allocation is in the arena, so we don't need to worry about a panic
-        // in the loop - can't lead to a memory leak.
-        unsafe {
-            let mut ptr = dst_ptr;
-            for item in slice {
-                ptr.write(item.clone_in_with_semantic_ids(allocator));
+                ptr.write(item.clone_in_impl(with_semantic_ids, allocator));
                 ptr = ptr.add(1);
             }
         }
@@ -164,9 +163,13 @@ where
 {
     type Cloned = Vec<'new_alloc, C>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         // The implementation below is equivalent to:
-        // `Vec::from_iter_in(self.iter().map(|it| it.clone_in(allocator)), allocator)`
+        // `Vec::from_iter_in(self.iter().map(|it| it.clone_in_impl(with_semantic_ids, allocator)), allocator)`
         // But `Vec::from_iter_in` is inefficient because it performs a bounds check for each item.
         // This is unnecessary in this case as we know the length of the slice with certainty.
         // This implementation takes advantage of that invariant, and skips those checks.
@@ -182,28 +185,7 @@ where
         unsafe {
             let mut ptr = vec.as_mut_ptr();
             for item in slice {
-                ptr.write(item.clone_in(allocator));
-                ptr = ptr.add(1);
-            }
-            vec.set_len(slice.len());
-        }
-
-        vec
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        let slice = self.as_slice();
-
-        let mut vec = Vec::<C>::with_capacity_in(slice.len(), &allocator);
-
-        // SAFETY: We allocated capacity for `slice.len()` elements in `vec`.
-        // Therefore, writing `slice.len()` elements to that memory region is safe.
-        // `C` and `Vec` aren't `Drop`, and allocation is in the arena, so we don't need to worry about
-        // a panic in this loop - can't lead to a memory leak. We just set length at the end.
-        unsafe {
-            let mut ptr = vec.as_mut_ptr();
-            for item in slice {
-                ptr.write(item.clone_in_with_semantic_ids(allocator));
+                ptr.write(item.clone_in_impl(with_semantic_ids, allocator));
                 ptr = ptr.add(1);
             }
             vec.set_len(slice.len());
@@ -222,7 +204,11 @@ where
 {
     type Cloned = HashMap<'new_alloc, CK, CV, S>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         // Keys in original hash map are guaranteed to be unique.
         // Unfortunately, we have no static guarantee that `CloneIn` maintains that uniqueness
         // - original keys (`K`) are guaranteed unique, but cloned keys (`CK`) might not be.
@@ -232,35 +218,41 @@ where
         // So sadly this is a lot slower than it could be, especially for `Copy` types.
         let mut cloned = HashMap::with_capacity_in(self.len(), allocator);
         for (key, value) in self {
-            cloned.insert(key.clone_in(allocator), value.clone_in(allocator));
-        }
-        cloned
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        let mut cloned = HashMap::with_capacity_in(self.len(), allocator);
-        for (key, value) in self {
             cloned.insert(
-                key.clone_in_with_semantic_ids(allocator),
-                value.clone_in_with_semantic_ids(allocator),
+                key.clone_in_impl(with_semantic_ids, allocator),
+                value.clone_in_impl(with_semantic_ids, allocator),
             );
         }
         cloned
     }
 }
 
-impl<'alloc, T: Copy> CloneIn<'alloc> for Cell<T> {
+impl<'alloc, T: Copy + Default> CloneIn<'alloc> for Cell<T> {
     type Cloned = Cell<T>;
 
-    fn clone_in(&self, _: &'alloc Allocator) -> Self::Cloned {
-        Cell::new(self.get())
+    // `#[inline(never)]` so the `with_semantic_ids` branch below is *not* inlined at every id-field
+    // clone site. Consumers that only clone *without* semantic ids (e.g. the napi transform/parse
+    // bindings, via `oxc_transformer`) would otherwise carry the dead preserve branch at every site
+    // — ~16 KiB on the transform binary. Outlining it to one function per `Cell<T>` keeps those
+    // binaries at their pre-`clone_in_impl` size, while consumers that clone *with* ids (rolldown,
+    // oxlint's react compiler) are unaffected — their win comes from the shared traversal, not this leaf.
+    #[inline(never)]
+    fn clone_in_impl(&self, with_semantic_ids: bool, _: &'alloc Allocator) -> Self::Cloned {
+        // `Cell` in the AST only ever holds semantic ids (`Cell<NodeId>`, `Cell<Option<ScopeId>>`,
+        // etc.). Preserve them when cloning *with* semantic ids, otherwise reset to the default
+        // (`NodeId::DUMMY`, `None`, ...) so ids aren't carried into a fresh clone.
+        if with_semantic_ids { Cell::new(self.get()) } else { Cell::new(T::default()) }
     }
 }
 
 impl<'new_alloc> CloneIn<'new_alloc> for &str {
     type Cloned = &'new_alloc str;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         allocator.alloc_str(self)
     }
 }
@@ -271,7 +263,7 @@ macro_rules! impl_clone_in {
             impl<'alloc> CloneIn<'alloc> for $t {
                 type Cloned = Self;
                 #[inline(always)]
-                fn clone_in(&self, _: &'alloc Allocator) -> Self {
+                fn clone_in_impl(&self, _with_semantic_ids: bool, _: &'alloc Allocator) -> Self {
                     *self
                 }
             }

--- a/crates/oxc_ast/src/ast/comment.rs
+++ b/crates/oxc_ast/src/ast/comment.rs
@@ -126,7 +126,7 @@ impl ContentEq for CommentNewlines {
 impl<'alloc> CloneIn<'alloc> for CommentNewlines {
     type Cloned = Self;
 
-    fn clone_in(&self, _: &'alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(&self, _with_semantic_ids: bool, _: &'alloc Allocator) -> Self::Cloned {
         *self
     }
 }

--- a/crates/oxc_ast/src/ast_impl/literal.rs
+++ b/crates/oxc_ast/src/ast_impl/literal.rs
@@ -172,7 +172,7 @@ impl ContentEq for RegExpFlags {
 impl<'alloc> CloneIn<'alloc> for RegExpFlags {
     type Cloned = Self;
 
-    fn clone_in(&self, _: &'alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(&self, _with_semantic_ids: bool, _: &'alloc Allocator) -> Self::Cloned {
         *self
     }
 }

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -16,31 +16,21 @@ use crate::ast::ts::*;
 impl<'new_alloc> CloneIn<'new_alloc> for Program<'_> {
     type Cloned = Program<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         Program {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            source_type: CloneIn::clone_in(&self.source_type, allocator),
-            source_text: CloneIn::clone_in(&self.source_text, allocator),
-            comments: CloneIn::clone_in(&self.comments, allocator),
-            hashbang: CloneIn::clone_in(&self.hashbang, allocator),
-            directives: CloneIn::clone_in(&self.directives, allocator),
-            body: CloneIn::clone_in(&self.body, allocator),
-            scope_id: Default::default(),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        Program {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            source_type: CloneIn::clone_in_with_semantic_ids(&self.source_type, allocator),
-            source_text: CloneIn::clone_in_with_semantic_ids(&self.source_text, allocator),
-            comments: CloneIn::clone_in_with_semantic_ids(&self.comments, allocator),
-            hashbang: CloneIn::clone_in_with_semantic_ids(&self.hashbang, allocator),
-            directives: CloneIn::clone_in_with_semantic_ids(&self.directives, allocator),
-            body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
-            scope_id: CloneIn::clone_in_with_semantic_ids(&self.scope_id, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            source_type: CloneIn::clone_in_impl(&self.source_type, with_semantic_ids, allocator),
+            source_text: CloneIn::clone_in_impl(&self.source_text, with_semantic_ids, allocator),
+            comments: CloneIn::clone_in_impl(&self.comments, with_semantic_ids, allocator),
+            hashbang: CloneIn::clone_in_impl(&self.hashbang, with_semantic_ids, allocator),
+            directives: CloneIn::clone_in_impl(&self.directives, with_semantic_ids, allocator),
+            body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
+            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
         }
     }
 }
@@ -48,243 +38,169 @@ impl<'new_alloc> CloneIn<'new_alloc> for Program<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for Expression<'_> {
     type Cloned = Expression<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
             Self::BooleanLiteral(it) => {
-                Expression::BooleanLiteral(CloneIn::clone_in(it, allocator))
-            }
-            Self::NullLiteral(it) => Expression::NullLiteral(CloneIn::clone_in(it, allocator)),
-            Self::NumericLiteral(it) => {
-                Expression::NumericLiteral(CloneIn::clone_in(it, allocator))
-            }
-            Self::BigIntLiteral(it) => Expression::BigIntLiteral(CloneIn::clone_in(it, allocator)),
-            Self::RegExpLiteral(it) => Expression::RegExpLiteral(CloneIn::clone_in(it, allocator)),
-            Self::StringLiteral(it) => Expression::StringLiteral(CloneIn::clone_in(it, allocator)),
-            Self::TemplateLiteral(it) => {
-                Expression::TemplateLiteral(CloneIn::clone_in(it, allocator))
-            }
-            Self::Identifier(it) => Expression::Identifier(CloneIn::clone_in(it, allocator)),
-            Self::MetaProperty(it) => Expression::MetaProperty(CloneIn::clone_in(it, allocator)),
-            Self::Super(it) => Expression::Super(CloneIn::clone_in(it, allocator)),
-            Self::ArrayExpression(it) => {
-                Expression::ArrayExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::ArrowFunctionExpression(it) => {
-                Expression::ArrowFunctionExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::AssignmentExpression(it) => {
-                Expression::AssignmentExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::AwaitExpression(it) => {
-                Expression::AwaitExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::BinaryExpression(it) => {
-                Expression::BinaryExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::CallExpression(it) => {
-                Expression::CallExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::ChainExpression(it) => {
-                Expression::ChainExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::ClassExpression(it) => {
-                Expression::ClassExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::ConditionalExpression(it) => {
-                Expression::ConditionalExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::FunctionExpression(it) => {
-                Expression::FunctionExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::ImportExpression(it) => {
-                Expression::ImportExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::LogicalExpression(it) => {
-                Expression::LogicalExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::NewExpression(it) => Expression::NewExpression(CloneIn::clone_in(it, allocator)),
-            Self::ObjectExpression(it) => {
-                Expression::ObjectExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::ParenthesizedExpression(it) => {
-                Expression::ParenthesizedExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::SequenceExpression(it) => {
-                Expression::SequenceExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::TaggedTemplateExpression(it) => {
-                Expression::TaggedTemplateExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::ThisExpression(it) => {
-                Expression::ThisExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::UnaryExpression(it) => {
-                Expression::UnaryExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::UpdateExpression(it) => {
-                Expression::UpdateExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::YieldExpression(it) => {
-                Expression::YieldExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::PrivateInExpression(it) => {
-                Expression::PrivateInExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::JSXElement(it) => Expression::JSXElement(CloneIn::clone_in(it, allocator)),
-            Self::JSXFragment(it) => Expression::JSXFragment(CloneIn::clone_in(it, allocator)),
-            Self::TSAsExpression(it) => {
-                Expression::TSAsExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSSatisfiesExpression(it) => {
-                Expression::TSSatisfiesExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSTypeAssertion(it) => {
-                Expression::TSTypeAssertion(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSNonNullExpression(it) => {
-                Expression::TSNonNullExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSInstantiationExpression(it) => {
-                Expression::TSInstantiationExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::V8IntrinsicExpression(it) => {
-                Expression::V8IntrinsicExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::ComputedMemberExpression(_)
-            | Self::StaticMemberExpression(_)
-            | Self::PrivateFieldExpression(_) => {
-                Expression::from(CloneIn::clone_in(self.to_member_expression(), allocator))
-            }
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::BooleanLiteral(it) => {
-                Expression::BooleanLiteral(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                Expression::BooleanLiteral(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::NullLiteral(it) => {
-                Expression::NullLiteral(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                Expression::NullLiteral(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::NumericLiteral(it) => {
-                Expression::NumericLiteral(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                Expression::NumericLiteral(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::BigIntLiteral(it) => {
-                Expression::BigIntLiteral(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                Expression::BigIntLiteral(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::RegExpLiteral(it) => {
-                Expression::RegExpLiteral(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                Expression::RegExpLiteral(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::StringLiteral(it) => {
-                Expression::StringLiteral(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                Expression::StringLiteral(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
-            Self::TemplateLiteral(it) => {
-                Expression::TemplateLiteral(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
+            Self::TemplateLiteral(it) => Expression::TemplateLiteral(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
             Self::Identifier(it) => {
-                Expression::Identifier(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                Expression::Identifier(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::MetaProperty(it) => {
-                Expression::MetaProperty(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                Expression::MetaProperty(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::Super(it) => {
-                Expression::Super(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                Expression::Super(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
-            Self::ArrayExpression(it) => {
-                Expression::ArrayExpression(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
+            Self::ArrayExpression(it) => Expression::ArrayExpression(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
             Self::ArrowFunctionExpression(it) => Expression::ArrowFunctionExpression(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
-            Self::AssignmentExpression(it) => {
-                Expression::AssignmentExpression(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
-            Self::AwaitExpression(it) => {
-                Expression::AwaitExpression(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
-            Self::BinaryExpression(it) => {
-                Expression::BinaryExpression(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
+            Self::AssignmentExpression(it) => Expression::AssignmentExpression(
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
+            ),
+            Self::AwaitExpression(it) => Expression::AwaitExpression(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
+            Self::BinaryExpression(it) => Expression::BinaryExpression(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
             Self::CallExpression(it) => {
-                Expression::CallExpression(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                Expression::CallExpression(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
-            Self::ChainExpression(it) => {
-                Expression::ChainExpression(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
-            Self::ClassExpression(it) => {
-                Expression::ClassExpression(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
+            Self::ChainExpression(it) => Expression::ChainExpression(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
+            Self::ClassExpression(it) => Expression::ClassExpression(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
             Self::ConditionalExpression(it) => Expression::ConditionalExpression(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
-            Self::FunctionExpression(it) => {
-                Expression::FunctionExpression(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
-            Self::ImportExpression(it) => {
-                Expression::ImportExpression(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
-            Self::LogicalExpression(it) => {
-                Expression::LogicalExpression(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
+            Self::FunctionExpression(it) => Expression::FunctionExpression(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
+            Self::ImportExpression(it) => Expression::ImportExpression(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
+            Self::LogicalExpression(it) => Expression::LogicalExpression(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
             Self::NewExpression(it) => {
-                Expression::NewExpression(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                Expression::NewExpression(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
-            Self::ObjectExpression(it) => {
-                Expression::ObjectExpression(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
+            Self::ObjectExpression(it) => Expression::ObjectExpression(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
             Self::ParenthesizedExpression(it) => Expression::ParenthesizedExpression(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
-            Self::SequenceExpression(it) => {
-                Expression::SequenceExpression(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
+            Self::SequenceExpression(it) => Expression::SequenceExpression(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
             Self::TaggedTemplateExpression(it) => Expression::TaggedTemplateExpression(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
             Self::ThisExpression(it) => {
-                Expression::ThisExpression(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                Expression::ThisExpression(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
-            Self::UnaryExpression(it) => {
-                Expression::UnaryExpression(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
-            Self::UpdateExpression(it) => {
-                Expression::UpdateExpression(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
-            Self::YieldExpression(it) => {
-                Expression::YieldExpression(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
-            Self::PrivateInExpression(it) => {
-                Expression::PrivateInExpression(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
+            Self::UnaryExpression(it) => Expression::UnaryExpression(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
+            Self::UpdateExpression(it) => Expression::UpdateExpression(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
+            Self::YieldExpression(it) => Expression::YieldExpression(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
+            Self::PrivateInExpression(it) => Expression::PrivateInExpression(
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
+            ),
             Self::JSXElement(it) => {
-                Expression::JSXElement(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                Expression::JSXElement(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::JSXFragment(it) => {
-                Expression::JSXFragment(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                Expression::JSXFragment(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::TSAsExpression(it) => {
-                Expression::TSAsExpression(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                Expression::TSAsExpression(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::TSSatisfiesExpression(it) => Expression::TSSatisfiesExpression(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
-            Self::TSTypeAssertion(it) => {
-                Expression::TSTypeAssertion(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
-            Self::TSNonNullExpression(it) => {
-                Expression::TSNonNullExpression(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
+            Self::TSTypeAssertion(it) => Expression::TSTypeAssertion(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
+            Self::TSNonNullExpression(it) => Expression::TSNonNullExpression(
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
+            ),
             Self::TSInstantiationExpression(it) => Expression::TSInstantiationExpression(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
             Self::V8IntrinsicExpression(it) => Expression::V8IntrinsicExpression(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
             Self::ComputedMemberExpression(_)
             | Self::StaticMemberExpression(_)
-            | Self::PrivateFieldExpression(_) => Expression::from(
-                CloneIn::clone_in_with_semantic_ids(self.to_member_expression(), allocator),
-            ),
+            | Self::PrivateFieldExpression(_) => Expression::from(CloneIn::clone_in_impl(
+                self.to_member_expression(),
+                with_semantic_ids,
+                allocator,
+            )),
         }
     }
 }
@@ -292,19 +208,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for Expression<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for IdentifierName<'_> {
     type Cloned = IdentifierName<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         IdentifierName {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            name: CloneIn::clone_in(&self.name, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        IdentifierName {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            name: CloneIn::clone_in_with_semantic_ids(&self.name, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            name: CloneIn::clone_in_impl(&self.name, with_semantic_ids, allocator),
         }
     }
 }
@@ -312,21 +224,16 @@ impl<'new_alloc> CloneIn<'new_alloc> for IdentifierName<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for IdentifierReference<'_> {
     type Cloned = IdentifierReference<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         IdentifierReference {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            name: CloneIn::clone_in(&self.name, allocator),
-            reference_id: Default::default(),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        IdentifierReference {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            name: CloneIn::clone_in_with_semantic_ids(&self.name, allocator),
-            reference_id: CloneIn::clone_in_with_semantic_ids(&self.reference_id, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            name: CloneIn::clone_in_impl(&self.name, with_semantic_ids, allocator),
+            reference_id: CloneIn::clone_in_impl(&self.reference_id, with_semantic_ids, allocator),
         }
     }
 }
@@ -334,21 +241,16 @@ impl<'new_alloc> CloneIn<'new_alloc> for IdentifierReference<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for BindingIdentifier<'_> {
     type Cloned = BindingIdentifier<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         BindingIdentifier {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            name: CloneIn::clone_in(&self.name, allocator),
-            symbol_id: Default::default(),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        BindingIdentifier {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            name: CloneIn::clone_in_with_semantic_ids(&self.name, allocator),
-            symbol_id: CloneIn::clone_in_with_semantic_ids(&self.symbol_id, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            name: CloneIn::clone_in_impl(&self.name, with_semantic_ids, allocator),
+            symbol_id: CloneIn::clone_in_impl(&self.symbol_id, with_semantic_ids, allocator),
         }
     }
 }
@@ -356,19 +258,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for BindingIdentifier<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for LabelIdentifier<'_> {
     type Cloned = LabelIdentifier<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         LabelIdentifier {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            name: CloneIn::clone_in(&self.name, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        LabelIdentifier {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            name: CloneIn::clone_in_with_semantic_ids(&self.name, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            name: CloneIn::clone_in_impl(&self.name, with_semantic_ids, allocator),
         }
     }
 }
@@ -376,17 +274,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for LabelIdentifier<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ThisExpression {
     type Cloned = ThisExpression;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         ThisExpression {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        ThisExpression {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
         }
     }
 }
@@ -394,19 +289,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for ThisExpression {
 impl<'new_alloc> CloneIn<'new_alloc> for ArrayExpression<'_> {
     type Cloned = ArrayExpression<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         ArrayExpression {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            elements: CloneIn::clone_in(&self.elements, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        ArrayExpression {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            elements: CloneIn::clone_in_with_semantic_ids(&self.elements, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            elements: CloneIn::clone_in_impl(&self.elements, with_semantic_ids, allocator),
         }
     }
 }
@@ -414,68 +305,20 @@ impl<'new_alloc> CloneIn<'new_alloc> for ArrayExpression<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ArrayExpressionElement<'_> {
     type Cloned = ArrayExpressionElement<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::SpreadElement(it) => {
-                ArrayExpressionElement::SpreadElement(CloneIn::clone_in(it, allocator))
-            }
-            Self::Elision(it) => ArrayExpressionElement::Elision(CloneIn::clone_in(it, allocator)),
-            Self::BooleanLiteral(_)
-            | Self::NullLiteral(_)
-            | Self::NumericLiteral(_)
-            | Self::BigIntLiteral(_)
-            | Self::RegExpLiteral(_)
-            | Self::StringLiteral(_)
-            | Self::TemplateLiteral(_)
-            | Self::Identifier(_)
-            | Self::MetaProperty(_)
-            | Self::Super(_)
-            | Self::ArrayExpression(_)
-            | Self::ArrowFunctionExpression(_)
-            | Self::AssignmentExpression(_)
-            | Self::AwaitExpression(_)
-            | Self::BinaryExpression(_)
-            | Self::CallExpression(_)
-            | Self::ChainExpression(_)
-            | Self::ClassExpression(_)
-            | Self::ConditionalExpression(_)
-            | Self::FunctionExpression(_)
-            | Self::ImportExpression(_)
-            | Self::LogicalExpression(_)
-            | Self::NewExpression(_)
-            | Self::ObjectExpression(_)
-            | Self::ParenthesizedExpression(_)
-            | Self::SequenceExpression(_)
-            | Self::TaggedTemplateExpression(_)
-            | Self::ThisExpression(_)
-            | Self::UnaryExpression(_)
-            | Self::UpdateExpression(_)
-            | Self::YieldExpression(_)
-            | Self::PrivateInExpression(_)
-            | Self::JSXElement(_)
-            | Self::JSXFragment(_)
-            | Self::TSAsExpression(_)
-            | Self::TSSatisfiesExpression(_)
-            | Self::TSTypeAssertion(_)
-            | Self::TSNonNullExpression(_)
-            | Self::TSInstantiationExpression(_)
-            | Self::V8IntrinsicExpression(_)
-            | Self::ComputedMemberExpression(_)
-            | Self::StaticMemberExpression(_)
-            | Self::PrivateFieldExpression(_) => {
-                ArrayExpressionElement::from(CloneIn::clone_in(self.to_expression(), allocator))
-            }
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
             Self::SpreadElement(it) => ArrayExpressionElement::SpreadElement(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
-            Self::Elision(it) => {
-                ArrayExpressionElement::Elision(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
+            Self::Elision(it) => ArrayExpressionElement::Elision(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
             Self::BooleanLiteral(_)
             | Self::NullLiteral(_)
             | Self::NumericLiteral(_)
@@ -519,7 +362,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ArrayExpressionElement<'_> {
             | Self::ComputedMemberExpression(_)
             | Self::StaticMemberExpression(_)
             | Self::PrivateFieldExpression(_) => ArrayExpressionElement::from(
-                CloneIn::clone_in_with_semantic_ids(self.to_expression(), allocator),
+                CloneIn::clone_in_impl(self.to_expression(), with_semantic_ids, allocator),
             ),
         }
     }
@@ -528,14 +371,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for ArrayExpressionElement<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for Elision {
     type Cloned = Elision;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        Elision { node_id: Default::default(), span: CloneIn::clone_in(&self.span, allocator) }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         Elision {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
         }
     }
 }
@@ -543,19 +386,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for Elision {
 impl<'new_alloc> CloneIn<'new_alloc> for ObjectExpression<'_> {
     type Cloned = ObjectExpression<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         ObjectExpression {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            properties: CloneIn::clone_in(&self.properties, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        ObjectExpression {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            properties: CloneIn::clone_in_with_semantic_ids(&self.properties, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            properties: CloneIn::clone_in_impl(&self.properties, with_semantic_ids, allocator),
         }
     }
 }
@@ -563,25 +402,22 @@ impl<'new_alloc> CloneIn<'new_alloc> for ObjectExpression<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ObjectPropertyKind<'_> {
     type Cloned = ObjectPropertyKind<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
-            Self::ObjectProperty(it) => {
-                ObjectPropertyKind::ObjectProperty(CloneIn::clone_in(it, allocator))
-            }
-            Self::SpreadProperty(it) => {
-                ObjectPropertyKind::SpreadProperty(CloneIn::clone_in(it, allocator))
-            }
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::ObjectProperty(it) => ObjectPropertyKind::ObjectProperty(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
-            ),
-            Self::SpreadProperty(it) => ObjectPropertyKind::SpreadProperty(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
-            ),
+            Self::ObjectProperty(it) => ObjectPropertyKind::ObjectProperty(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
+            Self::SpreadProperty(it) => ObjectPropertyKind::SpreadProperty(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
         }
     }
 }
@@ -589,29 +425,20 @@ impl<'new_alloc> CloneIn<'new_alloc> for ObjectPropertyKind<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ObjectProperty<'_> {
     type Cloned = ObjectProperty<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         ObjectProperty {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            kind: CloneIn::clone_in(&self.kind, allocator),
-            key: CloneIn::clone_in(&self.key, allocator),
-            value: CloneIn::clone_in(&self.value, allocator),
-            method: CloneIn::clone_in(&self.method, allocator),
-            shorthand: CloneIn::clone_in(&self.shorthand, allocator),
-            computed: CloneIn::clone_in(&self.computed, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        ObjectProperty {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            kind: CloneIn::clone_in_with_semantic_ids(&self.kind, allocator),
-            key: CloneIn::clone_in_with_semantic_ids(&self.key, allocator),
-            value: CloneIn::clone_in_with_semantic_ids(&self.value, allocator),
-            method: CloneIn::clone_in_with_semantic_ids(&self.method, allocator),
-            shorthand: CloneIn::clone_in_with_semantic_ids(&self.shorthand, allocator),
-            computed: CloneIn::clone_in_with_semantic_ids(&self.computed, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            kind: CloneIn::clone_in_impl(&self.kind, with_semantic_ids, allocator),
+            key: CloneIn::clone_in_impl(&self.key, with_semantic_ids, allocator),
+            value: CloneIn::clone_in_impl(&self.value, with_semantic_ids, allocator),
+            method: CloneIn::clone_in_impl(&self.method, with_semantic_ids, allocator),
+            shorthand: CloneIn::clone_in_impl(&self.shorthand, with_semantic_ids, allocator),
+            computed: CloneIn::clone_in_impl(&self.computed, with_semantic_ids, allocator),
         }
     }
 }
@@ -619,14 +446,22 @@ impl<'new_alloc> CloneIn<'new_alloc> for ObjectProperty<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for PropertyKey<'_> {
     type Cloned = PropertyKey<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
-            Self::StaticIdentifier(it) => {
-                PropertyKey::StaticIdentifier(CloneIn::clone_in(it, allocator))
-            }
-            Self::PrivateIdentifier(it) => {
-                PropertyKey::PrivateIdentifier(CloneIn::clone_in(it, allocator))
-            }
+            Self::StaticIdentifier(it) => PropertyKey::StaticIdentifier(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
+            Self::PrivateIdentifier(it) => PropertyKey::PrivateIdentifier(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
             Self::BooleanLiteral(_)
             | Self::NullLiteral(_)
             | Self::NumericLiteral(_)
@@ -669,65 +504,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for PropertyKey<'_> {
             | Self::V8IntrinsicExpression(_)
             | Self::ComputedMemberExpression(_)
             | Self::StaticMemberExpression(_)
-            | Self::PrivateFieldExpression(_) => {
-                PropertyKey::from(CloneIn::clone_in(self.to_expression(), allocator))
-            }
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::StaticIdentifier(it) => {
-                PropertyKey::StaticIdentifier(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
-            Self::PrivateIdentifier(it) => {
-                PropertyKey::PrivateIdentifier(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
-            Self::BooleanLiteral(_)
-            | Self::NullLiteral(_)
-            | Self::NumericLiteral(_)
-            | Self::BigIntLiteral(_)
-            | Self::RegExpLiteral(_)
-            | Self::StringLiteral(_)
-            | Self::TemplateLiteral(_)
-            | Self::Identifier(_)
-            | Self::MetaProperty(_)
-            | Self::Super(_)
-            | Self::ArrayExpression(_)
-            | Self::ArrowFunctionExpression(_)
-            | Self::AssignmentExpression(_)
-            | Self::AwaitExpression(_)
-            | Self::BinaryExpression(_)
-            | Self::CallExpression(_)
-            | Self::ChainExpression(_)
-            | Self::ClassExpression(_)
-            | Self::ConditionalExpression(_)
-            | Self::FunctionExpression(_)
-            | Self::ImportExpression(_)
-            | Self::LogicalExpression(_)
-            | Self::NewExpression(_)
-            | Self::ObjectExpression(_)
-            | Self::ParenthesizedExpression(_)
-            | Self::SequenceExpression(_)
-            | Self::TaggedTemplateExpression(_)
-            | Self::ThisExpression(_)
-            | Self::UnaryExpression(_)
-            | Self::UpdateExpression(_)
-            | Self::YieldExpression(_)
-            | Self::PrivateInExpression(_)
-            | Self::JSXElement(_)
-            | Self::JSXFragment(_)
-            | Self::TSAsExpression(_)
-            | Self::TSSatisfiesExpression(_)
-            | Self::TSTypeAssertion(_)
-            | Self::TSNonNullExpression(_)
-            | Self::TSInstantiationExpression(_)
-            | Self::V8IntrinsicExpression(_)
-            | Self::ComputedMemberExpression(_)
-            | Self::StaticMemberExpression(_)
-            | Self::PrivateFieldExpression(_) => PropertyKey::from(
-                CloneIn::clone_in_with_semantic_ids(self.to_expression(), allocator),
-            ),
+            | Self::PrivateFieldExpression(_) => PropertyKey::from(CloneIn::clone_in_impl(
+                self.to_expression(),
+                with_semantic_ids,
+                allocator,
+            )),
         }
     }
 }
@@ -736,12 +517,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for PropertyKind {
     type Cloned = PropertyKind;
 
     #[inline(always)]
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        *self
-    }
-
-    #[inline(always)]
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         *self
     }
 }
@@ -749,21 +529,16 @@ impl<'new_alloc> CloneIn<'new_alloc> for PropertyKind {
 impl<'new_alloc> CloneIn<'new_alloc> for TemplateLiteral<'_> {
     type Cloned = TemplateLiteral<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TemplateLiteral {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            quasis: CloneIn::clone_in(&self.quasis, allocator),
-            expressions: CloneIn::clone_in(&self.expressions, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TemplateLiteral {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            quasis: CloneIn::clone_in_with_semantic_ids(&self.quasis, allocator),
-            expressions: CloneIn::clone_in_with_semantic_ids(&self.expressions, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            quasis: CloneIn::clone_in_impl(&self.quasis, with_semantic_ids, allocator),
+            expressions: CloneIn::clone_in_impl(&self.expressions, with_semantic_ids, allocator),
         }
     }
 }
@@ -771,23 +546,21 @@ impl<'new_alloc> CloneIn<'new_alloc> for TemplateLiteral<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TaggedTemplateExpression<'_> {
     type Cloned = TaggedTemplateExpression<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TaggedTemplateExpression {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            tag: CloneIn::clone_in(&self.tag, allocator),
-            type_arguments: CloneIn::clone_in(&self.type_arguments, allocator),
-            quasi: CloneIn::clone_in(&self.quasi, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TaggedTemplateExpression {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            tag: CloneIn::clone_in_with_semantic_ids(&self.tag, allocator),
-            type_arguments: CloneIn::clone_in_with_semantic_ids(&self.type_arguments, allocator),
-            quasi: CloneIn::clone_in_with_semantic_ids(&self.quasi, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            tag: CloneIn::clone_in_impl(&self.tag, with_semantic_ids, allocator),
+            type_arguments: CloneIn::clone_in_impl(
+                &self.type_arguments,
+                with_semantic_ids,
+                allocator,
+            ),
+            quasi: CloneIn::clone_in_impl(&self.quasi, with_semantic_ids, allocator),
         }
     }
 }
@@ -795,23 +568,21 @@ impl<'new_alloc> CloneIn<'new_alloc> for TaggedTemplateExpression<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TemplateElement<'_> {
     type Cloned = TemplateElement<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TemplateElement {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            value: CloneIn::clone_in(&self.value, allocator),
-            tail: CloneIn::clone_in(&self.tail, allocator),
-            lone_surrogates: CloneIn::clone_in(&self.lone_surrogates, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TemplateElement {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            value: CloneIn::clone_in_with_semantic_ids(&self.value, allocator),
-            tail: CloneIn::clone_in_with_semantic_ids(&self.tail, allocator),
-            lone_surrogates: CloneIn::clone_in_with_semantic_ids(&self.lone_surrogates, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            value: CloneIn::clone_in_impl(&self.value, with_semantic_ids, allocator),
+            tail: CloneIn::clone_in_impl(&self.tail, with_semantic_ids, allocator),
+            lone_surrogates: CloneIn::clone_in_impl(
+                &self.lone_surrogates,
+                with_semantic_ids,
+                allocator,
+            ),
         }
     }
 }
@@ -819,17 +590,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for TemplateElement<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TemplateElementValue<'_> {
     type Cloned = TemplateElementValue<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TemplateElementValue {
-            raw: CloneIn::clone_in(&self.raw, allocator),
-            cooked: CloneIn::clone_in(&self.cooked, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TemplateElementValue {
-            raw: CloneIn::clone_in_with_semantic_ids(&self.raw, allocator),
-            cooked: CloneIn::clone_in_with_semantic_ids(&self.cooked, allocator),
+            raw: CloneIn::clone_in_impl(&self.raw, with_semantic_ids, allocator),
+            cooked: CloneIn::clone_in_impl(&self.cooked, with_semantic_ids, allocator),
         }
     }
 }
@@ -837,30 +605,20 @@ impl<'new_alloc> CloneIn<'new_alloc> for TemplateElementValue<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for MemberExpression<'_> {
     type Cloned = MemberExpression<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::ComputedMemberExpression(it) => {
-                MemberExpression::ComputedMemberExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::StaticMemberExpression(it) => {
-                MemberExpression::StaticMemberExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::PrivateFieldExpression(it) => {
-                MemberExpression::PrivateFieldExpression(CloneIn::clone_in(it, allocator))
-            }
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
             Self::ComputedMemberExpression(it) => MemberExpression::ComputedMemberExpression(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
             Self::StaticMemberExpression(it) => MemberExpression::StaticMemberExpression(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
             Self::PrivateFieldExpression(it) => MemberExpression::PrivateFieldExpression(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
         }
     }
@@ -869,23 +627,17 @@ impl<'new_alloc> CloneIn<'new_alloc> for MemberExpression<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ComputedMemberExpression<'_> {
     type Cloned = ComputedMemberExpression<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         ComputedMemberExpression {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            object: CloneIn::clone_in(&self.object, allocator),
-            expression: CloneIn::clone_in(&self.expression, allocator),
-            optional: CloneIn::clone_in(&self.optional, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        ComputedMemberExpression {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            object: CloneIn::clone_in_with_semantic_ids(&self.object, allocator),
-            expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
-            optional: CloneIn::clone_in_with_semantic_ids(&self.optional, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            object: CloneIn::clone_in_impl(&self.object, with_semantic_ids, allocator),
+            expression: CloneIn::clone_in_impl(&self.expression, with_semantic_ids, allocator),
+            optional: CloneIn::clone_in_impl(&self.optional, with_semantic_ids, allocator),
         }
     }
 }
@@ -893,23 +645,17 @@ impl<'new_alloc> CloneIn<'new_alloc> for ComputedMemberExpression<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for StaticMemberExpression<'_> {
     type Cloned = StaticMemberExpression<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         StaticMemberExpression {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            object: CloneIn::clone_in(&self.object, allocator),
-            property: CloneIn::clone_in(&self.property, allocator),
-            optional: CloneIn::clone_in(&self.optional, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        StaticMemberExpression {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            object: CloneIn::clone_in_with_semantic_ids(&self.object, allocator),
-            property: CloneIn::clone_in_with_semantic_ids(&self.property, allocator),
-            optional: CloneIn::clone_in_with_semantic_ids(&self.optional, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            object: CloneIn::clone_in_impl(&self.object, with_semantic_ids, allocator),
+            property: CloneIn::clone_in_impl(&self.property, with_semantic_ids, allocator),
+            optional: CloneIn::clone_in_impl(&self.optional, with_semantic_ids, allocator),
         }
     }
 }
@@ -917,23 +663,17 @@ impl<'new_alloc> CloneIn<'new_alloc> for StaticMemberExpression<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for PrivateFieldExpression<'_> {
     type Cloned = PrivateFieldExpression<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         PrivateFieldExpression {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            object: CloneIn::clone_in(&self.object, allocator),
-            field: CloneIn::clone_in(&self.field, allocator),
-            optional: CloneIn::clone_in(&self.optional, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        PrivateFieldExpression {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            object: CloneIn::clone_in_with_semantic_ids(&self.object, allocator),
-            field: CloneIn::clone_in_with_semantic_ids(&self.field, allocator),
-            optional: CloneIn::clone_in_with_semantic_ids(&self.optional, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            object: CloneIn::clone_in_impl(&self.object, with_semantic_ids, allocator),
+            field: CloneIn::clone_in_impl(&self.field, with_semantic_ids, allocator),
+            optional: CloneIn::clone_in_impl(&self.optional, with_semantic_ids, allocator),
         }
     }
 }
@@ -941,27 +681,23 @@ impl<'new_alloc> CloneIn<'new_alloc> for PrivateFieldExpression<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for CallExpression<'_> {
     type Cloned = CallExpression<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         CallExpression {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            callee: CloneIn::clone_in(&self.callee, allocator),
-            type_arguments: CloneIn::clone_in(&self.type_arguments, allocator),
-            arguments: CloneIn::clone_in(&self.arguments, allocator),
-            optional: CloneIn::clone_in(&self.optional, allocator),
-            pure: CloneIn::clone_in(&self.pure, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        CallExpression {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            callee: CloneIn::clone_in_with_semantic_ids(&self.callee, allocator),
-            type_arguments: CloneIn::clone_in_with_semantic_ids(&self.type_arguments, allocator),
-            arguments: CloneIn::clone_in_with_semantic_ids(&self.arguments, allocator),
-            optional: CloneIn::clone_in_with_semantic_ids(&self.optional, allocator),
-            pure: CloneIn::clone_in_with_semantic_ids(&self.pure, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            callee: CloneIn::clone_in_impl(&self.callee, with_semantic_ids, allocator),
+            type_arguments: CloneIn::clone_in_impl(
+                &self.type_arguments,
+                with_semantic_ids,
+                allocator,
+            ),
+            arguments: CloneIn::clone_in_impl(&self.arguments, with_semantic_ids, allocator),
+            optional: CloneIn::clone_in_impl(&self.optional, with_semantic_ids, allocator),
+            pure: CloneIn::clone_in_impl(&self.pure, with_semantic_ids, allocator),
         }
     }
 }
@@ -969,25 +705,22 @@ impl<'new_alloc> CloneIn<'new_alloc> for CallExpression<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for NewExpression<'_> {
     type Cloned = NewExpression<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         NewExpression {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            callee: CloneIn::clone_in(&self.callee, allocator),
-            type_arguments: CloneIn::clone_in(&self.type_arguments, allocator),
-            arguments: CloneIn::clone_in(&self.arguments, allocator),
-            pure: CloneIn::clone_in(&self.pure, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        NewExpression {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            callee: CloneIn::clone_in_with_semantic_ids(&self.callee, allocator),
-            type_arguments: CloneIn::clone_in_with_semantic_ids(&self.type_arguments, allocator),
-            arguments: CloneIn::clone_in_with_semantic_ids(&self.arguments, allocator),
-            pure: CloneIn::clone_in_with_semantic_ids(&self.pure, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            callee: CloneIn::clone_in_impl(&self.callee, with_semantic_ids, allocator),
+            type_arguments: CloneIn::clone_in_impl(
+                &self.type_arguments,
+                with_semantic_ids,
+                allocator,
+            ),
+            arguments: CloneIn::clone_in_impl(&self.arguments, with_semantic_ids, allocator),
+            pure: CloneIn::clone_in_impl(&self.pure, with_semantic_ids, allocator),
         }
     }
 }
@@ -995,21 +728,16 @@ impl<'new_alloc> CloneIn<'new_alloc> for NewExpression<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for MetaProperty<'_> {
     type Cloned = MetaProperty<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         MetaProperty {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            meta: CloneIn::clone_in(&self.meta, allocator),
-            property: CloneIn::clone_in(&self.property, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        MetaProperty {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            meta: CloneIn::clone_in_with_semantic_ids(&self.meta, allocator),
-            property: CloneIn::clone_in_with_semantic_ids(&self.property, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            meta: CloneIn::clone_in_impl(&self.meta, with_semantic_ids, allocator),
+            property: CloneIn::clone_in_impl(&self.property, with_semantic_ids, allocator),
         }
     }
 }
@@ -1017,19 +745,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for MetaProperty<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for SpreadElement<'_> {
     type Cloned = SpreadElement<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         SpreadElement {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            argument: CloneIn::clone_in(&self.argument, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        SpreadElement {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            argument: CloneIn::clone_in_with_semantic_ids(&self.argument, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            argument: CloneIn::clone_in_impl(&self.argument, with_semantic_ids, allocator),
         }
     }
 }
@@ -1037,61 +761,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for SpreadElement<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for Argument<'_> {
     type Cloned = Argument<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::SpreadElement(it) => Argument::SpreadElement(CloneIn::clone_in(it, allocator)),
-            Self::BooleanLiteral(_)
-            | Self::NullLiteral(_)
-            | Self::NumericLiteral(_)
-            | Self::BigIntLiteral(_)
-            | Self::RegExpLiteral(_)
-            | Self::StringLiteral(_)
-            | Self::TemplateLiteral(_)
-            | Self::Identifier(_)
-            | Self::MetaProperty(_)
-            | Self::Super(_)
-            | Self::ArrayExpression(_)
-            | Self::ArrowFunctionExpression(_)
-            | Self::AssignmentExpression(_)
-            | Self::AwaitExpression(_)
-            | Self::BinaryExpression(_)
-            | Self::CallExpression(_)
-            | Self::ChainExpression(_)
-            | Self::ClassExpression(_)
-            | Self::ConditionalExpression(_)
-            | Self::FunctionExpression(_)
-            | Self::ImportExpression(_)
-            | Self::LogicalExpression(_)
-            | Self::NewExpression(_)
-            | Self::ObjectExpression(_)
-            | Self::ParenthesizedExpression(_)
-            | Self::SequenceExpression(_)
-            | Self::TaggedTemplateExpression(_)
-            | Self::ThisExpression(_)
-            | Self::UnaryExpression(_)
-            | Self::UpdateExpression(_)
-            | Self::YieldExpression(_)
-            | Self::PrivateInExpression(_)
-            | Self::JSXElement(_)
-            | Self::JSXFragment(_)
-            | Self::TSAsExpression(_)
-            | Self::TSSatisfiesExpression(_)
-            | Self::TSTypeAssertion(_)
-            | Self::TSNonNullExpression(_)
-            | Self::TSInstantiationExpression(_)
-            | Self::V8IntrinsicExpression(_)
-            | Self::ComputedMemberExpression(_)
-            | Self::StaticMemberExpression(_)
-            | Self::PrivateFieldExpression(_) => {
-                Argument::from(CloneIn::clone_in(self.to_expression(), allocator))
-            }
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
             Self::SpreadElement(it) => {
-                Argument::SpreadElement(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                Argument::SpreadElement(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::BooleanLiteral(_)
             | Self::NullLiteral(_)
@@ -1135,9 +812,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for Argument<'_> {
             | Self::V8IntrinsicExpression(_)
             | Self::ComputedMemberExpression(_)
             | Self::StaticMemberExpression(_)
-            | Self::PrivateFieldExpression(_) => {
-                Argument::from(CloneIn::clone_in_with_semantic_ids(self.to_expression(), allocator))
-            }
+            | Self::PrivateFieldExpression(_) => Argument::from(CloneIn::clone_in_impl(
+                self.to_expression(),
+                with_semantic_ids,
+                allocator,
+            )),
         }
     }
 }
@@ -1145,23 +824,17 @@ impl<'new_alloc> CloneIn<'new_alloc> for Argument<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for UpdateExpression<'_> {
     type Cloned = UpdateExpression<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         UpdateExpression {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            operator: CloneIn::clone_in(&self.operator, allocator),
-            prefix: CloneIn::clone_in(&self.prefix, allocator),
-            argument: CloneIn::clone_in(&self.argument, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        UpdateExpression {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            operator: CloneIn::clone_in_with_semantic_ids(&self.operator, allocator),
-            prefix: CloneIn::clone_in_with_semantic_ids(&self.prefix, allocator),
-            argument: CloneIn::clone_in_with_semantic_ids(&self.argument, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            operator: CloneIn::clone_in_impl(&self.operator, with_semantic_ids, allocator),
+            prefix: CloneIn::clone_in_impl(&self.prefix, with_semantic_ids, allocator),
+            argument: CloneIn::clone_in_impl(&self.argument, with_semantic_ids, allocator),
         }
     }
 }
@@ -1169,21 +842,16 @@ impl<'new_alloc> CloneIn<'new_alloc> for UpdateExpression<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for UnaryExpression<'_> {
     type Cloned = UnaryExpression<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         UnaryExpression {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            operator: CloneIn::clone_in(&self.operator, allocator),
-            argument: CloneIn::clone_in(&self.argument, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        UnaryExpression {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            operator: CloneIn::clone_in_with_semantic_ids(&self.operator, allocator),
-            argument: CloneIn::clone_in_with_semantic_ids(&self.argument, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            operator: CloneIn::clone_in_impl(&self.operator, with_semantic_ids, allocator),
+            argument: CloneIn::clone_in_impl(&self.argument, with_semantic_ids, allocator),
         }
     }
 }
@@ -1191,23 +859,17 @@ impl<'new_alloc> CloneIn<'new_alloc> for UnaryExpression<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for BinaryExpression<'_> {
     type Cloned = BinaryExpression<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         BinaryExpression {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            left: CloneIn::clone_in(&self.left, allocator),
-            operator: CloneIn::clone_in(&self.operator, allocator),
-            right: CloneIn::clone_in(&self.right, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        BinaryExpression {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            left: CloneIn::clone_in_with_semantic_ids(&self.left, allocator),
-            operator: CloneIn::clone_in_with_semantic_ids(&self.operator, allocator),
-            right: CloneIn::clone_in_with_semantic_ids(&self.right, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            left: CloneIn::clone_in_impl(&self.left, with_semantic_ids, allocator),
+            operator: CloneIn::clone_in_impl(&self.operator, with_semantic_ids, allocator),
+            right: CloneIn::clone_in_impl(&self.right, with_semantic_ids, allocator),
         }
     }
 }
@@ -1215,21 +877,16 @@ impl<'new_alloc> CloneIn<'new_alloc> for BinaryExpression<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for PrivateInExpression<'_> {
     type Cloned = PrivateInExpression<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         PrivateInExpression {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            left: CloneIn::clone_in(&self.left, allocator),
-            right: CloneIn::clone_in(&self.right, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        PrivateInExpression {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            left: CloneIn::clone_in_with_semantic_ids(&self.left, allocator),
-            right: CloneIn::clone_in_with_semantic_ids(&self.right, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            left: CloneIn::clone_in_impl(&self.left, with_semantic_ids, allocator),
+            right: CloneIn::clone_in_impl(&self.right, with_semantic_ids, allocator),
         }
     }
 }
@@ -1237,23 +894,17 @@ impl<'new_alloc> CloneIn<'new_alloc> for PrivateInExpression<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for LogicalExpression<'_> {
     type Cloned = LogicalExpression<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         LogicalExpression {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            left: CloneIn::clone_in(&self.left, allocator),
-            operator: CloneIn::clone_in(&self.operator, allocator),
-            right: CloneIn::clone_in(&self.right, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        LogicalExpression {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            left: CloneIn::clone_in_with_semantic_ids(&self.left, allocator),
-            operator: CloneIn::clone_in_with_semantic_ids(&self.operator, allocator),
-            right: CloneIn::clone_in_with_semantic_ids(&self.right, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            left: CloneIn::clone_in_impl(&self.left, with_semantic_ids, allocator),
+            operator: CloneIn::clone_in_impl(&self.operator, with_semantic_ids, allocator),
+            right: CloneIn::clone_in_impl(&self.right, with_semantic_ids, allocator),
         }
     }
 }
@@ -1261,23 +912,17 @@ impl<'new_alloc> CloneIn<'new_alloc> for LogicalExpression<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ConditionalExpression<'_> {
     type Cloned = ConditionalExpression<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         ConditionalExpression {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            test: CloneIn::clone_in(&self.test, allocator),
-            consequent: CloneIn::clone_in(&self.consequent, allocator),
-            alternate: CloneIn::clone_in(&self.alternate, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        ConditionalExpression {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            test: CloneIn::clone_in_with_semantic_ids(&self.test, allocator),
-            consequent: CloneIn::clone_in_with_semantic_ids(&self.consequent, allocator),
-            alternate: CloneIn::clone_in_with_semantic_ids(&self.alternate, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            test: CloneIn::clone_in_impl(&self.test, with_semantic_ids, allocator),
+            consequent: CloneIn::clone_in_impl(&self.consequent, with_semantic_ids, allocator),
+            alternate: CloneIn::clone_in_impl(&self.alternate, with_semantic_ids, allocator),
         }
     }
 }
@@ -1285,23 +930,17 @@ impl<'new_alloc> CloneIn<'new_alloc> for ConditionalExpression<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for AssignmentExpression<'_> {
     type Cloned = AssignmentExpression<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         AssignmentExpression {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            operator: CloneIn::clone_in(&self.operator, allocator),
-            left: CloneIn::clone_in(&self.left, allocator),
-            right: CloneIn::clone_in(&self.right, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        AssignmentExpression {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            operator: CloneIn::clone_in_with_semantic_ids(&self.operator, allocator),
-            left: CloneIn::clone_in_with_semantic_ids(&self.left, allocator),
-            right: CloneIn::clone_in_with_semantic_ids(&self.right, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            operator: CloneIn::clone_in_impl(&self.operator, with_semantic_ids, allocator),
+            left: CloneIn::clone_in_impl(&self.left, with_semantic_ids, allocator),
+            right: CloneIn::clone_in_impl(&self.right, with_semantic_ids, allocator),
         }
     }
 }
@@ -1309,7 +948,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for AssignmentExpression<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for AssignmentTarget<'_> {
     type Cloned = AssignmentTarget<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
             Self::AssignmentTargetIdentifier(_)
             | Self::TSAsExpression(_)
@@ -1318,34 +961,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for AssignmentTarget<'_> {
             | Self::TSTypeAssertion(_)
             | Self::ComputedMemberExpression(_)
             | Self::StaticMemberExpression(_)
-            | Self::PrivateFieldExpression(_) => AssignmentTarget::from(CloneIn::clone_in(
+            | Self::PrivateFieldExpression(_) => AssignmentTarget::from(CloneIn::clone_in_impl(
                 self.to_simple_assignment_target(),
+                with_semantic_ids,
                 allocator,
             )),
             Self::ArrayAssignmentTarget(_) | Self::ObjectAssignmentTarget(_) => {
-                AssignmentTarget::from(CloneIn::clone_in(
+                AssignmentTarget::from(CloneIn::clone_in_impl(
                     self.to_assignment_target_pattern(),
-                    allocator,
-                ))
-            }
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::AssignmentTargetIdentifier(_)
-            | Self::TSAsExpression(_)
-            | Self::TSSatisfiesExpression(_)
-            | Self::TSNonNullExpression(_)
-            | Self::TSTypeAssertion(_)
-            | Self::ComputedMemberExpression(_)
-            | Self::StaticMemberExpression(_)
-            | Self::PrivateFieldExpression(_) => AssignmentTarget::from(
-                CloneIn::clone_in_with_semantic_ids(self.to_simple_assignment_target(), allocator),
-            ),
-            Self::ArrayAssignmentTarget(_) | Self::ObjectAssignmentTarget(_) => {
-                AssignmentTarget::from(CloneIn::clone_in_with_semantic_ids(
-                    self.to_assignment_target_pattern(),
+                    with_semantic_ids,
                     allocator,
                 ))
             }
@@ -1356,55 +980,35 @@ impl<'new_alloc> CloneIn<'new_alloc> for AssignmentTarget<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for SimpleAssignmentTarget<'_> {
     type Cloned = SimpleAssignmentTarget<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
             Self::AssignmentTargetIdentifier(it) => {
-                SimpleAssignmentTarget::AssignmentTargetIdentifier(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSAsExpression(it) => {
-                SimpleAssignmentTarget::TSAsExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSSatisfiesExpression(it) => {
-                SimpleAssignmentTarget::TSSatisfiesExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSNonNullExpression(it) => {
-                SimpleAssignmentTarget::TSNonNullExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSTypeAssertion(it) => {
-                SimpleAssignmentTarget::TSTypeAssertion(CloneIn::clone_in(it, allocator))
-            }
-            Self::ComputedMemberExpression(_)
-            | Self::StaticMemberExpression(_)
-            | Self::PrivateFieldExpression(_) => SimpleAssignmentTarget::from(CloneIn::clone_in(
-                self.to_member_expression(),
-                allocator,
-            )),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::AssignmentTargetIdentifier(it) => {
-                SimpleAssignmentTarget::AssignmentTargetIdentifier(
-                    CloneIn::clone_in_with_semantic_ids(it, allocator),
-                )
+                SimpleAssignmentTarget::AssignmentTargetIdentifier(CloneIn::clone_in_impl(
+                    it,
+                    with_semantic_ids,
+                    allocator,
+                ))
             }
             Self::TSAsExpression(it) => SimpleAssignmentTarget::TSAsExpression(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
             Self::TSSatisfiesExpression(it) => SimpleAssignmentTarget::TSSatisfiesExpression(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
             Self::TSNonNullExpression(it) => SimpleAssignmentTarget::TSNonNullExpression(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
             Self::TSTypeAssertion(it) => SimpleAssignmentTarget::TSTypeAssertion(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
             Self::ComputedMemberExpression(_)
             | Self::StaticMemberExpression(_)
             | Self::PrivateFieldExpression(_) => SimpleAssignmentTarget::from(
-                CloneIn::clone_in_with_semantic_ids(self.to_member_expression(), allocator),
+                CloneIn::clone_in_impl(self.to_member_expression(), with_semantic_ids, allocator),
             ),
         }
     }
@@ -1413,24 +1017,17 @@ impl<'new_alloc> CloneIn<'new_alloc> for SimpleAssignmentTarget<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for AssignmentTargetPattern<'_> {
     type Cloned = AssignmentTargetPattern<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::ArrayAssignmentTarget(it) => {
-                AssignmentTargetPattern::ArrayAssignmentTarget(CloneIn::clone_in(it, allocator))
-            }
-            Self::ObjectAssignmentTarget(it) => {
-                AssignmentTargetPattern::ObjectAssignmentTarget(CloneIn::clone_in(it, allocator))
-            }
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
             Self::ArrayAssignmentTarget(it) => AssignmentTargetPattern::ArrayAssignmentTarget(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
             Self::ObjectAssignmentTarget(it) => AssignmentTargetPattern::ObjectAssignmentTarget(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
         }
     }
@@ -1439,21 +1036,16 @@ impl<'new_alloc> CloneIn<'new_alloc> for AssignmentTargetPattern<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ArrayAssignmentTarget<'_> {
     type Cloned = ArrayAssignmentTarget<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         ArrayAssignmentTarget {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            elements: CloneIn::clone_in(&self.elements, allocator),
-            rest: CloneIn::clone_in(&self.rest, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        ArrayAssignmentTarget {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            elements: CloneIn::clone_in_with_semantic_ids(&self.elements, allocator),
-            rest: CloneIn::clone_in_with_semantic_ids(&self.rest, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            elements: CloneIn::clone_in_impl(&self.elements, with_semantic_ids, allocator),
+            rest: CloneIn::clone_in_impl(&self.rest, with_semantic_ids, allocator),
         }
     }
 }
@@ -1461,21 +1053,16 @@ impl<'new_alloc> CloneIn<'new_alloc> for ArrayAssignmentTarget<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ObjectAssignmentTarget<'_> {
     type Cloned = ObjectAssignmentTarget<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         ObjectAssignmentTarget {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            properties: CloneIn::clone_in(&self.properties, allocator),
-            rest: CloneIn::clone_in(&self.rest, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        ObjectAssignmentTarget {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            properties: CloneIn::clone_in_with_semantic_ids(&self.properties, allocator),
-            rest: CloneIn::clone_in_with_semantic_ids(&self.rest, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            properties: CloneIn::clone_in_impl(&self.properties, with_semantic_ids, allocator),
+            rest: CloneIn::clone_in_impl(&self.rest, with_semantic_ids, allocator),
         }
     }
 }
@@ -1483,19 +1070,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for ObjectAssignmentTarget<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for AssignmentTargetRest<'_> {
     type Cloned = AssignmentTargetRest<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         AssignmentTargetRest {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            target: CloneIn::clone_in(&self.target, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        AssignmentTargetRest {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            target: CloneIn::clone_in_with_semantic_ids(&self.target, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            target: CloneIn::clone_in_impl(&self.target, with_semantic_ids, allocator),
         }
     }
 }
@@ -1503,11 +1086,17 @@ impl<'new_alloc> CloneIn<'new_alloc> for AssignmentTargetRest<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for AssignmentTargetMaybeDefault<'_> {
     type Cloned = AssignmentTargetMaybeDefault<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
             Self::AssignmentTargetWithDefault(it) => {
-                AssignmentTargetMaybeDefault::AssignmentTargetWithDefault(CloneIn::clone_in(
-                    it, allocator,
+                AssignmentTargetMaybeDefault::AssignmentTargetWithDefault(CloneIn::clone_in_impl(
+                    it,
+                    with_semantic_ids,
+                    allocator,
                 ))
             }
             Self::AssignmentTargetIdentifier(_)
@@ -1520,29 +1109,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for AssignmentTargetMaybeDefault<'_> {
             | Self::PrivateFieldExpression(_)
             | Self::ArrayAssignmentTarget(_)
             | Self::ObjectAssignmentTarget(_) => AssignmentTargetMaybeDefault::from(
-                CloneIn::clone_in(self.to_assignment_target(), allocator),
-            ),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::AssignmentTargetWithDefault(it) => {
-                AssignmentTargetMaybeDefault::AssignmentTargetWithDefault(
-                    CloneIn::clone_in_with_semantic_ids(it, allocator),
-                )
-            }
-            Self::AssignmentTargetIdentifier(_)
-            | Self::TSAsExpression(_)
-            | Self::TSSatisfiesExpression(_)
-            | Self::TSNonNullExpression(_)
-            | Self::TSTypeAssertion(_)
-            | Self::ComputedMemberExpression(_)
-            | Self::StaticMemberExpression(_)
-            | Self::PrivateFieldExpression(_)
-            | Self::ArrayAssignmentTarget(_)
-            | Self::ObjectAssignmentTarget(_) => AssignmentTargetMaybeDefault::from(
-                CloneIn::clone_in_with_semantic_ids(self.to_assignment_target(), allocator),
+                CloneIn::clone_in_impl(self.to_assignment_target(), with_semantic_ids, allocator),
             ),
         }
     }
@@ -1551,21 +1118,16 @@ impl<'new_alloc> CloneIn<'new_alloc> for AssignmentTargetMaybeDefault<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for AssignmentTargetWithDefault<'_> {
     type Cloned = AssignmentTargetWithDefault<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         AssignmentTargetWithDefault {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            binding: CloneIn::clone_in(&self.binding, allocator),
-            init: CloneIn::clone_in(&self.init, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        AssignmentTargetWithDefault {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            binding: CloneIn::clone_in_with_semantic_ids(&self.binding, allocator),
-            init: CloneIn::clone_in_with_semantic_ids(&self.init, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            binding: CloneIn::clone_in_impl(&self.binding, with_semantic_ids, allocator),
+            init: CloneIn::clone_in_impl(&self.init, with_semantic_ids, allocator),
         }
     }
 }
@@ -1573,32 +1135,23 @@ impl<'new_alloc> CloneIn<'new_alloc> for AssignmentTargetWithDefault<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for AssignmentTargetProperty<'_> {
     type Cloned = AssignmentTargetProperty<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::AssignmentTargetPropertyIdentifier(it) => {
-                AssignmentTargetProperty::AssignmentTargetPropertyIdentifier(CloneIn::clone_in(
-                    it, allocator,
-                ))
-            }
-            Self::AssignmentTargetPropertyProperty(it) => {
-                AssignmentTargetProperty::AssignmentTargetPropertyProperty(CloneIn::clone_in(
-                    it, allocator,
-                ))
-            }
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
             Self::AssignmentTargetPropertyIdentifier(it) => {
                 AssignmentTargetProperty::AssignmentTargetPropertyIdentifier(
-                    CloneIn::clone_in_with_semantic_ids(it, allocator),
+                    CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
                 )
             }
             Self::AssignmentTargetPropertyProperty(it) => {
-                AssignmentTargetProperty::AssignmentTargetPropertyProperty(
-                    CloneIn::clone_in_with_semantic_ids(it, allocator),
-                )
+                AssignmentTargetProperty::AssignmentTargetPropertyProperty(CloneIn::clone_in_impl(
+                    it,
+                    with_semantic_ids,
+                    allocator,
+                ))
             }
         }
     }
@@ -1607,21 +1160,16 @@ impl<'new_alloc> CloneIn<'new_alloc> for AssignmentTargetProperty<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for AssignmentTargetPropertyIdentifier<'_> {
     type Cloned = AssignmentTargetPropertyIdentifier<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         AssignmentTargetPropertyIdentifier {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            binding: CloneIn::clone_in(&self.binding, allocator),
-            init: CloneIn::clone_in(&self.init, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        AssignmentTargetPropertyIdentifier {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            binding: CloneIn::clone_in_with_semantic_ids(&self.binding, allocator),
-            init: CloneIn::clone_in_with_semantic_ids(&self.init, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            binding: CloneIn::clone_in_impl(&self.binding, with_semantic_ids, allocator),
+            init: CloneIn::clone_in_impl(&self.init, with_semantic_ids, allocator),
         }
     }
 }
@@ -1629,23 +1177,17 @@ impl<'new_alloc> CloneIn<'new_alloc> for AssignmentTargetPropertyIdentifier<'_> 
 impl<'new_alloc> CloneIn<'new_alloc> for AssignmentTargetPropertyProperty<'_> {
     type Cloned = AssignmentTargetPropertyProperty<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         AssignmentTargetPropertyProperty {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            name: CloneIn::clone_in(&self.name, allocator),
-            binding: CloneIn::clone_in(&self.binding, allocator),
-            computed: CloneIn::clone_in(&self.computed, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        AssignmentTargetPropertyProperty {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            name: CloneIn::clone_in_with_semantic_ids(&self.name, allocator),
-            binding: CloneIn::clone_in_with_semantic_ids(&self.binding, allocator),
-            computed: CloneIn::clone_in_with_semantic_ids(&self.computed, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            name: CloneIn::clone_in_impl(&self.name, with_semantic_ids, allocator),
+            binding: CloneIn::clone_in_impl(&self.binding, with_semantic_ids, allocator),
+            computed: CloneIn::clone_in_impl(&self.computed, with_semantic_ids, allocator),
         }
     }
 }
@@ -1653,19 +1195,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for AssignmentTargetPropertyProperty<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for SequenceExpression<'_> {
     type Cloned = SequenceExpression<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         SequenceExpression {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            expressions: CloneIn::clone_in(&self.expressions, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        SequenceExpression {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            expressions: CloneIn::clone_in_with_semantic_ids(&self.expressions, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            expressions: CloneIn::clone_in_impl(&self.expressions, with_semantic_ids, allocator),
         }
     }
 }
@@ -1673,14 +1211,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for SequenceExpression<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for Super {
     type Cloned = Super;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        Super { node_id: Default::default(), span: CloneIn::clone_in(&self.span, allocator) }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         Super {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
         }
     }
 }
@@ -1688,19 +1226,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for Super {
 impl<'new_alloc> CloneIn<'new_alloc> for AwaitExpression<'_> {
     type Cloned = AwaitExpression<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         AwaitExpression {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            argument: CloneIn::clone_in(&self.argument, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        AwaitExpression {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            argument: CloneIn::clone_in_with_semantic_ids(&self.argument, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            argument: CloneIn::clone_in_impl(&self.argument, with_semantic_ids, allocator),
         }
     }
 }
@@ -1708,19 +1242,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for AwaitExpression<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ChainExpression<'_> {
     type Cloned = ChainExpression<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         ChainExpression {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            expression: CloneIn::clone_in(&self.expression, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        ChainExpression {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            expression: CloneIn::clone_in_impl(&self.expression, with_semantic_ids, allocator),
         }
     }
 }
@@ -1728,35 +1258,27 @@ impl<'new_alloc> CloneIn<'new_alloc> for ChainExpression<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ChainElement<'_> {
     type Cloned = ChainElement<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
-            Self::CallExpression(it) => {
-                ChainElement::CallExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSNonNullExpression(it) => {
-                ChainElement::TSNonNullExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::ComputedMemberExpression(_)
-            | Self::StaticMemberExpression(_)
-            | Self::PrivateFieldExpression(_) => {
-                ChainElement::from(CloneIn::clone_in(self.to_member_expression(), allocator))
-            }
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::CallExpression(it) => {
-                ChainElement::CallExpression(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
+            Self::CallExpression(it) => ChainElement::CallExpression(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
             Self::TSNonNullExpression(it) => ChainElement::TSNonNullExpression(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
             Self::ComputedMemberExpression(_)
             | Self::StaticMemberExpression(_)
-            | Self::PrivateFieldExpression(_) => ChainElement::from(
-                CloneIn::clone_in_with_semantic_ids(self.to_member_expression(), allocator),
-            ),
+            | Self::PrivateFieldExpression(_) => ChainElement::from(CloneIn::clone_in_impl(
+                self.to_member_expression(),
+                with_semantic_ids,
+                allocator,
+            )),
         }
     }
 }
@@ -1764,19 +1286,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for ChainElement<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ParenthesizedExpression<'_> {
     type Cloned = ParenthesizedExpression<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         ParenthesizedExpression {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            expression: CloneIn::clone_in(&self.expression, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        ParenthesizedExpression {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            expression: CloneIn::clone_in_impl(&self.expression, with_semantic_ids, allocator),
         }
     }
 }
@@ -1784,117 +1302,73 @@ impl<'new_alloc> CloneIn<'new_alloc> for ParenthesizedExpression<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for Statement<'_> {
     type Cloned = Statement<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::BlockStatement(it) => Statement::BlockStatement(CloneIn::clone_in(it, allocator)),
-            Self::BreakStatement(it) => Statement::BreakStatement(CloneIn::clone_in(it, allocator)),
-            Self::ContinueStatement(it) => {
-                Statement::ContinueStatement(CloneIn::clone_in(it, allocator))
-            }
-            Self::DebuggerStatement(it) => {
-                Statement::DebuggerStatement(CloneIn::clone_in(it, allocator))
-            }
-            Self::DoWhileStatement(it) => {
-                Statement::DoWhileStatement(CloneIn::clone_in(it, allocator))
-            }
-            Self::EmptyStatement(it) => Statement::EmptyStatement(CloneIn::clone_in(it, allocator)),
-            Self::ExpressionStatement(it) => {
-                Statement::ExpressionStatement(CloneIn::clone_in(it, allocator))
-            }
-            Self::ForInStatement(it) => Statement::ForInStatement(CloneIn::clone_in(it, allocator)),
-            Self::ForOfStatement(it) => Statement::ForOfStatement(CloneIn::clone_in(it, allocator)),
-            Self::ForStatement(it) => Statement::ForStatement(CloneIn::clone_in(it, allocator)),
-            Self::IfStatement(it) => Statement::IfStatement(CloneIn::clone_in(it, allocator)),
-            Self::LabeledStatement(it) => {
-                Statement::LabeledStatement(CloneIn::clone_in(it, allocator))
-            }
-            Self::ReturnStatement(it) => {
-                Statement::ReturnStatement(CloneIn::clone_in(it, allocator))
-            }
-            Self::SwitchStatement(it) => {
-                Statement::SwitchStatement(CloneIn::clone_in(it, allocator))
-            }
-            Self::ThrowStatement(it) => Statement::ThrowStatement(CloneIn::clone_in(it, allocator)),
-            Self::TryStatement(it) => Statement::TryStatement(CloneIn::clone_in(it, allocator)),
-            Self::WhileStatement(it) => Statement::WhileStatement(CloneIn::clone_in(it, allocator)),
-            Self::WithStatement(it) => Statement::WithStatement(CloneIn::clone_in(it, allocator)),
-            Self::VariableDeclaration(_)
-            | Self::FunctionDeclaration(_)
-            | Self::ClassDeclaration(_)
-            | Self::TSTypeAliasDeclaration(_)
-            | Self::TSInterfaceDeclaration(_)
-            | Self::TSEnumDeclaration(_)
-            | Self::TSModuleDeclaration(_)
-            | Self::TSGlobalDeclaration(_)
-            | Self::TSImportEqualsDeclaration(_) => {
-                Statement::from(CloneIn::clone_in(self.to_declaration(), allocator))
-            }
-            Self::ImportDeclaration(_)
-            | Self::ExportAllDeclaration(_)
-            | Self::ExportDefaultDeclaration(_)
-            | Self::ExportNamedDeclaration(_)
-            | Self::TSExportAssignment(_)
-            | Self::TSNamespaceExportDeclaration(_) => {
-                Statement::from(CloneIn::clone_in(self.to_module_declaration(), allocator))
-            }
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
             Self::BlockStatement(it) => {
-                Statement::BlockStatement(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                Statement::BlockStatement(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::BreakStatement(it) => {
-                Statement::BreakStatement(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                Statement::BreakStatement(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
-            Self::ContinueStatement(it) => {
-                Statement::ContinueStatement(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
-            Self::DebuggerStatement(it) => {
-                Statement::DebuggerStatement(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
-            Self::DoWhileStatement(it) => {
-                Statement::DoWhileStatement(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
+            Self::ContinueStatement(it) => Statement::ContinueStatement(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
+            Self::DebuggerStatement(it) => Statement::DebuggerStatement(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
+            Self::DoWhileStatement(it) => Statement::DoWhileStatement(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
             Self::EmptyStatement(it) => {
-                Statement::EmptyStatement(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                Statement::EmptyStatement(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
-            Self::ExpressionStatement(it) => {
-                Statement::ExpressionStatement(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
+            Self::ExpressionStatement(it) => Statement::ExpressionStatement(
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
+            ),
             Self::ForInStatement(it) => {
-                Statement::ForInStatement(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                Statement::ForInStatement(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::ForOfStatement(it) => {
-                Statement::ForOfStatement(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                Statement::ForOfStatement(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::ForStatement(it) => {
-                Statement::ForStatement(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                Statement::ForStatement(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::IfStatement(it) => {
-                Statement::IfStatement(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                Statement::IfStatement(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
-            Self::LabeledStatement(it) => {
-                Statement::LabeledStatement(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
+            Self::LabeledStatement(it) => Statement::LabeledStatement(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
             Self::ReturnStatement(it) => {
-                Statement::ReturnStatement(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                Statement::ReturnStatement(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::SwitchStatement(it) => {
-                Statement::SwitchStatement(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                Statement::SwitchStatement(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::ThrowStatement(it) => {
-                Statement::ThrowStatement(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                Statement::ThrowStatement(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::TryStatement(it) => {
-                Statement::TryStatement(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                Statement::TryStatement(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::WhileStatement(it) => {
-                Statement::WhileStatement(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                Statement::WhileStatement(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::WithStatement(it) => {
-                Statement::WithStatement(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                Statement::WithStatement(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::VariableDeclaration(_)
             | Self::FunctionDeclaration(_)
@@ -1904,17 +1378,21 @@ impl<'new_alloc> CloneIn<'new_alloc> for Statement<'_> {
             | Self::TSEnumDeclaration(_)
             | Self::TSModuleDeclaration(_)
             | Self::TSGlobalDeclaration(_)
-            | Self::TSImportEqualsDeclaration(_) => Statement::from(
-                CloneIn::clone_in_with_semantic_ids(self.to_declaration(), allocator),
-            ),
+            | Self::TSImportEqualsDeclaration(_) => Statement::from(CloneIn::clone_in_impl(
+                self.to_declaration(),
+                with_semantic_ids,
+                allocator,
+            )),
             Self::ImportDeclaration(_)
             | Self::ExportAllDeclaration(_)
             | Self::ExportDefaultDeclaration(_)
             | Self::ExportNamedDeclaration(_)
             | Self::TSExportAssignment(_)
-            | Self::TSNamespaceExportDeclaration(_) => Statement::from(
-                CloneIn::clone_in_with_semantic_ids(self.to_module_declaration(), allocator),
-            ),
+            | Self::TSNamespaceExportDeclaration(_) => Statement::from(CloneIn::clone_in_impl(
+                self.to_module_declaration(),
+                with_semantic_ids,
+                allocator,
+            )),
         }
     }
 }
@@ -1922,21 +1400,16 @@ impl<'new_alloc> CloneIn<'new_alloc> for Statement<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for Directive<'_> {
     type Cloned = Directive<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         Directive {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            expression: CloneIn::clone_in(&self.expression, allocator),
-            directive: CloneIn::clone_in(&self.directive, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        Directive {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
-            directive: CloneIn::clone_in_with_semantic_ids(&self.directive, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            expression: CloneIn::clone_in_impl(&self.expression, with_semantic_ids, allocator),
+            directive: CloneIn::clone_in_impl(&self.directive, with_semantic_ids, allocator),
         }
     }
 }
@@ -1944,19 +1417,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for Directive<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for Hashbang<'_> {
     type Cloned = Hashbang<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         Hashbang {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            value: CloneIn::clone_in(&self.value, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        Hashbang {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            value: CloneIn::clone_in_with_semantic_ids(&self.value, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            value: CloneIn::clone_in_impl(&self.value, with_semantic_ids, allocator),
         }
     }
 }
@@ -1964,21 +1433,16 @@ impl<'new_alloc> CloneIn<'new_alloc> for Hashbang<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for BlockStatement<'_> {
     type Cloned = BlockStatement<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         BlockStatement {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            body: CloneIn::clone_in(&self.body, allocator),
-            scope_id: Default::default(),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        BlockStatement {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
-            scope_id: CloneIn::clone_in_with_semantic_ids(&self.scope_id, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
+            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
         }
     }
 }
@@ -1986,66 +1450,42 @@ impl<'new_alloc> CloneIn<'new_alloc> for BlockStatement<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for Declaration<'_> {
     type Cloned = Declaration<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
-            Self::VariableDeclaration(it) => {
-                Declaration::VariableDeclaration(CloneIn::clone_in(it, allocator))
-            }
-            Self::FunctionDeclaration(it) => {
-                Declaration::FunctionDeclaration(CloneIn::clone_in(it, allocator))
-            }
-            Self::ClassDeclaration(it) => {
-                Declaration::ClassDeclaration(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSTypeAliasDeclaration(it) => {
-                Declaration::TSTypeAliasDeclaration(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSInterfaceDeclaration(it) => {
-                Declaration::TSInterfaceDeclaration(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSEnumDeclaration(it) => {
-                Declaration::TSEnumDeclaration(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSModuleDeclaration(it) => {
-                Declaration::TSModuleDeclaration(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSGlobalDeclaration(it) => {
-                Declaration::TSGlobalDeclaration(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSImportEqualsDeclaration(it) => {
-                Declaration::TSImportEqualsDeclaration(CloneIn::clone_in(it, allocator))
-            }
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::VariableDeclaration(it) => {
-                Declaration::VariableDeclaration(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
-            Self::FunctionDeclaration(it) => {
-                Declaration::FunctionDeclaration(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
-            Self::ClassDeclaration(it) => {
-                Declaration::ClassDeclaration(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
+            Self::VariableDeclaration(it) => Declaration::VariableDeclaration(
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
+            ),
+            Self::FunctionDeclaration(it) => Declaration::FunctionDeclaration(
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
+            ),
+            Self::ClassDeclaration(it) => Declaration::ClassDeclaration(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
             Self::TSTypeAliasDeclaration(it) => Declaration::TSTypeAliasDeclaration(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
             Self::TSInterfaceDeclaration(it) => Declaration::TSInterfaceDeclaration(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
-            Self::TSEnumDeclaration(it) => {
-                Declaration::TSEnumDeclaration(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
-            Self::TSModuleDeclaration(it) => {
-                Declaration::TSModuleDeclaration(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
-            Self::TSGlobalDeclaration(it) => {
-                Declaration::TSGlobalDeclaration(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
+            Self::TSEnumDeclaration(it) => Declaration::TSEnumDeclaration(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
+            Self::TSModuleDeclaration(it) => Declaration::TSModuleDeclaration(
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
+            ),
+            Self::TSGlobalDeclaration(it) => Declaration::TSGlobalDeclaration(
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
+            ),
             Self::TSImportEqualsDeclaration(it) => Declaration::TSImportEqualsDeclaration(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
         }
     }
@@ -2054,23 +1494,17 @@ impl<'new_alloc> CloneIn<'new_alloc> for Declaration<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for VariableDeclaration<'_> {
     type Cloned = VariableDeclaration<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         VariableDeclaration {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            kind: CloneIn::clone_in(&self.kind, allocator),
-            declarations: CloneIn::clone_in(&self.declarations, allocator),
-            declare: CloneIn::clone_in(&self.declare, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        VariableDeclaration {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            kind: CloneIn::clone_in_with_semantic_ids(&self.kind, allocator),
-            declarations: CloneIn::clone_in_with_semantic_ids(&self.declarations, allocator),
-            declare: CloneIn::clone_in_with_semantic_ids(&self.declare, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            kind: CloneIn::clone_in_impl(&self.kind, with_semantic_ids, allocator),
+            declarations: CloneIn::clone_in_impl(&self.declarations, with_semantic_ids, allocator),
+            declare: CloneIn::clone_in_impl(&self.declare, with_semantic_ids, allocator),
         }
     }
 }
@@ -2079,12 +1513,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for VariableDeclarationKind {
     type Cloned = VariableDeclarationKind;
 
     #[inline(always)]
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        *self
-    }
-
-    #[inline(always)]
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         *self
     }
 }
@@ -2092,27 +1525,23 @@ impl<'new_alloc> CloneIn<'new_alloc> for VariableDeclarationKind {
 impl<'new_alloc> CloneIn<'new_alloc> for VariableDeclarator<'_> {
     type Cloned = VariableDeclarator<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         VariableDeclarator {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            kind: CloneIn::clone_in(&self.kind, allocator),
-            id: CloneIn::clone_in(&self.id, allocator),
-            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
-            init: CloneIn::clone_in(&self.init, allocator),
-            definite: CloneIn::clone_in(&self.definite, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        VariableDeclarator {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            kind: CloneIn::clone_in_with_semantic_ids(&self.kind, allocator),
-            id: CloneIn::clone_in_with_semantic_ids(&self.id, allocator),
-            type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
-            init: CloneIn::clone_in_with_semantic_ids(&self.init, allocator),
-            definite: CloneIn::clone_in_with_semantic_ids(&self.definite, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            kind: CloneIn::clone_in_impl(&self.kind, with_semantic_ids, allocator),
+            id: CloneIn::clone_in_impl(&self.id, with_semantic_ids, allocator),
+            type_annotation: CloneIn::clone_in_impl(
+                &self.type_annotation,
+                with_semantic_ids,
+                allocator,
+            ),
+            init: CloneIn::clone_in_impl(&self.init, with_semantic_ids, allocator),
+            definite: CloneIn::clone_in_impl(&self.definite, with_semantic_ids, allocator),
         }
     }
 }
@@ -2120,17 +1549,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for VariableDeclarator<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for EmptyStatement {
     type Cloned = EmptyStatement;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         EmptyStatement {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        EmptyStatement {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
         }
     }
 }
@@ -2138,19 +1564,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for EmptyStatement {
 impl<'new_alloc> CloneIn<'new_alloc> for ExpressionStatement<'_> {
     type Cloned = ExpressionStatement<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         ExpressionStatement {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            expression: CloneIn::clone_in(&self.expression, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        ExpressionStatement {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            expression: CloneIn::clone_in_impl(&self.expression, with_semantic_ids, allocator),
         }
     }
 }
@@ -2158,23 +1580,17 @@ impl<'new_alloc> CloneIn<'new_alloc> for ExpressionStatement<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for IfStatement<'_> {
     type Cloned = IfStatement<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         IfStatement {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            test: CloneIn::clone_in(&self.test, allocator),
-            consequent: CloneIn::clone_in(&self.consequent, allocator),
-            alternate: CloneIn::clone_in(&self.alternate, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        IfStatement {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            test: CloneIn::clone_in_with_semantic_ids(&self.test, allocator),
-            consequent: CloneIn::clone_in_with_semantic_ids(&self.consequent, allocator),
-            alternate: CloneIn::clone_in_with_semantic_ids(&self.alternate, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            test: CloneIn::clone_in_impl(&self.test, with_semantic_ids, allocator),
+            consequent: CloneIn::clone_in_impl(&self.consequent, with_semantic_ids, allocator),
+            alternate: CloneIn::clone_in_impl(&self.alternate, with_semantic_ids, allocator),
         }
     }
 }
@@ -2182,21 +1598,16 @@ impl<'new_alloc> CloneIn<'new_alloc> for IfStatement<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for DoWhileStatement<'_> {
     type Cloned = DoWhileStatement<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         DoWhileStatement {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            body: CloneIn::clone_in(&self.body, allocator),
-            test: CloneIn::clone_in(&self.test, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        DoWhileStatement {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
-            test: CloneIn::clone_in_with_semantic_ids(&self.test, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
+            test: CloneIn::clone_in_impl(&self.test, with_semantic_ids, allocator),
         }
     }
 }
@@ -2204,21 +1615,16 @@ impl<'new_alloc> CloneIn<'new_alloc> for DoWhileStatement<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for WhileStatement<'_> {
     type Cloned = WhileStatement<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         WhileStatement {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            test: CloneIn::clone_in(&self.test, allocator),
-            body: CloneIn::clone_in(&self.body, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        WhileStatement {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            test: CloneIn::clone_in_with_semantic_ids(&self.test, allocator),
-            body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            test: CloneIn::clone_in_impl(&self.test, with_semantic_ids, allocator),
+            body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
         }
     }
 }
@@ -2226,27 +1632,19 @@ impl<'new_alloc> CloneIn<'new_alloc> for WhileStatement<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ForStatement<'_> {
     type Cloned = ForStatement<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         ForStatement {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            init: CloneIn::clone_in(&self.init, allocator),
-            test: CloneIn::clone_in(&self.test, allocator),
-            update: CloneIn::clone_in(&self.update, allocator),
-            body: CloneIn::clone_in(&self.body, allocator),
-            scope_id: Default::default(),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        ForStatement {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            init: CloneIn::clone_in_with_semantic_ids(&self.init, allocator),
-            test: CloneIn::clone_in_with_semantic_ids(&self.test, allocator),
-            update: CloneIn::clone_in_with_semantic_ids(&self.update, allocator),
-            body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
-            scope_id: CloneIn::clone_in_with_semantic_ids(&self.scope_id, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            init: CloneIn::clone_in_impl(&self.init, with_semantic_ids, allocator),
+            test: CloneIn::clone_in_impl(&self.test, with_semantic_ids, allocator),
+            update: CloneIn::clone_in_impl(&self.update, with_semantic_ids, allocator),
+            body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
+            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
         }
     }
 }
@@ -2254,63 +1652,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for ForStatement<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ForStatementInit<'_> {
     type Cloned = ForStatementInit<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::VariableDeclaration(it) => {
-                ForStatementInit::VariableDeclaration(CloneIn::clone_in(it, allocator))
-            }
-            Self::BooleanLiteral(_)
-            | Self::NullLiteral(_)
-            | Self::NumericLiteral(_)
-            | Self::BigIntLiteral(_)
-            | Self::RegExpLiteral(_)
-            | Self::StringLiteral(_)
-            | Self::TemplateLiteral(_)
-            | Self::Identifier(_)
-            | Self::MetaProperty(_)
-            | Self::Super(_)
-            | Self::ArrayExpression(_)
-            | Self::ArrowFunctionExpression(_)
-            | Self::AssignmentExpression(_)
-            | Self::AwaitExpression(_)
-            | Self::BinaryExpression(_)
-            | Self::CallExpression(_)
-            | Self::ChainExpression(_)
-            | Self::ClassExpression(_)
-            | Self::ConditionalExpression(_)
-            | Self::FunctionExpression(_)
-            | Self::ImportExpression(_)
-            | Self::LogicalExpression(_)
-            | Self::NewExpression(_)
-            | Self::ObjectExpression(_)
-            | Self::ParenthesizedExpression(_)
-            | Self::SequenceExpression(_)
-            | Self::TaggedTemplateExpression(_)
-            | Self::ThisExpression(_)
-            | Self::UnaryExpression(_)
-            | Self::UpdateExpression(_)
-            | Self::YieldExpression(_)
-            | Self::PrivateInExpression(_)
-            | Self::JSXElement(_)
-            | Self::JSXFragment(_)
-            | Self::TSAsExpression(_)
-            | Self::TSSatisfiesExpression(_)
-            | Self::TSTypeAssertion(_)
-            | Self::TSNonNullExpression(_)
-            | Self::TSInstantiationExpression(_)
-            | Self::V8IntrinsicExpression(_)
-            | Self::ComputedMemberExpression(_)
-            | Self::StaticMemberExpression(_)
-            | Self::PrivateFieldExpression(_) => {
-                ForStatementInit::from(CloneIn::clone_in(self.to_expression(), allocator))
-            }
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
             Self::VariableDeclaration(it) => ForStatementInit::VariableDeclaration(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
             Self::BooleanLiteral(_)
             | Self::NullLiteral(_)
@@ -2354,9 +1703,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for ForStatementInit<'_> {
             | Self::V8IntrinsicExpression(_)
             | Self::ComputedMemberExpression(_)
             | Self::StaticMemberExpression(_)
-            | Self::PrivateFieldExpression(_) => ForStatementInit::from(
-                CloneIn::clone_in_with_semantic_ids(self.to_expression(), allocator),
-            ),
+            | Self::PrivateFieldExpression(_) => ForStatementInit::from(CloneIn::clone_in_impl(
+                self.to_expression(),
+                with_semantic_ids,
+                allocator,
+            )),
         }
     }
 }
@@ -2364,25 +1715,18 @@ impl<'new_alloc> CloneIn<'new_alloc> for ForStatementInit<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ForInStatement<'_> {
     type Cloned = ForInStatement<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         ForInStatement {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            left: CloneIn::clone_in(&self.left, allocator),
-            right: CloneIn::clone_in(&self.right, allocator),
-            body: CloneIn::clone_in(&self.body, allocator),
-            scope_id: Default::default(),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        ForInStatement {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            left: CloneIn::clone_in_with_semantic_ids(&self.left, allocator),
-            right: CloneIn::clone_in_with_semantic_ids(&self.right, allocator),
-            body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
-            scope_id: CloneIn::clone_in_with_semantic_ids(&self.scope_id, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            left: CloneIn::clone_in_impl(&self.left, with_semantic_ids, allocator),
+            right: CloneIn::clone_in_impl(&self.right, with_semantic_ids, allocator),
+            body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
+            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
         }
     }
 }
@@ -2390,30 +1734,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for ForInStatement<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ForStatementLeft<'_> {
     type Cloned = ForStatementLeft<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::VariableDeclaration(it) => {
-                ForStatementLeft::VariableDeclaration(CloneIn::clone_in(it, allocator))
-            }
-            Self::AssignmentTargetIdentifier(_)
-            | Self::TSAsExpression(_)
-            | Self::TSSatisfiesExpression(_)
-            | Self::TSNonNullExpression(_)
-            | Self::TSTypeAssertion(_)
-            | Self::ComputedMemberExpression(_)
-            | Self::StaticMemberExpression(_)
-            | Self::PrivateFieldExpression(_)
-            | Self::ArrayAssignmentTarget(_)
-            | Self::ObjectAssignmentTarget(_) => {
-                ForStatementLeft::from(CloneIn::clone_in(self.to_assignment_target(), allocator))
-            }
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
             Self::VariableDeclaration(it) => ForStatementLeft::VariableDeclaration(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
             Self::AssignmentTargetIdentifier(_)
             | Self::TSAsExpression(_)
@@ -2424,9 +1752,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for ForStatementLeft<'_> {
             | Self::StaticMemberExpression(_)
             | Self::PrivateFieldExpression(_)
             | Self::ArrayAssignmentTarget(_)
-            | Self::ObjectAssignmentTarget(_) => ForStatementLeft::from(
-                CloneIn::clone_in_with_semantic_ids(self.to_assignment_target(), allocator),
-            ),
+            | Self::ObjectAssignmentTarget(_) => ForStatementLeft::from(CloneIn::clone_in_impl(
+                self.to_assignment_target(),
+                with_semantic_ids,
+                allocator,
+            )),
         }
     }
 }
@@ -2434,27 +1764,19 @@ impl<'new_alloc> CloneIn<'new_alloc> for ForStatementLeft<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ForOfStatement<'_> {
     type Cloned = ForOfStatement<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         ForOfStatement {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            r#await: CloneIn::clone_in(&self.r#await, allocator),
-            left: CloneIn::clone_in(&self.left, allocator),
-            right: CloneIn::clone_in(&self.right, allocator),
-            body: CloneIn::clone_in(&self.body, allocator),
-            scope_id: Default::default(),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        ForOfStatement {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            r#await: CloneIn::clone_in_with_semantic_ids(&self.r#await, allocator),
-            left: CloneIn::clone_in_with_semantic_ids(&self.left, allocator),
-            right: CloneIn::clone_in_with_semantic_ids(&self.right, allocator),
-            body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
-            scope_id: CloneIn::clone_in_with_semantic_ids(&self.scope_id, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            r#await: CloneIn::clone_in_impl(&self.r#await, with_semantic_ids, allocator),
+            left: CloneIn::clone_in_impl(&self.left, with_semantic_ids, allocator),
+            right: CloneIn::clone_in_impl(&self.right, with_semantic_ids, allocator),
+            body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
+            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
         }
     }
 }
@@ -2462,19 +1784,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for ForOfStatement<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ContinueStatement<'_> {
     type Cloned = ContinueStatement<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         ContinueStatement {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            label: CloneIn::clone_in(&self.label, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        ContinueStatement {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            label: CloneIn::clone_in_with_semantic_ids(&self.label, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            label: CloneIn::clone_in_impl(&self.label, with_semantic_ids, allocator),
         }
     }
 }
@@ -2482,19 +1800,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for ContinueStatement<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for BreakStatement<'_> {
     type Cloned = BreakStatement<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         BreakStatement {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            label: CloneIn::clone_in(&self.label, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        BreakStatement {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            label: CloneIn::clone_in_with_semantic_ids(&self.label, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            label: CloneIn::clone_in_impl(&self.label, with_semantic_ids, allocator),
         }
     }
 }
@@ -2502,19 +1816,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for BreakStatement<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ReturnStatement<'_> {
     type Cloned = ReturnStatement<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         ReturnStatement {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            argument: CloneIn::clone_in(&self.argument, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        ReturnStatement {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            argument: CloneIn::clone_in_with_semantic_ids(&self.argument, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            argument: CloneIn::clone_in_impl(&self.argument, with_semantic_ids, allocator),
         }
     }
 }
@@ -2522,23 +1832,17 @@ impl<'new_alloc> CloneIn<'new_alloc> for ReturnStatement<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for WithStatement<'_> {
     type Cloned = WithStatement<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         WithStatement {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            object: CloneIn::clone_in(&self.object, allocator),
-            body: CloneIn::clone_in(&self.body, allocator),
-            scope_id: Default::default(),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        WithStatement {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            object: CloneIn::clone_in_with_semantic_ids(&self.object, allocator),
-            body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
-            scope_id: CloneIn::clone_in_with_semantic_ids(&self.scope_id, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            object: CloneIn::clone_in_impl(&self.object, with_semantic_ids, allocator),
+            body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
+            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
         }
     }
 }
@@ -2546,23 +1850,17 @@ impl<'new_alloc> CloneIn<'new_alloc> for WithStatement<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for SwitchStatement<'_> {
     type Cloned = SwitchStatement<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         SwitchStatement {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            discriminant: CloneIn::clone_in(&self.discriminant, allocator),
-            cases: CloneIn::clone_in(&self.cases, allocator),
-            scope_id: Default::default(),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        SwitchStatement {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            discriminant: CloneIn::clone_in_with_semantic_ids(&self.discriminant, allocator),
-            cases: CloneIn::clone_in_with_semantic_ids(&self.cases, allocator),
-            scope_id: CloneIn::clone_in_with_semantic_ids(&self.scope_id, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            discriminant: CloneIn::clone_in_impl(&self.discriminant, with_semantic_ids, allocator),
+            cases: CloneIn::clone_in_impl(&self.cases, with_semantic_ids, allocator),
+            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
         }
     }
 }
@@ -2570,21 +1868,16 @@ impl<'new_alloc> CloneIn<'new_alloc> for SwitchStatement<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for SwitchCase<'_> {
     type Cloned = SwitchCase<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         SwitchCase {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            test: CloneIn::clone_in(&self.test, allocator),
-            consequent: CloneIn::clone_in(&self.consequent, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        SwitchCase {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            test: CloneIn::clone_in_with_semantic_ids(&self.test, allocator),
-            consequent: CloneIn::clone_in_with_semantic_ids(&self.consequent, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            test: CloneIn::clone_in_impl(&self.test, with_semantic_ids, allocator),
+            consequent: CloneIn::clone_in_impl(&self.consequent, with_semantic_ids, allocator),
         }
     }
 }
@@ -2592,21 +1885,16 @@ impl<'new_alloc> CloneIn<'new_alloc> for SwitchCase<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for LabeledStatement<'_> {
     type Cloned = LabeledStatement<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         LabeledStatement {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            label: CloneIn::clone_in(&self.label, allocator),
-            body: CloneIn::clone_in(&self.body, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        LabeledStatement {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            label: CloneIn::clone_in_with_semantic_ids(&self.label, allocator),
-            body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            label: CloneIn::clone_in_impl(&self.label, with_semantic_ids, allocator),
+            body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
         }
     }
 }
@@ -2614,19 +1902,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for LabeledStatement<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ThrowStatement<'_> {
     type Cloned = ThrowStatement<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         ThrowStatement {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            argument: CloneIn::clone_in(&self.argument, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        ThrowStatement {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            argument: CloneIn::clone_in_with_semantic_ids(&self.argument, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            argument: CloneIn::clone_in_impl(&self.argument, with_semantic_ids, allocator),
         }
     }
 }
@@ -2634,23 +1918,17 @@ impl<'new_alloc> CloneIn<'new_alloc> for ThrowStatement<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TryStatement<'_> {
     type Cloned = TryStatement<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TryStatement {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            block: CloneIn::clone_in(&self.block, allocator),
-            handler: CloneIn::clone_in(&self.handler, allocator),
-            finalizer: CloneIn::clone_in(&self.finalizer, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TryStatement {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            block: CloneIn::clone_in_with_semantic_ids(&self.block, allocator),
-            handler: CloneIn::clone_in_with_semantic_ids(&self.handler, allocator),
-            finalizer: CloneIn::clone_in_with_semantic_ids(&self.finalizer, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            block: CloneIn::clone_in_impl(&self.block, with_semantic_ids, allocator),
+            handler: CloneIn::clone_in_impl(&self.handler, with_semantic_ids, allocator),
+            finalizer: CloneIn::clone_in_impl(&self.finalizer, with_semantic_ids, allocator),
         }
     }
 }
@@ -2658,23 +1936,17 @@ impl<'new_alloc> CloneIn<'new_alloc> for TryStatement<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for CatchClause<'_> {
     type Cloned = CatchClause<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         CatchClause {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            param: CloneIn::clone_in(&self.param, allocator),
-            body: CloneIn::clone_in(&self.body, allocator),
-            scope_id: Default::default(),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        CatchClause {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            param: CloneIn::clone_in_with_semantic_ids(&self.param, allocator),
-            body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
-            scope_id: CloneIn::clone_in_with_semantic_ids(&self.scope_id, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            param: CloneIn::clone_in_impl(&self.param, with_semantic_ids, allocator),
+            body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
+            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
         }
     }
 }
@@ -2682,21 +1954,20 @@ impl<'new_alloc> CloneIn<'new_alloc> for CatchClause<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for CatchParameter<'_> {
     type Cloned = CatchParameter<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         CatchParameter {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            pattern: CloneIn::clone_in(&self.pattern, allocator),
-            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        CatchParameter {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            pattern: CloneIn::clone_in_with_semantic_ids(&self.pattern, allocator),
-            type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            pattern: CloneIn::clone_in_impl(&self.pattern, with_semantic_ids, allocator),
+            type_annotation: CloneIn::clone_in_impl(
+                &self.type_annotation,
+                with_semantic_ids,
+                allocator,
+            ),
         }
     }
 }
@@ -2704,17 +1975,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for CatchParameter<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for DebuggerStatement {
     type Cloned = DebuggerStatement;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         DebuggerStatement {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        DebuggerStatement {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
         }
     }
 }
@@ -2722,36 +1990,27 @@ impl<'new_alloc> CloneIn<'new_alloc> for DebuggerStatement {
 impl<'new_alloc> CloneIn<'new_alloc> for BindingPattern<'_> {
     type Cloned = BindingPattern<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::BindingIdentifier(it) => {
-                BindingPattern::BindingIdentifier(CloneIn::clone_in(it, allocator))
-            }
-            Self::ObjectPattern(it) => {
-                BindingPattern::ObjectPattern(CloneIn::clone_in(it, allocator))
-            }
-            Self::ArrayPattern(it) => {
-                BindingPattern::ArrayPattern(CloneIn::clone_in(it, allocator))
-            }
-            Self::AssignmentPattern(it) => {
-                BindingPattern::AssignmentPattern(CloneIn::clone_in(it, allocator))
-            }
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
             Self::BindingIdentifier(it) => BindingPattern::BindingIdentifier(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
-            Self::ObjectPattern(it) => {
-                BindingPattern::ObjectPattern(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
-            Self::ArrayPattern(it) => {
-                BindingPattern::ArrayPattern(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
+            Self::ObjectPattern(it) => BindingPattern::ObjectPattern(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
+            Self::ArrayPattern(it) => BindingPattern::ArrayPattern(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
             Self::AssignmentPattern(it) => BindingPattern::AssignmentPattern(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
         }
     }
@@ -2760,21 +2019,16 @@ impl<'new_alloc> CloneIn<'new_alloc> for BindingPattern<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for AssignmentPattern<'_> {
     type Cloned = AssignmentPattern<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         AssignmentPattern {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            left: CloneIn::clone_in(&self.left, allocator),
-            right: CloneIn::clone_in(&self.right, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        AssignmentPattern {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            left: CloneIn::clone_in_with_semantic_ids(&self.left, allocator),
-            right: CloneIn::clone_in_with_semantic_ids(&self.right, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            left: CloneIn::clone_in_impl(&self.left, with_semantic_ids, allocator),
+            right: CloneIn::clone_in_impl(&self.right, with_semantic_ids, allocator),
         }
     }
 }
@@ -2782,21 +2036,16 @@ impl<'new_alloc> CloneIn<'new_alloc> for AssignmentPattern<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ObjectPattern<'_> {
     type Cloned = ObjectPattern<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         ObjectPattern {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            properties: CloneIn::clone_in(&self.properties, allocator),
-            rest: CloneIn::clone_in(&self.rest, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        ObjectPattern {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            properties: CloneIn::clone_in_with_semantic_ids(&self.properties, allocator),
-            rest: CloneIn::clone_in_with_semantic_ids(&self.rest, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            properties: CloneIn::clone_in_impl(&self.properties, with_semantic_ids, allocator),
+            rest: CloneIn::clone_in_impl(&self.rest, with_semantic_ids, allocator),
         }
     }
 }
@@ -2804,25 +2053,18 @@ impl<'new_alloc> CloneIn<'new_alloc> for ObjectPattern<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for BindingProperty<'_> {
     type Cloned = BindingProperty<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         BindingProperty {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            key: CloneIn::clone_in(&self.key, allocator),
-            value: CloneIn::clone_in(&self.value, allocator),
-            shorthand: CloneIn::clone_in(&self.shorthand, allocator),
-            computed: CloneIn::clone_in(&self.computed, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        BindingProperty {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            key: CloneIn::clone_in_with_semantic_ids(&self.key, allocator),
-            value: CloneIn::clone_in_with_semantic_ids(&self.value, allocator),
-            shorthand: CloneIn::clone_in_with_semantic_ids(&self.shorthand, allocator),
-            computed: CloneIn::clone_in_with_semantic_ids(&self.computed, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            key: CloneIn::clone_in_impl(&self.key, with_semantic_ids, allocator),
+            value: CloneIn::clone_in_impl(&self.value, with_semantic_ids, allocator),
+            shorthand: CloneIn::clone_in_impl(&self.shorthand, with_semantic_ids, allocator),
+            computed: CloneIn::clone_in_impl(&self.computed, with_semantic_ids, allocator),
         }
     }
 }
@@ -2830,21 +2072,16 @@ impl<'new_alloc> CloneIn<'new_alloc> for BindingProperty<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ArrayPattern<'_> {
     type Cloned = ArrayPattern<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         ArrayPattern {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            elements: CloneIn::clone_in(&self.elements, allocator),
-            rest: CloneIn::clone_in(&self.rest, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        ArrayPattern {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            elements: CloneIn::clone_in_with_semantic_ids(&self.elements, allocator),
-            rest: CloneIn::clone_in_with_semantic_ids(&self.rest, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            elements: CloneIn::clone_in_impl(&self.elements, with_semantic_ids, allocator),
+            rest: CloneIn::clone_in_impl(&self.rest, with_semantic_ids, allocator),
         }
     }
 }
@@ -2852,19 +2089,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for ArrayPattern<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for BindingRestElement<'_> {
     type Cloned = BindingRestElement<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         BindingRestElement {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            argument: CloneIn::clone_in(&self.argument, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        BindingRestElement {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            argument: CloneIn::clone_in_with_semantic_ids(&self.argument, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            argument: CloneIn::clone_in_impl(&self.argument, with_semantic_ids, allocator),
         }
     }
 }
@@ -2872,43 +2105,31 @@ impl<'new_alloc> CloneIn<'new_alloc> for BindingRestElement<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for Function<'_> {
     type Cloned = Function<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         Function {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            r#type: CloneIn::clone_in(&self.r#type, allocator),
-            id: CloneIn::clone_in(&self.id, allocator),
-            generator: CloneIn::clone_in(&self.generator, allocator),
-            r#async: CloneIn::clone_in(&self.r#async, allocator),
-            declare: CloneIn::clone_in(&self.declare, allocator),
-            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
-            this_param: CloneIn::clone_in(&self.this_param, allocator),
-            params: CloneIn::clone_in(&self.params, allocator),
-            return_type: CloneIn::clone_in(&self.return_type, allocator),
-            body: CloneIn::clone_in(&self.body, allocator),
-            scope_id: Default::default(),
-            pure: CloneIn::clone_in(&self.pure, allocator),
-            pife: CloneIn::clone_in(&self.pife, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        Function {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            r#type: CloneIn::clone_in_with_semantic_ids(&self.r#type, allocator),
-            id: CloneIn::clone_in_with_semantic_ids(&self.id, allocator),
-            generator: CloneIn::clone_in_with_semantic_ids(&self.generator, allocator),
-            r#async: CloneIn::clone_in_with_semantic_ids(&self.r#async, allocator),
-            declare: CloneIn::clone_in_with_semantic_ids(&self.declare, allocator),
-            type_parameters: CloneIn::clone_in_with_semantic_ids(&self.type_parameters, allocator),
-            this_param: CloneIn::clone_in_with_semantic_ids(&self.this_param, allocator),
-            params: CloneIn::clone_in_with_semantic_ids(&self.params, allocator),
-            return_type: CloneIn::clone_in_with_semantic_ids(&self.return_type, allocator),
-            body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
-            scope_id: CloneIn::clone_in_with_semantic_ids(&self.scope_id, allocator),
-            pure: CloneIn::clone_in_with_semantic_ids(&self.pure, allocator),
-            pife: CloneIn::clone_in_with_semantic_ids(&self.pife, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            r#type: CloneIn::clone_in_impl(&self.r#type, with_semantic_ids, allocator),
+            id: CloneIn::clone_in_impl(&self.id, with_semantic_ids, allocator),
+            generator: CloneIn::clone_in_impl(&self.generator, with_semantic_ids, allocator),
+            r#async: CloneIn::clone_in_impl(&self.r#async, with_semantic_ids, allocator),
+            declare: CloneIn::clone_in_impl(&self.declare, with_semantic_ids, allocator),
+            type_parameters: CloneIn::clone_in_impl(
+                &self.type_parameters,
+                with_semantic_ids,
+                allocator,
+            ),
+            this_param: CloneIn::clone_in_impl(&self.this_param, with_semantic_ids, allocator),
+            params: CloneIn::clone_in_impl(&self.params, with_semantic_ids, allocator),
+            return_type: CloneIn::clone_in_impl(&self.return_type, with_semantic_ids, allocator),
+            body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
+            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
+            pure: CloneIn::clone_in_impl(&self.pure, with_semantic_ids, allocator),
+            pife: CloneIn::clone_in_impl(&self.pife, with_semantic_ids, allocator),
         }
     }
 }
@@ -2917,12 +2138,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for FunctionType {
     type Cloned = FunctionType;
 
     #[inline(always)]
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        *self
-    }
-
-    #[inline(always)]
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         *self
     }
 }
@@ -2930,23 +2150,17 @@ impl<'new_alloc> CloneIn<'new_alloc> for FunctionType {
 impl<'new_alloc> CloneIn<'new_alloc> for FormalParameters<'_> {
     type Cloned = FormalParameters<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         FormalParameters {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            kind: CloneIn::clone_in(&self.kind, allocator),
-            items: CloneIn::clone_in(&self.items, allocator),
-            rest: CloneIn::clone_in(&self.rest, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        FormalParameters {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            kind: CloneIn::clone_in_with_semantic_ids(&self.kind, allocator),
-            items: CloneIn::clone_in_with_semantic_ids(&self.items, allocator),
-            rest: CloneIn::clone_in_with_semantic_ids(&self.rest, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            kind: CloneIn::clone_in_impl(&self.kind, with_semantic_ids, allocator),
+            items: CloneIn::clone_in_impl(&self.items, with_semantic_ids, allocator),
+            rest: CloneIn::clone_in_impl(&self.rest, with_semantic_ids, allocator),
         }
     }
 }
@@ -2954,33 +2168,30 @@ impl<'new_alloc> CloneIn<'new_alloc> for FormalParameters<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for FormalParameter<'_> {
     type Cloned = FormalParameter<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         FormalParameter {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            decorators: CloneIn::clone_in(&self.decorators, allocator),
-            pattern: CloneIn::clone_in(&self.pattern, allocator),
-            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
-            initializer: CloneIn::clone_in(&self.initializer, allocator),
-            optional: CloneIn::clone_in(&self.optional, allocator),
-            accessibility: CloneIn::clone_in(&self.accessibility, allocator),
-            readonly: CloneIn::clone_in(&self.readonly, allocator),
-            r#override: CloneIn::clone_in(&self.r#override, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        FormalParameter {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            decorators: CloneIn::clone_in_with_semantic_ids(&self.decorators, allocator),
-            pattern: CloneIn::clone_in_with_semantic_ids(&self.pattern, allocator),
-            type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
-            initializer: CloneIn::clone_in_with_semantic_ids(&self.initializer, allocator),
-            optional: CloneIn::clone_in_with_semantic_ids(&self.optional, allocator),
-            accessibility: CloneIn::clone_in_with_semantic_ids(&self.accessibility, allocator),
-            readonly: CloneIn::clone_in_with_semantic_ids(&self.readonly, allocator),
-            r#override: CloneIn::clone_in_with_semantic_ids(&self.r#override, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            decorators: CloneIn::clone_in_impl(&self.decorators, with_semantic_ids, allocator),
+            pattern: CloneIn::clone_in_impl(&self.pattern, with_semantic_ids, allocator),
+            type_annotation: CloneIn::clone_in_impl(
+                &self.type_annotation,
+                with_semantic_ids,
+                allocator,
+            ),
+            initializer: CloneIn::clone_in_impl(&self.initializer, with_semantic_ids, allocator),
+            optional: CloneIn::clone_in_impl(&self.optional, with_semantic_ids, allocator),
+            accessibility: CloneIn::clone_in_impl(
+                &self.accessibility,
+                with_semantic_ids,
+                allocator,
+            ),
+            readonly: CloneIn::clone_in_impl(&self.readonly, with_semantic_ids, allocator),
+            r#override: CloneIn::clone_in_impl(&self.r#override, with_semantic_ids, allocator),
         }
     }
 }
@@ -2989,12 +2200,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for FormalParameterKind {
     type Cloned = FormalParameterKind;
 
     #[inline(always)]
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        *self
-    }
-
-    #[inline(always)]
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         *self
     }
 }
@@ -3002,23 +2212,21 @@ impl<'new_alloc> CloneIn<'new_alloc> for FormalParameterKind {
 impl<'new_alloc> CloneIn<'new_alloc> for FormalParameterRest<'_> {
     type Cloned = FormalParameterRest<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         FormalParameterRest {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            decorators: CloneIn::clone_in(&self.decorators, allocator),
-            rest: CloneIn::clone_in(&self.rest, allocator),
-            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        FormalParameterRest {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            decorators: CloneIn::clone_in_with_semantic_ids(&self.decorators, allocator),
-            rest: CloneIn::clone_in_with_semantic_ids(&self.rest, allocator),
-            type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            decorators: CloneIn::clone_in_impl(&self.decorators, with_semantic_ids, allocator),
+            rest: CloneIn::clone_in_impl(&self.rest, with_semantic_ids, allocator),
+            type_annotation: CloneIn::clone_in_impl(
+                &self.type_annotation,
+                with_semantic_ids,
+                allocator,
+            ),
         }
     }
 }
@@ -3026,21 +2234,16 @@ impl<'new_alloc> CloneIn<'new_alloc> for FormalParameterRest<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for FunctionBody<'_> {
     type Cloned = FunctionBody<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         FunctionBody {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            directives: CloneIn::clone_in(&self.directives, allocator),
-            statements: CloneIn::clone_in(&self.statements, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        FunctionBody {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            directives: CloneIn::clone_in_with_semantic_ids(&self.directives, allocator),
-            statements: CloneIn::clone_in_with_semantic_ids(&self.statements, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            directives: CloneIn::clone_in_impl(&self.directives, with_semantic_ids, allocator),
+            statements: CloneIn::clone_in_impl(&self.statements, with_semantic_ids, allocator),
         }
     }
 }
@@ -3048,35 +2251,27 @@ impl<'new_alloc> CloneIn<'new_alloc> for FunctionBody<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ArrowFunctionExpression<'_> {
     type Cloned = ArrowFunctionExpression<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         ArrowFunctionExpression {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            expression: CloneIn::clone_in(&self.expression, allocator),
-            r#async: CloneIn::clone_in(&self.r#async, allocator),
-            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
-            params: CloneIn::clone_in(&self.params, allocator),
-            return_type: CloneIn::clone_in(&self.return_type, allocator),
-            body: CloneIn::clone_in(&self.body, allocator),
-            scope_id: Default::default(),
-            pure: CloneIn::clone_in(&self.pure, allocator),
-            pife: CloneIn::clone_in(&self.pife, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        ArrowFunctionExpression {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
-            r#async: CloneIn::clone_in_with_semantic_ids(&self.r#async, allocator),
-            type_parameters: CloneIn::clone_in_with_semantic_ids(&self.type_parameters, allocator),
-            params: CloneIn::clone_in_with_semantic_ids(&self.params, allocator),
-            return_type: CloneIn::clone_in_with_semantic_ids(&self.return_type, allocator),
-            body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
-            scope_id: CloneIn::clone_in_with_semantic_ids(&self.scope_id, allocator),
-            pure: CloneIn::clone_in_with_semantic_ids(&self.pure, allocator),
-            pife: CloneIn::clone_in_with_semantic_ids(&self.pife, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            expression: CloneIn::clone_in_impl(&self.expression, with_semantic_ids, allocator),
+            r#async: CloneIn::clone_in_impl(&self.r#async, with_semantic_ids, allocator),
+            type_parameters: CloneIn::clone_in_impl(
+                &self.type_parameters,
+                with_semantic_ids,
+                allocator,
+            ),
+            params: CloneIn::clone_in_impl(&self.params, with_semantic_ids, allocator),
+            return_type: CloneIn::clone_in_impl(&self.return_type, with_semantic_ids, allocator),
+            body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
+            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
+            pure: CloneIn::clone_in_impl(&self.pure, with_semantic_ids, allocator),
+            pife: CloneIn::clone_in_impl(&self.pife, with_semantic_ids, allocator),
         }
     }
 }
@@ -3084,21 +2279,16 @@ impl<'new_alloc> CloneIn<'new_alloc> for ArrowFunctionExpression<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for YieldExpression<'_> {
     type Cloned = YieldExpression<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         YieldExpression {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            delegate: CloneIn::clone_in(&self.delegate, allocator),
-            argument: CloneIn::clone_in(&self.argument, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        YieldExpression {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            delegate: CloneIn::clone_in_with_semantic_ids(&self.delegate, allocator),
-            argument: CloneIn::clone_in_with_semantic_ids(&self.argument, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            delegate: CloneIn::clone_in_impl(&self.delegate, with_semantic_ids, allocator),
+            argument: CloneIn::clone_in_impl(&self.argument, with_semantic_ids, allocator),
         }
     }
 }
@@ -3106,42 +2296,33 @@ impl<'new_alloc> CloneIn<'new_alloc> for YieldExpression<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for Class<'_> {
     type Cloned = Class<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         Class {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            r#type: CloneIn::clone_in(&self.r#type, allocator),
-            decorators: CloneIn::clone_in(&self.decorators, allocator),
-            id: CloneIn::clone_in(&self.id, allocator),
-            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
-            super_class: CloneIn::clone_in(&self.super_class, allocator),
-            super_type_arguments: CloneIn::clone_in(&self.super_type_arguments, allocator),
-            implements: CloneIn::clone_in(&self.implements, allocator),
-            body: CloneIn::clone_in(&self.body, allocator),
-            r#abstract: CloneIn::clone_in(&self.r#abstract, allocator),
-            declare: CloneIn::clone_in(&self.declare, allocator),
-            scope_id: Default::default(),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        Class {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            r#type: CloneIn::clone_in_with_semantic_ids(&self.r#type, allocator),
-            decorators: CloneIn::clone_in_with_semantic_ids(&self.decorators, allocator),
-            id: CloneIn::clone_in_with_semantic_ids(&self.id, allocator),
-            type_parameters: CloneIn::clone_in_with_semantic_ids(&self.type_parameters, allocator),
-            super_class: CloneIn::clone_in_with_semantic_ids(&self.super_class, allocator),
-            super_type_arguments: CloneIn::clone_in_with_semantic_ids(
-                &self.super_type_arguments,
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            r#type: CloneIn::clone_in_impl(&self.r#type, with_semantic_ids, allocator),
+            decorators: CloneIn::clone_in_impl(&self.decorators, with_semantic_ids, allocator),
+            id: CloneIn::clone_in_impl(&self.id, with_semantic_ids, allocator),
+            type_parameters: CloneIn::clone_in_impl(
+                &self.type_parameters,
+                with_semantic_ids,
                 allocator,
             ),
-            implements: CloneIn::clone_in_with_semantic_ids(&self.implements, allocator),
-            body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
-            r#abstract: CloneIn::clone_in_with_semantic_ids(&self.r#abstract, allocator),
-            declare: CloneIn::clone_in_with_semantic_ids(&self.declare, allocator),
-            scope_id: CloneIn::clone_in_with_semantic_ids(&self.scope_id, allocator),
+            super_class: CloneIn::clone_in_impl(&self.super_class, with_semantic_ids, allocator),
+            super_type_arguments: CloneIn::clone_in_impl(
+                &self.super_type_arguments,
+                with_semantic_ids,
+                allocator,
+            ),
+            implements: CloneIn::clone_in_impl(&self.implements, with_semantic_ids, allocator),
+            body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
+            r#abstract: CloneIn::clone_in_impl(&self.r#abstract, with_semantic_ids, allocator),
+            declare: CloneIn::clone_in_impl(&self.declare, with_semantic_ids, allocator),
+            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
         }
     }
 }
@@ -3150,12 +2331,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for ClassType {
     type Cloned = ClassType;
 
     #[inline(always)]
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        *self
-    }
-
-    #[inline(always)]
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         *self
     }
 }
@@ -3163,19 +2343,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for ClassType {
 impl<'new_alloc> CloneIn<'new_alloc> for ClassBody<'_> {
     type Cloned = ClassBody<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         ClassBody {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            body: CloneIn::clone_in(&self.body, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        ClassBody {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
         }
     }
 }
@@ -3183,41 +2359,33 @@ impl<'new_alloc> CloneIn<'new_alloc> for ClassBody<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ClassElement<'_> {
     type Cloned = ClassElement<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::StaticBlock(it) => ClassElement::StaticBlock(CloneIn::clone_in(it, allocator)),
-            Self::MethodDefinition(it) => {
-                ClassElement::MethodDefinition(CloneIn::clone_in(it, allocator))
-            }
-            Self::PropertyDefinition(it) => {
-                ClassElement::PropertyDefinition(CloneIn::clone_in(it, allocator))
-            }
-            Self::AccessorProperty(it) => {
-                ClassElement::AccessorProperty(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSIndexSignature(it) => {
-                ClassElement::TSIndexSignature(CloneIn::clone_in(it, allocator))
-            }
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
             Self::StaticBlock(it) => {
-                ClassElement::StaticBlock(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                ClassElement::StaticBlock(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
-            Self::MethodDefinition(it) => {
-                ClassElement::MethodDefinition(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
-            Self::PropertyDefinition(it) => {
-                ClassElement::PropertyDefinition(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
-            Self::AccessorProperty(it) => {
-                ClassElement::AccessorProperty(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
-            Self::TSIndexSignature(it) => {
-                ClassElement::TSIndexSignature(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
+            Self::MethodDefinition(it) => ClassElement::MethodDefinition(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
+            Self::PropertyDefinition(it) => ClassElement::PropertyDefinition(
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
+            ),
+            Self::AccessorProperty(it) => ClassElement::AccessorProperty(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
+            Self::TSIndexSignature(it) => ClassElement::TSIndexSignature(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
         }
     }
 }
@@ -3225,37 +2393,28 @@ impl<'new_alloc> CloneIn<'new_alloc> for ClassElement<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for MethodDefinition<'_> {
     type Cloned = MethodDefinition<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         MethodDefinition {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            r#type: CloneIn::clone_in(&self.r#type, allocator),
-            decorators: CloneIn::clone_in(&self.decorators, allocator),
-            key: CloneIn::clone_in(&self.key, allocator),
-            value: CloneIn::clone_in(&self.value, allocator),
-            kind: CloneIn::clone_in(&self.kind, allocator),
-            computed: CloneIn::clone_in(&self.computed, allocator),
-            r#static: CloneIn::clone_in(&self.r#static, allocator),
-            r#override: CloneIn::clone_in(&self.r#override, allocator),
-            optional: CloneIn::clone_in(&self.optional, allocator),
-            accessibility: CloneIn::clone_in(&self.accessibility, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        MethodDefinition {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            r#type: CloneIn::clone_in_with_semantic_ids(&self.r#type, allocator),
-            decorators: CloneIn::clone_in_with_semantic_ids(&self.decorators, allocator),
-            key: CloneIn::clone_in_with_semantic_ids(&self.key, allocator),
-            value: CloneIn::clone_in_with_semantic_ids(&self.value, allocator),
-            kind: CloneIn::clone_in_with_semantic_ids(&self.kind, allocator),
-            computed: CloneIn::clone_in_with_semantic_ids(&self.computed, allocator),
-            r#static: CloneIn::clone_in_with_semantic_ids(&self.r#static, allocator),
-            r#override: CloneIn::clone_in_with_semantic_ids(&self.r#override, allocator),
-            optional: CloneIn::clone_in_with_semantic_ids(&self.optional, allocator),
-            accessibility: CloneIn::clone_in_with_semantic_ids(&self.accessibility, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            r#type: CloneIn::clone_in_impl(&self.r#type, with_semantic_ids, allocator),
+            decorators: CloneIn::clone_in_impl(&self.decorators, with_semantic_ids, allocator),
+            key: CloneIn::clone_in_impl(&self.key, with_semantic_ids, allocator),
+            value: CloneIn::clone_in_impl(&self.value, with_semantic_ids, allocator),
+            kind: CloneIn::clone_in_impl(&self.kind, with_semantic_ids, allocator),
+            computed: CloneIn::clone_in_impl(&self.computed, with_semantic_ids, allocator),
+            r#static: CloneIn::clone_in_impl(&self.r#static, with_semantic_ids, allocator),
+            r#override: CloneIn::clone_in_impl(&self.r#override, with_semantic_ids, allocator),
+            optional: CloneIn::clone_in_impl(&self.optional, with_semantic_ids, allocator),
+            accessibility: CloneIn::clone_in_impl(
+                &self.accessibility,
+                with_semantic_ids,
+                allocator,
+            ),
         }
     }
 }
@@ -3264,12 +2423,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for MethodDefinitionType {
     type Cloned = MethodDefinitionType;
 
     #[inline(always)]
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        *self
-    }
-
-    #[inline(always)]
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         *self
     }
 }
@@ -3277,43 +2435,35 @@ impl<'new_alloc> CloneIn<'new_alloc> for MethodDefinitionType {
 impl<'new_alloc> CloneIn<'new_alloc> for PropertyDefinition<'_> {
     type Cloned = PropertyDefinition<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         PropertyDefinition {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            r#type: CloneIn::clone_in(&self.r#type, allocator),
-            decorators: CloneIn::clone_in(&self.decorators, allocator),
-            key: CloneIn::clone_in(&self.key, allocator),
-            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
-            value: CloneIn::clone_in(&self.value, allocator),
-            computed: CloneIn::clone_in(&self.computed, allocator),
-            r#static: CloneIn::clone_in(&self.r#static, allocator),
-            declare: CloneIn::clone_in(&self.declare, allocator),
-            r#override: CloneIn::clone_in(&self.r#override, allocator),
-            optional: CloneIn::clone_in(&self.optional, allocator),
-            definite: CloneIn::clone_in(&self.definite, allocator),
-            readonly: CloneIn::clone_in(&self.readonly, allocator),
-            accessibility: CloneIn::clone_in(&self.accessibility, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        PropertyDefinition {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            r#type: CloneIn::clone_in_with_semantic_ids(&self.r#type, allocator),
-            decorators: CloneIn::clone_in_with_semantic_ids(&self.decorators, allocator),
-            key: CloneIn::clone_in_with_semantic_ids(&self.key, allocator),
-            type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
-            value: CloneIn::clone_in_with_semantic_ids(&self.value, allocator),
-            computed: CloneIn::clone_in_with_semantic_ids(&self.computed, allocator),
-            r#static: CloneIn::clone_in_with_semantic_ids(&self.r#static, allocator),
-            declare: CloneIn::clone_in_with_semantic_ids(&self.declare, allocator),
-            r#override: CloneIn::clone_in_with_semantic_ids(&self.r#override, allocator),
-            optional: CloneIn::clone_in_with_semantic_ids(&self.optional, allocator),
-            definite: CloneIn::clone_in_with_semantic_ids(&self.definite, allocator),
-            readonly: CloneIn::clone_in_with_semantic_ids(&self.readonly, allocator),
-            accessibility: CloneIn::clone_in_with_semantic_ids(&self.accessibility, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            r#type: CloneIn::clone_in_impl(&self.r#type, with_semantic_ids, allocator),
+            decorators: CloneIn::clone_in_impl(&self.decorators, with_semantic_ids, allocator),
+            key: CloneIn::clone_in_impl(&self.key, with_semantic_ids, allocator),
+            type_annotation: CloneIn::clone_in_impl(
+                &self.type_annotation,
+                with_semantic_ids,
+                allocator,
+            ),
+            value: CloneIn::clone_in_impl(&self.value, with_semantic_ids, allocator),
+            computed: CloneIn::clone_in_impl(&self.computed, with_semantic_ids, allocator),
+            r#static: CloneIn::clone_in_impl(&self.r#static, with_semantic_ids, allocator),
+            declare: CloneIn::clone_in_impl(&self.declare, with_semantic_ids, allocator),
+            r#override: CloneIn::clone_in_impl(&self.r#override, with_semantic_ids, allocator),
+            optional: CloneIn::clone_in_impl(&self.optional, with_semantic_ids, allocator),
+            definite: CloneIn::clone_in_impl(&self.definite, with_semantic_ids, allocator),
+            readonly: CloneIn::clone_in_impl(&self.readonly, with_semantic_ids, allocator),
+            accessibility: CloneIn::clone_in_impl(
+                &self.accessibility,
+                with_semantic_ids,
+                allocator,
+            ),
         }
     }
 }
@@ -3322,12 +2472,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for PropertyDefinitionType {
     type Cloned = PropertyDefinitionType;
 
     #[inline(always)]
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        *self
-    }
-
-    #[inline(always)]
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         *self
     }
 }
@@ -3336,12 +2485,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for MethodDefinitionKind {
     type Cloned = MethodDefinitionKind;
 
     #[inline(always)]
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        *self
-    }
-
-    #[inline(always)]
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         *self
     }
 }
@@ -3349,19 +2497,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for MethodDefinitionKind {
 impl<'new_alloc> CloneIn<'new_alloc> for PrivateIdentifier<'_> {
     type Cloned = PrivateIdentifier<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         PrivateIdentifier {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            name: CloneIn::clone_in(&self.name, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        PrivateIdentifier {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            name: CloneIn::clone_in_with_semantic_ids(&self.name, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            name: CloneIn::clone_in_impl(&self.name, with_semantic_ids, allocator),
         }
     }
 }
@@ -3369,21 +2513,16 @@ impl<'new_alloc> CloneIn<'new_alloc> for PrivateIdentifier<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for StaticBlock<'_> {
     type Cloned = StaticBlock<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         StaticBlock {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            body: CloneIn::clone_in(&self.body, allocator),
-            scope_id: Default::default(),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        StaticBlock {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
-            scope_id: CloneIn::clone_in_with_semantic_ids(&self.scope_id, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
+            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
         }
     }
 }
@@ -3391,50 +2530,33 @@ impl<'new_alloc> CloneIn<'new_alloc> for StaticBlock<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ModuleDeclaration<'_> {
     type Cloned = ModuleDeclaration<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::ImportDeclaration(it) => {
-                ModuleDeclaration::ImportDeclaration(CloneIn::clone_in(it, allocator))
-            }
-            Self::ExportAllDeclaration(it) => {
-                ModuleDeclaration::ExportAllDeclaration(CloneIn::clone_in(it, allocator))
-            }
-            Self::ExportDefaultDeclaration(it) => {
-                ModuleDeclaration::ExportDefaultDeclaration(CloneIn::clone_in(it, allocator))
-            }
-            Self::ExportNamedDeclaration(it) => {
-                ModuleDeclaration::ExportNamedDeclaration(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSExportAssignment(it) => {
-                ModuleDeclaration::TSExportAssignment(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSNamespaceExportDeclaration(it) => {
-                ModuleDeclaration::TSNamespaceExportDeclaration(CloneIn::clone_in(it, allocator))
-            }
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
             Self::ImportDeclaration(it) => ModuleDeclaration::ImportDeclaration(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
             Self::ExportAllDeclaration(it) => ModuleDeclaration::ExportAllDeclaration(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
             Self::ExportDefaultDeclaration(it) => ModuleDeclaration::ExportDefaultDeclaration(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
             Self::ExportNamedDeclaration(it) => ModuleDeclaration::ExportNamedDeclaration(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
             Self::TSExportAssignment(it) => ModuleDeclaration::TSExportAssignment(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
             Self::TSNamespaceExportDeclaration(it) => {
-                ModuleDeclaration::TSNamespaceExportDeclaration(
-                    CloneIn::clone_in_with_semantic_ids(it, allocator),
-                )
+                ModuleDeclaration::TSNamespaceExportDeclaration(CloneIn::clone_in_impl(
+                    it,
+                    with_semantic_ids,
+                    allocator,
+                ))
             }
         }
     }
@@ -3444,12 +2566,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for AccessorPropertyType {
     type Cloned = AccessorPropertyType;
 
     #[inline(always)]
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        *self
-    }
-
-    #[inline(always)]
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         *self
     }
 }
@@ -3457,37 +2578,32 @@ impl<'new_alloc> CloneIn<'new_alloc> for AccessorPropertyType {
 impl<'new_alloc> CloneIn<'new_alloc> for AccessorProperty<'_> {
     type Cloned = AccessorProperty<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         AccessorProperty {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            r#type: CloneIn::clone_in(&self.r#type, allocator),
-            decorators: CloneIn::clone_in(&self.decorators, allocator),
-            key: CloneIn::clone_in(&self.key, allocator),
-            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
-            value: CloneIn::clone_in(&self.value, allocator),
-            computed: CloneIn::clone_in(&self.computed, allocator),
-            r#static: CloneIn::clone_in(&self.r#static, allocator),
-            r#override: CloneIn::clone_in(&self.r#override, allocator),
-            definite: CloneIn::clone_in(&self.definite, allocator),
-            accessibility: CloneIn::clone_in(&self.accessibility, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        AccessorProperty {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            r#type: CloneIn::clone_in_with_semantic_ids(&self.r#type, allocator),
-            decorators: CloneIn::clone_in_with_semantic_ids(&self.decorators, allocator),
-            key: CloneIn::clone_in_with_semantic_ids(&self.key, allocator),
-            type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
-            value: CloneIn::clone_in_with_semantic_ids(&self.value, allocator),
-            computed: CloneIn::clone_in_with_semantic_ids(&self.computed, allocator),
-            r#static: CloneIn::clone_in_with_semantic_ids(&self.r#static, allocator),
-            r#override: CloneIn::clone_in_with_semantic_ids(&self.r#override, allocator),
-            definite: CloneIn::clone_in_with_semantic_ids(&self.definite, allocator),
-            accessibility: CloneIn::clone_in_with_semantic_ids(&self.accessibility, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            r#type: CloneIn::clone_in_impl(&self.r#type, with_semantic_ids, allocator),
+            decorators: CloneIn::clone_in_impl(&self.decorators, with_semantic_ids, allocator),
+            key: CloneIn::clone_in_impl(&self.key, with_semantic_ids, allocator),
+            type_annotation: CloneIn::clone_in_impl(
+                &self.type_annotation,
+                with_semantic_ids,
+                allocator,
+            ),
+            value: CloneIn::clone_in_impl(&self.value, with_semantic_ids, allocator),
+            computed: CloneIn::clone_in_impl(&self.computed, with_semantic_ids, allocator),
+            r#static: CloneIn::clone_in_impl(&self.r#static, with_semantic_ids, allocator),
+            r#override: CloneIn::clone_in_impl(&self.r#override, with_semantic_ids, allocator),
+            definite: CloneIn::clone_in_impl(&self.definite, with_semantic_ids, allocator),
+            accessibility: CloneIn::clone_in_impl(
+                &self.accessibility,
+                with_semantic_ids,
+                allocator,
+            ),
         }
     }
 }
@@ -3495,23 +2611,17 @@ impl<'new_alloc> CloneIn<'new_alloc> for AccessorProperty<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ImportExpression<'_> {
     type Cloned = ImportExpression<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         ImportExpression {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            source: CloneIn::clone_in(&self.source, allocator),
-            options: CloneIn::clone_in(&self.options, allocator),
-            phase: CloneIn::clone_in(&self.phase, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        ImportExpression {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            source: CloneIn::clone_in_with_semantic_ids(&self.source, allocator),
-            options: CloneIn::clone_in_with_semantic_ids(&self.options, allocator),
-            phase: CloneIn::clone_in_with_semantic_ids(&self.phase, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            source: CloneIn::clone_in_impl(&self.source, with_semantic_ids, allocator),
+            options: CloneIn::clone_in_impl(&self.options, with_semantic_ids, allocator),
+            phase: CloneIn::clone_in_impl(&self.phase, with_semantic_ids, allocator),
         }
     }
 }
@@ -3519,27 +2629,19 @@ impl<'new_alloc> CloneIn<'new_alloc> for ImportExpression<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ImportDeclaration<'_> {
     type Cloned = ImportDeclaration<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         ImportDeclaration {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            specifiers: CloneIn::clone_in(&self.specifiers, allocator),
-            source: CloneIn::clone_in(&self.source, allocator),
-            phase: CloneIn::clone_in(&self.phase, allocator),
-            with_clause: CloneIn::clone_in(&self.with_clause, allocator),
-            import_kind: CloneIn::clone_in(&self.import_kind, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        ImportDeclaration {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            specifiers: CloneIn::clone_in_with_semantic_ids(&self.specifiers, allocator),
-            source: CloneIn::clone_in_with_semantic_ids(&self.source, allocator),
-            phase: CloneIn::clone_in_with_semantic_ids(&self.phase, allocator),
-            with_clause: CloneIn::clone_in_with_semantic_ids(&self.with_clause, allocator),
-            import_kind: CloneIn::clone_in_with_semantic_ids(&self.import_kind, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            specifiers: CloneIn::clone_in_impl(&self.specifiers, with_semantic_ids, allocator),
+            source: CloneIn::clone_in_impl(&self.source, with_semantic_ids, allocator),
+            phase: CloneIn::clone_in_impl(&self.phase, with_semantic_ids, allocator),
+            with_clause: CloneIn::clone_in_impl(&self.with_clause, with_semantic_ids, allocator),
+            import_kind: CloneIn::clone_in_impl(&self.import_kind, with_semantic_ids, allocator),
         }
     }
 }
@@ -3548,12 +2650,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for ImportPhase {
     type Cloned = ImportPhase;
 
     #[inline(always)]
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        *self
-    }
-
-    #[inline(always)]
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         *self
     }
 }
@@ -3561,34 +2662,24 @@ impl<'new_alloc> CloneIn<'new_alloc> for ImportPhase {
 impl<'new_alloc> CloneIn<'new_alloc> for ImportDeclarationSpecifier<'_> {
     type Cloned = ImportDeclarationSpecifier<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::ImportSpecifier(it) => {
-                ImportDeclarationSpecifier::ImportSpecifier(CloneIn::clone_in(it, allocator))
-            }
-            Self::ImportDefaultSpecifier(it) => {
-                ImportDeclarationSpecifier::ImportDefaultSpecifier(CloneIn::clone_in(it, allocator))
-            }
-            Self::ImportNamespaceSpecifier(it) => {
-                ImportDeclarationSpecifier::ImportNamespaceSpecifier(CloneIn::clone_in(
-                    it, allocator,
-                ))
-            }
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
             Self::ImportSpecifier(it) => ImportDeclarationSpecifier::ImportSpecifier(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
             Self::ImportDefaultSpecifier(it) => ImportDeclarationSpecifier::ImportDefaultSpecifier(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
             Self::ImportNamespaceSpecifier(it) => {
-                ImportDeclarationSpecifier::ImportNamespaceSpecifier(
-                    CloneIn::clone_in_with_semantic_ids(it, allocator),
-                )
+                ImportDeclarationSpecifier::ImportNamespaceSpecifier(CloneIn::clone_in_impl(
+                    it,
+                    with_semantic_ids,
+                    allocator,
+                ))
             }
         }
     }
@@ -3597,23 +2688,17 @@ impl<'new_alloc> CloneIn<'new_alloc> for ImportDeclarationSpecifier<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ImportSpecifier<'_> {
     type Cloned = ImportSpecifier<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         ImportSpecifier {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            imported: CloneIn::clone_in(&self.imported, allocator),
-            local: CloneIn::clone_in(&self.local, allocator),
-            import_kind: CloneIn::clone_in(&self.import_kind, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        ImportSpecifier {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            imported: CloneIn::clone_in_with_semantic_ids(&self.imported, allocator),
-            local: CloneIn::clone_in_with_semantic_ids(&self.local, allocator),
-            import_kind: CloneIn::clone_in_with_semantic_ids(&self.import_kind, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            imported: CloneIn::clone_in_impl(&self.imported, with_semantic_ids, allocator),
+            local: CloneIn::clone_in_impl(&self.local, with_semantic_ids, allocator),
+            import_kind: CloneIn::clone_in_impl(&self.import_kind, with_semantic_ids, allocator),
         }
     }
 }
@@ -3621,19 +2706,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for ImportSpecifier<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ImportDefaultSpecifier<'_> {
     type Cloned = ImportDefaultSpecifier<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         ImportDefaultSpecifier {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            local: CloneIn::clone_in(&self.local, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        ImportDefaultSpecifier {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            local: CloneIn::clone_in_with_semantic_ids(&self.local, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            local: CloneIn::clone_in_impl(&self.local, with_semantic_ids, allocator),
         }
     }
 }
@@ -3641,19 +2722,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for ImportDefaultSpecifier<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ImportNamespaceSpecifier<'_> {
     type Cloned = ImportNamespaceSpecifier<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         ImportNamespaceSpecifier {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            local: CloneIn::clone_in(&self.local, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        ImportNamespaceSpecifier {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            local: CloneIn::clone_in_with_semantic_ids(&self.local, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            local: CloneIn::clone_in_impl(&self.local, with_semantic_ids, allocator),
         }
     }
 }
@@ -3661,21 +2738,16 @@ impl<'new_alloc> CloneIn<'new_alloc> for ImportNamespaceSpecifier<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for WithClause<'_> {
     type Cloned = WithClause<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         WithClause {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            keyword: CloneIn::clone_in(&self.keyword, allocator),
-            with_entries: CloneIn::clone_in(&self.with_entries, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        WithClause {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            keyword: CloneIn::clone_in_with_semantic_ids(&self.keyword, allocator),
-            with_entries: CloneIn::clone_in_with_semantic_ids(&self.with_entries, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            keyword: CloneIn::clone_in_impl(&self.keyword, with_semantic_ids, allocator),
+            with_entries: CloneIn::clone_in_impl(&self.with_entries, with_semantic_ids, allocator),
         }
     }
 }
@@ -3684,12 +2756,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for WithClauseKeyword {
     type Cloned = WithClauseKeyword;
 
     #[inline(always)]
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        *self
-    }
-
-    #[inline(always)]
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         *self
     }
 }
@@ -3697,21 +2768,16 @@ impl<'new_alloc> CloneIn<'new_alloc> for WithClauseKeyword {
 impl<'new_alloc> CloneIn<'new_alloc> for ImportAttribute<'_> {
     type Cloned = ImportAttribute<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         ImportAttribute {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            key: CloneIn::clone_in(&self.key, allocator),
-            value: CloneIn::clone_in(&self.value, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        ImportAttribute {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            key: CloneIn::clone_in_with_semantic_ids(&self.key, allocator),
-            value: CloneIn::clone_in_with_semantic_ids(&self.value, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            key: CloneIn::clone_in_impl(&self.key, with_semantic_ids, allocator),
+            value: CloneIn::clone_in_impl(&self.value, with_semantic_ids, allocator),
         }
     }
 }
@@ -3719,25 +2785,22 @@ impl<'new_alloc> CloneIn<'new_alloc> for ImportAttribute<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ImportAttributeKey<'_> {
     type Cloned = ImportAttributeKey<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
-            Self::Identifier(it) => {
-                ImportAttributeKey::Identifier(CloneIn::clone_in(it, allocator))
-            }
-            Self::StringLiteral(it) => {
-                ImportAttributeKey::StringLiteral(CloneIn::clone_in(it, allocator))
-            }
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Identifier(it) => {
-                ImportAttributeKey::Identifier(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
-            Self::StringLiteral(it) => ImportAttributeKey::StringLiteral(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
-            ),
+            Self::Identifier(it) => ImportAttributeKey::Identifier(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
+            Self::StringLiteral(it) => ImportAttributeKey::StringLiteral(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
         }
     }
 }
@@ -3745,27 +2808,19 @@ impl<'new_alloc> CloneIn<'new_alloc> for ImportAttributeKey<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ExportNamedDeclaration<'_> {
     type Cloned = ExportNamedDeclaration<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         ExportNamedDeclaration {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            declaration: CloneIn::clone_in(&self.declaration, allocator),
-            specifiers: CloneIn::clone_in(&self.specifiers, allocator),
-            source: CloneIn::clone_in(&self.source, allocator),
-            export_kind: CloneIn::clone_in(&self.export_kind, allocator),
-            with_clause: CloneIn::clone_in(&self.with_clause, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        ExportNamedDeclaration {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            declaration: CloneIn::clone_in_with_semantic_ids(&self.declaration, allocator),
-            specifiers: CloneIn::clone_in_with_semantic_ids(&self.specifiers, allocator),
-            source: CloneIn::clone_in_with_semantic_ids(&self.source, allocator),
-            export_kind: CloneIn::clone_in_with_semantic_ids(&self.export_kind, allocator),
-            with_clause: CloneIn::clone_in_with_semantic_ids(&self.with_clause, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            declaration: CloneIn::clone_in_impl(&self.declaration, with_semantic_ids, allocator),
+            specifiers: CloneIn::clone_in_impl(&self.specifiers, with_semantic_ids, allocator),
+            source: CloneIn::clone_in_impl(&self.source, with_semantic_ids, allocator),
+            export_kind: CloneIn::clone_in_impl(&self.export_kind, with_semantic_ids, allocator),
+            with_clause: CloneIn::clone_in_impl(&self.with_clause, with_semantic_ids, allocator),
         }
     }
 }
@@ -3773,19 +2828,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for ExportNamedDeclaration<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ExportDefaultDeclaration<'_> {
     type Cloned = ExportDefaultDeclaration<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         ExportDefaultDeclaration {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            declaration: CloneIn::clone_in(&self.declaration, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        ExportDefaultDeclaration {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            declaration: CloneIn::clone_in_with_semantic_ids(&self.declaration, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            declaration: CloneIn::clone_in_impl(&self.declaration, with_semantic_ids, allocator),
         }
     }
 }
@@ -3793,25 +2844,18 @@ impl<'new_alloc> CloneIn<'new_alloc> for ExportDefaultDeclaration<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ExportAllDeclaration<'_> {
     type Cloned = ExportAllDeclaration<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         ExportAllDeclaration {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            exported: CloneIn::clone_in(&self.exported, allocator),
-            source: CloneIn::clone_in(&self.source, allocator),
-            with_clause: CloneIn::clone_in(&self.with_clause, allocator),
-            export_kind: CloneIn::clone_in(&self.export_kind, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        ExportAllDeclaration {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            exported: CloneIn::clone_in_with_semantic_ids(&self.exported, allocator),
-            source: CloneIn::clone_in_with_semantic_ids(&self.source, allocator),
-            with_clause: CloneIn::clone_in_with_semantic_ids(&self.with_clause, allocator),
-            export_kind: CloneIn::clone_in_with_semantic_ids(&self.export_kind, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            exported: CloneIn::clone_in_impl(&self.exported, with_semantic_ids, allocator),
+            source: CloneIn::clone_in_impl(&self.source, with_semantic_ids, allocator),
+            with_clause: CloneIn::clone_in_impl(&self.with_clause, with_semantic_ids, allocator),
+            export_kind: CloneIn::clone_in_impl(&self.export_kind, with_semantic_ids, allocator),
         }
     }
 }
@@ -3819,23 +2863,17 @@ impl<'new_alloc> CloneIn<'new_alloc> for ExportAllDeclaration<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ExportSpecifier<'_> {
     type Cloned = ExportSpecifier<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         ExportSpecifier {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            local: CloneIn::clone_in(&self.local, allocator),
-            exported: CloneIn::clone_in(&self.exported, allocator),
-            export_kind: CloneIn::clone_in(&self.export_kind, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        ExportSpecifier {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            local: CloneIn::clone_in_with_semantic_ids(&self.local, allocator),
-            exported: CloneIn::clone_in_with_semantic_ids(&self.exported, allocator),
-            export_kind: CloneIn::clone_in_with_semantic_ids(&self.export_kind, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            local: CloneIn::clone_in_impl(&self.local, with_semantic_ids, allocator),
+            exported: CloneIn::clone_in_impl(&self.exported, with_semantic_ids, allocator),
+            export_kind: CloneIn::clone_in_impl(&self.export_kind, with_semantic_ids, allocator),
         }
     }
 }
@@ -3843,17 +2881,23 @@ impl<'new_alloc> CloneIn<'new_alloc> for ExportSpecifier<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ExportDefaultDeclarationKind<'_> {
     type Cloned = ExportDefaultDeclarationKind<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
-            Self::FunctionDeclaration(it) => {
-                ExportDefaultDeclarationKind::FunctionDeclaration(CloneIn::clone_in(it, allocator))
-            }
-            Self::ClassDeclaration(it) => {
-                ExportDefaultDeclarationKind::ClassDeclaration(CloneIn::clone_in(it, allocator))
-            }
+            Self::FunctionDeclaration(it) => ExportDefaultDeclarationKind::FunctionDeclaration(
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
+            ),
+            Self::ClassDeclaration(it) => ExportDefaultDeclarationKind::ClassDeclaration(
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
+            ),
             Self::TSInterfaceDeclaration(it) => {
-                ExportDefaultDeclarationKind::TSInterfaceDeclaration(CloneIn::clone_in(
-                    it, allocator,
+                ExportDefaultDeclarationKind::TSInterfaceDeclaration(CloneIn::clone_in_impl(
+                    it,
+                    with_semantic_ids,
+                    allocator,
                 ))
             }
             Self::BooleanLiteral(_)
@@ -3899,68 +2943,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ExportDefaultDeclarationKind<'_> {
             | Self::ComputedMemberExpression(_)
             | Self::StaticMemberExpression(_)
             | Self::PrivateFieldExpression(_) => ExportDefaultDeclarationKind::from(
-                CloneIn::clone_in(self.to_expression(), allocator),
-            ),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::FunctionDeclaration(it) => ExportDefaultDeclarationKind::FunctionDeclaration(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
-            ),
-            Self::ClassDeclaration(it) => ExportDefaultDeclarationKind::ClassDeclaration(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
-            ),
-            Self::TSInterfaceDeclaration(it) => {
-                ExportDefaultDeclarationKind::TSInterfaceDeclaration(
-                    CloneIn::clone_in_with_semantic_ids(it, allocator),
-                )
-            }
-            Self::BooleanLiteral(_)
-            | Self::NullLiteral(_)
-            | Self::NumericLiteral(_)
-            | Self::BigIntLiteral(_)
-            | Self::RegExpLiteral(_)
-            | Self::StringLiteral(_)
-            | Self::TemplateLiteral(_)
-            | Self::Identifier(_)
-            | Self::MetaProperty(_)
-            | Self::Super(_)
-            | Self::ArrayExpression(_)
-            | Self::ArrowFunctionExpression(_)
-            | Self::AssignmentExpression(_)
-            | Self::AwaitExpression(_)
-            | Self::BinaryExpression(_)
-            | Self::CallExpression(_)
-            | Self::ChainExpression(_)
-            | Self::ClassExpression(_)
-            | Self::ConditionalExpression(_)
-            | Self::FunctionExpression(_)
-            | Self::ImportExpression(_)
-            | Self::LogicalExpression(_)
-            | Self::NewExpression(_)
-            | Self::ObjectExpression(_)
-            | Self::ParenthesizedExpression(_)
-            | Self::SequenceExpression(_)
-            | Self::TaggedTemplateExpression(_)
-            | Self::ThisExpression(_)
-            | Self::UnaryExpression(_)
-            | Self::UpdateExpression(_)
-            | Self::YieldExpression(_)
-            | Self::PrivateInExpression(_)
-            | Self::JSXElement(_)
-            | Self::JSXFragment(_)
-            | Self::TSAsExpression(_)
-            | Self::TSSatisfiesExpression(_)
-            | Self::TSTypeAssertion(_)
-            | Self::TSNonNullExpression(_)
-            | Self::TSInstantiationExpression(_)
-            | Self::V8IntrinsicExpression(_)
-            | Self::ComputedMemberExpression(_)
-            | Self::StaticMemberExpression(_)
-            | Self::PrivateFieldExpression(_) => ExportDefaultDeclarationKind::from(
-                CloneIn::clone_in_with_semantic_ids(self.to_expression(), allocator),
+                CloneIn::clone_in_impl(self.to_expression(), with_semantic_ids, allocator),
             ),
         }
     }
@@ -3969,31 +2952,25 @@ impl<'new_alloc> CloneIn<'new_alloc> for ExportDefaultDeclarationKind<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ModuleExportName<'_> {
     type Cloned = ModuleExportName<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
-            Self::IdentifierName(it) => {
-                ModuleExportName::IdentifierName(CloneIn::clone_in(it, allocator))
-            }
-            Self::IdentifierReference(it) => {
-                ModuleExportName::IdentifierReference(CloneIn::clone_in(it, allocator))
-            }
-            Self::StringLiteral(it) => {
-                ModuleExportName::StringLiteral(CloneIn::clone_in(it, allocator))
-            }
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::IdentifierName(it) => {
-                ModuleExportName::IdentifierName(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
+            Self::IdentifierName(it) => ModuleExportName::IdentifierName(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
             Self::IdentifierReference(it) => ModuleExportName::IdentifierReference(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
-            Self::StringLiteral(it) => {
-                ModuleExportName::StringLiteral(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
+            Self::StringLiteral(it) => ModuleExportName::StringLiteral(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
         }
     }
 }
@@ -4001,21 +2978,16 @@ impl<'new_alloc> CloneIn<'new_alloc> for ModuleExportName<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for V8IntrinsicExpression<'_> {
     type Cloned = V8IntrinsicExpression<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         V8IntrinsicExpression {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            name: CloneIn::clone_in(&self.name, allocator),
-            arguments: CloneIn::clone_in(&self.arguments, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        V8IntrinsicExpression {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            name: CloneIn::clone_in_with_semantic_ids(&self.name, allocator),
-            arguments: CloneIn::clone_in_with_semantic_ids(&self.arguments, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            name: CloneIn::clone_in_impl(&self.name, with_semantic_ids, allocator),
+            arguments: CloneIn::clone_in_impl(&self.arguments, with_semantic_ids, allocator),
         }
     }
 }
@@ -4023,19 +2995,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for V8IntrinsicExpression<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for BooleanLiteral {
     type Cloned = BooleanLiteral;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         BooleanLiteral {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            value: CloneIn::clone_in(&self.value, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        BooleanLiteral {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            value: CloneIn::clone_in_with_semantic_ids(&self.value, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            value: CloneIn::clone_in_impl(&self.value, with_semantic_ids, allocator),
         }
     }
 }
@@ -4043,14 +3011,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for BooleanLiteral {
 impl<'new_alloc> CloneIn<'new_alloc> for NullLiteral {
     type Cloned = NullLiteral;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        NullLiteral { node_id: Default::default(), span: CloneIn::clone_in(&self.span, allocator) }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         NullLiteral {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
         }
     }
 }
@@ -4058,23 +3026,17 @@ impl<'new_alloc> CloneIn<'new_alloc> for NullLiteral {
 impl<'new_alloc> CloneIn<'new_alloc> for NumericLiteral<'_> {
     type Cloned = NumericLiteral<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         NumericLiteral {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            value: CloneIn::clone_in(&self.value, allocator),
-            raw: CloneIn::clone_in(&self.raw, allocator),
-            base: CloneIn::clone_in(&self.base, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        NumericLiteral {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            value: CloneIn::clone_in_with_semantic_ids(&self.value, allocator),
-            raw: CloneIn::clone_in_with_semantic_ids(&self.raw, allocator),
-            base: CloneIn::clone_in_with_semantic_ids(&self.base, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            value: CloneIn::clone_in_impl(&self.value, with_semantic_ids, allocator),
+            raw: CloneIn::clone_in_impl(&self.raw, with_semantic_ids, allocator),
+            base: CloneIn::clone_in_impl(&self.base, with_semantic_ids, allocator),
         }
     }
 }
@@ -4082,23 +3044,21 @@ impl<'new_alloc> CloneIn<'new_alloc> for NumericLiteral<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for StringLiteral<'_> {
     type Cloned = StringLiteral<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         StringLiteral {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            value: CloneIn::clone_in(&self.value, allocator),
-            raw: CloneIn::clone_in(&self.raw, allocator),
-            lone_surrogates: CloneIn::clone_in(&self.lone_surrogates, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        StringLiteral {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            value: CloneIn::clone_in_with_semantic_ids(&self.value, allocator),
-            raw: CloneIn::clone_in_with_semantic_ids(&self.raw, allocator),
-            lone_surrogates: CloneIn::clone_in_with_semantic_ids(&self.lone_surrogates, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            value: CloneIn::clone_in_impl(&self.value, with_semantic_ids, allocator),
+            raw: CloneIn::clone_in_impl(&self.raw, with_semantic_ids, allocator),
+            lone_surrogates: CloneIn::clone_in_impl(
+                &self.lone_surrogates,
+                with_semantic_ids,
+                allocator,
+            ),
         }
     }
 }
@@ -4106,23 +3066,17 @@ impl<'new_alloc> CloneIn<'new_alloc> for StringLiteral<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for BigIntLiteral<'_> {
     type Cloned = BigIntLiteral<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         BigIntLiteral {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            value: CloneIn::clone_in(&self.value, allocator),
-            raw: CloneIn::clone_in(&self.raw, allocator),
-            base: CloneIn::clone_in(&self.base, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        BigIntLiteral {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            value: CloneIn::clone_in_with_semantic_ids(&self.value, allocator),
-            raw: CloneIn::clone_in_with_semantic_ids(&self.raw, allocator),
-            base: CloneIn::clone_in_with_semantic_ids(&self.base, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            value: CloneIn::clone_in_impl(&self.value, with_semantic_ids, allocator),
+            raw: CloneIn::clone_in_impl(&self.raw, with_semantic_ids, allocator),
+            base: CloneIn::clone_in_impl(&self.base, with_semantic_ids, allocator),
         }
     }
 }
@@ -4130,21 +3084,16 @@ impl<'new_alloc> CloneIn<'new_alloc> for BigIntLiteral<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for RegExpLiteral<'_> {
     type Cloned = RegExpLiteral<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         RegExpLiteral {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            regex: CloneIn::clone_in(&self.regex, allocator),
-            raw: CloneIn::clone_in(&self.raw, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        RegExpLiteral {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            regex: CloneIn::clone_in_with_semantic_ids(&self.regex, allocator),
-            raw: CloneIn::clone_in_with_semantic_ids(&self.raw, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            regex: CloneIn::clone_in_impl(&self.regex, with_semantic_ids, allocator),
+            raw: CloneIn::clone_in_impl(&self.raw, with_semantic_ids, allocator),
         }
     }
 }
@@ -4152,17 +3101,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for RegExpLiteral<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for RegExp<'_> {
     type Cloned = RegExp<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         RegExp {
-            pattern: CloneIn::clone_in(&self.pattern, allocator),
-            flags: CloneIn::clone_in(&self.flags, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        RegExp {
-            pattern: CloneIn::clone_in_with_semantic_ids(&self.pattern, allocator),
-            flags: CloneIn::clone_in_with_semantic_ids(&self.flags, allocator),
+            pattern: CloneIn::clone_in_impl(&self.pattern, with_semantic_ids, allocator),
+            flags: CloneIn::clone_in_impl(&self.flags, with_semantic_ids, allocator),
         }
     }
 }
@@ -4170,17 +3116,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for RegExp<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for RegExpPattern<'_> {
     type Cloned = RegExpPattern<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         RegExpPattern {
-            text: CloneIn::clone_in(&self.text, allocator),
-            pattern: CloneIn::clone_in(&self.pattern, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        RegExpPattern {
-            text: CloneIn::clone_in_with_semantic_ids(&self.text, allocator),
-            pattern: CloneIn::clone_in_with_semantic_ids(&self.pattern, allocator),
+            text: CloneIn::clone_in_impl(&self.text, with_semantic_ids, allocator),
+            pattern: CloneIn::clone_in_impl(&self.pattern, with_semantic_ids, allocator),
         }
     }
 }
@@ -4188,23 +3131,25 @@ impl<'new_alloc> CloneIn<'new_alloc> for RegExpPattern<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for JSXElement<'_> {
     type Cloned = JSXElement<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         JSXElement {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            opening_element: CloneIn::clone_in(&self.opening_element, allocator),
-            children: CloneIn::clone_in(&self.children, allocator),
-            closing_element: CloneIn::clone_in(&self.closing_element, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        JSXElement {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            opening_element: CloneIn::clone_in_with_semantic_ids(&self.opening_element, allocator),
-            children: CloneIn::clone_in_with_semantic_ids(&self.children, allocator),
-            closing_element: CloneIn::clone_in_with_semantic_ids(&self.closing_element, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            opening_element: CloneIn::clone_in_impl(
+                &self.opening_element,
+                with_semantic_ids,
+                allocator,
+            ),
+            children: CloneIn::clone_in_impl(&self.children, with_semantic_ids, allocator),
+            closing_element: CloneIn::clone_in_impl(
+                &self.closing_element,
+                with_semantic_ids,
+                allocator,
+            ),
         }
     }
 }
@@ -4212,23 +3157,21 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXElement<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for JSXOpeningElement<'_> {
     type Cloned = JSXOpeningElement<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         JSXOpeningElement {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            name: CloneIn::clone_in(&self.name, allocator),
-            type_arguments: CloneIn::clone_in(&self.type_arguments, allocator),
-            attributes: CloneIn::clone_in(&self.attributes, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        JSXOpeningElement {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            name: CloneIn::clone_in_with_semantic_ids(&self.name, allocator),
-            type_arguments: CloneIn::clone_in_with_semantic_ids(&self.type_arguments, allocator),
-            attributes: CloneIn::clone_in_with_semantic_ids(&self.attributes, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            name: CloneIn::clone_in_impl(&self.name, with_semantic_ids, allocator),
+            type_arguments: CloneIn::clone_in_impl(
+                &self.type_arguments,
+                with_semantic_ids,
+                allocator,
+            ),
+            attributes: CloneIn::clone_in_impl(&self.attributes, with_semantic_ids, allocator),
         }
     }
 }
@@ -4236,19 +3179,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXOpeningElement<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for JSXClosingElement<'_> {
     type Cloned = JSXClosingElement<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         JSXClosingElement {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            name: CloneIn::clone_in(&self.name, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        JSXClosingElement {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            name: CloneIn::clone_in_with_semantic_ids(&self.name, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            name: CloneIn::clone_in_impl(&self.name, with_semantic_ids, allocator),
         }
     }
 }
@@ -4256,27 +3195,23 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXClosingElement<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for JSXFragment<'_> {
     type Cloned = JSXFragment<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         JSXFragment {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            opening_fragment: CloneIn::clone_in(&self.opening_fragment, allocator),
-            children: CloneIn::clone_in(&self.children, allocator),
-            closing_fragment: CloneIn::clone_in(&self.closing_fragment, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        JSXFragment {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            opening_fragment: CloneIn::clone_in_with_semantic_ids(
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            opening_fragment: CloneIn::clone_in_impl(
                 &self.opening_fragment,
+                with_semantic_ids,
                 allocator,
             ),
-            children: CloneIn::clone_in_with_semantic_ids(&self.children, allocator),
-            closing_fragment: CloneIn::clone_in_with_semantic_ids(
+            children: CloneIn::clone_in_impl(&self.children, with_semantic_ids, allocator),
+            closing_fragment: CloneIn::clone_in_impl(
                 &self.closing_fragment,
+                with_semantic_ids,
                 allocator,
             ),
         }
@@ -4286,17 +3221,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXFragment<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for JSXOpeningFragment {
     type Cloned = JSXOpeningFragment;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         JSXOpeningFragment {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        JSXOpeningFragment {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
         }
     }
 }
@@ -4304,17 +3236,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXOpeningFragment {
 impl<'new_alloc> CloneIn<'new_alloc> for JSXClosingFragment {
     type Cloned = JSXClosingFragment;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         JSXClosingFragment {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        JSXClosingFragment {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
         }
     }
 }
@@ -4322,41 +3251,33 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXClosingFragment {
 impl<'new_alloc> CloneIn<'new_alloc> for JSXElementName<'_> {
     type Cloned = JSXElementName<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Identifier(it) => JSXElementName::Identifier(CloneIn::clone_in(it, allocator)),
-            Self::IdentifierReference(it) => {
-                JSXElementName::IdentifierReference(CloneIn::clone_in(it, allocator))
-            }
-            Self::NamespacedName(it) => {
-                JSXElementName::NamespacedName(CloneIn::clone_in(it, allocator))
-            }
-            Self::MemberExpression(it) => {
-                JSXElementName::MemberExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::ThisExpression(it) => {
-                JSXElementName::ThisExpression(CloneIn::clone_in(it, allocator))
-            }
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
             Self::Identifier(it) => {
-                JSXElementName::Identifier(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                JSXElementName::Identifier(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::IdentifierReference(it) => JSXElementName::IdentifierReference(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
-            Self::NamespacedName(it) => {
-                JSXElementName::NamespacedName(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
-            Self::MemberExpression(it) => {
-                JSXElementName::MemberExpression(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
-            Self::ThisExpression(it) => {
-                JSXElementName::ThisExpression(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
+            Self::NamespacedName(it) => JSXElementName::NamespacedName(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
+            Self::MemberExpression(it) => JSXElementName::MemberExpression(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
+            Self::ThisExpression(it) => JSXElementName::ThisExpression(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
         }
     }
 }
@@ -4364,21 +3285,16 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXElementName<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for JSXNamespacedName<'_> {
     type Cloned = JSXNamespacedName<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         JSXNamespacedName {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            namespace: CloneIn::clone_in(&self.namespace, allocator),
-            name: CloneIn::clone_in(&self.name, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        JSXNamespacedName {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            namespace: CloneIn::clone_in_with_semantic_ids(&self.namespace, allocator),
-            name: CloneIn::clone_in_with_semantic_ids(&self.name, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            namespace: CloneIn::clone_in_impl(&self.namespace, with_semantic_ids, allocator),
+            name: CloneIn::clone_in_impl(&self.name, with_semantic_ids, allocator),
         }
     }
 }
@@ -4386,21 +3302,16 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXNamespacedName<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for JSXMemberExpression<'_> {
     type Cloned = JSXMemberExpression<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         JSXMemberExpression {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            object: CloneIn::clone_in(&self.object, allocator),
-            property: CloneIn::clone_in(&self.property, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        JSXMemberExpression {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            object: CloneIn::clone_in_with_semantic_ids(&self.object, allocator),
-            property: CloneIn::clone_in_with_semantic_ids(&self.property, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            object: CloneIn::clone_in_impl(&self.object, with_semantic_ids, allocator),
+            property: CloneIn::clone_in_impl(&self.property, with_semantic_ids, allocator),
         }
     }
 }
@@ -4408,30 +3319,20 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXMemberExpression<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for JSXMemberExpressionObject<'_> {
     type Cloned = JSXMemberExpressionObject<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::IdentifierReference(it) => {
-                JSXMemberExpressionObject::IdentifierReference(CloneIn::clone_in(it, allocator))
-            }
-            Self::MemberExpression(it) => {
-                JSXMemberExpressionObject::MemberExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::ThisExpression(it) => {
-                JSXMemberExpressionObject::ThisExpression(CloneIn::clone_in(it, allocator))
-            }
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
             Self::IdentifierReference(it) => JSXMemberExpressionObject::IdentifierReference(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
             Self::MemberExpression(it) => JSXMemberExpressionObject::MemberExpression(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
             Self::ThisExpression(it) => JSXMemberExpressionObject::ThisExpression(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
         }
     }
@@ -4440,19 +3341,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXMemberExpressionObject<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for JSXExpressionContainer<'_> {
     type Cloned = JSXExpressionContainer<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         JSXExpressionContainer {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            expression: CloneIn::clone_in(&self.expression, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        JSXExpressionContainer {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            expression: CloneIn::clone_in_impl(&self.expression, with_semantic_ids, allocator),
         }
     }
 }
@@ -4460,11 +3357,17 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXExpressionContainer<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for JSXExpression<'_> {
     type Cloned = JSXExpression<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
-            Self::EmptyExpression(it) => {
-                JSXExpression::EmptyExpression(CloneIn::clone_in(it, allocator))
-            }
+            Self::EmptyExpression(it) => JSXExpression::EmptyExpression(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
             Self::BooleanLiteral(_)
             | Self::NullLiteral(_)
             | Self::NumericLiteral(_)
@@ -4507,62 +3410,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXExpression<'_> {
             | Self::V8IntrinsicExpression(_)
             | Self::ComputedMemberExpression(_)
             | Self::StaticMemberExpression(_)
-            | Self::PrivateFieldExpression(_) => {
-                JSXExpression::from(CloneIn::clone_in(self.to_expression(), allocator))
-            }
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::EmptyExpression(it) => {
-                JSXExpression::EmptyExpression(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
-            Self::BooleanLiteral(_)
-            | Self::NullLiteral(_)
-            | Self::NumericLiteral(_)
-            | Self::BigIntLiteral(_)
-            | Self::RegExpLiteral(_)
-            | Self::StringLiteral(_)
-            | Self::TemplateLiteral(_)
-            | Self::Identifier(_)
-            | Self::MetaProperty(_)
-            | Self::Super(_)
-            | Self::ArrayExpression(_)
-            | Self::ArrowFunctionExpression(_)
-            | Self::AssignmentExpression(_)
-            | Self::AwaitExpression(_)
-            | Self::BinaryExpression(_)
-            | Self::CallExpression(_)
-            | Self::ChainExpression(_)
-            | Self::ClassExpression(_)
-            | Self::ConditionalExpression(_)
-            | Self::FunctionExpression(_)
-            | Self::ImportExpression(_)
-            | Self::LogicalExpression(_)
-            | Self::NewExpression(_)
-            | Self::ObjectExpression(_)
-            | Self::ParenthesizedExpression(_)
-            | Self::SequenceExpression(_)
-            | Self::TaggedTemplateExpression(_)
-            | Self::ThisExpression(_)
-            | Self::UnaryExpression(_)
-            | Self::UpdateExpression(_)
-            | Self::YieldExpression(_)
-            | Self::PrivateInExpression(_)
-            | Self::JSXElement(_)
-            | Self::JSXFragment(_)
-            | Self::TSAsExpression(_)
-            | Self::TSSatisfiesExpression(_)
-            | Self::TSTypeAssertion(_)
-            | Self::TSNonNullExpression(_)
-            | Self::TSInstantiationExpression(_)
-            | Self::V8IntrinsicExpression(_)
-            | Self::ComputedMemberExpression(_)
-            | Self::StaticMemberExpression(_)
-            | Self::PrivateFieldExpression(_) => JSXExpression::from(
-                CloneIn::clone_in_with_semantic_ids(self.to_expression(), allocator),
-            ),
+            | Self::PrivateFieldExpression(_) => JSXExpression::from(CloneIn::clone_in_impl(
+                self.to_expression(),
+                with_semantic_ids,
+                allocator,
+            )),
         }
     }
 }
@@ -4570,17 +3422,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXExpression<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for JSXEmptyExpression {
     type Cloned = JSXEmptyExpression;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         JSXEmptyExpression {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        JSXEmptyExpression {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
         }
     }
 }
@@ -4588,23 +3437,22 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXEmptyExpression {
 impl<'new_alloc> CloneIn<'new_alloc> for JSXAttributeItem<'_> {
     type Cloned = JSXAttributeItem<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
-            Self::Attribute(it) => JSXAttributeItem::Attribute(CloneIn::clone_in(it, allocator)),
-            Self::SpreadAttribute(it) => {
-                JSXAttributeItem::SpreadAttribute(CloneIn::clone_in(it, allocator))
-            }
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Attribute(it) => {
-                JSXAttributeItem::Attribute(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
-            Self::SpreadAttribute(it) => JSXAttributeItem::SpreadAttribute(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
-            ),
+            Self::Attribute(it) => JSXAttributeItem::Attribute(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
+            Self::SpreadAttribute(it) => JSXAttributeItem::SpreadAttribute(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
         }
     }
 }
@@ -4612,21 +3460,16 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXAttributeItem<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for JSXAttribute<'_> {
     type Cloned = JSXAttribute<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         JSXAttribute {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            name: CloneIn::clone_in(&self.name, allocator),
-            value: CloneIn::clone_in(&self.value, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        JSXAttribute {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            name: CloneIn::clone_in_with_semantic_ids(&self.name, allocator),
-            value: CloneIn::clone_in_with_semantic_ids(&self.value, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            name: CloneIn::clone_in_impl(&self.name, with_semantic_ids, allocator),
+            value: CloneIn::clone_in_impl(&self.value, with_semantic_ids, allocator),
         }
     }
 }
@@ -4634,19 +3477,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXAttribute<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for JSXSpreadAttribute<'_> {
     type Cloned = JSXSpreadAttribute<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         JSXSpreadAttribute {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            argument: CloneIn::clone_in(&self.argument, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        JSXSpreadAttribute {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            argument: CloneIn::clone_in_with_semantic_ids(&self.argument, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            argument: CloneIn::clone_in_impl(&self.argument, with_semantic_ids, allocator),
         }
     }
 }
@@ -4654,23 +3493,22 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXSpreadAttribute<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for JSXAttributeName<'_> {
     type Cloned = JSXAttributeName<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
-            Self::Identifier(it) => JSXAttributeName::Identifier(CloneIn::clone_in(it, allocator)),
-            Self::NamespacedName(it) => {
-                JSXAttributeName::NamespacedName(CloneIn::clone_in(it, allocator))
-            }
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Identifier(it) => {
-                JSXAttributeName::Identifier(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
-            Self::NamespacedName(it) => {
-                JSXAttributeName::NamespacedName(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
+            Self::Identifier(it) => JSXAttributeName::Identifier(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
+            Self::NamespacedName(it) => JSXAttributeName::NamespacedName(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
         }
     }
 }
@@ -4678,33 +3516,28 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXAttributeName<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for JSXAttributeValue<'_> {
     type Cloned = JSXAttributeValue<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
-            Self::StringLiteral(it) => {
-                JSXAttributeValue::StringLiteral(CloneIn::clone_in(it, allocator))
-            }
-            Self::ExpressionContainer(it) => {
-                JSXAttributeValue::ExpressionContainer(CloneIn::clone_in(it, allocator))
-            }
-            Self::Element(it) => JSXAttributeValue::Element(CloneIn::clone_in(it, allocator)),
-            Self::Fragment(it) => JSXAttributeValue::Fragment(CloneIn::clone_in(it, allocator)),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::StringLiteral(it) => {
-                JSXAttributeValue::StringLiteral(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
+            Self::StringLiteral(it) => JSXAttributeValue::StringLiteral(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
             Self::ExpressionContainer(it) => JSXAttributeValue::ExpressionContainer(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
             Self::Element(it) => {
-                JSXAttributeValue::Element(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                JSXAttributeValue::Element(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
-            Self::Fragment(it) => {
-                JSXAttributeValue::Fragment(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
+            Self::Fragment(it) => JSXAttributeValue::Fragment(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
         }
     }
 }
@@ -4712,19 +3545,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXAttributeValue<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for JSXIdentifier<'_> {
     type Cloned = JSXIdentifier<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         JSXIdentifier {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            name: CloneIn::clone_in(&self.name, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        JSXIdentifier {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            name: CloneIn::clone_in_with_semantic_ids(&self.name, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            name: CloneIn::clone_in_impl(&self.name, with_semantic_ids, allocator),
         }
     }
 }
@@ -4732,32 +3561,28 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXIdentifier<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for JSXChild<'_> {
     type Cloned = JSXChild<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
-            Self::Text(it) => JSXChild::Text(CloneIn::clone_in(it, allocator)),
-            Self::Element(it) => JSXChild::Element(CloneIn::clone_in(it, allocator)),
-            Self::Fragment(it) => JSXChild::Fragment(CloneIn::clone_in(it, allocator)),
-            Self::ExpressionContainer(it) => {
-                JSXChild::ExpressionContainer(CloneIn::clone_in(it, allocator))
+            Self::Text(it) => {
+                JSXChild::Text(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
-            Self::Spread(it) => JSXChild::Spread(CloneIn::clone_in(it, allocator)),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Text(it) => JSXChild::Text(CloneIn::clone_in_with_semantic_ids(it, allocator)),
             Self::Element(it) => {
-                JSXChild::Element(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                JSXChild::Element(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::Fragment(it) => {
-                JSXChild::Fragment(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                JSXChild::Fragment(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
-            Self::ExpressionContainer(it) => {
-                JSXChild::ExpressionContainer(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
+            Self::ExpressionContainer(it) => JSXChild::ExpressionContainer(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
             Self::Spread(it) => {
-                JSXChild::Spread(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                JSXChild::Spread(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
         }
     }
@@ -4766,19 +3591,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXChild<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for JSXSpreadChild<'_> {
     type Cloned = JSXSpreadChild<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         JSXSpreadChild {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            expression: CloneIn::clone_in(&self.expression, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        JSXSpreadChild {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            expression: CloneIn::clone_in_impl(&self.expression, with_semantic_ids, allocator),
         }
     }
 }
@@ -4786,21 +3607,16 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXSpreadChild<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for JSXText<'_> {
     type Cloned = JSXText<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         JSXText {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            value: CloneIn::clone_in(&self.value, allocator),
-            raw: CloneIn::clone_in(&self.raw, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        JSXText {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            value: CloneIn::clone_in_with_semantic_ids(&self.value, allocator),
-            raw: CloneIn::clone_in_with_semantic_ids(&self.raw, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            value: CloneIn::clone_in_impl(&self.value, with_semantic_ids, allocator),
+            raw: CloneIn::clone_in_impl(&self.raw, with_semantic_ids, allocator),
         }
     }
 }
@@ -4808,21 +3624,20 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXText<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSThisParameter<'_> {
     type Cloned = TSThisParameter<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSThisParameter {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            this_span: CloneIn::clone_in(&self.this_span, allocator),
-            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSThisParameter {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            this_span: CloneIn::clone_in_with_semantic_ids(&self.this_span, allocator),
-            type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            this_span: CloneIn::clone_in_impl(&self.this_span, with_semantic_ids, allocator),
+            type_annotation: CloneIn::clone_in_impl(
+                &self.type_annotation,
+                with_semantic_ids,
+                allocator,
+            ),
         }
     }
 }
@@ -4830,25 +3645,18 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSThisParameter<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSEnumDeclaration<'_> {
     type Cloned = TSEnumDeclaration<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSEnumDeclaration {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            id: CloneIn::clone_in(&self.id, allocator),
-            body: CloneIn::clone_in(&self.body, allocator),
-            r#const: CloneIn::clone_in(&self.r#const, allocator),
-            declare: CloneIn::clone_in(&self.declare, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSEnumDeclaration {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            id: CloneIn::clone_in_with_semantic_ids(&self.id, allocator),
-            body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
-            r#const: CloneIn::clone_in_with_semantic_ids(&self.r#const, allocator),
-            declare: CloneIn::clone_in_with_semantic_ids(&self.declare, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            id: CloneIn::clone_in_impl(&self.id, with_semantic_ids, allocator),
+            body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
+            r#const: CloneIn::clone_in_impl(&self.r#const, with_semantic_ids, allocator),
+            declare: CloneIn::clone_in_impl(&self.declare, with_semantic_ids, allocator),
         }
     }
 }
@@ -4856,21 +3664,16 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSEnumDeclaration<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSEnumBody<'_> {
     type Cloned = TSEnumBody<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSEnumBody {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            members: CloneIn::clone_in(&self.members, allocator),
-            scope_id: Default::default(),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSEnumBody {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            members: CloneIn::clone_in_with_semantic_ids(&self.members, allocator),
-            scope_id: CloneIn::clone_in_with_semantic_ids(&self.scope_id, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            members: CloneIn::clone_in_impl(&self.members, with_semantic_ids, allocator),
+            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
         }
     }
 }
@@ -4878,21 +3681,16 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSEnumBody<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSEnumMember<'_> {
     type Cloned = TSEnumMember<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSEnumMember {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            id: CloneIn::clone_in(&self.id, allocator),
-            initializer: CloneIn::clone_in(&self.initializer, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSEnumMember {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            id: CloneIn::clone_in_with_semantic_ids(&self.id, allocator),
-            initializer: CloneIn::clone_in_with_semantic_ids(&self.initializer, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            id: CloneIn::clone_in_impl(&self.id, with_semantic_ids, allocator),
+            initializer: CloneIn::clone_in_impl(&self.initializer, with_semantic_ids, allocator),
         }
     }
 }
@@ -4900,32 +3698,27 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSEnumMember<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSEnumMemberName<'_> {
     type Cloned = TSEnumMemberName<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
-            Self::Identifier(it) => TSEnumMemberName::Identifier(CloneIn::clone_in(it, allocator)),
-            Self::String(it) => TSEnumMemberName::String(CloneIn::clone_in(it, allocator)),
-            Self::ComputedString(it) => {
-                TSEnumMemberName::ComputedString(CloneIn::clone_in(it, allocator))
-            }
-            Self::ComputedTemplateString(it) => {
-                TSEnumMemberName::ComputedTemplateString(CloneIn::clone_in(it, allocator))
-            }
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Identifier(it) => {
-                TSEnumMemberName::Identifier(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
+            Self::Identifier(it) => TSEnumMemberName::Identifier(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
             Self::String(it) => {
-                TSEnumMemberName::String(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSEnumMemberName::String(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
-            Self::ComputedString(it) => {
-                TSEnumMemberName::ComputedString(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
+            Self::ComputedString(it) => TSEnumMemberName::ComputedString(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
             Self::ComputedTemplateString(it) => TSEnumMemberName::ComputedTemplateString(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
         }
     }
@@ -4934,19 +3727,19 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSEnumMemberName<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSTypeAnnotation<'_> {
     type Cloned = TSTypeAnnotation<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSTypeAnnotation {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSTypeAnnotation {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            type_annotation: CloneIn::clone_in_impl(
+                &self.type_annotation,
+                with_semantic_ids,
+                allocator,
+            ),
         }
     }
 }
@@ -4954,19 +3747,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeAnnotation<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSLiteralType<'_> {
     type Cloned = TSLiteralType<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSLiteralType {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            literal: CloneIn::clone_in(&self.literal, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSLiteralType {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            literal: CloneIn::clone_in_with_semantic_ids(&self.literal, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            literal: CloneIn::clone_in_impl(&self.literal, with_semantic_ids, allocator),
         }
     }
 }
@@ -4974,40 +3763,29 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSLiteralType<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSLiteral<'_> {
     type Cloned = TSLiteral<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::BooleanLiteral(it) => TSLiteral::BooleanLiteral(CloneIn::clone_in(it, allocator)),
-            Self::NumericLiteral(it) => TSLiteral::NumericLiteral(CloneIn::clone_in(it, allocator)),
-            Self::BigIntLiteral(it) => TSLiteral::BigIntLiteral(CloneIn::clone_in(it, allocator)),
-            Self::StringLiteral(it) => TSLiteral::StringLiteral(CloneIn::clone_in(it, allocator)),
-            Self::TemplateLiteral(it) => {
-                TSLiteral::TemplateLiteral(CloneIn::clone_in(it, allocator))
-            }
-            Self::UnaryExpression(it) => {
-                TSLiteral::UnaryExpression(CloneIn::clone_in(it, allocator))
-            }
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
             Self::BooleanLiteral(it) => {
-                TSLiteral::BooleanLiteral(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSLiteral::BooleanLiteral(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::NumericLiteral(it) => {
-                TSLiteral::NumericLiteral(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSLiteral::NumericLiteral(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::BigIntLiteral(it) => {
-                TSLiteral::BigIntLiteral(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSLiteral::BigIntLiteral(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::StringLiteral(it) => {
-                TSLiteral::StringLiteral(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSLiteral::StringLiteral(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::TemplateLiteral(it) => {
-                TSLiteral::TemplateLiteral(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSLiteral::TemplateLiteral(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::UnaryExpression(it) => {
-                TSLiteral::UnaryExpression(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSLiteral::UnaryExpression(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
         }
     }
@@ -5016,190 +3794,128 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSLiteral<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSType<'_> {
     type Cloned = TSType<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::TSAnyKeyword(it) => TSType::TSAnyKeyword(CloneIn::clone_in(it, allocator)),
-            Self::TSBigIntKeyword(it) => TSType::TSBigIntKeyword(CloneIn::clone_in(it, allocator)),
-            Self::TSBooleanKeyword(it) => {
-                TSType::TSBooleanKeyword(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSIntrinsicKeyword(it) => {
-                TSType::TSIntrinsicKeyword(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSNeverKeyword(it) => TSType::TSNeverKeyword(CloneIn::clone_in(it, allocator)),
-            Self::TSNullKeyword(it) => TSType::TSNullKeyword(CloneIn::clone_in(it, allocator)),
-            Self::TSNumberKeyword(it) => TSType::TSNumberKeyword(CloneIn::clone_in(it, allocator)),
-            Self::TSObjectKeyword(it) => TSType::TSObjectKeyword(CloneIn::clone_in(it, allocator)),
-            Self::TSStringKeyword(it) => TSType::TSStringKeyword(CloneIn::clone_in(it, allocator)),
-            Self::TSSymbolKeyword(it) => TSType::TSSymbolKeyword(CloneIn::clone_in(it, allocator)),
-            Self::TSUndefinedKeyword(it) => {
-                TSType::TSUndefinedKeyword(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSUnknownKeyword(it) => {
-                TSType::TSUnknownKeyword(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSVoidKeyword(it) => TSType::TSVoidKeyword(CloneIn::clone_in(it, allocator)),
-            Self::TSArrayType(it) => TSType::TSArrayType(CloneIn::clone_in(it, allocator)),
-            Self::TSConditionalType(it) => {
-                TSType::TSConditionalType(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSConstructorType(it) => {
-                TSType::TSConstructorType(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSFunctionType(it) => TSType::TSFunctionType(CloneIn::clone_in(it, allocator)),
-            Self::TSImportType(it) => TSType::TSImportType(CloneIn::clone_in(it, allocator)),
-            Self::TSIndexedAccessType(it) => {
-                TSType::TSIndexedAccessType(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSInferType(it) => TSType::TSInferType(CloneIn::clone_in(it, allocator)),
-            Self::TSIntersectionType(it) => {
-                TSType::TSIntersectionType(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSLiteralType(it) => TSType::TSLiteralType(CloneIn::clone_in(it, allocator)),
-            Self::TSMappedType(it) => TSType::TSMappedType(CloneIn::clone_in(it, allocator)),
-            Self::TSNamedTupleMember(it) => {
-                TSType::TSNamedTupleMember(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSTemplateLiteralType(it) => {
-                TSType::TSTemplateLiteralType(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSThisType(it) => TSType::TSThisType(CloneIn::clone_in(it, allocator)),
-            Self::TSTupleType(it) => TSType::TSTupleType(CloneIn::clone_in(it, allocator)),
-            Self::TSTypeLiteral(it) => TSType::TSTypeLiteral(CloneIn::clone_in(it, allocator)),
-            Self::TSTypeOperatorType(it) => {
-                TSType::TSTypeOperatorType(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSTypePredicate(it) => TSType::TSTypePredicate(CloneIn::clone_in(it, allocator)),
-            Self::TSTypeQuery(it) => TSType::TSTypeQuery(CloneIn::clone_in(it, allocator)),
-            Self::TSTypeReference(it) => TSType::TSTypeReference(CloneIn::clone_in(it, allocator)),
-            Self::TSUnionType(it) => TSType::TSUnionType(CloneIn::clone_in(it, allocator)),
-            Self::TSParenthesizedType(it) => {
-                TSType::TSParenthesizedType(CloneIn::clone_in(it, allocator))
-            }
-            Self::JSDocNullableType(it) => {
-                TSType::JSDocNullableType(CloneIn::clone_in(it, allocator))
-            }
-            Self::JSDocNonNullableType(it) => {
-                TSType::JSDocNonNullableType(CloneIn::clone_in(it, allocator))
-            }
-            Self::JSDocUnknownType(it) => {
-                TSType::JSDocUnknownType(CloneIn::clone_in(it, allocator))
-            }
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
             Self::TSAnyKeyword(it) => {
-                TSType::TSAnyKeyword(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSType::TSAnyKeyword(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::TSBigIntKeyword(it) => {
-                TSType::TSBigIntKeyword(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSType::TSBigIntKeyword(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::TSBooleanKeyword(it) => {
-                TSType::TSBooleanKeyword(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSType::TSBooleanKeyword(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::TSIntrinsicKeyword(it) => {
-                TSType::TSIntrinsicKeyword(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSType::TSIntrinsicKeyword(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::TSNeverKeyword(it) => {
-                TSType::TSNeverKeyword(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSType::TSNeverKeyword(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::TSNullKeyword(it) => {
-                TSType::TSNullKeyword(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSType::TSNullKeyword(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::TSNumberKeyword(it) => {
-                TSType::TSNumberKeyword(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSType::TSNumberKeyword(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::TSObjectKeyword(it) => {
-                TSType::TSObjectKeyword(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSType::TSObjectKeyword(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::TSStringKeyword(it) => {
-                TSType::TSStringKeyword(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSType::TSStringKeyword(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::TSSymbolKeyword(it) => {
-                TSType::TSSymbolKeyword(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSType::TSSymbolKeyword(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::TSUndefinedKeyword(it) => {
-                TSType::TSUndefinedKeyword(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSType::TSUndefinedKeyword(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::TSUnknownKeyword(it) => {
-                TSType::TSUnknownKeyword(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSType::TSUnknownKeyword(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::TSVoidKeyword(it) => {
-                TSType::TSVoidKeyword(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSType::TSVoidKeyword(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::TSArrayType(it) => {
-                TSType::TSArrayType(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSType::TSArrayType(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::TSConditionalType(it) => {
-                TSType::TSConditionalType(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSType::TSConditionalType(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::TSConstructorType(it) => {
-                TSType::TSConstructorType(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSType::TSConstructorType(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::TSFunctionType(it) => {
-                TSType::TSFunctionType(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSType::TSFunctionType(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::TSImportType(it) => {
-                TSType::TSImportType(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSType::TSImportType(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
-            Self::TSIndexedAccessType(it) => {
-                TSType::TSIndexedAccessType(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
+            Self::TSIndexedAccessType(it) => TSType::TSIndexedAccessType(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
             Self::TSInferType(it) => {
-                TSType::TSInferType(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSType::TSInferType(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::TSIntersectionType(it) => {
-                TSType::TSIntersectionType(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSType::TSIntersectionType(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::TSLiteralType(it) => {
-                TSType::TSLiteralType(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSType::TSLiteralType(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::TSMappedType(it) => {
-                TSType::TSMappedType(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSType::TSMappedType(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::TSNamedTupleMember(it) => {
-                TSType::TSNamedTupleMember(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSType::TSNamedTupleMember(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
-            Self::TSTemplateLiteralType(it) => {
-                TSType::TSTemplateLiteralType(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
+            Self::TSTemplateLiteralType(it) => TSType::TSTemplateLiteralType(
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
+            ),
             Self::TSThisType(it) => {
-                TSType::TSThisType(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSType::TSThisType(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::TSTupleType(it) => {
-                TSType::TSTupleType(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSType::TSTupleType(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::TSTypeLiteral(it) => {
-                TSType::TSTypeLiteral(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSType::TSTypeLiteral(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::TSTypeOperatorType(it) => {
-                TSType::TSTypeOperatorType(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSType::TSTypeOperatorType(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::TSTypePredicate(it) => {
-                TSType::TSTypePredicate(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSType::TSTypePredicate(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::TSTypeQuery(it) => {
-                TSType::TSTypeQuery(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSType::TSTypeQuery(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::TSTypeReference(it) => {
-                TSType::TSTypeReference(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSType::TSTypeReference(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::TSUnionType(it) => {
-                TSType::TSUnionType(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSType::TSUnionType(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
-            Self::TSParenthesizedType(it) => {
-                TSType::TSParenthesizedType(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
+            Self::TSParenthesizedType(it) => TSType::TSParenthesizedType(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
             Self::JSDocNullableType(it) => {
-                TSType::JSDocNullableType(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSType::JSDocNullableType(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
-            Self::JSDocNonNullableType(it) => {
-                TSType::JSDocNonNullableType(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
+            Self::JSDocNonNullableType(it) => TSType::JSDocNonNullableType(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
             Self::JSDocUnknownType(it) => {
-                TSType::JSDocUnknownType(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSType::JSDocUnknownType(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
         }
     }
@@ -5208,27 +3924,19 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSType<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSConditionalType<'_> {
     type Cloned = TSConditionalType<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSConditionalType {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            check_type: CloneIn::clone_in(&self.check_type, allocator),
-            extends_type: CloneIn::clone_in(&self.extends_type, allocator),
-            true_type: CloneIn::clone_in(&self.true_type, allocator),
-            false_type: CloneIn::clone_in(&self.false_type, allocator),
-            scope_id: Default::default(),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSConditionalType {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            check_type: CloneIn::clone_in_with_semantic_ids(&self.check_type, allocator),
-            extends_type: CloneIn::clone_in_with_semantic_ids(&self.extends_type, allocator),
-            true_type: CloneIn::clone_in_with_semantic_ids(&self.true_type, allocator),
-            false_type: CloneIn::clone_in_with_semantic_ids(&self.false_type, allocator),
-            scope_id: CloneIn::clone_in_with_semantic_ids(&self.scope_id, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            check_type: CloneIn::clone_in_impl(&self.check_type, with_semantic_ids, allocator),
+            extends_type: CloneIn::clone_in_impl(&self.extends_type, with_semantic_ids, allocator),
+            true_type: CloneIn::clone_in_impl(&self.true_type, with_semantic_ids, allocator),
+            false_type: CloneIn::clone_in_impl(&self.false_type, with_semantic_ids, allocator),
+            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
         }
     }
 }
@@ -5236,19 +3944,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSConditionalType<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSUnionType<'_> {
     type Cloned = TSUnionType<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSUnionType {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            types: CloneIn::clone_in(&self.types, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSUnionType {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            types: CloneIn::clone_in_with_semantic_ids(&self.types, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            types: CloneIn::clone_in_impl(&self.types, with_semantic_ids, allocator),
         }
     }
 }
@@ -5256,19 +3960,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSUnionType<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSIntersectionType<'_> {
     type Cloned = TSIntersectionType<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSIntersectionType {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            types: CloneIn::clone_in(&self.types, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSIntersectionType {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            types: CloneIn::clone_in_with_semantic_ids(&self.types, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            types: CloneIn::clone_in_impl(&self.types, with_semantic_ids, allocator),
         }
     }
 }
@@ -5276,19 +3976,19 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSIntersectionType<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSParenthesizedType<'_> {
     type Cloned = TSParenthesizedType<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSParenthesizedType {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSParenthesizedType {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            type_annotation: CloneIn::clone_in_impl(
+                &self.type_annotation,
+                with_semantic_ids,
+                allocator,
+            ),
         }
     }
 }
@@ -5296,21 +3996,20 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSParenthesizedType<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSTypeOperator<'_> {
     type Cloned = TSTypeOperator<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSTypeOperator {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            operator: CloneIn::clone_in(&self.operator, allocator),
-            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSTypeOperator {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            operator: CloneIn::clone_in_with_semantic_ids(&self.operator, allocator),
-            type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            operator: CloneIn::clone_in_impl(&self.operator, with_semantic_ids, allocator),
+            type_annotation: CloneIn::clone_in_impl(
+                &self.type_annotation,
+                with_semantic_ids,
+                allocator,
+            ),
         }
     }
 }
@@ -5319,12 +4018,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeOperatorOperator {
     type Cloned = TSTypeOperatorOperator;
 
     #[inline(always)]
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        *self
-    }
-
-    #[inline(always)]
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         *self
     }
 }
@@ -5332,19 +4030,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeOperatorOperator {
 impl<'new_alloc> CloneIn<'new_alloc> for TSArrayType<'_> {
     type Cloned = TSArrayType<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSArrayType {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            element_type: CloneIn::clone_in(&self.element_type, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSArrayType {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            element_type: CloneIn::clone_in_with_semantic_ids(&self.element_type, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            element_type: CloneIn::clone_in_impl(&self.element_type, with_semantic_ids, allocator),
         }
     }
 }
@@ -5352,21 +4046,16 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSArrayType<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSIndexedAccessType<'_> {
     type Cloned = TSIndexedAccessType<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSIndexedAccessType {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            object_type: CloneIn::clone_in(&self.object_type, allocator),
-            index_type: CloneIn::clone_in(&self.index_type, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSIndexedAccessType {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            object_type: CloneIn::clone_in_with_semantic_ids(&self.object_type, allocator),
-            index_type: CloneIn::clone_in_with_semantic_ids(&self.index_type, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            object_type: CloneIn::clone_in_impl(&self.object_type, with_semantic_ids, allocator),
+            index_type: CloneIn::clone_in_impl(&self.index_type, with_semantic_ids, allocator),
         }
     }
 }
@@ -5374,19 +4063,19 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSIndexedAccessType<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSTupleType<'_> {
     type Cloned = TSTupleType<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSTupleType {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            element_types: CloneIn::clone_in(&self.element_types, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSTupleType {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            element_types: CloneIn::clone_in_with_semantic_ids(&self.element_types, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            element_types: CloneIn::clone_in_impl(
+                &self.element_types,
+                with_semantic_ids,
+                allocator,
+            ),
         }
     }
 }
@@ -5394,23 +4083,17 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTupleType<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSNamedTupleMember<'_> {
     type Cloned = TSNamedTupleMember<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSNamedTupleMember {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            label: CloneIn::clone_in(&self.label, allocator),
-            element_type: CloneIn::clone_in(&self.element_type, allocator),
-            optional: CloneIn::clone_in(&self.optional, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSNamedTupleMember {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            label: CloneIn::clone_in_with_semantic_ids(&self.label, allocator),
-            element_type: CloneIn::clone_in_with_semantic_ids(&self.element_type, allocator),
-            optional: CloneIn::clone_in_with_semantic_ids(&self.optional, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            label: CloneIn::clone_in_impl(&self.label, with_semantic_ids, allocator),
+            element_type: CloneIn::clone_in_impl(&self.element_type, with_semantic_ids, allocator),
+            optional: CloneIn::clone_in_impl(&self.optional, with_semantic_ids, allocator),
         }
     }
 }
@@ -5418,19 +4101,19 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSNamedTupleMember<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSOptionalType<'_> {
     type Cloned = TSOptionalType<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSOptionalType {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSOptionalType {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            type_annotation: CloneIn::clone_in_impl(
+                &self.type_annotation,
+                with_semantic_ids,
+                allocator,
+            ),
         }
     }
 }
@@ -5438,19 +4121,19 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSOptionalType<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSRestType<'_> {
     type Cloned = TSRestType<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSRestType {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSRestType {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            type_annotation: CloneIn::clone_in_impl(
+                &self.type_annotation,
+                with_semantic_ids,
+                allocator,
+            ),
         }
     }
 }
@@ -5458,61 +4141,19 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSRestType<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSTupleElement<'_> {
     type Cloned = TSTupleElement<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
-            Self::TSOptionalType(it) => {
-                TSTupleElement::TSOptionalType(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSRestType(it) => TSTupleElement::TSRestType(CloneIn::clone_in(it, allocator)),
-            Self::TSAnyKeyword(_)
-            | Self::TSBigIntKeyword(_)
-            | Self::TSBooleanKeyword(_)
-            | Self::TSIntrinsicKeyword(_)
-            | Self::TSNeverKeyword(_)
-            | Self::TSNullKeyword(_)
-            | Self::TSNumberKeyword(_)
-            | Self::TSObjectKeyword(_)
-            | Self::TSStringKeyword(_)
-            | Self::TSSymbolKeyword(_)
-            | Self::TSUndefinedKeyword(_)
-            | Self::TSUnknownKeyword(_)
-            | Self::TSVoidKeyword(_)
-            | Self::TSArrayType(_)
-            | Self::TSConditionalType(_)
-            | Self::TSConstructorType(_)
-            | Self::TSFunctionType(_)
-            | Self::TSImportType(_)
-            | Self::TSIndexedAccessType(_)
-            | Self::TSInferType(_)
-            | Self::TSIntersectionType(_)
-            | Self::TSLiteralType(_)
-            | Self::TSMappedType(_)
-            | Self::TSNamedTupleMember(_)
-            | Self::TSTemplateLiteralType(_)
-            | Self::TSThisType(_)
-            | Self::TSTupleType(_)
-            | Self::TSTypeLiteral(_)
-            | Self::TSTypeOperatorType(_)
-            | Self::TSTypePredicate(_)
-            | Self::TSTypeQuery(_)
-            | Self::TSTypeReference(_)
-            | Self::TSUnionType(_)
-            | Self::TSParenthesizedType(_)
-            | Self::JSDocNullableType(_)
-            | Self::JSDocNonNullableType(_)
-            | Self::JSDocUnknownType(_) => {
-                TSTupleElement::from(CloneIn::clone_in(self.to_ts_type(), allocator))
-            }
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::TSOptionalType(it) => {
-                TSTupleElement::TSOptionalType(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
+            Self::TSOptionalType(it) => TSTupleElement::TSOptionalType(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
             Self::TSRestType(it) => {
-                TSTupleElement::TSRestType(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSTupleElement::TSRestType(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::TSAnyKeyword(_)
             | Self::TSBigIntKeyword(_)
@@ -5550,9 +4191,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTupleElement<'_> {
             | Self::TSParenthesizedType(_)
             | Self::JSDocNullableType(_)
             | Self::JSDocNonNullableType(_)
-            | Self::JSDocUnknownType(_) => TSTupleElement::from(
-                CloneIn::clone_in_with_semantic_ids(self.to_ts_type(), allocator),
-            ),
+            | Self::JSDocUnknownType(_) => TSTupleElement::from(CloneIn::clone_in_impl(
+                self.to_ts_type(),
+                with_semantic_ids,
+                allocator,
+            )),
         }
     }
 }
@@ -5560,14 +4203,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTupleElement<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSAnyKeyword {
     type Cloned = TSAnyKeyword;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSAnyKeyword { node_id: Default::default(), span: CloneIn::clone_in(&self.span, allocator) }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSAnyKeyword {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
         }
     }
 }
@@ -5575,17 +4218,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSAnyKeyword {
 impl<'new_alloc> CloneIn<'new_alloc> for TSStringKeyword {
     type Cloned = TSStringKeyword;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSStringKeyword {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSStringKeyword {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
         }
     }
 }
@@ -5593,17 +4233,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSStringKeyword {
 impl<'new_alloc> CloneIn<'new_alloc> for TSBooleanKeyword {
     type Cloned = TSBooleanKeyword;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSBooleanKeyword {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSBooleanKeyword {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
         }
     }
 }
@@ -5611,17 +4248,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSBooleanKeyword {
 impl<'new_alloc> CloneIn<'new_alloc> for TSNumberKeyword {
     type Cloned = TSNumberKeyword;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSNumberKeyword {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSNumberKeyword {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
         }
     }
 }
@@ -5629,17 +4263,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSNumberKeyword {
 impl<'new_alloc> CloneIn<'new_alloc> for TSNeverKeyword {
     type Cloned = TSNeverKeyword;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSNeverKeyword {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSNeverKeyword {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
         }
     }
 }
@@ -5647,17 +4278,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSNeverKeyword {
 impl<'new_alloc> CloneIn<'new_alloc> for TSIntrinsicKeyword {
     type Cloned = TSIntrinsicKeyword;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSIntrinsicKeyword {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSIntrinsicKeyword {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
         }
     }
 }
@@ -5665,17 +4293,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSIntrinsicKeyword {
 impl<'new_alloc> CloneIn<'new_alloc> for TSUnknownKeyword {
     type Cloned = TSUnknownKeyword;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSUnknownKeyword {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSUnknownKeyword {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
         }
     }
 }
@@ -5683,17 +4308,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSUnknownKeyword {
 impl<'new_alloc> CloneIn<'new_alloc> for TSNullKeyword {
     type Cloned = TSNullKeyword;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSNullKeyword {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSNullKeyword {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
         }
     }
 }
@@ -5701,17 +4323,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSNullKeyword {
 impl<'new_alloc> CloneIn<'new_alloc> for TSUndefinedKeyword {
     type Cloned = TSUndefinedKeyword;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSUndefinedKeyword {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSUndefinedKeyword {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
         }
     }
 }
@@ -5719,17 +4338,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSUndefinedKeyword {
 impl<'new_alloc> CloneIn<'new_alloc> for TSVoidKeyword {
     type Cloned = TSVoidKeyword;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSVoidKeyword {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSVoidKeyword {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
         }
     }
 }
@@ -5737,17 +4353,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSVoidKeyword {
 impl<'new_alloc> CloneIn<'new_alloc> for TSSymbolKeyword {
     type Cloned = TSSymbolKeyword;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSSymbolKeyword {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSSymbolKeyword {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
         }
     }
 }
@@ -5755,14 +4368,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSSymbolKeyword {
 impl<'new_alloc> CloneIn<'new_alloc> for TSThisType {
     type Cloned = TSThisType;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSThisType { node_id: Default::default(), span: CloneIn::clone_in(&self.span, allocator) }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSThisType {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
         }
     }
 }
@@ -5770,17 +4383,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSThisType {
 impl<'new_alloc> CloneIn<'new_alloc> for TSObjectKeyword {
     type Cloned = TSObjectKeyword;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSObjectKeyword {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSObjectKeyword {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
         }
     }
 }
@@ -5788,17 +4398,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSObjectKeyword {
 impl<'new_alloc> CloneIn<'new_alloc> for TSBigIntKeyword {
     type Cloned = TSBigIntKeyword;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSBigIntKeyword {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSBigIntKeyword {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
         }
     }
 }
@@ -5806,21 +4413,20 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSBigIntKeyword {
 impl<'new_alloc> CloneIn<'new_alloc> for TSTypeReference<'_> {
     type Cloned = TSTypeReference<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSTypeReference {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            type_name: CloneIn::clone_in(&self.type_name, allocator),
-            type_arguments: CloneIn::clone_in(&self.type_arguments, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSTypeReference {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            type_name: CloneIn::clone_in_with_semantic_ids(&self.type_name, allocator),
-            type_arguments: CloneIn::clone_in_with_semantic_ids(&self.type_arguments, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            type_name: CloneIn::clone_in_impl(&self.type_name, with_semantic_ids, allocator),
+            type_arguments: CloneIn::clone_in_impl(
+                &self.type_arguments,
+                with_semantic_ids,
+                allocator,
+            ),
         }
     }
 }
@@ -5828,28 +4434,20 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeReference<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSTypeName<'_> {
     type Cloned = TSTypeName<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
-            Self::IdentifierReference(it) => {
-                TSTypeName::IdentifierReference(CloneIn::clone_in(it, allocator))
-            }
-            Self::QualifiedName(it) => TSTypeName::QualifiedName(CloneIn::clone_in(it, allocator)),
-            Self::ThisExpression(it) => {
-                TSTypeName::ThisExpression(CloneIn::clone_in(it, allocator))
-            }
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::IdentifierReference(it) => {
-                TSTypeName::IdentifierReference(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
+            Self::IdentifierReference(it) => TSTypeName::IdentifierReference(
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
+            ),
             Self::QualifiedName(it) => {
-                TSTypeName::QualifiedName(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSTypeName::QualifiedName(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::ThisExpression(it) => {
-                TSTypeName::ThisExpression(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSTypeName::ThisExpression(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
         }
     }
@@ -5858,21 +4456,16 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeName<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSQualifiedName<'_> {
     type Cloned = TSQualifiedName<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSQualifiedName {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            left: CloneIn::clone_in(&self.left, allocator),
-            right: CloneIn::clone_in(&self.right, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSQualifiedName {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            left: CloneIn::clone_in_with_semantic_ids(&self.left, allocator),
-            right: CloneIn::clone_in_with_semantic_ids(&self.right, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            left: CloneIn::clone_in_impl(&self.left, with_semantic_ids, allocator),
+            right: CloneIn::clone_in_impl(&self.right, with_semantic_ids, allocator),
         }
     }
 }
@@ -5880,19 +4473,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSQualifiedName<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSTypeParameterInstantiation<'_> {
     type Cloned = TSTypeParameterInstantiation<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSTypeParameterInstantiation {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            params: CloneIn::clone_in(&self.params, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSTypeParameterInstantiation {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            params: CloneIn::clone_in_with_semantic_ids(&self.params, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            params: CloneIn::clone_in_impl(&self.params, with_semantic_ids, allocator),
         }
     }
 }
@@ -5900,29 +4489,20 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeParameterInstantiation<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSTypeParameter<'_> {
     type Cloned = TSTypeParameter<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSTypeParameter {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            name: CloneIn::clone_in(&self.name, allocator),
-            constraint: CloneIn::clone_in(&self.constraint, allocator),
-            default: CloneIn::clone_in(&self.default, allocator),
-            r#in: CloneIn::clone_in(&self.r#in, allocator),
-            out: CloneIn::clone_in(&self.out, allocator),
-            r#const: CloneIn::clone_in(&self.r#const, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSTypeParameter {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            name: CloneIn::clone_in_with_semantic_ids(&self.name, allocator),
-            constraint: CloneIn::clone_in_with_semantic_ids(&self.constraint, allocator),
-            default: CloneIn::clone_in_with_semantic_ids(&self.default, allocator),
-            r#in: CloneIn::clone_in_with_semantic_ids(&self.r#in, allocator),
-            out: CloneIn::clone_in_with_semantic_ids(&self.out, allocator),
-            r#const: CloneIn::clone_in_with_semantic_ids(&self.r#const, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            name: CloneIn::clone_in_impl(&self.name, with_semantic_ids, allocator),
+            constraint: CloneIn::clone_in_impl(&self.constraint, with_semantic_ids, allocator),
+            default: CloneIn::clone_in_impl(&self.default, with_semantic_ids, allocator),
+            r#in: CloneIn::clone_in_impl(&self.r#in, with_semantic_ids, allocator),
+            out: CloneIn::clone_in_impl(&self.out, with_semantic_ids, allocator),
+            r#const: CloneIn::clone_in_impl(&self.r#const, with_semantic_ids, allocator),
         }
     }
 }
@@ -5930,19 +4510,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeParameter<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSTypeParameterDeclaration<'_> {
     type Cloned = TSTypeParameterDeclaration<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSTypeParameterDeclaration {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            params: CloneIn::clone_in(&self.params, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSTypeParameterDeclaration {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            params: CloneIn::clone_in_with_semantic_ids(&self.params, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            params: CloneIn::clone_in_impl(&self.params, with_semantic_ids, allocator),
         }
     }
 }
@@ -5950,27 +4526,27 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeParameterDeclaration<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSTypeAliasDeclaration<'_> {
     type Cloned = TSTypeAliasDeclaration<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSTypeAliasDeclaration {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            id: CloneIn::clone_in(&self.id, allocator),
-            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
-            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
-            declare: CloneIn::clone_in(&self.declare, allocator),
-            scope_id: Default::default(),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSTypeAliasDeclaration {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            id: CloneIn::clone_in_with_semantic_ids(&self.id, allocator),
-            type_parameters: CloneIn::clone_in_with_semantic_ids(&self.type_parameters, allocator),
-            type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
-            declare: CloneIn::clone_in_with_semantic_ids(&self.declare, allocator),
-            scope_id: CloneIn::clone_in_with_semantic_ids(&self.scope_id, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            id: CloneIn::clone_in_impl(&self.id, with_semantic_ids, allocator),
+            type_parameters: CloneIn::clone_in_impl(
+                &self.type_parameters,
+                with_semantic_ids,
+                allocator,
+            ),
+            type_annotation: CloneIn::clone_in_impl(
+                &self.type_annotation,
+                with_semantic_ids,
+                allocator,
+            ),
+            declare: CloneIn::clone_in_impl(&self.declare, with_semantic_ids, allocator),
+            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
         }
     }
 }
@@ -5979,12 +4555,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSAccessibility {
     type Cloned = TSAccessibility;
 
     #[inline(always)]
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        *self
-    }
-
-    #[inline(always)]
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         *self
     }
 }
@@ -5992,21 +4567,20 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSAccessibility {
 impl<'new_alloc> CloneIn<'new_alloc> for TSClassImplements<'_> {
     type Cloned = TSClassImplements<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSClassImplements {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            expression: CloneIn::clone_in(&self.expression, allocator),
-            type_arguments: CloneIn::clone_in(&self.type_arguments, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSClassImplements {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
-            type_arguments: CloneIn::clone_in_with_semantic_ids(&self.type_arguments, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            expression: CloneIn::clone_in_impl(&self.expression, with_semantic_ids, allocator),
+            type_arguments: CloneIn::clone_in_impl(
+                &self.type_arguments,
+                with_semantic_ids,
+                allocator,
+            ),
         }
     }
 }
@@ -6014,29 +4588,24 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSClassImplements<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSInterfaceDeclaration<'_> {
     type Cloned = TSInterfaceDeclaration<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSInterfaceDeclaration {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            id: CloneIn::clone_in(&self.id, allocator),
-            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
-            extends: CloneIn::clone_in(&self.extends, allocator),
-            body: CloneIn::clone_in(&self.body, allocator),
-            declare: CloneIn::clone_in(&self.declare, allocator),
-            scope_id: Default::default(),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSInterfaceDeclaration {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            id: CloneIn::clone_in_with_semantic_ids(&self.id, allocator),
-            type_parameters: CloneIn::clone_in_with_semantic_ids(&self.type_parameters, allocator),
-            extends: CloneIn::clone_in_with_semantic_ids(&self.extends, allocator),
-            body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
-            declare: CloneIn::clone_in_with_semantic_ids(&self.declare, allocator),
-            scope_id: CloneIn::clone_in_with_semantic_ids(&self.scope_id, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            id: CloneIn::clone_in_impl(&self.id, with_semantic_ids, allocator),
+            type_parameters: CloneIn::clone_in_impl(
+                &self.type_parameters,
+                with_semantic_ids,
+                allocator,
+            ),
+            extends: CloneIn::clone_in_impl(&self.extends, with_semantic_ids, allocator),
+            body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
+            declare: CloneIn::clone_in_impl(&self.declare, with_semantic_ids, allocator),
+            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
         }
     }
 }
@@ -6044,19 +4613,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSInterfaceDeclaration<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSInterfaceBody<'_> {
     type Cloned = TSInterfaceBody<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSInterfaceBody {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            body: CloneIn::clone_in(&self.body, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSInterfaceBody {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
         }
     }
 }
@@ -6064,27 +4629,23 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSInterfaceBody<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSPropertySignature<'_> {
     type Cloned = TSPropertySignature<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSPropertySignature {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            computed: CloneIn::clone_in(&self.computed, allocator),
-            optional: CloneIn::clone_in(&self.optional, allocator),
-            readonly: CloneIn::clone_in(&self.readonly, allocator),
-            key: CloneIn::clone_in(&self.key, allocator),
-            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSPropertySignature {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            computed: CloneIn::clone_in_with_semantic_ids(&self.computed, allocator),
-            optional: CloneIn::clone_in_with_semantic_ids(&self.optional, allocator),
-            readonly: CloneIn::clone_in_with_semantic_ids(&self.readonly, allocator),
-            key: CloneIn::clone_in_with_semantic_ids(&self.key, allocator),
-            type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            computed: CloneIn::clone_in_impl(&self.computed, with_semantic_ids, allocator),
+            optional: CloneIn::clone_in_impl(&self.optional, with_semantic_ids, allocator),
+            readonly: CloneIn::clone_in_impl(&self.readonly, with_semantic_ids, allocator),
+            key: CloneIn::clone_in_impl(&self.key, with_semantic_ids, allocator),
+            type_annotation: CloneIn::clone_in_impl(
+                &self.type_annotation,
+                with_semantic_ids,
+                allocator,
+            ),
         }
     }
 }
@@ -6092,45 +4653,35 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSPropertySignature<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSSignature<'_> {
     type Cloned = TSSignature<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
-            Self::TSIndexSignature(it) => {
-                TSSignature::TSIndexSignature(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSPropertySignature(it) => {
-                TSSignature::TSPropertySignature(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSCallSignatureDeclaration(it) => {
-                TSSignature::TSCallSignatureDeclaration(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSConstructSignatureDeclaration(it) => {
-                TSSignature::TSConstructSignatureDeclaration(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSMethodSignature(it) => {
-                TSSignature::TSMethodSignature(CloneIn::clone_in(it, allocator))
-            }
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::TSIndexSignature(it) => {
-                TSSignature::TSIndexSignature(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
-            Self::TSPropertySignature(it) => {
-                TSSignature::TSPropertySignature(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
+            Self::TSIndexSignature(it) => TSSignature::TSIndexSignature(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
+            Self::TSPropertySignature(it) => TSSignature::TSPropertySignature(
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
+            ),
             Self::TSCallSignatureDeclaration(it) => TSSignature::TSCallSignatureDeclaration(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
             Self::TSConstructSignatureDeclaration(it) => {
-                TSSignature::TSConstructSignatureDeclaration(CloneIn::clone_in_with_semantic_ids(
-                    it, allocator,
+                TSSignature::TSConstructSignatureDeclaration(CloneIn::clone_in_impl(
+                    it,
+                    with_semantic_ids,
+                    allocator,
                 ))
             }
-            Self::TSMethodSignature(it) => {
-                TSSignature::TSMethodSignature(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
+            Self::TSMethodSignature(it) => TSSignature::TSMethodSignature(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
         }
     }
 }
@@ -6138,25 +4689,22 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSSignature<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSIndexSignature<'_> {
     type Cloned = TSIndexSignature<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSIndexSignature {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            parameters: CloneIn::clone_in(&self.parameters, allocator),
-            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
-            readonly: CloneIn::clone_in(&self.readonly, allocator),
-            r#static: CloneIn::clone_in(&self.r#static, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSIndexSignature {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            parameters: CloneIn::clone_in_with_semantic_ids(&self.parameters, allocator),
-            type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
-            readonly: CloneIn::clone_in_with_semantic_ids(&self.readonly, allocator),
-            r#static: CloneIn::clone_in_with_semantic_ids(&self.r#static, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            parameters: CloneIn::clone_in_impl(&self.parameters, with_semantic_ids, allocator),
+            type_annotation: CloneIn::clone_in_impl(
+                &self.type_annotation,
+                with_semantic_ids,
+                allocator,
+            ),
+            readonly: CloneIn::clone_in_impl(&self.readonly, with_semantic_ids, allocator),
+            r#static: CloneIn::clone_in_impl(&self.r#static, with_semantic_ids, allocator),
         }
     }
 }
@@ -6164,27 +4712,23 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSIndexSignature<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSCallSignatureDeclaration<'_> {
     type Cloned = TSCallSignatureDeclaration<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSCallSignatureDeclaration {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
-            this_param: CloneIn::clone_in(&self.this_param, allocator),
-            params: CloneIn::clone_in(&self.params, allocator),
-            return_type: CloneIn::clone_in(&self.return_type, allocator),
-            scope_id: Default::default(),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSCallSignatureDeclaration {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            type_parameters: CloneIn::clone_in_with_semantic_ids(&self.type_parameters, allocator),
-            this_param: CloneIn::clone_in_with_semantic_ids(&self.this_param, allocator),
-            params: CloneIn::clone_in_with_semantic_ids(&self.params, allocator),
-            return_type: CloneIn::clone_in_with_semantic_ids(&self.return_type, allocator),
-            scope_id: CloneIn::clone_in_with_semantic_ids(&self.scope_id, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            type_parameters: CloneIn::clone_in_impl(
+                &self.type_parameters,
+                with_semantic_ids,
+                allocator,
+            ),
+            this_param: CloneIn::clone_in_impl(&self.this_param, with_semantic_ids, allocator),
+            params: CloneIn::clone_in_impl(&self.params, with_semantic_ids, allocator),
+            return_type: CloneIn::clone_in_impl(&self.return_type, with_semantic_ids, allocator),
+            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
         }
     }
 }
@@ -6193,12 +4737,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSMethodSignatureKind {
     type Cloned = TSMethodSignatureKind;
 
     #[inline(always)]
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        *self
-    }
-
-    #[inline(always)]
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         *self
     }
 }
@@ -6206,35 +4749,27 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSMethodSignatureKind {
 impl<'new_alloc> CloneIn<'new_alloc> for TSMethodSignature<'_> {
     type Cloned = TSMethodSignature<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSMethodSignature {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            key: CloneIn::clone_in(&self.key, allocator),
-            computed: CloneIn::clone_in(&self.computed, allocator),
-            optional: CloneIn::clone_in(&self.optional, allocator),
-            kind: CloneIn::clone_in(&self.kind, allocator),
-            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
-            this_param: CloneIn::clone_in(&self.this_param, allocator),
-            params: CloneIn::clone_in(&self.params, allocator),
-            return_type: CloneIn::clone_in(&self.return_type, allocator),
-            scope_id: Default::default(),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSMethodSignature {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            key: CloneIn::clone_in_with_semantic_ids(&self.key, allocator),
-            computed: CloneIn::clone_in_with_semantic_ids(&self.computed, allocator),
-            optional: CloneIn::clone_in_with_semantic_ids(&self.optional, allocator),
-            kind: CloneIn::clone_in_with_semantic_ids(&self.kind, allocator),
-            type_parameters: CloneIn::clone_in_with_semantic_ids(&self.type_parameters, allocator),
-            this_param: CloneIn::clone_in_with_semantic_ids(&self.this_param, allocator),
-            params: CloneIn::clone_in_with_semantic_ids(&self.params, allocator),
-            return_type: CloneIn::clone_in_with_semantic_ids(&self.return_type, allocator),
-            scope_id: CloneIn::clone_in_with_semantic_ids(&self.scope_id, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            key: CloneIn::clone_in_impl(&self.key, with_semantic_ids, allocator),
+            computed: CloneIn::clone_in_impl(&self.computed, with_semantic_ids, allocator),
+            optional: CloneIn::clone_in_impl(&self.optional, with_semantic_ids, allocator),
+            kind: CloneIn::clone_in_impl(&self.kind, with_semantic_ids, allocator),
+            type_parameters: CloneIn::clone_in_impl(
+                &self.type_parameters,
+                with_semantic_ids,
+                allocator,
+            ),
+            this_param: CloneIn::clone_in_impl(&self.this_param, with_semantic_ids, allocator),
+            params: CloneIn::clone_in_impl(&self.params, with_semantic_ids, allocator),
+            return_type: CloneIn::clone_in_impl(&self.return_type, with_semantic_ids, allocator),
+            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
         }
     }
 }
@@ -6242,25 +4777,22 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSMethodSignature<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSConstructSignatureDeclaration<'_> {
     type Cloned = TSConstructSignatureDeclaration<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSConstructSignatureDeclaration {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
-            params: CloneIn::clone_in(&self.params, allocator),
-            return_type: CloneIn::clone_in(&self.return_type, allocator),
-            scope_id: Default::default(),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSConstructSignatureDeclaration {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            type_parameters: CloneIn::clone_in_with_semantic_ids(&self.type_parameters, allocator),
-            params: CloneIn::clone_in_with_semantic_ids(&self.params, allocator),
-            return_type: CloneIn::clone_in_with_semantic_ids(&self.return_type, allocator),
-            scope_id: CloneIn::clone_in_with_semantic_ids(&self.scope_id, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            type_parameters: CloneIn::clone_in_impl(
+                &self.type_parameters,
+                with_semantic_ids,
+                allocator,
+            ),
+            params: CloneIn::clone_in_impl(&self.params, with_semantic_ids, allocator),
+            return_type: CloneIn::clone_in_impl(&self.return_type, with_semantic_ids, allocator),
+            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
         }
     }
 }
@@ -6268,21 +4800,20 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSConstructSignatureDeclaration<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSIndexSignatureName<'_> {
     type Cloned = TSIndexSignatureName<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSIndexSignatureName {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            name: CloneIn::clone_in(&self.name, allocator),
-            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSIndexSignatureName {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            name: CloneIn::clone_in_with_semantic_ids(&self.name, allocator),
-            type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            name: CloneIn::clone_in_impl(&self.name, with_semantic_ids, allocator),
+            type_annotation: CloneIn::clone_in_impl(
+                &self.type_annotation,
+                with_semantic_ids,
+                allocator,
+            ),
         }
     }
 }
@@ -6290,21 +4821,20 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSIndexSignatureName<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSInterfaceHeritage<'_> {
     type Cloned = TSInterfaceHeritage<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSInterfaceHeritage {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            expression: CloneIn::clone_in(&self.expression, allocator),
-            type_arguments: CloneIn::clone_in(&self.type_arguments, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSInterfaceHeritage {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
-            type_arguments: CloneIn::clone_in_with_semantic_ids(&self.type_arguments, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            expression: CloneIn::clone_in_impl(&self.expression, with_semantic_ids, allocator),
+            type_arguments: CloneIn::clone_in_impl(
+                &self.type_arguments,
+                with_semantic_ids,
+                allocator,
+            ),
         }
     }
 }
@@ -6312,23 +4842,25 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSInterfaceHeritage<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSTypePredicate<'_> {
     type Cloned = TSTypePredicate<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSTypePredicate {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            parameter_name: CloneIn::clone_in(&self.parameter_name, allocator),
-            asserts: CloneIn::clone_in(&self.asserts, allocator),
-            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSTypePredicate {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            parameter_name: CloneIn::clone_in_with_semantic_ids(&self.parameter_name, allocator),
-            asserts: CloneIn::clone_in_with_semantic_ids(&self.asserts, allocator),
-            type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            parameter_name: CloneIn::clone_in_impl(
+                &self.parameter_name,
+                with_semantic_ids,
+                allocator,
+            ),
+            asserts: CloneIn::clone_in_impl(&self.asserts, with_semantic_ids, allocator),
+            type_annotation: CloneIn::clone_in_impl(
+                &self.type_annotation,
+                with_semantic_ids,
+                allocator,
+            ),
         }
     }
 }
@@ -6336,22 +4868,19 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypePredicate<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSTypePredicateName<'_> {
     type Cloned = TSTypePredicateName<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
-            Self::Identifier(it) => {
-                TSTypePredicateName::Identifier(CloneIn::clone_in(it, allocator))
-            }
-            Self::This(it) => TSTypePredicateName::This(CloneIn::clone_in(it, allocator)),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Identifier(it) => {
-                TSTypePredicateName::Identifier(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
+            Self::Identifier(it) => TSTypePredicateName::Identifier(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
             Self::This(it) => {
-                TSTypePredicateName::This(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                TSTypePredicateName::This(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
         }
     }
@@ -6360,27 +4889,19 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypePredicateName<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSModuleDeclaration<'_> {
     type Cloned = TSModuleDeclaration<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSModuleDeclaration {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            id: CloneIn::clone_in(&self.id, allocator),
-            body: CloneIn::clone_in(&self.body, allocator),
-            kind: CloneIn::clone_in(&self.kind, allocator),
-            declare: CloneIn::clone_in(&self.declare, allocator),
-            scope_id: Default::default(),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSModuleDeclaration {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            id: CloneIn::clone_in_with_semantic_ids(&self.id, allocator),
-            body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
-            kind: CloneIn::clone_in_with_semantic_ids(&self.kind, allocator),
-            declare: CloneIn::clone_in_with_semantic_ids(&self.declare, allocator),
-            scope_id: CloneIn::clone_in_with_semantic_ids(&self.scope_id, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            id: CloneIn::clone_in_impl(&self.id, with_semantic_ids, allocator),
+            body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
+            kind: CloneIn::clone_in_impl(&self.kind, with_semantic_ids, allocator),
+            declare: CloneIn::clone_in_impl(&self.declare, with_semantic_ids, allocator),
+            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
         }
     }
 }
@@ -6389,12 +4910,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSModuleDeclarationKind {
     type Cloned = TSModuleDeclarationKind;
 
     #[inline(always)]
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        *self
-    }
-
-    #[inline(always)]
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         *self
     }
 }
@@ -6402,24 +4922,19 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSModuleDeclarationKind {
 impl<'new_alloc> CloneIn<'new_alloc> for TSModuleDeclarationName<'_> {
     type Cloned = TSModuleDeclarationName<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
-            Self::Identifier(it) => {
-                TSModuleDeclarationName::Identifier(CloneIn::clone_in(it, allocator))
-            }
-            Self::StringLiteral(it) => {
-                TSModuleDeclarationName::StringLiteral(CloneIn::clone_in(it, allocator))
-            }
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Identifier(it) => TSModuleDeclarationName::Identifier(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
-            ),
+            Self::Identifier(it) => TSModuleDeclarationName::Identifier(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
             Self::StringLiteral(it) => TSModuleDeclarationName::StringLiteral(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
         }
     }
@@ -6428,24 +4943,17 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSModuleDeclarationName<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSModuleDeclarationBody<'_> {
     type Cloned = TSModuleDeclarationBody<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::TSModuleDeclaration(it) => {
-                TSModuleDeclarationBody::TSModuleDeclaration(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSModuleBlock(it) => {
-                TSModuleDeclarationBody::TSModuleBlock(CloneIn::clone_in(it, allocator))
-            }
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
             Self::TSModuleDeclaration(it) => TSModuleDeclarationBody::TSModuleDeclaration(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
             Self::TSModuleBlock(it) => TSModuleDeclarationBody::TSModuleBlock(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
         }
     }
@@ -6454,25 +4962,18 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSModuleDeclarationBody<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSGlobalDeclaration<'_> {
     type Cloned = TSGlobalDeclaration<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSGlobalDeclaration {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            global_span: CloneIn::clone_in(&self.global_span, allocator),
-            body: CloneIn::clone_in(&self.body, allocator),
-            declare: CloneIn::clone_in(&self.declare, allocator),
-            scope_id: Default::default(),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSGlobalDeclaration {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            global_span: CloneIn::clone_in_with_semantic_ids(&self.global_span, allocator),
-            body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
-            declare: CloneIn::clone_in_with_semantic_ids(&self.declare, allocator),
-            scope_id: CloneIn::clone_in_with_semantic_ids(&self.scope_id, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            global_span: CloneIn::clone_in_impl(&self.global_span, with_semantic_ids, allocator),
+            body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
+            declare: CloneIn::clone_in_impl(&self.declare, with_semantic_ids, allocator),
+            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
         }
     }
 }
@@ -6480,21 +4981,16 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSGlobalDeclaration<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSModuleBlock<'_> {
     type Cloned = TSModuleBlock<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSModuleBlock {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            directives: CloneIn::clone_in(&self.directives, allocator),
-            body: CloneIn::clone_in(&self.body, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSModuleBlock {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            directives: CloneIn::clone_in_with_semantic_ids(&self.directives, allocator),
-            body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            directives: CloneIn::clone_in_impl(&self.directives, with_semantic_ids, allocator),
+            body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
         }
     }
 }
@@ -6502,19 +4998,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSModuleBlock<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSTypeLiteral<'_> {
     type Cloned = TSTypeLiteral<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSTypeLiteral {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            members: CloneIn::clone_in(&self.members, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSTypeLiteral {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            members: CloneIn::clone_in_with_semantic_ids(&self.members, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            members: CloneIn::clone_in_impl(&self.members, with_semantic_ids, allocator),
         }
     }
 }
@@ -6522,19 +5014,19 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeLiteral<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSInferType<'_> {
     type Cloned = TSInferType<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSInferType {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            type_parameter: CloneIn::clone_in(&self.type_parameter, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSInferType {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            type_parameter: CloneIn::clone_in_with_semantic_ids(&self.type_parameter, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            type_parameter: CloneIn::clone_in_impl(
+                &self.type_parameter,
+                with_semantic_ids,
+                allocator,
+            ),
         }
     }
 }
@@ -6542,21 +5034,20 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSInferType<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSTypeQuery<'_> {
     type Cloned = TSTypeQuery<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSTypeQuery {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            expr_name: CloneIn::clone_in(&self.expr_name, allocator),
-            type_arguments: CloneIn::clone_in(&self.type_arguments, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSTypeQuery {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            expr_name: CloneIn::clone_in_with_semantic_ids(&self.expr_name, allocator),
-            type_arguments: CloneIn::clone_in_with_semantic_ids(&self.type_arguments, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            expr_name: CloneIn::clone_in_impl(&self.expr_name, with_semantic_ids, allocator),
+            type_arguments: CloneIn::clone_in_impl(
+                &self.type_arguments,
+                with_semantic_ids,
+                allocator,
+            ),
         }
     }
 }
@@ -6564,25 +5055,21 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeQuery<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSTypeQueryExprName<'_> {
     type Cloned = TSTypeQueryExprName<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
-            Self::TSImportType(it) => {
-                TSTypeQueryExprName::TSImportType(CloneIn::clone_in(it, allocator))
-            }
+            Self::TSImportType(it) => TSTypeQueryExprName::TSImportType(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
             Self::IdentifierReference(_) | Self::QualifiedName(_) | Self::ThisExpression(_) => {
-                TSTypeQueryExprName::from(CloneIn::clone_in(self.to_ts_type_name(), allocator))
-            }
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::TSImportType(it) => TSTypeQueryExprName::TSImportType(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
-            ),
-            Self::IdentifierReference(_) | Self::QualifiedName(_) | Self::ThisExpression(_) => {
-                TSTypeQueryExprName::from(CloneIn::clone_in_with_semantic_ids(
+                TSTypeQueryExprName::from(CloneIn::clone_in_impl(
                     self.to_ts_type_name(),
+                    with_semantic_ids,
                     allocator,
                 ))
             }
@@ -6593,25 +5080,22 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeQueryExprName<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSImportType<'_> {
     type Cloned = TSImportType<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSImportType {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            source: CloneIn::clone_in(&self.source, allocator),
-            options: CloneIn::clone_in(&self.options, allocator),
-            qualifier: CloneIn::clone_in(&self.qualifier, allocator),
-            type_arguments: CloneIn::clone_in(&self.type_arguments, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSImportType {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            source: CloneIn::clone_in_with_semantic_ids(&self.source, allocator),
-            options: CloneIn::clone_in_with_semantic_ids(&self.options, allocator),
-            qualifier: CloneIn::clone_in_with_semantic_ids(&self.qualifier, allocator),
-            type_arguments: CloneIn::clone_in_with_semantic_ids(&self.type_arguments, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            source: CloneIn::clone_in_impl(&self.source, with_semantic_ids, allocator),
+            options: CloneIn::clone_in_impl(&self.options, with_semantic_ids, allocator),
+            qualifier: CloneIn::clone_in_impl(&self.qualifier, with_semantic_ids, allocator),
+            type_arguments: CloneIn::clone_in_impl(
+                &self.type_arguments,
+                with_semantic_ids,
+                allocator,
+            ),
         }
     }
 }
@@ -6619,24 +5103,19 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSImportType<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSImportTypeQualifier<'_> {
     type Cloned = TSImportTypeQualifier<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
-            Self::Identifier(it) => {
-                TSImportTypeQualifier::Identifier(CloneIn::clone_in(it, allocator))
-            }
-            Self::QualifiedName(it) => {
-                TSImportTypeQualifier::QualifiedName(CloneIn::clone_in(it, allocator))
-            }
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Identifier(it) => TSImportTypeQualifier::Identifier(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
-            ),
+            Self::Identifier(it) => TSImportTypeQualifier::Identifier(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
             Self::QualifiedName(it) => TSImportTypeQualifier::QualifiedName(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
         }
     }
@@ -6645,21 +5124,16 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSImportTypeQualifier<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSImportTypeQualifiedName<'_> {
     type Cloned = TSImportTypeQualifiedName<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSImportTypeQualifiedName {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            left: CloneIn::clone_in(&self.left, allocator),
-            right: CloneIn::clone_in(&self.right, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSImportTypeQualifiedName {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            left: CloneIn::clone_in_with_semantic_ids(&self.left, allocator),
-            right: CloneIn::clone_in_with_semantic_ids(&self.right, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            left: CloneIn::clone_in_impl(&self.left, with_semantic_ids, allocator),
+            right: CloneIn::clone_in_impl(&self.right, with_semantic_ids, allocator),
         }
     }
 }
@@ -6667,27 +5141,23 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSImportTypeQualifiedName<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSFunctionType<'_> {
     type Cloned = TSFunctionType<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSFunctionType {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
-            this_param: CloneIn::clone_in(&self.this_param, allocator),
-            params: CloneIn::clone_in(&self.params, allocator),
-            return_type: CloneIn::clone_in(&self.return_type, allocator),
-            scope_id: Default::default(),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSFunctionType {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            type_parameters: CloneIn::clone_in_with_semantic_ids(&self.type_parameters, allocator),
-            this_param: CloneIn::clone_in_with_semantic_ids(&self.this_param, allocator),
-            params: CloneIn::clone_in_with_semantic_ids(&self.params, allocator),
-            return_type: CloneIn::clone_in_with_semantic_ids(&self.return_type, allocator),
-            scope_id: CloneIn::clone_in_with_semantic_ids(&self.scope_id, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            type_parameters: CloneIn::clone_in_impl(
+                &self.type_parameters,
+                with_semantic_ids,
+                allocator,
+            ),
+            this_param: CloneIn::clone_in_impl(&self.this_param, with_semantic_ids, allocator),
+            params: CloneIn::clone_in_impl(&self.params, with_semantic_ids, allocator),
+            return_type: CloneIn::clone_in_impl(&self.return_type, with_semantic_ids, allocator),
+            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
         }
     }
 }
@@ -6695,27 +5165,23 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSFunctionType<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSConstructorType<'_> {
     type Cloned = TSConstructorType<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSConstructorType {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            r#abstract: CloneIn::clone_in(&self.r#abstract, allocator),
-            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
-            params: CloneIn::clone_in(&self.params, allocator),
-            return_type: CloneIn::clone_in(&self.return_type, allocator),
-            scope_id: Default::default(),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSConstructorType {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            r#abstract: CloneIn::clone_in_with_semantic_ids(&self.r#abstract, allocator),
-            type_parameters: CloneIn::clone_in_with_semantic_ids(&self.type_parameters, allocator),
-            params: CloneIn::clone_in_with_semantic_ids(&self.params, allocator),
-            return_type: CloneIn::clone_in_with_semantic_ids(&self.return_type, allocator),
-            scope_id: CloneIn::clone_in_with_semantic_ids(&self.scope_id, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            r#abstract: CloneIn::clone_in_impl(&self.r#abstract, with_semantic_ids, allocator),
+            type_parameters: CloneIn::clone_in_impl(
+                &self.type_parameters,
+                with_semantic_ids,
+                allocator,
+            ),
+            params: CloneIn::clone_in_impl(&self.params, with_semantic_ids, allocator),
+            return_type: CloneIn::clone_in_impl(&self.return_type, with_semantic_ids, allocator),
+            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
         }
     }
 }
@@ -6723,31 +5189,25 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSConstructorType<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSMappedType<'_> {
     type Cloned = TSMappedType<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSMappedType {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            key: CloneIn::clone_in(&self.key, allocator),
-            constraint: CloneIn::clone_in(&self.constraint, allocator),
-            name_type: CloneIn::clone_in(&self.name_type, allocator),
-            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
-            optional: CloneIn::clone_in(&self.optional, allocator),
-            readonly: CloneIn::clone_in(&self.readonly, allocator),
-            scope_id: Default::default(),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSMappedType {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            key: CloneIn::clone_in_with_semantic_ids(&self.key, allocator),
-            constraint: CloneIn::clone_in_with_semantic_ids(&self.constraint, allocator),
-            name_type: CloneIn::clone_in_with_semantic_ids(&self.name_type, allocator),
-            type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
-            optional: CloneIn::clone_in_with_semantic_ids(&self.optional, allocator),
-            readonly: CloneIn::clone_in_with_semantic_ids(&self.readonly, allocator),
-            scope_id: CloneIn::clone_in_with_semantic_ids(&self.scope_id, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            key: CloneIn::clone_in_impl(&self.key, with_semantic_ids, allocator),
+            constraint: CloneIn::clone_in_impl(&self.constraint, with_semantic_ids, allocator),
+            name_type: CloneIn::clone_in_impl(&self.name_type, with_semantic_ids, allocator),
+            type_annotation: CloneIn::clone_in_impl(
+                &self.type_annotation,
+                with_semantic_ids,
+                allocator,
+            ),
+            optional: CloneIn::clone_in_impl(&self.optional, with_semantic_ids, allocator),
+            readonly: CloneIn::clone_in_impl(&self.readonly, with_semantic_ids, allocator),
+            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
         }
     }
 }
@@ -6756,12 +5216,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSMappedTypeModifierOperator {
     type Cloned = TSMappedTypeModifierOperator;
 
     #[inline(always)]
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        *self
-    }
-
-    #[inline(always)]
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         *self
     }
 }
@@ -6769,21 +5228,16 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSMappedTypeModifierOperator {
 impl<'new_alloc> CloneIn<'new_alloc> for TSTemplateLiteralType<'_> {
     type Cloned = TSTemplateLiteralType<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSTemplateLiteralType {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            quasis: CloneIn::clone_in(&self.quasis, allocator),
-            types: CloneIn::clone_in(&self.types, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSTemplateLiteralType {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            quasis: CloneIn::clone_in_with_semantic_ids(&self.quasis, allocator),
-            types: CloneIn::clone_in_with_semantic_ids(&self.types, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            quasis: CloneIn::clone_in_impl(&self.quasis, with_semantic_ids, allocator),
+            types: CloneIn::clone_in_impl(&self.types, with_semantic_ids, allocator),
         }
     }
 }
@@ -6791,21 +5245,20 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTemplateLiteralType<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSAsExpression<'_> {
     type Cloned = TSAsExpression<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSAsExpression {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            expression: CloneIn::clone_in(&self.expression, allocator),
-            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSAsExpression {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
-            type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            expression: CloneIn::clone_in_impl(&self.expression, with_semantic_ids, allocator),
+            type_annotation: CloneIn::clone_in_impl(
+                &self.type_annotation,
+                with_semantic_ids,
+                allocator,
+            ),
         }
     }
 }
@@ -6813,21 +5266,20 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSAsExpression<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSSatisfiesExpression<'_> {
     type Cloned = TSSatisfiesExpression<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSSatisfiesExpression {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            expression: CloneIn::clone_in(&self.expression, allocator),
-            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSSatisfiesExpression {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
-            type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            expression: CloneIn::clone_in_impl(&self.expression, with_semantic_ids, allocator),
+            type_annotation: CloneIn::clone_in_impl(
+                &self.type_annotation,
+                with_semantic_ids,
+                allocator,
+            ),
         }
     }
 }
@@ -6835,21 +5287,20 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSSatisfiesExpression<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSTypeAssertion<'_> {
     type Cloned = TSTypeAssertion<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSTypeAssertion {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
-            expression: CloneIn::clone_in(&self.expression, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSTypeAssertion {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
-            expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            type_annotation: CloneIn::clone_in_impl(
+                &self.type_annotation,
+                with_semantic_ids,
+                allocator,
+            ),
+            expression: CloneIn::clone_in_impl(&self.expression, with_semantic_ids, allocator),
         }
     }
 }
@@ -6857,26 +5308,21 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeAssertion<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSImportEqualsDeclaration<'_> {
     type Cloned = TSImportEqualsDeclaration<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSImportEqualsDeclaration {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            id: CloneIn::clone_in(&self.id, allocator),
-            module_reference: CloneIn::clone_in(&self.module_reference, allocator),
-            import_kind: CloneIn::clone_in(&self.import_kind, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSImportEqualsDeclaration {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            id: CloneIn::clone_in_with_semantic_ids(&self.id, allocator),
-            module_reference: CloneIn::clone_in_with_semantic_ids(
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            id: CloneIn::clone_in_impl(&self.id, with_semantic_ids, allocator),
+            module_reference: CloneIn::clone_in_impl(
                 &self.module_reference,
+                with_semantic_ids,
                 allocator,
             ),
-            import_kind: CloneIn::clone_in_with_semantic_ids(&self.import_kind, allocator),
+            import_kind: CloneIn::clone_in_impl(&self.import_kind, with_semantic_ids, allocator),
         }
     }
 }
@@ -6884,31 +5330,23 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSImportEqualsDeclaration<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSModuleReference<'_> {
     type Cloned = TSModuleReference<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::ExternalModuleReference(it) => {
-                TSModuleReference::ExternalModuleReference(CloneIn::clone_in(it, allocator))
-            }
-            Self::IdentifierReference(it) => {
-                TSModuleReference::IdentifierReference(CloneIn::clone_in(it, allocator))
-            }
-            Self::QualifiedName(it) => {
-                TSModuleReference::QualifiedName(CloneIn::clone_in(it, allocator))
-            }
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
             Self::ExternalModuleReference(it) => TSModuleReference::ExternalModuleReference(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
             Self::IdentifierReference(it) => TSModuleReference::IdentifierReference(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
-            Self::QualifiedName(it) => {
-                TSModuleReference::QualifiedName(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
+            Self::QualifiedName(it) => TSModuleReference::QualifiedName(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
         }
     }
 }
@@ -6916,19 +5354,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSModuleReference<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSExternalModuleReference<'_> {
     type Cloned = TSExternalModuleReference<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSExternalModuleReference {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            expression: CloneIn::clone_in(&self.expression, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSExternalModuleReference {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            expression: CloneIn::clone_in_impl(&self.expression, with_semantic_ids, allocator),
         }
     }
 }
@@ -6936,19 +5370,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSExternalModuleReference<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSNonNullExpression<'_> {
     type Cloned = TSNonNullExpression<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSNonNullExpression {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            expression: CloneIn::clone_in(&self.expression, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSNonNullExpression {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            expression: CloneIn::clone_in_impl(&self.expression, with_semantic_ids, allocator),
         }
     }
 }
@@ -6956,19 +5386,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSNonNullExpression<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for Decorator<'_> {
     type Cloned = Decorator<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         Decorator {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            expression: CloneIn::clone_in(&self.expression, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        Decorator {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            expression: CloneIn::clone_in_impl(&self.expression, with_semantic_ids, allocator),
         }
     }
 }
@@ -6976,19 +5402,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for Decorator<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSExportAssignment<'_> {
     type Cloned = TSExportAssignment<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSExportAssignment {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            expression: CloneIn::clone_in(&self.expression, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSExportAssignment {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            expression: CloneIn::clone_in_impl(&self.expression, with_semantic_ids, allocator),
         }
     }
 }
@@ -6996,19 +5418,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSExportAssignment<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSNamespaceExportDeclaration<'_> {
     type Cloned = TSNamespaceExportDeclaration<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSNamespaceExportDeclaration {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            id: CloneIn::clone_in(&self.id, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSNamespaceExportDeclaration {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            id: CloneIn::clone_in_with_semantic_ids(&self.id, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            id: CloneIn::clone_in_impl(&self.id, with_semantic_ids, allocator),
         }
     }
 }
@@ -7016,21 +5434,20 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSNamespaceExportDeclaration<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSInstantiationExpression<'_> {
     type Cloned = TSInstantiationExpression<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         TSInstantiationExpression {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            expression: CloneIn::clone_in(&self.expression, allocator),
-            type_arguments: CloneIn::clone_in(&self.type_arguments, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSInstantiationExpression {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
-            type_arguments: CloneIn::clone_in_with_semantic_ids(&self.type_arguments, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            expression: CloneIn::clone_in_impl(&self.expression, with_semantic_ids, allocator),
+            type_arguments: CloneIn::clone_in_impl(
+                &self.type_arguments,
+                with_semantic_ids,
+                allocator,
+            ),
         }
     }
 }
@@ -7039,12 +5456,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for ImportOrExportKind {
     type Cloned = ImportOrExportKind;
 
     #[inline(always)]
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        *self
-    }
-
-    #[inline(always)]
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         *self
     }
 }
@@ -7052,21 +5468,20 @@ impl<'new_alloc> CloneIn<'new_alloc> for ImportOrExportKind {
 impl<'new_alloc> CloneIn<'new_alloc> for JSDocNullableType<'_> {
     type Cloned = JSDocNullableType<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         JSDocNullableType {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
-            postfix: CloneIn::clone_in(&self.postfix, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        JSDocNullableType {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
-            postfix: CloneIn::clone_in_with_semantic_ids(&self.postfix, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            type_annotation: CloneIn::clone_in_impl(
+                &self.type_annotation,
+                with_semantic_ids,
+                allocator,
+            ),
+            postfix: CloneIn::clone_in_impl(&self.postfix, with_semantic_ids, allocator),
         }
     }
 }
@@ -7074,21 +5489,20 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSDocNullableType<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for JSDocNonNullableType<'_> {
     type Cloned = JSDocNonNullableType<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         JSDocNonNullableType {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
-            postfix: CloneIn::clone_in(&self.postfix, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        JSDocNonNullableType {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
-            postfix: CloneIn::clone_in_with_semantic_ids(&self.postfix, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            type_annotation: CloneIn::clone_in_impl(
+                &self.type_annotation,
+                with_semantic_ids,
+                allocator,
+            ),
+            postfix: CloneIn::clone_in_impl(&self.postfix, with_semantic_ids, allocator),
         }
     }
 }
@@ -7096,17 +5510,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSDocNonNullableType<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for JSDocUnknownType {
     type Cloned = JSDocUnknownType;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         JSDocUnknownType {
-            node_id: Default::default(),
-            span: CloneIn::clone_in(&self.span, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        JSDocUnknownType {
-            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
+            node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
         }
     }
 }
@@ -7115,12 +5526,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for CommentKind {
     type Cloned = CommentKind;
 
     #[inline(always)]
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        *self
-    }
-
-    #[inline(always)]
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         *self
     }
 }
@@ -7129,12 +5539,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for CommentPosition {
     type Cloned = CommentPosition;
 
     #[inline(always)]
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        *self
-    }
-
-    #[inline(always)]
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         *self
     }
 }
@@ -7143,12 +5552,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for CommentContent {
     type Cloned = CommentContent;
 
     #[inline(always)]
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        *self
-    }
-
-    #[inline(always)]
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         *self
     }
 }
@@ -7156,25 +5564,18 @@ impl<'new_alloc> CloneIn<'new_alloc> for CommentContent {
 impl<'new_alloc> CloneIn<'new_alloc> for Comment {
     type Cloned = Comment;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         Comment {
-            span: CloneIn::clone_in(&self.span, allocator),
-            attached_to: CloneIn::clone_in(&self.attached_to, allocator),
-            kind: CloneIn::clone_in(&self.kind, allocator),
-            position: CloneIn::clone_in(&self.position, allocator),
-            newlines: CloneIn::clone_in(&self.newlines, allocator),
-            content: CloneIn::clone_in(&self.content, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        Comment {
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            attached_to: CloneIn::clone_in_with_semantic_ids(&self.attached_to, allocator),
-            kind: CloneIn::clone_in_with_semantic_ids(&self.kind, allocator),
-            position: CloneIn::clone_in_with_semantic_ids(&self.position, allocator),
-            newlines: CloneIn::clone_in_with_semantic_ids(&self.newlines, allocator),
-            content: CloneIn::clone_in_with_semantic_ids(&self.content, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            attached_to: CloneIn::clone_in_impl(&self.attached_to, with_semantic_ids, allocator),
+            kind: CloneIn::clone_in_impl(&self.kind, with_semantic_ids, allocator),
+            position: CloneIn::clone_in_impl(&self.position, with_semantic_ids, allocator),
+            newlines: CloneIn::clone_in_impl(&self.newlines, with_semantic_ids, allocator),
+            content: CloneIn::clone_in_impl(&self.content, with_semantic_ids, allocator),
         }
     }
 }

--- a/crates/oxc_regular_expression/src/ast_impl/allocator.rs
+++ b/crates/oxc_regular_expression/src/ast_impl/allocator.rs
@@ -5,7 +5,7 @@ use crate::ast::Modifier;
 impl<'alloc> CloneIn<'alloc> for Modifier {
     type Cloned = Self;
 
-    fn clone_in(&self, _: &'alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(&self, _with_semantic_ids: bool, _: &'alloc Allocator) -> Self::Cloned {
         *self
     }
 }

--- a/crates/oxc_regular_expression/src/generated/derive_clone_in.rs
+++ b/crates/oxc_regular_expression/src/generated/derive_clone_in.rs
@@ -12,17 +12,14 @@ use crate::ast::*;
 impl<'new_alloc> CloneIn<'new_alloc> for Pattern<'_> {
     type Cloned = Pattern<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         Pattern {
-            span: CloneIn::clone_in(&self.span, allocator),
-            body: CloneIn::clone_in(&self.body, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        Pattern {
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
         }
     }
 }
@@ -30,17 +27,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for Pattern<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for Disjunction<'_> {
     type Cloned = Disjunction<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         Disjunction {
-            span: CloneIn::clone_in(&self.span, allocator),
-            body: CloneIn::clone_in(&self.body, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        Disjunction {
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
         }
     }
 }
@@ -48,17 +42,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for Disjunction<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for Alternative<'_> {
     type Cloned = Alternative<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         Alternative {
-            span: CloneIn::clone_in(&self.span, allocator),
-            body: CloneIn::clone_in(&self.body, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        Alternative {
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
         }
     }
 }
@@ -66,66 +57,47 @@ impl<'new_alloc> CloneIn<'new_alloc> for Alternative<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for Term<'_> {
     type Cloned = Term<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
             Self::BoundaryAssertion(it) => {
-                Term::BoundaryAssertion(CloneIn::clone_in(it, allocator))
+                Term::BoundaryAssertion(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::LookAroundAssertion(it) => {
-                Term::LookAroundAssertion(CloneIn::clone_in(it, allocator))
-            }
-            Self::Quantifier(it) => Term::Quantifier(CloneIn::clone_in(it, allocator)),
-            Self::Character(it) => Term::Character(CloneIn::clone_in(it, allocator)),
-            Self::Dot(it) => Term::Dot(CloneIn::clone_in(it, allocator)),
-            Self::CharacterClassEscape(it) => {
-                Term::CharacterClassEscape(CloneIn::clone_in(it, allocator))
-            }
-            Self::UnicodePropertyEscape(it) => {
-                Term::UnicodePropertyEscape(CloneIn::clone_in(it, allocator))
-            }
-            Self::CharacterClass(it) => Term::CharacterClass(CloneIn::clone_in(it, allocator)),
-            Self::CapturingGroup(it) => Term::CapturingGroup(CloneIn::clone_in(it, allocator)),
-            Self::IgnoreGroup(it) => Term::IgnoreGroup(CloneIn::clone_in(it, allocator)),
-            Self::IndexedReference(it) => Term::IndexedReference(CloneIn::clone_in(it, allocator)),
-            Self::NamedReference(it) => Term::NamedReference(CloneIn::clone_in(it, allocator)),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::BoundaryAssertion(it) => {
-                Term::BoundaryAssertion(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
-            Self::LookAroundAssertion(it) => {
-                Term::LookAroundAssertion(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                Term::LookAroundAssertion(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::Quantifier(it) => {
-                Term::Quantifier(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                Term::Quantifier(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::Character(it) => {
-                Term::Character(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                Term::Character(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
-            Self::Dot(it) => Term::Dot(CloneIn::clone_in_with_semantic_ids(it, allocator)),
+            Self::Dot(it) => Term::Dot(CloneIn::clone_in_impl(it, with_semantic_ids, allocator)),
             Self::CharacterClassEscape(it) => {
-                Term::CharacterClassEscape(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                Term::CharacterClassEscape(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
-            Self::UnicodePropertyEscape(it) => {
-                Term::UnicodePropertyEscape(CloneIn::clone_in_with_semantic_ids(it, allocator))
-            }
+            Self::UnicodePropertyEscape(it) => Term::UnicodePropertyEscape(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
             Self::CharacterClass(it) => {
-                Term::CharacterClass(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                Term::CharacterClass(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::CapturingGroup(it) => {
-                Term::CapturingGroup(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                Term::CapturingGroup(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::IgnoreGroup(it) => {
-                Term::IgnoreGroup(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                Term::IgnoreGroup(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::IndexedReference(it) => {
-                Term::IndexedReference(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                Term::IndexedReference(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
             Self::NamedReference(it) => {
-                Term::NamedReference(CloneIn::clone_in_with_semantic_ids(it, allocator))
+                Term::NamedReference(CloneIn::clone_in_impl(it, with_semantic_ids, allocator))
             }
         }
     }
@@ -134,17 +106,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for Term<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for BoundaryAssertion {
     type Cloned = BoundaryAssertion;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         BoundaryAssertion {
-            span: CloneIn::clone_in(&self.span, allocator),
-            kind: CloneIn::clone_in(&self.kind, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        BoundaryAssertion {
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            kind: CloneIn::clone_in_with_semantic_ids(&self.kind, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            kind: CloneIn::clone_in_impl(&self.kind, with_semantic_ids, allocator),
         }
     }
 }
@@ -153,12 +122,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for BoundaryAssertionKind {
     type Cloned = BoundaryAssertionKind;
 
     #[inline(always)]
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        *self
-    }
-
-    #[inline(always)]
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         *self
     }
 }
@@ -166,19 +134,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for BoundaryAssertionKind {
 impl<'new_alloc> CloneIn<'new_alloc> for LookAroundAssertion<'_> {
     type Cloned = LookAroundAssertion<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         LookAroundAssertion {
-            span: CloneIn::clone_in(&self.span, allocator),
-            kind: CloneIn::clone_in(&self.kind, allocator),
-            body: CloneIn::clone_in(&self.body, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        LookAroundAssertion {
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            kind: CloneIn::clone_in_with_semantic_ids(&self.kind, allocator),
-            body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            kind: CloneIn::clone_in_impl(&self.kind, with_semantic_ids, allocator),
+            body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
         }
     }
 }
@@ -187,12 +151,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for LookAroundAssertionKind {
     type Cloned = LookAroundAssertionKind;
 
     #[inline(always)]
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        *self
-    }
-
-    #[inline(always)]
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         *self
     }
 }
@@ -200,23 +163,17 @@ impl<'new_alloc> CloneIn<'new_alloc> for LookAroundAssertionKind {
 impl<'new_alloc> CloneIn<'new_alloc> for Quantifier<'_> {
     type Cloned = Quantifier<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         Quantifier {
-            span: CloneIn::clone_in(&self.span, allocator),
-            min: CloneIn::clone_in(&self.min, allocator),
-            max: CloneIn::clone_in(&self.max, allocator),
-            greedy: CloneIn::clone_in(&self.greedy, allocator),
-            body: CloneIn::clone_in(&self.body, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        Quantifier {
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            min: CloneIn::clone_in_with_semantic_ids(&self.min, allocator),
-            max: CloneIn::clone_in_with_semantic_ids(&self.max, allocator),
-            greedy: CloneIn::clone_in_with_semantic_ids(&self.greedy, allocator),
-            body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            min: CloneIn::clone_in_impl(&self.min, with_semantic_ids, allocator),
+            max: CloneIn::clone_in_impl(&self.max, with_semantic_ids, allocator),
+            greedy: CloneIn::clone_in_impl(&self.greedy, with_semantic_ids, allocator),
+            body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
         }
     }
 }
@@ -224,19 +181,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for Quantifier<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for Character {
     type Cloned = Character;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         Character {
-            span: CloneIn::clone_in(&self.span, allocator),
-            kind: CloneIn::clone_in(&self.kind, allocator),
-            value: CloneIn::clone_in(&self.value, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        Character {
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            kind: CloneIn::clone_in_with_semantic_ids(&self.kind, allocator),
-            value: CloneIn::clone_in_with_semantic_ids(&self.value, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            kind: CloneIn::clone_in_impl(&self.kind, with_semantic_ids, allocator),
+            value: CloneIn::clone_in_impl(&self.value, with_semantic_ids, allocator),
         }
     }
 }
@@ -245,12 +198,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for CharacterKind {
     type Cloned = CharacterKind;
 
     #[inline(always)]
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        *self
-    }
-
-    #[inline(always)]
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         *self
     }
 }
@@ -258,17 +210,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for CharacterKind {
 impl<'new_alloc> CloneIn<'new_alloc> for CharacterClassEscape {
     type Cloned = CharacterClassEscape;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         CharacterClassEscape {
-            span: CloneIn::clone_in(&self.span, allocator),
-            kind: CloneIn::clone_in(&self.kind, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        CharacterClassEscape {
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            kind: CloneIn::clone_in_with_semantic_ids(&self.kind, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            kind: CloneIn::clone_in_impl(&self.kind, with_semantic_ids, allocator),
         }
     }
 }
@@ -277,12 +226,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for CharacterClassEscapeKind {
     type Cloned = CharacterClassEscapeKind;
 
     #[inline(always)]
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        *self
-    }
-
-    #[inline(always)]
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         *self
     }
 }
@@ -290,23 +238,17 @@ impl<'new_alloc> CloneIn<'new_alloc> for CharacterClassEscapeKind {
 impl<'new_alloc> CloneIn<'new_alloc> for UnicodePropertyEscape<'_> {
     type Cloned = UnicodePropertyEscape<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         UnicodePropertyEscape {
-            span: CloneIn::clone_in(&self.span, allocator),
-            negative: CloneIn::clone_in(&self.negative, allocator),
-            strings: CloneIn::clone_in(&self.strings, allocator),
-            name: CloneIn::clone_in(&self.name, allocator),
-            value: CloneIn::clone_in(&self.value, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        UnicodePropertyEscape {
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            negative: CloneIn::clone_in_with_semantic_ids(&self.negative, allocator),
-            strings: CloneIn::clone_in_with_semantic_ids(&self.strings, allocator),
-            name: CloneIn::clone_in_with_semantic_ids(&self.name, allocator),
-            value: CloneIn::clone_in_with_semantic_ids(&self.value, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            negative: CloneIn::clone_in_impl(&self.negative, with_semantic_ids, allocator),
+            strings: CloneIn::clone_in_impl(&self.strings, with_semantic_ids, allocator),
+            name: CloneIn::clone_in_impl(&self.name, with_semantic_ids, allocator),
+            value: CloneIn::clone_in_impl(&self.value, with_semantic_ids, allocator),
         }
     }
 }
@@ -314,35 +256,29 @@ impl<'new_alloc> CloneIn<'new_alloc> for UnicodePropertyEscape<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for Dot {
     type Cloned = Dot;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        Dot { span: CloneIn::clone_in(&self.span, allocator) }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        Dot { span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator) }
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
+        Dot { span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator) }
     }
 }
 
 impl<'new_alloc> CloneIn<'new_alloc> for CharacterClass<'_> {
     type Cloned = CharacterClass<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         CharacterClass {
-            span: CloneIn::clone_in(&self.span, allocator),
-            negative: CloneIn::clone_in(&self.negative, allocator),
-            strings: CloneIn::clone_in(&self.strings, allocator),
-            kind: CloneIn::clone_in(&self.kind, allocator),
-            body: CloneIn::clone_in(&self.body, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        CharacterClass {
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            negative: CloneIn::clone_in_with_semantic_ids(&self.negative, allocator),
-            strings: CloneIn::clone_in_with_semantic_ids(&self.strings, allocator),
-            kind: CloneIn::clone_in_with_semantic_ids(&self.kind, allocator),
-            body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            negative: CloneIn::clone_in_impl(&self.negative, with_semantic_ids, allocator),
+            strings: CloneIn::clone_in_impl(&self.strings, with_semantic_ids, allocator),
+            kind: CloneIn::clone_in_impl(&self.kind, with_semantic_ids, allocator),
+            body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
         }
     }
 }
@@ -351,12 +287,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for CharacterClassContentsKind {
     type Cloned = CharacterClassContentsKind;
 
     #[inline(always)]
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        *self
-    }
-
-    #[inline(always)]
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         *self
     }
 }
@@ -364,48 +299,31 @@ impl<'new_alloc> CloneIn<'new_alloc> for CharacterClassContentsKind {
 impl<'new_alloc> CloneIn<'new_alloc> for CharacterClassContents<'_> {
     type Cloned = CharacterClassContents<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::CharacterClassRange(it) => {
-                CharacterClassContents::CharacterClassRange(CloneIn::clone_in(it, allocator))
-            }
-            Self::CharacterClassEscape(it) => {
-                CharacterClassContents::CharacterClassEscape(CloneIn::clone_in(it, allocator))
-            }
-            Self::UnicodePropertyEscape(it) => {
-                CharacterClassContents::UnicodePropertyEscape(CloneIn::clone_in(it, allocator))
-            }
-            Self::Character(it) => {
-                CharacterClassContents::Character(CloneIn::clone_in(it, allocator))
-            }
-            Self::NestedCharacterClass(it) => {
-                CharacterClassContents::NestedCharacterClass(CloneIn::clone_in(it, allocator))
-            }
-            Self::ClassStringDisjunction(it) => {
-                CharacterClassContents::ClassStringDisjunction(CloneIn::clone_in(it, allocator))
-            }
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         match self {
             Self::CharacterClassRange(it) => CharacterClassContents::CharacterClassRange(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
             Self::CharacterClassEscape(it) => CharacterClassContents::CharacterClassEscape(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
             Self::UnicodePropertyEscape(it) => CharacterClassContents::UnicodePropertyEscape(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
-            Self::Character(it) => CharacterClassContents::Character(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
-            ),
+            Self::Character(it) => CharacterClassContents::Character(CloneIn::clone_in_impl(
+                it,
+                with_semantic_ids,
+                allocator,
+            )),
             Self::NestedCharacterClass(it) => CharacterClassContents::NestedCharacterClass(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
             Self::ClassStringDisjunction(it) => CharacterClassContents::ClassStringDisjunction(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
+                CloneIn::clone_in_impl(it, with_semantic_ids, allocator),
             ),
         }
     }
@@ -414,19 +332,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for CharacterClassContents<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for CharacterClassRange {
     type Cloned = CharacterClassRange;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         CharacterClassRange {
-            span: CloneIn::clone_in(&self.span, allocator),
-            min: CloneIn::clone_in(&self.min, allocator),
-            max: CloneIn::clone_in(&self.max, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        CharacterClassRange {
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            min: CloneIn::clone_in_with_semantic_ids(&self.min, allocator),
-            max: CloneIn::clone_in_with_semantic_ids(&self.max, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            min: CloneIn::clone_in_impl(&self.min, with_semantic_ids, allocator),
+            max: CloneIn::clone_in_impl(&self.max, with_semantic_ids, allocator),
         }
     }
 }
@@ -434,19 +348,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for CharacterClassRange {
 impl<'new_alloc> CloneIn<'new_alloc> for ClassStringDisjunction<'_> {
     type Cloned = ClassStringDisjunction<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         ClassStringDisjunction {
-            span: CloneIn::clone_in(&self.span, allocator),
-            strings: CloneIn::clone_in(&self.strings, allocator),
-            body: CloneIn::clone_in(&self.body, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        ClassStringDisjunction {
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            strings: CloneIn::clone_in_with_semantic_ids(&self.strings, allocator),
-            body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            strings: CloneIn::clone_in_impl(&self.strings, with_semantic_ids, allocator),
+            body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
         }
     }
 }
@@ -454,19 +364,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for ClassStringDisjunction<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ClassString<'_> {
     type Cloned = ClassString<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         ClassString {
-            span: CloneIn::clone_in(&self.span, allocator),
-            strings: CloneIn::clone_in(&self.strings, allocator),
-            body: CloneIn::clone_in(&self.body, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        ClassString {
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            strings: CloneIn::clone_in_with_semantic_ids(&self.strings, allocator),
-            body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            strings: CloneIn::clone_in_impl(&self.strings, with_semantic_ids, allocator),
+            body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
         }
     }
 }
@@ -474,19 +380,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for ClassString<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for CapturingGroup<'_> {
     type Cloned = CapturingGroup<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         CapturingGroup {
-            span: CloneIn::clone_in(&self.span, allocator),
-            name: CloneIn::clone_in(&self.name, allocator),
-            body: CloneIn::clone_in(&self.body, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        CapturingGroup {
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            name: CloneIn::clone_in_with_semantic_ids(&self.name, allocator),
-            body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            name: CloneIn::clone_in_impl(&self.name, with_semantic_ids, allocator),
+            body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
         }
     }
 }
@@ -494,19 +396,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for CapturingGroup<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for IgnoreGroup<'_> {
     type Cloned = IgnoreGroup<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         IgnoreGroup {
-            span: CloneIn::clone_in(&self.span, allocator),
-            modifiers: CloneIn::clone_in(&self.modifiers, allocator),
-            body: CloneIn::clone_in(&self.body, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        IgnoreGroup {
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            modifiers: CloneIn::clone_in_with_semantic_ids(&self.modifiers, allocator),
-            body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            modifiers: CloneIn::clone_in_impl(&self.modifiers, with_semantic_ids, allocator),
+            body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
         }
     }
 }
@@ -514,19 +412,15 @@ impl<'new_alloc> CloneIn<'new_alloc> for IgnoreGroup<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for Modifiers {
     type Cloned = Modifiers;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         Modifiers {
-            span: CloneIn::clone_in(&self.span, allocator),
-            enabling: CloneIn::clone_in(&self.enabling, allocator),
-            disabling: CloneIn::clone_in(&self.disabling, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        Modifiers {
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            enabling: CloneIn::clone_in_with_semantic_ids(&self.enabling, allocator),
-            disabling: CloneIn::clone_in_with_semantic_ids(&self.disabling, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            enabling: CloneIn::clone_in_impl(&self.enabling, with_semantic_ids, allocator),
+            disabling: CloneIn::clone_in_impl(&self.disabling, with_semantic_ids, allocator),
         }
     }
 }
@@ -534,17 +428,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for Modifiers {
 impl<'new_alloc> CloneIn<'new_alloc> for IndexedReference {
     type Cloned = IndexedReference;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         IndexedReference {
-            span: CloneIn::clone_in(&self.span, allocator),
-            index: CloneIn::clone_in(&self.index, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        IndexedReference {
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            index: CloneIn::clone_in_with_semantic_ids(&self.index, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            index: CloneIn::clone_in_impl(&self.index, with_semantic_ids, allocator),
         }
     }
 }
@@ -552,17 +443,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for IndexedReference {
 impl<'new_alloc> CloneIn<'new_alloc> for NamedReference<'_> {
     type Cloned = NamedReference<'new_alloc>;
 
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         NamedReference {
-            span: CloneIn::clone_in(&self.span, allocator),
-            name: CloneIn::clone_in(&self.name, allocator),
-        }
-    }
-
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        NamedReference {
-            span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            name: CloneIn::clone_in_with_semantic_ids(&self.name, allocator),
+            span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
+            name: CloneIn::clone_in_impl(&self.name, with_semantic_ids, allocator),
         }
     }
 }

--- a/crates/oxc_semantic/src/scoping.rs
+++ b/crates/oxc_semantic/src/scoping.rs
@@ -31,13 +31,12 @@ impl CloneIn<'_> for Redeclaration {
     type Cloned = Self;
 
     #[inline]
-    fn clone_in(&self, _allocator: &Allocator) -> Self::Cloned {
-        Self { span: self.span, declaration: NodeId::DUMMY, flags: self.flags }
-    }
-
-    #[inline]
-    fn clone_in_with_semantic_ids(&self, _allocator: &Allocator) -> Self::Cloned {
-        self.clone()
+    fn clone_in_impl(&self, with_semantic_ids: bool, _allocator: &Allocator) -> Self::Cloned {
+        if with_semantic_ids {
+            self.clone()
+        } else {
+            Self { span: self.span, declaration: NodeId::DUMMY, flags: self.flags }
+        }
     }
 }
 

--- a/crates/oxc_span/src/source_type.rs
+++ b/crates/oxc_span/src/source_type.rs
@@ -103,7 +103,7 @@ impl<'a> CloneIn<'a> for SourceType {
     type Cloned = Self;
 
     #[inline]
-    fn clone_in(&self, _: &'a Allocator) -> Self {
+    fn clone_in_impl(&self, _with_semantic_ids: bool, _: &'a Allocator) -> Self {
         *self
     }
 }

--- a/crates/oxc_span/src/span.rs
+++ b/crates/oxc_span/src/span.rs
@@ -635,7 +635,7 @@ impl<'a> CloneIn<'a> for Span {
     type Cloned = Self;
 
     #[inline]
-    fn clone_in(&self, _: &'a Allocator) -> Self {
+    fn clone_in_impl(&self, _with_semantic_ids: bool, _: &'a Allocator) -> Self {
         *self
     }
 }

--- a/crates/oxc_str/src/ident.rs
+++ b/crates/oxc_str/src/ident.rs
@@ -413,7 +413,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for Ident<'_> {
 
     /// Clone the identifier into a new allocator, preserving the precomputed hash.
     #[inline]
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         let s = allocator.alloc_str(self.as_str());
         let ptr = NonNull::from_ref(s).cast::<u8>();
         // SAFETY: `ptr` points to a `&str`, with length `self.ident_len()`.

--- a/crates/oxc_str/src/str.rs
+++ b/crates/oxc_str/src/str.rs
@@ -117,7 +117,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for Str<'_> {
     type Cloned = Str<'new_alloc>;
 
     #[inline]
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         Str::from_in(self.as_str(), allocator)
     }
 }

--- a/crates/oxc_syntax/src/generated/derive_clone_in.rs
+++ b/crates/oxc_syntax/src/generated/derive_clone_in.rs
@@ -14,12 +14,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for NumberBase {
     type Cloned = NumberBase;
 
     #[inline(always)]
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        *self
-    }
-
-    #[inline(always)]
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         *self
     }
 }
@@ -28,12 +27,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for BigintBase {
     type Cloned = BigintBase;
 
     #[inline(always)]
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        *self
-    }
-
-    #[inline(always)]
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         *self
     }
 }
@@ -42,12 +40,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for AssignmentOperator {
     type Cloned = AssignmentOperator;
 
     #[inline(always)]
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        *self
-    }
-
-    #[inline(always)]
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         *self
     }
 }
@@ -56,12 +53,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for BinaryOperator {
     type Cloned = BinaryOperator;
 
     #[inline(always)]
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        *self
-    }
-
-    #[inline(always)]
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         *self
     }
 }
@@ -70,12 +66,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for LogicalOperator {
     type Cloned = LogicalOperator;
 
     #[inline(always)]
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        *self
-    }
-
-    #[inline(always)]
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         *self
     }
 }
@@ -84,12 +79,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for UnaryOperator {
     type Cloned = UnaryOperator;
 
     #[inline(always)]
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        *self
-    }
-
-    #[inline(always)]
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         *self
     }
 }
@@ -98,12 +92,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for UpdateOperator {
     type Cloned = UpdateOperator;
 
     #[inline(always)]
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        *self
-    }
-
-    #[inline(always)]
-    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: bool,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
         *self
     }
 }

--- a/crates/oxc_syntax/src/node.rs
+++ b/crates/oxc_syntax/src/node.rs
@@ -9,7 +9,6 @@ use oxc_index::define_nonmax_u32_index_type;
 define_nonmax_u32_index_type! {
     /// AST Node ID
     #[ast]
-    #[clone_in(default)]
     #[content_eq(skip)]
     #[estree(skip)]
     pub struct NodeId;
@@ -42,14 +41,15 @@ impl<'a> Dummy<'a> for NodeId {
 impl<'alloc> CloneIn<'alloc> for NodeId {
     type Cloned = Self;
 
-    fn clone_in(&self, _: &'alloc Allocator) -> Self {
-        // `clone_in` should never reach this, because `CloneIn` skips `node_id` field
-        unreachable!();
-    }
-
     #[inline]
-    fn clone_in_with_semantic_ids(&self, _: &'alloc Allocator) -> Self {
-        *self
+    fn clone_in_impl(&self, with_semantic_ids: bool, _: &'alloc Allocator) -> Self {
+        if with_semantic_ids {
+            *self
+        } else {
+            // `with_semantic_ids == false` should never reach this, because `CloneIn` skips
+            // `node_id` field, filling it with its default instead.
+            unreachable!();
+        }
     }
 }
 

--- a/crates/oxc_syntax/src/reference.rs
+++ b/crates/oxc_syntax/src/reference.rs
@@ -12,7 +12,6 @@ use oxc_ast_macros::ast;
 define_nonmax_u32_index_type! {
     #[ast]
     #[builder(default)]
-    #[clone_in(default)]
     #[content_eq(skip)]
     #[estree(skip)]
     pub struct ReferenceId;
@@ -21,15 +20,16 @@ define_nonmax_u32_index_type! {
 impl<'alloc> CloneIn<'alloc> for ReferenceId {
     type Cloned = Self;
 
-    fn clone_in(&self, _: &'alloc Allocator) -> Self {
-        // `clone_in` should never reach this, because `CloneIn` skips reference_id field
-        unreachable!();
-    }
-
     #[expect(clippy::inline_always)]
     #[inline(always)]
-    fn clone_in_with_semantic_ids(&self, _: &'alloc Allocator) -> Self {
-        *self
+    fn clone_in_impl(&self, with_semantic_ids: bool, _: &'alloc Allocator) -> Self {
+        if with_semantic_ids {
+            *self
+        } else {
+            // `with_semantic_ids == false` should never reach this, because `CloneIn` skips
+            // `reference_id` field, filling it with its default instead.
+            unreachable!();
+        }
     }
 }
 
@@ -224,7 +224,11 @@ impl ReferenceFlags {
 impl<'alloc> CloneIn<'alloc> for ReferenceFlags {
     type Cloned = Self;
 
-    fn clone_in(&self, _: &'alloc oxc_allocator::Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: bool,
+        _: &'alloc oxc_allocator::Allocator,
+    ) -> Self::Cloned {
         *self
     }
 }

--- a/crates/oxc_syntax/src/scope.rs
+++ b/crates/oxc_syntax/src/scope.rs
@@ -7,7 +7,6 @@ use oxc_ast_macros::ast;
 define_nonmax_u32_index_type! {
     #[ast]
     #[builder(default)]
-    #[clone_in(default)]
     #[content_eq(skip)]
     #[estree(skip)]
     pub struct ScopeId;
@@ -16,15 +15,16 @@ define_nonmax_u32_index_type! {
 impl<'alloc> CloneIn<'alloc> for ScopeId {
     type Cloned = Self;
 
-    fn clone_in(&self, _: &'alloc Allocator) -> Self {
-        // `clone_in` should never reach this, because `CloneIn` skips scope_id field
-        unreachable!();
-    }
-
     #[expect(clippy::inline_always)]
     #[inline(always)]
-    fn clone_in_with_semantic_ids(&self, _: &'alloc Allocator) -> Self {
-        *self
+    fn clone_in_impl(&self, with_semantic_ids: bool, _: &'alloc Allocator) -> Self {
+        if with_semantic_ids {
+            *self
+        } else {
+            // `with_semantic_ids == false` should never reach this, because `CloneIn` skips
+            // `scope_id` field, filling it with its default instead.
+            unreachable!();
+        }
     }
 }
 

--- a/crates/oxc_syntax/src/symbol.rs
+++ b/crates/oxc_syntax/src/symbol.rs
@@ -9,7 +9,6 @@ use oxc_ast_macros::ast;
 define_nonmax_u32_index_type! {
     #[ast]
     #[builder(default)]
-    #[clone_in(default)]
     #[content_eq(skip)]
     #[estree(skip)]
     pub struct SymbolId;
@@ -18,15 +17,16 @@ define_nonmax_u32_index_type! {
 impl<'alloc> CloneIn<'alloc> for SymbolId {
     type Cloned = Self;
 
-    fn clone_in(&self, _: &'alloc Allocator) -> Self {
-        // `clone_in` should never reach this, because `CloneIn` skips symbol_id field
-        unreachable!();
-    }
-
     #[expect(clippy::inline_always)]
     #[inline(always)]
-    fn clone_in_with_semantic_ids(&self, _: &'alloc Allocator) -> Self {
-        *self
+    fn clone_in_impl(&self, with_semantic_ids: bool, _: &'alloc Allocator) -> Self {
+        if with_semantic_ids {
+            *self
+        } else {
+            // `with_semantic_ids == false` should never reach this, because `CloneIn` skips
+            // `symbol_id` field, filling it with its default instead.
+            unreachable!();
+        }
     }
 }
 

--- a/tasks/ast_tools/src/derives/clone_in.rs
+++ b/tasks/ast_tools/src/derives/clone_in.rs
@@ -80,45 +80,26 @@ impl Derive for DeriveCloneIn {
 fn derive_struct(struct_def: &StructDef, schema: &Schema) -> TokenStream {
     let type_ident = struct_def.ident();
 
-    let (clone_in_body, clone_in_with_semantic_ids_body) = if struct_def.clone_in.is_default {
-        let clone_in_body = quote!(Default::default());
-        (clone_in_body.clone(), clone_in_body)
+    let (body, body_uses_flag) = if struct_def.clone_in.is_default {
+        (quote!(Default::default()), false)
+    } else if struct_def.fields.is_empty() {
+        (quote!( #type_ident ), false)
     } else {
-        let has_fields = !struct_def.fields.is_empty();
-        let clone_in_body = if has_fields {
-            let fields = struct_def.fields.iter().map(|field| {
-                let field_ident = field.ident();
-                if struct_field_is_default(field, schema) {
-                    quote!( #field_ident: Default::default() )
-                } else {
-                    quote!( #field_ident: CloneIn::clone_in(&self.#field_ident, allocator) )
-                }
-            });
-            quote!( #type_ident { #(#fields),* } )
-        } else {
-            quote!( #type_ident )
-        };
-
-        let clone_in_with_semantic_ids_body = if has_fields {
-            let fields = struct_def.fields.iter().map(|field| {
-                let field_ident = field.ident();
-                quote!( #field_ident: CloneIn::clone_in_with_semantic_ids(&self.#field_ident, allocator) )
-            });
-            quote!( #type_ident { #(#fields),* } )
-        } else {
-            quote!( #type_ident )
-        };
-
-        (clone_in_body, clone_in_with_semantic_ids_body)
+        let fields = struct_def.fields.iter().map(|field| {
+            let field_ident = field.ident();
+            if struct_field_is_default(field, schema) {
+                // Fields (or fields whose type is) marked `#[clone_in(default)]` always reset to
+                // their default. Semantic id `Cell`s are *not* marked — they thread the
+                // `with_semantic_ids` flag through their `CloneIn` impl instead (see `oxc_allocator`).
+                quote!( #field_ident: Default::default() )
+            } else {
+                quote!( #field_ident: CloneIn::clone_in_impl(&self.#field_ident, with_semantic_ids, allocator) )
+            }
+        });
+        (quote!( #type_ident { #(#fields),* } ), true)
     };
 
-    generate_impl(
-        &type_ident,
-        &clone_in_body,
-        &clone_in_with_semantic_ids_body,
-        struct_def.has_lifetime,
-        false,
-    )
+    generate_impl(&type_ident, &body, struct_def.has_lifetime, false, body_uses_flag)
 }
 
 /// Get if a struct field should be filled with default value when cloning.
@@ -142,33 +123,22 @@ fn struct_field_is_default(field: &FieldDef, schema: &Schema) -> bool {
 fn derive_enum(enum_def: &EnumDef, schema: &Schema) -> TokenStream {
     let type_ident = enum_def.ident();
 
-    let (clone_in_body, clone_in_with_semantic_ids_body) = if enum_def.clone_in.is_default {
-        let clone_in_body = quote!(Default::default());
-        (clone_in_body.clone(), clone_in_body)
+    let (body, body_uses_flag) = if enum_def.clone_in.is_default {
+        (quote!(Default::default()), false)
     } else if enum_def.is_fieldless() {
         // Fieldless enums are always `Copy`
-        let clone_in_body = quote!(*self);
-        (clone_in_body.clone(), clone_in_body)
+        (quote!(*self), false)
     } else {
-        (
-            derive_enum_body(enum_def, &type_ident, schema, false),
-            derive_enum_body(enum_def, &type_ident, schema, true),
-        )
+        (derive_enum_body(enum_def, &type_ident, schema), true)
     };
 
     // Add `#[inline(always)]` to methods for fieldless enums, because they're no-ops
     let inline_always = enum_def.is_fieldless();
 
-    generate_impl(
-        &type_ident,
-        &clone_in_body,
-        &clone_in_with_semantic_ids_body,
-        enum_def.has_lifetime,
-        inline_always,
-    )
+    generate_impl(&type_ident, &body, enum_def.has_lifetime, inline_always, body_uses_flag)
 }
 
-/// Generate the `match` body for an enum's `clone_in` / `clone_in_with_semantic_ids` method.
+/// Generate the `match` body for an enum's `clone_in_impl` method.
 ///
 /// Own variants are cloned arm-by-arm. Variants inherited via `INHERIT` are *not* expanded individually.
 /// Instead they are delegated to the inherited enum's own `CloneIn` impl, using `to_*` reference cast
@@ -177,21 +147,16 @@ fn derive_enum(enum_def: &EnumDef, schema: &Schema) -> TokenStream {
 ///
 /// This avoids re-emitting the parent enum's variant arms (e.g. all of `Expression`'s ~30 variants)
 /// in every inheriting enum (`Argument`, `PropertyKey`, ...), which is a large source of binary bloat.
-fn derive_enum_body(
-    enum_def: &EnumDef,
-    type_ident: &Ident,
-    schema: &Schema,
-    with_semantic_ids: bool,
-) -> TokenStream {
-    let clone_method =
-        if with_semantic_ids { quote!(clone_in_with_semantic_ids) } else { quote!(clone_in) };
-
+///
+/// `with_semantic_ids` is threaded through as a runtime flag so a single traversal serves both
+/// `clone_in` and `clone_in_with_semantic_ids`.
+fn derive_enum_body(enum_def: &EnumDef, type_ident: &Ident, schema: &Schema) -> TokenStream {
     let own_arms = enum_def.variants.iter().map(|variant| {
         let ident = variant.ident();
         if variant.is_fieldless() {
             quote!( Self::#ident => #type_ident::#ident )
         } else {
-            quote!( Self::#ident(it) => #type_ident::#ident(CloneIn::#clone_method(it, allocator)) )
+            quote!( Self::#ident(it) => #type_ident::#ident(CloneIn::clone_in_impl(it, with_semantic_ids, allocator)) )
         }
     });
 
@@ -206,7 +171,7 @@ fn derive_enum_body(
         let to_inherited = create_ident(&format!("to_{}", inherited.snake_name()));
         quote! {
             #(#patterns)|* => {
-                #type_ident::from(CloneIn::#clone_method(self.#to_inherited(), allocator))
+                #type_ident::from(CloneIn::clone_in_impl(self.#to_inherited(), with_semantic_ids, allocator))
             }
         }
     });
@@ -221,15 +186,20 @@ fn derive_enum_body(
 
 fn generate_impl(
     type_ident: &Ident,
-    clone_in_body: &TokenStream,
-    clone_in_with_semantic_ids_body: &TokenStream,
+    clone_in_impl_body: &TokenStream,
     has_lifetime: bool,
     inline_always: bool,
+    body_uses_flag: bool,
 ) -> TokenStream {
     let (from_lifetime, to_lifetime) =
         if has_lifetime { (quote!( <'_> ), quote!( <'new_alloc> )) } else { (quote!(), quote!()) };
 
     let inline = if inline_always { quote!( #[inline(always)] ) } else { quote!() };
+
+    // A single `clone_in_impl` traversal serves both public methods. Name the flag `_`-prefixed when
+    // the body ignores it (default structs, empty structs, fieldless enums) to avoid an unused warning.
+    let flag_param =
+        if body_uses_flag { quote!(with_semantic_ids) } else { quote!(_with_semantic_ids) };
 
     quote! {
         impl<'new_alloc> CloneIn<'new_alloc> for #type_ident #from_lifetime {
@@ -237,14 +207,12 @@ fn generate_impl(
 
             ///@@line_break
             #inline
-            fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-                #clone_in_body
-            }
-
-            ///@@line_break
-            #inline
-            fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-                #clone_in_with_semantic_ids_body
+            fn clone_in_impl(
+                &self,
+                #flag_param: bool,
+                allocator: &'new_alloc Allocator,
+            ) -> Self::Cloned {
+                #clone_in_impl_body
             }
         }
     }


### PR DESCRIPTION
## Summary

The `CloneIn` derive generated **two near-identical traversals over the whole AST** — `clone_in` (resets semantic ids to their default) and `clone_in_with_semantic_ids` (preserves them). Almost every node carries an id field, so the two bodies diverge nearly everywhere and the pair roughly doubled the clone codegen.

This threads *"preserve semantic ids?"* as a **runtime `bool`** through a **single** traversal:

- **`CloneIn::clone_in_impl(&self, with_semantic_ids: bool, allocator)` is the one required method.** `clone_in` / `clone_in_with_semantic_ids` are `#[inline(always)]` default wrappers that call it with `false` / `true`. Hand-written impls provide only `clone_in_impl`.
- The **derive emits a single `clone_in_impl` body per type** — no per-type `clone_in` / `clone_in_with_semantic_ids` wrappers.
- Semantic ids live in `Cell<NodeId>` / `Cell<Option<{Scope,Symbol,Reference}Id>>`. **`Cell<T: Copy + Default>::clone_in_impl` threads the flag**: preserve (`Cell::new(self.get())`) when `with_semantic_ids`, otherwise reset to the default (`Cell::new(T::default())` = `NodeId::DUMMY` / `None`). So the derive emits a plain `clone_in_impl(&self.node_id, …)` per id field — no per-field `if/else`.
- **`Cell::clone_in_impl` is `#[inline(never)]`** so the (for some consumers dead) preserve branch isn't inlined at every id-field site — see Results.

## Results

Measured `f736d87e77` → `db9f2ab41a` on this branch (release, stripped, fat-LTO):

| | before | after | Δ |
|---|--:|--:|--:|
| `oxc_ast` generated `CloneIn` (source lines) | 7,180 | 5,581 | **−1,599 (−22%)** |
| oxlint binary | 14,192,816 B | 14,126,656 B | **−66,160 B (−64.6 KiB)** |
| napi transform cdylib (`--features allocator`) | 3,633,312 B | 3,633,312 B | **0 (neutral)** |

The two binaries move differently because they clone differently:

- **oxlint / rolldown clone *with* semantic ids** (react compiler on `TSType`; whole-`Program` clones). They already carried chunks of both traversals; merging dedups them → **−64.6 KiB**.
- **napi transform / parse clone *without* ids** — `oxc_transformer` never calls `clone_in_with_semantic_ids`, so before this PR `--gc-sections` dropped that whole half. The merged traversal would force the preserve branch live at every id field (~+16 KiB); `#[inline(never)]` on the `Cell` leaf outlines it to one function per `Cell<T>`, keeping these binaries **flat**.

## Behavior & perf

Behavior is identical by construction — `clone_in` resets ids (`Cell::new(None)` / `Cell::new(DUMMY)`), `clone_in_with_semantic_ids` preserves them. The runtime flag is loop-invariant and well predicted; the `#[inline(never)]` leaf adds one outlined call per id-cell on the clone path (expected negligible — worth a benchmark spot-check). Generated files were produced by `just ast`.

---
🤖 AI-assisted (Claude Code), reviewed and measured by the author.
