### PR TITLE
refactor(formatter): unify type cast binding classification into `TypeCast` enum

### DIFF
--- a/crates/oxc_formatter/src/formatter/comments.rs
+++ b/crates/oxc_formatter/src/formatter/comments.rs
@@ -549,28 +549,32 @@ impl<'a> Comments<'a> {
         false
     }
 
+    /// Checks if a comment forms the type cast pattern:
+    /// a type cast comment immediately followed by an opening parenthesis.
+    pub fn is_type_cast_comment_followed_by_paren(&self, comment: &Comment) -> bool {
+        self.source_text.next_non_whitespace_byte_is(comment.span.end, b'(')
+            && self.is_type_cast_comment(comment)
+    }
+
     /// Finds the index of a type cast comment before the given span.
     ///
     /// Searches for a JSDoc comment containing @type or @satisfies that is followed
     /// by an opening parenthesis, which indicates a type cast pattern.
     pub fn get_type_cast_comment_index(&self, span: Span) -> Option<usize> {
-        self.unprinted_comments().iter().take_while(|c| c.span.end <= span.start).position(
-            |comment| {
-                self.source_text.next_non_whitespace_byte_is(comment.span.end, b'(')
-                    && self.is_type_cast_comment(comment)
-            },
-        )
+        self.unprinted_comments()
+            .iter()
+            .take_while(|c| c.span.end <= span.start)
+            .position(|comment| self.is_type_cast_comment_followed_by_paren(comment))
     }
 
     /// Checks if there is a type cast comment in the given range,
     /// searching all comments regardless of print state.
     pub fn has_type_cast_comment_in_range(&self, start: u32, end: u32) -> bool {
-        self.inner.iter().skip_while(|c| c.span.end < start).take_while(|c| c.span.end <= end).any(
-            |comment| {
-                self.source_text.next_non_whitespace_byte_is(comment.span.end, b'(')
-                    && self.is_type_cast_comment(comment)
-            },
-        )
+        self.inner
+            .iter()
+            .skip_while(|c| c.span.end < start)
+            .take_while(|c| c.span.end <= end)
+            .any(|comment| self.is_type_cast_comment_followed_by_paren(comment))
     }
 
     /// Marks the given span as a type cast node.
@@ -584,8 +588,11 @@ impl<'a> Comments<'a> {
         self.printed_count == self.last_handled_type_cast_comment
     }
 
+    /// Checks if the node is the one currently being formatted as a cast target
+    /// (the read side of [`Comments::mark_as_type_cast_node`];
+    /// not the source-based classification, see `classify_type_cast`).
     #[inline]
