### PR TITLE
refactor(react_compiler): use oxc utilities instead of reimplementations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2439,6 +2439,7 @@ dependencies = [
  "oxc_ast_visit",
  "oxc_codegen",
  "oxc_diagnostics",
+ "oxc_ecmascript",
  "oxc_parser",
  "oxc_semantic",
  "oxc_span",

--- a/crates/oxc_react_compiler/Cargo.toml
+++ b/crates/oxc_react_compiler/Cargo.toml
@@ -32,10 +32,11 @@ oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }
 oxc_diagnostics = { workspace = true }
+oxc_ecmascript = { workspace = true }
 oxc_semantic = { workspace = true }
 oxc_span = { workspace = true }
 oxc_str = { workspace = true }
-oxc_syntax = { workspace = true }
+oxc_syntax = { workspace = true, features = ["to_js_string"] }
 
 # External crates the vendored React Compiler modules (`src/react_compiler*`) depend
 # on. The compiler core is frontend-agnostic — serde/indexmap/hashing only, no oxc.

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -27,6 +27,8 @@ use crate::react_compiler_lowering::FunctionNode;
 use crate::scope::ScopeResolver;
 use oxc_allocator::{Allocator, ArenaBox, ArenaVec, CloneIn, GetAddress, GetAllocator};
 use oxc_semantic::{AstNodes, NodeId, Scoping, Semantic};
+use oxc_syntax::identifier::is_identifier_name;
+use oxc_syntax::keyword::is_reserved_keyword;
 use oxc_syntax::scope::ScopeId;
 use oxc_syntax::symbol::SymbolId;
 
@@ -193,69 +195,10 @@ fn parse_dynamic_gating_directive(value: &str) -> Option<&str> {
     Some(condition)
 }
 
-/// Simple check for valid JavaScript identifier (alphanumeric + underscore + $, starting with letter/$/_ )
-/// Also rejects reserved words like `true`, `false`, `null`, etc.
+/// Check if a string is a valid JavaScript identifier that is not a reserved
+/// word (matching Babel's `isValidIdentifier`).
 fn is_valid_identifier(s: &str) -> bool {
-    if s.is_empty() {
-        return false;
-    }
-    let mut chars = s.chars();
-    let first = chars.next().unwrap();
-    if !first.is_alphabetic() && first != '_' && first != '$' {
-        return false;
-    }
-    if !chars.all(|c| c.is_alphanumeric() || c == '_' || c == '$') {
-        return false;
-    }
-    // Check for reserved words (matching Babel's t.isValidIdentifier)
-    !matches!(
-        s,
-        "break"
-            | "case"
-            | "catch"
-            | "continue"
-            | "debugger"
-            | "default"
-            | "do"
-            | "else"
-            | "finally"
-            | "for"
-            | "function"
-            | "if"
-            | "in"
-            | "instanceof"
-            | "new"
-            | "return"
-            | "switch"
-            | "this"
-            | "throw"
-            | "try"
-            | "typeof"
-            | "var"
-            | "void"
-            | "while"
-            | "with"
-            | "class"
-            | "const"
-            | "enum"
-            | "export"
-            | "extends"
-            | "import"
-            | "super"
-            | "implements"
-            | "interface"
-            | "let"
-            | "package"
-            | "private"
-            | "protected"
-            | "public"
-            | "static"
-            | "yield"
-            | "null"
-            | "true"
-            | "false"
-            | "delete"
-    )
+    is_identifier_name(s) && !is_reserved_keyword(s)
 }
 
 // -----------------------------------------------------------------------

--- a/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
@@ -15,6 +15,7 @@ use oxc_ast::ast as oxc;
 use oxc_diagnostics::OxcDiagnostic;
 pub use oxc_span::Span;
 use oxc_str::{Ident, Str};
+use oxc_syntax::number::ToJsString;
 pub use raw::RawTypeCategory;
 pub use reactive::*;
 
