### PR TITLE
refactor(react_compiler): remove dead code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1007,12 +1007,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0b3ba31f6dc772cc8221ce81dbbbd64fa1e668255a6737d95eeace59b5a8823"
 
 [[package]]
-name = "hmac-sha256"
-version = "1.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
-
-[[package]]
 name = "http"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2438,7 +2432,6 @@ version = "0.139.0"
 dependencies = [
  "convert_case",
  "cow-utils",
- "hmac-sha256",
  "indexmap",
  "insta",
  "oxc_allocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -216,7 +216,6 @@ futures = "0.3.32" # Async utilities
 handlebars = "6.4.2" # Template engine
 hashbrown = { version = "0.17.1", default-features = false } # Fast hash map
 hmac-sha1-compact = "1.1.7" # Self-contained, zero-dependency SHA-1
-hmac-sha256 = "1" # Self-contained, zero-dependency SHA-256 (react_compiler reactive-scope cache keys)
 humansize = "2.1.3" # Human-readable sizes
 ignore = "0.4.27" # Gitignore matching
 insta = "1.48.0" # Snapshot testing

--- a/crates/oxc_react_compiler/Cargo.toml
+++ b/crates/oxc_react_compiler/Cargo.toml
@@ -39,7 +39,6 @@ oxc_syntax = { workspace = true }
 
 # External crates the vendored React Compiler modules (`src/react_compiler*`) depend
 # on. The compiler core is frontend-agnostic — serde/indexmap/hashing only, no oxc.
-hmac-sha256 = { workspace = true }
 indexmap = { workspace = true }
 rustc-hash = { workspace = true }
 cow-utils = { workspace = true }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
@@ -381,20 +381,6 @@ impl InferenceState {
         }
     }
 
-    #[allow(dead_code)]
-    fn kind_opt(&self, place_id: IdentifierId) -> Option<AbstractValue> {
-        let values = self.variables.get(&place_id)?;
-        let mut merged_kind: Option<AbstractValue> = None;
-        for value_id in values {
-            let kind = self.values.get(value_id)?;
-            merged_kind = Some(match merged_kind {
-                Some(prev) => merge_abstract_values(&prev, kind),
-                None => kind.clone(),
-            });
-        }
-        merged_kind
-    }
-
     fn kind(&self, place_id: IdentifierId) -> AbstractValue {
         self.kind_with_span(place_id, None)
     }
@@ -428,16 +414,6 @@ impl InferenceState {
         // Note: In TS, this also transitively freezes FunctionExpression captures
         // if enableTransitivelyFreezeFunctionExpressions is set. We skip that here
         // since we don't have access to the function arena from within state.
-    }
-
-    #[allow(dead_code)]
-    fn mutate(
-        &self,
-        variant: MutateVariant,
-        place_id: IdentifierId,
-        env: &Environment,
-    ) -> MutationResult {
-        self.mutate_with_span(variant, place_id, env, None)
     }
 
     fn mutate_with_span(

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_ranges.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_ranges.rs
@@ -37,9 +37,7 @@ use crate::react_compiler_hir::{
 // =============================================================================
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-#[allow(dead_code)]
 enum MutationKind {
-    None = 0,
     Conditional = 1,
     Definite = 2,
 }
@@ -1086,7 +1084,6 @@ fn collect_param_effects(
                     reason: node.mutation_reason.clone(),
                 });
             }
-            MutationKind::None => {}
         }
     }
 
@@ -1102,7 +1099,6 @@ fn collect_param_effects(
                     value: Place { span: transitive.span, ..place.clone() },
                 });
             }
-            MutationKind::None => {}
         }
     }
 }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
@@ -69,13 +69,8 @@ pub fn propagate_scope_dependencies_hir<'a>(func: &mut HirFunction<'a>, env: &mu
         merged_temporaries.insert(k, v);
     }
 
-    let scope_deps = collect_dependencies(
-        func,
-        env,
-        &used_outside_declaring_scope,
-        &merged_temporaries,
-        &processed_instrs_in_optional,
-    );
+    let scope_deps =
+        collect_dependencies(func, env, &merged_temporaries, &processed_instrs_in_optional);
 
     // Derive the minimal set of hoistable dependencies for each scope.
     for (scope_id, deps) in &scope_deps {
@@ -723,12 +718,8 @@ fn traverse_optional_block<'a>(
 struct PropertyPathNode<'a> {
     properties: FxHashMap<PropertyLiteral<'a>, usize>, // index into registry
     optional_properties: FxHashMap<PropertyLiteral<'a>, usize>, // index into registry
-    #[allow(dead_code)]
-    parent: Option<usize>,
     full_path: ReactiveScopeDependency<'a>,
     has_optional: bool,
-    #[allow(dead_code)]
-    root: Option<IdentifierId>,
 }
 
 struct PropertyPathRegistry<'a> {