-    pub fn is_type_cast_node(&self, node: &impl GetSpan) -> bool {
+    pub fn is_marked_as_type_cast_node(&self, node: &impl GetSpan) -> bool {
         self.type_cast_node_span == node.span()
     }
 

--- a/crates/oxc_formatter/src/parentheses/expression.rs
+++ b/crates/oxc_formatter/src/parentheses/expression.rs
@@ -68,7 +68,7 @@ impl NeedsParentheses<'_> for AstNode<'_, Expression<'_>> {
 
 impl NeedsParentheses<'_> for AstNode<'_, IdentifierReference<'_>> {
     fn needs_parentheses(&self, f: &JsFormatter<'_, '_>) -> bool {
-        if f.comments().is_type_cast_node(self) {
+        if f.comments().is_marked_as_type_cast_node(self) {
             return false;
         }
 
@@ -221,7 +221,7 @@ impl NeedsParentheses<'_> for AstNode<'_, Super> {
 
 impl NeedsParentheses<'_> for AstNode<'_, NumericLiteral<'_>> {
     fn needs_parentheses(&self, f: &JsFormatter<'_, '_>) -> bool {
-        if f.comments().is_type_cast_node(self) {
+        if f.comments().is_marked_as_type_cast_node(self) {
             return false;
         }
 
@@ -234,7 +234,7 @@ impl NeedsParentheses<'_> for AstNode<'_, NumericLiteral<'_>> {
 
 impl NeedsParentheses<'_> for AstNode<'_, StringLiteral<'_>> {
     fn needs_parentheses(&self, f: &JsFormatter<'_, '_>) -> bool {
-        if f.comments().is_type_cast_node(self) {
+        if f.comments().is_marked_as_type_cast_node(self) {
             return false;
         }
 
@@ -276,7 +276,7 @@ impl NeedsParentheses<'_> for AstNode<'_, ArrayExpression<'_>> {
 
 impl NeedsParentheses<'_> for AstNode<'_, ObjectExpression<'_>> {
     fn needs_parentheses(&self, f: &JsFormatter<'_, '_>) -> bool {
-        if f.comments().is_type_cast_node(self) {
+        if f.comments().is_marked_as_type_cast_node(self) {
             return false;
         }
 
@@ -324,7 +324,7 @@ impl NeedsParentheses<'_> for AstNode<'_, ComputedMemberExpression<'_>> {
 
 impl NeedsParentheses<'_> for AstNode<'_, StaticMemberExpression<'_>> {
     fn needs_parentheses(&self, f: &JsFormatter<'_, '_>) -> bool {
-        if f.comments().is_type_cast_node(self) {
+        if f.comments().is_marked_as_type_cast_node(self) {
             return false;
         }
 
@@ -341,7 +341,7 @@ impl NeedsParentheses<'_> for AstNode<'_, PrivateFieldExpression<'_>> {
 
 impl NeedsParentheses<'_> for AstNode<'_, CallExpression<'_>> {
     fn needs_parentheses(&self, f: &JsFormatter<'_, '_>) -> bool {
-        if f.comments().is_type_cast_node(self) {
+        if f.comments().is_marked_as_type_cast_node(self) {
             return false;
         }
 
@@ -365,7 +365,7 @@ impl NeedsParentheses<'_> for AstNode<'_, CallExpression<'_>> {
 
 impl NeedsParentheses<'_> for AstNode<'_, NewExpression<'_>> {
     fn needs_parentheses(&self, f: &JsFormatter<'_, '_>) -> bool {
-        if f.comments().is_type_cast_node(self) {
+        if f.comments().is_marked_as_type_cast_node(self) {
             return false;
         }
 
@@ -375,7 +375,7 @@ impl NeedsParentheses<'_> for AstNode<'_, NewExpression<'_>> {
 
 impl NeedsParentheses<'_> for AstNode<'_, UpdateExpression<'_>> {
     fn needs_parentheses(&self, f: &JsFormatter<'_, '_>) -> bool {
-        if f.comments().is_type_cast_node(self) {
+        if f.comments().is_marked_as_type_cast_node(self) {
             return false;
         }
 
@@ -396,7 +396,7 @@ impl NeedsParentheses<'_> for AstNode<'_, UpdateExpression<'_>> {
 
 impl NeedsParentheses<'_> for AstNode<'_, UnaryExpression<'_>> {
     fn needs_parentheses(&self, f: &JsFormatter<'_, '_>) -> bool {
-        if f.comments().is_type_cast_node(self) {
+        if f.comments().is_marked_as_type_cast_node(self) {
             return false;
         }
 
@@ -420,7 +420,7 @@ impl NeedsParentheses<'_> for AstNode<'_, UnaryExpression<'_>> {
 
 impl NeedsParentheses<'_> for AstNode<'_, BinaryExpression<'_>> {
     fn needs_parentheses(&self, f: &JsFormatter<'_, '_>) -> bool {
-        if f.comments().is_type_cast_node(self) {
+        if f.comments().is_marked_as_type_cast_node(self) {
             return false;
         }
 
@@ -508,7 +508,7 @@ fn is_for_in_statement_init<T: GetSpan>(node: &T, parent: &AstNodes<'_>) -> bool
 impl NeedsParentheses<'_> for AstNode<'_, PrivateInExpression<'_>> {
     #[inline]
     fn needs_parentheses(&self, f: &JsFormatter<'_, '_>) -> bool {
-        if f.comments().is_type_cast_node(self) {
+        if f.comments().is_marked_as_type_cast_node(self) {
             return false;
         }
 
@@ -519,7 +519,7 @@ impl NeedsParentheses<'_> for AstNode<'_, PrivateInExpression<'_>> {
 
 impl NeedsParentheses<'_> for AstNode<'_, LogicalExpression<'_>> {
     fn needs_parentheses(&self, f: &JsFormatter<'_, '_>) -> bool {
-        if f.comments().is_type_cast_node(self) {
+        if f.comments().is_marked_as_type_cast_node(self) {
             return false;
         }
 
@@ -545,7 +545,7 @@ impl NeedsParentheses<'_> for AstNode<'_, LogicalExpression<'_>> {
 
 impl NeedsParentheses<'_> for AstNode<'_, ConditionalExpression<'_>> {
     fn needs_parentheses(&self, f: &JsFormatter<'_, '_>) -> bool {
-        if f.comments().is_type_cast_node(self) {
+        if f.comments().is_marked_as_type_cast_node(self) {
             return false;
         }
 
@@ -578,7 +578,7 @@ impl NeedsParentheses<'_> for AstNode<'_, Function<'_>> {
             return false;
         }
 
-        if f.comments().is_type_cast_node(self) {
+        if f.comments().is_marked_as_type_cast_node(self) {
             return false;
         }
 
@@ -602,7 +602,7 @@ impl NeedsParentheses<'_> for AstNode<'_, Function<'_>> {
 
 impl NeedsParentheses<'_> for AstNode<'_, AssignmentExpression<'_>> {
     fn needs_parentheses(&self, f: &JsFormatter<'_, '_>) -> bool {
-        if f.comments().is_type_cast_node(self) {
+        if f.comments().is_marked_as_type_cast_node(self) {
             return false;
         }
 
@@ -681,7 +681,7 @@ impl NeedsParentheses<'_> for AstNode<'_, AssignmentExpression<'_>> {
 
 impl NeedsParentheses<'_> for AstNode<'_, SequenceExpression<'_>> {
     fn needs_parentheses(&self, f: &JsFormatter<'_, '_>) -> bool {
-        if f.comments().is_type_cast_node(self) {
+        if f.comments().is_marked_as_type_cast_node(self) {
             return false;
         }
 
@@ -698,7 +698,7 @@ impl NeedsParentheses<'_> for AstNode<'_, SequenceExpression<'_>> {
 
 impl NeedsParentheses<'_> for AstNode<'_, AwaitExpression<'_>> {
     fn needs_parentheses(&self, f: &JsFormatter<'_, '_>) -> bool {
-        if f.comments().is_type_cast_node(self) {
+        if f.comments().is_marked_as_type_cast_node(self) {
             return false;
         }
 
@@ -708,7 +708,7 @@ impl NeedsParentheses<'_> for AstNode<'_, AwaitExpression<'_>> {
 
 impl NeedsParentheses<'_> for AstNode<'_, ChainExpression<'_>> {
     fn needs_parentheses(&self, f: &JsFormatter<'_, '_>) -> bool {
-        if f.comments().is_type_cast_node(self) {
+        if f.comments().is_marked_as_type_cast_node(self) {
             return false;
         }
         // Check if chain expression needs parens based on how it's being accessed
@@ -744,7 +744,7 @@ impl NeedsParentheses<'_> for AstNode<'_, Class<'_>> {
             return false;
         }
 
-        if f.comments().is_type_cast_node(self) {
+        if f.comments().is_marked_as_type_cast_node(self) {
             return false;
         }
 
@@ -775,7 +775,7 @@ impl NeedsParentheses<'_> for AstNode<'_, ParenthesizedExpression<'_>> {
 
 impl NeedsParentheses<'_> for AstNode<'_, ArrowFunctionExpression<'_>> {
     fn needs_parentheses(&self, f: &JsFormatter<'_, '_>) -> bool {
-        if f.comments().is_type_cast_node(self) {
+        if f.comments().is_marked_as_type_cast_node(self) {
             return false;
         }
 
@@ -810,7 +810,7 @@ impl NeedsParentheses<'_> for AstNode<'_, ArrowFunctionExpression<'_>> {
 
 impl NeedsParentheses<'_> for AstNode<'_, YieldExpression<'_>> {
     fn needs_parentheses(&self, f: &JsFormatter<'_, '_>) -> bool {
-        if f.comments().is_type_cast_node(self) {
+        if f.comments().is_marked_as_type_cast_node(self) {
             return false;
         }
 
@@ -822,7 +822,7 @@ impl NeedsParentheses<'_> for AstNode<'_, YieldExpression<'_>> {
 
 impl NeedsParentheses<'_> for AstNode<'_, ImportExpression<'_>> {
     fn needs_parentheses(&self, f: &JsFormatter<'_, '_>) -> bool {
-        if f.comments().is_type_cast_node(self) {
+        if f.comments().is_marked_as_type_cast_node(self) {
             return false;
         }
 
@@ -1278,7 +1278,7 @@ fn jsx_element_or_fragment_needs_paren(span: Span, parent: &AstNodes<'_>) -> boo
 
 impl NeedsParentheses<'_> for AstNode<'_, JSXElement<'_>> {
     fn needs_parentheses(&self, f: &JsFormatter<'_, '_>) -> bool {
-        if f.comments().is_type_cast_node(self) {
+        if f.comments().is_marked_as_type_cast_node(self) {
             return false;
         }
 
@@ -1288,7 +1288,7 @@ impl NeedsParentheses<'_> for AstNode<'_, JSXElement<'_>> {
 
 impl NeedsParentheses<'_> for AstNode<'_, JSXFragment<'_>> {
     fn needs_parentheses(&self, f: &JsFormatter<'_, '_>) -> bool {
-        if f.comments().is_type_cast_node(self) {
+        if f.comments().is_marked_as_type_cast_node(self) {
             return false;
         }
 

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -79,7 +79,7 @@ use crate::{
         string::{FormatLiteralStringToken, StringLiteralParentKind},
         suppressed::FormatSuppressedNode,
         tailwindcss::{tailwind_context_for_string_literal, write_tailwind_string_literal},
-        typecast::is_type_cast_node,
+        typecast::classify_type_cast,
     },
     write,
 };
@@ -543,7 +543,7 @@ fn expression_statement_needs_semicolon<'a>(
                 // so the line starts with `(` even though `needs_parentheses` is false:
                 // `/** @type {string} */ (this.s).length`
                 // Checked last: this scans source text/comments, unlike the checks above.
-                || is_type_cast_node(expr, f).is_some()
+                || classify_type_cast(expr.span(), f).is_target()
         }
         ExpressionLeftSide::AssignmentTarget(assignment) => {
             matches!(

--- a/crates/oxc_formatter/src/utils/member_chain/mod.rs
+++ b/crates/oxc_formatter/src/utils/member_chain/mod.rs
@@ -23,7 +23,7 @@ use crate::{
 use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 
-use super::typecast::is_type_cast_node;
+use super::typecast::classify_type_cast;
 
 #[derive(Debug)]
 pub struct MemberChain<'a, 'b> {
@@ -435,7 +435,7 @@ fn chain_members_iter<'a, 'b>(
 
         let expression = next.take()?;
 
-        if is_type_cast_node(expression, f).is_some() {
+        if classify_type_cast(expression.span(), f).is_target() {
             return ChainMember::Node(expression).into();
         }
 

--- a/crates/oxc_formatter/src/utils/typecast.rs
+++ b/crates/oxc_formatter/src/utils/typecast.rs
@@ -11,102 +11,117 @@ use crate::{
     write,
 };
 
-/// Checks if a node is a type cast node and returns the comments to be printed.
+/// How a JSDoc type cast comment relates to a node.
 ///
-/// This function detects if a node is part of a TypeScript type cast pattern
-/// by checking for JSDoc type cast comments and proper parenthesis structure.
-///
-/// Returns:
-/// - `Some(&[])` if the node is a type cast node but no comments need to be printed
-/// - `Some(&[Comment, ...])` if the node is a type cast node with comments to print
-/// - `None` if the node is not a type cast node
-pub fn is_type_cast_node<'a>(
-    node: &impl GetSpan,
-    f: &JsFormatter<'_, 'a>,
-) -> Option<&'a [Comment]> {
-    let comments = f.context().comments();
-    let span = node.span();
-    let source = f.source_text();
+/// A cast is a `/** @type */`-like comment immediately followed by a
+/// parenthesized expression; where that parenthesis closes decides the binding.
+pub enum TypeCast<'a> {
+    /// The node itself is the cast target
+    /// (the parenthesis right after the comment closes right after the node):
+    /// ```js
+    /// /** @type {string} */ (value).length
+    ///                        ^^^^^ Target
+    /// /** @type {Document} */ (root.head ?? fallback)
+    ///                          ^^^^^^^^^^^^^^^^^^^^^ Target
+    /// ```
+    /// The slice holds the comments still to be printed;
+    /// it is empty when the cast comment was already printed
+    /// (re-entry from [`format_type_cast_comment_node`], or printed by an ancestor).
+    Target(&'a [Comment]),
+    /// The node's unprinted leading comments end with a cast comment that binds
+    /// to an inner expression (its parenthesis closes before the node ends):
+    /// ```js
+    /// /** @type {Number} */ (bar).zoo
+    ///                       ^^^^^^^^^ BindsInner (the member expression)
+    ///                       ^^^^^ the cast target is inside it
+    /// x ? y : /** @type {D} */ (a).b ?? c
+    ///                          ^^^^^^^^^^ BindsInner (the `??` expression)
+    /// ```
+    /// Formatter-added parentheses around the node must not separate the
+    /// comment from its target (see [`format_leading_comments_and_open_paren`]).
+    /// The slice holds the node's leading comments, ending with the cast comment.
+    BindsInner(&'a [Comment]),
+    /// No cast is involved with this node:
+    /// no adjacent cast comment, a cast-shaped comment without following `(`
+    /// (`/** @type {N} */ value`), or an already-printed cast settled at an
+    /// inner level (`.zoo` in the `BindsInner` example above, once the comment is printed).
+    None,
+}
 
-    // Check if there's a closing parenthesis after the node (possibly after comments)
-    if !source.next_non_whitespace_byte_is(span.end, b')') {
-        let comments_after_node = comments.comments_after(span.end);
-        let mut start = span.end;
-        // Skip comments after the node to find the next non-whitespace byte whether it's a `)`
-        for comment in comments_after_node {
-            if !source.bytes_range(start, comment.span.start).trim_ascii_start().is_empty() {
-                break;
-            }
-            start = comment.span.end;
-        }
-        // Still not a `)`, return early because it's not a type cast
-        if !source.next_non_whitespace_byte_is(start, b')') {
-            return None;
-        }
-    }
-
-    // Check for type cast comment in printed or unprinted comments
-    if !comments.is_handled_type_cast_comment()
-        && let Some(last_printed_comment) = comments.printed_comments().last()
-        && last_printed_comment.span.end <= span.start
-        && source.next_non_whitespace_byte_is(last_printed_comment.span.end, b'(')
-        && f.comments().is_type_cast_comment(last_printed_comment)
-    {
-        // Get the source text from the end of type cast comment to the node span
-        let node_source_text = source.bytes_range(last_printed_comment.span.end, span.end);
-
-        // `(/** @type {Number} */ (bar).zoo)`
-        //                         ^^^^
-        // Should wrap for `baz` rather than `baz.zoo`
-        if has_closed_parentheses(node_source_text) {
-            None
-        } else {
-            // Type cast node, but comment was already printed
-            Some(&[])
-        }
-    } else if let Some(type_cast_comment_index) = comments.get_type_cast_comment_index(span) {
-        let comments = f.context().comments().unprinted_comments();
-        let type_cast_comment = &comments[type_cast_comment_index];
-
-        // Get the source text from the end of type cast comment to the node span
-        let node_source_text = source.bytes_range(type_cast_comment.span.end, span.end);
-
-        // `(/** @type {Number} */ (bar).zoo)`
-        //                         ^^^^
-        // Should wrap for `baz` rather than `baz.zoo`
-        if has_closed_parentheses(node_source_text) {
-            None
-        } else {
-            // Type cast node with comments to print
-            Some(&comments[..=type_cast_comment_index])
-        }
-    } else {
-        // No typecast comment
-        None
+impl TypeCast<'_> {
+    pub fn is_target(&self) -> bool {
+        matches!(self, TypeCast::Target(_))
     }
 }
 
-/// Formats a node with TypeScript type cast comments if present.
+/// Classifies how a type cast comment relates to the node at `span`.
+/// This is the single source of truth for cast binding;
+/// both [`format_type_cast_comment_node`] and [`format_leading_comments_and_open_paren`] consume it.
+pub fn classify_type_cast<'a>(span: Span, f: &JsFormatter<'_, 'a>) -> TypeCast<'a> {
+    let comments = f.context().comments();
+    let source = f.source_text();
+
+    // The cast comment may already be printed:
+    // by the re-entry from `format_type_cast_comment_node`,
+    // or as the leading comment of an ancestor starting at the same position.
+    if !comments.is_handled_type_cast_comment()
+        && let Some(last_printed_comment) = comments.printed_comments().last()
+        && last_printed_comment.span.end <= span.start
+        && comments.is_type_cast_comment_followed_by_paren(last_printed_comment)
+    {
+        // Cheap gate first: a cast target must be followed by `)`.
+        // Every node formatted after a printed cast comment re-enters this branch
+        // (e.g. each member chain link), and `has_closed_parentheses` scans the source up to the node end.
+        return if !is_followed_by_closing_paren(span, f) {
+            TypeCast::None
+        } else if has_closed_parentheses(
+            source.bytes_range(last_printed_comment.span.end, span.end),
+        ) {
+            // The cast binds to an inner node; since the comment is already printed,
+            // there is nothing left to keep adjacent at this level.
+            TypeCast::None
+        } else {
+            TypeCast::Target(&[])
+        };
+    }
+
+    if let Some(type_cast_comment_index) = comments.get_type_cast_comment_index(span) {
+        let unprinted_comments = comments.unprinted_comments();
+        let type_cast_comment = &unprinted_comments[type_cast_comment_index];
+
+        return if has_closed_parentheses(source.bytes_range(type_cast_comment.span.end, span.end)) {
+            TypeCast::BindsInner(&unprinted_comments[..=type_cast_comment_index])
+        } else if is_followed_by_closing_paren(span, f) {
+            TypeCast::Target(&unprinted_comments[..=type_cast_comment_index])
+        } else {
+            TypeCast::None
+        };
+    }
+
+    TypeCast::None
+}
+
+/// Whether the next non-whitespace byte after the node (skipping comments adjacent to it) is `)`.
+/// i.e. source parentheses close right after the node, as a cast target requires.
+fn is_followed_by_closing_paren(span: Span, f: &JsFormatter<'_, '_>) -> bool {
+    f.source_text().next_non_whitespace_byte_is(span.end, b')')
+        || f.context().comments().comments_before_closing_paren(span.end).is_some()
+}
+
+/// Formats a node that is the target of a JSDoc type cast (see [`TypeCast::Target`]):
+/// prints the pending cast comments, marks the node
+/// (so `NeedsParentheses` rules skip their own parentheses), and wraps it in parentheses,
+/// like `/** @type {string} */ (value)` or `/** @type {number} */ ((expression))`.
 ///
-/// This function handles the formatting of JSDoc type cast comments that appear
-/// immediately before parenthesized expressions, creating patterns like:
-/// `(/** @type {string} */ value)` or `(/** @type {number} */ (expression))`
-///
-/// The function:
-/// 1. Checks if there's a closing parenthesis after the node (indicating a type cast)
-/// 2. Looks for associated type cast comments that precede the node
-/// 3. Wraps the node in parentheses with proper formatting and indentation
-/// 4. Handles both object/array expressions and other expression types differently
-///
-/// Returns `Ok(true)` if the node was formatted as a type cast, `Ok(false)` otherwise.
-/// This allows callers to know whether they need to apply their own formatting.
+/// Returns `true` if the node was formatted as a cast target, `false` otherwise;
+/// callers apply their own formatting on `false`.
 pub fn format_type_cast_comment_node<'a>(
     node: &(impl Format<'a, JsFormatContext<'a>> + GetSpan),
     is_object_or_array_expression: bool,
     f: &mut JsFormatter<'_, 'a>,
 ) -> bool {
-    // Check if this is a type cast node and get the comments to print
-    let Some(type_cast_comments) = is_type_cast_node(node, f) else {
+    // Check if this node is a cast target and get the comments to print
+    let TypeCast::Target(type_cast_comments) = classify_type_cast(node.span(), f) else {
         return false;
     };
 
@@ -131,43 +146,42 @@ pub fn format_type_cast_comment_node<'a>(
 /// Prints a node's leading comments and the formatter-added `(` in the correct order.
 /// The caller prints the matching `)` when `needs_parentheses` is true.
 ///
-/// When the leading comments end with a type cast comment whose cast binds to an
-/// inner expression (the `(` right after the comment closes before the end of the
-/// node; a cast applying to the node itself is already handled by
-/// [`format_type_cast_comment_node`]), printing the comments first would insert
-/// the added `(` between the comment and its cast target, rebinding the cast and
-/// changing the type semantics:
-/// `x ? y : /** @type {D} */ (a).b ?? c`
-/// must become `x ? y : (/** @type {D} */ (a).b ?? c)`,
-/// not `x ? y : /** @type {D} */ ((a).b ?? c)`.
-/// In that case the comments are printed inside the added parenthesis.
+/// When the leading comments end with a cast comment binding into the node (see [`TypeCast::BindsInner`]),
+/// printing them all first would insert the added `(` between the comment and its cast target,
+/// rebinding the cast and changing the type semantics:
+/// ```js
+/// x ? y : /** @type {D} */ (a).b ?? c
+/// ```
+/// must become:
+/// ```js
+/// x ? y : (/** @type {D} */ (a).b ?? c)
+/// ```
+/// Not
+/// ```js
+/// x ? y : /** @type {D} */ ((a).b ?? c)
+/// ```
+/// So the cast comment is printed inside the added parenthesis.
 pub fn format_leading_comments_and_open_paren(
     span: Span,
     needs_parentheses: bool,
     f: &mut JsFormatter<'_, '_>,
 ) {
     if needs_parentheses {
-        let comments = f.context().comments().comments_before(span.start);
-        if let Some(last) = comments.last() {
-            let source = f.source_text();
-            if source.next_non_whitespace_byte_is(last.span.end, b'(')
-                && f.comments().is_type_cast_comment(last)
-                && has_closed_parentheses(source.bytes_range(last.span.end, span.end))
-            {
-                // Only the cast comment moves inside; earlier comments stay outside.
-                let split = comments.len() - 1;
-                write!(
-                    f,
-                    [
-                        FormatLeadingComments::Comments(&comments[..split]),
-                        "(",
-                        FormatLeadingComments::Comments(&comments[split..])
-                    ]
-                );
-                return;
-            }
+        if let TypeCast::BindsInner(comments) = classify_type_cast(span, f)
+            && let Some((cast_comment, rest)) = comments.split_last()
+        {
+            // Only the cast comment moves inside; earlier comments stay outside.
+            write!(
+                f,
+                [
+                    FormatLeadingComments::Comments(rest),
+                    "(",
+                    FormatLeadingComments::Comments(std::slice::from_ref(cast_comment))
+                ]
+            );
+        } else {
+            write!(f, [format_leading_comments(span), "("]);
         }
-        write!(f, [format_leading_comments(span), "("]);
     } else {
         write!(f, format_leading_comments(span));
     }
@@ -175,6 +189,19 @@ pub fn format_leading_comments_and_open_paren(
 
 /// Check if the source text has properly closed parentheses starting with '('.
 /// Returns true if the text starts with '(' and all parentheses are balanced.
+///
+/// NOTE: This lexical scan skips strings and comments but NOT regex literals,
+/// so a `)` byte inside a regex (`/\)/`, `/[)]/`) is miscounted as a closing parenthesis
+/// and the cast target is misidentified:
+/// `/** @type {D} */ (s.replace(/\)/g, ""))` loses its cast parentheses.
+///
+/// This interior scan can be replaced by a span-based check with
+/// no scanning of expression bytes at all: even with `preserve_parens: false`,
+/// the parser excludes a node's own wrapping parentheses from its span
+/// but includes a leftmost descendant's parentheses (`(a).b ?? c` spans from `(`).
+/// So: span starts at the `(` right after the cast comment → the cast binds inner;
+/// the gap between the comment and span start holds only `(`s/trivia (and the node is followed by `)`)
+/// → the node is the cast target.
 fn has_closed_parentheses(source: &[u8]) -> bool {
     let mut paren_count = 0i32;
     let mut i = 0;


### PR DESCRIPTION
Use `TypeCast` enum for SoT to handle JSDoc type-cast and parens printing.