@@ -102,50 +103,7 @@ impl std::hash::Hash for FloatValue {
 
 impl std::fmt::Display for FloatValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", format_js_number(self.value()))
-    }
-}
-
-/// Format an f64 the way JavaScript's `Number.prototype.toString()` does.
-///
-/// Key differences from Rust's default `Display`:
-/// - Uses scientific notation for |x| >= 1e21 (e.g. `1e+21`, `2.18739127891275e+22`)
-/// - Uses scientific notation for 0 < |x| < 1e-6 (e.g. `1e-7`, `1.5e-8`)
-/// - Uses minimal significant digits that round-trip to the same f64
-/// - Formats -0 as "0"
-pub fn format_js_number(n: f64) -> String {
-    if n.is_nan() {
-        return "NaN".to_string();
-    }
-    if n.is_infinite() {
-        return if n > 0.0 { "Infinity".to_string() } else { "-Infinity".to_string() };
-    }
-    if n == 0.0 {
-        return "0".to_string();
-    }
-
-    let abs = n.abs();
-    let sign = if n < 0.0 { "-" } else { "" };
-
-    if abs >= 1e21 || (abs > 0.0 && abs < 1e-6) {
-        // Use scientific notation matching JS format: coefficient + "e+" or "e-" + exponent
-        // Rust's {:e} uses "e" (lowercase) like JS, but formats as e.g. "1.5e21" not "1.5e+21"
-        let formatted = format!("{:e}", abs);
-        // Split into coefficient and exponent parts
-        let (coeff, exp_str) = formatted.split_once('e').unwrap();
-        let exp: i32 = exp_str.parse().unwrap();
-        // JS uses e+N for positive exponents, e-N for negative
-        if exp >= 0 {
-            format!("{}{}e+{}", sign, coeff, exp)
-        } else {
-            format!("{}{}e-{}", sign, coeff, exp.unsigned_abs())
-        }
-    } else if abs.fract() == 0.0 && abs < (i64::MAX as f64) {
-        // Integer that fits in i64 — format without decimal point
-        format!("{}{}", sign, abs as i64)
-    } else {
-        // Regular float: Rust's default Display gives us the right digits
-        format!("{}", n)
+        write!(f, "{}", self.value().to_js_string())
     }
 }
 

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
@@ -29,14 +29,17 @@ use std::mem::replace;
 use rustc_hash::FxHashMap;
 
 use oxc_allocator::Allocator;
+use oxc_ecmascript::{StringToNumber, ToInt32, ToUint32};
 use oxc_str::Ident;
