### PR TITLE
refactor(react_compiler): allocate per-pass temporaries in a scratch arena

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler_hir/dominator.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/dominator.rs
@@ -11,6 +11,7 @@
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
+use oxc_allocator::{Allocator, HashMap as ArenaHashMap, HashSet as ArenaHashSet, Vec as ArenaVec};
 use oxc_diagnostics::OxcDiagnostic;
 
 use crate::diagnostics::ErrorCategory;
@@ -42,23 +43,23 @@ impl PostDominator {
 // Graph representation
 // =============================================================================
 
-struct Node {
+struct Node<'alloc> {
     id: BlockId,
     index: usize,
-    preds: FxHashSet<BlockId>,
-    succs: FxHashSet<BlockId>,
+    preds: ArenaHashSet<'alloc, BlockId>,
+    succs: ArenaHashSet<'alloc, BlockId>,
 }
 
-struct Graph {
+struct Graph<'alloc> {
     entry: BlockId,
     /// Nodes stored in iteration order (RPO for reverse graph).
-    nodes: Vec<Node>,
+    nodes: ArenaVec<'alloc, Node<'alloc>>,
     /// Map from BlockId to index in the nodes vec.
-    node_index: FxHashMap<BlockId, usize>,
+    node_index: ArenaHashMap<'alloc, BlockId, usize>,
 }
 
-impl Graph {
-    fn get_node(&self, id: BlockId) -> &Node {
+impl<'alloc> Graph<'alloc> {
+    fn get_node(&self, id: BlockId) -> &Node<'alloc> {
         let idx = self.node_index[&id];
         &self.nodes[idx]
     }
@@ -77,7 +78,11 @@ pub fn compute_post_dominator_tree(
     next_block_id_counter: u32,
     include_throws_as_exit_node: bool,
 ) -> Result<PostDominator, OxcDiagnostic> {
-    let graph = build_reverse_graph(func, next_block_id_counter, include_throws_as_exit_node);
+    // Scratch arena for the temporary reverse graph; released on return.
+    let scratch = Allocator::default();
+    let scratch = &scratch;
+    let graph =
+        build_reverse_graph(func, next_block_id_counter, include_throws_as_exit_node, scratch);
     let mut nodes = compute_immediate_dominators(&graph)?;
 
     // When include_throws_as_exit_node is false, nodes that flow into a throw
@@ -96,26 +101,33 @@ pub fn compute_post_dominator_tree(
 ///
 /// Reverses all edges and adds a synthetic exit node that receives edges from
 /// return (and optionally throw) terminals. The result is put into RPO order.
-fn build_reverse_graph(
+fn build_reverse_graph<'alloc>(
     func: &HirFunction,
     next_block_id_counter: u32,
     include_throws_as_exit_node: bool,
-) -> Graph {
+    allocator: &'alloc Allocator,
+) -> Graph<'alloc> {
     let exit_id = BlockId(next_block_id_counter);
 
     // Build initial nodes with reversed edges
-    let mut raw_nodes: FxHashMap<BlockId, Node> = FxHashMap::default();
+    let mut raw_nodes: ArenaHashMap<'alloc, BlockId, Node<'alloc>> =
+        ArenaHashMap::new_in(allocator);
 
     // Create exit node
     raw_nodes.insert(
         exit_id,
-        Node { id: exit_id, index: 0, preds: FxHashSet::default(), succs: FxHashSet::default() },
+        Node {
+            id: exit_id,
+            index: 0,
+            preds: ArenaHashSet::new_in(allocator),
+            succs: ArenaHashSet::new_in(allocator),
+        },
     );
 
     for (id, block) in &func.body.blocks {
         let successors = each_terminal_successor(&block.terminal);
-        let mut preds_set: FxHashSet<BlockId> = successors.into_iter().collect();
-        let succs_set: FxHashSet<BlockId> = block.preds.iter().copied().collect();
+        let mut preds_set = ArenaHashSet::from_iter_in(successors, allocator);
+        let succs_set = ArenaHashSet::from_iter_in(block.preds.iter().copied(), allocator);
 
         let is_return = matches!(&block.terminal, Terminal::Return { .. });
         let is_throw = matches!(&block.terminal, Terminal::Throw { .. });
@@ -129,15 +141,16 @@ fn build_reverse_graph(
     }
 
     // DFS from exit to compute RPO
-    let mut visited = FxHashSet::default();
-    let mut postorder = Vec::new();
+    let mut visited: ArenaHashSet<'alloc, BlockId> = ArenaHashSet::new_in(allocator);
+    let mut postorder: ArenaVec<'alloc, BlockId> = ArenaVec::new_in(&allocator);
     dfs_postorder(exit_id, &raw_nodes, &mut visited, &mut postorder);
 
     // Reverse postorder
     postorder.reverse();
 
-    let mut nodes = Vec::with_capacity(postorder.len());
-    let mut node_index = FxHashMap::default();
+    let mut nodes: ArenaVec<'alloc, Node<'alloc>> =
+        ArenaVec::with_capacity_in(postorder.len(), &allocator);
+    let mut node_index: ArenaHashMap<'alloc, BlockId, usize> = ArenaHashMap::new_in(allocator);
     for (idx, id) in postorder.into_iter().enumerate() {
         let mut node = raw_nodes.remove(&id).unwrap();
         node.index = idx;
@@ -148,11 +161,11 @@ fn build_reverse_graph(
     Graph { entry: exit_id, nodes, node_index }
 }
 
-fn dfs_postorder(
+fn dfs_postorder<'alloc>(
     id: BlockId,
-    nodes: &FxHashMap<BlockId, Node>,
-    visited: &mut FxHashSet<BlockId>,
-    postorder: &mut Vec<BlockId>,
+    nodes: &ArenaHashMap<'alloc, BlockId, Node<'alloc>>,
+    visited: &mut ArenaHashSet<'alloc, BlockId>,
+    postorder: &mut ArenaVec<'alloc, BlockId>,
 ) {
     if !visited.insert(id) {
         return;

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/merge_consecutive_blocks.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/merge_consecutive_blocks.rs
@@ -15,7 +15,7 @@
 
 use std::mem::replace;
 
-use rustc_hash::{FxHashMap, FxHashSet};
+use oxc_allocator::{Allocator, HashMap as ArenaHashMap, HashSet as ArenaHashSet, Vec as ArenaVec};
 
 use crate::react_compiler_hir::visitors;
 use crate::react_compiler_hir::{
@@ -54,18 +54,22 @@ pub fn merge_consecutive_blocks(func: &mut HirFunction, functions: &mut [HirFunc
         functions[func_id] = inner_func;
     }
 
+    // Scratch arena for this pass's temporary collections; released on return.
+    let scratch = Allocator::default();
+    let scratch = &scratch;
+
     // Build fallthrough set
-    let mut fallthrough_blocks: FxHashSet<BlockId> = FxHashSet::default();
+    let mut fallthrough_blocks: ArenaHashSet<'_, BlockId> = ArenaHashSet::new_in(scratch);
     for block in func.body.blocks.values() {
         if let Some(ft) = visitors::terminal_fallthrough(&block.terminal) {
             fallthrough_blocks.insert(ft);
         }
     }
 
-    let mut merged = MergedBlocks::new();
+    let mut merged = MergedBlocks::new_in(scratch);
 
     // Collect block IDs for iteration (since we modify during iteration)
-    let block_ids: Vec<BlockId> = func.body.blocks.keys().copied().collect();
+    let block_ids = ArenaVec::from_iter_in(func.body.blocks.keys().copied(), &scratch);
 
     for block_id in &block_ids {
         let block = match func.body.blocks.get(block_id) {
@@ -117,7 +121,7 @@ pub fn merge_consecutive_blocks(func: &mut HirFunction, functions: &mut [HirFunc
         let block_terminal = block.terminal.clone();
 
         // Create phi instructions and add to instruction table
-        let mut new_instr_ids = Vec::new();
+        let mut new_instr_ids = ArenaVec::new_in(&scratch);
         for (identifier, operand) in phis {
             let lvalue = Place {
                 identifier,
@@ -184,13 +188,13 @@ pub fn merge_consecutive_blocks(func: &mut HirFunction, functions: &mut [HirFunc
 }
 
 /// Tracks which blocks have been merged and into which target.
-struct MergedBlocks {
-    map: FxHashMap<BlockId, BlockId>,
+struct MergedBlocks<'alloc> {
+    map: ArenaHashMap<'alloc, BlockId, BlockId>,
 }
 
-impl MergedBlocks {
-    fn new() -> Self {
-        Self { map: FxHashMap::default() }
+impl<'alloc> MergedBlocks<'alloc> {
+    fn new_in(allocator: &'alloc Allocator) -> Self {
+        Self { map: ArenaHashMap::new_in(allocator) }
     }
 
     /// Record that `block` was merged into `into`.

--- a/crates/oxc_react_compiler/src/react_compiler_ssa/enter_ssa.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_ssa/enter_ssa.rs
@@ -1,6 +1,6 @@
 use std::mem::{replace, take};
 
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use oxc_allocator::{Allocator, HashMap as ArenaHashMap, HashSet as ArenaHashSet, Vec as ArenaVec};
 use oxc_diagnostics::OxcDiagnostic;
@@ -156,11 +156,12 @@ impl<'alloc> SSABuilder<'alloc> {
             }
         }
 
-        let allocator = self.allocator;
-        let preds: ArenaVec<BlockId> = ArenaVec::from_iter_in(
-            self.block_preds.get(&block_id).into_iter().flatten().copied(),
-            &allocator,
-        );
+        // Per-lookup temporary: keep on the heap so it is freed when this call
+        // returns. The pass-lived scratch arena is not reset mid-pass, so cloning
+        // predecessor lists into it here (once per operand, recursively) would
+        // accumulate O(uses x preds) retained memory.
+        let preds: Vec<BlockId> =
+            self.block_preds.get(&block_id).into_iter().flatten().copied().collect();
 
         if preds.is_empty() {
             self.unknown.insert(old_place.identifier);
@@ -208,11 +209,9 @@ impl<'alloc> SSABuilder<'alloc> {
         new_place: &Place,
         env: &mut Environment,
     ) {
-        let allocator = self.allocator;
-        let preds: ArenaVec<BlockId> = ArenaVec::from_iter_in(
-            self.block_preds.get(&block_id).into_iter().flatten().copied(),
-            &allocator,
-        );
+        // Per-call temporary: keep on the heap (see `get_id_at`).
+        let preds: Vec<BlockId> =
+            self.block_preds.get(&block_id).into_iter().flatten().copied().collect();
 
         let mut pred_defs: FxIndexMap<BlockId, Place> = FxIndexMap::default();
         for pred_block_id in &preds {
@@ -234,11 +233,9 @@ impl<'alloc> SSABuilder<'alloc> {
     }
 
     fn fix_incomplete_phis(&mut self, block_id: BlockId, env: &mut Environment) {
-        let allocator = self.allocator;
-        let incomplete_phis = ArenaVec::from_iter_in(
-            self.states.get_mut(&block_id).unwrap().incomplete_phis.drain(..),
-            &allocator,
-        );
+        // Per-call temporary: keep on the heap (see `get_id_at`).
+        let incomplete_phis: Vec<IncompletePhi> =
+            self.states.get_mut(&block_id).unwrap().incomplete_phis.drain(..).collect();
         for phi in &incomplete_phis {
             self.add_phi(block_id, &phi.old_place, &phi.new_place, env);
         }
@@ -281,9 +278,9 @@ fn apply_pending_phis(func: &mut HirFunction, env: &mut Environment, builder: &m
             block.phis.extend(phis);
         }
     }
-    let allocator = builder.allocator;
-    let processed_functions =
-        ArenaVec::from_iter_in(builder.processed_functions.iter().copied(), &allocator);
+    // Per-call temporary: keep on the heap so it is freed when this call returns.
+    let processed_functions: Vec<FunctionId> =
+        builder.processed_functions.iter().copied().collect();
     for fid in &processed_functions {
         let inner_func = &mut env.functions[fid.0 as usize];
         for (block_id, block) in inner_func.body.blocks.iter_mut() {
@@ -300,9 +297,11 @@ fn enter_ssa_impl(
     env: &mut Environment,
     root_entry: BlockId,
 ) -> Result<(), OxcDiagnostic> {
+    // `allocator` is used only to grow the pass-lived `block_preds` map below;
+    // per-call worklists (`visited_blocks`, `block_ids`, ...) stay on the heap.
     let allocator = builder.allocator;
-    let mut visited_blocks: ArenaHashSet<'_, BlockId> = ArenaHashSet::new_in(allocator);
-    let block_ids = ArenaVec::from_iter_in(func.body.blocks.keys().copied(), &allocator);
+    let mut visited_blocks: FxHashSet<BlockId> = FxHashSet::default();
+    let block_ids: Vec<BlockId> = func.body.blocks.keys().copied().collect();
 
     for block_id in &block_ids {
         let block_id = *block_id;
@@ -336,10 +335,8 @@ fn enter_ssa_impl(
         }
 
         // Process instructions
-        let instruction_ids = ArenaVec::from_iter_in(
-            func.body.blocks.get(&block_id).unwrap().instructions.iter().copied(),
-            &allocator,
-        );
+        let instruction_ids: Vec<InstructionId> =
+            func.body.blocks.get(&block_id).unwrap().instructions.clone();
 
         for instr_id in &instruction_ids {
             let instr_idx = instr_id.0 as usize;
@@ -385,10 +382,11 @@ fn enter_ssa_impl(
 
             // Handle inner function SSA
             if let Some(fid) = func_expr_id {
-                let context_ids = ArenaVec::from_iter_in(
-                    env.functions[fid.0 as usize].context.iter().map(|place| place.identifier),
-                    &allocator,
-                );
+                let context_ids: Vec<IdentifierId> = env.functions[fid.0 as usize]
+                    .context
+                    .iter()
+                    .map(|place| place.identifier)
+                    .collect();
                 for id in context_ids {
                     builder.unmark_unknown(id);
                 }

--- a/crates/oxc_react_compiler/src/react_compiler_ssa/enter_ssa.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_ssa/enter_ssa.rs
@@ -1,7 +1,8 @@
 use std::mem::{replace, take};
 
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 
+use oxc_allocator::{Allocator, HashMap as ArenaHashMap, HashSet as ArenaHashSet, Vec as ArenaVec};
 use oxc_diagnostics::OxcDiagnostic;
 
 use crate::diagnostics::ErrorCategory;
@@ -19,47 +20,54 @@ struct IncompletePhi {
     new_place: Place,
 }
 
-struct State {
-    defs: FxHashMap<IdentifierId, IdentifierId>,
-    incomplete_phis: Vec<IncompletePhi>,
+struct State<'alloc> {
+    defs: ArenaHashMap<'alloc, IdentifierId, IdentifierId>,
+    incomplete_phis: ArenaVec<'alloc, IncompletePhi>,
 }
 
-struct SSABuilder {
-    states: FxHashMap<BlockId, State>,
+struct SSABuilder<'alloc> {
+    allocator: &'alloc Allocator,
+    states: ArenaHashMap<'alloc, BlockId, State<'alloc>>,
     current: Option<BlockId>,
-    unsealed_preds: FxHashMap<BlockId, u32>,
-    block_preds: FxHashMap<BlockId, Vec<BlockId>>,
-    unknown: FxHashSet<IdentifierId>,
-    context: FxHashSet<IdentifierId>,
+    unsealed_preds: ArenaHashMap<'alloc, BlockId, u32>,
+    block_preds: ArenaHashMap<'alloc, BlockId, ArenaVec<'alloc, BlockId>>,
+    unknown: ArenaHashSet<'alloc, IdentifierId>,
+    context: ArenaHashSet<'alloc, IdentifierId>,
+    // Stays on the heap: `Phi.operands` is an insertion-ordered `FxIndexMap`,
+    // which has no arena equivalent, so `Phi` (and `Vec<Phi>`) is a `Drop` type.
     pending_phis: FxHashMap<BlockId, Vec<Phi>>,
-    processed_functions: Vec<FunctionId>,
+    processed_functions: ArenaVec<'alloc, FunctionId>,
 }
 
-impl SSABuilder {
-    fn new(blocks: &FxIndexMap<BlockId, BasicBlock>) -> Self {
-        let mut block_preds = FxHashMap::default();
+impl<'alloc> SSABuilder<'alloc> {
+    fn new_in(blocks: &FxIndexMap<BlockId, BasicBlock>, allocator: &'alloc Allocator) -> Self {
+        let mut block_preds = ArenaHashMap::new_in(allocator);
         for (id, block) in blocks {
-            block_preds.insert(*id, block.preds.iter().copied().collect());
+            block_preds
+                .insert(*id, ArenaVec::from_iter_in(block.preds.iter().copied(), &allocator));
         }
         SSABuilder {
-            states: FxHashMap::default(),
+            allocator,
+            states: ArenaHashMap::new_in(allocator),
             current: None,
-            unsealed_preds: FxHashMap::default(),
+            unsealed_preds: ArenaHashMap::new_in(allocator),
             block_preds,
-            unknown: FxHashSet::default(),
-            context: FxHashSet::default(),
+            unknown: ArenaHashSet::new_in(allocator),
+            context: ArenaHashSet::new_in(allocator),
             pending_phis: FxHashMap::default(),
-            processed_functions: Vec::new(),
+            processed_functions: ArenaVec::new_in(&allocator),
         }
     }
 
     fn define_function(&mut self, func: &HirFunction) {
+        let allocator = self.allocator;
         for (id, block) in &func.body.blocks {
-            self.block_preds.insert(*id, block.preds.iter().copied().collect());
+            self.block_preds
+                .insert(*id, ArenaVec::from_iter_in(block.preds.iter().copied(), &allocator));
         }
     }
 
-    fn state_mut(&mut self) -> &mut State {
+    fn state_mut(&mut self) -> &mut State<'alloc> {
         let current = self.current.expect("we need to be in a block to access state!");
         self.states.get_mut(&current).expect("state not found for current block")
     }
@@ -148,7 +156,11 @@ impl SSABuilder {
             }
         }
 
-        let preds = self.block_preds.get(&block_id).cloned().unwrap_or_default();
+        let allocator = self.allocator;
+        let preds: ArenaVec<BlockId> = ArenaVec::from_iter_in(
+            self.block_preds.get(&block_id).into_iter().flatten().copied(),
+            &allocator,
+        );
 
         if preds.is_empty() {
             self.unknown.insert(old_place.identifier);
@@ -196,7 +208,11 @@ impl SSABuilder {
         new_place: &Place,
         env: &mut Environment,
     ) {
-        let preds = self.block_preds.get(&block_id).cloned().unwrap_or_default();
+        let allocator = self.allocator;
+        let preds: ArenaVec<BlockId> = ArenaVec::from_iter_in(
+            self.block_preds.get(&block_id).into_iter().flatten().copied(),
+            &allocator,
+        );
 
         let mut pred_defs: FxIndexMap<BlockId, Place> = FxIndexMap::default();
         for pred_block_id in &preds {
@@ -218,17 +234,26 @@ impl SSABuilder {
     }
 
     fn fix_incomplete_phis(&mut self, block_id: BlockId, env: &mut Environment) {
-        let incomplete_phis: Vec<IncompletePhi> =
-            self.states.get_mut(&block_id).unwrap().incomplete_phis.drain(..).collect();
+        let allocator = self.allocator;
+        let incomplete_phis = ArenaVec::from_iter_in(
+            self.states.get_mut(&block_id).unwrap().incomplete_phis.drain(..),
+            &allocator,
+        );
         for phi in &incomplete_phis {
             self.add_phi(block_id, &phi.old_place, &phi.new_place, env);
         }
     }
 
     fn start_block(&mut self, block_id: BlockId) {
+        let allocator = self.allocator;
         self.current = Some(block_id);
-        self.states
-            .insert(block_id, State { defs: FxHashMap::default(), incomplete_phis: Vec::new() });
+        self.states.insert(
+            block_id,
+            State {
+                defs: ArenaHashMap::new_in(allocator),
+                incomplete_phis: ArenaVec::new_in(&allocator),
+            },
+        );
     }
 }
 
@@ -237,7 +262,10 @@ impl SSABuilder {
 // =============================================================================
 
 pub fn enter_ssa(func: &mut HirFunction, env: &mut Environment) -> Result<(), OxcDiagnostic> {
-    let mut builder = SSABuilder::new(&func.body.blocks);
+    // Scratch arena for this pass's temporary SSA state; released on return.
+    let scratch = Allocator::default();
+    let scratch = &scratch;
+    let mut builder = SSABuilder::new_in(&func.body.blocks, scratch);
     let root_entry = func.body.entry;
     enter_ssa_impl(func, &mut builder, env, root_entry)?;
 
@@ -253,7 +281,10 @@ fn apply_pending_phis(func: &mut HirFunction, env: &mut Environment, builder: &m
             block.phis.extend(phis);
         }
     }
-    for fid in &builder.processed_functions.clone() {
+    let allocator = builder.allocator;
+    let processed_functions =
+        ArenaVec::from_iter_in(builder.processed_functions.iter().copied(), &allocator);
+    for fid in &processed_functions {
         let inner_func = &mut env.functions[fid.0 as usize];
         for (block_id, block) in inner_func.body.blocks.iter_mut() {
             if let Some(phis) = builder.pending_phis.remove(block_id) {
@@ -269,8 +300,9 @@ fn enter_ssa_impl(
     env: &mut Environment,
     root_entry: BlockId,
 ) -> Result<(), OxcDiagnostic> {
-    let mut visited_blocks: FxHashSet<BlockId> = FxHashSet::default();
-    let block_ids: Vec<BlockId> = func.body.blocks.keys().copied().collect();
+    let allocator = builder.allocator;
+    let mut visited_blocks: ArenaHashSet<'_, BlockId> = ArenaHashSet::new_in(allocator);
+    let block_ids = ArenaVec::from_iter_in(func.body.blocks.keys().copied(), &allocator);
 
     for block_id in &block_ids {
         let block_id = *block_id;
@@ -304,8 +336,10 @@ fn enter_ssa_impl(
         }
 
         // Process instructions
-        let instruction_ids: Vec<InstructionId> =
-            func.body.blocks.get(&block_id).unwrap().instructions.clone();
+        let instruction_ids = ArenaVec::from_iter_in(
+            func.body.blocks.get(&block_id).unwrap().instructions.iter().copied(),
+            &allocator,
+        );
 
         for instr_id in &instruction_ids {
             let instr_idx = instr_id.0 as usize;
@@ -351,11 +385,10 @@ fn enter_ssa_impl(
 
             // Handle inner function SSA
             if let Some(fid) = func_expr_id {
-                let context_ids: Vec<IdentifierId> = env.functions[fid.0 as usize]
-                    .context
-                    .iter()
-                    .map(|place| place.identifier)
-                    .collect();
+                let context_ids = ArenaVec::from_iter_in(
+                    env.functions[fid.0 as usize].context.iter().map(|place| place.identifier),
+                    &allocator,
+                );
                 for id in context_ids {
                     builder.unmark_unknown(id);
                 }
@@ -409,7 +442,7 @@ fn enter_ssa_impl(
                     .unwrap()
                     .preds
                     .clear();
-                builder.block_preds.insert(inner_entry, Vec::new());
+                builder.block_preds.insert(inner_entry, ArenaVec::new_in(&allocator));
             }
         }
 


### PR DESCRIPTION
## Summary

The `oxc_react_compiler` pipeline runs ~60 passes per function, and most passes build short-lived hash maps/sets/vecs — hundreds of `malloc`/`free` pairs per compiled function.

This introduces a **pass-local scratch `Allocator`** in three self-contained passes and moves their collections to the arena forms (`ArenaHashMap`/`ArenaHashSet`/`ArenaVec`), which bump-allocate and free in bulk. The borrow checker guarantees nothing escapes: any value outliving the scratch fails to compile.

## Changes

- **`merge_consecutive_blocks`** — the scratch arena is created and dropped **within each call**, so all of its temporaries can live there: the fallthrough set, the merge map, and two local vecs.
- **`dominator`** — one scratch per `compute_post_dominator_tree` call backs the temporary reverse-graph `Node`/`Graph` and their sets/vecs. The escaping `PostDominator` and the `FxHashSet`-returning helpers stay on the heap.
- **`enter_ssa`** — here the scratch **spans the whole recursive traversal** and is not reset mid-pass, so it holds **only pass-lived state**: the `SSABuilder`/`State` fields (`states`, `unsealed_preds`, `block_preds` + its `Vec<BlockId>` values, `unknown`, `context`, `processed_functions`, `State.defs`/`incomplete_phis`). Per-call temporaries — predecessor clones, block/instruction/context worklists, the visited set — stay on the heap so each is freed when its call returns rather than accumulating (e.g. the `get_id_at` predecessor clone runs once per operand). `pending_phis` stays on the heap regardless (its `Phi` holds an insertion-ordered `FxIndexMap`, which has no arena form).

## Notes

- **Output is byte-identical** — all snapshot and transform tests pass unchanged (arena maps use the same `FxBuildHasher`, and no migrated collection is order-load-bearing).
- **No public API changes**, so downstream crates are untouched.
- `FxIndexMap`/`FxIndexSet`/`BTreeSet`-backed collections (order load-bearing, no arena form) and AST-arena HIR types are intentionally left as-is. `infer_mutation_aliasing_effects` was investigated and left unchanged: its hot per-block `InferenceState` transitively contains an `FxIndexSet<ValueReason>`, so it isn't arena-representable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