@@ -754,7 +745,6 @@ impl<'a> PropertyPathRegistry<'a> {
         self.nodes.push(PropertyPathNode {
             properties: FxHashMap::default(),
             optional_properties: FxHashMap::default(),
-            parent: None,
             full_path: ReactiveScopeDependency {
                 identifier: identifier_id,
                 reactive,
@@ -762,7 +752,6 @@ impl<'a> PropertyPathRegistry<'a> {
                 span,
             },
             has_optional: false,
-            root: Some(identifier_id),
         });
         self.roots.insert(identifier_id, idx);
         idx
@@ -790,7 +779,6 @@ impl<'a> PropertyPathRegistry<'a> {
         self.nodes.push(PropertyPathNode {
             properties: FxHashMap::default(),
             optional_properties: FxHashMap::default(),
-            parent: Some(parent_idx),
             full_path: ReactiveScopeDependency {
                 identifier: parent_full_path.identifier,
                 reactive: parent_full_path.reactive,
@@ -798,7 +786,6 @@ impl<'a> PropertyPathRegistry<'a> {
                 span: entry.span,
             },
             has_optional: parent_has_optional || entry.optional,
-            root: None,
         });
         if entry.optional {
             self.nodes[parent_idx].optional_properties.insert(map_key, idx);
@@ -883,41 +870,6 @@ struct BlockInfo {
     assumed_non_null_objects: BTreeSet<usize>, // indices into PropertyPathRegistry
 }
 
-#[allow(dead_code)]
-fn collect_hoistable_property_loads<'a>(
-    func: &HirFunction<'a>,
-    env: &Environment<'a>,
-    temporaries: &FxHashMap<IdentifierId, ReactiveScopeDependency<'a>>,
-    hoistable_from_optionals: &FxHashMap<BlockId, ReactiveScopeDependency<'a>>,
-) -> FxHashMap<BlockId, BlockInfo> {
-    let mut registry = PropertyPathRegistry::new();
-    let known_immutable_identifiers: FxHashSet<IdentifierId> = if func.fn_type
-        == ReactFunctionType::Component
-        || func.fn_type == ReactFunctionType::Hook
-    {
-        func.params
-            .iter()
-            .filter_map(|p| match p {
-                ParamPattern::Place(place) => Some(place.identifier),
-                _ => None,
-            })
-            .collect()
-    } else {
-        FxHashSet::default()
-    };
-
-    let assumed_invoked_fns = get_assumed_invoked_functions(func, env);
-    let ctx = CollectHoistableContext {
-        temporaries,
-        known_immutable_identifiers: &known_immutable_identifiers,
-        hoistable_from_optionals,
-        nested_fn_immutable_context: None,
-        assumed_invoked_fns: &assumed_invoked_fns,
-    };
-
-    collect_hoistable_property_loads_impl(func, env, &ctx, &mut registry)
-}
-
 struct CollectHoistableContext<'a, 'e> {
     temporaries: &'e FxHashMap<IdentifierId, ReactiveScopeDependency<'a>>,
     known_immutable_identifiers: &'e FxHashSet<IdentifierId>,
@@ -973,19 +925,6 @@ fn get_maybe_non_null_in_instruction<'a>(
         }
         _ => None,
     }
-}
-
-#[allow(dead_code)]
-fn collect_hoistable_property_loads_impl<'a>(
-    func: &HirFunction<'a>,
-    env: &Environment<'a>,
-    ctx: &CollectHoistableContext<'a, '_>,
-    registry: &mut PropertyPathRegistry<'a>,
-) -> FxHashMap<BlockId, BlockInfo> {
-    let nodes = collect_non_nulls_in_blocks(func, env, ctx, registry);
-    let working = propagate_non_null(func, &nodes, registry);
-    // Return the propagated results, converting FxHashSet<usize> back to BlockInfo
-    working.into_iter().map(|(k, v)| (k, BlockInfo { assumed_non_null_objects: v })).collect()
 }
 
 /// Corresponds to TS `getAssumedInvokedFunctions`.
@@ -1427,23 +1366,6 @@ fn collect_hoistable_and_propagate<'a>(
     (working, registry)
 }
 