+use oxc_syntax::identifier::is_identifier_name;
+use oxc_syntax::keyword::is_reserved_keyword;
+use oxc_syntax::number::ToJsString;
 
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::{
     BinaryOperator, BlockKind, FloatValue, FunctionId, GotoVariant, HirFunction, IdentifierId,
     InstructionId, InstructionValue, ManualMemoDependencyRoot, NonLocalBinding, Phi, Place,
     PrimitiveValue, PropertyLiteral, Span, Terminal, UnaryOperator, UpdateOperator,
-    format_js_number,
 };
 use crate::react_compiler_lowering::{
     get_reverse_postordered_blocks, mark_instruction_ids, mark_predecessors,
@@ -513,7 +516,7 @@ fn evaluate_instruction<'a>(
                 let expression_str = match sub_prim {
                     PrimitiveValue::Null => "null".to_string(),
                     PrimitiveValue::Boolean(b) => b.to_string(),
-                    PrimitiveValue::Number(n) => format_js_number(n.value()),
+                    PrimitiveValue::Number(n) => n.value().to_js_string(),
                     PrimitiveValue::String(s) => s.to_marker_string(),
                     // TS rejects undefined subexpression values
                     PrimitiveValue::Undefined => return None,
@@ -648,90 +651,10 @@ fn read<'a>(constants: &Constants<'a>, place: &Place) -> Option<Constant<'a>> {
 // Helper: is_valid_identifier
 // =============================================================================
 
-/// Check if a string is a valid JavaScript identifier.
-/// Supports Unicode identifier characters per ECMAScript spec (ID_Start / ID_Continue).
-/// Rejects JS reserved words (matching Babel's `isValidIdentifier` default behavior).
+/// Check if a string is a valid JavaScript identifier that is not a reserved
+/// word (matching Babel's `isValidIdentifier` default behavior).
 fn is_valid_identifier(s: &str) -> bool {
-    if s.is_empty() {
-        return false;
-    }
-    let mut chars = s.chars();
-    match chars.next() {
-        Some(c) if is_id_start(c) => {}
-        _ => return false,
-    }
-    if !chars.all(is_id_continue) {
-        return false;
-    }
-    !is_reserved_word(s)
-}
-
-/// JS reserved words that cannot be used as identifiers.
-/// Includes keywords, future reserved words, and strict mode reserved words.
-fn is_reserved_word(s: &str) -> bool {
-    matches!(
-        s,
-        "break"
-            | "case"
-            | "catch"
-            | "continue"
-            | "debugger"
-            | "default"
-            | "do"
-            | "else"
-            | "finally"
-            | "for"
-            | "function"
-            | "if"
-            | "in"
-            | "instanceof"
-            | "new"
-            | "return"
-            | "switch"
-            | "this"
-            | "throw"
-            | "try"
-            | "typeof"
-            | "var"
-            | "void"
-            | "while"
-            | "with"
-            | "class"
-            | "const"
-            | "enum"
-            | "export"
-            | "extends"
-            | "import"
-            | "super"
-            | "implements"
-            | "interface"
-            | "let"
-            | "package"
-            | "private"
-            | "protected"
-            | "public"
-            | "static"
-            | "yield"
-            | "await"
-            | "delete"
-            | "null"
-            | "true"
-            | "false"
-    )
-}
-
-/// Check if a character is valid as the start of a JS identifier (ID_Start + _ + $).
-fn is_id_start(c: char) -> bool {
-    c == '_' || c == '$' || c.is_alphabetic()
-}
-
-/// Check if a character is valid as a continuation of a JS identifier (ID_Continue + $ + \u200C + \u200D).
-fn is_id_continue(c: char) -> bool {
-    c == '$'
-        || c == '_'
-        || c.is_alphanumeric()
-        || c == '\u{200C}' // ZWNJ
-        || c == '\u{200D}' // ZWJ
+    is_identifier_name(s) && !is_reserved_keyword(s)
 }
 
 // =============================================================================
@@ -807,42 +730,42 @@ fn evaluate_binary_op<'a>(
         },
         BinaryOperator::BitwiseOr => match (lhs, rhs) {
             (PrimitiveValue::Number(l), PrimitiveValue::Number(r)) => {
-                let result = js_to_int32(l.value()) | js_to_int32(r.value());
+                let result = l.value().to_int_32() | r.value().to_int_32();
                 Some(PrimitiveValue::Number(FloatValue::new(result as f64)))
             }
             _ => None,
         },
         BinaryOperator::BitwiseAnd => match (lhs, rhs) {
             (PrimitiveValue::Number(l), PrimitiveValue::Number(r)) => {
-                let result = js_to_int32(l.value()) & js_to_int32(r.value());
+                let result = l.value().to_int_32() & r.value().to_int_32();
                 Some(PrimitiveValue::Number(FloatValue::new(result as f64)))
             }
             _ => None,
         },
         BinaryOperator::BitwiseXor => match (lhs, rhs) {
             (PrimitiveValue::Number(l), PrimitiveValue::Number(r)) => {
-                let result = js_to_int32(l.value()) ^ js_to_int32(r.value());
+                let result = l.value().to_int_32() ^ r.value().to_int_32();
                 Some(PrimitiveValue::Number(FloatValue::new(result as f64)))
             }
             _ => None,
         },
         BinaryOperator::ShiftLeft => match (lhs, rhs) {
             (PrimitiveValue::Number(l), PrimitiveValue::Number(r)) => {
-                let result = js_to_int32(l.value()) << (js_to_uint32(r.value()) & 0x1f);
+                let result = l.value().to_int_32() << (r.value().to_uint_32() & 0x1f);
                 Some(PrimitiveValue::Number(FloatValue::new(result as f64)))
             }
             _ => None,
         },
         BinaryOperator::ShiftRight => match (lhs, rhs) {
             (PrimitiveValue::Number(l), PrimitiveValue::Number(r)) => {
-                let result = js_to_int32(l.value()) >> (js_to_uint32(r.value()) & 0x1f);
+                let result = l.value().to_int_32() >> (r.value().to_uint_32() & 0x1f);
                 Some(PrimitiveValue::Number(FloatValue::new(result as f64)))
             }
             _ => None,
         },
         BinaryOperator::UnsignedShiftRight => match (lhs, rhs) {
             (PrimitiveValue::Number(l), PrimitiveValue::Number(r)) => {
-                let result = js_to_uint32(l.value()) >> (js_to_uint32(r.value()) & 0x1f);
+                let result = l.value().to_uint_32() >> (r.value().to_uint_32() & 0x1f);
                 Some(PrimitiveValue::Number(FloatValue::new(result as f64)))
             }
             _ => None,
@@ -903,43 +826,6 @@ fn js_strict_equal(lhs: &PrimitiveValue, rhs: &PrimitiveValue) -> bool {
     }
 }
 
