### PR TITLE
fix(formatter): break arrow signature that exactly fills the line when cond body may hug

### DIFF
--- a/crates/oxc_formatter/src/print/arrow_function_expression.rs
+++ b/crates/oxc_formatter/src/print/arrow_function_expression.rs
@@ -193,24 +193,34 @@ impl<'a, 'b> FormatJsArrowFunctionExpression<'a, 'b> {
                         || (matches!(self.arrow.parent(), AstNodes::JSXExpressionContainer(container)
                             if !f.context().comments().has_comment_in_range(arrow.span.end, container.span.end)));
 
-                    write!(
-                        f,
-                        group(&format_args!(
-                            soft_line_indent_or_space(&format_with(|f| {
-                                if should_add_parens {
-                                    write!(f, if_group_fits_on_line(&"("));
-                                }
-
-                                write!(f, format_body);
-
-                                if should_add_parens {
-                                    write!(f, if_group_fits_on_line(&")"));
-                                }
-                            })),
-                            is_last_call_arg.then_some(&FormatTrailingCommas::All),
-                            should_add_soft_line.then_some(soft_line_break())
-                        ))
-                    );
+                    if should_add_parens {
+                        // The leading space must be a literal space rather than a soft line:
+                        // it is counted when measuring whether the signature fits,
+                        // so a signature that fills the line exactly gets broken,
+                        // matching Prettier's `printArrowFunctionBody`.
+                        write!(
+                            f,
+                            [
+                                space(),
+                                group(&format_args!(
+                                    if_group_fits_on_line(&token("(")),
+                                    indent(&format_args!(soft_line_break(), format_body)),
+                                    if_group_fits_on_line(&token(")")),
+                                    is_last_call_arg.then_some(&FormatTrailingCommas::All),
+                                    should_add_soft_line.then_some(soft_line_break())
+                                ))
+                            ]
+                        );
+                    } else {
+                        write!(
+                            f,
+                            group(&format_args!(
+                                soft_line_indent_or_space(&format_body),
+                                is_last_call_arg.then_some(&FormatTrailingCommas::All),
+                                should_add_soft_line.then_some(soft_line_break())
+                            ))
+                        );
+                    }
                 }
             }
         }