-// Restructured version used by the main entry point
-#[allow(dead_code)]
-fn key_by_scope_id(
-    func: &HirFunction,
-    block_keyed: &FxHashMap<BlockId, BlockInfo>,
-) -> FxHashMap<ScopeId, BlockInfo> {
-    let mut keyed: FxHashMap<ScopeId, BlockInfo> = FxHashMap::default();
-    for (_block_id, block) in &func.body.blocks {
-        if let Terminal::Scope { scope, block: inner_block, .. } = &block.terminal {
-            if let Some(info) = block_keyed.get(inner_block) {
-                keyed.insert(*scope, info.clone());
-            }
-        }
-    }
-    keyed
-}
-
 // =============================================================================
 // DeriveMinimalDependenciesHIR
 // =============================================================================
@@ -1667,15 +1589,12 @@ struct DependencyCollectionContext<'a, 'e> {
     dep_stack: Vec<Vec<ReactiveScopeDependency<'a>>>,
     deps: FxIndexMap<ScopeId, Vec<ReactiveScopeDependency<'a>>>,
     temporaries: &'e FxHashMap<IdentifierId, ReactiveScopeDependency<'a>>,
-    #[allow(dead_code)]
-    temporaries_used_outside_scope: &'e FxHashSet<DeclarationId>,
     processed_instrs_in_optional: &'e FxHashSet<ProcessedInstr>,
     inner_fn_context: Option<EvaluationOrder>,
 }
 
 impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
     fn new(
-        temporaries_used_outside_scope: &'e FxHashSet<DeclarationId>,
         temporaries: &'e FxHashMap<IdentifierId, ReactiveScopeDependency<'a>>,
         processed_instrs_in_optional: &'e FxHashSet<ProcessedInstr>,
     ) -> Self {
@@ -1686,7 +1605,6 @@ impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
             dep_stack: Vec::new(),
             deps: FxIndexMap::default(),
             temporaries,
-            temporaries_used_outside_scope,
             processed_instrs_in_optional,
             inner_fn_context: None,
         }
@@ -2007,15 +1925,10 @@ fn handle_instruction<'a>(
 fn collect_dependencies<'a>(
     func: &HirFunction<'a>,
     env: &mut Environment<'a>,
-    used_outside_declaring_scope: &FxHashSet<DeclarationId>,
     temporaries: &FxHashMap<IdentifierId, ReactiveScopeDependency<'a>>,
     processed_instrs_in_optional: &FxHashSet<ProcessedInstr>,
 ) -> FxIndexMap<ScopeId, Vec<ReactiveScopeDependency<'a>>> {
-    let mut ctx = DependencyCollectionContext::new(
-        used_outside_declaring_scope,
-        temporaries,
-        processed_instrs_in_optional,
-    );
+    let mut ctx = DependencyCollectionContext::new(temporaries, processed_instrs_in_optional);
 
     // Declare params
     for param in &func.params {

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/outline_jsx.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/outline_jsx.rs
@@ -40,8 +40,6 @@ pub fn outline_jsx<'a>(func: &mut HirFunction<'a>, env: &mut Environment<'a>) {
 /// Data about a JSX instruction for outlining
 struct JsxInstrInfo {
     instr_idx: usize, // index into func.instructions
-    #[allow(dead_code)]
-    instr_id: InstructionId, // the InstructionId
     lvalue_id: IdentifierId,
     eval_order: EvaluationOrder,
 }
@@ -150,12 +148,7 @@ fn outline_jsx_impl<'a>(
                         jsx_group.clear();
                         children_ids.clear();
                     }
-                    jsx_group.push(JsxInstrInfo {
-                        instr_idx,
-                        instr_id: InstructionId(instr_idx as u32),
-                        lvalue_id,
-                        eval_order,
-                    });
+                    jsx_group.push(JsxInstrInfo { instr_idx, lvalue_id, eval_order });
                     for child_id in child_ids {
                         children_ids.insert(child_id);
                     }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/build_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/build_reactive_function.rs