-/// Convert a string to a number using JS `ToNumber` semantics.
-/// In JS: `""` → 0, `" "` → 0, `" 42 "` → 42, `"0x1A"` → 26, `"Infinity"` → Infinity.
-fn js_to_number(s: &str) -> f64 {
-    let trimmed = s.trim();
-    if trimmed.is_empty() {
-        return 0.0;
-    }
-    if trimmed == "Infinity" || trimmed == "+Infinity" {
-        return f64::INFINITY;
-    }
-    if trimmed == "-Infinity" {
-        return f64::NEG_INFINITY;
-    }
-    // Handle hex literals (0x/0X)
-    if trimmed.starts_with("0x") || trimmed.starts_with("0X") {
-        return match u64::from_str_radix(&trimmed[2..], 16) {
-            Ok(v) => v as f64,
-            Err(_) => f64::NAN,
-        };
-    }
-    // Handle octal literals (0o/0O)
-    if trimmed.starts_with("0o") || trimmed.starts_with("0O") {
-        return match u64::from_str_radix(&trimmed[2..], 8) {
-            Ok(v) => v as f64,
-            Err(_) => f64::NAN,
-        };
-    }
-    // Handle binary literals (0b/0B)
-    if trimmed.starts_with("0b") || trimmed.starts_with("0B") {
-        return match u64::from_str_radix(&trimmed[2..], 2) {
-            Ok(v) => v as f64,
-            Err(_) => f64::NAN,
-        };
-    }
-    trimmed.parse::<f64>().unwrap_or(f64::NAN)
-}
-
 fn js_abstract_equal(lhs: &PrimitiveValue, rhs: &PrimitiveValue) -> bool {
     match (lhs, rhs) {
         (PrimitiveValue::Null, PrimitiveValue::Null) => true,
@@ -962,7 +848,7 @@ fn js_abstract_equal(lhs: &PrimitiveValue, rhs: &PrimitiveValue) -> bool {
             // String is coerced to number using JS ToNumber semantics.
             // Ill-formed strings coerce to NaN, like any non-numeric text.
             let sv = match s.as_str() {
-                Some(utf8) => js_to_number(utf8),
+                Some(utf8) => utf8.string_to_number(),
                 None => f64::NAN,
             };
             let nv = n.value();
@@ -979,24 +865,4 @@ fn js_abstract_equal(lhs: &PrimitiveValue, rhs: &PrimitiveValue) -> bool {
         // null/undefined vs number/string => false
         _ => false,
     }
-}
-
-// =============================================================================
-// JavaScript Number.toString() approximation
-// =============================================================================
-
-/// ECMAScript ToInt32: convert f64 to i32 with modular (wrapping) semantics.
-fn js_to_int32(n: f64) -> i32 {
-    if n.is_nan() || n.is_infinite() || n == 0.0 {
-        return 0;
-    }
-    // Truncate, then wrap to 32 bits
-    let int64 = (n.trunc() as i64) & 0xFFFFFFFF;
-    // Reinterpret as signed i32
-    if int64 >= 0x80000000 { (int64 as u32) as i32 } else { int64 as i32 }
-}
-
-/// ECMAScript ToUint32: convert f64 to u32 with modular (wrapping) semantics.
-fn js_to_uint32(n: f64) -> u32 {
-    js_to_int32(n) as u32
 }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
@@ -3355,16 +3355,9 @@ fn ox_codegen_primitive_value<'a>(
 fn ox_parse_regexp_flags(flags_str: &str) -> oxc::RegExpFlags {
     let mut flags = oxc::RegExpFlags::empty();
     for c in flags_str.chars() {
-        match c {
-            'g' => flags |= oxc::RegExpFlags::G,
-            'i' => flags |= oxc::RegExpFlags::I,
-            'm' => flags |= oxc::RegExpFlags::M,
-            's' => flags |= oxc::RegExpFlags::S,
-            'u' => flags |= oxc::RegExpFlags::U,
-            'y' => flags |= oxc::RegExpFlags::Y,
-            'd' => flags |= oxc::RegExpFlags::D,
-            'v' => flags |= oxc::RegExpFlags::V,
-            _ => {}
+        // Unknown flag chars are ignored (oxc's `TryFrom` returns `Err` for them).
+        if let Ok(flag) = oxc::RegExpFlags::try_from(c) {
+            flags |= flag;
         }
     }
     flags


### PR DESCRIPTION
Replaces hand-rolled JavaScript utilities in `oxc_react_compiler` with oxc's canonical implementations, each of which is also strictly more spec-correct than the local version.

## Replaced

- **`is_valid_identifier`** (two copies) → `oxc_syntax::identifier::is_identifier_name` + `oxc_syntax::keyword::is_reserved_keyword`. Removes duplicated 46-word reserved-word lists and approximate `is_alphabetic`/`is_alphanumeric` char checks (oxc uses exact ECMAScript `ID_Start`/`ID_Continue`). Also fixes one copy that silently allowed `await` as an identifier.
- **`js_to_number`** → `oxc_ecmascript::StringToNumber`. The local version accepted `"inf"`/`"nan"` and used Rust's Unicode `.trim()` instead of JS whitespace.
- **`js_to_int32` / `js_to_uint32`** → `oxc_ecmascript::{ToInt32, ToUint32}`. The local `(n.trunc() as i64) & 0xFFFFFFFF` saturated for large magnitudes (e.g. `1e300` produced `-1` instead of `0`).
- **`format_js_number`** → `oxc_syntax::number::ToJsString`. Replaces a documented `Number.prototype.toString()` approximation (which fell back to Rust's `Display`) with the dragonbox-based, spec-correct formatter.
- **`ox_parse_regexp_flags`** → `oxc::RegExpFlags::try_from(char)`. Removes a duplicated 8-arm flag `match`.

Adds the `oxc_ecmascript` dependency and enables the `to_js_string` feature on `oxc_syntax`. The single-call numeric conversions are inlined at their call sites; `is_valid_identifier` (composes two calls, used as a fn-pointer), `format_js_number` (pub, cross-file `Display` helper), and `ox_parse_regexp_flags` (a per-char loop) remain thin helpers.

Snapshot conformance (over the upstream fixture corpus) and the transform integration tests pass unchanged.