@@ -645,6 +655,13 @@ impl<'a> Format<'a, JsFormatContext<'a>> for ArrowChain<'a, '_> {
             } else {
                 let should_add_parens = tail.expression && should_add_parens(tail_body);
                 if should_add_parens {
+                    // Known divergence from Prettier: with a signature that exactly fills the line,
+                    // Prettier breaks it because the hug layout's literal space is counted
+                    // when measuring fits (see the single-arrow branch above), while this soft-line
+                    // wrapping (`soft_line_indent_or_space` in `format_tail_body`) stops the measurement.
+                    // Porting the literal-space structure here is NOT enough: Prettier gates the hug
+                    // on `!shouldBreakChain` (`expand_signatures` here) and otherwise breaks without
+                    // parens; a naive port regresses `js/arrows/currying-4.js`.
                     write!(
                         f,
                         [

--- a/crates/oxc_formatter/tests/fixtures/ts/arrow-function/issue-24416.tsx
+++ b/crates/oxc_formatter/tests/fixtures/ts/arrow-function/issue-24416.tsx
@@ -1,0 +1,24 @@
+//      10        20        30        40        50        60        70        80
+// 45678901234567890123456789012345678901234567890123456789012345678901234567890
+
+// Every signature below is exactly 80 chars including `=>`.
+
+// A conditional body plans the hug layout `=> (cond ? a : b)`,
+// whose literal space is counted when measuring the signature: 81 > 80 breaks the params.
+const MachineConsoleLink = ({ ipAddress }: { ipAddress: string | undefined }) =>
+  ipAddress ? (
+    <a target={"_blank"} rel="noreferrer" href={`http://${ipAddress}`}>
+      {ipAddress}
+    </a>
+  ) : (
+    "--"
+  );
+
+// Non-JSX conditional body: params break, then the body hugs with parens.
+const MachineConsoleLinkAA = ({ hostName }: { hostName: string | undefined }) =>
+  hostName ? hostName : "--";
+
+// Call body: the body starts with a soft line instead of the hug space,
+// so the measurement stops at 80 and the signature is kept.
+const MachineConsoleLinkAB = ({ hostName }: { hostName: string | undefined }) =>
+  foo(hostName);

--- a/crates/oxc_formatter/tests/fixtures/ts/arrow-function/issue-24416.tsx.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/arrow-function/issue-24416.tsx.snap
@@ -1,0 +1,93 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+//      10        20        30        40        50        60        70        80
+// 45678901234567890123456789012345678901234567890123456789012345678901234567890
+
+// Every signature below is exactly 80 chars including `=>`.
+
+// A conditional body plans the hug layout `=> (cond ? a : b)`,
+// whose literal space is counted when measuring the signature: 81 > 80 breaks the params.
+const MachineConsoleLink = ({ ipAddress }: { ipAddress: string | undefined }) =>
+  ipAddress ? (
+    <a target={"_blank"} rel="noreferrer" href={`http://${ipAddress}`}>
+      {ipAddress}
+    </a>
+  ) : (
+    "--"
+  );
+
+// Non-JSX conditional body: params break, then the body hugs with parens.
+const MachineConsoleLinkAA = ({ hostName }: { hostName: string | undefined }) =>
+  hostName ? hostName : "--";
+
+// Call body: the body starts with a soft line instead of the hug space,
+// so the measurement stops at 80 and the signature is kept.
+const MachineConsoleLinkAB = ({ hostName }: { hostName: string | undefined }) =>
+  foo(hostName);
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+//      10        20        30        40        50        60        70        80
+// 45678901234567890123456789012345678901234567890123456789012345678901234567890
+
+// Every signature below is exactly 80 chars including `=>`.
+
+// A conditional body plans the hug layout `=> (cond ? a : b)`,
+// whose literal space is counted when measuring the signature: 81 > 80 breaks the params.
+const MachineConsoleLink = ({
+  ipAddress,
+}: {
+  ipAddress: string | undefined;
+}) =>
+  ipAddress ? (
+    <a target={"_blank"} rel="noreferrer" href={`http://${ipAddress}`}>
+      {ipAddress}
+    </a>
+  ) : (
+    "--"
+  );
+
+// Non-JSX conditional body: params break, then the body hugs with parens.
+const MachineConsoleLinkAA = ({
+  hostName,
+}: {
+  hostName: string | undefined;
+}) => (hostName ? hostName : "--");
+
+// Call body: the body starts with a soft line instead of the hug space,
+// so the measurement stops at 80 and the signature is kept.
+const MachineConsoleLinkAB = ({ hostName }: { hostName: string | undefined }) =>
+  foo(hostName);
+
+-------------------
+{ printWidth: 100 }
+-------------------
+//      10        20        30        40        50        60        70        80
+// 45678901234567890123456789012345678901234567890123456789012345678901234567890
+
+// Every signature below is exactly 80 chars including `=>`.
+
+// A conditional body plans the hug layout `=> (cond ? a : b)`,
+// whose literal space is counted when measuring the signature: 81 > 80 breaks the params.
+const MachineConsoleLink = ({ ipAddress }: { ipAddress: string | undefined }) =>
+  ipAddress ? (
+    <a target={"_blank"} rel="noreferrer" href={`http://${ipAddress}`}>
+      {ipAddress}
+    </a>
+  ) : (
+    "--"
+  );
+
+// Non-JSX conditional body: params break, then the body hugs with parens.
+const MachineConsoleLinkAA = ({ hostName }: { hostName: string | undefined }) =>
+  hostName ? hostName : "--";
+
+// Call body: the body starts with a soft line instead of the hug space,
+// so the measurement stops at 80 and the signature is kept.
+const MachineConsoleLinkAB = ({ hostName }: { hostName: string | undefined }) => foo(hostName);
+
+===================== End =====================


### PR DESCRIPTION
Fixes #24416