@@ -66,8 +66,6 @@ enum ControlFlowTarget {
     },
     Loop {
         block: BlockId,
-        #[allow(dead_code)]
-        owns_block: bool,
         continue_block: BlockId,
         loop_block: Option<BlockId>,
         owns_loop: bool,
@@ -168,7 +166,6 @@ impl<'a, 'h> Context<'a, 'h> {
     ) -> Result<u32, OxcDiagnostic> {
         let id = self.next_schedule_id;
         self.next_schedule_id += 1;
-        let owns_block = !self.scheduled.contains(&fallthrough_block);
         self.scheduled.insert(fallthrough_block);
         if self.scheduled.contains(&continue_block) {
             return Err(ErrorCategory::Invariant.diagnostic(format!(
@@ -185,7 +182,6 @@ impl<'a, 'h> Context<'a, 'h> {
 
         self.control_flow_stack.push(ControlFlowTarget::Loop {
             block: fallthrough_block,
-            owns_block,
             continue_block,
             loop_block,
             owns_loop,

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
@@ -37,7 +37,6 @@ use crate::react_compiler_hir::PlaceOrSpread;
 use crate::react_compiler_hir::PrimitiveValue;
 use crate::react_compiler_hir::PropertyLiteral;
 use crate::react_compiler_hir::ScopeId;
-use crate::react_compiler_hir::SpreadPattern;
 use crate::react_compiler_hir::TypeCast;
 use crate::react_compiler_hir::environment::{Environment, OutputMode};
 use crate::react_compiler_hir::reactive::PrunedReactiveScopeBlock;
@@ -70,18 +69,6 @@ pub const EARLY_RETURN_SENTINEL: &str = "react.early_return_sentinel";
 /// FBT tags whose children get special codegen treatment.
 const SINGLE_CHILD_FBT_TAGS: &[&str] = &["fbt:param", "fbs:param"];
 
-/// Computes the Fast Refresh source hash used to bust the memo cache when the
-/// source file changes. Matches the TS compiler's
-/// `createHmac('sha256', code).digest('hex')`: an HMAC-SHA256 keyed by the
-/// source code, hashing empty data.
-///
-/// Not yet wired into the oxc emission path (Fast Refresh hashing is deferred);
-/// kept with its verified test as the primitive the port will reuse.
-#[allow(dead_code)]
-fn source_file_hash(code: &str) -> String {
-    hmac_sha256::HMAC::mac(b"", code.as_bytes()).iter().map(|b| format!("{b:02x}")).collect()
-}
-
 /// Top-level entry point: produces an oxc-shaped
 /// [`crate::react_compiler::entrypoint::compile_result::CodegenFunction`] from a
 /// reactive function, building oxc AST directly via [`oxc_ast::builder::AstBuilder`].
@@ -95,14 +82,12 @@ pub fn codegen_function<'a>(
     use crate::react_compiler::entrypoint::compile_result::CodegenFunction as OxcCodegenFunction;
     use oxc_span::SPAN;
 
-    let fn_name = func.id.unwrap_or(Ident::from("[[ anonymous ]]"));
     // Outlined functions reuse the same `fbtOperands` set as the main function
     // (see TS `codegenFunction`), so keep a copy before it is moved into the context.
     let fbt_operands_for_outlined = fbt_operands.clone();
     let mut cx = OxcContext::new(
         oxc_ast::builder::AstBuilder::new(ast.allocator()),
         env,
-        fn_name,
         unique_identifiers,
         fbt_operands,
     );
@@ -279,8 +264,6 @@ fn ox_clone_temporaries<'a>(
 struct OxcContext<'a, 'env> {
     ast: oxc_ast::builder::AstBuilder<'a>,
     env: &'env mut Environment<'a>,
-    #[allow(dead_code)]
-    fn_name: Ident<'a>,
     next_cache_index: u32,
     declarations: FxHashSet<DeclarationId>,
     temp: OxcTemporaries<'a>,
@@ -295,14 +278,12 @@ impl<'a, 'env> OxcContext<'a, 'env> {
     fn new(
         ast: oxc_ast::builder::AstBuilder<'a>,
         env: &'env mut Environment<'a>,
-        fn_name: Ident<'a>,
         unique_identifiers: IdentHashSet<'a>,
         fbt_operands: FxHashSet<IdentifierId>,
     ) -> Self {
         OxcContext {
             ast,
             env,
-            fn_name,
             next_cache_index: 0,
             declarations: FxHashSet::default(),
             temp: FxHashMap::default(),
@@ -376,10 +357,6 @@ const STRING_REQUIRES_EXPR_CONTAINER_CHARS: &str = "\"\\";
 enum LvalueRef<'a> {
     Place(&'a Place),
     Pattern(&'a Pattern<'a>),
-    // Constructed once nested spread/rest lvalue emission is ported; the match arm
-    // in `ox_codegen_lvalue` already handles it.
-    #[allow(dead_code)]
-    Spread(&'a SpreadPattern),
 }
 
 fn ox_number<'a>(ast: &oxc_ast::builder::AstBuilder<'a>, value: f64) -> oxc::Expression<'a> {
@@ -2274,7 +2251,6 @@ fn ox_codegen_lvalue<'a>(
             Pattern::Array(arr) => ox_codegen_array_pattern(cx, arr),
             Pattern::Object(obj) => ox_codegen_object_pattern(cx, obj),
         },
-        LvalueRef::Spread(spread) => ox_binding_for_identifier(cx, spread.place.identifier),
     }
 }
 
@@ -2721,11 +2697,9 @@ fn ox_codegen_inner_function<'a>(
     cx: &mut OxcContext<'a, '_>,
     reactive_fn: &ReactiveFunction<'a>,
 ) -> Result<OxcCompiledFunction<'a>, OxcDiagnostic> {
-    let fn_name = reactive_fn.id.unwrap_or(Ident::from("[[ anonymous ]]"));
     let mut inner_cx = OxcContext::new(
         oxc_ast::builder::AstBuilder::new(cx.ast.allocator()),
         cx.env,
-        fn_name,
         cx.unique_identifiers.clone(),
         cx.fbt_operands.clone(),
     );

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/visitors.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/visitors.rs
@@ -274,7 +274,7 @@ pub fn visit_reactive_function<'a, V: ReactiveFunctionVisitor<'a>>(
 }
 
 // =============================================================================
-// Transformed / TransformedValue enums
+// Transformed enum
 // =============================================================================
 
 /// Result of transforming a ReactiveStatement.
@@ -284,14 +284,6 @@ pub enum Transformed<T> {
     Remove,
     Replace(T),
     ReplaceMany(Vec<T>),
-}
-
-/// Result of transforming a ReactiveValue.
-/// TS: `TransformedValue`
-#[allow(dead_code)]
-pub enum TransformedValue<'a> {
-    Keep,
-    Replace(ReactiveValue<'a>),
 }
 
 // =============================================================================
@@ -356,34 +348,16 @@ pub trait ReactiveFunctionTransform<'a> {
     ) -> Result<(), OxcDiagnostic> {
         match value {
             ReactiveValue::OptionalExpression { value: inner, .. } => {
-                let next = self.transform_value(id, inner, state)?;
-                if let TransformedValue::Replace(new_value) = next {
-                    **inner = new_value;
-                }
+                self.visit_value(id, inner, state)?;
             }
             ReactiveValue::LogicalExpression { left, right, .. } => {
-                let next_left = self.transform_value(id, left, state)?;
-                if let TransformedValue::Replace(new_value) = next_left {
-                    **left = new_value;
-                }
-                let next_right = self.transform_value(id, right, state)?;
-                if let TransformedValue::Replace(new_value) = next_right {
-                    **right = new_value;
-                }
+                self.visit_value(id, left, state)?;
+                self.visit_value(id, right, state)?;
             }
             ReactiveValue::ConditionalExpression { test, consequent, alternate, .. } => {
-                let next_test = self.transform_value(id, test, state)?;
-                if let TransformedValue::Replace(new_value) = next_test {
-                    **test = new_value;
-                }
-                let next_cons = self.transform_value(id, consequent, state)?;
-                if let TransformedValue::Replace(new_value) = next_cons {
-                    **consequent = new_value;
-                }
-                let next_alt = self.transform_value(id, alternate, state)?;
-                if let TransformedValue::Replace(new_value) = next_alt {
-                    **alternate = new_value;
-                }
+                self.visit_value(id, test, state)?;
+                self.visit_value(id, consequent, state)?;
+                self.visit_value(id, alternate, state)?;
             }
             ReactiveValue::SequenceExpression {
                 instructions, id: seq_id, value: inner, ..
@@ -392,10 +366,7 @@ pub trait ReactiveFunctionTransform<'a> {
                 for instr in instructions.iter_mut() {
                     self.visit_instruction(instr, state)?;
                 }
-                let next = self.transform_value(seq_id, inner, state)?;
-                if let TransformedValue::Replace(new_value) = next {
-                    **inner = new_value;
-                }
+                self.visit_value(seq_id, inner, state)?;
             }
             ReactiveValue::Instruction(instr_value) => {
                 // Collect operands before visiting to avoid borrow conflict
@@ -417,16 +388,6 @@ pub trait ReactiveFunctionTransform<'a> {
         self.traverse_instruction(instruction, state)
     }
 
-    fn transform_value(
-        &mut self,
-        id: EvaluationOrder,
-        value: &mut ReactiveValue<'a>,
-        state: &mut Self::State,
-    ) -> Result<TransformedValue<'a>, OxcDiagnostic> {
-        self.visit_value(id, value, state)?;
-        Ok(TransformedValue::Keep)
-    }
-
     fn traverse_instruction(
         &mut self,
         instruction: &mut ReactiveInstruction<'a>,
@@ -443,10 +404,7 @@ pub trait ReactiveFunctionTransform<'a> {
                 self.visit_lvalue(instruction.id, &place, state)?;
             }
         }
-        let next_value = self.transform_value(instruction.id, &mut instruction.value, state)?;
-        if let TransformedValue::Replace(new_value) = next_value {
-            instruction.value = new_value;
-        }
+        self.visit_value(instruction.id, &mut instruction.value, state)?;
         Ok(())
     }
 
@@ -476,56 +434,32 @@ pub trait ReactiveFunctionTransform<'a> {
             }
             ReactiveTerminal::For { init, test, update, loop_block, id, .. } => {
                 let id = *id;
-                let next_init = self.transform_value(id, init, state)?;
-                if let TransformedValue::Replace(new_value) = next_init {
-                    *init = new_value;
-                }
-                let next_test = self.transform_value(id, test, state)?;
-                if let TransformedValue::Replace(new_value) = next_test {
-                    *test = new_value;
-                }
+                self.visit_value(id, init, state)?;
+                self.visit_value(id, test, state)?;
                 if let Some(update) = update {
-                    let next_update = self.transform_value(id, update, state)?;
-                    if let TransformedValue::Replace(new_value) = next_update {
-                        *update = new_value;
-                    }
+                    self.visit_value(id, update, state)?;
                 }
                 self.visit_block(loop_block, state)?;
             }
             ReactiveTerminal::ForOf { init, test, loop_block, id, .. } => {
                 let id = *id;
-                let next_init = self.transform_value(id, init, state)?;
-                if let TransformedValue::Replace(new_value) = next_init {
-                    *init = new_value;
-                }
-                let next_test = self.transform_value(id, test, state)?;
-                if let TransformedValue::Replace(new_value) = next_test {
-                    *test = new_value;
-                }
+                self.visit_value(id, init, state)?;
+                self.visit_value(id, test, state)?;
                 self.visit_block(loop_block, state)?;
             }
             ReactiveTerminal::ForIn { init, loop_block, id, .. } => {
                 let id = *id;
-                let next_init = self.transform_value(id, init, state)?;
-                if let TransformedValue::Replace(new_value) = next_init {
-                    *init = new_value;
-                }
+                self.visit_value(id, init, state)?;
                 self.visit_block(loop_block, state)?;
             }
             ReactiveTerminal::DoWhile { loop_block, test, id, .. } => {
                 let id = *id;
                 self.visit_block(loop_block, state)?;
-                let next_test = self.transform_value(id, test, state)?;
-                if let TransformedValue::Replace(new_value) = next_test {
-                    *test = new_value;
-                }
+                self.visit_value(id, test, state)?;
             }
             ReactiveTerminal::While { test, loop_block, id, .. } => {
                 let id = *id;
-                let next_test = self.transform_value(id, test, state)?;
-                if let TransformedValue::Replace(new_value) = next_test {
-                    *test = new_value;
-                }
+                self.visit_value(id, test, state)?;
                 self.visit_block(loop_block, state)?;
             }
             ReactiveTerminal::If { test, consequent, alternate, id, .. } => {

--- a/crates/oxc_react_compiler/src/react_compiler_ssa/enter_ssa.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_ssa/enter_ssa.rs
@@ -113,18 +113,6 @@ impl SSABuilder {
         })
     }
 
-    #[allow(dead_code)]
-    fn define_context(
-        &mut self,
-        old_place: &Place,
-        env: &mut Environment,
-    ) -> Result<Place, OxcDiagnostic> {
-        let old_id = old_place.identifier;
-        let new_place = self.define_place(old_place, env)?;
-        self.context.insert(old_id);
-        Ok(new_place)
-    }
-
     /// A function's context places capture a *binding*, not a value: the
     /// variable is only read when the function is later called, so a context
     /// place may reference a binding that is declared after the function

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_exhaustive_dependencies.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_exhaustive_dependencies.rs
@@ -53,12 +53,10 @@ pub fn validate_exhaustive_dependencies(
     }
 
     let mut start_memo: Option<StartMemoInfo> = None;
-    let mut memo_locals: FxHashSet<IdentifierId> = FxHashSet::default();
 
     // Callbacks struct holding the mutable state
     let mut callbacks = Callbacks {
         start_memo: &mut start_memo,
-        memo_locals: &mut memo_locals,
         validate_memo: env.config.validate_exhaustive_memoization_dependencies,
         validate_effect: env.config.validate_exhaustive_effect_dependencies,
         reactive: &reactive,
@@ -105,8 +103,6 @@ struct StartMemoInfo<'a> {
     manual_memo_id: u32,
     deps: Option<Vec<ManualMemoDependency<'a>>>,
     deps_span: Option<Option<Span>>,
-    #[allow(dead_code)]
-    span: Option<Span>,
 }
 
 /// A temporary value tracked during dependency collection
@@ -170,8 +166,6 @@ fn path_to_string(path: &[DependencyPathEntry]) -> String {
 /// Callbacks for StartMemoize/FinishMemoize/Effect events
 struct Callbacks<'s, 'a> {
     start_memo: &'s mut Option<StartMemoInfo<'a>>,
-    #[allow(dead_code)]
-    memo_locals: &'s mut FxHashSet<IdentifierId>,
     validate_memo: bool,
     validate_effect: ExhaustiveEffectDepsMode,
     reactive: &'s FxHashSet<IdentifierId>,
@@ -720,16 +714,13 @@ fn collect_dependencies<'a>(
                     temporaries.insert(lvalue_id, function_deps.clone());
                     add_dependency(&function_deps, &mut dependencies, &mut dep_keys, &locals);
                 }
-                InstructionValue::StartMemoize {
-                    manual_memo_id, deps, deps_span, span, ..
-                } => {
+                InstructionValue::StartMemoize { manual_memo_id, deps, deps_span, .. } => {
                     if let Some(cb) = callbacks.as_mut() {
                         // onStartMemoize — mirrors TS behavior of clearing dependencies and locals
                         *cb.start_memo = Some(StartMemoInfo {
                             manual_memo_id: *manual_memo_id,
                             deps: deps.clone(),
                             deps_span: *deps_span,
-                            span: *span,
                         });
                         // Save current state and clear, matching TS which clears the shared
                         // dependencies/locals sets on StartMemoize


### PR DESCRIPTION
Removes all compiler-flagged dead code from `oxc_react_compiler`.

## Removed

- **Superseded functions** (`propagate_scope_dependencies_hir`): `collect_hoistable_property_loads`, `collect_hoistable_property_loads_impl`, `key_by_scope_id` — the live pipeline uses the restructured `collect_hoistable_and_propagate` instead.
- **Unused methods/wrappers**: `kind_opt`, `mutate`, `define_context`.
- **Unused fields** (removed with their construction sites): `PropertyPathNode::{parent, root}`, `DependencyCollectionContext::temporaries_used_outside_scope` (cascaded cleanly through `collect_dependencies`), `JsxInstrInfo::instr_id`, `ControlFlowTarget::Loop::owns_block`, `OxcContext::fn_name`, `StartMemoInfo::span`, `Callbacks::memo_locals`.
- **Unused enum variant**: `MutationKind::None` (the `Ord` ordering of the remaining variants is preserved).
- **Dormant scaffolding**: `TransformedValue::Replace` — collapsed the base traversal's replace path down to direct `visit_value` calls (the 11 transform passes are unaffected) — and `LvalueRef::Spread` plus its codegen match arm.
- **`hmac-sha256` dependency** — orphaned once `source_file_hash` was removed; dropped from the crate and workspace manifests.

Pre-existing `#[allow(dead_code)]` markers on live-but-unread code were left intact, so the diff is purely dead-code removal. Snapshot conformance (over the upstream fixture corpus) and the transform integration tests pass unchanged.
