### PR TITLE
chore(ci): remove global npm upgrade in release workflows

### DIFF
--- a/.github/workflows/release_apps.yml
+++ b/.github/workflows/release_apps.yml
@@ -337,8 +337,6 @@ jobs:
         run: |
           cp -r apps/oxlint/dist-pkg-plugin-eslint/. ${plugin_eslint_package_path}/
 
-      - run: npm install -g npm@latest # For trusted publishing support
-
       - name: Check Publish
         run: |
           node .github/scripts/check-npm-packages.js "${npm_dir}/*" "${package_path}"
@@ -623,8 +621,6 @@ jobs:
 
       - name: Copy dist files to npm package
         run: cp -r apps/oxfmt/dist npm/oxfmt/dist
-
-      - run: npm install -g npm@latest # For trusted publishing support
 
       - name: Check Publish
         run: node .github/scripts/check-npm-packages.js "${npm_dir}/*" "${package_path}"

--- a/.github/workflows/release_runtime.yml
+++ b/.github/workflows/release_runtime.yml
@@ -43,8 +43,6 @@ jobs:
 
       - uses: oxc-project/setup-node@4c588e9266bd930b6ddc34307df0659ed511d187 # v1.3.1
 
-      - run: npm install -g npm@latest # For trusted publishing support
-
       # Trusted publishing is configured, publish token is not required.
       - name: Trusted Publish
         working-directory: npm/runtime

--- a/.github/workflows/release_types.yml
+++ b/.github/workflows/release_types.yml
@@ -43,8 +43,6 @@ jobs:
 
       - uses: oxc-project/setup-node@4c588e9266bd930b6ddc34307df0659ed511d187 # v1.3.1
 
-      - run: npm install -g npm@latest # For trusted publishing support
-
       # Trusted publishing is configured, publish token is not required.
       - name: Trusted Publish
         working-directory: npm/oxc-types

--- a/.github/workflows/reusable_release_napi.yml
+++ b/.github/workflows/reusable_release_napi.yml
@@ -249,8 +249,6 @@ jobs:
       - run: pnpm -C ${package_path} build-browser-bundle --npmDir ../../${npm_dir}
         if: ${{ inputs.name == 'parser' }}
 
-      - run: npm install -g npm@latest # For trusted publishing support
-
       - name: Check Publish
         run: node .github/scripts/check-npm-packages.js "${npm_dir}/*" "${package_path}"
 


### PR DESCRIPTION
Publishing across all release workflows is done exclusively via `pnpm publish` (directly, or through `publish-if-needed.sh` and `check-npm-packages.js`). Trusted publishing (OIDC) support therefore depends on the pnpm version, not the global npm CLI, so the `npm install -g npm@latest` step was dead weight.

Removed all 5 occurrences of:

```yaml
- run: npm install -g npm@latest # For trusted publishing support
```

from:

- `.github/workflows/reusable_release_napi.yml`
- `.github/workflows/release_types.yml`
- `.github/workflows/release_runtime.yml`
- `.github/workflows/release_apps.yml` (2 occurrences)

The `id-token: write` permission that actually enables trusted publishing is untouched.