### PR TITLE
fix(formatter): do not add extra parens with type cast comment

### DIFF
--- a/crates/oxc_formatter/src/ast_nodes/generated/format.rs
+++ b/crates/oxc_formatter/src/ast_nodes/generated/format.rs
@@ -13,7 +13,10 @@ use crate::{
     },
     parentheses::NeedsParentheses,
     print::{FormatFunctionOptions, FormatJsArrowFunctionExpressionOptions, FormatWrite},
-    utils::{suppressed::FormatSuppressedNode, typecast::format_type_cast_comment_node},
+    utils::{
+        suppressed::FormatSuppressedNode,
+        typecast::{format_leading_comments_and_open_paren, format_type_cast_comment_node},
+    },
 };
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Program<'a>> {
@@ -473,11 +476,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, IdentifierReference<'a>
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -522,11 +522,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ThisExpression> {
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -545,11 +542,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrayExpression<'a>> {
         if !is_suppressed && format_type_cast_comment_node(self, true, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -622,11 +616,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ObjectExpression<'a>> {
         if !is_suppressed && format_type_cast_comment_node(self, true, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -729,11 +720,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TemplateLiteral<'a>> {
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -752,11 +740,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TaggedTemplateExpressio
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -828,11 +813,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ComputedMemberExpressio
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -851,11 +833,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, StaticMemberExpression<
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -874,11 +853,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PrivateFieldExpression<
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -897,11 +873,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, CallExpression<'a>> {
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -920,11 +893,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NewExpression<'a>> {
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -943,11 +913,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, MetaProperty<'a>> {
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -1010,11 +977,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, UpdateExpression<'a>> {
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -1033,11 +997,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, UnaryExpression<'a>> {
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -1056,11 +1017,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BinaryExpression<'a>> {
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -1079,11 +1037,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PrivateInExpression<'a>
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -1102,11 +1057,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, LogicalExpression<'a>> 
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -1125,11 +1077,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ConditionalExpression<'
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -1148,11 +1097,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentExpression<'a
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -1443,11 +1389,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, SequenceExpression<'a>>
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -1466,11 +1409,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Super> {
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -1489,11 +1429,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AwaitExpression<'a>> {
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -1512,11 +1449,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ChainExpression<'a>> {
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -1576,11 +1510,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ParenthesizedExpression
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -2426,11 +2357,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Function<'a>> {
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -2449,11 +2377,8 @@ impl<'a> AstNode<'a, Function<'a>> {
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -2524,11 +2449,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrowFunctionExpression
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -2551,11 +2473,8 @@ impl<'a> AstNode<'a, ArrowFunctionExpression<'a>> {
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -2574,11 +2493,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, YieldExpression<'a>> {
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -2597,11 +2513,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Class<'a>> {
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -2828,11 +2741,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportExpression<'a>> {
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -3142,11 +3052,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, V8IntrinsicExpression<'
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -3165,11 +3072,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BooleanLiteral> {
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -3188,11 +3092,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NullLiteral> {
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -3211,11 +3112,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NumericLiteral<'a>> {
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -3234,11 +3132,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, StringLiteral<'a>> {
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -3257,11 +3152,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BigIntLiteral<'a>> {
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -3280,11 +3172,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, RegExpLiteral<'a>> {
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -4383,11 +4272,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSConditionalType<'a>> 
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -4429,11 +4315,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSIntersectionType<'a>>
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -4465,11 +4348,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeOperator<'a>> {
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -5252,11 +5132,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInferType<'a>> {
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -5275,11 +5152,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeQuery<'a>> {
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -5385,11 +5259,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSFunctionType<'a>> {
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -5408,11 +5279,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSConstructorType<'a>> 
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -5457,11 +5325,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSAsExpression<'a>> {
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -5480,11 +5345,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSSatisfiesExpression<'
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -5503,11 +5365,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeAssertion<'a>> {
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -5592,11 +5451,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNonNullExpression<'a>
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
@@ -5654,11 +5510,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInstantiationExpressi
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
-        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {

--- a/crates/oxc_formatter/src/print/arrow_function_expression.rs
+++ b/crates/oxc_formatter/src/print/arrow_function_expression.rs
@@ -13,7 +13,7 @@ use crate::{
     utils::{
         assignment_like::AssignmentLikeLayout, expression::ExpressionLeftSide,
         format_node_without_trailing_comments::FormatNodeWithoutTrailingComments,
-        suppressed::FormatSuppressedNode,
+        suppressed::FormatSuppressedNode, typecast::format_leading_comments_and_open_paren,
     },
     write,
 };
@@ -894,7 +894,7 @@ fn format_sequence_with_leading_comment<'a, 'b>(
     let is_suppressed = f.comments().is_suppressed(sequence_span.start);
 
     let format_sequence = format_with(move |f| {
-        write!(f, [format_leading_comments(sequence_span), "("]);
+        format_leading_comments_and_open_paren(sequence_span, true, f);
         if is_suppressed {
             write!(f, FormatSuppressedNode(sequence_span));
         } else {

--- a/crates/oxc_formatter/src/print/return_or_throw_statement.rs
+++ b/crates/oxc_formatter/src/print/return_or_throw_statement.rs
@@ -7,7 +7,10 @@ use crate::{
     format_args,
     formatter::prelude::*,
     print::{ExpressionLeftSide, semicolon::OptionalSemicolon},
-    utils::format_node_without_trailing_comments::format_content_without_comments_after,
+    utils::{
+        format_node_without_trailing_comments::format_content_without_comments_after,
+        typecast::format_leading_comments_and_open_paren,
+    },
     write,
 };
 
@@ -113,15 +116,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatAdjacentArgument<'a, '_> {
             // e.g. `return ( // comment\n a, b )` -> `return (\n  // comment\n  (a, b)\n)`
             let inner = format_with(|f| {
                 if matches!(argument.as_ref(), Expression::SequenceExpression(_)) {
-                    write!(
-                        f,
-                        [
-                            format_leading_comments(argument.span()),
-                            token("("),
-                            argument,
-                            token(")")
-                        ]
-                    );
+                    format_leading_comments_and_open_paren(argument.span(), true, f);
+                    write!(f, [argument, token(")")]);
                 } else {
                     write!(f, argument);
                 }

--- a/crates/oxc_formatter/src/utils/typecast.rs
+++ b/crates/oxc_formatter/src/utils/typecast.rs
@@ -1,9 +1,13 @@
 use oxc_ast::Comment;
-use oxc_span::GetSpan;
+use oxc_span::{GetSpan, Span};
 
 use crate::{
     Buffer, Format, format_args,
-    formatter::{JsFormatter, prelude::*, trivia::FormatLeadingComments},
+    formatter::{
+        JsFormatter,
+        prelude::*,
+        trivia::{FormatLeadingComments, format_leading_comments},
+    },
     write,
 };
 
@@ -122,6 +126,51 @@ pub fn format_type_cast_comment_node<'a>(
     }
 
     true
+}
+
+/// Prints a node's leading comments and the formatter-added `(` in the correct order.
+/// The caller prints the matching `)` when `needs_parentheses` is true.
+///
+/// When the leading comments end with a type cast comment whose cast binds to an
+/// inner expression (the `(` right after the comment closes before the end of the
+/// node; a cast applying to the node itself is already handled by
+/// [`format_type_cast_comment_node`]), printing the comments first would insert
+/// the added `(` between the comment and its cast target, rebinding the cast and
+/// changing the type semantics:
+/// `x ? y : /** @type {D} */ (a).b ?? c`
+/// must become `x ? y : (/** @type {D} */ (a).b ?? c)`,
+/// not `x ? y : /** @type {D} */ ((a).b ?? c)`.
+/// In that case the comments are printed inside the added parenthesis.
+pub fn format_leading_comments_and_open_paren(
+    span: Span,
+    needs_parentheses: bool,
+    f: &mut JsFormatter<'_, '_>,
+) {
+    if needs_parentheses {
+        let comments = f.context().comments().comments_before(span.start);
+        if let Some(last) = comments.last() {
+            let source = f.source_text();
+            if source.next_non_whitespace_byte_is(last.span.end, b'(')
+                && f.comments().is_type_cast_comment(last)
+                && has_closed_parentheses(source.bytes_range(last.span.end, span.end))
+            {
+                // Only the cast comment moves inside; earlier comments stay outside.
+                let split = comments.len() - 1;
+                write!(
+                    f,
+                    [
+                        FormatLeadingComments::Comments(&comments[..split]),
+                        "(",
+                        FormatLeadingComments::Comments(&comments[split..])
+                    ]
+                );
+                return;
+            }
+        }
+        write!(f, [format_leading_comments(span), "("]);
+    } else {
+        write!(f, format_leading_comments(span));
+    }
 }
 
 /// Check if the source text has properly closed parentheses starting with '('.

--- a/crates/oxc_formatter/tests/fixtures/js/comments/type-cast-comment-inside-added-parens.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/type-cast-comment-inside-added-parens.js
@@ -1,0 +1,42 @@
+// When the formatter adds parentheses around an expression whose
+// leading JSDoc type cast comment binds to an inner expression,
+// the comment must be printed inside the added parentheses;
+// printing it outside would rebind the cast to the added parentheses
+// and change the type semantics (issue #20182).
+//
+// NOTE: Prettier 3.9.5 prints the comment outside (and breaks the cast);
+
+// Cast binds to `(root)`; the `??` gets formatter-added parens in ternary branches.
+var target = /** @type {ShadowRoot} */ (root).host
+  ? /** @type {ShadowRoot} */ (root)
+  : /** @type {Document} */ (root).head ??
+    /** @type {Document} */ (root.ownerDocument).head;
+
+// The corrected form is a fixed point.
+var stable = x ? y : (/** @type {D} */ (b).head ?? c);
+
+// Object expression as cast target.
+var o = x ? y : /** @type {D} */ ({ a: 1 }).a ?? c;
+
+// Sequence expression keeps the cast on its first element.
+var p = (/** @type {D} */ (a), b);
+
+// Return argument.
+function w() {
+  return x ? y : /** @type {P} */ (a).b ?? c;
+}
+
+// A cast applying to the whole parenthesized expression still prints before its parens.
+var whole = x ? y : /** @type {D} */ (b.head ?? c);
+
+// Hand-written paren sites follow the same rule:
+// arrow body sequence with a leading cast comment,
+const arrow = () => (/** @type {D} */ (a).b, x);
+
+// and return argument sequence; only the cast comment moves inside the added parens.
+function ret() {
+  return (
+    // c
+    /** @type {D} */ (a).b, x
+  );
+}

--- a/crates/oxc_formatter/tests/fixtures/js/comments/type-cast-comment-inside-added-parens.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/type-cast-comment-inside-added-parens.js.snap
@@ -1,0 +1,142 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// When the formatter adds parentheses around an expression whose
+// leading JSDoc type cast comment binds to an inner expression,
+// the comment must be printed inside the added parentheses;
+// printing it outside would rebind the cast to the added parentheses
+// and change the type semantics (issue #20182).
+//
+// NOTE: Prettier 3.9.5 prints the comment outside (and breaks the cast);
+
+// Cast binds to `(root)`; the `??` gets formatter-added parens in ternary branches.
+var target = /** @type {ShadowRoot} */ (root).host
+  ? /** @type {ShadowRoot} */ (root)
+  : /** @type {Document} */ (root).head ??
+    /** @type {Document} */ (root.ownerDocument).head;
+
+// The corrected form is a fixed point.
+var stable = x ? y : (/** @type {D} */ (b).head ?? c);
+
+// Object expression as cast target.
+var o = x ? y : /** @type {D} */ ({ a: 1 }).a ?? c;
+
+// Sequence expression keeps the cast on its first element.
+var p = (/** @type {D} */ (a), b);
+
+// Return argument.
+function w() {
+  return x ? y : /** @type {P} */ (a).b ?? c;
+}
+
+// A cast applying to the whole parenthesized expression still prints before its parens.
+var whole = x ? y : /** @type {D} */ (b.head ?? c);
+
+// Hand-written paren sites follow the same rule:
+// arrow body sequence with a leading cast comment,
+const arrow = () => (/** @type {D} */ (a).b, x);
+
+// and return argument sequence; only the cast comment moves inside the added parens.
+function ret() {
+  return (
+    // c
+    /** @type {D} */ (a).b, x
+  );
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// When the formatter adds parentheses around an expression whose
+// leading JSDoc type cast comment binds to an inner expression,
+// the comment must be printed inside the added parentheses;
+// printing it outside would rebind the cast to the added parentheses
+// and change the type semantics (issue #20182).
+//
+// NOTE: Prettier 3.9.5 prints the comment outside (and breaks the cast);
+
+// Cast binds to `(root)`; the `??` gets formatter-added parens in ternary branches.
+var target = /** @type {ShadowRoot} */ (root).host
+  ? /** @type {ShadowRoot} */ (root)
+  : (/** @type {Document} */ (root).head ??
+    /** @type {Document} */ (root.ownerDocument).head);
+
+// The corrected form is a fixed point.
+var stable = x ? y : (/** @type {D} */ (b).head ?? c);
+
+// Object expression as cast target.
+var o = x ? y : (/** @type {D} */ ({ a: 1 }).a ?? c);
+
+// Sequence expression keeps the cast on its first element.
+var p = (/** @type {D} */ (a), b);
+
+// Return argument.
+function w() {
+  return x ? y : (/** @type {P} */ (a).b ?? c);
+}
+
+// A cast applying to the whole parenthesized expression still prints before its parens.
+var whole = x ? y : /** @type {D} */ (b.head ?? c);
+
+// Hand-written paren sites follow the same rule:
+// arrow body sequence with a leading cast comment,
+const arrow = () =>
+  (/** @type {D} */ (a).b, x);
+
+// and return argument sequence; only the cast comment moves inside the added parens.
+function ret() {
+  return (
+    // c
+    (/** @type {D} */ (a).b, x)
+  );
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// When the formatter adds parentheses around an expression whose
+// leading JSDoc type cast comment binds to an inner expression,
+// the comment must be printed inside the added parentheses;
+// printing it outside would rebind the cast to the added parentheses
+// and change the type semantics (issue #20182).
+//
+// NOTE: Prettier 3.9.5 prints the comment outside (and breaks the cast);
+
+// Cast binds to `(root)`; the `??` gets formatter-added parens in ternary branches.
+var target = /** @type {ShadowRoot} */ (root).host
+  ? /** @type {ShadowRoot} */ (root)
+  : (/** @type {Document} */ (root).head ?? /** @type {Document} */ (root.ownerDocument).head);
+
+// The corrected form is a fixed point.
+var stable = x ? y : (/** @type {D} */ (b).head ?? c);
+
+// Object expression as cast target.
+var o = x ? y : (/** @type {D} */ ({ a: 1 }).a ?? c);
+
+// Sequence expression keeps the cast on its first element.
+var p = (/** @type {D} */ (a), b);
+
+// Return argument.
+function w() {
+  return x ? y : (/** @type {P} */ (a).b ?? c);
+}
+
+// A cast applying to the whole parenthesized expression still prints before its parens.
+var whole = x ? y : /** @type {D} */ (b.head ?? c);
+
+// Hand-written paren sites follow the same rule:
+// arrow body sequence with a leading cast comment,
+const arrow = () =>
+  (/** @type {D} */ (a).b, x);
+
+// and return argument sequence; only the cast comment moves inside the added parens.
+function ret() {
+  return (
+    // c
+    (/** @type {D} */ (a).b, x)
+  );
+}
+
+===================== End =====================

--- a/tasks/ast_tools/src/generators/formatter/format.rs
+++ b/tasks/ast_tools/src/generators/formatter/format.rs
@@ -104,7 +104,7 @@ impl Generator for FormatterFormatGenerator {
                 formatter::{Format, JsFormatContext, JsFormatter, JsFormatterExt as _, trivia::{format_leading_comments, format_trailing_comments}},
                 parentheses::NeedsParentheses,
                 ast_nodes::AstNode,
-                utils::{suppressed::FormatSuppressedNode, typecast::format_type_cast_comment_node},
+                utils::{suppressed::FormatSuppressedNode, typecast::{format_type_cast_comment_node, format_leading_comments_and_open_paren}},
                 print::{FormatWrite #(#options)*},
             };
 
@@ -130,7 +130,12 @@ fn generate_struct_implementation(
     let do_not_print_leading_comment = do_not_print_comment
         || AST_NODE_WITHOUT_PRINTING_LEADING_COMMENTS_LIST.contains(&struct_name);
 
-    let leading_comments = (!do_not_print_leading_comment).then(|| {
+    let needs_parentheses = parenthesis_type_ids.contains(&struct_def.id);
+
+    // For nodes that may get formatter-added parentheses,
+    // leading comments are printed by the parentheses block below (ordering depends on the comments),
+    // not as a standalone step.
+    let leading_comments = (!do_not_print_leading_comment && !needs_parentheses).then(|| {
         quote! {
             self.format_leading_comments(f);
         }
@@ -141,13 +146,21 @@ fn generate_struct_implementation(
         }
     });
 
-    let needs_parentheses = parenthesis_type_ids.contains(&struct_def.id);
-
     let needs_parentheses_before = if needs_parentheses {
-        quote! {
-            let needs_parentheses = self.needs_parentheses(f);
-            if needs_parentheses {
-                "(".fmt(f);
+        if do_not_print_leading_comment {
+            quote! {
+                let needs_parentheses = self.needs_parentheses(f);
+                if needs_parentheses {
+                    "(".fmt(f);
+                }
+            }
+        } else {
+            // A leading type cast comment must stay adjacent to the `(` of its cast target inside this node;
+            // the helper prints the comments inside the added parentheses in that case,
+            // or the cast would rebind to them.
+            quote! {
+                let needs_parentheses = self.needs_parentheses(f);
+                format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
             }
         }
     } else {
@@ -216,7 +229,7 @@ fn generate_struct_implementation(
             }
         };
 
-        let type_cast_comment_formatting = parenthesis_type_ids.contains(&struct_def.id).then(|| {
+        let type_cast_comment_formatting = needs_parentheses.then(|| {
             let is_object_or_array_argument =
                 if matches!(struct_def.name.as_str(), "ObjectExpression" | "ArrayExpression") {
                     quote! {
@@ -239,7 +252,7 @@ fn generate_struct_implementation(
             }
         });
 
-        if needs_parentheses_before.is_empty() && trailing_comments.is_none() {
+        if !needs_parentheses && trailing_comments.is_none() {
             quote! {
                 #suppressed_check
                 #type_cast_comment_formatting


### PR DESCRIPTION
Fixes #20182
