### PR TITLE
refactor(react_compiler): define IDs with oxc_index nonmax index types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2440,6 +2440,7 @@ dependencies = [
  "oxc_codegen",
  "oxc_diagnostics",
  "oxc_ecmascript",
+ "oxc_index",
  "oxc_parser",
  "oxc_semantic",
  "oxc_span",

--- a/crates/oxc_react_compiler/Cargo.toml
+++ b/crates/oxc_react_compiler/Cargo.toml
@@ -33,6 +33,7 @@ oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }
 oxc_diagnostics = { workspace = true }
 oxc_ecmascript = { workspace = true }
+oxc_index = { workspace = true }
 oxc_semantic = { workspace = true }
 oxc_span = { workspace = true }
 oxc_str = { workspace = true }

--- a/crates/oxc_react_compiler/src/react_compiler_hir/dominator.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/dominator.rs
@@ -101,7 +101,7 @@ fn build_reverse_graph(
     next_block_id_counter: u32,
     include_throws_as_exit_node: bool,
 ) -> Graph {
-    let exit_id = BlockId(next_block_id_counter);
+    let exit_id = BlockId::from_usize(next_block_id_counter as usize);
 
     // Build initial nodes with reversed edges
     let mut raw_nodes: FxHashMap<BlockId, Node> = FxHashMap::default();

--- a/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
@@ -206,7 +206,7 @@ impl<'a> Environment<'a> {
     }
 
     pub fn next_block_id(&mut self) -> BlockId {
-        let id = BlockId(self.next_block_id_counter);
+        let id = BlockId::from_usize(self.next_block_id_counter as usize);
         self.next_block_id_counter += 1;
         id
     }
@@ -219,7 +219,7 @@ impl<'a> Environment<'a> {
         start: EvaluationOrder,
         end: EvaluationOrder,
     ) -> MutableRange {
-        let id = MutableRangeId(self.next_mutable_range_id_counter);
+        let id = MutableRangeId::from_usize(self.next_mutable_range_id_counter as usize);
         self.next_mutable_range_id_counter += 1;
         MutableRange { id, start, end }
     }
@@ -227,12 +227,12 @@ impl<'a> Environment<'a> {
     /// Allocate a new Identifier in the arena with default values,
     /// returns its IdentifierId.
     pub fn next_identifier_id(&mut self) -> IdentifierId {
-        let id = IdentifierId(self.identifiers.len() as u32);
+        let id = IdentifierId::from_usize(self.identifiers.len());
         let type_id = self.make_type();
-        let mutable_range = self.new_mutable_range(EvaluationOrder(0), EvaluationOrder(0));
+        let mutable_range = self.new_mutable_range(EvaluationOrder::UNSET, EvaluationOrder::UNSET);
         self.identifiers.push(Identifier {
             id,
-            declaration_id: DeclarationId(id.0),
+            declaration_id: DeclarationId::from_usize(id.index()),
             name: None,
             mutable_range,
             scope: None,
@@ -244,9 +244,9 @@ impl<'a> Environment<'a> {
 
     /// Allocate a new ReactiveScope in the arena, returns its ScopeId.
     pub fn next_scope_id(&mut self) -> ScopeId {
-        let id = ScopeId(self.next_scope_id_counter);
+        let id = ScopeId::from_usize(self.next_scope_id_counter as usize);
         self.next_scope_id_counter += 1;
-        let range = self.new_mutable_range(EvaluationOrder(0), EvaluationOrder(0));
+        let range = self.new_mutable_range(EvaluationOrder::UNSET, EvaluationOrder::UNSET);
         self.scopes.push(ReactiveScope {
             id,
             range,
@@ -262,7 +262,7 @@ impl<'a> Environment<'a> {
 
     /// Allocate a new Type in the arena, returns its TypeId.
     pub fn next_type_id(&mut self) -> TypeId {
-        let id = TypeId(self.types.len() as u32);
+        let id = TypeId::from_usize(self.types.len());
         self.types.push(Type::TypeVar { id });
         id
     }
@@ -273,7 +273,7 @@ impl<'a> Environment<'a> {
     }
 
     pub fn add_function(&mut self, func: HirFunction<'a>) -> FunctionId {
-        let id = FunctionId(self.functions.len() as u32);
+        let id = FunctionId::from_usize(self.functions.len());
         self.functions.push(func);
         id
     }
@@ -710,7 +710,7 @@ impl<'a> Environment<'a> {
     /// Check whether the function type for an identifier has a noAlias signature.
     /// Looks up the identifier's type and checks its function signature.
     pub fn has_no_alias_signature(&self, identifier_id: IdentifierId) -> bool {
-        let ty = &self.types[self.identifiers[identifier_id.0 as usize].type_.0 as usize];
+        let ty = &self.types[self.identifiers[identifier_id.index()].type_.index()];
         self.get_function_signature(ty).ok().flatten().is_some_and(|sig| sig.no_alias)
     }
 
@@ -720,7 +720,7 @@ impl<'a> Environment<'a> {
         &self,
         identifier_id: IdentifierId,
     ) -> Result<Option<&HookKind>, OxcDiagnostic> {
-        let ty = &self.types[self.identifiers[identifier_id.0 as usize].type_.0 as usize];
+        let ty = &self.types[self.identifiers[identifier_id.index()].type_.index()];
         self.get_hook_kind_for_type(ty)
     }
 }

--- a/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
@@ -13,6 +13,7 @@ use crate::react_compiler_utils::FxIndexMap;
 use crate::react_compiler_utils::FxIndexSet;
 use oxc_ast::ast::*;
 use oxc_diagnostics::OxcDiagnostic;
+use oxc_index::define_nonmax_u32_index_type;
 use oxc_str::{Ident, Str};
 use oxc_syntax::number::ToJsString;
 pub use raw::RawTypeCategory;
@@ -25,35 +26,58 @@ pub const GENERATED_SOURCE: Option<Span> = None;
 // ID newtypes
 // =============================================================================
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct BlockId(pub u32);
+define_nonmax_u32_index_type! {
+    pub struct BlockId;
+}
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct IdentifierId(pub u32);
+define_nonmax_u32_index_type! {
+    pub struct IdentifierId;
+}
 
-/// Index into the flat instruction table on HirFunction.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct InstructionId(pub u32);
+define_nonmax_u32_index_type! {
+    /// Index into the flat instruction table on HirFunction.
+    pub struct InstructionId;
+}
 
-/// Evaluation order assigned to instructions and terminals during numbering.
-/// This was previously called InstructionId in the TypeScript compiler.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct EvaluationOrder(pub u32);
+define_nonmax_u32_index_type! {
+    /// Evaluation order assigned to instructions and terminals during numbering.
+    /// This was previously called InstructionId in the TypeScript compiler.
+    pub struct EvaluationOrder;
+}
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct DeclarationId(pub u32);
+define_nonmax_u32_index_type! {
+    pub struct DeclarationId;
+}
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct ScopeId(pub u32);
+define_nonmax_u32_index_type! {
+    pub struct ScopeId;
+}
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct TypeId(pub u32);
+define_nonmax_u32_index_type! {
+    pub struct TypeId;
+}
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct FunctionId(pub u32);
+define_nonmax_u32_index_type! {
+    pub struct FunctionId;
+}
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct MutableRangeId(pub u32);
+define_nonmax_u32_index_type! {
+    pub struct MutableRangeId;
+}
+
+impl BlockId {
+    /// Placeholder id for the never-read block that the final `terminate()` installs as
+    /// `current`. Uses the largest representable index so it can never alias a real block
+    /// (blocks are numbered from 0).
+    pub const PLACEHOLDER: Self = Self::from_usize(Self::MAX_INDEX);
+}
+
+impl EvaluationOrder {
+    /// Placeholder order for instructions, terminals, and ranges before
+    /// `mark_instruction_ids` assigns the real, 1-based orders. `0` is never a valid
+    /// assigned order.
+    pub const UNSET: Self = Self::from_usize(0);
+}
 
 // =============================================================================
 // FloatValue wrapper

--- a/crates/oxc_react_compiler/src/react_compiler_hir/visitors.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/visitors.rs
@@ -218,7 +218,7 @@ pub fn each_instruction_value_operand_with_functions(
         }
         InstructionValue::ObjectMethod { lowered_func, .. }
         | InstructionValue::FunctionExpression { lowered_func, .. } => {
-            let func = &functions[lowered_func.func.0 as usize];
+            let func = &functions[lowered_func.func.index()];
             for ctx_place in &func.context {
                 result.push(ctx_place.clone());
             }
@@ -857,7 +857,7 @@ pub fn each_terminal_operand_ids(terminal: &Terminal) -> Vec<IdentifierId> {
 //   for_each_instruction_value_operand_mut(&mut instr.value, &mut |place| { ... });
 //   if let InstructionValue::FunctionExpression { lowered_func, .. }
 //       | InstructionValue::ObjectMethod { lowered_func, .. } = &mut instr.value {
-//       let func = &mut env.functions[lowered_func.func.0 as usize];
+//       let func = &mut env.functions[lowered_func.func.index()];
 //       for ctx in func.context.iter_mut() { ... }
 //   }
 //

--- a/crates/oxc_react_compiler/src/react_compiler_inference/align_method_call_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/align_method_call_scopes.rs
@@ -37,11 +37,11 @@ pub fn align_method_call_scopes(func: &mut HirFunction, env: &mut Environment) {
     // Phase 1: Walk instructions and collect scope relationships
     for (_block_id, block) in &func.body.blocks {
         for &instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             match &instr.value {
                 InstructionValue::MethodCall { property, .. } => {
-                    let lvalue_scope = env.identifiers[instr.lvalue.identifier.0 as usize].scope;
-                    let property_scope = env.identifiers[property.identifier.0 as usize].scope;
+                    let lvalue_scope = env.identifiers[instr.lvalue.identifier.index()].scope;
+                    let property_scope = env.identifiers[property.identifier.index()].scope;
 
                     match (lvalue_scope, property_scope) {
                         (Some(lvalue_sid), Some(property_sid)) => {
@@ -68,9 +68,9 @@ pub fn align_method_call_scopes(func: &mut HirFunction, env: &mut Environment) {
                     // Recurse into inner functions
                     let func_id = lowered_func.func;
                     let mut inner_func =
-                        replace(&mut env.functions[func_id.0 as usize], placeholder_function());
+                        replace(&mut env.functions[func_id.index()], placeholder_function());
                     align_method_call_scopes(&mut inner_func, env);
-                    env.functions[func_id.0 as usize] = inner_func;
+                    env.functions[func_id.index()] = inner_func;
                 }
                 _ => {}
             }
@@ -87,27 +87,27 @@ pub fn align_method_call_scopes(func: &mut HirFunction, env: &mut Environment) {
         if scope_id == root_id {
             return;
         }
-        let scope_range = env.scopes[scope_id.0 as usize].range.clone();
-        let root_range = env.scopes[root_id.0 as usize].range.clone();
+        let scope_range = env.scopes[scope_id.index()].range.clone();
+        let root_range = env.scopes[root_id.index()].range.clone();
 
         let entry =
             range_updates.entry(root_id).or_insert_with(|| (root_range.start, root_range.end));
-        entry.0 = EvaluationOrder(min(entry.0.0, scope_range.start.0));
-        entry.1 = EvaluationOrder(max(entry.1.0, scope_range.end.0));
+        entry.0 = min(entry.0, scope_range.start);
+        entry.1 = max(entry.1, scope_range.end);
     });
 
     // Save original scope range IDs before updating
     let original_range_ids: FxHashMap<ScopeId, MutableRangeId> = range_updates
         .keys()
         .map(|&root_id| {
-            let range_id = env.scopes[root_id.0 as usize].range.id;
+            let range_id = env.scopes[root_id.index()].range.id;
             (root_id, range_id)
         })
         .collect();
 
     for (root_id, (new_start, new_end)) in &range_updates {
-        env.scopes[root_id.0 as usize].range.start = *new_start;
-        env.scopes[root_id.0 as usize].range.end = *new_end;
+        env.scopes[root_id.index()].range.start = *new_start;
+        env.scopes[root_id.index()].range.end = *new_end;
     }
 
     // Sync identifier mutable_ranges that shared the old scope range.
@@ -116,7 +116,7 @@ pub fn align_method_call_scopes(func: &mut HirFunction, env: &mut Environment) {
         if let Some(scope_id) = ident.scope {
             if let Some(&orig_range_id) = original_range_ids.get(&scope_id) {
                 if ident.mutable_range.id == orig_range_id {
-                    let new_range = &env.scopes[scope_id.0 as usize].range;
+                    let new_range = &env.scopes[scope_id.index()].range;
                     ident.mutable_range.start = new_range.start;
                     ident.mutable_range.end = new_range.end;
                 }
@@ -127,14 +127,14 @@ pub fn align_method_call_scopes(func: &mut HirFunction, env: &mut Environment) {
     // Phase 3: Apply scope mappings and merged scope reassignments
     for (_block_id, block) in &func.body.blocks {
         for &instr_id in &block.instructions {
-            let lvalue_id = func.instructions[instr_id.0 as usize].lvalue.identifier;
+            let lvalue_id = func.instructions[instr_id.index()].lvalue.identifier;
 
             if let Some(mapped_scope) = scope_mapping.get(&lvalue_id) {
-                env.identifiers[lvalue_id.0 as usize].scope = *mapped_scope;
-            } else if let Some(current_scope) = env.identifiers[lvalue_id.0 as usize].scope {
+                env.identifiers[lvalue_id.index()].scope = *mapped_scope;
+            } else if let Some(current_scope) = env.identifiers[lvalue_id.index()].scope {
                 // TS: mergedScopes.find() returns null if not in the set
                 if let Some(merged) = merged_scopes.find_opt(current_scope) {
-                    env.identifiers[lvalue_id.0 as usize].scope = Some(merged);
+                    env.identifiers[lvalue_id.index()].scope = Some(merged);
                 }
             }
         }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/align_object_method_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/align_object_method_scopes.rs
@@ -34,7 +34,7 @@ fn find_scopes_to_merge(func: &HirFunction, env: &Environment) -> DisjointSet<Sc
 
     for (_block_id, block) in &func.body.blocks {
         for &instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             match &instr.value {
                 InstructionValue::ObjectMethod { .. } => {
                     object_method_decls.insert(instr.lvalue.identifier);
@@ -47,9 +47,9 @@ fn find_scopes_to_merge(func: &HirFunction, env: &Environment) -> DisjointSet<Sc
                         };
                         if object_method_decls.contains(&operand_place.identifier) {
                             let operand_scope =
-                                env.identifiers[operand_place.identifier.0 as usize].scope;
+                                env.identifiers[operand_place.identifier.index()].scope;
                             let lvalue_scope =
-                                env.identifiers[instr.lvalue.identifier.0 as usize].scope;
+                                env.identifiers[instr.lvalue.identifier.index()].scope;
 
                             // TS: Diagnostics.invariant(operandScope != null && lvalueScope != null, ...)
                             let operand_sid = operand_scope.expect(
@@ -82,15 +82,15 @@ pub fn align_object_method_scopes(func: &mut HirFunction, env: &mut Environment)
     // Handle inner functions first (TS recurses before processing the outer function)
     for (_block_id, block) in &func.body.blocks {
         for &instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             match &instr.value {
                 InstructionValue::FunctionExpression { lowered_func, .. }
                 | InstructionValue::ObjectMethod { lowered_func, .. } => {
                     let func_id = lowered_func.func;
                     let mut inner_func =
-                        replace(&mut env.functions[func_id.0 as usize], placeholder_function());
+                        replace(&mut env.functions[func_id.index()], placeholder_function());
                     align_object_method_scopes(&mut inner_func, env);
-                    env.functions[func_id.0 as usize] = inner_func;
+                    env.functions[func_id.index()] = inner_func;
                 }
                 _ => {}
             }
@@ -109,27 +109,27 @@ pub fn align_object_method_scopes(func: &mut HirFunction, env: &mut Environment)
         if scope_id == root_id {
             return;
         }
-        let scope_range = env.scopes[scope_id.0 as usize].range.clone();
-        let root_range = env.scopes[root_id.0 as usize].range.clone();
+        let scope_range = env.scopes[scope_id.index()].range.clone();
+        let root_range = env.scopes[root_id.index()].range.clone();
 
         let entry =
             range_updates.entry(root_id).or_insert_with(|| (root_range.start, root_range.end));
-        entry.0 = EvaluationOrder(cmp::min(entry.0.0, scope_range.start.0));
-        entry.1 = EvaluationOrder(cmp::max(entry.1.0, scope_range.end.0));
+        entry.0 = cmp::min(entry.0, scope_range.start);
+        entry.1 = cmp::max(entry.1, scope_range.end);
     });
 
     // Save original scope range IDs before updating
     let original_range_ids: FxHashMap<ScopeId, MutableRangeId> = range_updates
         .keys()
         .map(|&root_id| {
-            let range_id = env.scopes[root_id.0 as usize].range.id;
+            let range_id = env.scopes[root_id.index()].range.id;
             (root_id, range_id)
         })
         .collect();
 
     for (root_id, (new_start, new_end)) in &range_updates {
-        env.scopes[root_id.0 as usize].range.start = *new_start;
-        env.scopes[root_id.0 as usize].range.end = *new_end;
+        env.scopes[root_id.index()].range.start = *new_start;
+        env.scopes[root_id.index()].range.end = *new_end;
     }
 
     // Sync identifier mutable_ranges that shared the old scope range.
@@ -138,7 +138,7 @@ pub fn align_object_method_scopes(func: &mut HirFunction, env: &mut Environment)
         if let Some(scope_id) = ident.scope {
             if let Some(&orig_range_id) = original_range_ids.get(&scope_id) {
                 if ident.mutable_range.id == orig_range_id {
-                    let new_range = &env.scopes[scope_id.0 as usize].range;
+                    let new_range = &env.scopes[scope_id.index()].range;
                     ident.mutable_range.start = new_range.start;
                     ident.mutable_range.end = new_range.end;
                 }
@@ -157,11 +157,11 @@ pub fn align_object_method_scopes(func: &mut HirFunction, env: &mut Environment)
 
     for (_block_id, block) in &func.body.blocks {
         for &instr_id in &block.instructions {
-            let lvalue_id = func.instructions[instr_id.0 as usize].lvalue.identifier;
+            let lvalue_id = func.instructions[instr_id.index()].lvalue.identifier;
 
-            if let Some(current_scope) = env.identifiers[lvalue_id.0 as usize].scope {
+            if let Some(current_scope) = env.identifiers[lvalue_id.index()].scope {
                 if let Some(&root) = scope_remap.get(&current_scope) {
-                    env.identifiers[lvalue_id.0 as usize].scope = Some(root);
+                    env.identifiers[lvalue_id.index()].scope = Some(root);
                 }
             }
         }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/align_reactive_scopes_to_block_scopes_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/align_reactive_scopes_to_block_scopes_hir.rs
@@ -66,7 +66,7 @@ fn all_terminal_block_ids(terminal: &Terminal) -> Vec<BlockId> {
 fn block_first_id(func: &HirFunction, block_id: BlockId) -> EvaluationOrder {
     let block = func.body.blocks.get(&block_id).unwrap();
     if !block.instructions.is_empty() {
-        func.instructions[block.instructions[0].0 as usize].id
+        func.instructions[block.instructions[0].index()].id
     } else {
         block.terminal.evaluation_order()
     }
@@ -112,7 +112,7 @@ pub fn align_reactive_scopes_to_block_scopes_hir(func: &mut HirFunction, env: &m
         let starting_id = block_first_id(func, block_id);
 
         // Retain only active scopes whose range.end > startingId
-        active_scopes.retain(|&scope_id| env.scopes[scope_id.0 as usize].range.end > starting_id);
+        active_scopes.retain(|&scope_id| env.scopes[scope_id.index()].range.end > starting_id);
 
         // Check if we've reached a fallthrough block
         if let Some(top) = active_block_fallthrough_ranges.last().cloned() {
@@ -121,7 +121,7 @@ pub fn align_reactive_scopes_to_block_scopes_hir(func: &mut HirFunction, env: &m
                 // All active scopes overlap this block-fallthrough range;
                 // extend their start to include the range start.
                 for &scope_id in &active_scopes {
-                    let scope = &mut env.scopes[scope_id.0 as usize];
+                    let scope = &mut env.scopes[scope_id.index()];
                     scope.range.start = min(scope.range.start, top.range.start);
                 }
             }
@@ -133,7 +133,7 @@ pub fn align_reactive_scopes_to_block_scopes_hir(func: &mut HirFunction, env: &m
         let block = func.body.blocks.get(&block_id).unwrap();
         let instr_ids: Vec<InstructionId> = block.instructions.to_vec();
         for &instr_id in &instr_ids {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             let eval_order = instr.id;
 
             let lvalue_ids = each_instruction_lvalue_ids(instr);
@@ -182,7 +182,7 @@ pub fn align_reactive_scopes_to_block_scopes_hir(func: &mut HirFunction, env: &m
                 let next_id = block_first_id(func, ft);
 
                 for &scope_id in &active_scopes {
-                    let scope = &mut env.scopes[scope_id.0 as usize];
+                    let scope = &mut env.scopes[scope_id.index()];
                     if scope.range.end > terminal_eval_order {
                         scope.range.end = max(scope.range.end, next_id);
                     }
@@ -216,7 +216,7 @@ pub fn align_reactive_scopes_to_block_scopes_hir(func: &mut HirFunction, env: &m
                     let first_id = block_first_id(func, start_range.fallthrough);
 
                     for &scope_id in &active_scopes {
-                        let scope = &mut env.scopes[scope_id.0 as usize];
+                        let scope = &mut env.scopes[scope_id.index()];
                         if scope.range.end <= terminal_eval_order {
                             continue;
                         }
@@ -269,9 +269,9 @@ pub fn align_reactive_scopes_to_block_scopes_hir(func: &mut HirFunction, env: &m
     // be updated when the scope's range changes.
     for ident in &mut env.identifiers {
         if let Some(scope_id) = ident.scope {
-            let original = &original_scope_ranges[scope_id.0 as usize];
+            let original = &original_scope_ranges[scope_id.index()];
             if ident.mutable_range.same_range(original) {
-                let scope_range = &env.scopes[scope_id.0 as usize].range;
+                let scope_range = &env.scopes[scope_id.index()].range;
                 ident.mutable_range.start = scope_range.start;
                 ident.mutable_range.end = scope_range.end;
             }
@@ -291,9 +291,9 @@ fn record_place_id(
     seen: &mut FxHashSet<ScopeId>,
 ) {
     // Get the scope for this identifier, if active at this instruction
-    let scope_id = match env.identifiers[identifier_id.0 as usize].scope {
+    let scope_id = match env.identifiers[identifier_id.index()].scope {
         Some(scope_id) => {
-            let scope = &env.scopes[scope_id.0 as usize];
+            let scope = &env.scopes[scope_id.index()];
             if id >= scope.range.start && id < scope.range.end { Some(scope_id) } else { None }
         }
         None => None,
@@ -308,7 +308,7 @@ fn record_place_id(
         seen.insert(scope_id);
 
         if let Some(n) = node {
-            let scope = &mut env.scopes[scope_id.0 as usize];
+            let scope = &mut env.scopes[scope_id.index()];
             scope.range.start = min(n.value_range.start, scope.range.start);
             scope.range.end = max(n.value_range.end, scope.range.end);
         }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/analyse_functions.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/analyse_functions.rs
@@ -54,7 +54,7 @@ where
     let mut inner_func_ids: Vec<FunctionId> = Vec::new();
     for (_block_id, block) in &func.body.blocks {
         for instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             match &instr.value {
                 InstructionValue::FunctionExpression { lowered_func, .. }
                 | InstructionValue::ObjectMethod { lowered_func, .. } => {
@@ -68,14 +68,13 @@ where
     // Process each inner function
     for func_id in inner_func_ids {
         // Take the inner function out of the arena to avoid borrow conflicts
-        let mut inner_func =
-            replace(&mut env.functions[func_id.0 as usize], placeholder_function());
+        let mut inner_func = replace(&mut env.functions[func_id.index()], placeholder_function());
 
         lower_with_mutation_aliasing(&mut inner_func, env, debug_logger)?;
 
         // If an invariant error was recorded, put the function back and stop processing
         if env.has_invariant_errors() {
-            env.functions[func_id.0 as usize] = inner_func;
+            env.functions[func_id.index()] = inner_func;
             return Ok(());
         }
 
@@ -86,14 +85,14 @@ where
         // are stored in an arena, so we reset both the identifier's range
         // and clear its scope.
         for operand in &inner_func.context {
-            let new_range = env.new_mutable_range(EvaluationOrder(0), EvaluationOrder(0));
-            let ident = &mut env.identifiers[operand.identifier.0 as usize];
+            let new_range = env.new_mutable_range(EvaluationOrder::UNSET, EvaluationOrder::UNSET);
+            let ident = &mut env.identifiers[operand.identifier.index()];
             ident.mutable_range = new_range;
             ident.scope = None;
         }
 
         // Put the function back
-        env.functions[func_id.0 as usize] = inner_func;
+        env.functions[func_id.index()] = inner_func;
     }
 
     Ok(())
@@ -201,13 +200,13 @@ fn placeholder_function<'a>() -> HirFunction<'a> {
         fn_type: ReactFunctionType::Other,
         params: Vec::new(),
         returns: Place {
-            identifier: IdentifierId(0),
+            identifier: IdentifierId::from_usize(0),
             effect: Effect::Unknown,
             reactive: false,
             span: None,
         },
         context: Vec::new(),
-        body: HIR { entry: BlockId(0), blocks: FxIndexMap::default() },
+        body: HIR { entry: BlockId::from_usize(0), blocks: FxIndexMap::default() },
         instructions: Vec::new(),
         generator: false,
         is_async: false,

--- a/crates/oxc_react_compiler/src/react_compiler_inference/build_reactive_scope_terminals_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/build_reactive_scope_terminals_hir.rs
@@ -45,8 +45,8 @@ fn get_scopes(func: &HirFunction, env: &Environment) -> Vec<ScopeId> {
     let mut scope_ids: FxHashSet<ScopeId> = FxHashSet::default();
 
     let mut visit_place = |identifier_id: IdentifierId| {
-        if let Some(scope_id) = env.identifiers[identifier_id.0 as usize].scope {
-            let range = &env.scopes[scope_id.0 as usize].range;
+        if let Some(scope_id) = env.identifiers[identifier_id.index()].scope {
+            let range = &env.scopes[scope_id.index()].range;
             if range.start != range.end {
                 scope_ids.insert(scope_id);
             }
@@ -55,7 +55,7 @@ fn get_scopes(func: &HirFunction, env: &Environment) -> Vec<ScopeId> {
 
     for (_block_id, block) in &func.body.blocks {
         for &instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             // lvalues
             for id in each_instruction_lvalue_ids(instr) {
                 visit_place(id);
@@ -111,13 +111,13 @@ fn collect_scope_rewrites(func: &HirFunction, env: &mut Environment) -> Vec<Term
     // Sort: ascending by start, descending by end for ties
     let mut items: Vec<ScopeId> = scope_ids;
     items.sort_by(|a, b| {
-        let a_range = &env.scopes[a.0 as usize].range;
-        let b_range = &env.scopes[b.0 as usize].range;
-        let start_diff = a_range.start.0.cmp(&b_range.start.0);
+        let a_range = &env.scopes[a.index()].range;
+        let b_range = &env.scopes[b.index()].range;
+        let start_diff = a_range.start.cmp(&b_range.start);
         if start_diff != Ordering::Equal {
             return start_diff;
         }
-        b_range.end.0.cmp(&a_range.end.0)
+        b_range.end.cmp(&a_range.end)
     });
 
     let mut rewrites: Vec<TerminalRewriteInfo> = Vec::new();
@@ -125,15 +125,15 @@ fn collect_scope_rewrites(func: &HirFunction, env: &mut Environment) -> Vec<Term
     let mut active_items: Vec<ScopeId> = Vec::new();
 
     for &curr in &items {
-        let curr_start = env.scopes[curr.0 as usize].range.start;
-        let curr_end = env.scopes[curr.0 as usize].range.end;
+        let curr_start = env.scopes[curr.index()].range.start;
+        let curr_end = env.scopes[curr.index()].range.end;
 
         // Pop active items that are disjoint with current
         let mut j = active_items.len();
         while j > 0 {
             j -= 1;
             let maybe_parent = active_items[j];
-            let parent_end = env.scopes[maybe_parent.0 as usize].range.end;
+            let parent_end = env.scopes[maybe_parent.index()].range.end;
             let disjoint = curr_start >= parent_end;
             let nested = curr_end <= parent_end;
             assert!(disjoint || nested, "Invalid nesting in program blocks or scopes");
@@ -141,7 +141,7 @@ fn collect_scope_rewrites(func: &HirFunction, env: &mut Environment) -> Vec<Term
                 // Exit this scope
                 let fallthrough_id =
                     *fallthroughs.get(&maybe_parent).expect("Expected scope to exist");
-                let end_instr_id = env.scopes[maybe_parent.0 as usize].range.end;
+                let end_instr_id = env.scopes[maybe_parent.index()].range.end;
                 rewrites
                     .push(TerminalRewriteInfo::EndScope { instr_id: end_instr_id, fallthrough_id });
                 active_items.truncate(j);
@@ -153,7 +153,7 @@ fn collect_scope_rewrites(func: &HirFunction, env: &mut Environment) -> Vec<Term
         // Enter scope
         let block_id = env.next_block_id();
         let fallthrough_id = env.next_block_id();
-        let start_instr_id = env.scopes[curr.0 as usize].range.start;
+        let start_instr_id = env.scopes[curr.index()].range.start;
         rewrites.push(TerminalRewriteInfo::StartScope {
             block_id,
             fallthrough_id,
@@ -167,7 +167,7 @@ fn collect_scope_rewrites(func: &HirFunction, env: &mut Environment) -> Vec<Term
     // Exit remaining active items
     while let Some(curr) = active_items.pop() {
         let fallthrough_id = *fallthroughs.get(&curr).expect("Expected scope to exist");
-        let end_instr_id = env.scopes[curr.0 as usize].range.end;
+        let end_instr_id = env.scopes[curr.index()].range.end;
         rewrites.push(TerminalRewriteInfo::EndScope { instr_id: end_instr_id, fallthrough_id });
     }
 
@@ -267,7 +267,7 @@ pub fn build_reactive_scope_terminals_hir(func: &mut HirFunction, env: &mut Envi
         for i in 0..block.instructions.len() + 1 {
             let instr_id = if i < block.instructions.len() {
                 let instr_idx = block.instructions[i];
-                func.instructions[instr_idx.0 as usize].id
+                func.instructions[instr_idx.index()].id
             } else {
                 block.terminal.evaluation_order()
             };
@@ -365,12 +365,12 @@ fn fix_scope_and_identifier_ranges(func: &HirFunction, env: &mut Environment) {
             | Terminal::PrunedScope { fallthrough, scope, id, .. } => {
                 let fallthrough_block = func.body.blocks.get(fallthrough).unwrap();
                 let first_id = if !fallthrough_block.instructions.is_empty() {
-                    func.instructions[fallthrough_block.instructions[0].0 as usize].id
+                    func.instructions[fallthrough_block.instructions[0].index()].id
                 } else {
                     fallthrough_block.terminal.evaluation_order()
                 };
-                env.scopes[scope.0 as usize].range.start = *id;
-                env.scopes[scope.0 as usize].range.end = first_id;
+                env.scopes[scope.index()].range.start = *id;
+                env.scopes[scope.index()].range.end = first_id;
             }
             _ => {}
         }
@@ -386,9 +386,9 @@ fn fix_scope_and_identifier_ranges(func: &HirFunction, env: &mut Environment) {
     // not the root scope's range — so they should NOT be synced here.
     for ident in &mut env.identifiers {
         if let Some(scope_id) = ident.scope {
-            let original = &original_scope_ranges[scope_id.0 as usize];
+            let original = &original_scope_ranges[scope_id.index()];
             if ident.mutable_range.same_range(original) {
-                let scope_range = &env.scopes[scope_id.0 as usize].range;
+                let scope_range = &env.scopes[scope_id.index()].range;
                 ident.mutable_range.start = scope_range.start;
                 ident.mutable_range.end = scope_range.end;
             }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/flatten_scopes_with_hooks_or_use_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/flatten_scopes_with_hooks_or_use_hir.rs
@@ -56,11 +56,11 @@ pub fn flatten_scopes_with_hooks_or_use_hir(
 
         // Check instructions for hook or use calls
         for instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             match &instr.value {
                 InstructionValue::CallExpression { callee, .. } => {
                     let callee_ty =
-                        &env.types[env.identifiers[callee.identifier.0 as usize].type_.0 as usize];
+                        &env.types[env.identifiers[callee.identifier.index()].type_.index()];
                     if is_hook_or_use(env, callee_ty)? {
                         // All active scopes must be pruned
                         prune.extend(active_scopes.iter().map(|s| s.block));
@@ -68,8 +68,8 @@ pub fn flatten_scopes_with_hooks_or_use_hir(
                     }
                 }
                 InstructionValue::MethodCall { property, .. } => {
-                    let property_ty = &env.types
-                        [env.identifiers[property.identifier.0 as usize].type_.0 as usize];
+                    let property_ty =
+                        &env.types[env.identifiers[property.identifier.index()].type_.index()];
                     if is_hook_or_use(env, property_ty)? {
                         prune.extend(active_scopes.iter().map(|s| s.block));
                         active_scopes.clear();
@@ -95,8 +95,10 @@ pub fn flatten_scopes_with_hooks_or_use_hir(
                 (*block, *fallthrough, *id, *span, *scope)
             }
             _ => {
-                return Err(ErrorCategory::Invariant
-                    .diagnostic(format!("Expected block bb{} to end in a scope terminal", id.0)));
+                return Err(ErrorCategory::Invariant.diagnostic(format!(
+                    "Expected block bb{} to end in a scope terminal",
+                    id.index()
+                )));
             }
         };
 

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
@@ -197,7 +197,7 @@ pub fn infer_mutation_aliasing_effects(
             // Check for uninitialized identifier access (matches TS invariant:
             // "Expected value kind to be initialized")
             if let Some((uninitialized_id, usage_span)) = state.uninitialized_access.get() {
-                let ident_info = env.identifiers.get(uninitialized_id.0 as usize);
+                let ident_info = env.identifiers.get(uninitialized_id.index());
                 let name = ident_info
                     .and_then(|ident| ident.name.as_ref())
                     .map(|n| n.value().to_string())
@@ -207,11 +207,12 @@ pub fn infer_mutation_aliasing_effects(
                 // Match TS printPlace format: "<unknown> name$id:type"
                 let type_str = ident_info
                     .map(|ident| {
-                        let ty = &env.types[ident.type_.0 as usize];
+                        let ty = &env.types[ident.type_.index()];
                         format_type_for_print(ty)
                     })
                     .unwrap_or_default();
-                let description = format!("<unknown> {}${}{}", name, uninitialized_id.0, type_str);
+                let description =
+                    format!("<unknown> {}${}{}", name, uninitialized_id.index(), type_str);
                 let diag = ErrorCategory::Invariant
                     .diagnostic(
                         "[InferMutationAliasingEffects] Expected value kind to be initialized",
@@ -247,6 +248,12 @@ static NEXT_VALUE_ID: AtomicU32 = AtomicU32::new(1);
 impl ValueId {
     fn new() -> Self {
         ValueId(NEXT_VALUE_ID.fetch_add(1, Ordering::Relaxed))
+    }
+
+    /// Deterministic value id derived from an identifier's current value. The high bit is
+    /// set so these never collide with the counter-allocated ids from `new()`.
+    fn from_identifier(id: IdentifierId) -> Self {
+        ValueId(id.index() as u32 | 0x80000000)
     }
 }
 
@@ -344,7 +351,7 @@ impl InferenceState {
             None => {
                 // Create a stable value for uninitialized identifiers
                 // Use a deterministic ID based on the from identifier
-                let vid = ValueId(from.0 | 0x80000000);
+                let vid = ValueId::from_identifier(from);
                 let mut set = FxHashSet::default();
                 set.insert(vid);
                 self.values.entry(vid).or_insert_with(|| AbstractValue {
@@ -423,7 +430,7 @@ impl InferenceState {
         env: &Environment,
         usage_span: Option<Span>,
     ) -> MutationResult {
-        let ty = &env.types[env.identifiers[place_id.0 as usize].type_.0 as usize];
+        let ty = &env.types[env.identifiers[place_id.index()].type_.index()];
         if is_ref_or_ref_value(ty) {
             return MutationResult::MutateRef;
         }
@@ -596,67 +603,74 @@ fn hash_effect(effect: &AliasingEffect) -> String {
                 .iter()
                 .map(|a| match a {
                     PlaceOrSpreadOrHole::Hole => Cow::Borrowed(""),
-                    PlaceOrSpreadOrHole::Place(p) => Cow::Owned(format!("{}", p.identifier.0)),
+                    PlaceOrSpreadOrHole::Place(p) => {
+                        Cow::Owned(format!("{}", p.identifier.index()))
+                    }
                     PlaceOrSpreadOrHole::Spread(s) => {
-                        Cow::Owned(format!("...{}", s.place.identifier.0))
+                        Cow::Owned(format!("...{}", s.place.identifier.index()))
                     }
                 })
                 .collect();
             format!(
                 "Apply:{}:{}:{}:{}:{}",
-                receiver.identifier.0,
-                function.identifier.0,
+                receiver.identifier.index(),
+                function.identifier.index(),
                 mutates_function,
                 args_str.join(","),
-                into.identifier.0
+                into.identifier.index()
             )
         }
         AliasingEffect::CreateFrom { from, into } => {
-            format!("CreateFrom:{}:{}", from.identifier.0, into.identifier.0)
+            format!("CreateFrom:{}:{}", from.identifier.index(), into.identifier.index())
         }
         AliasingEffect::ImmutableCapture { from, into } => {
-            format!("ImmutableCapture:{}:{}", from.identifier.0, into.identifier.0)
+            format!("ImmutableCapture:{}:{}", from.identifier.index(), into.identifier.index())
         }
         AliasingEffect::Assign { from, into } => {
-            format!("Assign:{}:{}", from.identifier.0, into.identifier.0)
+            format!("Assign:{}:{}", from.identifier.index(), into.identifier.index())
         }
         AliasingEffect::Alias { from, into } => {
-            format!("Alias:{}:{}", from.identifier.0, into.identifier.0)
+            format!("Alias:{}:{}", from.identifier.index(), into.identifier.index())
         }
         AliasingEffect::Capture { from, into } => {
-            format!("Capture:{}:{}", from.identifier.0, into.identifier.0)
+            format!("Capture:{}:{}", from.identifier.index(), into.identifier.index())
         }
         AliasingEffect::MaybeAlias { from, into } => {
-            format!("MaybeAlias:{}:{}", from.identifier.0, into.identifier.0)
+            format!("MaybeAlias:{}:{}", from.identifier.index(), into.identifier.index())
         }
         AliasingEffect::Create { into, value, reason } => {
-            format!("Create:{}:{:?}:{:?}", into.identifier.0, value, reason)
+            format!("Create:{}:{:?}:{:?}", into.identifier.index(), value, reason)
         }
         AliasingEffect::Freeze { value, reason } => {
-            format!("Freeze:{}:{:?}", value.identifier.0, reason)
+            format!("Freeze:{}:{:?}", value.identifier.index(), reason)
         }
-        AliasingEffect::Impure { place, .. } => format!("Impure:{}", place.identifier.0),
-        AliasingEffect::Render { place } => format!("Render:{}", place.identifier.0),
+        AliasingEffect::Impure { place, .. } => format!("Impure:{}", place.identifier.index()),
+        AliasingEffect::Render { place } => format!("Render:{}", place.identifier.index()),
         AliasingEffect::MutateFrozen { place, error } => {
-            format!("MutateFrozen:{}:{}:{:?}", place.identifier.0, error.message, error.help)
+            format!("MutateFrozen:{}:{}:{:?}", place.identifier.index(), error.message, error.help)
         }
         AliasingEffect::MutateGlobal { place, error } => {
-            format!("MutateGlobal:{}:{}:{:?}", place.identifier.0, error.message, error.help)
+            format!("MutateGlobal:{}:{}:{:?}", place.identifier.index(), error.message, error.help)
         }
-        AliasingEffect::Mutate { value, .. } => format!("Mutate:{}", value.identifier.0),
+        AliasingEffect::Mutate { value, .. } => format!("Mutate:{}", value.identifier.index()),
         AliasingEffect::MutateConditionally { value } => {
-            format!("MutateConditionally:{}", value.identifier.0)
+            format!("MutateConditionally:{}", value.identifier.index())
         }
         AliasingEffect::MutateTransitive { value } => {
-            format!("MutateTransitive:{}", value.identifier.0)
+            format!("MutateTransitive:{}", value.identifier.index())
         }
         AliasingEffect::MutateTransitiveConditionally { value } => {
-            format!("MutateTransitiveConditionally:{}", value.identifier.0)
+            format!("MutateTransitiveConditionally:{}", value.identifier.index())
         }
         AliasingEffect::CreateFunction { into, function_id, captures } => {
             let cap_str: Vec<String> =
-                captures.iter().map(|p| format!("{}", p.identifier.0)).collect();
-            format!("CreateFunction:{}:{}:{}", into.identifier.0, function_id.0, cap_str.join(","))
+                captures.iter().map(|p| format!("{}", p.identifier.index())).collect();
+            format!(
+                "CreateFunction:{}:{}:{}",
+                into.identifier.index(),
+                function_id.index(),
+                cap_str.join(",")
+            )
         }
     }
 }
@@ -724,7 +738,7 @@ fn find_hoisted_context_declarations(
         place: &Place,
         env: &Environment,
     ) {
-        let decl_id = env.identifiers[place.identifier.0 as usize].declaration_id;
+        let decl_id = env.identifiers[place.identifier.index()].declaration_id;
         if hoisted.contains_key(&decl_id) && hoisted.get(&decl_id).unwrap().is_none() {
             hoisted.insert(decl_id, Some(place.clone()));
         }
@@ -732,7 +746,7 @@ fn find_hoisted_context_declarations(
 
     for (_block_id, block) in &func.body.blocks {
         for instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             match &instr.value {
                 InstructionValue::DeclareContext { lvalue, .. } => {
                     let kind = lvalue.kind;
@@ -741,7 +755,7 @@ fn find_hoisted_context_declarations(
                         || kind == InstructionKind::HoistedLet
                     {
                         let decl_id =
-                            env.identifiers[lvalue.place.identifier.0 as usize].declaration_id;
+                            env.identifiers[lvalue.place.identifier.index()].declaration_id;
                         hoisted.insert(decl_id, None);
                     }
                 }
@@ -791,7 +805,7 @@ fn find_non_mutated_destructure_spreads(
             }
         }
         for instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             let lvalue_id = instr.lvalue.identifier;
             match &instr.value {
                 InstructionValue::Destructure { lvalue, value, .. } => {
@@ -839,7 +853,7 @@ fn find_non_mutated_destructure_spreads(
                 InstructionValue::CallExpression { callee, .. }
                 | InstructionValue::MethodCall { property: callee, .. } => {
                     let callee_ty =
-                        &env.types[env.identifiers[callee.identifier.0 as usize].type_.0 as usize];
+                        &env.types[env.identifiers[callee.identifier.index()].type_.index()];
                     if get_hook_kind_for_type(env, callee_ty).ok().flatten().is_some() {
                         if !is_ref_or_ref_value_for_id(env, lvalue_id) {
                             known_frozen.insert(lvalue_id);
@@ -913,7 +927,7 @@ fn infer_block(
     }
 
     // Process instructions
-    let instr_ids: Vec<u32> = block.instructions.iter().map(|id| id.0).collect();
+    let instr_ids: Vec<u32> = block.instructions.iter().map(|id| id.index() as u32).collect();
     for instr_idx in &instr_ids {
         let instr_index = *instr_idx as usize;
 
@@ -1034,7 +1048,7 @@ fn apply_signature(
     match &instr.value {
         InstructionValue::FunctionExpression { lowered_func, .. }
         | InstructionValue::ObjectMethod { lowered_func, .. } => {
-            let inner_func = &env.functions[lowered_func.func.0 as usize];
+            let inner_func = &env.functions[lowered_func.func.index()];
             if let Some(ref aliasing_effects) = inner_func.aliasing_effects {
                 let context_ids: FxHashSet<IdentifierId> =
                     inner_func.context.iter().map(|p| p.identifier).collect();
@@ -1053,7 +1067,7 @@ fn apply_signature(
                     let value_abstract = state.kind(mutate_value.identifier);
                     if value_abstract.kind == ValueKind::Frozen {
                         let reason_str = get_write_error_reason(&value_abstract);
-                        let ident = &env.identifiers[mutate_value.identifier.0 as usize];
+                        let ident = &env.identifiers[mutate_value.identifier.index()];
                         let variable = match &ident.name {
                             Some(IdentifierName::Named(n)) => {
                                 format!("`{}`", n)
@@ -1094,7 +1108,7 @@ fn apply_signature(
     // The TS version asserts this as an invariant, but the Rust port may have
     // edge cases where effects don't cover the lvalue (e.g. missing signature entries).
     if !state.is_defined(instr.lvalue.identifier) {
-        let vid = ValueId(instr.lvalue.identifier.0 | 0x80000000);
+        let vid = ValueId::from_identifier(instr.lvalue.identifier);
         state.initialize(
             vid,
             AbstractValue { kind: ValueKind::Mutable, reason: hashset_of(ValueReason::Other) },
@@ -1122,7 +1136,7 @@ fn freeze_function_captures_transitive(
 ) {
     if let Some(&func_id) = context.function_values.get(&value_id) {
         let ctx_ids: Vec<IdentifierId> =
-            env.functions[func_id.0 as usize].context.iter().map(|p| p.identifier).collect();
+            env.functions[func_id.index()].context.iter().map(|p| p.identifier).collect();
         for ctx_id in ctx_ids {
             // Replicate InferenceState::freeze() logic inline —
             // we need to recurse with context/env which freeze() doesn't have.
@@ -1266,7 +1280,7 @@ fn apply_effect(
                 k == ValueKind::Context || k == ValueKind::Mutable
             });
 
-            let inner_func = &env.functions[function_id.0 as usize];
+            let inner_func = &env.functions[function_id.index()];
             let has_tracked_side_effects = inner_func
                 .aliasing_effects
                 .as_ref()
@@ -1304,7 +1318,7 @@ fn apply_effect(
                     || kind == ValueKind::Global
                 {
                     // Downgrade to Read - we need to mutate the inner function
-                    let inner_func_mut = &mut env.functions[function_id.0 as usize];
+                    let inner_func_mut = &mut env.functions[function_id.index()];
                     for ctx in &mut inner_func_mut.context {
                         if ctx.identifier == operand.identifier && ctx.effect == Effect::Capture {
                             ctx.effect = Effect::Read;
@@ -1410,8 +1424,11 @@ fn apply_effect(
                         env,
                         func,
                     )?;
-                    let cache_key =
-                        format!("Assign_frozen:{}:{}", from.identifier.0, into.identifier.0);
+                    let cache_key = format!(
+                        "Assign_frozen:{}:{}",
+                        from.identifier.index(),
+                        into.identifier.index()
+                    );
                     let value_id = *context
                         .effect_value_id_cache
                         .entry(cache_key)
@@ -1423,8 +1440,11 @@ fn apply_effect(
                     state.define(into.identifier, value_id);
                 }
                 ValueKind::Global | ValueKind::Primitive => {
-                    let cache_key =
-                        format!("Assign_copy:{}:{}", from.identifier.0, into.identifier.0);
+                    let cache_key = format!(
+                        "Assign_copy:{}:{}",
+                        from.identifier.index(),
+                        into.identifier.index()
+                    );
                     let value_id = *context
                         .effect_value_id_cache
                         .entry(cache_key)
@@ -1457,7 +1477,7 @@ fn apply_effect(
                 if function_values.len() == 1 {
                     let value_id = function_values[0];
                     if let Some(func_id) = context.function_values.get(&value_id).copied() {
-                        let inner_func = &env.functions[func_id.0 as usize];
+                        let inner_func = &env.functions[func_id.index()];
                         if inner_func.aliasing_effects.is_some() {
                             // Build or retrieve the signature from the function expression
                             context.function_signature_cache.entry(func_id).or_insert_with(|| {
@@ -1465,7 +1485,7 @@ fn apply_effect(
                             });
                             let sig =
                                 context.function_signature_cache.get(&func_id).unwrap().clone();
-                            let inner_func = &env.functions[func_id.0 as usize];
+                            let inner_func = &env.functions[func_id.index()];
                             let context_places: Vec<Place> = inner_func.context.clone();
                             let sig_effects = compute_effects_for_aliasing_signature(
                                 env,
@@ -1603,8 +1623,8 @@ fn apply_effect(
                     }
 
                     if *is_spread {
-                        let ty = &env.types
-                            [env.identifiers[operand.identifier.0 as usize].type_.0 as usize];
+                        let ty =
+                            &env.types[env.identifiers[operand.identifier.index()].type_.index()];
                         if let Some(mutate_iter) = conditionally_mutate_iterator(operand, ty) {
                             apply_effect(
                                 context,
@@ -1680,7 +1700,7 @@ fn apply_effect(
             {
                 let abstract_value = state.kind(value.identifier);
 
-                let ident = &env.identifiers[value.identifier.0 as usize];
+                let ident = &env.identifiers[value.identifier.index()];
                 let decl_id = ident.declaration_id;
 
                 if mutation_kind == MutationResult::MutateFrozen
@@ -1786,8 +1806,8 @@ fn compute_signature_for_instruction(
                         });
                     }
                     ArrayElement::Spread(s) => {
-                        let ty = &env.types
-                            [env.identifiers[s.place.identifier.0 as usize].type_.0 as usize];
+                        let ty =
+                            &env.types[env.identifiers[s.place.identifier.index()].type_.index()];
                         if let Some(mutate_iter) = conditionally_mutate_iterator(&s.place, ty) {
                             effects.push(mutate_iter);
                         }
@@ -1881,7 +1901,7 @@ fn compute_signature_for_instruction(
         }
         InstructionValue::PropertyLoad { object, .. }
         | InstructionValue::ComputedLoad { object, .. } => {
-            let ty = &env.types[env.identifiers[lvalue.identifier.0 as usize].type_.0 as usize];
+            let ty = &env.types[env.identifiers[lvalue.identifier.index()].type_.index()];
             if is_primitive_type(ty) {
                 effects.push(AliasingEffect::Create {
                     into: lvalue.clone(),
@@ -1897,8 +1917,7 @@ fn compute_signature_for_instruction(
         }
         InstructionValue::PropertyStore { object, property, value: store_value, .. } => {
             let mutation_reason: Option<MutationReason> = {
-                let obj_ty =
-                    &env.types[env.identifiers[object.identifier.0 as usize].type_.0 as usize];
+                let obj_ty = &env.types[env.identifiers[object.identifier.index()].type_.index()];
                 if let PropertyLiteral::String(prop_name) = property {
                     if prop_name == "current" && matches!(obj_ty, Type::TypeVar { .. }) {
                         Some(MutationReason::AssignCurrentProperty)
@@ -1930,7 +1949,7 @@ fn compute_signature_for_instruction(
         }
         InstructionValue::FunctionExpression { lowered_func, .. }
         | InstructionValue::ObjectMethod { lowered_func, .. } => {
-            let inner_func = &env.functions[lowered_func.func.0 as usize];
+            let inner_func = &env.functions[lowered_func.func.index()];
             let captures: Vec<Place> = inner_func
                 .context
                 .iter()
@@ -1949,7 +1968,7 @@ fn compute_signature_for_instruction(
                 value: ValueKind::Mutable,
                 reason: ValueReason::Other,
             });
-            let ty = &env.types[env.identifiers[collection.identifier.0 as usize].type_.0 as usize];
+            let ty = &env.types[env.identifiers[collection.identifier.index()].type_.index()];
             if is_builtin_collection_type(ty) {
                 effects.push(AliasingEffect::Capture {
                     from: collection.clone(),
@@ -2001,8 +2020,8 @@ fn compute_signature_for_instruction(
             }
             for prop in props {
                 if let JsxAttribute::Attribute { place: prop_place, .. } = prop {
-                    let prop_ty = &env.types
-                        [env.identifiers[prop_place.identifier.0 as usize].type_.0 as usize];
+                    let prop_ty =
+                        &env.types[env.identifiers[prop_place.identifier.index()].type_.index()];
                     if let Type::Function { return_type, .. } = prop_ty {
                         if is_jsx_type(return_type) || is_phi_with_jsx(return_type) {
                             effects.push(AliasingEffect::Render { place: prop_place.clone() });
@@ -2042,8 +2061,8 @@ fn compute_signature_for_instruction(
             for pat_item in each_pattern_items(&dl.pattern) {
                 match pat_item {
                     PatternItem::Place(place) => {
-                        let ty = &env.types
-                            [env.identifiers[place.identifier.0 as usize].type_.0 as usize];
+                        let ty =
+                            &env.types[env.identifiers[place.identifier.index()].type_.index()];
                         if is_primitive_type(ty) {
                             effects.push(AliasingEffect::Create {
                                 into: place.clone(),
@@ -2082,7 +2101,7 @@ fn compute_signature_for_instruction(
             effects.push(AliasingEffect::CreateFrom { from: place.clone(), into: lvalue.clone() });
         }
         InstructionValue::DeclareContext { lvalue: dcl, .. } => {
-            let decl_id = env.identifiers[dcl.place.identifier.0 as usize].declaration_id;
+            let decl_id = env.identifiers[dcl.place.identifier.index()].declaration_id;
             let kind = dcl.kind;
             if !context.hoisted_context_declarations.contains_key(&decl_id)
                 || kind == InstructionKind::HoistedConst
@@ -2104,7 +2123,7 @@ fn compute_signature_for_instruction(
             });
         }
         InstructionValue::StoreContext { lvalue: scl, value: sc_value, .. } => {
-            let decl_id = env.identifiers[scl.place.identifier.0 as usize].declaration_id;
+            let decl_id = env.identifiers[scl.place.identifier.index()].declaration_id;
             if scl.kind == InstructionKind::Reassign
                 || context.hoisted_context_declarations.contains_key(&decl_id)
             {
@@ -2281,7 +2300,7 @@ fn compute_effects_for_legacy_signature(
             effects.push(AliasingEffect::MutateTransitiveConditionally { value: place.clone() });
         }
         Effect::ConditionallyMutateIterator => {
-            let ty = &env.types[env.identifiers[place.identifier.0 as usize].type_.0 as usize];
+            let ty = &env.types[env.identifiers[place.identifier.index()].type_.index()];
             if let Some(mutate_iter) = conditionally_mutate_iterator(place, ty) {
                 effects.push(mutate_iter);
             }
@@ -2389,8 +2408,7 @@ fn are_arguments_immutable_and_non_mutating(
                 // Check if it's a function type with a known signature
                 let is_place = matches!(arg, PlaceOrSpreadOrHole::Place(_));
                 if is_place {
-                    let ty =
-                        &env.types[env.identifiers[place.identifier.0 as usize].type_.0 as usize];
+                    let ty = &env.types[env.identifiers[place.identifier.index()].type_.index()];
                     if let Type::Function { .. } = ty {
                         let fn_shape = env.get_function_signature(ty).ok().flatten();
                         if let Some(fn_sig) = fn_shape {
@@ -2420,14 +2438,14 @@ fn are_arguments_immutable_and_non_mutating(
                 let value_ids = state.values_for(place.identifier);
                 for vid in &value_ids {
                     if let Some(&func_id) = function_values.get(vid) {
-                        let inner_func = &env.functions[func_id.0 as usize];
+                        let inner_func = &env.functions[func_id.index()];
                         let mutates_params = inner_func.params.iter().any(|param| {
                             let param_id = match param {
                                 ParamPattern::Place(p) => p.identifier,
                                 ParamPattern::Spread(s) => s.place.identifier,
                             };
-                            let ident = &env.identifiers[param_id.0 as usize];
-                            ident.mutable_range.end.0 > ident.mutable_range.start.0 + 1
+                            let ident = &env.identifiers[param_id.index()];
+                            ident.mutable_range.end > ident.mutable_range.start + 1
                         });
                         if mutates_params {
                             return false;
@@ -2486,8 +2504,7 @@ fn compute_effects_for_aliasing_signature_config(
                 }
 
                 if matches!(arg, PlaceOrSpreadOrHole::Spread(_)) {
-                    let ty =
-                        &env.types[env.identifiers[place.identifier.0 as usize].type_.0 as usize];
+                    let ty = &env.types[env.identifiers[place.identifier.index()].type_.index()];
                     let mutate_iterator = conditionally_mutate_iterator(place, ty);
                     if mutate_iterator.is_some() {
                         mutable_spreads.insert(place.identifier);
@@ -2498,7 +2515,7 @@ fn compute_effects_for_aliasing_signature_config(
     }
 
     for operand in context {
-        let ident = &env.identifiers[operand.identifier.0 as usize];
+        let ident = &env.identifiers[operand.identifier.index()];
         if let Some(ref name) = ident.name {
             substitutions.insert(format!("@{}", name.value()), vec![operand.clone()]);
         }
@@ -2673,7 +2690,7 @@ fn build_signature_from_function_expression(
     env: &mut Environment,
     func_id: FunctionId,
 ) -> AliasingSignature {
-    let inner_func = &env.functions[func_id.0 as usize];
+    let inner_func = &env.functions[func_id.index()];
     let mut params: Vec<IdentifierId> = Vec::new();
     let mut rest: Option<IdentifierId> = None;
     for param in &inner_func.params {
@@ -2692,7 +2709,7 @@ fn build_signature_from_function_expression(
     }
 
     AliasingSignature {
-        receiver: IdentifierId(0),
+        receiver: IdentifierId::from_usize(0),
         params,
         rest,
         returns,
@@ -2738,8 +2755,7 @@ fn compute_effects_for_aliasing_signature(
                 }
 
                 if is_spread {
-                    let ty =
-                        &env.types[env.identifiers[place.identifier.0 as usize].type_.0 as usize];
+                    let ty = &env.types[env.identifiers[place.identifier.index()].type_.index()];
                     let mutate_iterator = conditionally_mutate_iterator(place, ty);
                     if mutate_iterator.is_some() {
                         mutable_spreads.insert(place.identifier);
@@ -2991,12 +3007,12 @@ fn get_function_call_signature(
     env: &Environment,
     callee_id: IdentifierId,
 ) -> Result<Option<FunctionSignature>, OxcDiagnostic> {
-    let ty = &env.types[env.identifiers[callee_id.0 as usize].type_.0 as usize];
+    let ty = &env.types[env.identifiers[callee_id.index()].type_.index()];
     Ok(env.get_function_signature(ty)?.cloned())
 }
 
 fn is_ref_or_ref_value_for_id(env: &Environment, id: IdentifierId) -> bool {
-    let ty = &env.types[env.identifiers[id.0 as usize].type_.0 as usize];
+    let ty = &env.types[env.identifiers[id.index()].type_.index()];
     is_ref_or_ref_value(ty)
 }
 
@@ -3069,7 +3085,7 @@ fn build_apply_operands(
 
 fn create_temp_place(env: &mut Environment, span: Option<Span>) -> Place {
     let id = env.next_identifier_id();
-    env.identifiers[id.0 as usize].span = span;
+    env.identifiers[id.index()].span = span;
     Place { identifier: id, effect: Effect::Unknown, reactive: false, span }
 }
 

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_ranges.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_ranges.rs
@@ -269,8 +269,8 @@ impl AliasingState {
             node.last_mutated = node.last_mutated.max(index);
 
             if let Some(end_val) = end {
-                let ident = &mut env.identifiers[node.id.0 as usize];
-                ident.mutable_range.end = EvaluationOrder(ident.mutable_range.end.0.max(end_val.0));
+                let ident = &mut env.identifiers[node.id.index()];
+                ident.mutable_range.end = ident.mutable_range.end.max(end_val);
             }
 
             if let NodeValue::Function { function_id } = &node.value {
@@ -398,7 +398,7 @@ impl AliasingState {
 // =============================================================================
 
 fn append_function_errors(env: &mut Environment, function_id: FunctionId) {
-    let func = &env.functions[function_id.0 as usize];
+    let func = &env.functions[function_id.index()];
     if let Some(ref effects) = func.aliasing_effects {
         // Collect errors first to avoid borrow conflict
         let errors: Vec<_> = effects
@@ -508,7 +508,7 @@ pub fn infer_mutation_aliasing_ranges(
         // Process instruction effects
         let instr_ids: Vec<_> = block.instructions.clone();
         for instr_id in &instr_ids {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             let instr_eval_order = instr.id;
             let effects = match &instr.effects {
                 Some(e) => e.clone(),
@@ -657,7 +657,7 @@ pub fn infer_mutation_aliasing_ranges(
         state.mutate(
             mutation.index,
             mutation.place.identifier,
-            Some(EvaluationOrder(mutation.id.0 + 1)),
+            Some(mutation.id + 1),
             mutation.transitive,
             mutation.kind,
             mutation.place.span,
@@ -742,11 +742,11 @@ pub fn infer_mutation_aliasing_ranges(
                 let first_instr_id = block
                     .instructions
                     .first()
-                    .map(|id| func.instructions[id.0 as usize].id)
+                    .map(|id| func.instructions[id.index()].id)
                     .unwrap_or_else(|| block.terminal.evaluation_order());
 
                 let is_mutated_after_creation =
-                    env.identifiers[phi.place.identifier.0 as usize].mutable_range.end
+                    env.identifiers[phi.place.identifier.index()].mutable_range.end
                         > first_instr_id;
 
                 (
@@ -774,9 +774,10 @@ pub fn infer_mutation_aliasing_ranges(
             }
 
             if *is_mutated_after_creation {
-                let ident = &mut env.identifiers[phi_id.0 as usize];
-                if ident.mutable_range.start == EvaluationOrder(0) {
-                    ident.mutable_range.start = EvaluationOrder(first_instr_id.0.saturating_sub(1));
+                let ident = &mut env.identifiers[phi_id.index()];
+                if ident.mutable_range.start == EvaluationOrder::UNSET {
+                    ident.mutable_range.start =
+                        EvaluationOrder::from_usize(first_instr_id.index().saturating_sub(1));
                 }
             }
         }
@@ -785,42 +786,40 @@ pub fn infer_mutation_aliasing_ranges(
         let instr_ids: Vec<_> = block.instructions.clone();
 
         for instr_id in &instr_ids {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             let eval_order = instr.id;
 
             // Set lvalue effect to ConditionallyMutate and fix up mutable range
             // This covers the top-level lvalue
             let lvalue_id = instr.lvalue.identifier;
             {
-                let ident = &mut env.identifiers[lvalue_id.0 as usize];
-                if ident.mutable_range.start == EvaluationOrder(0) {
+                let ident = &mut env.identifiers[lvalue_id.index()];
+                if ident.mutable_range.start == EvaluationOrder::UNSET {
                     ident.mutable_range.start = eval_order;
                 }
-                if ident.mutable_range.end == EvaluationOrder(0) {
-                    ident.mutable_range.end =
-                        EvaluationOrder((eval_order.0 + 1).max(ident.mutable_range.end.0));
+                if ident.mutable_range.end == EvaluationOrder::UNSET {
+                    ident.mutable_range.end = (eval_order + 1).max(ident.mutable_range.end);
                 }
             }
-            func.instructions[instr_id.0 as usize].lvalue.effect = Effect::ConditionallyMutate;
+            func.instructions[instr_id.index()].lvalue.effect = Effect::ConditionallyMutate;
 
             // Also handle value-level lvalues (DeclareLocal, StoreLocal, etc.)
             let value_lvalue_ids: Vec<IdentifierId> =
-                each_instruction_value_lvalue(&func.instructions[instr_id.0 as usize].value)
+                each_instruction_value_lvalue(&func.instructions[instr_id.index()].value)
                     .into_iter()
                     .map(|p| p.identifier)
                     .collect();
             for vlid in &value_lvalue_ids {
-                let ident = &mut env.identifiers[vlid.0 as usize];
-                if ident.mutable_range.start == EvaluationOrder(0) {
+                let ident = &mut env.identifiers[vlid.index()];
+                if ident.mutable_range.start == EvaluationOrder::UNSET {
                     ident.mutable_range.start = eval_order;
                 }
-                if ident.mutable_range.end == EvaluationOrder(0) {
-                    ident.mutable_range.end =
-                        EvaluationOrder((eval_order.0 + 1).max(ident.mutable_range.end.0));
+                if ident.mutable_range.end == EvaluationOrder::UNSET {
+                    ident.mutable_range.end = (eval_order + 1).max(ident.mutable_range.end);
                 }
             }
             for_each_instruction_value_lvalue_mut(
-                &mut func.instructions[instr_id.0 as usize].value,
+                &mut func.instructions[instr_id.index()].value,
                 &mut |place| {
                     place.effect = Effect::ConditionallyMutate;
                 },
@@ -828,13 +827,13 @@ pub fn infer_mutation_aliasing_ranges(
 
             // Set operand effects to Read
             for_each_instruction_value_operand_mut(
-                &mut func.instructions[instr_id.0 as usize].value,
+                &mut func.instructions[instr_id.index()].value,
                 &mut |place| {
                     place.effect = Effect::Read;
                 },
             );
 
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             if instr.effects.is_none() {
                 continue;
             }
@@ -851,8 +850,7 @@ pub fn infer_mutation_aliasing_ranges(
                     | AliasingEffect::CreateFrom { from, into }
                     | AliasingEffect::MaybeAlias { from, into } => {
                         let is_mutated_or_reassigned =
-                            env.identifiers[into.identifier.0 as usize].mutable_range.end
-                                > eval_order;
+                            env.identifiers[into.identifier.index()].mutable_range.end > eval_order;
                         if is_mutated_or_reassigned {
                             operand_effects.insert(from.identifier, Effect::Capture);
                             operand_effects.insert(into.identifier, Effect::Store);
@@ -893,7 +891,7 @@ pub fn infer_mutation_aliasing_ranges(
             }
 
             // Apply operand effects to top-level lvalue
-            let instr = &mut func.instructions[instr_id.0 as usize];
+            let instr = &mut func.instructions[instr_id.index()];
             let lvalue_id = instr.lvalue.identifier;
             if let Some(&effect) = operand_effects.get(&lvalue_id) {
                 instr.lvalue.effect = effect;
@@ -909,12 +907,11 @@ pub fn infer_mutation_aliasing_ranges(
             {
                 let mut apply = |place: &mut Place| {
                     // Fix up mutable range start
-                    let ident = &env.identifiers[place.identifier.0 as usize];
+                    let ident = &env.identifiers[place.identifier.index()];
                     if ident.mutable_range.end > eval_order
-                        && ident.mutable_range.start == EvaluationOrder(0)
+                        && ident.mutable_range.start == EvaluationOrder::UNSET
                     {
-                        env.identifiers[place.identifier.0 as usize].mutable_range.start =
-                            eval_order;
+                        env.identifiers[place.identifier.index()].mutable_range.start = eval_order;
                     }
                     // Apply effect
                     if let Some(&effect) = operand_effects.get(&place.identifier) {
@@ -929,20 +926,20 @@ pub fn infer_mutation_aliasing_ranges(
                 | InstructionValue::ObjectMethod { lowered_func, .. } = &instr.value
                 {
                     let func_id = lowered_func.func;
-                    let ctx_ids: Vec<IdentifierId> = env.functions[func_id.0 as usize]
+                    let ctx_ids: Vec<IdentifierId> = env.functions[func_id.index()]
                         .context
                         .iter()
                         .map(|c| c.identifier)
                         .collect();
                     for ctx_id in &ctx_ids {
-                        let ident = &env.identifiers[ctx_id.0 as usize];
+                        let ident = &env.identifiers[ctx_id.index()];
                         if ident.mutable_range.end > eval_order
-                            && ident.mutable_range.start == EvaluationOrder(0)
+                            && ident.mutable_range.start == EvaluationOrder::UNSET
                         {
-                            env.identifiers[ctx_id.0 as usize].mutable_range.start = eval_order;
+                            env.identifiers[ctx_id.index()].mutable_range.start = eval_order;
                         }
                         let effect = operand_effects.get(ctx_id).copied().unwrap_or(Effect::Read);
-                        let inner_func = &mut env.functions[func_id.0 as usize];
+                        let inner_func = &mut env.functions[func_id.index()];
                         for ctx_place in &mut inner_func.context {
                             if ctx_place.identifier == *ctx_id {
                                 ctx_place.effect = effect;
@@ -953,13 +950,12 @@ pub fn infer_mutation_aliasing_ranges(
             }
 
             // Handle StoreContext case: extend rvalue range if needed
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             if let InstructionValue::StoreContext { value, .. } = &instr.value {
                 let val_id = value.identifier;
-                let val_range_end = env.identifiers[val_id.0 as usize].mutable_range.end;
+                let val_range_end = env.identifiers[val_id.index()].mutable_range.end;
                 if val_range_end <= eval_order {
-                    env.identifiers[val_id.0 as usize].mutable_range.end =
-                        EvaluationOrder(eval_order.0 + 1);
+                    env.identifiers[val_id.index()].mutable_range.end = eval_order + 1;
                 }
             }
         }
@@ -982,8 +978,8 @@ pub fn infer_mutation_aliasing_ranges(
     // Part 3: Finish populating the externally visible effects
     // =========================================================================
     let returns_id = func.returns.identifier;
-    let returns_type_id = env.identifiers[returns_id.0 as usize].type_;
-    let returns_type = &env.types[returns_type_id.0 as usize];
+    let returns_type_id = env.identifiers[returns_id.index()].type_;
+    let returns_type = &env.types[returns_type_id.index()];
     let return_value_kind = if is_primitive_type(returns_type) {
         ValueKind::Primitive
     } else if is_jsx_type(returns_type) {

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_places.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_places.rs
@@ -58,7 +58,8 @@ pub fn infer_reactive_places(
     }
 
     // Compute control dominators
-    let post_dominators = compute_post_dominator_tree(func, env.next_block_id().0, false)?;
+    let post_dominators =
+        compute_post_dominator_tree(func, env.next_block_id().index() as u32, false)?;
 
     // Collect block IDs for iteration
     let block_ids: Vec<BlockId> = func.body.blocks.keys().copied().collect();
@@ -115,7 +116,7 @@ pub fn infer_reactive_places(
             // Process instructions
             let block = func.body.blocks.get(block_id).unwrap();
             for instr_id in &block.instructions {
-                let instr = &func.instructions[instr_id.0 as usize];
+                let instr = &func.instructions[instr_id.index()];
 
                 // Handle stable identifier sources
                 stable_sidemap.handle_instruction(instr, env);
@@ -137,8 +138,8 @@ pub fn infer_reactive_places(
                 // Hooks and `use` operator are sources of reactivity
                 match value {
                     InstructionValue::CallExpression { callee, .. } => {
-                        let callee_ty = &env.types
-                            [env.identifiers[callee.identifier.0 as usize].type_.0 as usize];
+                        let callee_ty =
+                            &env.types[env.identifiers[callee.identifier.index()].type_.index()];
                         if get_hook_kind_for_type(env, callee_ty)?.is_some()
                             || is_use_operator_type(callee_ty)
                         {
@@ -146,8 +147,8 @@ pub fn infer_reactive_places(
                         }
                     }
                     InstructionValue::MethodCall { property, .. } => {
-                        let property_ty = &env.types
-                            [env.identifiers[property.identifier.0 as usize].type_.0 as usize];
+                        let property_ty =
+                            &env.types[env.identifiers[property.identifier.index()].type_.index()];
                         if get_hook_kind_for_type(env, property_ty)?.is_some()
                             || is_use_operator_type(property_ty)
                         {
@@ -182,7 +183,7 @@ pub fn infer_reactive_places(
                             | Effect::ConditionallyMutateIterator
                             | Effect::Mutate => {
                                 let op_range =
-                                    &env.identifiers[op_place.identifier.0 as usize].mutable_range;
+                                    &env.identifiers[op_place.identifier.index()].mutable_range;
                                 if op_range.contains(instr.id) {
                                     reactive_map.mark_reactive(op_place.identifier);
                                 }
@@ -282,10 +283,9 @@ impl StableSidemap {
         match value {
             InstructionValue::CallExpression { callee, .. } => {
                 let callee_ty =
-                    &env.types[env.identifiers[callee.identifier.0 as usize].type_.0 as usize];
+                    &env.types[env.identifiers[callee.identifier.index()].type_.index()];
                 if evaluates_to_stable_type_or_container(env, callee_ty) {
-                    let lvalue_ty =
-                        &env.types[env.identifiers[lvalue_id.0 as usize].type_.0 as usize];
+                    let lvalue_ty = &env.types[env.identifiers[lvalue_id.index()].type_.index()];
                     if is_stable_type(lvalue_ty) {
                         self.map.insert(lvalue_id, true);
                     } else {
@@ -295,10 +295,9 @@ impl StableSidemap {
             }
             InstructionValue::MethodCall { property, .. } => {
                 let property_ty =
-                    &env.types[env.identifiers[property.identifier.0 as usize].type_.0 as usize];
+                    &env.types[env.identifiers[property.identifier.index()].type_.index()];
                 if evaluates_to_stable_type_or_container(env, property_ty) {
-                    let lvalue_ty =
-                        &env.types[env.identifiers[lvalue_id.0 as usize].type_.0 as usize];
+                    let lvalue_ty = &env.types[env.identifiers[lvalue_id.index()].type_.index()];
                     if is_stable_type(lvalue_ty) {
                         self.map.insert(lvalue_id, true);
                     } else {
@@ -309,8 +308,7 @@ impl StableSidemap {
             InstructionValue::PropertyLoad { object, .. } => {
                 let source_id = object.identifier;
                 if self.map.contains_key(&source_id) {
-                    let lvalue_ty =
-                        &env.types[env.identifiers[lvalue_id.0 as usize].type_.0 as usize];
+                    let lvalue_ty = &env.types[env.identifiers[lvalue_id.index()].type_.index()];
                     if is_stable_type_container(lvalue_ty) {
                         self.map.insert(lvalue_id, false);
                     } else if is_stable_type(lvalue_ty) {
@@ -326,7 +324,7 @@ impl StableSidemap {
                         .map(|p| p.identifier)
                         .collect();
                     for lid in lvalue_ids {
-                        let lid_ty = &env.types[env.identifiers[lid.0 as usize].type_.0 as usize];
+                        let lid_ty = &env.types[env.identifiers[lid.index()].type_.index()];
                         if is_stable_type_container(lid_ty) {
                             self.map.insert(lid, false);
                         } else if is_stable_type(lid_ty) {
@@ -467,7 +465,7 @@ fn propagate_reactivity_to_inner_functions_outer(
 ) {
     for (_block_id, block) in &func.body.blocks {
         for instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             match &instr.value {
                 InstructionValue::FunctionExpression { lowered_func, .. }
                 | InstructionValue::ObjectMethod { lowered_func, .. } => {
@@ -488,11 +486,11 @@ fn propagate_reactivity_to_inner_functions_inner(
     env: &Environment,
     reactive_map: &mut ReactivityMap,
 ) {
-    let inner_func = &env.functions[func_id.0 as usize];
+    let inner_func = &env.functions[func_id.index()];
 
     for (_block_id, block) in &inner_func.body.blocks {
         for instr_id in &block.instructions {
-            let instr = &inner_func.instructions[instr_id.0 as usize];
+            let instr = &inner_func.instructions[instr_id.index()];
 
             for op in visitors::each_instruction_value_operand(&instr.value, env) {
                 reactive_map.is_reactive(op.identifier);
@@ -570,7 +568,7 @@ fn apply_reactive_flags_replay(
         let instr_ids: Vec<InstructionId> = block.instructions.clone();
 
         for instr_id in &instr_ids {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
 
             // Compute hasReactiveInput by checking value operands
             let value_operand_ids: Vec<IdentifierId> =
@@ -589,7 +587,7 @@ fn apply_reactive_flags_replay(
             match &instr.value {
                 InstructionValue::CallExpression { callee, .. } => {
                     let callee_ty =
-                        &env.types[env.identifiers[callee.identifier.0 as usize].type_.0 as usize];
+                        &env.types[env.identifiers[callee.identifier.index()].type_.index()];
                     if get_hook_kind_for_type(env, callee_ty).ok().flatten().is_some()
                         || is_use_operator_type(callee_ty)
                     {
@@ -597,8 +595,8 @@ fn apply_reactive_flags_replay(
                     }
                 }
                 InstructionValue::MethodCall { property, .. } => {
-                    let property_ty = &env.types
-                        [env.identifiers[property.identifier.0 as usize].type_.0 as usize];
+                    let property_ty =
+                        &env.types[env.identifiers[property.identifier.index()].type_.index()];
                     if get_hook_kind_for_type(env, property_ty).ok().flatten().is_some()
                         || is_use_operator_type(property_ty)
                     {
@@ -609,7 +607,7 @@ fn apply_reactive_flags_replay(
             }
 
             // Value operands: set reactive flag using canonical visitor
-            let instr = &mut func.instructions[instr_id.0 as usize];
+            let instr = &mut func.instructions[instr_id.index()];
             visitors::for_each_instruction_value_operand_mut(&mut instr.value, &mut |place| {
                 if reactive_ids.contains(&place.identifier) {
                     place.reactive = true;
@@ -619,7 +617,7 @@ fn apply_reactive_flags_replay(
             if let InstructionValue::FunctionExpression { lowered_func, .. }
             | InstructionValue::ObjectMethod { lowered_func, .. } = &mut instr.value
             {
-                let inner_func = &mut env.functions[lowered_func.func.0 as usize];
+                let inner_func = &mut env.functions[lowered_func.func.index()];
                 for ctx in &mut inner_func.context {
                     if reactive_ids.contains(&ctx.identifier) {
                         ctx.reactive = true;
@@ -700,7 +698,7 @@ fn apply_reactive_flags_to_inner_functions(
 ) {
     for (_block_id, block) in &func.body.blocks {
         for instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             match &instr.value {
                 InstructionValue::FunctionExpression { lowered_func, .. }
                 | InstructionValue::ObjectMethod { lowered_func, .. } => {
@@ -719,11 +717,11 @@ fn apply_reactive_flags_to_inner_func(
 ) {
     // Collect nested function IDs first to avoid borrow issues
     let nested_func_ids: Vec<FunctionId> = {
-        let func = &env.functions[func_id.0 as usize];
+        let func = &env.functions[func_id.index()];
         let mut ids = Vec::new();
         for (_block_id, block) in &func.body.blocks {
             for instr_id in &block.instructions {
-                let instr = &func.instructions[instr_id.0 as usize];
+                let instr = &func.instructions[instr_id.index()];
                 match &instr.value {
                     InstructionValue::FunctionExpression { lowered_func, .. }
                     | InstructionValue::ObjectMethod { lowered_func, .. } => {
@@ -737,10 +735,10 @@ fn apply_reactive_flags_to_inner_func(
     };
 
     // Apply reactive flags using canonical visitors
-    let inner_func = &mut env.functions[func_id.0 as usize];
+    let inner_func = &mut env.functions[func_id.index()];
     for (_block_id, block) in &mut inner_func.body.blocks {
         for instr_id in &block.instructions {
-            let instr = &mut inner_func.instructions[instr_id.0 as usize];
+            let instr = &mut inner_func.instructions[instr_id.index()];
             visitors::for_each_instruction_value_operand_mut(&mut instr.value, &mut |place| {
                 if reactive_ids.contains(&place.identifier) {
                     place.reactive = true;
@@ -756,7 +754,7 @@ fn apply_reactive_flags_to_inner_func(
 
     // Recurse into nested functions, and set reactive on their context variables
     for nested_id in nested_func_ids {
-        let nested_func = &mut env.functions[nested_id.0 as usize];
+        let nested_func = &mut env.functions[nested_id.index()];
         for ctx in &mut nested_func.context {
             if reactive_ids.contains(&ctx.identifier) {
                 ctx.reactive = true;

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_scope_variables.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_scope_variables.rs
@@ -50,28 +50,28 @@ pub fn infer_reactive_scope_variables(
     let mut scopes: FxHashMap<IdentifierId, ScopeState> = FxHashMap::default();
 
     scope_identifiers.for_each(|identifier_id, group_id| {
-        let ident_range = env.identifiers[identifier_id.0 as usize].mutable_range.clone();
-        let ident_span = env.identifiers[identifier_id.0 as usize].span;
+        let ident_range = env.identifiers[identifier_id.index()].mutable_range.clone();
+        let ident_span = env.identifiers[identifier_id.index()].span;
 
         let state = scopes.entry(group_id).or_insert_with(|| {
             let scope_id = env.next_scope_id();
             // Initialize scope range from the first member
-            let scope = &mut env.scopes[scope_id.0 as usize];
+            let scope = &mut env.scopes[scope_id.index()];
             scope.range = ident_range.clone();
             ScopeState { scope_id, span: ident_span }
         });
 
         // Update scope range
-        let scope = &mut env.scopes[state.scope_id.0 as usize];
+        let scope = &mut env.scopes[state.scope_id.index()];
 
         // If this is not the first identifier (scope was already created), merge ranges
         if scope.range.start != ident_range.start || scope.range.end != ident_range.end {
-            if scope.range.start == EvaluationOrder(0) {
+            if scope.range.start == EvaluationOrder::UNSET {
                 scope.range.start = ident_range.start;
-            } else if ident_range.start != EvaluationOrder(0) {
-                scope.range.start = EvaluationOrder(scope.range.start.0.min(ident_range.start.0));
+            } else if ident_range.start != EvaluationOrder::UNSET {
+                scope.range.start = scope.range.start.min(ident_range.start);
             }
-            scope.range.end = EvaluationOrder(scope.range.end.0.max(ident_range.end.0));
+            scope.range.end = scope.range.end.max(ident_range.end);
         }
 
         // Merge location
@@ -79,17 +79,17 @@ pub fn infer_reactive_scope_variables(
 
         // Assign the scope to this identifier
         let scope_id = state.scope_id;
-        env.identifiers[identifier_id.0 as usize].scope = Some(scope_id);
+        env.identifiers[identifier_id.index()].scope = Some(scope_id);
     });
 
     // Set span on each scope
     for state in scopes.values() {
-        env.scopes[state.scope_id.0 as usize].span = state.span;
+        env.scopes[state.scope_id.index()].span = state.span;
     }
 
     // Update each identifier's mutable_range to match its scope's range
     for (&_identifier_id, state) in &scopes {
-        let scope_range = env.scopes[state.scope_id.0 as usize].range.clone();
+        let scope_range = env.scopes[state.scope_id.index()].range.clone();
         // Find all identifiers with this scope and update their mutable_range
         // We iterate through all identifiers and check their scope
         for ident in &mut env.identifiers {
@@ -100,29 +100,28 @@ pub fn infer_reactive_scope_variables(
     }
 
     // Validate scope ranges
-    let mut max_instruction = EvaluationOrder(0);
+    let mut max_instruction = EvaluationOrder::UNSET;
     for (_block_id, block) in &func.body.blocks {
         for instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
-            max_instruction = EvaluationOrder(max_instruction.0.max(instr.id.0));
+            let instr = &func.instructions[instr_id.index()];
+            max_instruction = max_instruction.max(instr.id);
         }
-        max_instruction =
-            EvaluationOrder(max_instruction.0.max(block.terminal.evaluation_order().0));
+        max_instruction = max_instruction.max(block.terminal.evaluation_order());
     }
 
     for state in scopes.values() {
-        let scope = &env.scopes[state.scope_id.0 as usize];
-        if scope.range.start == EvaluationOrder(0)
-            || scope.range.end == EvaluationOrder(0)
-            || max_instruction == EvaluationOrder(0)
-            || scope.range.end.0 > max_instruction.0 + 1
+        let scope = &env.scopes[state.scope_id.index()];
+        if scope.range.start == EvaluationOrder::UNSET
+            || scope.range.end == EvaluationOrder::UNSET
+            || max_instruction == EvaluationOrder::UNSET
+            || scope.range.end > max_instruction + 1
         {
             return Err(ErrorCategory::Invariant.diagnostic(format!(
                 "Invalid mutable range for scope: Scope @{} has range [{}:{}] but the valid range is [1:{}]",
-                scope.id.0,
-                scope.range.start.0,
-                scope.range.end.0,
-                max_instruction.0 + 1,
+                scope.id.index(),
+                scope.range.start.index(),
+                scope.range.end.index(),
+                max_instruction.index() + 1,
             )));
         }
     }
@@ -242,17 +241,17 @@ pub(crate) fn find_disjoint_mutable_values(
         // Handle phi nodes
         for phi in &block.phis {
             let phi_id = phi.place.identifier;
-            let phi_range = &env.identifiers[phi_id.0 as usize].mutable_range;
-            let phi_decl_id = env.identifiers[phi_id.0 as usize].declaration_id;
+            let phi_range = &env.identifiers[phi_id.index()].mutable_range;
+            let phi_decl_id = env.identifiers[phi_id.index()].declaration_id;
 
             let first_instr_id = block
                 .instructions
                 .first()
-                .map(|iid| func.instructions[iid.0 as usize].id)
+                .map(|iid| func.instructions[iid.index()].id)
                 .unwrap_or(block.terminal.evaluation_order());
 
             let is_phi_mutated_after_creation =
-                phi_range.start.0 + 1 != phi_range.end.0 && phi_range.end > first_instr_id;
+                phi_range.start + 1 != phi_range.end && phi_range.end > first_instr_id;
             // A phi operand defined at or after the phi's block is a loop
             // back-edge: the variable is reassigned within the loop (eg a
             // counter `a++` or `a = a + 1`). The reassignment must count as
@@ -265,7 +264,7 @@ pub(crate) fn find_disjoint_mutable_values(
             // compared at the top of the scope).
             let is_loop_carried_reassignment = !is_phi_mutated_after_creation
                 && phi.operands.iter().any(|(_pred_id, operand)| {
-                    env.identifiers[operand.identifier.0 as usize].mutable_range.start
+                    env.identifiers[operand.identifier.index()].mutable_range.start
                         >= first_instr_id
                 });
             if is_phi_mutated_after_creation || is_loop_carried_reassignment {
@@ -286,15 +285,15 @@ pub(crate) fn find_disjoint_mutable_values(
 
         // Handle instructions
         for instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             let mut operands: Vec<IdentifierId> = Vec::new();
 
             let lvalue_id = instr.lvalue.identifier;
-            let lvalue_range = &env.identifiers[lvalue_id.0 as usize].mutable_range;
-            let lvalue_type = &env.types[env.identifiers[lvalue_id.0 as usize].type_.0 as usize];
+            let lvalue_range = &env.identifiers[lvalue_id.index()].mutable_range;
+            let lvalue_type = &env.types[env.identifiers[lvalue_id.index()].type_.index()];
             let lvalue_type_is_primitive = is_primitive_type(lvalue_type);
 
-            if lvalue_range.end.0 > lvalue_range.start.0 + 1
+            if lvalue_range.end > lvalue_range.start + 1
                 || may_allocate(&instr.value, lvalue_type_is_primitive)
             {
                 operands.push(lvalue_id);
@@ -304,39 +303,39 @@ pub(crate) fn find_disjoint_mutable_values(
                 InstructionValue::DeclareLocal { lvalue, .. }
                 | InstructionValue::DeclareContext { lvalue, .. } => {
                     let place_id = lvalue.place.identifier;
-                    let decl_id = env.identifiers[place_id.0 as usize].declaration_id;
+                    let decl_id = env.identifiers[place_id.index()].declaration_id;
                     declarations.entry(decl_id).or_insert(place_id);
                 }
                 InstructionValue::StoreLocal { lvalue, value, .. }
                 | InstructionValue::StoreContext { lvalue, value, .. } => {
                     let place_id = lvalue.place.identifier;
-                    let decl_id = env.identifiers[place_id.0 as usize].declaration_id;
+                    let decl_id = env.identifiers[place_id.index()].declaration_id;
                     declarations.entry(decl_id).or_insert(place_id);
 
-                    let place_range = &env.identifiers[place_id.0 as usize].mutable_range;
-                    if place_range.end.0 > place_range.start.0 + 1 {
+                    let place_range = &env.identifiers[place_id.index()].mutable_range;
+                    if place_range.end > place_range.start + 1 {
                         operands.push(place_id);
                     }
 
-                    let value_range = &env.identifiers[value.identifier.0 as usize].mutable_range;
-                    if value_range.contains(instr.id) && value_range.start.0 > 0 {
+                    let value_range = &env.identifiers[value.identifier.index()].mutable_range;
+                    if value_range.contains(instr.id) && value_range.start > 0 {
                         operands.push(value.identifier);
                     }
                 }
                 InstructionValue::Destructure { lvalue, value, .. } => {
                     let pattern_places = each_pattern_operand(&lvalue.pattern);
                     for place_id in &pattern_places {
-                        let decl_id = env.identifiers[place_id.0 as usize].declaration_id;
+                        let decl_id = env.identifiers[place_id.index()].declaration_id;
                         declarations.entry(decl_id).or_insert(*place_id);
 
-                        let place_range = &env.identifiers[place_id.0 as usize].mutable_range;
-                        if place_range.end.0 > place_range.start.0 + 1 {
+                        let place_range = &env.identifiers[place_id.index()].mutable_range;
+                        if place_range.end > place_range.start + 1 {
                             operands.push(*place_id);
                         }
                     }
 
-                    let value_range = &env.identifiers[value.identifier.0 as usize].mutable_range;
-                    if value_range.contains(instr.id) && value_range.start.0 > 0 {
+                    let value_range = &env.identifiers[value.identifier.index()].mutable_range;
+                    if value_range.contains(instr.id) && value_range.start > 0 {
                         operands.push(value.identifier);
                     }
                 }
@@ -344,8 +343,8 @@ pub(crate) fn find_disjoint_mutable_values(
                     // For MethodCall: include all mutable operands plus the computed property
                     let all_operands = each_instruction_value_operand(&instr.value, env);
                     for op_id in &all_operands {
-                        let op_range = &env.identifiers[op_id.0 as usize].mutable_range;
-                        if op_range.contains(instr.id) && op_range.start.0 > 0 {
+                        let op_range = &env.identifiers[op_id.index()].mutable_range;
+                        if op_range.contains(instr.id) && op_range.start > 0 {
                             operands.push(*op_id);
                         }
                     }
@@ -356,8 +355,8 @@ pub(crate) fn find_disjoint_mutable_values(
                     // For all other instructions: include mutable operands
                     let all_operands = each_instruction_value_operand(&instr.value, env);
                     for op_id in &all_operands {
-                        let op_range = &env.identifiers[op_id.0 as usize].mutable_range;
-                        if op_range.contains(instr.id) && op_range.start.0 > 0 {
+                        let op_range = &env.identifiers[op_id.index()].mutable_range;
+                        if op_range.contains(instr.id) && op_range.start > 0 {
                             operands.push(*op_id);
                         }
                     }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/memoize_fbt_and_macro_operands_in_same_scope.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/memoize_fbt_and_macro_operands_in_same_scope.rs
@@ -113,7 +113,7 @@ fn populate_macro_tags(
 
     for block in func.body.blocks.values() {
         for &instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             let lvalue_id = instr.lvalue.identifier;
 
             match &instr.value {
@@ -173,7 +173,7 @@ fn merge_macro_arguments(
 
         // Iterate instructions in reverse order
         for &instr_id in block.instructions.iter().rev() {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             let lvalue_id = instr.lvalue.identifier;
 
             match &instr.value {
@@ -192,7 +192,7 @@ fn merge_macro_arguments(
 
                 InstructionValue::CallExpression { callee, .. }
                 | InstructionValue::MethodCall { property: callee, .. } => {
-                    let scope_id = match env.identifiers[lvalue_id.0 as usize].scope {
+                    let scope_id = match env.identifiers[lvalue_id.index()].scope {
                         Some(s) => s,
                         None => continue,
                     };
@@ -216,7 +216,7 @@ fn merge_macro_arguments(
                 }
 
                 InstructionValue::JsxExpression { tag, .. } => {
-                    let scope_id = match env.identifiers[lvalue_id.0 as usize].scope {
+                    let scope_id = match env.identifiers[lvalue_id.index()].scope {
                         Some(s) => s,
                         None => continue,
                     };
@@ -243,7 +243,7 @@ fn merge_macro_arguments(
 
                 // Default case: check if lvalue is a macro tag
                 _ => {
-                    let scope_id = match env.identifiers[lvalue_id.0 as usize].scope {
+                    let scope_id = match env.identifiers[lvalue_id.index()].scope {
                         Some(s) => s,
                         None => continue,
                     };
@@ -267,7 +267,7 @@ fn merge_macro_arguments(
         // Handle phis
         let block = &func.body.blocks[&block_id];
         for phi in &block.phis {
-            let scope_id = match env.identifiers[phi.place.identifier.0 as usize].scope {
+            let scope_id = match env.identifiers[phi.place.identifier.index()].scope {
                 Some(s) => s,
                 None => continue,
             };
@@ -291,7 +291,7 @@ fn merge_macro_arguments(
                 .collect();
 
             for (operand_id, def) in operand_updates {
-                env.identifiers[operand_id.0 as usize].scope = Some(scope_id);
+                env.identifiers[operand_id.index()].scope = Some(scope_id);
                 expand_fbt_scope_range(env, scope_id, operand_id);
                 macro_tags.insert(operand_id, def);
                 macro_values.insert(operand_id);
@@ -308,18 +308,18 @@ fn merge_macro_arguments(
 /// scope.range, so mutations are automatically visible; in Rust we must propagate.
 /// Equivalent to TS `expandFbtScopeRange`.
 fn expand_fbt_scope_range(env: &mut Environment, scope_id: ScopeId, operand_id: IdentifierId) {
-    let extend_start = env.identifiers[operand_id.0 as usize].mutable_range.start;
-    if extend_start.0 == 0 {
+    let extend_start = env.identifiers[operand_id.index()].mutable_range.start;
+    if extend_start == 0 {
         return;
     }
-    let old_range_id = env.scopes[scope_id.0 as usize].range.id;
-    let old_start = env.scopes[scope_id.0 as usize].range.start;
-    let new_start = old_start.0.min(extend_start.0);
-    if new_start == old_start.0 {
+    let old_range_id = env.scopes[scope_id.index()].range.id;
+    let old_start = env.scopes[scope_id.index()].range.start;
+    let new_start = old_start.min(extend_start);
+    if new_start == old_start {
         return;
     }
-    env.scopes[scope_id.0 as usize].range.start.0 = new_start;
-    let new_range = env.scopes[scope_id.0 as usize].range.clone();
+    env.scopes[scope_id.index()].range.start = new_start;
+    let new_range = env.scopes[scope_id.index()].range.clone();
     for ident in &mut env.identifiers {
         if ident.scope == Some(scope_id) && ident.mutable_range.id == old_range_id {
             ident.mutable_range = new_range.clone();
@@ -348,7 +348,7 @@ fn visit_operands(
 
     for operand_id in operand_ids {
         if matches!(macro_def.level, InlineLevel::Transitive) {
-            env.identifiers[operand_id.0 as usize].scope = Some(scope_id);
+            env.identifiers[operand_id.index()].scope = Some(scope_id);
             expand_fbt_scope_range(env, scope_id, operand_id);
             macro_tags.insert(operand_id, macro_def.clone());
         }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/merge_overlapping_reactive_scopes_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/merge_overlapping_reactive_scopes_hir.rs
@@ -68,7 +68,7 @@ struct TraversalState {
 /// Check if a scope is active at the given instruction id.
 /// Corresponds to TS `isScopeActive(scope, id)`.
 fn is_scope_active(env: &Environment, scope_id: ScopeId, id: EvaluationOrder) -> bool {
-    env.scopes[scope_id.0 as usize].range.contains(id)
+    env.scopes[scope_id.index()].range.contains(id)
 }
 
 /// Get the scope for a place if it's active at the given instruction.
@@ -78,14 +78,14 @@ fn get_place_scope(
     id: EvaluationOrder,
     identifier_id: IdentifierId,
 ) -> Option<ScopeId> {
-    let scope_id = env.identifiers[identifier_id.0 as usize].scope?;
+    let scope_id = env.identifiers[identifier_id.index()].scope?;
     if is_scope_active(env, scope_id, id) { Some(scope_id) } else { None }
 }
 
 /// Check if a place is mutable at the given instruction.
 /// Corresponds to TS `isMutable({id}, place)`.
 fn is_mutable(env: &Environment, id: EvaluationOrder, identifier_id: IdentifierId) -> bool {
-    let range = &env.identifiers[identifier_id.0 as usize].mutable_range;
+    let range = &env.identifiers[identifier_id.index()].mutable_range;
     range.contains(id)
 }
 
@@ -99,12 +99,12 @@ fn collect_scope_info(func: &HirFunction, env: &Environment) -> ScopeInfo {
     let mut place_scopes: FxHashMap<IdentifierId, ScopeId> = FxHashMap::default();
 
     let mut collect_place_scope = |identifier_id: IdentifierId, env: &Environment| {
-        let scope_id = match env.identifiers[identifier_id.0 as usize].scope {
+        let scope_id = match env.identifiers[identifier_id.index()].scope {
             Some(s) => s,
             None => return,
         };
         place_scopes.insert(identifier_id, scope_id);
-        let range = &env.scopes[scope_id.0 as usize].range;
+        let range = &env.scopes[scope_id.index()].range;
         if range.start != range.end {
             scope_starts_map.entry(range.start).or_default().push(scope_id);
             scope_ends_map.entry(range.end).or_default().push(scope_id);
@@ -113,7 +113,7 @@ fn collect_scope_info(func: &HirFunction, env: &Environment) -> ScopeInfo {
 
     for (_block_id, block) in &func.body.blocks {
         for &instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             // lvalues
             let lvalue_ids = each_instruction_lvalue_ids(instr);
             for id in lvalue_ids {
@@ -177,8 +177,8 @@ fn visit_instruction_id(
         // Sort scopes by start descending (matching active_scopes order)
         let mut scopes_sorted = scope_end_entry.scopes;
         scopes_sorted.sort_by(|a, b| {
-            let a_start = env.scopes[a.0 as usize].range.start;
-            let b_start = env.scopes[b.0 as usize].range.start;
+            let a_start = env.scopes[a.index()].range.start;
+            let b_start = env.scopes[b.index()].range.start;
             b_start.cmp(&a_start)
         });
 
@@ -201,8 +201,8 @@ fn visit_instruction_id(
         // Sort by end descending
         let mut scopes_sorted = scope_start_entry.scopes;
         scopes_sorted.sort_by(|a, b| {
-            let a_end = env.scopes[a.0 as usize].range.end;
-            let b_end = env.scopes[b.0 as usize].range.end;
+            let a_end = env.scopes[a.index()].range.end;
+            let b_end = env.scopes[b.index()].range.end;
             b_end.cmp(&a_end)
         });
 
@@ -212,7 +212,7 @@ fn visit_instruction_id(
         for i in 1..scopes_sorted.len() {
             let prev = scopes_sorted[i - 1];
             let curr = scopes_sorted[i];
-            if env.scopes[prev.0 as usize].range.end == env.scopes[curr.0 as usize].range.end {
+            if env.scopes[prev.index()].range.end == env.scopes[curr.index()].range.end {
                 state.joined.union(&[prev, curr]);
             }
         }
@@ -260,7 +260,7 @@ fn get_overlapping_reactive_scopes(
 
     for (_block_id, block) in &func.body.blocks {
         for &instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             visit_instruction_id(instr.id, &mut scope_info, &mut state, env);
 
             // Visit operands
@@ -329,18 +329,18 @@ pub fn merge_overlapping_reactive_scopes_hir(func: &mut HirFunction, env: &mut E
     let mut original_root_range_ids: FxHashMap<ScopeId, MutableRangeId> = FxHashMap::default();
     for (_, root_id) in &scope_groups {
         if !original_root_range_ids.contains_key(root_id) {
-            let range_id = env.scopes[root_id.0 as usize].range.id;
+            let range_id = env.scopes[root_id.index()].range.id;
             original_root_range_ids.insert(*root_id, range_id);
         }
     }
 
     // Update root scope ranges
     for (scope_id, root_id) in &scope_groups {
-        let scope_start = env.scopes[scope_id.0 as usize].range.start;
-        let scope_end = env.scopes[scope_id.0 as usize].range.end;
-        let root_range = &mut env.scopes[root_id.0 as usize].range;
-        root_range.start = EvaluationOrder(cmp::min(root_range.start.0, scope_start.0));
-        root_range.end = EvaluationOrder(cmp::max(root_range.end.0, scope_end.0));
+        let scope_start = env.scopes[scope_id.index()].range.start;
+        let scope_end = env.scopes[scope_id.index()].range.end;
+        let root_range = &mut env.scopes[root_id.index()].range;
+        root_range.start = cmp::min(root_range.start, scope_start);
+        root_range.end = cmp::max(root_range.end, scope_end);
     }
     // Sync mutable_range for ALL identifiers whose mutable_range has the same
     // identity as a root scope's original range. In TS, identifier.mutableRange
@@ -350,7 +350,7 @@ pub fn merge_overlapping_reactive_scopes_hir(func: &mut HirFunction, env: &mut E
     for ident in &mut env.identifiers {
         for (root_id, orig_range_id) in &original_root_range_ids {
             if ident.mutable_range.id == *orig_range_id {
-                let new_range = &env.scopes[root_id.0 as usize].range;
+                let new_range = &env.scopes[root_id.index()].range;
                 ident.mutable_range.start = new_range.start;
                 ident.mutable_range.end = new_range.end;
                 break;
@@ -365,7 +365,7 @@ pub fn merge_overlapping_reactive_scopes_hir(func: &mut HirFunction, env: &mut E
     for (identifier_id, original_scope) in &place_scopes {
         let next_scope = joined_scopes.find(*original_scope);
         if next_scope != *original_scope {
-            env.identifiers[identifier_id.0 as usize].scope = Some(next_scope);
+            env.identifiers[identifier_id.index()].scope = Some(next_scope);
         }
     }
 }
@@ -383,8 +383,7 @@ fn each_instruction_operand_ids_with_types<'a>(
     visitors::each_instruction_operand(instr, env)
         .into_iter()
         .map(|p| {
-            let type_ =
-                env.types[env.identifiers[p.identifier.0 as usize].type_.0 as usize].clone();
+            let type_ = env.types[env.identifiers[p.identifier.index()].type_.index()].clone();
             (p.identifier, type_)
         })
         .collect()

--- a/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
@@ -90,13 +90,13 @@ pub fn propagate_scope_dependencies_hir<'a>(func: &mut HirFunction<'a>, env: &mu
 
         // Step 3: Reduce dependencies to a minimal set.
         let candidates = tree.derive_minimal_dependencies();
-        let scope = &mut env.scopes[scope_id.0 as usize];
+        let scope = &mut env.scopes[scope_id.index()];
         for candidate_dep in candidates {
             let already_exists = scope.dependencies.iter().any(|existing_dep| {
                 let existing_decl_id =
-                    env.identifiers[existing_dep.identifier.0 as usize].declaration_id;
+                    env.identifiers[existing_dep.identifier.index()].declaration_id;
                 let candidate_decl_id =
-                    env.identifiers[candidate_dep.identifier.0 as usize].declaration_id;
+                    env.identifiers[candidate_dep.identifier.index()].declaration_id;
                 existing_decl_id == candidate_decl_id
                     && are_equal_paths(&existing_dep.path, &candidate_dep.path)
             });
@@ -134,7 +134,7 @@ fn find_temporaries_used_outside_declaring_scope(
                         pruned_scopes: &FxHashSet<ScopeId>,
                         used_outside: &mut FxHashSet<DeclarationId>,
                         env: &Environment| {
-        let decl_id = env.identifiers[place_id.0 as usize].declaration_id;
+        let decl_id = env.identifiers[place_id.index()].declaration_id;
         if let Some(&declaring_scope) = declarations.get(&decl_id) {
             if !traversal.is_scope_active(declaring_scope)
                 && !pruned_scopes.contains(&declaring_scope)
@@ -154,7 +154,7 @@ fn find_temporaries_used_outside_declaring_scope(
         }
 
         for &instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             // Handle operands
             for op_id in visitors::each_instruction_operand(instr, env)
                 .into_iter()
@@ -179,7 +179,7 @@ fn find_temporaries_used_outside_declaring_scope(
                         | InstructionValue::LoadContext { .. }
                         | InstructionValue::PropertyLoad { .. } => {
                             let decl_id =
-                                env.identifiers[instr.lvalue.identifier.0 as usize].declaration_id;
+                                env.identifiers[instr.lvalue.identifier.index()].declaration_id;
                             declarations.insert(decl_id, scope);
                         }
                         _ => {}
@@ -236,8 +236,8 @@ fn is_load_context_mutable(
     env: &Environment,
 ) -> bool {
     if let InstructionValue::LoadContext { place, .. } = value {
-        if let Some(scope_id) = env.identifiers[place.identifier.0 as usize].scope {
-            let scope_range = &env.scopes[scope_id.0 as usize].range;
+        if let Some(scope_id) = env.identifiers[place.identifier.index()].scope {
+            let scope_range = &env.scopes[scope_id.index()].range;
             return id >= scope_range.end;
         }
     }
@@ -264,10 +264,10 @@ fn collect_temporaries_sidemap_impl<'a>(
 ) {
     for (_block_id, block) in &func.body.blocks {
         for &instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             let instr_eval_order =
                 if let Some(outer_id) = inner_fn_context { outer_id } else { instr.id };
-            let lvalue_decl_id = env.identifiers[instr.lvalue.identifier.0 as usize].declaration_id;
+            let lvalue_decl_id = env.identifiers[instr.lvalue.identifier.index()].declaration_id;
             let used_outside = used_outside_declaring_scope.contains(&lvalue_decl_id);
 
             match &instr.value {
@@ -278,8 +278,8 @@ fn collect_temporaries_sidemap_impl<'a>(
                     }
                 }
                 InstructionValue::LoadLocal { place, span, .. }
-                    if env.identifiers[instr.lvalue.identifier.0 as usize].name.is_none()
-                        && env.identifiers[place.identifier.0 as usize].name.is_some()
+                    if env.identifiers[instr.lvalue.identifier.index()].name.is_none()
+                        && env.identifiers[place.identifier.index()].name.is_some()
                         && !used_outside =>
                 {
                     if inner_fn_context.is_none()
@@ -298,8 +298,8 @@ fn collect_temporaries_sidemap_impl<'a>(
                 }
                 value @ InstructionValue::LoadContext { place, span, .. }
                     if is_load_context_mutable(value, instr_eval_order, env)
-                        && env.identifiers[instr.lvalue.identifier.0 as usize].name.is_none()
-                        && env.identifiers[place.identifier.0 as usize].name.is_some()
+                        && env.identifiers[instr.lvalue.identifier.index()].name.is_none()
+                        && env.identifiers[place.identifier.index()].name.is_some()
                         && !used_outside =>
                 {
                     if inner_fn_context.is_none()
@@ -318,7 +318,7 @@ fn collect_temporaries_sidemap_impl<'a>(
                 }
                 InstructionValue::FunctionExpression { lowered_func, .. }
                 | InstructionValue::ObjectMethod { lowered_func, .. } => {
-                    let inner_func = &env.functions[lowered_func.func.0 as usize];
+                    let inner_func = &env.functions[lowered_func.func.index()];
                     let ctx = inner_fn_context.unwrap_or(instr.id);
                     collect_temporaries_sidemap_impl(
                         inner_func,
@@ -417,11 +417,11 @@ fn traverse_function_optional<'a>(
 ) {
     for (_block_id, block) in &func.body.blocks {
         for &instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             match &instr.value {
                 InstructionValue::FunctionExpression { lowered_func, .. }
                 | InstructionValue::ObjectMethod { lowered_func, .. } => {
-                    let inner_func = &env.functions[lowered_func.func.0 as usize];
+                    let inner_func = &env.functions[lowered_func.func.index()];
                     traverse_function_optional(inner_func, env, ctx);
                 }
                 _ => {}
@@ -458,8 +458,8 @@ fn match_optional_test_block<'a>(
         return None;
     }
 
-    let instr0 = &func.instructions[consequent_block.instructions[0].0 as usize];
-    let instr1 = &func.instructions[consequent_block.instructions[1].0 as usize];
+    let instr0 = &func.instructions[consequent_block.instructions[0].index()];
+    let instr1 = &func.instructions[consequent_block.instructions[1].index()];
 
     let (property_load_object, property, property_load_span) = match &instr0.value {
         InstructionValue::PropertyLoad { object, property, span } => (object, property, span),
@@ -490,8 +490,8 @@ fn match_optional_test_block<'a>(
             if alternate_block.instructions.len() != 2 {
                 return None;
             }
-            let alt_instr0 = &func.instructions[alternate_block.instructions[0].0 as usize];
-            let alt_instr1 = &func.instructions[alternate_block.instructions[1].0 as usize];
+            let alt_instr0 = &func.instructions[alternate_block.instructions[0].index()];
+            let alt_instr1 = &func.instructions[alternate_block.instructions[1].index()];
             match (&alt_instr0.value, &alt_instr1.value) {
                 (InstructionValue::Primitive { .. }, InstructionValue::StoreLocal { .. }) => {}
                 _ => return None,
@@ -535,16 +535,15 @@ fn traverse_optional_block<'a>(
             if maybe_test_block.instructions.is_empty() {
                 return None;
             }
-            let first_instr = &func.instructions[maybe_test_block.instructions[0].0 as usize];
+            let first_instr = &func.instructions[maybe_test_block.instructions[0].index()];
             if !matches!(&first_instr.value, InstructionValue::LoadLocal { .. }) {
                 return None;
             }
 
             let mut path: Vec<DependencyPathEntry> = Vec::new();
             for i in 1..maybe_test_block.instructions.len() {
-                let curr_instr = &func.instructions[maybe_test_block.instructions[i].0 as usize];
-                let prev_instr =
-                    &func.instructions[maybe_test_block.instructions[i - 1].0 as usize];
+                let curr_instr = &func.instructions[maybe_test_block.instructions[i].index()];
+                let prev_instr = &func.instructions[maybe_test_block.instructions[i - 1].index()];
                 match &curr_instr.value {
                     InstructionValue::PropertyLoad { object, property, span, .. }
                         if object.identifier == prev_instr.lvalue.identifier =>
@@ -561,7 +560,7 @@ fn traverse_optional_block<'a>(
 
             // Verify test expression matches last instruction's lvalue
             let last_instr_id = *maybe_test_block.instructions.last().unwrap();
-            let last_instr = &func.instructions[last_instr_id.0 as usize];
+            let last_instr = &func.instructions[last_instr_id.index()];
             let test_ident = match &maybe_test_block.terminal {
                 Terminal::Branch { test, .. } => test.identifier,
                 _ => return None,
@@ -693,7 +692,7 @@ fn traverse_optional_block<'a>(
 
             // For simplicity, use a sentinel approach: just check all blocks.
             // This is O(n) but only happens for optional chains.
-            let mut found_block = BlockId(0);
+            let mut found_block = BlockId::from_usize(0);
             for (bid, blk) in &func.body.blocks {
                 if eq(&blk.terminal, test_terminal) {
                     found_block = *bid;
@@ -702,7 +701,7 @@ fn traverse_optional_block<'a>(
             }
             found_block
         }
-        _ => BlockId(0),
+        _ => BlockId::from_usize(0),
     }));
     ctx.temporaries_read_in_optional.insert(match_result.consequent_id, load.clone());
     ctx.temporaries_read_in_optional.insert(match_result.property_id, load);
@@ -887,12 +886,10 @@ fn is_immutable_at_instr(
     if let Some(nested_ctx) = ctx.nested_fn_immutable_context {
         return nested_ctx.contains(&identifier_id);
     }
-    let ident = &env.identifiers[identifier_id.0 as usize];
-    let mutable_at_instr = ident.mutable_range.end
-        > EvaluationOrder(ident.mutable_range.start.0 + 1)
-        && ident.scope.is_some()
-        && {
-            let scope = &env.scopes[ident.scope.unwrap().0 as usize];
+    let ident = &env.identifiers[identifier_id.index()];
+    let mutable_at_instr =
+        ident.mutable_range.end > ident.mutable_range.start + 1 && ident.scope.is_some() && {
+            let scope = &env.scopes[ident.scope.unwrap().index()];
             in_range(instr_id, &scope.range)
         };
     !mutable_at_instr || ctx.known_immutable_identifiers.contains(&identifier_id)
@@ -947,7 +944,7 @@ fn get_assumed_invoked_functions_impl(
     // Step 1: Collect identifier to function expression mappings
     for (_block_id, block) in &func.body.blocks {
         for &instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             match &instr.value {
                 InstructionValue::FunctionExpression { lowered_func, .. } => {
                     temporaries
@@ -971,11 +968,11 @@ fn get_assumed_invoked_functions_impl(
     // Step 2: Forward pass to analyze assumed function calls
     for (_block_id, block) in &func.body.blocks {
         for &instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             match &instr.value {
                 InstructionValue::CallExpression { callee, args, .. } => {
                     let callee_ty =
-                        &env.types[env.identifiers[callee.identifier.0 as usize].type_.0 as usize];
+                        &env.types[env.identifiers[callee.identifier.index()].type_.index()];
                     let maybe_hook = env.get_hook_kind_for_type(callee_ty).ok().flatten();
                     if let Some(entry) = temporaries.get(&callee.identifier) {
                         // Direct calls
@@ -1018,7 +1015,7 @@ fn get_assumed_invoked_functions_impl(
                 InstructionValue::FunctionExpression { lowered_func, .. } => {
                     // Recursively traverse into other function expressions
                     // TS passes the shared temporaries map to the recursive call
-                    let inner_func = &env.functions[lowered_func.func.0 as usize];
+                    let inner_func = &env.functions[lowered_func.func.index()];
                     let lambdas_called =
                         get_assumed_invoked_functions_impl(inner_func, env, temporaries);
                     if let Some(entry) = temporaries.get_mut(&instr.lvalue.identifier) {
@@ -1093,7 +1090,7 @@ fn collect_non_nulls_in_blocks<'a>(
         }
 
         for &instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             if let Some(path) = get_maybe_non_null_in_instruction(&instr.value, ctx.temporaries) {
                 let path_ident = path.identifier;
                 if is_immutable_at_instr(path_ident, instr.id, env, ctx) {
@@ -1131,7 +1128,7 @@ fn collect_non_nulls_in_blocks<'a>(
             // Handle assumed-invoked inner functions
             if let InstructionValue::FunctionExpression { lowered_func, .. } = &instr.value {
                 if ctx.assumed_invoked_fns.contains(&lowered_func.func) {
-                    let inner_func = &env.functions[lowered_func.func.0 as usize];
+                    let inner_func = &env.functions[lowered_func.func.index()];
                     // Build nested fn immutable context
                     let nested_fn_immutable_context: FxHashSet<IdentifierId> =
                         if ctx.nested_fn_immutable_context.is_some() {
@@ -1642,19 +1639,19 @@ impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
         if self.inner_fn_context.is_some() {
             return;
         }
-        let decl_id = env.identifiers[identifier_id.0 as usize].declaration_id;
+        let decl_id = env.identifiers[identifier_id.index()].declaration_id;
         self.declarations.entry(decl_id).or_insert_with(|| decl.clone());
         self.reassignments.insert(identifier_id, decl);
     }
 
     fn has_declared(&self, identifier_id: IdentifierId, env: &Environment) -> bool {
-        let decl_id = env.identifiers[identifier_id.0 as usize].declaration_id;
+        let decl_id = env.identifiers[identifier_id.index()].declaration_id;
         self.declarations.contains_key(&decl_id)
     }
 
     fn check_valid_dependency(&self, dep: &ReactiveScopeDependency, env: &Environment) -> bool {
         // Ref value is not a valid dep
-        let ty = &env.types[env.identifiers[dep.identifier.0 as usize].type_.0 as usize];
+        let ty = &env.types[env.identifiers[dep.identifier.index()].type_.index()];
         if is_ref_value_type(ty) {
             return false;
         }
@@ -1663,7 +1660,7 @@ impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
             return false;
         }
 
-        let ident = &env.identifiers[dep.identifier.0 as usize];
+        let ident = &env.identifiers[dep.identifier.index()];
         let current_declaration = self
             .reassignments
             .get(&dep.identifier)
@@ -1671,7 +1668,7 @@ impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
 
         if let Some(current_scope) = self.current_scope() {
             if let Some(decl) = current_declaration {
-                let scope_range_start = env.scopes[current_scope.0 as usize].range.start;
+                let scope_range_start = env.scopes[current_scope.index()].range.start;
                 return decl.id < scope_range_start;
             }
         }
@@ -1703,7 +1700,7 @@ impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
     }
 
     fn visit_dependency(&mut self, dep: ReactiveScopeDependency<'a>, env: &mut Environment) {
-        let ident = &env.identifiers[dep.identifier.0 as usize];
+        let ident = &env.identifiers[dep.identifier.index()];
         let decl_id = ident.declaration_id;
 
         // Record scope declarations for values used outside their declaring scope
@@ -1713,9 +1710,9 @@ impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
                 for &scope_id in &orig_scope_stack {
                     if !self.scope_stack.contains(&scope_id) {
                         // Check if already declared in this scope
-                        let scope = &env.scopes[scope_id.0 as usize];
+                        let scope = &env.scopes[scope_id.index()];
                         let already_declared = scope.declarations.iter().any(|(_, d)| {
-                            env.identifiers[d.identifier.0 as usize].declaration_id == decl_id
+                            env.identifiers[d.identifier.index()].declaration_id == decl_id
                         });
                         if !already_declared {
                             let orig_scope_id = *orig_scope_stack.last().unwrap();
@@ -1723,7 +1720,7 @@ impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
                                 identifier: dep.identifier,
                                 scope: orig_scope_id,
                             };
-                            env.scopes[scope_id.0 as usize]
+                            env.scopes[scope_id.index()]
                                 .declarations
                                 .push((dep.identifier, new_decl));
                         }
@@ -1733,19 +1730,19 @@ impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
         }
 
         // Handle ref.current access
-        let dep = if is_use_ref_type(
-            &env.types[env.identifiers[dep.identifier.0 as usize].type_.0 as usize],
-        ) && dep.path.first().map(|p| p.property.is_string("current")).unwrap_or(false)
-        {
-            ReactiveScopeDependency {
-                identifier: dep.identifier,
-                reactive: dep.reactive,
-                path: vec![],
-                span: dep.span,
-            }
-        } else {
-            dep
-        };
+        let dep =
+            if is_use_ref_type(&env.types[env.identifiers[dep.identifier.index()].type_.index()])
+                && dep.path.first().map(|p| p.property.is_string("current")).unwrap_or(false)
+            {
+                ReactiveScopeDependency {
+                    identifier: dep.identifier,
+                    reactive: dep.reactive,
+                    path: vec![],
+                    span: dep.span,
+                }
+            } else {
+                dep
+            };
 
         if self.check_valid_dependency(&dep, env) {
             if let Some(top) = self.dep_stack.last_mut() {
@@ -1756,10 +1753,10 @@ impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
 
     fn visit_reassignment(&mut self, place: &Place, env: &mut Environment) {
         if let Some(current_scope) = self.current_scope() {
-            let scope = &env.scopes[current_scope.0 as usize];
+            let scope = &env.scopes[current_scope.index()];
             let already = scope.reassignments.iter().any(|id| {
-                env.identifiers[id.0 as usize].declaration_id
-                    == env.identifiers[place.identifier.0 as usize].declaration_id
+                env.identifiers[id.index()].declaration_id
+                    == env.identifiers[place.identifier.index()].declaration_id
             });
             if !already
                 && self.check_valid_dependency(
@@ -1772,7 +1769,7 @@ impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
                     env,
                 )
             {
-                env.scopes[current_scope.0 as usize].reassignments.push(place.identifier);
+                env.scopes[current_scope.index()].reassignments.push(place.identifier);
             }
         }
     }
@@ -1798,9 +1795,9 @@ fn visit_inner_function_blocks<'a>(
 ) {
     // Clone inner function's instructions and block structure to avoid
     // borrow conflicts when mutating env through handle_instruction.
-    let inner_instrs: Vec<Instruction> = env.functions[func_id.0 as usize].instructions.clone();
+    let inner_instrs: Vec<Instruction> = env.functions[func_id.index()].instructions.clone();
     type InnerBlockSnapshot = (BlockId, Vec<InstructionId>, Vec<(BlockId, IdentifierId)>, Terminal);
-    let inner_blocks: Vec<InnerBlockSnapshot> = env.functions[func_id.0 as usize]
+    let inner_blocks: Vec<InnerBlockSnapshot> = env.functions[func_id.index()]
         .body
         .blocks
         .iter()
@@ -1822,7 +1819,7 @@ fn visit_inner_function_blocks<'a>(
         }
 
         for &iid in inner_instr_ids {
-            let inner_instr = &inner_instrs[iid.0 as usize];
+            let inner_instr = &inner_instrs[iid.index()];
             match &inner_instr.value {
                 InstructionValue::FunctionExpression { lowered_func, .. }
                 | InstructionValue::ObjectMethod { lowered_func, .. } => {
@@ -1936,14 +1933,14 @@ fn collect_dependencies<'a>(
             ParamPattern::Place(place) => {
                 ctx.declare(
                     place.identifier,
-                    Decl { id: EvaluationOrder(0), scope_stack: vec![] },
+                    Decl { id: EvaluationOrder::UNSET, scope_stack: vec![] },
                     env,
                 );
             }
             ParamPattern::Spread(spread) => {
                 ctx.declare(
                     spread.place.identifier,
-                    Decl { id: EvaluationOrder(0), scope_stack: vec![] },
+                    Decl { id: EvaluationOrder::UNSET, scope_stack: vec![] },
                     env,
                 );
             }
@@ -1988,7 +1985,7 @@ fn handle_function_deps<'a>(
         }
 
         for &instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             match &instr.value {
                 InstructionValue::FunctionExpression { lowered_func, .. }
                 | InstructionValue::ObjectMethod { lowered_func, .. } => {

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -72,9 +72,9 @@ fn build_temporary_place(builder: &mut HirBuilder<'_, '_>, span: Option<Span>) -
 /// Corresponds to TS `promoteTemporary(identifier)`.
 fn promote_temporary(builder: &mut HirBuilder<'_, '_>, identifier_id: IdentifierId) {
     let env = builder.environment_mut();
-    let decl_id = env.identifiers[identifier_id.0 as usize].declaration_id;
-    env.identifiers[identifier_id.0 as usize].name =
-        Some(IdentifierName::Promoted(format_ident!(env.allocator, "#t{}", decl_id.0)));
+    let decl_id = env.identifiers[identifier_id.index()].declaration_id;
+    env.identifiers[identifier_id.index()].name =
+        Some(IdentifierName::Promoted(format_ident!(env.allocator, "#t{}", decl_id.index())));
 }
 
 fn lower_value_to_temporary<'a>(
@@ -83,7 +83,7 @@ fn lower_value_to_temporary<'a>(
 ) -> Result<Place, OxcDiagnostic> {
     // Optimization: if loading an unnamed temporary, skip creating a new instruction
     if let InstructionValue::LoadLocal { ref place, .. } = value {
-        let ident = &builder.environment().identifiers[place.identifier.0 as usize];
+        let ident = &builder.environment().identifiers[place.identifier.index()];
         if ident.name.is_none() {
             return Ok(place.clone());
         }
@@ -91,7 +91,7 @@ fn lower_value_to_temporary<'a>(
     let span = value.span().cloned();
     let place = build_temporary_place(builder, span);
     builder.push(Instruction {
-        id: EvaluationOrder(0),
+        id: EvaluationOrder::UNSET,
         lvalue: place.clone(),
         value,
         span,
@@ -758,7 +758,7 @@ fn lower_inner<'a>(
                 Terminal::Return {
                     value,
                     return_variant: ReturnVariant::Implicit,
-                    id: EvaluationOrder(0),
+                    id: EvaluationOrder::UNSET,
                     span: None,
                     effects: None,
                 },
@@ -781,7 +781,7 @@ fn lower_inner<'a>(
         Terminal::Return {
             value: return_value,
             return_variant: ReturnVariant::Void,
-            id: EvaluationOrder(0),
+            id: EvaluationOrder::UNSET,
             span: None,
             effects: None,
         },
@@ -1660,7 +1660,7 @@ fn lower_default_to_temp<'a>(
         Ok(Terminal::Goto {
             block: continuation_id,
             variant: GotoVariant::Break,
-            id: EvaluationOrder(0),
+            id: EvaluationOrder::UNSET,
             span: Some(pat_span),
         })
     });
@@ -1679,7 +1679,7 @@ fn lower_default_to_temp<'a>(
         Ok(Terminal::Goto {
             block: continuation_id,
             variant: GotoVariant::Break,
-            id: EvaluationOrder(0),
+            id: EvaluationOrder::UNSET,
             span: Some(pat_span),
         })
     });
@@ -1688,7 +1688,7 @@ fn lower_default_to_temp<'a>(
         Terminal::Ternary {
             test: test_block.id,
             fallthrough: continuation_id,
-            id: EvaluationOrder(0),
+            id: EvaluationOrder::UNSET,
             span: Some(pat_span),
         },
         test_block,
@@ -1713,7 +1713,7 @@ fn lower_default_to_temp<'a>(
             consequent: consequent?,
             alternate: alternate?,
             fallthrough: continuation_id,
-            id: EvaluationOrder(0),
+            id: EvaluationOrder::UNSET,
             span: Some(pat_span),
         },
         continuation_block,
@@ -2498,7 +2498,7 @@ fn lower_assignment_target_default<'a>(
         Ok(Terminal::Goto {
             block: continuation_id,
             variant: GotoVariant::Break,
-            id: EvaluationOrder(0),
+            id: EvaluationOrder::UNSET,
             span: Some(span),
         })
     });
@@ -2517,7 +2517,7 @@ fn lower_assignment_target_default<'a>(
         Ok(Terminal::Goto {
             block: continuation_id,
             variant: GotoVariant::Break,
-            id: EvaluationOrder(0),
+            id: EvaluationOrder::UNSET,
             span: Some(span),
         })
     });
@@ -2526,7 +2526,7 @@ fn lower_assignment_target_default<'a>(
         Terminal::Ternary {
             test: test_block.id,
             fallthrough: continuation_id,
-            id: EvaluationOrder(0),
+            id: EvaluationOrder::UNSET,
             span: Some(span),
         },
         test_block,
@@ -2551,7 +2551,7 @@ fn lower_assignment_target_default<'a>(
             consequent: consequent?,
             alternate: alternate?,
             fallthrough: continuation_id,
-            id: EvaluationOrder(0),
+            id: EvaluationOrder::UNSET,
             span: Some(span),
         },
         continuation_block,
@@ -2691,7 +2691,7 @@ fn lower_optional_member_expression_impl<'a>(
             Ok(Terminal::Goto {
                 block: continuation_id,
                 variant: GotoVariant::Break,
-                id: EvaluationOrder(0),
+                id: EvaluationOrder::UNSET,
                 span,
             })
         })
@@ -2727,7 +2727,7 @@ fn lower_optional_member_expression_impl<'a>(
             consequent: consequent.id,
             alternate,
             fallthrough: continuation_id,
-            id: EvaluationOrder(0),
+            id: EvaluationOrder::UNSET,
             span,
         })
     });
@@ -2749,7 +2749,7 @@ fn lower_optional_member_expression_impl<'a>(
         Ok(Terminal::Goto {
             block: continuation_id,
             variant: GotoVariant::Break,
-            id: EvaluationOrder(0),
+            id: EvaluationOrder::UNSET,
             span,
         })
     })?;
@@ -2759,7 +2759,7 @@ fn lower_optional_member_expression_impl<'a>(
             optional,
             test: test_block?,
             fallthrough: continuation_id,
-            id: EvaluationOrder(0),
+            id: EvaluationOrder::UNSET,
             span,
         },
         continuation_block,
@@ -2800,7 +2800,7 @@ fn lower_optional_call_expression_impl<'a>(
             Ok(Terminal::Goto {
                 block: continuation_id,
                 variant: GotoVariant::Break,
-                id: EvaluationOrder(0),
+                id: EvaluationOrder::UNSET,
                 span,
             })
         })
@@ -2859,7 +2859,7 @@ fn lower_optional_call_expression_impl<'a>(
             consequent: consequent.id,
             alternate,
             fallthrough: continuation_id,
-            id: EvaluationOrder(0),
+            id: EvaluationOrder::UNSET,
             span,
         })
     });
@@ -2872,7 +2872,7 @@ fn lower_optional_call_expression_impl<'a>(
         match callee_info.as_ref().unwrap() {
             CalleeInfo::CallExpression { callee } => {
                 builder.push(Instruction {
-                    id: EvaluationOrder(0),
+                    id: EvaluationOrder::UNSET,
                     lvalue: temp.clone(),
                     value: InstructionValue::CallExpression { callee: callee.clone(), args, span },
                     span,
@@ -2881,7 +2881,7 @@ fn lower_optional_call_expression_impl<'a>(
             }
             CalleeInfo::MethodCall { receiver, property } => {
                 builder.push(Instruction {
-                    id: EvaluationOrder(0),
+                    id: EvaluationOrder::UNSET,
                     lvalue: temp.clone(),
                     value: InstructionValue::MethodCall {
                         receiver: receiver.clone(),
@@ -2906,7 +2906,7 @@ fn lower_optional_call_expression_impl<'a>(
         Ok(Terminal::Goto {
             block: continuation_id,
             variant: GotoVariant::Break,
-            id: EvaluationOrder(0),
+            id: EvaluationOrder::UNSET,
             span,
         })
     })?;
@@ -2916,7 +2916,7 @@ fn lower_optional_call_expression_impl<'a>(
             optional: call.optional,
             test: test_block?,
             fallthrough: continuation_id,
-            id: EvaluationOrder(0),
+            id: EvaluationOrder::UNSET,
             span,
         },
         continuation_block,
@@ -3490,7 +3490,7 @@ fn lower_expression<'a>(
                 Ok(Terminal::Goto {
                     block: continuation_id,
                     variant: GotoVariant::Break,
-                    id: EvaluationOrder(0),
+                    id: EvaluationOrder::UNSET,
                     span: left_place.span,
                 })
             });
@@ -3509,7 +3509,7 @@ fn lower_expression<'a>(
                 Ok(Terminal::Goto {
                     block: continuation_id,
                     variant: GotoVariant::Break,
-                    id: EvaluationOrder(0),
+                    id: EvaluationOrder::UNSET,
                     span: right_span,
                 })
             });
@@ -3521,7 +3521,7 @@ fn lower_expression<'a>(
                     operator: hir_op,
                     test: test_block_id,
                     fallthrough: continuation_id,
-                    id: EvaluationOrder(0),
+                    id: EvaluationOrder::UNSET,
                     span,
                 },
                 test_block,
@@ -3529,7 +3529,7 @@ fn lower_expression<'a>(
 
             let left_value = lower_expression_to_temporary(builder, &logical.left)?;
             builder.push(Instruction {
-                id: EvaluationOrder(0),
+                id: EvaluationOrder::UNSET,
                 lvalue: left_place.clone(),
                 value: InstructionValue::LoadLocal { place: left_value, span },
                 effects: None,
@@ -3542,7 +3542,7 @@ fn lower_expression<'a>(
                     consequent: consequent_block?,
                     alternate: alternate_block?,
                     fallthrough: continuation_id,
-                    id: EvaluationOrder(0),
+                    id: EvaluationOrder::UNSET,
                     span,
                 },
                 continuation_block,
@@ -3592,7 +3592,7 @@ fn lower_expression<'a>(
                 Ok(Terminal::Goto {
                     block: continuation_id,
                     variant: GotoVariant::Break,
-                    id: EvaluationOrder(0),
+                    id: EvaluationOrder::UNSET,
                     span: consequent_ast_span,
                 })
             });
@@ -3612,7 +3612,7 @@ fn lower_expression<'a>(
                 Ok(Terminal::Goto {
                     block: continuation_id,
                     variant: GotoVariant::Break,
-                    id: EvaluationOrder(0),
+                    id: EvaluationOrder::UNSET,
                     span: alternate_ast_span,
                 })
             });
@@ -3621,7 +3621,7 @@ fn lower_expression<'a>(
                 Terminal::Ternary {
                     test: test_block_id,
                     fallthrough: continuation_id,
-                    id: EvaluationOrder(0),
+                    id: EvaluationOrder::UNSET,
                     span,
                 },
                 test_block,
@@ -3635,7 +3635,7 @@ fn lower_expression<'a>(
                     consequent: consequent_block?,
                     alternate: alternate_block?,
                     fallthrough: continuation_id,
-                    id: EvaluationOrder(0),
+                    id: EvaluationOrder::UNSET,
                     span,
                 },
                 continuation_block,
@@ -3677,7 +3677,7 @@ fn lower_expression<'a>(
                 Ok(Terminal::Goto {
                     block: continuation_id,
                     variant: GotoVariant::Break,
-                    id: EvaluationOrder(0),
+                    id: EvaluationOrder::UNSET,
                     span,
                 })
             });
@@ -3686,7 +3686,7 @@ fn lower_expression<'a>(
                 Terminal::Sequence {
                     block: sequence_block?,
                     fallthrough: continuation_id,
-                    id: EvaluationOrder(0),
+                    id: EvaluationOrder::UNSET,
                     span,
                 },
                 continuation_block,
@@ -5573,7 +5573,7 @@ fn lower_statement<'a>(
                 Terminal::Return {
                     value,
                     return_variant: ReturnVariant::Explicit,
-                    id: EvaluationOrder(0),
+                    id: EvaluationOrder::UNSET,
                     span,
                     effects: None,
                 },
@@ -5594,7 +5594,7 @@ fn lower_statement<'a>(
             }
             let fallthrough = builder.reserve(BlockKind::Block);
             builder.terminate_with_continuation(
-                Terminal::Throw { value, id: EvaluationOrder(0), span },
+                Terminal::Throw { value, id: EvaluationOrder::UNSET, span },
                 fallthrough,
             );
         }
@@ -5620,7 +5620,7 @@ fn lower_statement<'a>(
                 Ok(Terminal::Goto {
                     block: continuation_id,
                     variant: GotoVariant::Break,
-                    id: EvaluationOrder(0),
+                    id: EvaluationOrder::UNSET,
                     span: consequent_span,
                 })
             })?;
@@ -5633,7 +5633,7 @@ fn lower_statement<'a>(
                     Ok(Terminal::Goto {
                         block: continuation_id,
                         variant: GotoVariant::Break,
-                        id: EvaluationOrder(0),
+                        id: EvaluationOrder::UNSET,
                         span: alternate_span,
                     })
                 })?
@@ -5649,7 +5649,7 @@ fn lower_statement<'a>(
                     consequent: consequent_block,
                     alternate: alternate_block,
                     fallthrough: continuation_id,
-                    id: EvaluationOrder(0),
+                    id: EvaluationOrder::UNSET,
                     span,
                 },
                 continuation_block,
@@ -5696,7 +5696,7 @@ fn lower_statement<'a>(
                 Ok(Terminal::Goto {
                     block: test_block_id,
                     variant: GotoVariant::Break,
-                    id: EvaluationOrder(0),
+                    id: EvaluationOrder::UNSET,
                     span: init_span,
                 })
             })?;
@@ -5709,7 +5709,7 @@ fn lower_statement<'a>(
                     Ok(Terminal::Goto {
                         block: test_block_id,
                         variant: GotoVariant::Break,
-                        id: EvaluationOrder(0),
+                        id: EvaluationOrder::UNSET,
                         span: update_span,
                     })
                 })?)
@@ -5726,7 +5726,7 @@ fn lower_statement<'a>(
                     Ok(Terminal::Goto {
                         block: continue_target,
                         variant: GotoVariant::Continue,
-                        id: EvaluationOrder(0),
+                        id: EvaluationOrder::UNSET,
                         span: body_span,
                     })
                 })
@@ -5740,7 +5740,7 @@ fn lower_statement<'a>(
                     update: update_block_id,
                     loop_block: body_block,
                     fallthrough: continuation_id,
-                    id: EvaluationOrder(0),
+                    id: EvaluationOrder::UNSET,
                     span,
                 },
                 test_block,
@@ -5755,7 +5755,7 @@ fn lower_statement<'a>(
                         consequent: body_block,
                         alternate: continuation_id,
                         fallthrough: continuation_id,
-                        id: EvaluationOrder(0),
+                        id: EvaluationOrder::UNSET,
                         span,
                     },
                     continuation_block,
@@ -5776,7 +5776,7 @@ fn lower_statement<'a>(
                         consequent: body_block,
                         alternate: continuation_id,
                         fallthrough: continuation_id,
-                        id: EvaluationOrder(0),
+                        id: EvaluationOrder::UNSET,
                         span,
                     },
                     continuation_block,
@@ -5800,7 +5800,7 @@ fn lower_statement<'a>(
                     Ok(Terminal::Goto {
                         block: conditional_id,
                         variant: GotoVariant::Continue,
-                        id: EvaluationOrder(0),
+                        id: EvaluationOrder::UNSET,
                         span: body_span,
                     })
                 })
@@ -5812,7 +5812,7 @@ fn lower_statement<'a>(
                     test: conditional_id,
                     loop_block,
                     fallthrough: continuation_id,
-                    id: EvaluationOrder(0),
+                    id: EvaluationOrder::UNSET,
                     span,
                 },
                 conditional_block,
@@ -5826,7 +5826,7 @@ fn lower_statement<'a>(
                     consequent: loop_block,
                     alternate: continuation_id,
                     fallthrough: conditional_id,
-                    id: EvaluationOrder(0),
+                    id: EvaluationOrder::UNSET,
                     span,
                 },
                 continuation_block,
@@ -5849,7 +5849,7 @@ fn lower_statement<'a>(
                     Ok(Terminal::Goto {
                         block: conditional_id,
                         variant: GotoVariant::Continue,
-                        id: EvaluationOrder(0),
+                        id: EvaluationOrder::UNSET,
                         span: body_span,
                     })
                 })
@@ -5861,7 +5861,7 @@ fn lower_statement<'a>(
                     loop_block,
                     test: conditional_id,
                     fallthrough: continuation_id,
-                    id: EvaluationOrder(0),
+                    id: EvaluationOrder::UNSET,
                     span,
                 },
                 conditional_block,
@@ -5875,7 +5875,7 @@ fn lower_statement<'a>(
                     consequent: loop_block,
                     alternate: continuation_id,
                     fallthrough: conditional_id,
-                    id: EvaluationOrder(0),
+                    id: EvaluationOrder::UNSET,
                     span,
                 },
                 continuation_block,
@@ -5895,7 +5895,7 @@ fn lower_statement<'a>(
                     Ok(Terminal::Goto {
                         block: init_block_id,
                         variant: GotoVariant::Continue,
-                        id: EvaluationOrder(0),
+                        id: EvaluationOrder::UNSET,
                         span: body_span,
                     })
                 })
@@ -5907,7 +5907,7 @@ fn lower_statement<'a>(
                     init: init_block_id,
                     loop_block,
                     fallthrough: continuation_id,
-                    id: EvaluationOrder(0),
+                    id: EvaluationOrder::UNSET,
                     span,
                 },
                 init_block,
@@ -5934,7 +5934,7 @@ fn lower_statement<'a>(
                     consequent: loop_block,
                     alternate: continuation_id,
                     fallthrough: continuation_id,
-                    id: EvaluationOrder(0),
+                    id: EvaluationOrder::UNSET,
                     span,
                 },
                 continuation_block,
@@ -5965,7 +5965,7 @@ fn lower_statement<'a>(
                     Ok(Terminal::Goto {
                         block: init_block_id,
                         variant: GotoVariant::Continue,
-                        id: EvaluationOrder(0),
+                        id: EvaluationOrder::UNSET,
                         span: body_span,
                     })
                 })
@@ -5978,7 +5978,7 @@ fn lower_statement<'a>(
                     test: test_block_id,
                     loop_block,
                     fallthrough: continuation_id,
-                    id: EvaluationOrder(0),
+                    id: EvaluationOrder::UNSET,
                     span,
                 },
                 init_block,
@@ -5993,7 +5993,7 @@ fn lower_statement<'a>(
                 Terminal::Goto {
                     block: test_block_id,
                     variant: GotoVariant::Break,
-                    id: EvaluationOrder(0),
+                    id: EvaluationOrder::UNSET,
                     span,
                 },
                 test_block,
@@ -6024,7 +6024,7 @@ fn lower_statement<'a>(
                     consequent: loop_block,
                     alternate: continuation_id,
                     fallthrough: continuation_id,
-                    id: EvaluationOrder(0),
+                    id: EvaluationOrder::UNSET,
                     span,
                 },
                 continuation_block,
@@ -6068,7 +6068,7 @@ fn lower_statement<'a>(
                         Ok(Terminal::Goto {
                             block: fallthrough_target,
                             variant: GotoVariant::Break,
-                            id: EvaluationOrder(0),
+                            id: EvaluationOrder::UNSET,
                             span: case_span,
                         })
                     })
@@ -6098,7 +6098,7 @@ fn lower_statement<'a>(
                     test,
                     cases,
                     fallthrough: continuation_id,
-                    id: EvaluationOrder(0),
+                    id: EvaluationOrder::UNSET,
                     span,
                 },
                 continuation_block,
@@ -6209,7 +6209,7 @@ fn lower_statement<'a>(
                 Ok(Terminal::Goto {
                     block: continuation_id,
                     variant: GotoVariant::Break,
-                    id: EvaluationOrder(0),
+                    id: EvaluationOrder::UNSET,
                     span: Some(handler_span),
                 })
             })?;
@@ -6229,7 +6229,7 @@ fn lower_statement<'a>(
                 Ok(Terminal::Goto {
                     block: continuation_id,
                     variant: GotoVariant::Try,
-                    id: EvaluationOrder(0),
+                    id: EvaluationOrder::UNSET,
                     span: try_body_span,
                 })
             })?;
@@ -6240,7 +6240,7 @@ fn lower_statement<'a>(
                     handler_binding: handler_binding_info.map(|(place, _)| place),
                     handler: handler_block,
                     fallthrough: continuation_id,
-                    id: EvaluationOrder(0),
+                    id: EvaluationOrder::UNSET,
                     span,
                 },
                 continuation_block,
@@ -6255,7 +6255,7 @@ fn lower_statement<'a>(
                 Terminal::Goto {
                     block: target,
                     variant: GotoVariant::Break,
-                    id: EvaluationOrder(0),
+                    id: EvaluationOrder::UNSET,
                     span,
                 },
                 fallthrough,
@@ -6270,7 +6270,7 @@ fn lower_statement<'a>(
                 Terminal::Goto {
                     block: target,
                     variant: GotoVariant::Continue,
-                    id: EvaluationOrder(0),
+                    id: EvaluationOrder::UNSET,
                     span,
                 },
                 fallthrough,
@@ -6303,7 +6303,7 @@ fn lower_statement<'a>(
                         Ok(Terminal::Goto {
                             block: continuation_id,
                             variant: GotoVariant::Break,
-                            id: EvaluationOrder(0),
+                            id: EvaluationOrder::UNSET,
                             span: body_span,
                         })
                     })?;
@@ -6312,7 +6312,7 @@ fn lower_statement<'a>(
                         Terminal::Label {
                             block,
                             fallthrough: continuation_id,
-                            id: EvaluationOrder(0),
+                            id: EvaluationOrder::UNSET,
                             span,
                         },
                         continuation_block,

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/hir_builder.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/hir_builder.rs
@@ -312,7 +312,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
     /// then continues in a new block.
     pub fn push(&mut self, instruction: Instruction<'a>) {
         let span = instruction.span;
-        let instr_id = InstructionId(self.instruction_table.len() as u32);
+        let instr_id = InstructionId::from_usize(self.instruction_table.len());
         self.instruction_table.push(instruction);
         self.current.instructions.push(instr_id);
 
@@ -322,7 +322,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
                 Terminal::MaybeThrow {
                     continuation: continuation.id,
                     handler: Some(handler),
-                    id: EvaluationOrder(0),
+                    id: EvaluationOrder::UNSET,
                     span,
                     effects: None,
                 },
@@ -355,12 +355,12 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
     /// If `next_block_kind` is `Some`, a new current block is created with that kind.
     /// Returns the BlockId of the completed block.
     pub fn terminate(&mut self, terminal: Terminal, next_block_kind: Option<BlockKind>) -> BlockId {
-        // The placeholder block created here (BlockId(u32::MAX)) is only used when
+        // The placeholder block created here (`BlockId::PLACEHOLDER`) is only used when
         // next_block_kind is None, meaning this is the final terminate() call.
         // It will never be read or completed because build() consumes self
         // immediately after, and no further operations should occur on the builder.
         let wip =
-            std::mem::replace(&mut self.current, new_block(BlockId(u32::MAX), BlockKind::Block));
+            std::mem::replace(&mut self.current, new_block(BlockId::PLACEHOLDER, BlockKind::Block));
         let block_id = wip.id;
 
         self.complete_block(wip, terminal);
@@ -542,7 +542,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
     pub fn make_temporary(&mut self, span: Option<Span>) -> IdentifierId {
         let id = self.env.next_identifier_id();
         // Update the span on the allocated identifier
-        self.env.identifiers[id.0 as usize].span = span;
+        self.env.identifiers[id.index()].span = span;
         id
     }
 
@@ -596,7 +596,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
             if !rpo_blocks.contains_key(id) {
                 let has_function_expr = block.instructions.iter().any(|&instr_id| {
                     matches!(
-                        instructions[instr_id.0 as usize].value,
+                        instructions[instr_id.index()].value,
                         InstructionValue::FunctionExpression { .. }
                     )
                 });
@@ -604,7 +604,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
                     let span = block
                         .instructions
                         .first()
-                        .and_then(|&i| instructions[i.0 as usize].span)
+                        .and_then(|&i| instructions[i.index()].span)
                         .or_else(|| block.terminal.span().copied());
                     self.env.record_error(
                         ErrorCategory::Todo
@@ -662,7 +662,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
             let should_record_fbt_error =
                 if let Some(&identifier_id) = self.bindings.get(&symbol_id) {
                     // Already resolved - check if the resolved name is still "fbt"
-                    match &self.env.identifiers[identifier_id.0 as usize].name {
+                    match &self.env.identifiers[identifier_id.index()].name {
                         Some(IdentifierName::Named(resolved_name)) => resolved_name == "fbt",
                         _ => false,
                     }
@@ -715,15 +715,15 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
         // Allocate identifier in the arena
         let id = self.env.next_identifier_id();
         // Update the name and span on the allocated identifier
-        self.env.identifiers[id.0 as usize].name = Some(IdentifierName::Named(candidate));
+        self.env.identifiers[id.index()].name = Some(IdentifierName::Named(candidate));
         // Prefer the binding's declaration span over the reference span.
         // This matches TS behavior where Babel's resolveBinding returns the
         // binding identifier's original span (the declaration site).
         let decl_span = self.declaration_span(symbol_id);
         if let Some(ref dl) = decl_span {
-            self.env.identifiers[id.0 as usize].span = Some(*dl);
+            self.env.identifiers[id.index()].span = Some(*dl);
         } else if let Some(ref span) = span {
-            self.env.identifiers[id.0 as usize].span = Some(*span);
+            self.env.identifiers[id.index()].span = Some(*span);
         }
 
         self.used_names.insert(candidate, symbol_id);
@@ -734,7 +734,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
     /// Set the span on an identifier to the declaration-site span.
     /// This overrides any previously-set span (which may have come from a reference site).
     pub fn set_identifier_declaration_span(&mut self, id: IdentifierId, span: Span) {
-        self.env.identifiers[id.0 as usize].span = Some(span);
+        self.env.identifiers[id.index()].span = Some(span);
     }
 
     /// Resolve an identifier reference to a VariableBinding.
@@ -848,7 +848,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
         // None = unresolved binding; Some(matches) = resolved, current name comparison
         let resolved_name_matches = |sid: SymbolId| -> Option<bool> {
             let &identifier_id = self.bindings.get(&sid)?;
-            match &self.env.identifiers[identifier_id.0 as usize].name {
+            match &self.env.identifiers[identifier_id.index()].name {
                 Some(IdentifierName::Named(n)) => Some(n == name),
                 _ => Some(false),
             }
@@ -1000,7 +1000,7 @@ pub fn remove_dead_do_while_statements(hir: &mut HIR) {
         if should_replace {
             if let Terminal::DoWhile { loop_block, id, span, .. } = std::mem::replace(
                 &mut block.terminal,
-                Terminal::Unreachable { id: EvaluationOrder(0), span: None },
+                Terminal::Unreachable { id: EvaluationOrder::UNSET, span: None },
             ) {
                 block.terminal =
                     Terminal::Goto { block: loop_block, variant: GotoVariant::Break, id, span };
@@ -1038,7 +1038,7 @@ pub fn remove_unnecessary_try_catch(hir: &mut HIR) {
         if let Some(block) = hir.blocks.get_mut(&block_id) {
             block.terminal = Terminal::Goto {
                 block: try_block,
-                id: EvaluationOrder(0),
+                id: EvaluationOrder::UNSET,
                 span,
                 variant: GotoVariant::Break,
             };
@@ -1062,10 +1062,10 @@ pub fn mark_instruction_ids(hir: &mut HIR, instructions: &mut [Instruction]) {
     for block in hir.blocks.values_mut() {
         for &instr_id in &block.instructions {
             order += 1;
-            instructions[instr_id.0 as usize].id = EvaluationOrder(order);
+            instructions[instr_id.index()].id = EvaluationOrder::from_usize(order as usize);
         }
         order += 1;
-        block.terminal.set_evaluation_order(EvaluationOrder(order));
+        block.terminal.set_evaluation_order(EvaluationOrder::from_usize(order as usize));
     }
 }
 
@@ -1127,6 +1127,6 @@ pub fn mark_predecessors(hir: &mut HIR) {
 pub fn create_temporary_place(env: &mut Environment<'_>, span: Option<Span>) -> Place {
     let id = env.next_identifier_id();
     // Update the span on the allocated identifier
-    env.identifiers[id.0 as usize].span = span;
+    env.identifiers[id.index()].span = span;
     Place { identifier: id, reactive: false, effect: Effect::Unknown, span: None }
 }

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
@@ -173,7 +173,7 @@ fn apply_constant_propagation<'a>(
             }
             let result = evaluate_instruction(constants, func, env, *instr_id);
             if let Some(value) = result {
-                let lvalue_id = func.instructions[instr_id.0 as usize].lvalue.identifier;
+                let lvalue_id = func.instructions[instr_id.index()].lvalue.identifier;
                 constants.insert(lvalue_id, value);
             }
         }
@@ -274,7 +274,7 @@ fn evaluate_instruction<'a>(
     env: &mut Environment<'a>,
     instr_id: InstructionId,
 ) -> Option<Constant<'a>> {
-    let instr = &func.instructions[instr_id.0 as usize];
+    let instr = &func.instructions[instr_id.index()];
     match &instr.value {
         InstructionValue::Primitive { value, span } => {
             Some(Constant::Primitive { value: *value, span: *span })
@@ -290,14 +290,14 @@ fn evaluate_instruction<'a>(
                         let object = object.clone();
                         let span = *span;
                         let new_property = PropertyLiteral::String(Ident::from(s.as_str()));
-                        func.instructions[instr_id.0 as usize].value =
+                        func.instructions[instr_id.index()].value =
                             InstructionValue::PropertyLoad { object, property: new_property, span };
                     }
                     PrimitiveValue::Number(n) => {
                         let object = object.clone();
                         let span = *span;
                         let new_property = PropertyLiteral::Number(*n);
-                        func.instructions[instr_id.0 as usize].value =
+                        func.instructions[instr_id.index()].value =
                             InstructionValue::PropertyLoad { object, property: new_property, span };
                     }
                     PrimitiveValue::Null
@@ -317,7 +317,7 @@ fn evaluate_instruction<'a>(
                         let store_value = value.clone();
                         let span = *span;
                         let new_property = PropertyLiteral::String(Ident::from(s.as_str()));
-                        func.instructions[instr_id.0 as usize].value =
+                        func.instructions[instr_id.index()].value =
                             InstructionValue::PropertyStore {
                                 object,
                                 property: new_property,
@@ -330,7 +330,7 @@ fn evaluate_instruction<'a>(
                         let store_value = value.clone();
                         let span = *span;
                         let new_property = PropertyLiteral::Number(*n);
-                        func.instructions[instr_id.0 as usize].value =
+                        func.instructions[instr_id.index()].value =
                             InstructionValue::PropertyStore {
                                 object,
                                 property: new_property,
@@ -400,7 +400,7 @@ fn evaluate_instruction<'a>(
                     let span = *span;
                     let result =
                         Constant::Primitive { value: PrimitiveValue::Boolean(negated), span };
-                    func.instructions[instr_id.0 as usize].value = InstructionValue::Primitive {
+                    func.instructions[instr_id.index()].value = InstructionValue::Primitive {
                         value: PrimitiveValue::Boolean(negated),
                         span,
                     };
@@ -418,7 +418,7 @@ fn evaluate_instruction<'a>(
                         value: PrimitiveValue::Number(FloatValue::new(negated)),
                         span,
                     };
-                    func.instructions[instr_id.0 as usize].value = InstructionValue::Primitive {
+                    func.instructions[instr_id.index()].value = InstructionValue::Primitive {
                         value: PrimitiveValue::Number(FloatValue::new(negated)),
                         span,
                     };
@@ -442,7 +442,7 @@ fn evaluate_instruction<'a>(
                 let result = evaluate_binary_op(*operator, lhs, rhs, env.allocator);
                 if let Some(prim) = result {
                     let span = *span;
-                    func.instructions[instr_id.0 as usize].value =
+                    func.instructions[instr_id.index()].value =
                         InstructionValue::Primitive { value: prim, span };
                     return Some(Constant::Primitive { value: prim, span });
                 }
@@ -463,11 +463,10 @@ fn evaluate_instruction<'a>(
                             value: PrimitiveValue::Number(FloatValue::new(len)),
                             span,
                         };
-                        func.instructions[instr_id.0 as usize].value =
-                            InstructionValue::Primitive {
-                                value: PrimitiveValue::Number(FloatValue::new(len)),
-                                span,
-                            };
+                        func.instructions[instr_id.index()].value = InstructionValue::Primitive {
+                            value: PrimitiveValue::Number(FloatValue::new(len)),
+                            span,
+                        };
                         return Some(result);
                     }
                 }
@@ -485,7 +484,7 @@ fn evaluate_instruction<'a>(
                 let value =
                     PrimitiveValue::String(Str::from_str_in(&result_string, &env.allocator));
                 let result = Constant::Primitive { value, span };
-                func.instructions[instr_id.0 as usize].value =
+                func.instructions[instr_id.index()].value =
                     InstructionValue::Primitive { value, span };
                 return Some(result);
             }
@@ -529,15 +528,14 @@ fn evaluate_instruction<'a>(
             let span = *span;
             let value = PrimitiveValue::String(Str::from_str_in(&result_string, &env.allocator));
             let result = Constant::Primitive { value, span };
-            func.instructions[instr_id.0 as usize].value =
-                InstructionValue::Primitive { value, span };
+            func.instructions[instr_id.index()].value = InstructionValue::Primitive { value, span };
             Some(result)
         }
         InstructionValue::LoadLocal { place, .. } => {
             let place_value = read(constants, place);
             if let Some(ref constant) = place_value {
                 // Replace the LoadLocal with the constant value (including the constant's original span)
-                func.instructions[instr_id.0 as usize].value =
+                func.instructions[instr_id.index()].value =
                     constant.clone().into_instruction_value();
             }
             place_value
@@ -578,7 +576,7 @@ fn evaluate_instruction<'a>(
                     .collect();
                 for idx in const_dep_indices {
                     if let InstructionValue::StartMemoize { deps: Some(ref mut deps), .. } =
-                        func.instructions[instr_id.0 as usize].value
+                        func.instructions[instr_id.index()].value
                     {
                         if let ManualMemoDependencyRoot::NamedLocal { constant, .. } =
                             &mut deps[idx].root
@@ -630,9 +628,9 @@ fn process_inner_function<'a>(
     env: &mut Environment<'a>,
     constants: &mut Constants<'a>,
 ) {
-    let mut inner = replace(&mut env.functions[func_id.0 as usize], placeholder_function());
+    let mut inner = replace(&mut env.functions[func_id.index()], placeholder_function());
     constant_propagation_impl(&mut inner, env, constants);
-    env.functions[func_id.0 as usize] = inner;
+    env.functions[func_id.index()] = inner;
 }
 
 // =============================================================================

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/dead_code_elimination.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/dead_code_elimination.rs
@@ -41,7 +41,7 @@ pub fn dead_code_elimination<'a>(func: &mut HirFunction<'a>, env: &Environment<'
 
         // Remove instructions with unused lvalues
         block.instructions.retain(|instr_id| {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             is_id_or_name_used(&state, &env.identifiers, instr.lvalue.identifier)
         });
 
@@ -89,7 +89,7 @@ fn reference<'a>(
     identifier_id: IdentifierId,
 ) {
     state.identifiers.insert(identifier_id);
-    let ident = &identifiers[identifier_id.0 as usize];
+    let ident = &identifiers[identifier_id.index()];
     if let Some(IdentifierName::Named(name) | IdentifierName::Promoted(name)) = ident.name {
         state.named.insert(name);
     }
@@ -105,7 +105,7 @@ fn is_id_or_name_used(
     if state.identifiers.contains(&identifier_id) {
         return true;
     }
-    let ident = &identifiers[identifier_id.0 as usize];
+    let ident = &identifiers[identifier_id.index()];
     if let Some(ref name) = ident.name { state.named.contains(name.value()) } else { false }
 }
 
@@ -138,7 +138,7 @@ fn find_referenced_identifiers<'a>(func: &HirFunction<'a>, env: &Environment<'a>
             let instr_count = block.instructions.len();
             for i in (0..instr_count).rev() {
                 let instr_id = block.instructions[i];
-                let instr = &func.instructions[instr_id.0 as usize];
+                let instr = &func.instructions[instr_id.index()];
 
                 let is_block_value = block.kind != BlockKind::Block && i == instr_count - 1;
 
@@ -194,7 +194,7 @@ fn rewrite_instruction(
     state: &State,
     env: &Environment,
 ) {
-    let instr = &mut func.instructions[instr_id.0 as usize];
+    let instr = &mut func.instructions[instr_id.index()];
 
     match &mut instr.value {
         InstructionValue::Destructure { lvalue, .. } => {
@@ -309,7 +309,7 @@ fn pruneable_value(value: &InstructionValue, state: &State, env: &Environment) -
         InstructionValue::CallExpression { callee, .. } => {
             if env.output_mode == OutputMode::Ssr {
                 let callee_ty =
-                    &env.types[env.identifiers[callee.identifier.0 as usize].type_.0 as usize];
+                    &env.types[env.identifiers[callee.identifier.index()].type_.index()];
                 if let Some(HookKind::UseState | HookKind::UseReducer | HookKind::UseRef) =
                     env.get_hook_kind_for_type(callee_ty).ok().flatten()
                 {
@@ -321,7 +321,7 @@ fn pruneable_value(value: &InstructionValue, state: &State, env: &Environment) -
         InstructionValue::MethodCall { property, .. } => {
             if env.output_mode == OutputMode::Ssr {
                 let callee_ty =
-                    &env.types[env.identifiers[property.identifier.0 as usize].type_.0 as usize];
+                    &env.types[env.identifiers[property.identifier.index()].type_.index()];
                 if let Some(HookKind::UseState | HookKind::UseReducer | HookKind::UseRef) =
                     env.get_hook_kind_for_type(callee_ty).ok().flatten()
                 {

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/drop_manual_memoization.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/drop_manual_memoization.rs
@@ -126,7 +126,7 @@ pub fn drop_manual_memoization<'a>(
 
     for block_instructions in &all_block_instructions {
         for &instr_id in block_instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
 
             // Extract the identifier we need to look up, and whether it's a call/method
             let lookup_id = match &instr.value {
@@ -168,7 +168,7 @@ pub fn drop_manual_memoization<'a>(
                     let ni = next_instructions.as_mut().unwrap();
                     ni.push(instr_id);
                     // Add the new instruction to the flat table and get its InstructionId
-                    let new_instr_id = InstructionId(func.instructions.len() as u32);
+                    let new_instr_id = InstructionId::from_usize(func.instructions.len());
                     func.instructions.push(insert_instr);
                     ni.push(new_instr_id);
                 } else if let Some(ni) = next_instructions.as_mut() {
@@ -204,7 +204,7 @@ fn process_manual_memo_call<'a>(
     next_manual_memo_id: &mut u32,
     queued_inserts: &mut FxHashMap<InstructionId, Instruction<'a>>,
 ) {
-    let instr = &func.instructions[instr_id.0 as usize];
+    let instr = &func.instructions[instr_id.index()];
 
     let memo_details = extract_manual_memoization_args(instr, manual_memo.kind, sidemap, env);
 
@@ -214,11 +214,11 @@ fn process_manual_memo_call<'a>(
 
     let ExtractedMemoArgs { fn_place, deps_list, deps_span } = memo_details;
 
-    let span = func.instructions[instr_id.0 as usize].value.span().cloned();
+    let span = func.instructions[instr_id.index()].value.span().cloned();
 
     // Replace the instruction value with the memoization replacement
     let replacement = get_manual_memoization_replacement(&fn_place, span, manual_memo.kind);
-    func.instructions[instr_id.0 as usize].value = replacement;
+    func.instructions[instr_id.index()].value = replacement;
 
     if is_validation_enabled {
         // Bail out when we encounter manual memoization without inline function expressions
@@ -239,7 +239,7 @@ fn process_manual_memo_call<'a>(
         }
 
         let memo_decl: Place = if manual_memo.kind == ManualMemoKind::UseMemo {
-            func.instructions[instr_id.0 as usize].lvalue.clone()
+            func.instructions[instr_id.index()].lvalue.clone()
         } else {
             Place {
                 identifier: fn_place.identifier,
@@ -272,7 +272,7 @@ fn collect_temporaries<'a>(
     instr_id: InstructionId,
     sidemap: &mut IdentifierSidemap<'a>,
 ) {
-    let instr = &func.instructions[instr_id.0 as usize];
+    let instr = &func.instructions[instr_id.index()];
     let lvalue_id = instr.lvalue.identifier;
 
     match &instr.value {
@@ -394,7 +394,7 @@ pub fn collect_maybe_memo_dependencies<'a>(
             if let Some(source) = maybe_deps.get(&place.identifier) {
                 Some(source.clone())
             } else if matches!(
-                &env.identifiers[place.identifier.0 as usize].name,
+                &env.identifiers[place.identifier.index()].name,
                 Some(IdentifierName::Named(_))
             ) {
                 Some(ManualMemoDependency {
@@ -416,7 +416,7 @@ pub fn collect_maybe_memo_dependencies<'a>(
             let lvalue_id = lvalue.place.identifier;
             let rvalue_id = val.identifier;
             if let Some(aliased) = maybe_deps.get(&rvalue_id) {
-                let lvalue_name = &env.identifiers[lvalue_id.0 as usize].name;
+                let lvalue_name = &env.identifiers[lvalue_id.index()].name;
                 if !matches!(lvalue_name, Some(IdentifierName::Named(_))) {
                     // Note: we can't insert into maybe_deps here since we only have
                     // a shared reference. The caller handles insertion.
@@ -464,7 +464,7 @@ fn make_manual_memoization_markers<'a>(
     manual_memo_id: u32,
 ) -> (Instruction<'a>, Instruction<'a>) {
     let start = Instruction {
-        id: EvaluationOrder(0),
+        id: EvaluationOrder::UNSET,
         lvalue: create_temporary_place(env, fn_expr.span),
         value: InstructionValue::StartMemoize {
             manual_memo_id,
@@ -477,7 +477,7 @@ fn make_manual_memoization_markers<'a>(
         effects: None,
     };
     let finish = Instruction {
-        id: EvaluationOrder(0),
+        id: EvaluationOrder::UNSET,
         lvalue: create_temporary_place(env, fn_expr.span),
         value: InstructionValue::FinishMemoize {
             manual_memo_id,
@@ -607,7 +607,7 @@ fn find_optional_places(func: &HirFunction) -> Result<FxHashSet<IdentifierId>, O
                             // Found it
                             let consequent_block = &func.body.blocks[consequent];
                             if let Some(&last_instr_id) = consequent_block.instructions.last() {
-                                let last_instr = &func.instructions[last_instr_id.0 as usize];
+                                let last_instr = &func.instructions[last_instr_id.index()];
                                 if let InstructionValue::StoreLocal { value, .. } =
                                     &last_instr.value
                                 {

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/inline_iifes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/inline_iifes.rs
@@ -94,12 +94,12 @@ pub fn inline_immediately_invoked_function_expressions<'a>(
         let num_instructions = block.instructions.len();
         for ii in 0..num_instructions {
             let instr_id = func.body.blocks[&block_id].instructions[ii];
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
 
             match &instr.value {
                 InstructionValue::FunctionExpression { lowered_func, .. } => {
                     let identifier_id = instr.lvalue.identifier;
-                    if env.identifiers[identifier_id.0 as usize].name.is_none() {
+                    if env.identifiers[identifier_id.index()].name.is_none() {
                         functions.insert(identifier_id, lowered_func.func);
                     }
                     continue;
@@ -116,7 +116,7 @@ pub fn inline_immediately_invoked_function_expressions<'a>(
                         None => continue, // Not invoking a local function expression
                     };
 
-                    let inner_func = &env.functions[inner_func_id.0 as usize];
+                    let inner_func = &env.functions[inner_func_id.index()];
                     if !inner_func.params.is_empty() || inner_func.is_async || inner_func.generator
                     {
                         // Can't inline functions with params, or async/generator functions
@@ -127,7 +127,7 @@ pub fn inline_immediately_invoked_function_expressions<'a>(
                     inlined_functions.insert(callee_id);
 
                     // Capture the lvalue from the call instruction
-                    let call_lvalue = func.instructions[instr_id.0 as usize].lvalue.clone();
+                    let call_lvalue = func.instructions[instr_id.index()].lvalue.clone();
                     let block_terminal_id = func.body.blocks[&block_id].terminal.evaluation_order();
                     let block_terminal_span = func.body.blocks[&block_id].terminal.span().cloned();
                     let block_kind = func.body.blocks[&block_id].kind;
@@ -152,8 +152,8 @@ pub fn inline_immediately_invoked_function_expressions<'a>(
                     func.body.blocks.get_mut(&block_id).unwrap().instructions.truncate(ii);
 
                     let has_single_return =
-                        has_single_exit_return_terminal(&env.functions[inner_func_id.0 as usize]);
-                    let inner_entry = env.functions[inner_func_id.0 as usize].body.entry;
+                        has_single_exit_return_terminal(&env.functions[inner_func_id.index()]);
+                    let inner_entry = env.functions[inner_func_id.index()].body.entry;
 
                     if has_single_return {
                         // Single-return path: simple goto replacement
@@ -165,7 +165,7 @@ pub fn inline_immediately_invoked_function_expressions<'a>(
                         };
 
                         // Take blocks and instructions from inner function
-                        let inner_func = &mut env.functions[inner_func_id.0 as usize];
+                        let inner_func = &mut env.functions[inner_func_id.index()];
                         let inner_blocks: Vec<(BlockId, BasicBlock)> =
                             inner_func.body.blocks.drain(..).collect();
                         let inner_instructions: Vec<Instruction> =
@@ -178,7 +178,7 @@ pub fn inline_immediately_invoked_function_expressions<'a>(
                         for (_, mut inner_block) in inner_blocks {
                             // Remap instruction IDs in the block
                             for iid in &mut inner_block.instructions {
-                                *iid = InstructionId(iid.0 + instr_offset);
+                                *iid += instr_offset as usize;
                             }
                             inner_block.preds.clear();
 
@@ -187,7 +187,7 @@ pub fn inline_immediately_invoked_function_expressions<'a>(
                             {
                                 // Replace return with LoadLocal + goto
                                 let load_instr = Instruction {
-                                    id: EvaluationOrder(0),
+                                    id: EvaluationOrder::UNSET,
                                     span: *ret_span,
                                     lvalue: call_lvalue.clone(),
                                     value: InstructionValue::LoadLocal {
@@ -196,7 +196,8 @@ pub fn inline_immediately_invoked_function_expressions<'a>(
                                     },
                                     effects: None,
                                 };
-                                let load_instr_id = InstructionId(func.instructions.len() as u32);
+                                let load_instr_id =
+                                    InstructionId::from_usize(func.instructions.len());
                                 func.instructions.push(load_instr);
                                 inner_block.instructions.push(load_instr_id);
 
@@ -219,7 +220,7 @@ pub fn inline_immediately_invoked_function_expressions<'a>(
                         // Set block terminal to Label
                         func.body.blocks.get_mut(&block_id).unwrap().terminal = Terminal::Label {
                             block: inner_entry,
-                            id: EvaluationOrder(0),
+                            id: EvaluationOrder::UNSET,
                             fallthrough: continuation_block_id,
                             span: block_terminal_span,
                         };
@@ -229,12 +230,12 @@ pub fn inline_immediately_invoked_function_expressions<'a>(
 
                         // Promote the temporary with a name as we require this to persist
                         let identifier_id = result.identifier;
-                        if env.identifiers[identifier_id.0 as usize].name.is_none() {
+                        if env.identifiers[identifier_id.index()].name.is_none() {
                             promote_temporary(env, identifier_id);
                         }
 
                         // Take blocks and instructions from inner function
-                        let inner_func = &mut env.functions[inner_func_id.0 as usize];
+                        let inner_func = &mut env.functions[inner_func_id.index()];
                         let inner_blocks: Vec<(BlockId, BasicBlock)> =
                             inner_func.body.blocks.drain(..).collect();
                         let inner_instructions: Vec<Instruction> =
@@ -246,7 +247,7 @@ pub fn inline_immediately_invoked_function_expressions<'a>(
 
                         for (_, mut inner_block) in inner_blocks {
                             for iid in &mut inner_block.instructions {
-                                *iid = InstructionId(iid.0 + instr_offset);
+                                *iid += instr_offset as usize;
                             }
                             inner_block.preds.clear();
 
@@ -284,7 +285,7 @@ pub fn inline_immediately_invoked_function_expressions<'a>(
         // Remove instructions that define lambdas which we inlined
         for block in func.body.blocks.values_mut() {
             block.instructions.retain(|instr_id| {
-                let instr = &func.instructions[instr_id.0 as usize];
+                let instr = &func.instructions[instr_id.index()];
                 !inlined_functions.contains(&instr.lvalue.identifier)
             });
         }
@@ -336,7 +337,7 @@ fn rewrite_block<'a>(
     if let Terminal::Return { value, span: ret_span, .. } = &block.terminal {
         let store_lvalue = create_temporary_place(env, *ret_span);
         let store_instr = Instruction {
-            id: EvaluationOrder(0),
+            id: EvaluationOrder::UNSET,
             span: *ret_span,
             lvalue: store_lvalue,
             value: InstructionValue::StoreLocal {
@@ -346,14 +347,14 @@ fn rewrite_block<'a>(
             },
             effects: None,
         };
-        let store_instr_id = InstructionId(instructions.len() as u32);
+        let store_instr_id = InstructionId::from_usize(instructions.len());
         instructions.push(store_instr);
         block.instructions.push(store_instr_id);
 
         let ret_span = *ret_span;
         block.terminal = Terminal::Goto {
             block: return_target,
-            id: EvaluationOrder(0),
+            id: EvaluationOrder::UNSET,
             variant: GotoVariant::Break,
             span: ret_span,
         };
@@ -369,7 +370,7 @@ fn declare_temporary<'a>(
 ) {
     let declare_lvalue = create_temporary_place(env, result.span);
     let declare_instr = Instruction {
-        id: EvaluationOrder(0),
+        id: EvaluationOrder::UNSET,
         span: GENERATED_SOURCE,
         lvalue: declare_lvalue,
         value: InstructionValue::DeclareLocal {
@@ -378,14 +379,14 @@ fn declare_temporary<'a>(
         },
         effects: None,
     };
-    let instr_id = InstructionId(func.instructions.len() as u32);
+    let instr_id = InstructionId::from_usize(func.instructions.len());
     func.instructions.push(declare_instr);
     func.body.blocks.get_mut(&block_id).unwrap().instructions.push(instr_id);
 }
 
 /// Promote a temporary identifier to a named identifier.
 fn promote_temporary(env: &mut Environment<'_>, identifier_id: IdentifierId) {
-    let decl_id = env.identifiers[identifier_id.0 as usize].declaration_id;
-    env.identifiers[identifier_id.0 as usize].name =
-        Some(IdentifierName::Promoted(format_ident!(env.allocator, "#t{}", decl_id.0)));
+    let decl_id = env.identifiers[identifier_id.index()].declaration_id;
+    env.identifiers[identifier_id.index()].name =
+        Some(IdentifierName::Promoted(format_ident!(env.allocator, "#t{}", decl_id.index())));
 }

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/merge_consecutive_blocks.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/merge_consecutive_blocks.rs
@@ -34,11 +34,11 @@ pub fn merge_consecutive_blocks(func: &mut HirFunction, functions: &mut [HirFunc
         .values()
         .flat_map(|block| block.instructions.iter())
         .filter_map(|instr_id| {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             match &instr.value {
                 InstructionValue::FunctionExpression { lowered_func, .. }
                 | InstructionValue::ObjectMethod { lowered_func, .. } => {
-                    Some(lowered_func.func.0 as usize)
+                    Some(lowered_func.func.index())
                 }
                 _ => None,
             }
@@ -135,7 +135,7 @@ pub fn merge_consecutive_blocks(func: &mut HirFunction, functions: &mut [HirFunc
                 span: GENERATED_SOURCE,
                 effects: Some(vec![AliasingEffect::Alias { from: operand, into: lvalue }]),
             };
-            let instr_id = InstructionId(func.instructions.len() as u32);
+            let instr_id = InstructionId::from_usize(func.instructions.len());
             func.instructions.push(instr);
             new_instr_ids.push(instr_id);
         }

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/name_anonymous_functions.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/name_anonymous_functions.rs
@@ -72,7 +72,7 @@ pub fn name_anonymous_functions<'a>(func: &mut HirFunction<'a>, env: &mut Enviro
 
     // Apply name updates to the inner HirFunction in the arena
     for (function_id, name) in &updates {
-        env.functions[function_id.0 as usize].name_hint = Some(*name);
+        env.functions[function_id.index()].name_hint = Some(*name);
     }
 
     // Update name_hint on FunctionExpression instruction values in the outer function
@@ -129,7 +129,7 @@ fn name_anonymous_functions_impl<'a>(
 
     for block in func.body.blocks.values() {
         for instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             let lvalue_id = instr.lvalue.identifier;
             match &instr.value {
                 InstructionValue::LoadGlobal { binding, .. } => {
@@ -137,7 +137,7 @@ fn name_anonymous_functions_impl<'a>(
                 }
                 InstructionValue::LoadContext { place, .. }
                 | InstructionValue::LoadLocal { place, .. } => {
-                    let ident = &env.identifiers[place.identifier.0 as usize];
+                    let ident = &env.identifiers[place.identifier.index()];
                     if let Some(IdentifierName::Named(name)) = ident.name {
                         names.insert(lvalue_id, name);
                     }
@@ -153,7 +153,7 @@ fn name_anonymous_functions_impl<'a>(
                     }
                 }
                 InstructionValue::FunctionExpression { name, lowered_func, .. } => {
-                    let inner_func = &env.functions[lowered_func.func.0 as usize];
+                    let inner_func = &env.functions[lowered_func.func.index()];
                     let inner = name_anonymous_functions_impl(inner_func, env);
                     let node = Node {
                         function_id: lowered_func.func,
@@ -173,7 +173,7 @@ fn name_anonymous_functions_impl<'a>(
                 | InstructionValue::StoreLocal { lvalue: store_lvalue, value, .. } => {
                     if let Some(&node_idx) = functions.get(&value.identifier) {
                         let node = &mut nodes[node_idx];
-                        let var_ident = &env.identifiers[store_lvalue.place.identifier.0 as usize];
+                        let var_ident = &env.identifiers[store_lvalue.place.identifier.index()];
                         if node.generated_name.is_none() {
                             if let Some(IdentifierName::Named(var_name)) = var_ident.name {
                                 node.generated_name = Some(var_name);
@@ -236,8 +236,8 @@ fn handle_call<'a>(
     names: &FxHashMap<IdentifierId, Ident<'a>>,
     nodes: &mut [Node<'a>],
 ) {
-    let callee_ident = &env.identifiers[callee_id.0 as usize];
-    let callee_ty = &env.types[callee_ident.type_.0 as usize];
+    let callee_ident = &env.identifiers[callee_id.index()];
+    let callee_ty = &env.types[callee_ident.type_.index()];
     let hook_kind = env.get_hook_kind_for_type(callee_ty).ok().flatten();
 
     let callee_name: Cow<'_, str> = if let Some(hk) = hook_kind {

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/optimize_for_ssr.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/optimize_for_ssr.rs
@@ -49,11 +49,10 @@ pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
 
     for (_block_id, block) in &func.body.blocks {
         for &instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             match &instr.value {
                 InstructionValue::Destructure { value, lvalue, .. } => {
-                    if inlined_state.contains_key(&env.identifiers[value.identifier.0 as usize].id)
-                    {
+                    if inlined_state.contains_key(&env.identifiers[value.identifier.index()].id) {
                         if let Pattern::Array(arr) = &lvalue.pattern {
                             if !arr.items.is_empty() {
                                 if let ArrayPatternElement::Place(_) = &arr.items[0] {
@@ -76,7 +75,7 @@ pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
                                     (&args[0], &args[1])
                                 {
                                     let lvalue_id =
-                                        env.identifiers[instr.lvalue.identifier.0 as usize].id;
+                                        env.identifiers[instr.lvalue.identifier.index()].id;
                                     inlined_state.insert(
                                         lvalue_id,
                                         InlinedStateReplacement::LoadLocal {
@@ -93,7 +92,7 @@ pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
                                 ) = (&args[0], &args[1], &args[2])
                                 {
                                     let lvalue_id =
-                                        env.identifiers[instr.lvalue.identifier.0 as usize].id;
+                                        env.identifiers[instr.lvalue.identifier.index()].id;
                                     let call_span = instr.value.span().copied();
                                     inlined_state.insert(
                                         lvalue_id,
@@ -109,13 +108,13 @@ pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
                         Some(HookKind::UseState) if args.len() == 1 => {
                             if let PlaceOrSpread::Place(arg) = &args[0] {
                                 let arg_type = &env.types
-                                    [env.identifiers[arg.identifier.0 as usize].type_.0 as usize];
+                                    [env.identifiers[arg.identifier.index()].type_.index()];
                                 if is_primitive_type(arg_type)
                                     || is_plain_object_type(arg_type)
                                     || is_array_type(arg_type)
                                 {
                                     let lvalue_id =
-                                        env.identifiers[instr.lvalue.identifier.0 as usize].id;
+                                        env.identifiers[instr.lvalue.identifier.index()].id;
                                     inlined_state.insert(
                                         lvalue_id,
                                         InlinedStateReplacement::LoadLocal {
@@ -136,7 +135,7 @@ pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
             if !inlined_state.is_empty() {
                 let operands = each_instruction_value_operand(&instr.value, env);
                 for operand in &operands {
-                    let id = env.identifiers[operand.identifier.0 as usize].id;
+                    let id = env.identifiers[operand.identifier.index()].id;
                     inlined_state.remove(&id);
                 }
             }
@@ -144,7 +143,7 @@ pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
         if !inlined_state.is_empty() {
             let operands = each_terminal_operand(&block.terminal);
             for operand in &operands {
-                let id = env.identifiers[operand.identifier.0 as usize].id;
+                let id = env.identifiers[operand.identifier.index()].id;
                 inlined_state.remove(&id);
             }
         }
@@ -160,10 +159,10 @@ pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
     // - Replace useState/useReducer with their inlined replacement
     for (_block_id, block) in &mut func.body.blocks {
         for &instr_id in &block.instructions {
-            let instr = &mut func.instructions[instr_id.0 as usize];
+            let instr = &mut func.instructions[instr_id.index()];
             match &instr.value {
                 InstructionValue::FunctionExpression { lowered_func, span, .. } => {
-                    let inner_func = &env.functions[lowered_func.func.0 as usize];
+                    let inner_func = &env.functions[lowered_func.func.index()];
                     if has_known_non_render_call(inner_func, env) {
                         let span = *span;
                         instr.value =
@@ -185,7 +184,7 @@ pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
                     }
                 }
                 InstructionValue::Destructure { value, lvalue, span } => {
-                    let value_id = env.identifiers[value.identifier.0 as usize].id;
+                    let value_id = env.identifiers[value.identifier.index()].id;
                     if inlined_state.contains_key(&value_id) {
                         // Invariant: destructuring pattern must be ArrayPattern with at least one Identifier item
                         if let Pattern::Array(arr) = &lvalue.pattern {
@@ -230,7 +229,7 @@ pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
                             };
                         }
                         Some(HookKind::UseReducer | HookKind::UseState) => {
-                            let lvalue_id = env.identifiers[instr.lvalue.identifier.0 as usize].id;
+                            let lvalue_id = env.identifiers[instr.lvalue.identifier.index()].id;
                             if let Some(replacement) = inlined_state.get(&lvalue_id) {
                                 instr.value = match replacement {
                                     InlinedStateReplacement::LoadLocal { place, span } => {
@@ -277,10 +276,10 @@ enum InlinedStateReplacement {
 fn has_known_non_render_call(func: &HirFunction, env: &Environment) -> bool {
     for (_block_id, block) in &func.body.blocks {
         for &instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             if let InstructionValue::CallExpression { callee, .. } = &instr.value {
                 let callee_type =
-                    &env.types[env.identifiers[callee.identifier.0 as usize].type_.0 as usize];
+                    &env.types[env.identifiers[callee.identifier.index()].type_.index()];
                 if is_set_state_type(callee_type) || is_start_transition_type(callee_type) {
                     return true;
                 }

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/optimize_props_method_calls.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/optimize_props_method_calls.rs
@@ -22,13 +22,13 @@ pub fn optimize_props_method_calls(func: &mut HirFunction, env: &Environment) {
     for (_block_id, block) in &func.body.blocks {
         let instruction_ids: Vec<_> = block.instructions.clone();
         for instr_id in instruction_ids {
-            let instr = &mut func.instructions[instr_id.0 as usize];
+            let instr = &mut func.instructions[instr_id.index()];
             let should_replace = matches!(
                 &instr.value,
                 InstructionValue::MethodCall { receiver, .. }
                     if {
-                        let identifier = &env.identifiers[receiver.identifier.0 as usize];
-                        let ty = &env.types[identifier.type_.0 as usize];
+                        let identifier = &env.identifiers[receiver.identifier.index()];
+                        let ty = &env.types[identifier.type_.index()];
                         is_props_type(ty)
                     }
             );

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/outline_functions.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/outline_functions.rs
@@ -44,12 +44,12 @@ pub fn outline_functions<'a>(
 
     for block in func.body.blocks.values() {
         for &instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             let lvalue_id = instr.lvalue.identifier;
 
             match &instr.value {
                 InstructionValue::FunctionExpression { lowered_func, .. } => {
-                    let inner_func = &env.functions[lowered_func.func.0 as usize];
+                    let inner_func = &env.functions[lowered_func.func.index()];
 
                     // Check outlining conditions (TS only checks func.id === null, not name):
                     // 1. No captured context variables
@@ -60,7 +60,7 @@ pub fn outline_functions<'a>(
                         && !fbt_operands.contains(&lvalue_id)
                     {
                         actions.push(Action::RecurseAndOutline {
-                            instr_idx: instr_id.0 as usize,
+                            instr_idx: instr_id.index(),
                             function_id: lowered_func.func,
                         });
                     } else {
@@ -83,27 +83,27 @@ pub fn outline_functions<'a>(
         match action {
             Action::Recurse(function_id) => {
                 let mut inner_func =
-                    replace(&mut env.functions[function_id.0 as usize], placeholder_function());
+                    replace(&mut env.functions[function_id.index()], placeholder_function());
                 outline_functions(&mut inner_func, env, fbt_operands);
-                env.functions[function_id.0 as usize] = inner_func;
+                env.functions[function_id.index()] = inner_func;
             }
             Action::RecurseAndOutline { instr_idx, function_id } => {
                 // First recurse into the inner function (depth-first)
                 let mut inner_func =
-                    replace(&mut env.functions[function_id.0 as usize], placeholder_function());
+                    replace(&mut env.functions[function_id.index()], placeholder_function());
                 outline_functions(&mut inner_func, env, fbt_operands);
-                env.functions[function_id.0 as usize] = inner_func;
+                env.functions[function_id.index()] = inner_func;
 
                 // Then generate the name and outline (after recursion, matching TS order)
-                let inner = &env.functions[function_id.0 as usize];
+                let inner = &env.functions[function_id.index()];
                 let hint: Option<Ident<'a>> = inner.id.or(inner.name_hint);
                 let generated_name = env.generate_globally_unique_identifier_name(hint.as_deref());
 
                 // Set the id on the inner function
-                env.functions[function_id.0 as usize].id = Some(generated_name);
+                env.functions[function_id.index()].id = Some(generated_name);
 
                 // Outline the function
-                let outlined_func = env.functions[function_id.0 as usize].clone();
+                let outlined_func = env.functions[function_id.index()].clone();
                 env.outline_function(outlined_func, None);
 
                 // Replace the instruction value with LoadGlobal

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/outline_jsx.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/outline_jsx.rs
@@ -95,12 +95,12 @@ fn outline_jsx_impl<'a>(
         let mut actions: Vec<InstrAction> = Vec::new();
         for i in (0..instr_ids.len()).rev() {
             let iid = instr_ids[i];
-            let instr = &func.instructions[iid.0 as usize];
+            let instr = &func.instructions[iid.index()];
             let lvalue_id = instr.lvalue.identifier;
 
             match &instr.value {
                 InstructionValue::LoadGlobal { .. } => {
-                    actions.push(InstrAction::LoadGlobal { lvalue_id, instr_idx: iid.0 as usize });
+                    actions.push(InstrAction::LoadGlobal { lvalue_id, instr_idx: iid.index() });
                 }
                 InstructionValue::FunctionExpression { lowered_func, .. } => {
                     actions.push(InstrAction::FunctionExpr { func_id: lowered_func.func });
@@ -112,7 +112,7 @@ fn outline_jsx_impl<'a>(
                         .unwrap_or_default();
                     actions.push(InstrAction::JsxExpr {
                         lvalue_id,
-                        instr_idx: iid.0 as usize,
+                        instr_idx: iid.index(),
                         eval_order: instr.id,
                         child_ids,
                     });
@@ -131,9 +131,9 @@ fn outline_jsx_impl<'a>(
                 }
                 InstrAction::FunctionExpr { func_id } => {
                     let mut inner_func =
-                        replace(&mut env.functions[func_id.0 as usize], placeholder_function());
+                        replace(&mut env.functions[func_id.index()], placeholder_function());
                     outline_jsx_impl(&mut inner_func, env, outlined_fns);
-                    env.functions[func_id.0 as usize] = inner_func;
+                    env.functions[func_id.index()] = inner_func;
                 }
                 InstrAction::JsxExpr { lvalue_id, instr_idx, eval_order, child_ids } => {
                     if !children_ids.contains(&lvalue_id) {
@@ -170,13 +170,13 @@ fn outline_jsx_impl<'a>(
             let old_instr_ids = block.instructions.clone();
             let mut new_instr_ids = Vec::new();
             for &iid in &old_instr_ids {
-                let eval_order = func.instructions[iid.0 as usize].id;
+                let eval_order = func.instructions[iid.index()].id;
                 if let Some(replacement_instrs) = rewrite_instr.get(&eval_order) {
                     // Add replacement instructions to the instruction table and reference them
                     for new_instr in replacement_instrs {
                         let new_idx = func.instructions.len();
                         func.instructions.push(new_instr.clone());
-                        new_instr_ids.push(InstructionId(new_idx as u32));
+                        new_instr_ids.push(InstructionId::from_usize(new_idx));
                     }
                 } else {
                     new_instr_ids.push(iid);
@@ -288,17 +288,17 @@ fn collect_props<'a>(
                     }
                     // Promote the child's identifier to a named temporary
                     let child_id = child.identifier;
-                    let decl_id = env.identifiers[child_id.0 as usize].declaration_id;
-                    if env.identifiers[child_id.0 as usize].name.is_none() {
-                        env.identifiers[child_id.0 as usize].name = Some(IdentifierName::Promoted(
-                            format_ident!(allocator, "#t{}", decl_id.0),
+                    let decl_id = env.identifiers[child_id.index()].declaration_id;
+                    if env.identifiers[child_id.index()].name.is_none() {
+                        env.identifiers[child_id.index()].name = Some(IdentifierName::Promoted(
+                            format_ident!(allocator, "#t{}", decl_id.index()),
                         ));
                     }
 
-                    let child_name = match env.identifiers[child_id.0 as usize].name {
+                    let child_name = match env.identifiers[child_id.index()].name {
                         Some(IdentifierName::Named(n)) => n,
                         Some(IdentifierName::Promoted(n)) => n,
-                        None => format_ident!(allocator, "#t{}", decl_id.0),
+                        None => format_ident!(allocator, "#t{}", decl_id.index()),
                     };
                     let new_name = generate_name(Ident::from("t"));
                     attributes.push(OutlinedJsxAttribute {
@@ -329,15 +329,15 @@ fn emit_outlined_jsx<'a>(
     // Create LoadGlobal for the outlined component
     let load_id = env.next_identifier_id();
     // Promote it as a JSX tag temporary
-    let decl_id = env.identifiers[load_id.0 as usize].declaration_id;
-    env.identifiers[load_id.0 as usize].name =
-        Some(IdentifierName::Promoted(format_ident!(env.allocator, "#T{}", decl_id.0)));
+    let decl_id = env.identifiers[load_id.index()].declaration_id;
+    env.identifiers[load_id.index()].name =
+        Some(IdentifierName::Promoted(format_ident!(env.allocator, "#T{}", decl_id.index())));
 
     let load_place =
         Place { identifier: load_id, effect: Effect::Unknown, reactive: false, span: None };
 
     let load_jsx = Instruction {
-        id: EvaluationOrder(0),
+        id: EvaluationOrder::UNSET,
         lvalue: load_place.clone(),
         value: InstructionValue::LoadGlobal {
             binding: NonLocalBinding::ModuleLocal { name: outlined_tag },
@@ -351,7 +351,7 @@ fn emit_outlined_jsx<'a>(
     let last_info = jsx_group.last().unwrap();
     let last_instr = &func.instructions[last_info.instr_idx];
     let jsx_expr = Instruction {
-        id: EvaluationOrder(0),
+        id: EvaluationOrder::UNSET,
         lvalue: last_instr.lvalue.clone(),
         value: InstructionValue::JsxExpression {
             tag: JsxTag::Place(load_place),
@@ -379,9 +379,9 @@ fn emit_outlined_fn<'a>(
 
     // Create props parameter
     let props_obj_id = env.next_identifier_id();
-    let decl_id = env.identifiers[props_obj_id.0 as usize].declaration_id;
-    env.identifiers[props_obj_id.0 as usize].name =
-        Some(IdentifierName::Promoted(format_ident!(env.allocator, "#t{}", decl_id.0)));
+    let decl_id = env.identifiers[props_obj_id.index()].declaration_id;
+    env.identifiers[props_obj_id.index()].name =
+        Some(IdentifierName::Promoted(format_ident!(env.allocator, "#t{}", decl_id.index())));
     let props_obj =
         Place { identifier: props_obj_id, effect: Effect::Unknown, reactive: false, span: None };
 
@@ -406,7 +406,7 @@ fn emit_outlined_fn<'a>(
     for instr in instructions {
         let idx = instr_table.len();
         instr_table.push(instr);
-        instr_ids.push(InstructionId(idx as u32));
+        instr_ids.push(InstructionId::from_usize(idx));
     }
 
     // Return terminal uses the last instruction's lvalue
@@ -419,13 +419,13 @@ fn emit_outlined_fn<'a>(
 
     let block = BasicBlock {
         kind: BlockKind::Block,
-        id: BlockId(0),
+        id: BlockId::from_usize(0),
         instructions: instr_ids,
         preds: FxIndexSet::default(),
         terminal: Terminal::Return {
             value: last_lvalue,
             return_variant: ReturnVariant::Explicit,
-            id: EvaluationOrder(0),
+            id: EvaluationOrder::UNSET,
             span: None,
             effects: None,
         },
@@ -433,7 +433,7 @@ fn emit_outlined_fn<'a>(
     };
 
     let mut blocks = FxIndexMap::default();
-    blocks.insert(BlockId(0), block);
+    blocks.insert(BlockId::from_usize(0), block);
 
     let outlined_fn = HirFunction {
         id: None,
@@ -442,7 +442,7 @@ fn emit_outlined_fn<'a>(
         params: vec![ParamPattern::Place(props_obj)],
         returns: returns_place,
         context: Vec::new(),
-        body: HIR { entry: BlockId(0), blocks },
+        body: HIR { entry: BlockId::from_usize(0), blocks },
         instructions: instr_table,
         generator: false,
         is_async: false,
@@ -561,7 +561,7 @@ fn create_old_to_new_props_mapping<'a>(
         }
 
         let new_id = env.next_identifier_id();
-        env.identifiers[new_id.0 as usize].name = Some(IdentifierName::Named(old_prop.new_name));
+        env.identifiers[new_id.index()].name = Some(IdentifierName::Named(old_prop.new_name));
 
         let new_place =
             Place { identifier: new_id, effect: Effect::Unknown, reactive: false, span: None };
@@ -598,7 +598,7 @@ fn emit_destructure_props<'a>(
         Place { identifier: lvalue_id, effect: Effect::Unknown, reactive: false, span: None };
 
     Instruction {
-        id: EvaluationOrder(0),
+        id: EvaluationOrder::UNSET,
         lvalue,
         value: InstructionValue::Destructure {
             lvalue: LValuePattern {

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/prune_maybe_throws.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/prune_maybe_throws.rs
@@ -54,7 +54,7 @@ pub fn prune_maybe_throws(
                                     .diagnostic("Expected non-existing phi operand's predecessor to have been mapped to a new terminal")
                                     .with_help(format!(
                                         "Could not find mapping for predecessor bb{} in block bb{}",
-                                        predecessor.0, block.id.0,
+                                        predecessor.index(), block.id.index(),
                                     ))
                             })?;
                         updates.push((*predecessor, mapped_terminal));
@@ -89,7 +89,7 @@ fn prune_maybe_throws_impl(func: &mut HirFunction) -> Option<FxHashMap<BlockId, 
         let can_throw = block
             .instructions
             .iter()
-            .any(|instr_id| instruction_may_throw(&instructions[instr_id.0 as usize]));
+            .any(|instr_id| instruction_may_throw(&instructions[instr_id.index()]));
 
         if !can_throw {
             let source = terminal_mapping.get(&block.id).copied().unwrap_or(block.id);

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/assert_scope_instructions_within_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/assert_scope_instructions_within_scopes.rs
@@ -89,9 +89,9 @@ impl<'a, 'e> ReactiveFunctionVisitor<'a> for CheckInstructionsAgainstScopesVisit
 
     fn visit_place(&self, id: EvaluationOrder, place: &Place, state: &mut CheckState) {
         // getPlaceScope: check if the place's identifier has a scope that is active at this id
-        let identifier = &self.env.identifiers[place.identifier.0 as usize];
+        let identifier = &self.env.identifiers[place.identifier.index()];
         if let Some(scope_id) = identifier.scope {
-            let scope = &self.env.scopes[scope_id.0 as usize];
+            let scope = &self.env.scopes[scope_id.index()];
             // isScopeActive: id >= scope.range.start && id < scope.range.end
             let is_active_at_id = id >= scope.range.start && id < scope.range.end;
             if is_active_at_id

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/build_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/build_reactive_function.rs
@@ -143,7 +143,7 @@ impl<'a, 'h> Context<'a, 'h> {
         self.next_schedule_id += 1;
         if self.scheduled.contains(&block) {
             return Err(ErrorCategory::Invariant
-                .diagnostic(format!("Break block is already scheduled: bb{}", block.0)));
+                .diagnostic(format!("Break block is already scheduled: bb{}", block.index())));
         }
         self.scheduled.insert(block);
         let target = match target_type {
@@ -171,7 +171,7 @@ impl<'a, 'h> Context<'a, 'h> {
         if self.scheduled.contains(&continue_block) {
             return Err(ErrorCategory::Invariant.diagnostic(format!(
                 "Continue block is already scheduled: bb{}",
-                continue_block.0
+                continue_block.index()
             )));
         }
         self.scheduled.insert(continue_block);
@@ -250,7 +250,7 @@ impl<'a, 'h> Context<'a, 'h> {
             has_preceding_loop = has_preceding_loop || target.is_loop();
         }
         Err(ErrorCategory::Invariant
-            .diagnostic(format!("Expected a break target for bb{}", block.0)))
+            .diagnostic(format!("Expected a break target for bb{}", block.index())))
     }
 
     fn get_continue_target(&self, block: BlockId) -> Option<(BlockId, ReactiveTerminalTargetKind)> {
@@ -311,12 +311,12 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
 
             if !self.cx.emitted.insert(block_id_val) {
                 return Err(ErrorCategory::Invariant
-                    .diagnostic(format!("Block bb{} was already emitted", block_id_val.0)));
+                    .diagnostic(format!("Block bb{} was already emitted", block_id_val.index())));
             }
 
             // Emit instructions
             for instr_id in &instructions {
-                let instr = &self.hir.instructions[instr_id.0 as usize];
+                let instr = &self.hir.instructions[instr_id.index()];
                 block_value.push(ReactiveStatement::Instruction(ReactiveInstruction {
                     id: instr.id,
                     lvalue: Some(instr.lvalue.clone()),
@@ -349,7 +349,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                     let consequent_block = if self.cx.is_scheduled(*consequent) {
                         return Err(ErrorCategory::Invariant.diagnostic(format!(
                             "Unexpected 'if' where consequent is already scheduled (bb{})",
-                            consequent.0
+                            consequent.index()
                         )));
                     } else {
                         self.traverse_block(*consequent)?
@@ -359,7 +359,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                         if self.cx.is_scheduled(alt) {
                             return Err(ErrorCategory::Invariant.diagnostic(format!(
                                 "Unexpected 'if' where the alternate is already scheduled (bb{})",
-                                alt.0
+                                alt.index()
                             )));
                         } else {
                             Some(self.traverse_block(alt)?)
@@ -892,7 +892,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
             if block_id == ft {
                 return Err(ErrorCategory::Invariant.diagnostic(format!(
                     "Did not expect to reach the fallthrough of a value block (bb{})",
-                    block_id.0
+                    block_id.index()
                 )));
             }
         }
@@ -917,7 +917,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                 if instructions.is_empty() {
                     return Err(ErrorCategory::Invariant
                         .diagnostic("Unexpected empty block with `goto` terminal")
-                        .with_help(format!("Block bb{} is empty", block_id.0))
+                        .with_help(format!("Block bb{} is empty", block_id.index()))
                         .with_labels(
                             span.map(|s| s.label("Unexpected empty block with `goto` terminal")),
                         ));
@@ -957,7 +957,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                 let mut all_instrs: Vec<ReactiveInstruction<'a>> = instructions
                     .iter()
                     .map(|iid| {
-                        let instr = &self.hir.instructions[iid.0 as usize];
+                        let instr = &self.hir.instructions[iid.index()];
                         ReactiveInstruction {
                             id: instr.id,
                             lvalue: Some(instr.lvalue.clone()),
@@ -1110,12 +1110,12 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
         block_id: BlockId,
     ) -> ValueBlockResult<'a> {
         let last_id = instructions.last().expect("Expected non-empty instructions");
-        let last_instr = &self.hir.instructions[last_id.0 as usize];
+        let last_instr = &self.hir.instructions[last_id.index()];
 
         let remaining: Vec<ReactiveInstruction<'a>> = instructions[..instructions.len() - 1]
             .iter()
             .map(|iid| {
-                let instr = &self.hir.instructions[iid.0 as usize];
+                let instr = &self.hir.instructions[iid.index()];
                 ReactiveInstruction {
                     id: instr.id,
                     lvalue: Some(instr.lvalue.clone()),
@@ -1129,7 +1129,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
         // convert it to a LoadLocal of the value being stored, matching the TS behavior.
         let (value, place) = match &last_instr.value {
             InstructionValue::StoreLocal { lvalue, value: store_value, .. } => {
-                let ident = &self.env.identifiers[lvalue.place.identifier.0 as usize];
+                let ident = &self.env.identifiers[lvalue.place.identifier.index()];
                 if ident.name.is_none() {
                     (
                         ReactiveValue::Instruction(InstructionValue::LoadLocal {
@@ -1177,7 +1177,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
         let reactive_instrs: Vec<ReactiveInstruction<'a>> = instructions
             .iter()
             .map(|iid| {
-                let instr = &self.hir.instructions[iid.0 as usize];
+                let instr = &self.hir.instructions[iid.index()];
                 ReactiveInstruction {
                     id: instr.id,
                     lvalue: Some(instr.lvalue.clone()),
@@ -1281,7 +1281,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
             None => {
                 return Err(ErrorCategory::Invariant.diagnostic(format!(
                     "Expected continue target to be scheduled for bb{}",
-                    block.0
+                    block.index()
                 )));
             }
         };

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
@@ -300,12 +300,12 @@ impl<'a, 'env> OxcContext<'a, 'env> {
     }
 
     fn declare(&mut self, identifier_id: IdentifierId) {
-        let ident = &self.env.identifiers[identifier_id.0 as usize];
+        let ident = &self.env.identifiers[identifier_id.index()];
         self.declarations.insert(ident.declaration_id);
     }
 
     fn has_declared(&self, identifier_id: IdentifierId) -> bool {
-        let ident = &self.env.identifiers[identifier_id.0 as usize];
+        let ident = &self.env.identifiers[identifier_id.index()];
         self.declarations.contains(&ident.declaration_id)
     }
 
@@ -451,7 +451,7 @@ fn ox_codegen_reactive_function<'a>(
             ParamPattern::Place(p) => p,
             ParamPattern::Spread(sp) => &sp.place,
         };
-        let ident = &cx.env.identifiers[place.identifier.0 as usize];
+        let ident = &cx.env.identifiers[place.identifier.index()];
         cx.temp.insert(ident.declaration_id, None);
         cx.declare(place.identifier);
     }
@@ -555,7 +555,7 @@ fn ox_identifier_name<'a>(
     env: &Environment<'a>,
     identifier_id: IdentifierId,
 ) -> Result<Ident<'a>, OxcDiagnostic> {
-    let ident = &env.identifiers[identifier_id.0 as usize];
+    let ident = &env.identifiers[identifier_id.index()];
     match ident.name {
         Some(crate::react_compiler_hir::IdentifierName::Named(n))
         | Some(crate::react_compiler_hir::IdentifierName::Promoted(n)) => Ok(n),
@@ -670,9 +670,9 @@ fn ox_codegen_reactive_scope<'a>(
     scope_id: ScopeId,
     block: &ReactiveBlock<'a>,
 ) -> Result<(), OxcDiagnostic> {
-    let scope_deps = cx.env.scopes[scope_id.0 as usize].dependencies.clone();
-    let scope_decls = cx.env.scopes[scope_id.0 as usize].declarations.clone();
-    let scope_reassignments = cx.env.scopes[scope_id.0 as usize].reassignments.clone();
+    let scope_deps = cx.env.scopes[scope_id.index()].dependencies.clone();
+    let scope_decls = cx.env.scopes[scope_id.index()].declarations.clone();
+    let scope_reassignments = cx.env.scopes[scope_id.index()].reassignments.clone();
 
     let mut cache_store_stmts: oxc_allocator::Vec<'a, oxc::Statement<'a>> =
         oxc_allocator::ArenaVec::new_in(&cx.ast);
@@ -832,9 +832,9 @@ fn ox_codegen_reactive_scope<'a>(
     statements.push(memo_stmt);
 
     // Early return
-    let early_return_value = cx.env.scopes[scope_id.0 as usize].early_return_value.clone();
+    let early_return_value = cx.env.scopes[scope_id.index()].early_return_value.clone();
     if let Some(ref early_return) = early_return_value {
-        let early_ident = &cx.env.identifiers[early_return.value.0 as usize];
+        let early_ident = &cx.env.identifiers[early_return.value.index()];
         let name = match &early_ident.name {
             Some(
                 crate::react_compiler_hir::IdentifierName::Named(n)
@@ -1041,7 +1041,7 @@ fn ox_codegen_terminal<'a>(
         ReactiveTerminal::Try { block, handler_binding, handler, .. } => {
             let catch_param = match handler_binding.as_ref() {
                 Some(binding) => {
-                    let ident = &cx.env.identifiers[binding.identifier.0 as usize];
+                    let ident = &cx.env.identifiers[binding.identifier.index()];
                     cx.temp.insert(ident.declaration_id, None);
                     let pattern = ox_binding_for_identifier(cx, binding.identifier)?;
                     Some(oxc_ast::ast::CatchParameter::new(
@@ -1383,7 +1383,7 @@ fn ox_codegen_store_or_declare<'a>(
             let kind = lvalue.kind;
             for place in crate::react_compiler_hir::visitors::each_pattern_operand(&lvalue.pattern)
             {
-                let ident = &cx.env.identifiers[place.identifier.0 as usize];
+                let ident = &cx.env.identifiers[place.identifier.index()];
                 if kind != InstructionKind::Reassign && ident.name.is_none() {
                     cx.temp.insert(ident.declaration_id, None);
                 }
@@ -1483,7 +1483,7 @@ fn ox_emit_store<'a>(
                     ReactiveValue::Instruction(InstructionValue::StoreContext { .. })
                 );
                 if !is_store_context {
-                    let ident = &cx.env.identifiers[lvalue_place.identifier.0 as usize];
+                    let ident = &cx.env.identifiers[lvalue_place.identifier.index()];
                     cx.temp.insert(ident.declaration_id, Some(OxValue::Expression(expr)));
                     return Ok(None);
                 }
@@ -1541,7 +1541,7 @@ fn ox_codegen_instruction<'a>(
         let expr = ox_convert_value_to_expression(&cx.ast, value);
         return Ok(oxc_ast::ast::Statement::new_expression_statement(SPAN, expr, &cx.ast));
     };
-    let ident = &cx.env.identifiers[lvalue.identifier.0 as usize];
+    let ident = &cx.env.identifiers[lvalue.identifier.index()];
     if ident.name.is_none() {
         cx.temp.insert(ident.declaration_id, Some(value));
         return Ok(oxc_ast::ast::Statement::new_empty_statement(SPAN, &cx.ast));
@@ -2201,7 +2201,7 @@ fn ox_codegen_place<'a>(
     cx: &mut OxcContext<'a, '_>,
     place: &Place,
 ) -> Result<OxValue<'a>, OxcDiagnostic> {
-    let ident = &cx.env.identifiers[place.identifier.0 as usize];
+    let ident = &cx.env.identifiers[place.identifier.index()];
     let declaration_id = ident.declaration_id;
     if let Some(tmp) = cx.temp.get(&declaration_id) {
         if let Some(val) = tmp {
@@ -2211,7 +2211,7 @@ fn ox_codegen_place<'a>(
         return Err(invariant_err(
             &format!(
                 "[Codegen] No value found for temporary, identifier id={}",
-                place.identifier.0
+                place.identifier.index()
             ),
             place.span,
         ));
@@ -2548,7 +2548,7 @@ fn ox_codegen_function_expression<'a>(
     lowered_func: &crate::react_compiler_hir::LoweredFunction,
     expr_type: &FunctionExpressionType,
 ) -> Result<OxValue<'a>, OxcDiagnostic> {
-    let func = cx.env.functions[lowered_func.func.0 as usize].clone();
+    let func = cx.env.functions[lowered_func.func.index()].clone();
     let mut reactive_fn = build_reactive_function(&func, cx.env)?;
     prune_unused_labels(&mut reactive_fn, cx.env)?;
     prune_unused_lvalues(&mut reactive_fn, cx.env);
@@ -2734,7 +2734,7 @@ fn ox_codegen_object_expression<'a>(
                             return Err(invariant_err("Expected ObjectMethod instruction", None));
                         };
 
-                        let func = cx.env.functions[lowered_func.func.0 as usize].clone();
+                        let func = cx.env.functions[lowered_func.func.index()].clone();
                         let mut reactive_fn = build_reactive_function(&func, cx.env)?;
                         prune_unused_labels(&mut reactive_fn, cx.env)?;
                         prune_unused_lvalues(&mut reactive_fn, cx.env);
@@ -3321,7 +3321,7 @@ impl<'a, 'e> ReactiveFunctionVisitor<'a> for CountMemoBlockVisitor<'a, 'e> {
 
     fn visit_scope(&self, scope_block: &ReactiveScopeBlock<'a>, state: &mut CountMemoBlockState) {
         state.memo_blocks += 1;
-        let scope = &self.env.scopes[scope_block.scope.0 as usize];
+        let scope = &self.env.scopes[scope_block.scope.index()];
         state.memo_values += scope.declarations.len() as u32;
         self.traverse_scope(scope_block, state);
     }
@@ -3332,7 +3332,7 @@ impl<'a, 'e> ReactiveFunctionVisitor<'a> for CountMemoBlockVisitor<'a, 'e> {
         state: &mut CountMemoBlockState,
     ) {
         state.pruned_memo_blocks += 1;
-        let scope = &self.env.scopes[scope_block.scope.0 as usize];
+        let scope = &self.env.scopes[scope_block.scope.index()];
         state.pruned_memo_values += scope.declarations.len() as u32;
         self.traverse_pruned_scope(scope_block, state);
     }
@@ -3354,7 +3354,7 @@ fn count_memo_blocks<'a>(
 }
 
 fn codegen_label(id: BlockId) -> String {
-    format!("bb{}", id.0)
+    format!("bb{}", id.index())
 }
 
 fn get_instruction_value<'x, 'a>(
@@ -3398,10 +3398,10 @@ fn dep_to_sort_key(
     dep: &crate::react_compiler_hir::ReactiveScopeDependency,
     env: &Environment,
 ) -> String {
-    let ident = &env.identifiers[dep.identifier.0 as usize];
+    let ident = &env.identifiers[dep.identifier.index()];
     let base = match ident.name {
         Some(name) => name.value().to_string(),
-        None => format!("_t{}", dep.identifier.0),
+        None => format!("_t{}", dep.identifier.index()),
     };
     let mut parts = vec![base];
     for entry in &dep.path {
@@ -3426,9 +3426,9 @@ fn compare_scope_declaration(
 }
 
 fn ident_sort_key(id: IdentifierId, env: &Environment) -> String {
-    let ident = &env.identifiers[id.0 as usize];
+    let ident = &env.identifiers[id.index()];
     match ident.name {
         Some(name) => name.value().to_string(),
-        None => format!("_t{}", id.0),
+        None => format!("_t{}", id.index()),
     }
 }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/extract_scope_declarations_from_destructuring.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/extract_scope_declarations_from_destructuring.rs
@@ -40,7 +40,7 @@ pub fn extract_scope_declarations_from_destructuring<'a>(
             ParamPattern::Place(p) => p,
             ParamPattern::Spread(s) => &s.place,
         };
-        let identifier = &env.identifiers[place.identifier.0 as usize];
+        let identifier = &env.identifiers[place.identifier.index()];
         declared.insert(identifier.declaration_id);
     }
     let mut transform = Transform { env };
@@ -68,12 +68,12 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
         scope: &mut ReactiveScopeBlock<'a>,
         state: &mut ExtractState,
     ) -> Result<(), OxcDiagnostic> {
-        let scope_data = &self.env.scopes[scope.scope.0 as usize];
+        let scope_data = &self.env.scopes[scope.scope.index()];
         let decl_ids: Vec<DeclarationId> = scope_data
             .declarations
             .iter()
             .map(|(_, d)| {
-                let identifier = &self.env.identifiers[d.identifier.0 as usize];
+                let identifier = &self.env.identifiers[d.identifier.index()];
                 identifier.declaration_id
             })
             .collect();
@@ -103,7 +103,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
             let mut has_declaration = false;
 
             for place in visitors::each_pattern_operand(&lvalue.pattern) {
-                let identifier = &self.env.identifiers[place.identifier.0 as usize];
+                let identifier = &self.env.identifiers[place.identifier.index()];
                 if state.declared.contains(&identifier.declaration_id) {
                     reassigned.insert(place.identifier);
                 } else {
@@ -127,16 +127,16 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
                     }
                     // Create a temporary place (matches TS clonePlaceToTemporary)
                     let temp_id = env.next_identifier_id();
-                    let decl_id = env.identifiers[temp_id.0 as usize].declaration_id;
+                    let decl_id = env.identifiers[temp_id.index()].declaration_id;
                     // Copy type from original identifier to temporary
-                    let original_type = env.identifiers[place.identifier.0 as usize].type_;
-                    env.identifiers[temp_id.0 as usize].type_ = original_type;
+                    let original_type = env.identifiers[place.identifier.index()].type_;
+                    env.identifiers[temp_id.index()].type_ = original_type;
                     // Set identifier span to the place's source location
                     // (matches TS makeTemporaryIdentifier which receives place.span)
-                    env.identifiers[temp_id.0 as usize].span = place.span;
+                    env.identifiers[temp_id.index()].span = place.span;
                     // Promote the temporary
-                    env.identifiers[temp_id.0 as usize].name = Some(IdentifierName::Promoted(
-                        format_ident!(env.allocator, "#t{}", decl_id.0),
+                    env.identifiers[temp_id.index()].name = Some(IdentifierName::Promoted(
+                        format_ident!(env.allocator, "#t{}", decl_id.index()),
                     ));
                     let temporary = Place {
                         identifier: temp_id,
@@ -205,7 +205,7 @@ fn update_declared_from_instruction<'a>(
             | InstructionValue::DeclareLocal { lvalue, .. }
             | InstructionValue::StoreLocal { lvalue, .. } => {
                 if lvalue.kind != InstructionKind::Reassign {
-                    let identifier = &env.identifiers[lvalue.place.identifier.0 as usize];
+                    let identifier = &env.identifiers[lvalue.place.identifier.index()];
                     state.declared.insert(identifier.declaration_id);
                 }
             }
@@ -213,7 +213,7 @@ fn update_declared_from_instruction<'a>(
                 if lvalue.kind != InstructionKind::Reassign =>
             {
                 for place in visitors::each_pattern_operand(&lvalue.pattern) {
-                    let identifier = &env.identifiers[place.identifier.0 as usize];
+                    let identifier = &env.identifiers[place.identifier.index()];
                     state.declared.insert(identifier.declaration_id);
                 }
             }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/merge_reactive_scopes_that_invalidate_together.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/merge_reactive_scopes_that_invalidate_together.rs
@@ -66,7 +66,7 @@ impl<'a, 'e> ReactiveFunctionVisitor<'a> for FindLastUsageVisitor<'a, 'e> {
     }
 
     fn visit_place(&self, id: EvaluationOrder, place: &Place, state: &mut Self::State) {
-        let decl_id = self.env.identifiers[place.identifier.0 as usize].declaration_id;
+        let decl_id = self.env.identifiers[place.identifier.index()].declaration_id;
         let entry = state.entry(decl_id).or_insert(id);
         if id > *entry {
             *entry = id;
@@ -98,7 +98,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for MergeTransform<'a, 'e> {
         scope: &mut ReactiveScopeBlock<'a>,
         state: &mut Self::State,
     ) -> Result<Transformed<ReactiveStatement<'a>>, OxcDiagnostic> {
-        let scope_deps = self.env.scopes[scope.scope.0 as usize].dependencies.clone();
+        let scope_deps = self.env.scopes[scope.scope.index()].dependencies.clone();
         // Save parent state and recurse with this scope's deps as state
         let parent_state = state.take();
         *state = Some(scope_deps.clone());
@@ -181,13 +181,13 @@ impl<'a, 'e> MergeTransform<'a, 'e> {
                                     if let Some(ref mut c) = current {
                                         if let Some(lvalue) = &instr.lvalue {
                                             let decl_id = self.env.identifiers
-                                                [lvalue.identifier.0 as usize]
-                                                .declaration_id;
+                                                [lvalue.identifier.index()]
+                                            .declaration_id;
                                             c.lvalues.insert(decl_id);
                                             if let InstructionValue::LoadLocal { place, .. } = iv {
                                                 let src_decl = self.env.identifiers
-                                                    [place.identifier.0 as usize]
-                                                    .declaration_id;
+                                                    [place.identifier.index()]
+                                                .declaration_id;
                                                 self.temporaries.insert(decl_id, src_decl);
                                             }
                                         }
@@ -199,19 +199,19 @@ impl<'a, 'e> MergeTransform<'a, 'e> {
                                             // Add the instruction lvalue (if any)
                                             if let Some(instr_lvalue) = &instr.lvalue {
                                                 let decl_id = self.env.identifiers
-                                                    [instr_lvalue.identifier.0 as usize]
-                                                    .declaration_id;
+                                                    [instr_lvalue.identifier.index()]
+                                                .declaration_id;
                                                 c.lvalues.insert(decl_id);
                                             }
                                             // Add the StoreLocal's lvalue place
                                             let store_decl = self.env.identifiers
-                                                [lvalue.place.identifier.0 as usize]
-                                                .declaration_id;
+                                                [lvalue.place.identifier.index()]
+                                            .declaration_id;
                                             c.lvalues.insert(store_decl);
                                             // Track temporary mapping
                                             let value_decl = self.env.identifiers
-                                                [value.identifier.0 as usize]
-                                                .declaration_id;
+                                                [value.identifier.index()]
+                                            .declaration_id;
                                             let mapped = self
                                                 .temporaries
                                                 .get(&value_decl)
@@ -263,19 +263,18 @@ impl<'a, 'e> MergeTransform<'a, 'e> {
                             self.env,
                         ) {
                             // Merge: extend the current scope's range
-                            let next_range_end =
-                                self.env.scopes[next_scope_id.0 as usize].range.end;
+                            let next_range_end = self.env.scopes[next_scope_id.index()].range.end;
                             let current_range_end =
-                                self.env.scopes[current_scope_id.0 as usize].range.end;
-                            self.env.scopes[current_scope_id.0 as usize].range.end =
-                                EvaluationOrder(current_range_end.0.max(next_range_end.0));
+                                self.env.scopes[current_scope_id.index()].range.end;
+                            self.env.scopes[current_scope_id.index()].range.end =
+                                current_range_end.max(next_range_end);
 
                             // Merge declarations from next into current
                             let next_decls =
-                                self.env.scopes[next_scope_id.0 as usize].declarations.clone();
+                                self.env.scopes[next_scope_id.index()].declarations.clone();
                             for (key, value) in next_decls {
                                 let current_decls =
-                                    &mut self.env.scopes[current_scope_id.0 as usize].declarations;
+                                    &mut self.env.scopes[current_scope_id.index()].declarations;
                                 if let Some(existing) =
                                     current_decls.iter_mut().find(|(k, _)| *k == key)
                                 {
@@ -364,9 +363,7 @@ impl<'a, 'e> MergeTransform<'a, 'e> {
                 match stmt {
                     ReactiveStatement::Scope(inner_scope) => {
                         merged_scope.instructions.extend(inner_scope.instructions.clone());
-                        self.env.scopes[merged_scope.scope.0 as usize]
-                            .merged
-                            .push(inner_scope.scope);
+                        self.env.scopes[merged_scope.scope.index()].merged.push(inner_scope.scope);
                     }
                     _ => {
                         merged_scope.instructions.push(stmt.clone());
@@ -396,9 +393,9 @@ fn update_scope_declarations<'a>(
     last_usage: &FxHashMap<DeclarationId, EvaluationOrder>,
     env: &mut Environment<'a>,
 ) {
-    let range_end = env.scopes[scope_id.0 as usize].range.end;
-    env.scopes[scope_id.0 as usize].declarations.retain(|(_id, decl)| {
-        let decl_declaration_id = env.identifiers[decl.identifier.0 as usize].declaration_id;
+    let range_end = env.scopes[scope_id.index()].range.end;
+    env.scopes[scope_id.index()].declarations.retain(|(_id, decl)| {
+        let decl_declaration_id = env.identifiers[decl.identifier.index()].declaration_id;
         match last_usage.get(&decl_declaration_id) {
             Some(last_used_at) => *last_used_at >= range_end,
             // If not tracked, keep the declaration (conservative)
@@ -414,7 +411,7 @@ fn are_lvalues_last_used_by_scope<'a>(
     last_usage: &FxHashMap<DeclarationId, EvaluationOrder>,
     env: &Environment<'a>,
 ) -> bool {
-    let range_end = env.scopes[scope_id.0 as usize].range.end;
+    let range_end = env.scopes[scope_id.index()].range.end;
     for lvalue in lvalues {
         if let Some(&last_used_at) = last_usage.get(lvalue) {
             if last_used_at >= range_end {
@@ -432,8 +429,8 @@ fn can_merge_scopes<'a>(
     env: &Environment<'a>,
     temporaries: &FxHashMap<DeclarationId, DeclarationId>,
 ) -> bool {
-    let current = &env.scopes[current_id.0 as usize];
-    let next = &env.scopes[next_id.0 as usize];
+    let current = &env.scopes[current_id.index()];
+    let next = &env.scopes[next_id.index()];
 
     // Don't merge scopes with reassignments
     if !current.reassignments.is_empty() || !next.reassignments.is_empty() {
@@ -469,13 +466,13 @@ fn can_merge_scopes<'a>(
             if !dep.path.is_empty() {
                 return false;
             }
-            let dep_type = &env.types[env.identifiers[dep.identifier.0 as usize].type_.0 as usize];
+            let dep_type = &env.types[env.identifiers[dep.identifier.index()].type_.index()];
             if !is_always_invalidating_type(dep_type) {
                 return false;
             }
-            let dep_decl = env.identifiers[dep.identifier.0 as usize].declaration_id;
+            let dep_decl = env.identifiers[dep.identifier.index()].declaration_id;
             current.declarations.iter().any(|(_key, decl)| {
-                let decl_decl_id = env.identifiers[decl.identifier.0 as usize].declaration_id;
+                let decl_decl_id = env.identifiers[decl.identifier.index()].declaration_id;
                 decl_decl_id == dep_decl
                     || temporaries.get(&dep_decl).copied() == Some(decl_decl_id)
             })
@@ -513,9 +510,9 @@ fn are_equal_dependencies<'a>(
         return false;
     }
     for a_val in a {
-        let a_decl = env.identifiers[a_val.identifier.0 as usize].declaration_id;
+        let a_decl = env.identifiers[a_val.identifier.index()].declaration_id;
         let found = b.iter().any(|b_val| {
-            let b_decl = env.identifiers[b_val.identifier.0 as usize].declaration_id;
+            let b_decl = env.identifiers[b_val.identifier.index()].declaration_id;
             a_decl == b_decl && are_equal_paths(&a_val.path, &b_val.path)
         });
         if !found {
@@ -535,13 +532,13 @@ fn are_equal_paths(a: &[DependencyPathEntry], b: &[DependencyPathEntry]) -> bool
 
 /// Check if a scope is eligible for merging with subsequent scopes.
 fn scope_is_eligible_for_merging<'a>(scope_id: ScopeId, env: &Environment<'a>) -> bool {
-    let scope = &env.scopes[scope_id.0 as usize];
+    let scope = &env.scopes[scope_id.index()];
     if scope.dependencies.is_empty() {
         // No dependencies means output never changes — eligible
         return true;
     }
     scope.declarations.iter().any(|(_key, decl)| {
-        let ty = &env.types[env.identifiers[decl.identifier.0 as usize].type_.0 as usize];
+        let ty = &env.types[env.identifiers[decl.identifier.index()].type_.index()];
         is_always_invalidating_type(ty)
     })
 }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/promote_used_temporaries.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/promote_used_temporaries.rs
@@ -71,7 +71,7 @@ pub fn promote_used_temporaries(func: &mut ReactiveFunction, env: &mut Environme
             ParamPattern::Place(p) => p,
             ParamPattern::Spread(s) => &s.place,
         };
-        let identifier = &env.identifiers[place.identifier.0 as usize];
+        let identifier = &env.identifiers[place.identifier.index()];
         if identifier.name.is_none() {
             promote_identifier(place.identifier, &mut state, env);
         }
@@ -130,9 +130,9 @@ fn collect_promotable_block(
                 active_scopes.pop();
             }
             ReactiveStatement::PrunedScope(scope) => {
-                let scope_data = &env.scopes[scope.scope.0 as usize];
+                let scope_data = &env.scopes[scope.scope.index()];
                 for (_id, decl) in &scope_data.declarations {
-                    let identifier = &env.identifiers[decl.identifier.0 as usize];
+                    let identifier = &env.identifiers[decl.identifier.index()];
                     state.pruned.insert(
                         identifier.declaration_id,
                         PrunedInfo {
@@ -157,7 +157,7 @@ fn collect_promotable_place(
     env: &Environment,
 ) {
     if !active_scopes.is_empty() {
-        let identifier = &env.identifiers[place.identifier.0 as usize];
+        let identifier = &env.identifiers[place.identifier.index()];
         if let Some(pruned) = state.pruned.get_mut(&identifier.declaration_id) {
             if let Some(last) = active_scopes.last() {
                 if !pruned.active_scopes.contains(last) {
@@ -191,7 +191,7 @@ fn collect_promotable_value(
             }
             // Check for JSX tag
             if let InstructionValue::JsxExpression { tag: JsxTag::Place(place), .. } = instr_value {
-                let identifier = &env.identifiers[place.identifier.0 as usize];
+                let identifier = &env.identifiers[place.identifier.index()];
                 state.tags.insert(identifier.declaration_id);
             }
         }
@@ -295,13 +295,13 @@ fn promote_temporaries_block(block: &ReactiveBlock, state: &mut State, env: &mut
             }
             ReactiveStatement::Scope(scope) => {
                 let scope_id = scope.scope;
-                let scope_data = &env.scopes[scope_id.0 as usize];
+                let scope_data = &env.scopes[scope_id.index()];
                 // Collect all IDs to promote first
                 let mut ids_to_check: Vec<IdentifierId> = Vec::new();
                 ids_to_check.extend(scope_data.dependencies.iter().map(|d| d.identifier));
                 ids_to_check.extend(scope_data.declarations.iter().map(|(_, d)| d.identifier));
                 for id in ids_to_check {
-                    let identifier = &env.identifiers[id.0 as usize];
+                    let identifier = &env.identifiers[id.index()];
                     if identifier.name.is_none() {
                         promote_identifier(id, state, env);
                     }
@@ -310,17 +310,17 @@ fn promote_temporaries_block(block: &ReactiveBlock, state: &mut State, env: &mut
             }
             ReactiveStatement::PrunedScope(scope) => {
                 let scope_id = scope.scope;
-                let scope_data = &env.scopes[scope_id.0 as usize];
+                let scope_data = &env.scopes[scope_id.index()];
                 let decls: Vec<(IdentifierId, DeclarationId)> = scope_data
                     .declarations
                     .iter()
                     .map(|(_, d)| {
-                        let identifier = &env.identifiers[d.identifier.0 as usize];
+                        let identifier = &env.identifiers[d.identifier.index()];
                         (d.identifier, identifier.declaration_id)
                     })
                     .collect();
                 for (id, decl_id) in decls {
-                    let identifier = &env.identifiers[id.0 as usize];
+                    let identifier = &env.identifiers[id.index()];
                     if identifier.name.is_none() {
                         if let Some(pruned) = state.pruned.get(&decl_id) {
                             if pruned.used_outside_scope {
@@ -440,7 +440,7 @@ fn promote_temporaries_terminal(
 fn visit_hir_function_for_promotion(func_id: FunctionId, state: &mut State, env: &mut Environment) {
     // Promote params of this function
     let param_ids: Vec<IdentifierId> = {
-        let func = &env.functions[func_id.0 as usize];
+        let func = &env.functions[func_id.index()];
         func.params
             .iter()
             .map(|param| match param {
@@ -450,7 +450,7 @@ fn visit_hir_function_for_promotion(func_id: FunctionId, state: &mut State, env:
             .collect()
     };
     for id in param_ids {
-        let identifier = &env.identifiers[id.0 as usize];
+        let identifier = &env.identifiers[id.index()];
         if identifier.name.is_none() {
             promote_identifier(id, state, env);
         }
@@ -458,11 +458,11 @@ fn visit_hir_function_for_promotion(func_id: FunctionId, state: &mut State, env:
 
     // Find nested FunctionExpression/ObjectMethod in body instructions
     let nested_func_ids: Vec<FunctionId> = {
-        let func = &env.functions[func_id.0 as usize];
+        let func = &env.functions[func_id.index()];
         let mut nested = Vec::new();
         for (_, block) in &func.body.blocks {
             for &instr_id in &block.instructions {
-                let instr = &func.instructions[instr_id.0 as usize];
+                let instr = &func.instructions[instr_id.index()];
                 match &instr.value {
                     InstructionValue::FunctionExpression { lowered_func, .. }
                     | InstructionValue::ObjectMethod { lowered_func, .. } => {
@@ -531,7 +531,7 @@ fn promote_interposed_place(
     env: &mut Environment,
 ) {
     if let Some(&(id, needs_promotion)) = inter_state.get(&place.identifier) {
-        let identifier = &env.identifiers[id.0 as usize];
+        let identifier = &env.identifiers[id.index()];
         if needs_promotion && identifier.name.is_none() && !consts.contains(&id) {
             promote_identifier(id, state, env);
         }
@@ -600,8 +600,7 @@ fn promote_interposed_instruction(
 
                     if !const_store
                         && (instr.lvalue.is_none()
-                            || env.identifiers
-                                [instr.lvalue.as_ref().unwrap().identifier.0 as usize]
+                            || env.identifiers[instr.lvalue.as_ref().unwrap().identifier.index()]
                                 .name
                                 .is_some())
                     {
@@ -614,7 +613,7 @@ fn promote_interposed_instruction(
                         }
                     }
                     if let Some(lvalue) = &instr.lvalue {
-                        let identifier = &env.identifiers[lvalue.identifier.0 as usize];
+                        let identifier = &env.identifiers[lvalue.identifier.index()];
                         if identifier.name.is_none() {
                             inter_state.insert(lvalue.identifier, (lvalue.identifier, false));
                         }
@@ -635,7 +634,7 @@ fn promote_interposed_instruction(
                 InstructionValue::LoadContext { place: load_place, .. }
                 | InstructionValue::LoadLocal { place: load_place, .. } => {
                     if let Some(lvalue) = &instr.lvalue {
-                        let identifier = &env.identifiers[lvalue.identifier.0 as usize];
+                        let identifier = &env.identifiers[lvalue.identifier.index()];
                         if identifier.name.is_none() {
                             if consts.contains(&load_place.identifier) {
                                 consts.insert(lvalue.identifier);
@@ -655,7 +654,7 @@ fn promote_interposed_instruction(
                             globals.insert(lvalue.identifier);
                             consts.insert(lvalue.identifier);
                         }
-                        let identifier = &env.identifiers[lvalue.identifier.0 as usize];
+                        let identifier = &env.identifiers[lvalue.identifier.index()];
                         if identifier.name.is_none() {
                             inter_state.insert(lvalue.identifier, (lvalue.identifier, false));
                         }
@@ -817,7 +816,7 @@ fn promote_all_instances_params(func: &ReactiveFunction, state: &mut State, env:
             ParamPattern::Place(p) => p,
             ParamPattern::Spread(s) => &s.place,
         };
-        let identifier = &env.identifiers[place.identifier.0 as usize];
+        let identifier = &env.identifiers[place.identifier.index()];
         if identifier.name.is_none() && state.promoted.contains(&identifier.declaration_id) {
             promote_identifier(place.identifier, state, env);
         }
@@ -850,7 +849,7 @@ fn promote_all_instances_scope_identifiers(
     state: &mut State,
     env: &mut Environment,
 ) {
-    let scope_data = &env.scopes[scope_id.0 as usize];
+    let scope_data = &env.scopes[scope_id.index()];
 
     // Collect identifiers to promote
     let decl_ids: Vec<IdentifierId> =
@@ -859,19 +858,19 @@ fn promote_all_instances_scope_identifiers(
     let reassign_ids: Vec<IdentifierId> = scope_data.reassignments.clone();
 
     for id in decl_ids {
-        let identifier = &env.identifiers[id.0 as usize];
+        let identifier = &env.identifiers[id.index()];
         if identifier.name.is_none() && state.promoted.contains(&identifier.declaration_id) {
             promote_identifier(id, state, env);
         }
     }
     for id in dep_ids {
-        let identifier = &env.identifiers[id.0 as usize];
+        let identifier = &env.identifiers[id.index()];
         if identifier.name.is_none() && state.promoted.contains(&identifier.declaration_id) {
             promote_identifier(id, state, env);
         }
     }
     for id in reassign_ids {
-        let identifier = &env.identifiers[id.0 as usize];
+        let identifier = &env.identifiers[id.index()];
         if identifier.name.is_none() && state.promoted.contains(&identifier.declaration_id) {
             promote_identifier(id, state, env);
         }
@@ -879,7 +878,7 @@ fn promote_all_instances_scope_identifiers(
 }
 
 fn promote_all_instances_place(place: &Place, state: &mut State, env: &mut Environment) {
-    let identifier = &env.identifiers[place.identifier.0 as usize];
+    let identifier = &env.identifiers[place.identifier.index()];
     if identifier.name.is_none() && state.promoted.contains(&identifier.declaration_id) {
         promote_identifier(place.identifier, state, env);
     }
@@ -907,7 +906,7 @@ fn promote_all_instances_value(value: &ReactiveValue, state: &mut State, env: &m
                 InstructionValue::FunctionExpression { lowered_func, .. }
                 | InstructionValue::ObjectMethod { lowered_func, .. } => {
                     let func_id = lowered_func.func;
-                    let inner_func = &env.functions[func_id.0 as usize];
+                    let inner_func = &env.functions[func_id.index()];
                     let param_ids: Vec<IdentifierId> = inner_func
                         .params
                         .iter()
@@ -917,7 +916,7 @@ fn promote_all_instances_value(value: &ReactiveValue, state: &mut State, env: &m
                         })
                         .collect();
                     for id in param_ids {
-                        let identifier = &env.identifiers[id.0 as usize];
+                        let identifier = &env.identifiers[id.index()];
                         if identifier.name.is_none()
                             && state.promoted.contains(&identifier.declaration_id)
                         {
@@ -1020,7 +1019,7 @@ fn promote_all_instances_terminal(
 // =============================================================================
 
 fn promote_identifier(identifier_id: IdentifierId, state: &mut State, env: &mut Environment) {
-    let identifier = &env.identifiers[identifier_id.0 as usize];
+    let identifier = &env.identifiers[identifier_id.index()];
     assert!(
         identifier.name.is_none(),
         "promoteTemporary: Expected to be called only for temporary variables"
@@ -1028,11 +1027,11 @@ fn promote_identifier(identifier_id: IdentifierId, state: &mut State, env: &mut 
     let decl_id = identifier.declaration_id;
     if state.tags.contains(&decl_id) {
         // JSX tag temporary: use capitalized name
-        env.identifiers[identifier_id.0 as usize].name =
-            Some(IdentifierName::Promoted(format_ident!(env.allocator, "#T{}", decl_id.0)));
+        env.identifiers[identifier_id.index()].name =
+            Some(IdentifierName::Promoted(format_ident!(env.allocator, "#T{}", decl_id.index())));
     } else {
-        env.identifiers[identifier_id.0 as usize].name =
-            Some(IdentifierName::Promoted(format_ident!(env.allocator, "#t{}", decl_id.0)));
+        env.identifiers[identifier_id.index()].name =
+            Some(IdentifierName::Promoted(format_ident!(env.allocator, "#t{}", decl_id.index())));
     }
     state.promoted.insert(decl_id);
 }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/propagate_early_returns.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/propagate_early_returns.rs
@@ -85,7 +85,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
         let scope_id = scope_block.scope;
 
         // Exit early if an earlier pass has already created an early return
-        if self.env.scopes[scope_id.0 as usize].early_return_value.is_some() {
+        if self.env.scopes[scope_id.index()].early_return_value.is_some() {
             return Ok(());
         }
 
@@ -135,7 +135,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
                 return Ok(Transformed::ReplaceMany(vec![
                     // StoreLocal: reassign the early return value
                     ReactiveStatement::Instruction(ReactiveInstruction {
-                        id: EvaluationOrder(0),
+                        id: EvaluationOrder::UNSET,
                         lvalue: None,
                         value: ReactiveValue::Instruction(InstructionValue::StoreLocal {
                             lvalue: LValue {
@@ -156,7 +156,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
                     ReactiveStatement::Terminal(ReactiveTerminalStatement {
                         terminal: ReactiveTerminal::Break {
                             target: early_return_value.label,
-                            id: EvaluationOrder(0),
+                            id: EvaluationOrder::UNSET,
                             target_kind: ReactiveTerminalTargetKind::Labeled,
                         },
                         label: None,
@@ -184,14 +184,14 @@ fn apply_early_return_to_scope<'a>(
     let span = early_return.span;
 
     // Set early return value on the scope
-    env.scopes[scope_id.0 as usize].early_return_value = Some(ReactiveScopeEarlyReturn {
+    env.scopes[scope_id.index()].early_return_value = Some(ReactiveScopeEarlyReturn {
         value: early_return.value,
         span: early_return.span,
         label: early_return.label,
     });
 
     // Add the early return identifier as a scope declaration
-    env.scopes[scope_id.0 as usize].declarations.push((
+    env.scopes[scope_id.index()].declarations.push((
         early_return.value,
         ReactiveScopeDeclaration { identifier: early_return.value, scope: scope_id },
     ));
@@ -207,7 +207,7 @@ fn apply_early_return_to_scope<'a>(
     scope_block.instructions = vec![
         // LoadGlobal Symbol
         ReactiveStatement::Instruction(ReactiveInstruction {
-            id: EvaluationOrder(0),
+            id: EvaluationOrder::UNSET,
             lvalue: Some(Place {
                 identifier: symbol_temp,
                 effect: Effect::Unknown,
@@ -222,7 +222,7 @@ fn apply_early_return_to_scope<'a>(
         }),
         // PropertyLoad Symbol.for
         ReactiveStatement::Instruction(ReactiveInstruction {
-            id: EvaluationOrder(0),
+            id: EvaluationOrder::UNSET,
             lvalue: Some(Place {
                 identifier: for_temp,
                 effect: Effect::Unknown,
@@ -243,7 +243,7 @@ fn apply_early_return_to_scope<'a>(
         }),
         // Primitive: the sentinel string
         ReactiveStatement::Instruction(ReactiveInstruction {
-            id: EvaluationOrder(0),
+            id: EvaluationOrder::UNSET,
             lvalue: Some(Place {
                 identifier: arg_temp,
                 effect: Effect::Unknown,
@@ -258,7 +258,7 @@ fn apply_early_return_to_scope<'a>(
         }),
         // MethodCall: Symbol.for("react.early_return_sentinel")
         ReactiveStatement::Instruction(ReactiveInstruction {
-            id: EvaluationOrder(0),
+            id: EvaluationOrder::UNSET,
             lvalue: Some(Place {
                 identifier: sentinel_temp,
                 effect: Effect::Unknown,
@@ -290,7 +290,7 @@ fn apply_early_return_to_scope<'a>(
         }),
         // StoreLocal: let earlyReturnValue = sentinel
         ReactiveStatement::Instruction(ReactiveInstruction {
-            id: EvaluationOrder(0),
+            id: EvaluationOrder::UNSET,
             lvalue: None,
             value: ReactiveValue::Instruction(InstructionValue::StoreLocal {
                 lvalue: LValue {
@@ -317,7 +317,7 @@ fn apply_early_return_to_scope<'a>(
             label: Some(ReactiveLabel { id: early_return.label, implicit: false }),
             terminal: ReactiveTerminal::Label {
                 block: original_instructions,
-                id: EvaluationOrder(0),
+                id: EvaluationOrder::UNSET,
             },
         }),
     ];
@@ -329,12 +329,12 @@ fn apply_early_return_to_scope<'a>(
 
 fn create_temporary_place_id(env: &mut Environment, span: Option<Span>) -> IdentifierId {
     let id = env.next_identifier_id();
-    env.identifiers[id.0 as usize].span = span;
+    env.identifiers[id.index()].span = span;
     id
 }
 
 fn promote_temporary<'a>(env: &mut Environment<'a>, identifier_id: IdentifierId) {
-    let decl_id = env.identifiers[identifier_id.0 as usize].declaration_id;
-    env.identifiers[identifier_id.0 as usize].name =
-        Some(IdentifierName::Promoted(format_ident!(env.allocator, "#t{}", decl_id.0)));
+    let decl_id = env.identifiers[identifier_id.index()].declaration_id;
+    env.identifiers[identifier_id.index()].name =
+        Some(IdentifierName::Promoted(format_ident!(env.allocator, "#t{}", decl_id.index())));
 }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_always_invalidating_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_always_invalidating_scopes.rs
@@ -115,7 +115,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
         self.visit_scope(scope, &mut within_scope)?;
 
         let scope_id = scope.scope;
-        let scope_data = &self.env.scopes[scope_id.0 as usize];
+        let scope_data = &self.env.scopes[scope_id.index()];
 
         for dep in &scope_data.dependencies {
             if self.unmemoized_values.contains(&dep.identifier) {

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_hoisted_contexts.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_hoisted_contexts.rs
@@ -81,7 +81,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
         scope: &mut ReactiveScopeBlock<'a>,
         state: &mut VisitorState,
     ) -> Result<(), OxcDiagnostic> {
-        let scope_data = &self.env.scopes[scope.scope.0 as usize];
+        let scope_data = &self.env.scopes[scope.scope.index()];
         let decl_ids: FxHashSet<IdentifierId> =
             scope_data.declarations.iter().map(|(id, _)| *id).collect();
 
@@ -95,7 +95,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
         state.active_scopes.pop();
 
         // Clean up uninitialized after scope
-        let scope_data = &self.env.scopes[scope.scope.0 as usize];
+        let scope_data = &self.env.scopes[scope.scope.index()];
         for (_, decl) in &scope_data.declarations {
             state.uninitialized.remove(&decl.identifier);
         }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_escaping_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_escaping_scopes.rs
@@ -70,7 +70,7 @@ pub fn prune_non_escaping_scopes<'a>(
             ParamPattern::Place(p) => p,
             ParamPattern::Spread(s) => &s.place,
         };
-        let identifier = &env.identifiers[place.identifier.0 as usize];
+        let identifier = &env.identifiers[place.identifier.index()];
         state.declare(identifier.declaration_id);
     }
     let visitor = CollectDependenciesVisitor::new(env);
@@ -188,11 +188,11 @@ impl CollectState {
     ) {
         if let Some(scope_id) = get_place_scope(env, id, place.identifier) {
             self.scopes.entry(scope_id).or_insert_with(|| {
-                let scope_data = &env.scopes[scope_id.0 as usize];
+                let scope_data = &env.scopes[scope_id.index()];
                 let dependencies = scope_data
                     .dependencies
                     .iter()
-                    .map(|dep| env.identifiers[dep.identifier.0 as usize].declaration_id)
+                    .map(|dep| env.identifiers[dep.identifier.index()].declaration_id)
                     .collect();
                 ScopeNode { dependencies, seen: false }
             });
@@ -237,8 +237,8 @@ fn get_place_scope<'a>(
     id: EvaluationOrder,
     identifier_id: IdentifierId,
 ) -> Option<ScopeId> {
-    let scope_id = env.identifiers[identifier_id.0 as usize].scope?;
-    if env.scopes[scope_id.0 as usize].range.contains(id) { Some(scope_id) } else { None }
+    let scope_id = env.identifiers[identifier_id.index()].scope?;
+    if env.scopes[scope_id.index()].range.contains(id) { Some(scope_id) } else { None }
 }
 
 // =============================================================================
@@ -792,7 +792,7 @@ impl<'a, 'e> CollectDependenciesVisitor<'a, 'e> {
         let rvalue_data: Vec<(IdentifierId, DeclarationId)> = aliasing_rvalues
             .iter()
             .map(|(identifier_id, _)| {
-                let decl_id = env.identifiers[identifier_id.0 as usize].declaration_id;
+                let decl_id = env.identifiers[identifier_id.index()].declaration_id;
                 let operand_id = state.resolve(decl_id);
                 (*identifier_id, operand_id)
             })
@@ -815,7 +815,7 @@ impl<'a, 'e> CollectDependenciesVisitor<'a, 'e> {
 
         // Add the operands as dependencies of all lvalues
         for lv in &aliasing_lvalues {
-            let lvalue_decl_id = env.identifiers[lv.place_identifier.0 as usize].declaration_id;
+            let lvalue_decl_id = env.identifiers[lv.place_identifier.index()].declaration_id;
             let lvalue_id = state.resolve(lvalue_decl_id);
             let node = state.identifiers.entry(lvalue_id).or_insert_with(|| IdentifierNode {
                 level: MemoizationLevel::Never,
@@ -849,8 +849,8 @@ impl<'a, 'e> CollectDependenciesVisitor<'a, 'e> {
         if let ReactiveValue::Instruction(instr_value) = value {
             if let InstructionValue::LoadLocal { place, .. } = instr_value {
                 if let Some(lv_id) = lvalue {
-                    let lv_decl = env.identifiers[lv_id.0 as usize].declaration_id;
-                    let place_decl = env.identifiers[place.identifier.0 as usize].declaration_id;
+                    let lv_decl = env.identifiers[lv_id.index()].declaration_id;
+                    let place_decl = env.identifiers[place.identifier.index()].declaration_id;
                     state.definitions.insert(lv_decl, place_decl);
                 }
             } else if let InstructionValue::CallExpression { callee, args, .. } = instr_value {
@@ -862,7 +862,7 @@ impl<'a, 'e> CollectDependenciesVisitor<'a, 'e> {
                                 PlaceOrSpread::Spread(spread) => &spread.place,
                                 PlaceOrSpread::Place(place) => place,
                             };
-                            let decl = env.identifiers[place.identifier.0 as usize].declaration_id;
+                            let decl = env.identifiers[place.identifier.index()].declaration_id;
                             state.escaping_values.insert(decl);
                         }
                     }
@@ -876,7 +876,7 @@ impl<'a, 'e> CollectDependenciesVisitor<'a, 'e> {
                                 PlaceOrSpread::Spread(spread) => &spread.place,
                                 PlaceOrSpread::Place(place) => place,
                             };
-                            let decl = env.identifiers[place.identifier.0 as usize].declaration_id;
+                            let decl = env.identifiers[place.identifier.index()].declaration_id;
                             state.escaping_values.insert(decl);
                         }
                     }
@@ -913,7 +913,7 @@ impl<'a, 'e> ReactiveFunctionVisitor<'a> for CollectDependenciesVisitor<'a, 'e> 
         // Handle return terminals
         if let ReactiveTerminal::Return { value, .. } = &stmt.terminal {
             let env = self.env;
-            let decl = env.identifiers[value.identifier.0 as usize].declaration_id;
+            let decl = env.identifiers[value.identifier.index()].declaration_id;
             state.0.escaping_values.insert(decl);
 
             // If the return is within a scope, associate those scopes with the returned value
@@ -928,12 +928,12 @@ impl<'a, 'e> ReactiveFunctionVisitor<'a> for CollectDependenciesVisitor<'a, 'e> 
     fn visit_scope(&self, scope: &ReactiveScopeBlock<'a>, state: &mut Self::State) {
         let env = self.env;
         let scope_id = scope.scope;
-        let scope_data = &env.scopes[scope_id.0 as usize];
+        let scope_data = &env.scopes[scope_id.index()];
 
         // If a scope reassigns any variables, set the chain of active scopes as a dependency
         // of those variables.
         for reassignment_id in &scope_data.reassignments {
-            let decl = env.identifiers[reassignment_id.0 as usize].declaration_id;
+            let decl = env.identifiers[reassignment_id.index()].declaration_id;
             let identifier_node =
                 state.0.identifiers.get_mut(&decl).expect("Expected identifier to be initialized");
             for s in &state.1 {
@@ -1075,7 +1075,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for PruneScopesTransform<'a, 'e> {
         self.visit_scope(scope, state)?;
 
         let scope_id = scope.scope;
-        let scope_data = &self.env.scopes[scope_id.0 as usize];
+        let scope_data = &self.env.scopes[scope_id.index()];
 
         // Keep scopes that appear empty (value being memoized may be early-returned)
         // or have early return values
@@ -1086,10 +1086,10 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for PruneScopesTransform<'a, 'e> {
         }
 
         let has_memoized_output = scope_data.declarations.iter().any(|(_, decl)| {
-            let decl_id = self.env.identifiers[decl.identifier.0 as usize].declaration_id;
+            let decl_id = self.env.identifiers[decl.identifier.index()].declaration_id;
             state.contains(&decl_id)
         }) || scope_data.reassignments.iter().any(|reassign_id| {
-            let decl_id = self.env.identifiers[reassign_id.0 as usize].declaration_id;
+            let decl_id = self.env.identifiers[reassign_id.index()].declaration_id;
             state.contains(&decl_id)
         });
 
@@ -1115,20 +1115,20 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for PruneScopesTransform<'a, 'e> {
                 ..
             }) if store_lvalue.kind == InstructionKind::Reassign => {
                 let decl_id =
-                    self.env.identifiers[store_lvalue.place.identifier.0 as usize].declaration_id;
+                    self.env.identifiers[store_lvalue.place.identifier.index()].declaration_id;
                 let ids = self.reassignments.entry(decl_id).or_default();
                 ids.insert(store_value.identifier);
             }
             ReactiveValue::Instruction(InstructionValue::LoadLocal { place, .. }) => {
-                let has_scope = self.env.identifiers[place.identifier.0 as usize].scope.is_some();
+                let has_scope = self.env.identifiers[place.identifier.index()].scope.is_some();
                 let lvalue_no_scope = instruction
                     .lvalue
                     .as_ref()
-                    .map(|lv| self.env.identifiers[lv.identifier.0 as usize].scope.is_none())
+                    .map(|lv| self.env.identifiers[lv.identifier.index()].scope.is_none())
                     .unwrap_or(false);
                 if has_scope && lvalue_no_scope {
                     if let Some(lv) = &instruction.lvalue {
-                        let decl_id = self.env.identifiers[lv.identifier.0 as usize].declaration_id;
+                        let decl_id = self.env.identifiers[lv.identifier.index()].declaration_id;
                         let ids = self.reassignments.entry(decl_id).or_default();
                         ids.insert(place.identifier);
                     }
@@ -1137,12 +1137,11 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for PruneScopesTransform<'a, 'e> {
             ReactiveValue::Instruction(InstructionValue::FinishMemoize {
                 decl, pruned, ..
             }) => {
-                let decl_has_scope =
-                    self.env.identifiers[decl.identifier.0 as usize].scope.is_some();
+                let decl_has_scope = self.env.identifiers[decl.identifier.index()].scope.is_some();
                 if !decl_has_scope {
                     // If the manual memo was a useMemo that got inlined, iterate through
                     // all reassignments to the iife temporary to ensure they're memoized.
-                    let decl_id = self.env.identifiers[decl.identifier.0 as usize].declaration_id;
+                    let decl_id = self.env.identifiers[decl.identifier.index()].declaration_id;
                     let decls: Vec<IdentifierId> = self
                         .reassignments
                         .get(&decl_id)
@@ -1150,13 +1149,13 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for PruneScopesTransform<'a, 'e> {
                         .unwrap_or_else(|| vec![decl.identifier]);
 
                     if decls.iter().all(|d| {
-                        let scope = self.env.identifiers[d.0 as usize].scope;
+                        let scope = self.env.identifiers[d.index()].scope;
                         scope.is_none() || self.pruned_scopes.contains(&scope.unwrap())
                     }) {
                         *pruned = true;
                     }
                 } else {
-                    let scope = self.env.identifiers[decl.identifier.0 as usize].scope;
+                    let scope = self.env.identifiers[decl.identifier.index()].scope;
                     if let Some(scope_id) = scope {
                         if self.pruned_scopes.contains(&scope_id) {
                             *pruned = true;

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_reactive_dependencies.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_reactive_dependencies.rs
@@ -64,10 +64,10 @@ impl<'a, 'e> ReactiveFunctionVisitor<'a> for CollectVisitor<'a, 'e> {
     fn visit_pruned_scope(&self, scope: &PrunedReactiveScopeBlock<'a>, state: &mut Self::State) {
         self.traverse_pruned_scope(scope, state);
 
-        let scope_data = &self.env.scopes[scope.scope.0 as usize];
+        let scope_data = &self.env.scopes[scope.scope.index()];
         for (_id, decl) in &scope_data.declarations {
-            let identifier = &self.env.identifiers[decl.identifier.0 as usize];
-            let ty = &self.env.types[identifier.type_.0 as usize];
+            let identifier = &self.env.identifiers[decl.identifier.index()];
+            let ty = &self.env.types[identifier.type_.index()];
             if !is_primitive_type(ty) && !is_stable_ref_type(ty, state, identifier.id) {
                 state.insert(*_id);
             }
@@ -181,8 +181,8 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for PruneVisitor<'a, 'e> {
             }) => {
                 if state.contains(&destr_value.identifier) {
                     for operand in hir_visitors::each_pattern_operand(&destr_lvalue.pattern) {
-                        let ident = &self.env.identifiers[operand.identifier.0 as usize];
-                        let ty = &self.env.types[ident.type_.0 as usize];
+                        let ident = &self.env.identifiers[operand.identifier.index()];
+                        let ty = &self.env.types[ident.type_.index()];
                         if is_stable_type(ty) {
                             continue;
                         }
@@ -195,8 +195,8 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for PruneVisitor<'a, 'e> {
             }
             ReactiveValue::Instruction(InstructionValue::PropertyLoad { object, .. }) => {
                 if let Some(lv) = lvalue {
-                    let ident = &self.env.identifiers[lv.identifier.0 as usize];
-                    let ty = &self.env.types[ident.type_.0 as usize];
+                    let ident = &self.env.identifiers[lv.identifier.index()];
+                    let ty = &self.env.types[ident.type_.index()];
                     if state.contains(&object.identifier) && !is_stable_type(ty) {
                         state.insert(lv.identifier);
                     }
@@ -224,7 +224,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for PruneVisitor<'a, 'e> {
         self.traverse_scope(scope, state)?;
 
         let scope_id = scope.scope;
-        let scope_data = &mut self.env.scopes[scope_id.0 as usize];
+        let scope_data = &mut self.env.scopes[scope_id.index()];
 
         // Remove non-reactive dependencies
         scope_data.dependencies.retain(|dep| state.contains(&dep.identifier));

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_unused_lvalues.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_unused_lvalues.rs
@@ -64,7 +64,7 @@ impl<'a, 'e> ReactiveFunctionVisitor<'a> for Visitor<'a, 'e> {
 
     /// TS: `visitPlace(_id, place, state) { state.delete(place.identifier.declarationId) }`
     fn visit_place(&self, _id: EvaluationOrder, place: &Place, state: &mut LValues) {
-        let ident = &self.env.identifiers[place.identifier.0 as usize];
+        let ident = &self.env.identifiers[place.identifier.index()];
         state.remove(&ident.declaration_id);
     }
 
@@ -74,7 +74,7 @@ impl<'a, 'e> ReactiveFunctionVisitor<'a> for Visitor<'a, 'e> {
     fn visit_instruction(&self, instruction: &ReactiveInstruction<'a>, state: &mut LValues) {
         self.traverse_instruction(instruction, state);
         if let Some(lv) = &instruction.lvalue {
-            let ident = &self.env.identifiers[lv.identifier.0 as usize];
+            let ident = &self.env.identifiers[lv.identifier.index()];
             if ident.name.is_none() {
                 state.insert(ident.declaration_id);
             }
@@ -113,7 +113,7 @@ fn null_unused_in_instruction<'a>(
     unused: &FxHashSet<DeclarationId>,
 ) {
     if let Some(lv) = &instr.lvalue {
-        let ident = &env.identifiers[lv.identifier.0 as usize];
+        let ident = &env.identifiers[lv.identifier.index()];
         if unused.contains(&ident.declaration_id) {
             instr.lvalue = None;
         }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_unused_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_unused_scopes.rs
@@ -68,7 +68,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
         self.visit_scope(scope, &mut scope_state)?;
 
         let scope_id = scope.scope;
-        let scope_data = &self.env.scopes[scope_id.0 as usize];
+        let scope_data = &self.env.scopes[scope_id.index()];
 
         if !scope_state.has_return_statement
             && scope_data.reassignments.is_empty()

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/rename_variables.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/rename_variables.rs
@@ -55,7 +55,7 @@ impl<'a> Scopes<'a> {
     }
 
     fn visit_identifier(&mut self, identifier_id: IdentifierId, env: &Environment<'a>) {
-        let identifier = &env.identifiers[identifier_id.0 as usize];
+        let identifier = &env.identifiers[identifier_id.index()];
         let original_name = match &identifier.name {
             Some(name) => *name,
             None => return,
@@ -166,7 +166,7 @@ impl<'a, 'e> ReactiveFunctionVisitor<'a> for Visitor<'a, 'e> {
 
     /// TS: `visitScope(scope, state) { for (const [_, decl] of scope.scope.declarations) state.visit(decl.identifier); this.traverseScope(scope, state) }`
     fn visit_scope(&self, scope: &ReactiveScopeBlock<'a>, state: &mut Scopes<'a>) {
-        let scope_data = &self.env.scopes[scope.scope.0 as usize];
+        let scope_data = &self.env.scopes[scope.scope.index()];
         let decl_ids: Vec<IdentifierId> =
             scope_data.declarations.iter().map(|(_, d)| d.identifier).collect();
         for id in decl_ids {
@@ -219,7 +219,9 @@ fn rename_variables_with_parent<'a>(
     if let Some(parent) = parent_names {
         scopes.enter();
         for name in parent {
-            scopes.stack.last_mut().unwrap().insert(*name, DeclarationId(u32::MAX));
+            // Sentinel value: `stack` is used purely as a set (only key presence is
+            // read via `lookup().is_some()`), so any id works here.
+            scopes.stack.last_mut().unwrap().insert(*name, DeclarationId::from_usize(0));
             scopes.names.insert(*name);
         }
     }
@@ -341,13 +343,13 @@ fn collect_globals_hir_function<'a>(
     globals: &mut IdentHashSet<'a>,
     env: &Environment<'a>,
 ) {
-    let inner_func = &env.functions[func_id.0 as usize];
+    let inner_func = &env.functions[func_id.index()];
     let block_ids: Vec<_> = inner_func.body.blocks.keys().copied().collect();
     for block_id in block_ids {
-        let inner_func = &env.functions[func_id.0 as usize];
+        let inner_func = &env.functions[func_id.index()];
         let block = &inner_func.body.blocks[&block_id];
         for instr_id in &block.instructions {
-            let instr = &inner_func.instructions[instr_id.0 as usize];
+            let instr = &inner_func.instructions[instr_id.index()];
             if let InstructionValue::LoadGlobal { binding, .. } = &instr.value {
                 globals.insert(binding.name());
             }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/stabilize_block_ids.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/stabilize_block_ids.rs
@@ -36,8 +36,8 @@ pub fn stabilize_block_ids<'a>(func: &mut ReactiveFunction<'a>, env: &mut Enviro
     // Build mappings: referenced block IDs -> sequential IDs (insertion-order deterministic)
     let mut mappings: FxHashMap<BlockId, BlockId> = FxHashMap::default();
     for block_id in &referenced {
-        let len = mappings.len() as u32;
-        mappings.entry(*block_id).or_insert(BlockId(len));
+        let len = mappings.len();
+        mappings.entry(*block_id).or_insert(BlockId::from_usize(len));
     }
 
     // Pass 2: Rewrite block IDs using ReactiveFunctionTransform
@@ -61,7 +61,7 @@ impl<'a, 'e> ReactiveFunctionVisitor<'a> for CollectReferencedLabels<'a, 'e> {
     }
 
     fn visit_scope(&self, scope: &ReactiveScopeBlock<'a>, state: &mut Self::State) {
-        let scope_data = &self.env.scopes[scope.scope.0 as usize];
+        let scope_data = &self.env.scopes[scope.scope.index()];
         if let Some(ref early_return) = scope_data.early_return_value {
             state.insert(early_return.label);
         }
@@ -83,8 +83,8 @@ impl<'a, 'e> ReactiveFunctionVisitor<'a> for CollectReferencedLabels<'a, 'e> {
 // =============================================================================
 
 fn get_or_insert_mapping(mappings: &mut FxHashMap<BlockId, BlockId>, id: BlockId) -> BlockId {
-    let len = mappings.len() as u32;
-    *mappings.entry(id).or_insert(BlockId(len))
+    let len = mappings.len();
+    *mappings.entry(id).or_insert(BlockId::from_usize(len))
 }
 
 /// TS: `class RewriteBlockIds extends ReactiveFunctionVisitor<Map<BlockId, BlockId>>`
@@ -104,7 +104,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for RewriteBlockIds<'a, 'e> {
         scope: &mut ReactiveScopeBlock<'a>,
         state: &mut Self::State,
     ) -> Result<(), OxcDiagnostic> {
-        let scope_data = &mut self.env.scopes[scope.scope.0 as usize];
+        let scope_data = &mut self.env.scopes[scope.scope.index()];
         if let Some(ref mut early_return) = scope_data.early_return_value {
             early_return.label = get_or_insert_mapping(state, early_return.label);
         }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/visitors.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/visitors.rs
@@ -50,7 +50,7 @@ pub trait ReactiveFunctionVisitor<'a> {
     /// value-lvalues, operands, and nested functions), and terminal operands.
     /// TS: `visitHirFunction`
     fn visit_hir_function(&self, func_id: FunctionId, state: &mut Self::State) {
-        let inner_func = &self.env().functions[func_id.0 as usize];
+        let inner_func = &self.env().functions[func_id.index()];
         for param in &inner_func.params {
             let place = match param {
                 ParamPattern::Place(p) => p,
@@ -60,15 +60,15 @@ pub trait ReactiveFunctionVisitor<'a> {
         }
         let block_ids: Vec<_> = inner_func.body.blocks.keys().copied().collect();
         for block_id in block_ids {
-            let inner_func = &self.env().functions[func_id.0 as usize];
+            let inner_func = &self.env().functions[func_id.index()];
             let block = &inner_func.body.blocks[&block_id];
             let instr_ids: Vec<_> = block.instructions.clone();
             let terminal_operands: Vec<Place> = each_terminal_operand(&block.terminal);
             let terminal_id = block.terminal.evaluation_order();
 
             for instr_id in &instr_ids {
-                let inner_func = &self.env().functions[func_id.0 as usize];
-                let instr = &inner_func.instructions[instr_id.0 as usize];
+                let inner_func = &self.env().functions[func_id.index()];
+                let instr = &inner_func.instructions[instr_id.index()];
                 // Build a temporary ReactiveInstruction for the visitor
                 let reactive_instr = ReactiveInstruction {
                     id: instr.id,
@@ -585,7 +585,7 @@ pub trait ReactiveFunctionTransform<'a> {
                 &mut block[i],
                 // Placeholder — will be overwritten or discarded
                 ReactiveStatement::Instruction(ReactiveInstruction {
-                    id: EvaluationOrder(0),
+                    id: EvaluationOrder::UNSET,
                     lvalue: None,
                     value: ReactiveValue::Instruction(InstructionValue::Debugger { span: None }),
                     span: None,

--- a/crates/oxc_react_compiler/src/react_compiler_ssa/eliminate_redundant_phi.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_ssa/eliminate_redundant_phi.rs
@@ -98,7 +98,7 @@ fn eliminate_redundant_phi_impl(
                 ir.blocks.get(&block_id).unwrap().instructions.clone();
 
             for instr_id in &instruction_ids {
-                let instr_idx = instr_id.0 as usize;
+                let instr_idx = instr_id.index();
                 let instr = &mut func.instructions[instr_idx];
 
                 // Rewrite all lvalues (matches TS eachInstructionLValue)
@@ -127,18 +127,18 @@ fn eliminate_redundant_phi_impl(
 
                 if let Some(fid) = func_expr_id {
                     // Rewrite context places
-                    let context = &mut env.functions[fid.0 as usize].context;
+                    let context = &mut env.functions[fid.index()].context;
                     for place in context.iter_mut() {
                         rewrite_place(place, rewrites);
                     }
 
                     // Take inner function out, process it, put it back
                     let mut inner_func =
-                        replace(&mut env.functions[fid.0 as usize], placeholder_function());
+                        replace(&mut env.functions[fid.index()], placeholder_function());
 
                     eliminate_redundant_phi_impl(&mut inner_func, env, rewrites);
 
-                    env.functions[fid.0 as usize] = inner_func;
+                    env.functions[fid.index()] = inner_func;
                 }
             }
 

--- a/crates/oxc_react_compiler/src/react_compiler_ssa/enter_ssa.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_ssa/enter_ssa.rs
@@ -66,11 +66,11 @@ impl SSABuilder {
 
     fn make_id(&mut self, old_id: IdentifierId, env: &mut Environment) -> IdentifierId {
         let new_id = env.next_identifier_id();
-        let old = &env.identifiers[old_id.0 as usize];
+        let old = &env.identifiers[old_id.index()];
         let declaration_id = old.declaration_id;
         let name = old.name;
         let span = old.span;
-        let new_ident = &mut env.identifiers[new_id.0 as usize];
+        let new_ident = &mut env.identifiers[new_id.index()];
         new_ident.declaration_id = declaration_id;
         new_ident.name = name;
         new_ident.span = span;
@@ -85,10 +85,10 @@ impl SSABuilder {
         let old_id = old_place.identifier;
 
         if self.unknown.contains(&old_id) {
-            let ident = &env.identifiers[old_id.0 as usize];
+            let ident = &env.identifiers[old_id.index()];
             let name = match &ident.name {
-                Some(name) => format!("{}${}", name.value(), old_id.0),
-                None => format!("${}", old_id.0),
+                Some(name) => format!("{}${}", name.value(), old_id.index()),
+                None => format!("${}", old_id.index()),
             };
             return Err(ErrorCategory::Todo
                 .diagnostic(
@@ -254,7 +254,7 @@ fn apply_pending_phis(func: &mut HirFunction, env: &mut Environment, builder: &m
         }
     }
     for fid in &builder.processed_functions.clone() {
-        let inner_func = &mut env.functions[fid.0 as usize];
+        let inner_func = &mut env.functions[fid.index()];
         for (block_id, block) in inner_func.body.blocks.iter_mut() {
             if let Some(phis) = builder.pending_phis.remove(block_id) {
                 block.phis.extend(phis);
@@ -277,7 +277,7 @@ fn enter_ssa_impl(
 
         if visited_blocks.contains(&block_id) {
             return Err(ErrorCategory::Invariant
-                .diagnostic(format!("found a cycle! visiting bb{} again", block_id.0)));
+                .diagnostic(format!("found a cycle! visiting bb{} again", block_id.index())));
         }
 
         visited_blocks.insert(block_id);
@@ -308,7 +308,7 @@ fn enter_ssa_impl(
             func.body.blocks.get(&block_id).unwrap().instructions.clone();
 
         for instr_id in &instruction_ids {
-            let instr_idx = instr_id.0 as usize;
+            let instr_idx = instr_id.index();
             let instr = &mut func.instructions[instr_idx];
 
             // For FunctionExpression/ObjectMethod, we need to handle context
@@ -323,8 +323,8 @@ fn enter_ssa_impl(
 
             // Map context places for function expressions before other operands
             if let Some(fid) = func_expr_id {
-                let context = take(&mut env.functions[fid.0 as usize].context);
-                env.functions[fid.0 as usize].context =
+                let context = take(&mut env.functions[fid.index()].context);
+                env.functions[fid.index()].context =
                     context.into_iter().map(|place| builder.get_place(&place, env)).collect();
             }
 
@@ -351,7 +351,7 @@ fn enter_ssa_impl(
 
             // Handle inner function SSA
             if let Some(fid) = func_expr_id {
-                let context_ids: Vec<IdentifierId> = env.functions[fid.0 as usize]
+                let context_ids: Vec<IdentifierId> = env.functions[fid.index()]
                     .context
                     .iter()
                     .map(|place| place.identifier)
@@ -360,7 +360,7 @@ fn enter_ssa_impl(
                     builder.unmark_unknown(id);
                 }
                 builder.processed_functions.push(fid);
-                let inner_func = &mut env.functions[fid.0 as usize];
+                let inner_func = &mut env.functions[fid.index()];
                 let inner_entry = inner_func.body.entry;
                 let entry_block = inner_func.body.blocks.get_mut(&inner_entry).unwrap();
 
@@ -376,7 +376,7 @@ fn enter_ssa_impl(
                 let saved_current = builder.current;
 
                 // Map inner function params
-                let inner_params = take(&mut env.functions[fid.0 as usize].params);
+                let inner_params = take(&mut env.functions[fid.index()].params);
                 let mut new_inner_params = Vec::with_capacity(inner_params.len());
                 for param in inner_params {
                     new_inner_params.push(match param {
@@ -388,27 +388,21 @@ fn enter_ssa_impl(
                         }),
                     });
                 }
-                env.functions[fid.0 as usize].params = new_inner_params;
+                env.functions[fid.index()].params = new_inner_params;
 
                 // Take the inner function out of the arena to process it
                 let mut inner_func =
-                    replace(&mut env.functions[fid.0 as usize], placeholder_function());
+                    replace(&mut env.functions[fid.index()], placeholder_function());
 
                 enter_ssa_impl(&mut inner_func, builder, env, root_entry)?;
 
                 // Put it back
-                env.functions[fid.0 as usize] = inner_func;
+                env.functions[fid.index()] = inner_func;
 
                 builder.current = saved_current;
 
                 // Clear entry preds
-                env.functions[fid.0 as usize]
-                    .body
-                    .blocks
-                    .get_mut(&inner_entry)
-                    .unwrap()
-                    .preds
-                    .clear();
+                env.functions[fid.index()].body.blocks.get_mut(&inner_entry).unwrap().preds.clear();
                 builder.block_preds.insert(inner_entry, Vec::new());
             }
         }
@@ -453,13 +447,13 @@ pub fn placeholder_function<'a>() -> HirFunction<'a> {
         fn_type: ReactFunctionType::Other,
         params: Vec::new(),
         returns: Place {
-            identifier: IdentifierId(0),
+            identifier: IdentifierId::from_usize(0),
             effect: Effect::Unknown,
             reactive: false,
             span: None,
         },
         context: Vec::new(),
-        body: HIR { entry: BlockId(0), blocks: FxIndexMap::default() },
+        body: HIR { entry: BlockId::from_usize(0), blocks: FxIndexMap::default() },
         instructions: Vec::new(),
         generator: false,
         is_async: false,

--- a/crates/oxc_react_compiler/src/react_compiler_ssa/rewrite_instruction_kinds_based_on_reassignment.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_ssa/rewrite_instruction_kinds_based_on_reassignment.rs
@@ -67,19 +67,29 @@ fn format_kind(kind: Option<InstructionKind>) -> &'static str {
 
 /// Format a Place like TS `printPlace()`: `<effect> <name>$<id>[<range>]{reactive}`
 fn format_place(place: &Place, env: &Environment) -> String {
-    let ident = &env.identifiers[place.identifier.0 as usize];
+    let ident = &env.identifiers[place.identifier.index()];
     let name = ident.name.as_ref().map_or("", |name| name.value());
-    let scope =
-        ident.scope.map_or(Cow::Borrowed(""), |scope_id| Cow::Owned(format!("_@{}", scope_id.0)));
-    let mutable_range = if ident.mutable_range.end.0 > ident.mutable_range.start.0 + 1 {
-        Cow::Owned(format!("[{}:{}]", ident.mutable_range.start.0, ident.mutable_range.end.0))
+    let scope = ident
+        .scope
+        .map_or(Cow::Borrowed(""), |scope_id| Cow::Owned(format!("_@{}", scope_id.index())));
+    let mutable_range = if ident.mutable_range.end > ident.mutable_range.start + 1 {
+        Cow::Owned(format!(
+            "[{}:{}]",
+            ident.mutable_range.start.index(),
+            ident.mutable_range.end.index()
+        ))
     } else {
         Cow::Borrowed("")
     };
     let reactive = if place.reactive { "{reactive}" } else { "" };
     format!(
         "{} {}${}{}{}{}",
-        place.effect, name, place.identifier.0, scope, mutable_range, reactive
+        place.effect,
+        name,
+        place.identifier.index(),
+        scope,
+        mutable_range,
+        reactive
     )
 }
 
@@ -120,7 +130,7 @@ pub fn rewrite_instruction_kinds_based_on_reassignment(
             ParamPattern::Place(p) => p,
             ParamPattern::Spread(s) => &s.place,
         };
-        let ident = &env.identifiers[place.identifier.0 as usize];
+        let ident = &env.identifiers[place.identifier.index()];
         if ident.name.is_some() {
             declarations.insert(ident.declaration_id, DeclarationLoc::ParamOrContext);
         }
@@ -128,7 +138,7 @@ pub fn rewrite_instruction_kinds_based_on_reassignment(
 
     // Seed with context variables
     for place in &func.context {
-        let ident = &env.identifiers[place.identifier.0 as usize];
+        let ident = &env.identifiers[place.identifier.index()];
         if ident.name.is_some() {
             declarations.insert(ident.declaration_id, DeclarationLoc::ParamOrContext);
         }
@@ -140,11 +150,10 @@ pub fn rewrite_instruction_kinds_based_on_reassignment(
         let block = &func.body.blocks[block_id];
         let block_kind = block.kind;
         for (local_idx, instr_id) in block.instructions.iter().enumerate() {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             match &instr.value {
                 InstructionValue::DeclareLocal { lvalue, .. } => {
-                    let decl_id =
-                        env.identifiers[lvalue.place.identifier.0 as usize].declaration_id;
+                    let decl_id = env.identifiers[lvalue.place.identifier.index()].declaration_id;
                     if declarations.contains_key(&decl_id) {
                         return Err(invariant_error_with_span(
                             "Expected variable not to be defined prior to declaration",
@@ -161,7 +170,7 @@ pub fn rewrite_instruction_kinds_based_on_reassignment(
                     );
                 }
                 InstructionValue::StoreLocal { lvalue, .. } => {
-                    let ident = &env.identifiers[lvalue.place.identifier.0 as usize];
+                    let ident = &env.identifiers[lvalue.place.identifier.index()];
                     if ident.name.is_some() {
                         let decl_id = ident.declaration_id;
                         if let Some(existing) = declarations.get(&decl_id) {
@@ -205,7 +214,7 @@ pub fn rewrite_instruction_kinds_based_on_reassignment(
                 InstructionValue::Destructure { lvalue, .. } => {
                     let mut kind: Option<InstructionKind> = None;
                     for place in each_pattern_operand(&lvalue.pattern) {
-                        let ident = &env.identifiers[place.identifier.0 as usize];
+                        let ident = &env.identifiers[place.identifier.index()];
                         if ident.name.is_none() {
                             if !(kind.is_none() || kind == Some(InstructionKind::Const)) {
                                 return Err(invariant_error_with_span(
@@ -283,7 +292,7 @@ pub fn rewrite_instruction_kinds_based_on_reassignment(
                 }
                 InstructionValue::PostfixUpdate { lvalue, .. }
                 | InstructionValue::PrefixUpdate { lvalue, .. } => {
-                    let ident = &env.identifiers[lvalue.identifier.0 as usize];
+                    let ident = &env.identifiers[lvalue.identifier.index()];
                     let decl_id = ident.declaration_id;
                     let Some(existing) = declarations.get(&decl_id) else {
                         return Err(invariant_error_with_span(
@@ -313,7 +322,7 @@ pub fn rewrite_instruction_kinds_based_on_reassignment(
     for (bi, ili) in const_spans {
         let block_id = &block_keys[bi];
         let instr_id = func.body.blocks[block_id].instructions[ili];
-        let instr = &mut func.instructions[instr_id.0 as usize];
+        let instr = &mut func.instructions[instr_id.index()];
         if let InstructionValue::StoreLocal { lvalue, .. } = &mut instr.value {
             lvalue.kind = InstructionKind::Const;
         }
@@ -322,7 +331,7 @@ pub fn rewrite_instruction_kinds_based_on_reassignment(
     for (bi, ili) in reassign_spans {
         let block_id = &block_keys[bi];
         let instr_id = func.body.blocks[block_id].instructions[ili];
-        let instr = &mut func.instructions[instr_id.0 as usize];
+        let instr = &mut func.instructions[instr_id.index()];
         if let InstructionValue::StoreLocal { lvalue, .. } = &mut instr.value {
             lvalue.kind = InstructionKind::Reassign;
         }
@@ -337,7 +346,7 @@ pub fn rewrite_instruction_kinds_based_on_reassignment(
     for (bi, ili, kind) in destructure_kind_spans {
         let block_id = &block_keys[bi];
         let instr_id = func.body.blocks[block_id].instructions[ili];
-        let instr = &mut func.instructions[instr_id.0 as usize];
+        let instr = &mut func.instructions[instr_id.index()];
         if let InstructionValue::Destructure { lvalue, .. } = &mut instr.value {
             lvalue.kind = kind;
         }
@@ -346,7 +355,7 @@ pub fn rewrite_instruction_kinds_based_on_reassignment(
     for (bi, ili) in let_spans {
         let block_id = &block_keys[bi];
         let instr_id = func.body.blocks[block_id].instructions[ili];
-        let instr = &mut func.instructions[instr_id.0 as usize];
+        let instr = &mut func.instructions[instr_id.index()];
         match &mut instr.value {
             InstructionValue::DeclareLocal { lvalue, .. }
             | InstructionValue::StoreLocal { lvalue, .. } => {

--- a/crates/oxc_react_compiler/src/react_compiler_typeinference/infer_types.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_typeinference/infer_types.rs
@@ -65,13 +65,13 @@ pub fn infer_types<'a>(
 
 /// Get the type for an identifier as a TypeVar referencing its type slot.
 fn get_type<'a>(id: IdentifierId, identifiers: &[Identifier<'a>]) -> Type<'a> {
-    let type_id = identifiers[id.0 as usize].type_;
+    let type_id = identifiers[id.index()].type_;
     Type::TypeVar { id: type_id }
 }
 
 /// Allocate a new TypeVar in the types arena (standalone, no &mut Environment needed).
 fn make_type<'a>(types: &mut Vec<Type<'a>>) -> Type<'a> {
-    let id = TypeId(types.len() as u32);
+    let id = TypeId::from_usize(types.len());
     types.push(Type::TypeVar { id });
     Type::TypeVar { id }
 }
@@ -84,7 +84,7 @@ fn pre_resolve_globals<'a>(
     global_types: &mut FxHashMap<(u32, InstructionId), Type<'a>>,
 ) {
     for &instr_id in func.body.blocks.values().flat_map(|b| &b.instructions) {
-        let instr = &func.instructions[instr_id.0 as usize];
+        let instr = &func.instructions[instr_id.index()];
         if let InstructionValue::LoadGlobal { binding, span, .. } = &instr.value {
             if let Some(global_type) = env.get_global_declaration(binding, *span).ok().flatten() {
                 global_types.insert((function_key, instr_id), global_type);
@@ -102,13 +102,13 @@ fn pre_resolve_globals_recursive<'a>(
     // Collect LoadGlobal bindings and child function IDs in one pass to avoid
     // borrow conflicts (we need &env.functions to read, then &mut env for
     // get_global_declaration).
-    let inner = &env.functions[func_id.0 as usize];
+    let inner = &env.functions[func_id.index()];
     let mut load_globals: Vec<(InstructionId, NonLocalBinding, Option<Span>)> = Vec::new();
     let mut child_func_ids: Vec<FunctionId> = Vec::new();
 
     for block in inner.body.blocks.values() {
         for &instr_id in &block.instructions {
-            let instr = &inner.instructions[instr_id.0 as usize];
+            let instr = &inner.instructions[instr_id.index()];
             match &instr.value {
                 InstructionValue::LoadGlobal { binding, span, .. } => {
                     load_globals.push((instr_id, binding.clone(), *span));
@@ -131,7 +131,7 @@ fn pre_resolve_globals_recursive<'a>(
     // Now resolve globals (no longer borrowing env.functions)
     for (instr_id, binding, span) in load_globals {
         if let Some(global_type) = env.get_global_declaration(&binding, span).ok().flatten() {
-            global_types.insert((func_id.0, instr_id), global_type);
+            global_types.insert((func_id.index() as u32, instr_id), global_type);
         }
     }
 
@@ -306,12 +306,12 @@ fn generate<'a>(
     // this before the instruction loop because get_global_declaration needs
     // &mut env, but generate_instruction_types takes split borrows on env fields.
     // The key is (function_key, InstructionId) where function_key is u32::MAX
-    // for the outer function and FunctionId.0 for inner functions.
+    // for the outer function and the FunctionId index for inner functions.
     let mut global_types: FxHashMap<(u32, InstructionId), Type<'a>> = FxHashMap::default();
     pre_resolve_globals(func, u32::MAX, env, &mut global_types);
     // Also pre-resolve inner functions recursively
     for &instr_id in func.body.blocks.values().flat_map(|b| &b.instructions) {
-        let instr = &func.instructions[instr_id.0 as usize];
+        let instr = &func.instructions[instr_id.index()];
         match &instr.value {
             InstructionValue::FunctionExpression {
                 lowered_func: LoweredFunction { func: func_id },
@@ -342,7 +342,7 @@ fn generate<'a>(
         // Instructions — use split borrows: &env.identifiers, &env.shapes
         // are immutable, while &mut env.types and &mut env.functions are mutable.
         for &instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             generate_instruction_types(
                 instr,
                 instr_id,
@@ -387,7 +387,7 @@ fn generate_for_function_id<'a>(
     allocator: &'a Allocator,
 ) -> Result<(), OxcDiagnostic> {
     // Take the function out temporarily to avoid borrow conflicts
-    let inner = replace(&mut functions[func_id.0 as usize], placeholder_function());
+    let inner = replace(&mut functions[func_id.index()], placeholder_function());
 
     // Process params for component inner functions
     if inner.fn_type == ReactFunctionType::Component {
@@ -415,11 +415,11 @@ fn generate_for_function_id<'a>(
         }
 
         for &instr_id in &block.instructions {
-            let instr = &inner.instructions[instr_id.0 as usize];
+            let instr = &inner.instructions[instr_id.index()];
             generate_instruction_types(
                 instr,
                 instr_id,
-                func_id.0,
+                func_id.index() as u32,
                 identifiers,
                 types,
                 functions,
@@ -444,7 +444,7 @@ fn generate_for_function_id<'a>(
     }
 
     // Put the function back
-    functions[func_id.0 as usize] = inner;
+    functions[func_id.index()] = inner;
     Ok(())
 }
 
@@ -476,7 +476,7 @@ fn generate_instruction_types<'a>(
         }
 
         InstructionValue::LoadLocal { place, .. } => {
-            set_name(names, instr.lvalue.identifier, &identifiers[place.identifier.0 as usize]);
+            set_name(names, instr.lvalue.identifier, &identifiers[place.identifier.index()]);
             let place_type = get_type(place.identifier, identifiers);
             unifier.unify(left, place_type, shapes)?;
         }
@@ -718,7 +718,7 @@ fn generate_instruction_types<'a>(
                 allocator,
             )?;
             // Get the inner function's return type
-            let inner_func = &functions[func_id.0 as usize];
+            let inner_func = &functions[func_id.index()];
             let inner_return_type = get_type(inner_func.returns.identifier, identifiers);
             unifier.unify(
                 left,
@@ -840,7 +840,7 @@ fn apply_function<'a>(
         }
 
         for &instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
 
             // Instruction lvalue
             resolve_identifier(instr.lvalue.identifier, identifiers, types, unifier);
@@ -861,7 +861,7 @@ fn apply_function<'a>(
                     lowered_func: LoweredFunction { func: func_id },
                     ..
                 } => {
-                    let inner_func = &functions[func_id.0 as usize];
+                    let inner_func = &functions[func_id.index()];
                     // Resolve types for captured context variable places (matching TS
                     // where eachInstructionValueOperand yields func.context places)
                     for ctx in &inner_func.context {
@@ -884,10 +884,10 @@ fn resolve_identifier<'a>(
     types: &mut [Type<'a>],
     unifier: &Unifier<'a>,
 ) {
-    let type_id = identifiers[id.0 as usize].type_;
-    let current_type = types[type_id.0 as usize].clone();
+    let type_id = identifiers[id.index()].type_;
+    let current_type = types[type_id.index()].clone();
     let resolved = unifier.get(&current_type);
-    types[type_id.0 as usize] = resolved;
+    types[type_id.index()] = resolved;
 }
 
 /// Resolve types for instruction lvalues (mirrors TS eachInstructionLValue).

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_context_variable_lvalues.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_context_variable_lvalues.rs
@@ -76,7 +76,7 @@ fn validate_context_variable_lvalues_impl(
 
     for (_block_id, block) in &func.body.blocks {
         for &instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             let value = &instr.value;
 
             match value {
@@ -136,7 +136,7 @@ fn validate_context_variable_lvalues_impl(
 
     // Process inner functions after the block loop to avoid borrow conflicts
     for func_id in inner_function_ids {
-        let inner_func = &functions[func_id.0 as usize];
+        let inner_func = &functions[func_id.index()];
         validate_context_variable_lvalues_impl(
             inner_func,
             identifier_kinds,
@@ -152,9 +152,9 @@ fn validate_context_variable_lvalues_impl(
 /// Format a place like TS `printPlace()`: `<effect> <name>$<id>`
 fn format_place(place: &Place, identifiers: &[Identifier]) -> String {
     let id = place.identifier;
-    let ident = &identifiers[id.0 as usize];
+    let ident = &identifiers[id.index()];
     let name = ident.name.as_ref().map_or("", |name| name.value());
-    format!("{} {}${}", place.effect, name, id.0)
+    format!("{} {}${}", place.effect, name, id.index())
 }
 
 fn visit(

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_exhaustive_dependencies.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_exhaustive_dependencies.rs
@@ -219,12 +219,12 @@ fn get_identifier_type<'a>(
     identifiers: &'a [Identifier<'a>],
     types: &'a [Type<'a>],
 ) -> &'a Type<'a> {
-    let ident = &identifiers[id.0 as usize];
-    &types[ident.type_.0 as usize]
+    let ident = &identifiers[id.index()];
+    &types[ident.type_.index()]
 }
 
 fn get_identifier_name<'a>(id: IdentifierId, identifiers: &[Identifier<'a>]) -> Option<&'a str> {
-    identifiers[id.0 as usize].name.as_ref().map(IdentifierName::value)
+    identifiers[id.index()].name.as_ref().map(IdentifierName::value)
 }
 
 // =============================================================================
@@ -265,7 +265,7 @@ fn collect_reactive_identifiers(
     let mut reactive = FxHashSet::default();
     for (_block_id, block) in &func.body.blocks {
         for &instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             // Check instruction lvalue
             if instr.lvalue.reactive {
                 reactive.insert(instr.lvalue.identifier);
@@ -327,7 +327,7 @@ fn find_optional_places(func: &HirFunction) -> FxHashMap<IdentifierId, bool> {
                             // Found the end of the optional chain
                             let consequent_block = &func.body.blocks[consequent];
                             if let Some(last_id) = consequent_block.instructions.last() {
-                                let last_instr = &func.instructions[last_id.0 as usize];
+                                let last_instr = &func.instructions[last_id.index()];
                                 if let InstructionValue::StoreLocal { value, .. } =
                                     &last_instr.value
                                 {
@@ -536,7 +536,7 @@ fn collect_dependencies<'a>(
 
         // Process instructions
         for &instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             let lvalue_id = instr.lvalue.identifier;
 
             match &instr.value {
@@ -577,7 +577,7 @@ fn collect_dependencies<'a>(
                     locals.insert(decl_lv.place.identifier);
                 }
                 InstructionValue::StoreLocal { lvalue: store_lv, value: store_val, .. } => {
-                    let has_name = identifiers[store_lv.place.identifier.0 as usize].name.is_some();
+                    let has_name = identifiers[store_lv.place.identifier.index()].name.is_some();
                     if !has_name {
                         // Unnamed: propagate temporary
                         if let Some(temp) = temporaries.get(&store_val.identifier).cloned() {
@@ -702,7 +702,7 @@ fn collect_dependencies<'a>(
                 }
                 InstructionValue::FunctionExpression { lowered_func, .. }
                 | InstructionValue::ObjectMethod { lowered_func, .. } => {
-                    let inner_func = &functions[lowered_func.func.0 as usize];
+                    let inner_func = &functions[lowered_func.func.index()];
                     let function_deps = collect_dependencies(
                         inner_func,
                         identifiers,

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_hooks_usage.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_hooks_usage.rs
@@ -58,7 +58,7 @@ fn get_kind_for_place(
     identifiers: &[Identifier],
 ) -> Kind {
     let known_kind = value_kinds.get(&place.identifier).copied();
-    let ident = &identifiers[place.identifier.0 as usize];
+    let ident = &identifiers[place.identifier.index()];
     if let Some(ref name) = ident.name {
         if is_hook_name(name.value()) {
             return join_kinds(known_kind.unwrap_or(Kind::Local), Kind::PotentialHook);
@@ -68,7 +68,7 @@ fn get_kind_for_place(
 }
 
 fn ident_is_hook_name(identifier_id: IdentifierId, identifiers: &[Identifier]) -> bool {
-    let ident = &identifiers[identifier_id.0 as usize];
+    let ident = &identifiers[identifier_id.index()];
     if let Some(ref name) = ident.name { is_hook_name(name.value()) } else { false }
 }
 
@@ -78,8 +78,8 @@ fn get_hook_kind_for_id<'a>(
     types: &[Type],
     env: &'a Environment,
 ) -> Result<Option<&'a HookKind>, OxcDiagnostic> {
-    let identifier = &identifiers[identifier_id.0 as usize];
-    let ty = &types[identifier.type_.0 as usize];
+    let identifier = &identifiers[identifier_id.index()];
+    let ty = &types[identifier.type_.index()];
     env.get_hook_kind_for_type(ty)
 }
 
@@ -153,7 +153,8 @@ pub fn validate_hooks_usage(
     func: &HirFunction,
     env: &mut Environment,
 ) -> Result<(), OxcDiagnostic> {
-    let unconditional_blocks = compute_unconditional_blocks(func, env.next_block_id().0)?;
+    let unconditional_blocks =
+        compute_unconditional_blocks(func, env.next_block_id().index() as u32)?;
     let mut errors_by_span: FxIndexMap<Span, OxcDiagnostic> = FxIndexMap::default();
     let mut value_kinds: FxHashMap<IdentifierId, Kind> = FxHashMap::default();
 
@@ -186,7 +187,7 @@ pub fn validate_hooks_usage(
 
         // Process instructions
         for &instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             let lvalue_id = instr.lvalue.identifier;
 
             match &instr.value {
@@ -379,12 +380,12 @@ fn visit_function_expression(
         NestedFunc(FunctionId),
     }
 
-    let func = &env.functions[func_id.0 as usize];
+    let func = &env.functions[func_id.index()];
     let mut items: Vec<Item> = Vec::new();
 
     for (_block_id, block) in &func.body.blocks {
         for &instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             match &instr.value {
                 InstructionValue::ObjectMethod { lowered_func, .. }
                 | InstructionValue::FunctionExpression { lowered_func, .. } => {
@@ -406,8 +407,8 @@ fn visit_function_expression(
     for item in items {
         match item {
             Item::Call(identifier_id, span) => {
-                let identifier = &env.identifiers[identifier_id.0 as usize];
-                let ty = &env.types[identifier.type_.0 as usize];
+                let identifier = &env.identifiers[identifier_id.index()];
+                let ty = &env.types[identifier.type_.index()];
                 let hook_kind = env.get_hook_kind_for_type(ty).ok().flatten().cloned();
                 if let Some(hook_kind) = hook_kind {
                     let description = format!(

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_locals_not_reassigned_after_render.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_locals_not_reassigned_after_render.rs
@@ -63,7 +63,7 @@ pub fn validate_locals_not_reassigned_after_render(func: &HirFunction, env: &mut
 /// Format a variable name for error messages. Uses the named identifier if
 /// available, otherwise falls back to "variable".
 fn format_variable_name(place: &Place, identifiers: &[Identifier]) -> String {
-    let identifier = &identifiers[place.identifier.0 as usize];
+    let identifier = &identifiers[place.identifier.index()];
     match &identifier.name {
         Some(IdentifierName::Named(name)) => format!("`{}`", name),
         _ => "variable".to_string(),
@@ -91,12 +91,12 @@ fn get_context_reassignment(
 
     for (_block_id, block) in &func.body.blocks {
         for &instruction_id in &block.instructions {
-            let instr = &func.instructions[instruction_id.0 as usize];
+            let instr = &func.instructions[instruction_id.index()];
 
             match &instr.value {
                 InstructionValue::FunctionExpression { lowered_func, .. }
                 | InstructionValue::ObjectMethod { lowered_func, .. } => {
-                    let inner_function = &functions[lowered_func.func.0 as usize];
+                    let inner_function = &functions[lowered_func.func.index()];
                     let inner_is_async = is_async || inner_function.is_async;
 
                     // Recursively check the inner function

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_capitalized_calls.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_capitalized_calls.rs
@@ -30,7 +30,7 @@ pub fn validate_no_capitalized_calls(
 
     for (_block_id, block) in &func.body.blocks {
         for &instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             let lvalue_id = instr.lvalue.identifier;
             let value = &instr.value;
 

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_derived_computations_in_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_derived_computations_in_effects.rs
@@ -240,16 +240,16 @@ fn maybe_record_set_state_for_instr(
                 set_state_loads.insert(lvalue_id, Some(place.identifier));
             } else {
                 // Only check root setState if not a LoadLocal from a known chain
-                let lvalue_ident = &identifiers[lvalue_id.0 as usize];
-                let lvalue_ty = &types[lvalue_ident.type_.0 as usize];
+                let lvalue_ident = &identifiers[lvalue_id.index()];
+                let lvalue_ty = &types[lvalue_ident.type_.index()];
                 if is_set_state_type(lvalue_ty) {
                     set_state_loads.insert(lvalue_id, None);
                 }
             }
         } else {
             // Check if lvalue is a setState type (root setState)
-            let lvalue_ident = &identifiers[lvalue_id.0 as usize];
-            let lvalue_ty = &types[lvalue_ident.type_.0 as usize];
+            let lvalue_ident = &identifiers[lvalue_id.index()];
+            let lvalue_ty = &types[lvalue_ident.type_.index()];
             if is_set_state_type(lvalue_ty) {
                 set_state_loads.insert(lvalue_id, None);
             }
@@ -271,7 +271,7 @@ fn is_mutable_at(
     eval_order: EvaluationOrder,
     identifier_id: IdentifierId,
 ) -> bool {
-    env.identifiers[identifier_id.0 as usize].mutable_range.contains(eval_order)
+    env.identifiers[identifier_id.index()].mutable_range.contains(eval_order)
 }
 
 pub fn validate_no_derived_computations_in_effects_exp(
@@ -293,7 +293,7 @@ pub fn validate_no_derived_computations_in_effects_exp(
     if func.fn_type == ReactFunctionType::Hook {
         for param in &func.params {
             if let ParamPattern::Place(place) = param {
-                let name = identifiers[place.identifier.0 as usize].name;
+                let name = identifiers[place.identifier.index()].name;
                 context.derivation_cache.cache.insert(
                     place.identifier,
                     DerivationMetadata {
@@ -308,7 +308,7 @@ pub fn validate_no_derived_computations_in_effects_exp(
         }
     } else if func.fn_type == ReactFunctionType::Component {
         if let Some(ParamPattern::Place(place)) = func.params.first() {
-            let name = identifiers[place.identifier.0 as usize].name;
+            let name = identifiers[place.identifier.index()].name;
             context.derivation_cache.cache.insert(
                 place.identifier,
                 DerivationMetadata {
@@ -331,7 +331,7 @@ pub fn validate_no_derived_computations_in_effects_exp(
         for (_block_id, block) in &func.body.blocks {
             record_phi_derivations(block, &mut context, env);
             for &instr_id in &block.instructions {
-                let instr = &func.instructions[instr_id.0 as usize];
+                let instr = &func.instructions[instr_id.index()];
                 record_instruction_derivations(instr, &mut context, is_first_pass, env)?;
             }
         }
@@ -383,7 +383,7 @@ fn record_phi_derivations<'a>(
         }
 
         if type_of_value != TypeOfValue::Ignored {
-            let name = identifiers[phi.place.identifier.0 as usize].name;
+            let name = identifiers[phi.place.identifier.index()].name;
             context.derivation_cache.add_derivation_entry(
                 phi.place.identifier,
                 name,
@@ -423,17 +423,17 @@ fn record_instruction_derivations<'a>(
         InstructionValue::FunctionExpression { lowered_func, .. } => {
             context.functions.insert(lvalue_id, lowered_func.func);
             // Recurse into the inner function
-            let inner_func = &functions[lowered_func.func.0 as usize];
+            let inner_func = &functions[lowered_func.func.index()];
             for (_block_id, block) in &inner_func.body.blocks {
                 record_phi_derivations(block, context, env);
                 for &inner_instr_id in &block.instructions {
-                    let inner_instr = &inner_func.instructions[inner_instr_id.0 as usize];
+                    let inner_instr = &inner_func.instructions[inner_instr_id.index()];
                     record_instruction_derivations(inner_instr, context, is_first_pass, env)?;
                 }
             }
         }
         InstructionValue::CallExpression { callee, args, .. } => {
-            let callee_type = &types[identifiers[callee.identifier.0 as usize].type_.0 as usize];
+            let callee_type = &types[identifiers[callee.identifier.index()].type_.index()];
             if is_use_effect_hook_type(callee_type) && args.len() == 2 {
                 if let (PlaceOrSpread::Place(arg0), PlaceOrSpread::Place(arg1)) =
                     (&args[0], &args[1])
@@ -450,9 +450,9 @@ fn record_instruction_derivations<'a>(
             }
 
             // Check if lvalue is useState type
-            let lvalue_type = &types[identifiers[lvalue_id.0 as usize].type_.0 as usize];
+            let lvalue_type = &types[identifiers[lvalue_id.index()].type_.index()];
             if is_use_state_type(lvalue_type) {
-                let name = identifiers[lvalue_id.0 as usize].name;
+                let name = identifiers[lvalue_id.index()].name;
                 context.derivation_cache.add_derivation_entry(
                     lvalue_id,
                     name,
@@ -464,7 +464,7 @@ fn record_instruction_derivations<'a>(
             }
         }
         InstructionValue::MethodCall { property, args, .. } => {
-            let prop_type = &types[identifiers[property.identifier.0 as usize].type_.0 as usize];
+            let prop_type = &types[identifiers[property.identifier.index()].type_.index()];
             if is_use_effect_hook_type(prop_type) && args.len() == 2 {
                 if let (PlaceOrSpread::Place(arg0), PlaceOrSpread::Place(arg1)) =
                     (&args[0], &args[1])
@@ -481,9 +481,9 @@ fn record_instruction_derivations<'a>(
             }
 
             // Check if lvalue is useState type
-            let lvalue_type = &types[identifiers[lvalue_id.0 as usize].type_.0 as usize];
+            let lvalue_type = &types[identifiers[lvalue_id.index()].type_.index()];
             if is_use_state_type(lvalue_type) {
-                let name = identifiers[lvalue_id.0 as usize].name;
+                let name = identifiers[lvalue_id.index()].name;
                 context.derivation_cache.add_derivation_entry(
                     lvalue_id,
                     name,
@@ -534,7 +534,7 @@ fn record_instruction_derivations<'a>(
 
     // Record derivation for ALL lvalue places (including destructured variables)
     for &lv_id in &each_instruction_lvalue_ids(instr) {
-        let name = identifiers[lv_id.0 as usize].name;
+        let name = identifiers[lv_id.index()].name;
         context.derivation_cache.add_derivation_entry(
             lv_id,
             name,
@@ -556,7 +556,7 @@ fn record_instruction_derivations<'a>(
                 if let Some(existing) = context.derivation_cache.cache.get_mut(&operand.id) {
                     existing.type_of_value = join_value(type_of_value, existing.type_of_value);
                 } else {
-                    let name = identifiers[operand.id.0 as usize].name;
+                    let name = identifiers[operand.id.index()].name;
                     context.derivation_cache.add_derivation_entry(
                         operand.id,
                         name,
@@ -726,12 +726,12 @@ fn get_fn_local_deps(
     env: &Environment,
 ) -> Option<FxHashSet<IdentifierId>> {
     let func_id = func_id?;
-    let inner = &env.functions[func_id.0 as usize];
+    let inner = &env.functions[func_id.index()];
     let mut deps: FxHashSet<IdentifierId> = FxHashSet::default();
 
     for (_block_id, block) in &inner.body.blocks {
         for &instr_id in &block.instructions {
-            let instr = &inner.instructions[instr_id.0 as usize];
+            let instr = &inner.instructions[instr_id.index()];
             if let InstructionValue::LoadLocal { place, .. } = &instr.value {
                 deps.insert(place.identifier);
             }
@@ -751,7 +751,7 @@ fn validate_effect<'a>(
     let identifiers = &env.identifiers;
     let types = &env.types;
     let functions = &env.functions;
-    let effect_function = &functions[effect_func_id.0 as usize];
+    let effect_function = &functions[effect_func_id.index()];
     let mut seen_blocks: FxHashSet<BlockId> = FxHashSet::default();
 
     struct DerivedSetStateCall {
@@ -794,11 +794,10 @@ fn validate_effect<'a>(
         }
 
         for &instr_id in &block.instructions {
-            let instr = &effect_function.instructions[instr_id.0 as usize];
+            let instr = &effect_function.instructions[instr_id.index()];
 
             // Early return if any instruction derives from a ref
-            let lvalue_type =
-                &types[identifiers[instr.lvalue.identifier.0 as usize].type_.0 as usize];
+            let lvalue_type = &types[identifiers[instr.lvalue.identifier.index()].type_.index()];
             if is_use_ref_type(lvalue_type) {
                 return;
             }
@@ -829,8 +828,7 @@ fn validate_effect<'a>(
 
             match &instr.value {
                 InstructionValue::CallExpression { callee, args, .. } => {
-                    let callee_type =
-                        &types[identifiers[callee.identifier.0 as usize].type_.0 as usize];
+                    let callee_type = &types[identifiers[callee.identifier.index()].type_.index()];
                     if is_set_state_type(callee_type) && args.len() == 1 {
                         if let PlaceOrSpread::Place(arg0) = &args[0] {
                             let callee_metadata =
@@ -999,7 +997,7 @@ pub fn validate_no_derived_computations_in_effects(
 
         for (_, block) in &func.body.blocks {
             for &iid in &block.instructions {
-                let instr = &func.instructions[iid.0 as usize];
+                let instr = &func.instructions[iid.index()];
                 match &instr.value {
                     InstructionValue::LoadLocal { place, .. } => {
                         locals_map.insert(instr.lvalue.identifier, place.identifier);
@@ -1020,7 +1018,7 @@ pub fn validate_no_derived_computations_in_effects(
                         functions_map.insert(instr.lvalue.identifier, lowered_func.func);
                     }
                     InstructionValue::CallExpression { callee, args, .. } => {
-                        let callee_ty = &tys[ids[callee.identifier.0 as usize].type_.0 as usize];
+                        let callee_ty = &tys[ids[callee.identifier.index()].type_.index()];
                         if is_use_effect_hook_type(callee_ty) && args.len() == 2 {
                             if let (PlaceOrSpread::Place(arg0), PlaceOrSpread::Place(arg1)) =
                                 (&args[0], &args[1])
@@ -1041,7 +1039,7 @@ pub fn validate_no_derived_computations_in_effects(
                         }
                     }
                     InstructionValue::MethodCall { property, args, .. } => {
-                        let callee_ty = &tys[ids[property.identifier.0 as usize].type_.0 as usize];
+                        let callee_ty = &tys[ids[property.identifier.index()].type_.index()];
                         if is_use_effect_hook_type(callee_ty) && args.len() == 2 {
                             if let (PlaceOrSpread::Place(arg0), PlaceOrSpread::Place(arg1)) =
                                 (&args[0], &args[1])
@@ -1072,7 +1070,7 @@ pub fn validate_no_derived_computations_in_effects(
     // Matches TS behavior where env.recordError(new CompilerErrorDetail({...})) is used.
     for (func_id, resolved_deps) in effects_to_validate {
         let details = validate_effect_non_exp(
-            &env.functions[func_id.0 as usize],
+            &env.functions[func_id.index()],
             &resolved_deps,
             &env.identifiers,
             &env.types,
@@ -1092,7 +1090,7 @@ fn validate_effect_non_exp(
 ) -> Vec<OxcDiagnostic> {
     // Check that the effect function only captures effect deps and setState
     for ctx in &effect_func.context {
-        let ctx_ty = &tys[ids[ctx.identifier.0 as usize].type_.0 as usize];
+        let ctx_ty = &tys[ids[ctx.identifier.index()].type_.index()];
         if is_set_state_type(ctx_ty) || effect_deps.contains(&ctx.identifier) {
             continue;
         } else {
@@ -1137,7 +1135,7 @@ fn validate_effect_non_exp(
         }
 
         for &iid in &block.instructions {
-            let instr = &effect_func.instructions[iid.0 as usize];
+            let instr = &effect_func.instructions[iid.index()];
             match &instr.value {
                 InstructionValue::Primitive { .. }
                 | InstructionValue::JSXText { .. }
@@ -1166,7 +1164,7 @@ fn validate_effect_non_exp(
                     }
 
                     if let InstructionValue::CallExpression { callee, args, .. } = &instr.value {
-                        let callee_ty = &tys[ids[callee.identifier.0 as usize].type_.0 as usize];
+                        let callee_ty = &tys[ids[callee.identifier.index()].type_.index()];
                         if is_set_state_type(callee_ty) && args.len() == 1 {
                             if let PlaceOrSpread::Place(arg) = &args[0] {
                                 if let Some(deps) = dep_values.get(&arg.identifier) {

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_freezing_known_mutable_functions.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_freezing_known_mutable_functions.rs
@@ -59,7 +59,7 @@ fn check_no_freezing_known_mutable_functions(
 
     for (_block_id, block) in &func.body.blocks {
         for &instruction_id in &block.instructions {
-            let instr = &func.instructions[instruction_id.0 as usize];
+            let instr = &func.instructions[instruction_id.index()];
 
             match &instr.value {
                 InstructionValue::LoadLocal { place, .. } => {
@@ -82,7 +82,7 @@ fn check_no_freezing_known_mutable_functions(
                 }
 
                 InstructionValue::FunctionExpression { lowered_func, .. } => {
-                    let inner_function = &functions[lowered_func.func.0 as usize];
+                    let inner_function = &functions[lowered_func.func.index()];
                     if let Some(ref aliasing_effects) = inner_function.aliasing_effects {
                         let context_ids: FxHashSet<IdentifierId> =
                             inner_function.context.iter().map(|place| place.identifier).collect();
@@ -174,7 +174,7 @@ fn check_operand_for_freeze_violation(
 ) {
     if operand.effect == Effect::Freeze {
         if let Some(mutation_info) = context_mutation_effects.get(&operand.identifier) {
-            let identifier = &identifiers[mutation_info.value_identifier.0 as usize];
+            let identifier = &identifiers[mutation_info.value_identifier.index()];
             let variable_name = match &identifier.name {
                 Some(IdentifierName::Named(name)) => format!("`{}`", name),
                 _ => "a local variable".to_string(),
@@ -211,6 +211,6 @@ fn is_ref_or_ref_like_mutable_type(
     identifiers: &[Identifier],
     types: &[Type],
 ) -> bool {
-    let identifier = &identifiers[identifier_id.0 as usize];
-    crate::react_compiler_hir::is_ref_or_ref_like_mutable_type(&types[identifier.type_.0 as usize])
+    let identifier = &identifiers[identifier_id.index()];
+    crate::react_compiler_hir::is_ref_or_ref_like_mutable_type(&types[identifier.type_.index()])
 }

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_jsx_in_try_statement.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_jsx_in_try_statement.rs
@@ -30,7 +30,7 @@ pub fn validate_no_jsx_in_try_statement(func: &HirFunction) -> Diagnostics {
 
         if !active_try_blocks.is_empty() {
             for &instr_id in &block.instructions {
-                let instr = &func.instructions[instr_id.0 as usize];
+                let instr = &func.instructions[instr_id.index()];
                 match &instr.value {
                     InstructionValue::JsxExpression { span, .. }
                     | InstructionValue::JsxFragment { span, .. } => {

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_ref_access_in_render.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_ref_access_in_render.rs
@@ -24,12 +24,14 @@ const ERROR_DESCRIPTION: &str = "React refs are values that are not needed for r
 
 // --- RefId ---
 
-type RefId = u32;
+oxc_index::define_nonmax_u32_index_type! {
+    struct RefId;
+}
 
 static REF_ID_COUNTER: AtomicU32 = AtomicU32::new(0);
 
 fn next_ref_id() -> RefId {
-    REF_ID_COUNTER.fetch_add(1, Ordering::Relaxed)
+    RefId::from_usize(REF_ID_COUNTER.fetch_add(1, Ordering::Relaxed) as usize)
 }
 
 // --- RefAccessType / RefAccessRefType / RefFnType ---
@@ -256,8 +258,8 @@ impl Env {
 // --- Helper functions ---
 
 fn ref_type_of_type(id: IdentifierId, identifiers: &[Identifier], types: &[Type]) -> RefAccessType {
-    let identifier = &identifiers[id.0 as usize];
-    let ty = &types[identifier.type_.0 as usize];
+    let identifier = &identifiers[id.index()];
+    let ty = &types[identifier.type_.index()];
     if crate::react_compiler_hir::is_ref_value_type(ty) {
         RefAccessType::RefValue { span: None, ref_id: None }
     } else if is_use_ref_type(ty) {
@@ -268,13 +270,13 @@ fn ref_type_of_type(id: IdentifierId, identifiers: &[Identifier], types: &[Type]
 }
 
 fn is_ref_type(id: IdentifierId, identifiers: &[Identifier], types: &[Type]) -> bool {
-    let identifier = &identifiers[id.0 as usize];
-    is_use_ref_type(&types[identifier.type_.0 as usize])
+    let identifier = &identifiers[id.index()];
+    is_use_ref_type(&types[identifier.type_.index()])
 }
 
 fn is_ref_value_type(id: IdentifierId, identifiers: &[Identifier], types: &[Type]) -> bool {
-    let identifier = &identifiers[id.0 as usize];
-    crate::react_compiler_hir::is_ref_value_type(&types[identifier.type_.0 as usize])
+    let identifier = &identifiers[id.index()];
+    crate::react_compiler_hir::is_ref_value_type(&types[identifier.type_.index()])
 }
 
 fn destructure(ty: &RefAccessType) -> RefAccessType {
@@ -448,7 +450,7 @@ fn collect_temporaries_sidemap(
 ) {
     for (_, block) in &func.body.blocks {
         for &instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             match &instr.value {
                 InstructionValue::LoadLocal { place, .. } => {
                     let temp = env
@@ -510,7 +512,7 @@ fn validate_no_ref_access_in_render_impl(
     let mut interpolated_as_jsx: FxHashSet<IdentifierId> = FxHashSet::default();
     for (_, block) in &func.body.blocks {
         for &instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             match &instr.value {
                 InstructionValue::JsxExpression { children: Some(children), .. } => {
                     for child in children {
@@ -553,7 +555,7 @@ fn validate_no_ref_access_in_render_impl(
 
             // Process instructions
             for &instr_id in &block.instructions {
-                let instr = &func.instructions[instr_id.0 as usize];
+                let instr = &func.instructions[instr_id.index()];
                 match &instr.value {
                     InstructionValue::JsxExpression { .. }
                     | InstructionValue::JsxFragment { .. } => {
@@ -658,7 +660,7 @@ fn validate_no_ref_access_in_render_impl(
                     }
                     InstructionValue::ObjectMethod { lowered_func, .. }
                     | InstructionValue::FunctionExpression { lowered_func, .. } => {
-                        let inner = &functions[lowered_func.func.0 as usize];
+                        let inner = &functions[lowered_func.func.index()];
                         let mut inner_errors: Vec<OxcDiagnostic> = Vec::new();
                         let result = validate_no_ref_access_in_render_impl(
                             inner,
@@ -716,8 +718,8 @@ fn validate_no_ref_access_in_render_impl(
                         if !did_error {
                             let is_ref_lvalue =
                                 is_ref_type(instr.lvalue.identifier, identifiers, types);
-                            let callee_identifier = &identifiers[callee.identifier.0 as usize];
-                            let callee_type = &types[callee_identifier.type_.0 as usize];
+                            let callee_identifier = &identifiers[callee.identifier.index()];
+                            let callee_type = &types[callee_identifier.type_.index()];
                             let hook_kind = env.get_hook_kind_for_type(callee_type).ok().flatten();
 
                             if is_ref_lvalue
@@ -806,7 +808,8 @@ fn validate_no_ref_access_in_render_impl(
                                             if validation != "none" {
                                                 let key = format!(
                                                     "{}:{}",
-                                                    place.identifier.0, validation
+                                                    place.identifier.index(),
+                                                    validation
                                                 );
                                                 if visited_effects.insert(key) {
                                                     if validation == "direct-ref" {

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_set_state_in_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_set_state_in_effects.rs
@@ -43,7 +43,7 @@ pub fn validate_no_set_state_in_effects(
 
     for (_block_id, block) in &func.body.blocks {
         for &instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             match &instr.value {
                 InstructionValue::LoadLocal { place, .. } => {
                     if set_state_functions.contains_key(&place.identifier) {
@@ -60,7 +60,7 @@ pub fn validate_no_set_state_in_effects(
                 }
                 InstructionValue::FunctionExpression { lowered_func, .. } => {
                     // Check if any context capture references a setState
-                    let inner_func = &functions[lowered_func.func.0 as usize];
+                    let inner_func = &functions[lowered_func.func.index()];
                     let has_set_state_operand = inner_func.context.iter().any(|ctx_place| {
                         is_set_state_type_by_id(ctx_place.identifier, identifiers, types)
                             || set_state_functions.contains_key(&ctx_place.identifier)
@@ -82,8 +82,7 @@ pub fn validate_no_set_state_in_effects(
                     }
                 }
                 InstructionValue::MethodCall { property, args, .. } => {
-                    let prop_type =
-                        &types[identifiers[property.identifier.0 as usize].type_.0 as usize];
+                    let prop_type = &types[identifiers[property.identifier.index()].type_.index()];
                     if is_use_effect_event_type(prop_type) {
                         if let Some(PlaceOrSpread::Place(arg_place)) = args.first() {
                             if let Some(info) = set_state_functions.get(&arg_place.identifier) {
@@ -106,8 +105,7 @@ pub fn validate_no_set_state_in_effects(
                     }
                 }
                 InstructionValue::CallExpression { callee, args, .. } => {
-                    let callee_type =
-                        &types[identifiers[callee.identifier.0 as usize].type_.0 as usize];
+                    let callee_type = &types[identifiers[callee.identifier.index()].type_.index()];
                     if is_use_effect_event_type(callee_type) {
                         if let Some(PlaceOrSpread::Place(arg_place)) = args.first() {
                             if let Some(info) = set_state_functions.get(&arg_place.identifier) {
@@ -147,8 +145,8 @@ fn is_set_state_type_by_id(
     identifiers: &[Identifier],
     types: &[Type],
 ) -> bool {
-    let ident = &identifiers[identifier_id.0 as usize];
-    let ty = &types[ident.type_.0 as usize];
+    let ident = &identifiers[identifier_id.index()];
+    let ty = &types[ident.type_.index()];
     is_set_state_type(ty)
 }
 
@@ -241,8 +239,8 @@ fn is_derived_from_ref(
     if ref_derived_values.contains(&id) {
         return true;
     }
-    let ident = &identifiers[id.0 as usize];
-    let ty = &types[ident.type_.0 as usize];
+    let ident = &identifiers[id.index()];
+    let ty = &types[ident.type_.index()];
     is_use_ref_type(ty) || is_ref_value_type(ty)
 }
 
@@ -344,7 +342,7 @@ fn get_set_state_call(
             }
 
             for &instr_id in &block.instructions {
-                let instr = &func.instructions[instr_id.0 as usize];
+                let instr = &func.instructions[instr_id.index()];
 
                 let operands = collect_operands(&instr.value, functions);
                 let has_ref_operand = operands.iter().any(|op_id| {
@@ -363,8 +361,8 @@ fn get_set_state_call(
 
                 if let InstructionValue::PropertyLoad { object, property, .. } = &instr.value {
                     if property.is_string("current") {
-                        let obj_ident = &identifiers[object.identifier.0 as usize];
-                        let obj_ty = &types[obj_ident.type_.0 as usize];
+                        let obj_ident = &identifiers[object.identifier.index()];
+                        let obj_ty = &types[obj_ident.type_.index()];
                         if is_use_ref_type(obj_ty) || is_ref_value_type(obj_ty) {
                             ref_derived_values.insert(instr.lvalue.identifier);
                         }
@@ -429,7 +427,7 @@ fn get_set_state_call(
         }
 
         for &instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
 
             // Track ref-derived values through instructions
             if enable_allow_set_state_from_refs {
@@ -453,8 +451,8 @@ fn get_set_state_call(
                 // Special case: PropertyLoad of .current on ref/refValue
                 if let InstructionValue::PropertyLoad { object, property, .. } = &instr.value {
                     if property.is_string("current") {
-                        let obj_ident = &identifiers[object.identifier.0 as usize];
-                        let obj_ty = &types[obj_ident.type_.0 as usize];
+                        let obj_ident = &identifiers[object.identifier.index()];
+                        let obj_ty = &types[obj_ident.type_.index()];
                         if is_use_ref_type(obj_ty) || is_ref_value_type(obj_ty) {
                             ref_derived_values.insert(instr.lvalue.identifier);
                         }

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_set_state_in_render.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_set_state_in_render.rs
@@ -24,7 +24,7 @@ pub fn validate_no_set_state_in_render(
     env: &mut Environment,
 ) -> Result<(), OxcDiagnostic> {
     let mut unconditional_set_state_functions: FxHashSet<IdentifierId> = FxHashSet::default();
-    let next_block_id = env.next_block_id().0;
+    let next_block_id = env.next_block_id().index() as u32;
     let diagnostics = validate_impl(
         func,
         &env.identifiers,
@@ -45,8 +45,8 @@ fn is_set_state_id(
     identifiers: &[Identifier],
     types: &[Type],
 ) -> bool {
-    let ident = &identifiers[identifier_id.0 as usize];
-    let ty = &types[ident.type_.0 as usize];
+    let ident = &identifiers[identifier_id.index()];
+    let ty = &types[ident.type_.index()];
     is_set_state_type(ty)
 }
 
@@ -66,7 +66,7 @@ fn validate_impl(
 
     for (_block_id, block) in &func.body.blocks {
         for &instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             match &instr.value {
                 InstructionValue::LoadLocal { place, .. } => {
                     if unconditional_set_state_functions.contains(&place.identifier) {
@@ -81,7 +81,7 @@ fn validate_impl(
                 }
                 InstructionValue::ObjectMethod { lowered_func, .. }
                 | InstructionValue::FunctionExpression { lowered_func, .. } => {
-                    let inner_func = &functions[lowered_func.func.0 as usize];
+                    let inner_func = &functions[lowered_func.func.index()];
 
                     // Check if any operand references a setState.
                     // For FunctionExpression/ObjectMethod, operands are the context captures.

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_preserved_manual_memoization.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_preserved_manual_memoization.rs
@@ -139,7 +139,7 @@ fn visit_scope<'h>(scope_block: &ReactiveScopeBlock<'h>, state: &mut VisitorStat
     // After traversing, validate scope dependencies against manual memo deps
     if let Some(ref memo_state) = state.manual_memo_state {
         if let Some(ref deps_from_source) = memo_state.deps_from_source {
-            let scope = &state.env.scopes[scope_block.scope.0 as usize];
+            let scope = &state.env.scopes[scope_block.scope.index()];
             let deps = scope.dependencies.clone();
             let memo_span = memo_state.span;
             let decls = memo_state.decls.clone();
@@ -160,7 +160,7 @@ fn visit_scope<'h>(scope_block: &ReactiveScopeBlock<'h>, state: &mut VisitorStat
     }
 
     // Mark scope and merged scopes as completed
-    let scope = &state.env.scopes[scope_block.scope.0 as usize];
+    let scope = &state.env.scopes[scope_block.scope.index()];
     let merged = scope.merged.clone();
     state.scopes.insert(scope_block.scope);
     for merged_id in merged {
@@ -208,7 +208,7 @@ fn visit_instruction<'h>(instr: &ReactiveInstruction<'h>, state: &mut VisitorSta
             // TS: for (const {identifier, span} of eachInstructionValueOperand(value))
             let operand_places = start_memoize_operands(deps);
             for place in &operand_places {
-                let ident = &state.env.identifiers[place.identifier.0 as usize];
+                let ident = &state.env.identifiers[place.identifier.index()];
                 if let Some(scope_id) = ident.scope {
                     if !state.scopes.contains(&scope_id) && !state.pruned_scopes.contains(&scope_id)
                     {
@@ -250,7 +250,7 @@ fn visit_instruction<'h>(instr: &ReactiveInstruction<'h>, state: &mut VisitorSta
 
             if !pruned {
                 // Check if the declared value is unmemoized
-                let decl_ident = &state.env.identifiers[decl.identifier.0 as usize];
+                let decl_ident = &state.env.identifiers[decl.identifier.index()];
 
                 if decl_ident.scope.is_none() {
                     // If the manual memo was inlined (useMemo -> IIFE), check reassignments
@@ -278,17 +278,16 @@ fn visit_instruction<'h>(instr: &ReactiveInstruction<'h>, state: &mut VisitorSta
             if let Some(memo_state) = &mut state.manual_memo_state
                 && lvalue.kind == InstructionKind::Reassign
             {
-                let decl_id =
-                    state.env.identifiers[lvalue.place.identifier.0 as usize].declaration_id;
+                let decl_id = state.env.identifiers[lvalue.place.identifier.index()].declaration_id;
                 memo_state.reassignments.entry(decl_id).or_default().insert(value.identifier);
             }
         }
         ReactiveValue::Instruction(InstructionValue::LoadLocal { place, .. })
             if let Some(memo_state) = &mut state.manual_memo_state =>
         {
-            let place_ident = &state.env.identifiers[place.identifier.0 as usize];
+            let place_ident = &state.env.identifiers[place.identifier.index()];
             if let Some(ref lvalue) = instr.lvalue {
-                let lvalue_ident = &state.env.identifiers[lvalue.identifier.0 as usize];
+                let lvalue_ident = &state.env.identifiers[lvalue.identifier.index()];
                 if place_ident.scope.is_some() && lvalue_ident.scope.is_none() {
                     memo_state
                         .reassignments
@@ -324,7 +323,7 @@ fn record_temporaries<'h>(instr: &ReactiveInstruction<'h>, state: &mut VisitorSt
     }
 
     if let Some(ref lvalue) = instr.lvalue {
-        let lv_ident = &state.env.identifiers[lvalue.identifier.0 as usize];
+        let lv_ident = &state.env.identifiers[lvalue.identifier.index()];
         if is_named(lv_ident) && state.manual_memo_state.is_some() {
             state.manual_memo_state.as_mut().unwrap().decls.insert(lv_ident.declaration_id);
         }
@@ -385,7 +384,7 @@ fn record_deps_in_value<'h>(value: &ReactiveValue<'h>, state: &mut VisitorState<
                 InstructionValue::StoreLocal { lvalue, .. }
                 | InstructionValue::StoreContext { lvalue, .. } => {
                     if let Some(ref mut memo_state) = state.manual_memo_state {
-                        let ident = &state.env.identifiers[lvalue.place.identifier.0 as usize];
+                        let ident = &state.env.identifiers[lvalue.place.identifier.index()];
                         memo_state.decls.insert(ident.declaration_id);
                         if is_named(ident) {
                             state.temporaries.insert(
@@ -405,7 +404,7 @@ fn record_deps_in_value<'h>(value: &ReactiveValue<'h>, state: &mut VisitorState<
                 InstructionValue::Destructure { lvalue, .. } => {
                     if let Some(ref mut memo_state) = state.manual_memo_state {
                         for place in destructure_lvalue_places(&lvalue.pattern) {
-                            let ident = &state.env.identifiers[place.identifier.0 as usize];
+                            let ident = &state.env.identifiers[place.identifier.index()];
                             memo_state.decls.insert(ident.declaration_id);
                             if is_named(ident) {
                                 state.temporaries.insert(
@@ -481,7 +480,7 @@ fn is_unmemoized(
     completed_scopes: &FxHashSet<ScopeId>,
     identifiers: &[Identifier],
 ) -> bool {
-    let ident = &identifiers[id.0 as usize];
+    let ident = &identifiers[id.index()];
     if let Some(scope_id) = ident.scope { !completed_scopes.contains(&scope_id) } else { false }
 }
 
@@ -553,7 +552,7 @@ fn pretty_print_scope_dependency(
     dep_path: &[DependencyPathEntry],
     identifiers: &[Identifier],
 ) -> String {
-    let ident = &identifiers[dep_id.0 as usize];
+    let ident = &identifiers[dep_id.index()];
     let root_str = match &ident.name {
         Some(IdentifierName::Named(n) | IdentifierName::Promoted(n)) => n.as_str(),
         None => "[unnamed]",
@@ -579,7 +578,7 @@ fn print_manual_memo_dependency(
 ) -> String {
     let root_str = match &dep.root {
         ManualMemoDependencyRoot::NamedLocal { value, .. } => {
-            let ident = &identifiers[value.identifier.0 as usize];
+            let ident = &identifiers[value.identifier.index()];
             match &ident.name {
                 Some(IdentifierName::Named(n) | IdentifierName::Promoted(n)) => n.as_str(),
                 None => "[unnamed]",
@@ -629,7 +628,7 @@ fn validate_inferred_dep<'h>(
         path.extend_from_slice(dep_path);
         ManualMemoDependency { root: temp.root.clone(), path, span: temp.span }
     } else {
-        let ident = &env.identifiers[dep_id.0 as usize];
+        let ident = &env.identifiers[dep_id.index()];
         // TS: Diagnostics.invariant(dep.identifier.name?.kind === 'named', ...)
         if !is_named(ident) {
             return;
@@ -651,7 +650,7 @@ fn validate_inferred_dep<'h>(
 
     // Check if the dep was declared within the memo block
     if let ManualMemoDependencyRoot::NamedLocal { value, .. } = &normalized_dep.root {
-        let ident = &env.identifiers[value.identifier.0 as usize];
+        let ident = &env.identifiers[value.identifier.index()];
         if decls_within_memo_block.contains(&ident.declaration_id) {
             return;
         }
@@ -670,7 +669,7 @@ fn validate_inferred_dep<'h>(
         });
     }
 
-    let ident = &env.identifiers[dep_id.0 as usize];
+    let ident = &env.identifiers[dep_id.index()];
 
     let extra = if is_named(ident) {
         // Use the original dep_id/dep_path (matching TS prettyPrintScopeDependency(dep))

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_static_components.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_static_components.rs
@@ -38,7 +38,7 @@ pub fn validate_static_components(func: &HirFunction) -> Diagnostics {
 
         // Process instructions
         for &instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             let lvalue_id = instr.lvalue.identifier;
             let value = &instr.value;
 

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_use_memo.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_use_memo.rs
@@ -47,7 +47,7 @@ fn validate_use_memo_impl(
 
     for (_block_id, block) in &func.body.blocks {
         for &instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             let lvalue = &instr.lvalue;
             let value = &instr.value;
 
@@ -167,7 +167,7 @@ fn handle_possible_use_memo_call(
         None => return,
     };
 
-    let body_func = &functions[body_info.func_id.0 as usize];
+    let body_func = &functions[body_info.func_id.index()];
 
     // Validate no parameters
     if !body_func.params.is_empty() {
@@ -231,7 +231,7 @@ fn validate_no_context_variable_assignment(func: &HirFunction, errors: &mut Diag
 
     for (_block_id, block) in &func.body.blocks {
         for &instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
+            let instr = &func.instructions[instr_id.index()];
             if let InstructionValue::StoreContext { lvalue, .. } = &instr.value {
                 if context.contains(&lvalue.place.identifier) {
                     errors.push(


### PR DESCRIPTION
## What

Migrate the React Compiler's HIR ID newtypes from hand-rolled `pub struct X(pub u32)` / `type X = u32` to oxc's `oxc_index::define_nonmax_u32_index_type!` — the same index-type idiom used by `SymbolId`, `ScopeId`, `NodeId`, `ReferenceId`, `BasicBlockId`, etc.

Migrated: `BlockId`, `IdentifierId`, `InstructionId`, `EvaluationOrder`, `DeclarationId`, `ScopeId`, `TypeId`, `FunctionId`, `MutableRangeId`, and the validation-pass `RefId`.

## Why

`NonMaxU32` backing adds a niche, so `Option<Id>` is **4 bytes instead of 8**. The crate has 48 `Option<Id>` fields — many on hot HIR structs (`Identifier`, `Place`, `MutableRange`, `ReactiveScope`, `Instruction`) — which shrink for free, plus `RefId`'s `Option<RefId>` fields. It also aligns the crate with the rest of oxc, and the macro's `Add`/`PartialOrd<usize>` impls let the pervasive `id.0 + 1` / `a.0 > b.0 + 1` arithmetic collapse to `id + 1` / `a > b + 1`.

## Notes

- `ValueId` is intentionally **not** migrated. It overlays two id-spaces by OR-ing bit 31 (`| 0x80000000`), whose value space includes `u32::MAX` and would panic under `NonMaxU32`; it is also only ever a hashmap/set key (never a `Vec` index or inside `Option<ValueId>`), so a nonmax index buys nothing. It stays a plain `u32` newtype, with the bit-tag now behind a named `ValueId::from_identifier` constructor.
- Named sentinels replace repeated magic zeros: `EvaluationOrder::UNSET` (the "not-yet-numbered" order, ~106 sites) and `BlockId::PLACEHOLDER` (the never-read block installed by the final `terminate()`; uses `MAX_INDEX` so it can't alias the real entry block, which is `0`).
- The old `u32::MAX` sentinels: the two never-read placeholders now use the named consts above; the `infer_types` one is a plain `u32` function-key and is unchanged.
- Behavior-preserving: the insta snapshot corpus and all 15 transform tests are byte-identical.
- These `src/` modules track upstream closely; this deliberately diverges, consistent with the recent oxc-integration work on this crate.
