### PR TITLE
refactor(react_compiler): store HIR arenas in IndexVec

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
@@ -6,6 +6,7 @@ use rustc_hash::FxHashSet;
 
 use oxc_allocator::{Allocator, GetAllocator};
 use oxc_diagnostics::{Diagnostics, OxcDiagnostic};
+use oxc_index::IndexVec;
 use oxc_span::Span;
 use oxc_str::{Ident, IdentHashMap, IdentHashSet, format_ident};
 use oxc_syntax::reference::ReferenceId;
@@ -49,10 +50,10 @@ pub struct Environment<'a> {
     next_mutable_range_id_counter: u32,
 
     // Arenas (use direct field access for sliced borrows)
-    pub identifiers: Vec<Identifier<'a>>,
-    pub types: Vec<Type<'a>>,
-    pub scopes: Vec<ReactiveScope<'a>>,
-    pub functions: Vec<HirFunction<'a>>,
+    pub identifiers: IndexVec<IdentifierId, Identifier<'a>>,
+    pub types: IndexVec<TypeId, Type<'a>>,
+    pub scopes: IndexVec<ScopeId, ReactiveScope<'a>>,
+    pub functions: IndexVec<FunctionId, HirFunction<'a>>,
 
     // Error accumulation
     pub errors: Diagnostics,
@@ -174,10 +175,10 @@ impl<'a> Environment<'a> {
             next_block_id_counter: 0,
             next_scope_id_counter: 0,
             next_mutable_range_id_counter: 0,
-            identifiers: Vec::new(),
-            types: Vec::new(),
-            scopes: Vec::new(),
-            functions: Vec::new(),
+            identifiers: IndexVec::new(),
+            types: IndexVec::new(),
+            scopes: IndexVec::new(),
+            functions: IndexVec::new(),
             errors: Diagnostics::new(),
             skip_compilation: false,
             fn_type: ReactFunctionType::Other,
@@ -227,7 +228,7 @@ impl<'a> Environment<'a> {
     /// Allocate a new Identifier in the arena with default values,
     /// returns its IdentifierId.
     pub fn next_identifier_id(&mut self) -> IdentifierId {
-        let id = IdentifierId::from_usize(self.identifiers.len());
+        let id = self.identifiers.next_idx();
         let type_id = self.make_type();
         let mutable_range = self.new_mutable_range(EvaluationOrder::UNSET, EvaluationOrder::UNSET);
         self.identifiers.push(Identifier {
@@ -262,7 +263,7 @@ impl<'a> Environment<'a> {
 
     /// Allocate a new Type in the arena, returns its TypeId.
     pub fn next_type_id(&mut self) -> TypeId {
-        let id = TypeId::from_usize(self.types.len());
+        let id = self.types.next_idx();
         self.types.push(Type::TypeVar { id });
         id
     }
@@ -273,7 +274,7 @@ impl<'a> Environment<'a> {
     }
 
     pub fn add_function(&mut self, func: HirFunction<'a>) -> FunctionId {
-        let id = FunctionId::from_usize(self.functions.len());
+        let id = self.functions.next_idx();
         self.functions.push(func);
         id
     }
@@ -710,7 +711,7 @@ impl<'a> Environment<'a> {
     /// Check whether the function type for an identifier has a noAlias signature.
     /// Looks up the identifier's type and checks its function signature.
     pub fn has_no_alias_signature(&self, identifier_id: IdentifierId) -> bool {
-        let ty = &self.types[self.identifiers[identifier_id.index()].type_.index()];
+        let ty = &self.types[self.identifiers[identifier_id].type_];
         self.get_function_signature(ty).ok().flatten().is_some_and(|sig| sig.no_alias)
     }
 
@@ -720,7 +721,7 @@ impl<'a> Environment<'a> {
         &self,
         identifier_id: IdentifierId,
     ) -> Result<Option<&HookKind>, OxcDiagnostic> {
-        let ty = &self.types[self.identifiers[identifier_id.index()].type_.index()];
+        let ty = &self.types[self.identifiers[identifier_id].type_];
         self.get_hook_kind_for_type(ty)
     }
 }

--- a/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
@@ -66,6 +66,10 @@ define_nonmax_u32_index_type! {
 }
 
 impl BlockId {
+    /// The entry block of a function's CFG. Blocks are numbered from 0, so the first
+    /// block allocated is always the entry.
+    pub const ENTRY: Self = Self::from_usize(0);
+
     /// Placeholder id for the never-read block that the final `terminate()` installs as
     /// `current`. Uses the largest representable index so it can never alias a real block
     /// (blocks are numbered from 0).

--- a/crates/oxc_react_compiler/src/react_compiler_hir/visitors.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/visitors.rs
@@ -6,11 +6,13 @@
  */
 use rustc_hash::FxHashMap;
 
+use oxc_index::IndexSlice;
+
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::{
-    ArrayElement, ArrayPatternElement, BasicBlock, BlockId, HirFunction, IdentifierId, Instruction,
-    InstructionValue, JsxAttribute, JsxTag, ManualMemoDependencyRoot, ObjectPropertyKey,
-    ObjectPropertyOrSpread, Pattern, Place, PlaceOrSpread, ScopeId, Terminal,
+    ArrayElement, ArrayPatternElement, BasicBlock, BlockId, FunctionId, HirFunction, IdentifierId,
+    Instruction, InstructionValue, JsxAttribute, JsxTag, ManualMemoDependencyRoot,
+    ObjectPropertyKey, ObjectPropertyOrSpread, Pattern, Place, PlaceOrSpread, ScopeId, Terminal,
 };
 
 // =============================================================================
@@ -100,7 +102,7 @@ pub fn each_instruction_value_operand(value: &InstructionValue, env: &Environmen
 /// Useful when borrow splitting prevents passing the full `Environment`.
 pub fn each_instruction_value_operand_with_functions(
     value: &InstructionValue,
-    functions: &[HirFunction],
+    functions: &IndexSlice<FunctionId, [HirFunction]>,
 ) -> Vec<Place> {
     let mut result = Vec::new();
     match value {
@@ -218,7 +220,7 @@ pub fn each_instruction_value_operand_with_functions(
         }
         InstructionValue::ObjectMethod { lowered_func, .. }
         | InstructionValue::FunctionExpression { lowered_func, .. } => {
-            let func = &functions[lowered_func.func.index()];
+            let func = &functions[lowered_func.func];
             for ctx_place in &func.context {
                 result.push(ctx_place.clone());
             }
@@ -857,7 +859,7 @@ pub fn each_terminal_operand_ids(terminal: &Terminal) -> Vec<IdentifierId> {
 //   for_each_instruction_value_operand_mut(&mut instr.value, &mut |place| { ... });
 //   if let InstructionValue::FunctionExpression { lowered_func, .. }
 //       | InstructionValue::ObjectMethod { lowered_func, .. } = &mut instr.value {
-//       let func = &mut env.functions[lowered_func.func.index()];
+//       let func = &mut env.functions[lowered_func.func];
 //       for ctx in func.context.iter_mut() { ... }
 //   }
 //

--- a/crates/oxc_react_compiler/src/react_compiler_inference/align_method_call_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/align_method_call_scopes.rs
@@ -40,8 +40,8 @@ pub fn align_method_call_scopes(func: &mut HirFunction, env: &mut Environment) {
             let instr = &func.instructions[instr_id.index()];
             match &instr.value {
                 InstructionValue::MethodCall { property, .. } => {
-                    let lvalue_scope = env.identifiers[instr.lvalue.identifier.index()].scope;
-                    let property_scope = env.identifiers[property.identifier.index()].scope;
+                    let lvalue_scope = env.identifiers[instr.lvalue.identifier].scope;
+                    let property_scope = env.identifiers[property.identifier].scope;
 
                     match (lvalue_scope, property_scope) {
                         (Some(lvalue_sid), Some(property_sid)) => {
@@ -68,9 +68,9 @@ pub fn align_method_call_scopes(func: &mut HirFunction, env: &mut Environment) {
                     // Recurse into inner functions
                     let func_id = lowered_func.func;
                     let mut inner_func =
-                        replace(&mut env.functions[func_id.index()], placeholder_function());
+                        replace(&mut env.functions[func_id], placeholder_function());
                     align_method_call_scopes(&mut inner_func, env);
-                    env.functions[func_id.index()] = inner_func;
+                    env.functions[func_id] = inner_func;
                 }
                 _ => {}
             }
@@ -87,8 +87,8 @@ pub fn align_method_call_scopes(func: &mut HirFunction, env: &mut Environment) {
         if scope_id == root_id {
             return;
         }
-        let scope_range = env.scopes[scope_id.index()].range.clone();
-        let root_range = env.scopes[root_id.index()].range.clone();
+        let scope_range = env.scopes[scope_id].range.clone();
+        let root_range = env.scopes[root_id].range.clone();
 
         let entry =
             range_updates.entry(root_id).or_insert_with(|| (root_range.start, root_range.end));
@@ -100,14 +100,14 @@ pub fn align_method_call_scopes(func: &mut HirFunction, env: &mut Environment) {
     let original_range_ids: FxHashMap<ScopeId, MutableRangeId> = range_updates
         .keys()
         .map(|&root_id| {
-            let range_id = env.scopes[root_id.index()].range.id;
+            let range_id = env.scopes[root_id].range.id;
             (root_id, range_id)
         })
         .collect();
 
     for (root_id, (new_start, new_end)) in &range_updates {
-        env.scopes[root_id.index()].range.start = *new_start;
-        env.scopes[root_id.index()].range.end = *new_end;
+        env.scopes[*root_id].range.start = *new_start;
+        env.scopes[*root_id].range.end = *new_end;
     }
 
     // Sync identifier mutable_ranges that shared the old scope range.
@@ -116,7 +116,7 @@ pub fn align_method_call_scopes(func: &mut HirFunction, env: &mut Environment) {
         if let Some(scope_id) = ident.scope {
             if let Some(&orig_range_id) = original_range_ids.get(&scope_id) {
                 if ident.mutable_range.id == orig_range_id {
-                    let new_range = &env.scopes[scope_id.index()].range;
+                    let new_range = &env.scopes[scope_id].range;
                     ident.mutable_range.start = new_range.start;
                     ident.mutable_range.end = new_range.end;
                 }
@@ -130,11 +130,11 @@ pub fn align_method_call_scopes(func: &mut HirFunction, env: &mut Environment) {
             let lvalue_id = func.instructions[instr_id.index()].lvalue.identifier;
 
             if let Some(mapped_scope) = scope_mapping.get(&lvalue_id) {
-                env.identifiers[lvalue_id.index()].scope = *mapped_scope;
-            } else if let Some(current_scope) = env.identifiers[lvalue_id.index()].scope {
+                env.identifiers[lvalue_id].scope = *mapped_scope;
+            } else if let Some(current_scope) = env.identifiers[lvalue_id].scope {
                 // TS: mergedScopes.find() returns null if not in the set
                 if let Some(merged) = merged_scopes.find_opt(current_scope) {
-                    env.identifiers[lvalue_id.index()].scope = Some(merged);
+                    env.identifiers[lvalue_id].scope = Some(merged);
                 }
             }
         }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/align_object_method_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/align_object_method_scopes.rs
@@ -46,10 +46,8 @@ fn find_scopes_to_merge(func: &HirFunction, env: &Environment) -> DisjointSet<Sc
                             ObjectPropertyOrSpread::Spread(spread) => &spread.place,
                         };
                         if object_method_decls.contains(&operand_place.identifier) {
-                            let operand_scope =
-                                env.identifiers[operand_place.identifier.index()].scope;
-                            let lvalue_scope =
-                                env.identifiers[instr.lvalue.identifier.index()].scope;
+                            let operand_scope = env.identifiers[operand_place.identifier].scope;
+                            let lvalue_scope = env.identifiers[instr.lvalue.identifier].scope;
 
                             // TS: Diagnostics.invariant(operandScope != null && lvalueScope != null, ...)
                             let operand_sid = operand_scope.expect(
@@ -88,9 +86,9 @@ pub fn align_object_method_scopes(func: &mut HirFunction, env: &mut Environment)
                 | InstructionValue::ObjectMethod { lowered_func, .. } => {
                     let func_id = lowered_func.func;
                     let mut inner_func =
-                        replace(&mut env.functions[func_id.index()], placeholder_function());
+                        replace(&mut env.functions[func_id], placeholder_function());
                     align_object_method_scopes(&mut inner_func, env);
-                    env.functions[func_id.index()] = inner_func;
+                    env.functions[func_id] = inner_func;
                 }
                 _ => {}
             }
@@ -109,8 +107,8 @@ pub fn align_object_method_scopes(func: &mut HirFunction, env: &mut Environment)
         if scope_id == root_id {
             return;
         }
-        let scope_range = env.scopes[scope_id.index()].range.clone();
-        let root_range = env.scopes[root_id.index()].range.clone();
+        let scope_range = env.scopes[scope_id].range.clone();
+        let root_range = env.scopes[root_id].range.clone();
 
         let entry =
             range_updates.entry(root_id).or_insert_with(|| (root_range.start, root_range.end));
@@ -122,14 +120,14 @@ pub fn align_object_method_scopes(func: &mut HirFunction, env: &mut Environment)
     let original_range_ids: FxHashMap<ScopeId, MutableRangeId> = range_updates
         .keys()
         .map(|&root_id| {
-            let range_id = env.scopes[root_id.index()].range.id;
+            let range_id = env.scopes[root_id].range.id;
             (root_id, range_id)
         })
         .collect();
 
-    for (root_id, (new_start, new_end)) in &range_updates {
-        env.scopes[root_id.index()].range.start = *new_start;
-        env.scopes[root_id.index()].range.end = *new_end;
+    for (&root_id, (new_start, new_end)) in &range_updates {
+        env.scopes[root_id].range.start = *new_start;
+        env.scopes[root_id].range.end = *new_end;
     }
 
     // Sync identifier mutable_ranges that shared the old scope range.
@@ -138,7 +136,7 @@ pub fn align_object_method_scopes(func: &mut HirFunction, env: &mut Environment)
         if let Some(scope_id) = ident.scope {
             if let Some(&orig_range_id) = original_range_ids.get(&scope_id) {
                 if ident.mutable_range.id == orig_range_id {
-                    let new_range = &env.scopes[scope_id.index()].range;
+                    let new_range = &env.scopes[scope_id].range;
                     ident.mutable_range.start = new_range.start;
                     ident.mutable_range.end = new_range.end;
                 }
@@ -159,9 +157,9 @@ pub fn align_object_method_scopes(func: &mut HirFunction, env: &mut Environment)
         for &instr_id in &block.instructions {
             let lvalue_id = func.instructions[instr_id.index()].lvalue.identifier;
 
-            if let Some(current_scope) = env.identifiers[lvalue_id.index()].scope {
+            if let Some(current_scope) = env.identifiers[lvalue_id].scope {
                 if let Some(&root) = scope_remap.get(&current_scope) {
-                    env.identifiers[lvalue_id.index()].scope = Some(root);
+                    env.identifiers[lvalue_id].scope = Some(root);
                 }
             }
         }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/align_reactive_scopes_to_block_scopes_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/align_reactive_scopes_to_block_scopes_hir.rs
@@ -112,7 +112,7 @@ pub fn align_reactive_scopes_to_block_scopes_hir(func: &mut HirFunction, env: &m
         let starting_id = block_first_id(func, block_id);
 
         // Retain only active scopes whose range.end > startingId
-        active_scopes.retain(|&scope_id| env.scopes[scope_id.index()].range.end > starting_id);
+        active_scopes.retain(|&scope_id| env.scopes[scope_id].range.end > starting_id);
 
         // Check if we've reached a fallthrough block
         if let Some(top) = active_block_fallthrough_ranges.last().cloned() {
@@ -121,7 +121,7 @@ pub fn align_reactive_scopes_to_block_scopes_hir(func: &mut HirFunction, env: &m
                 // All active scopes overlap this block-fallthrough range;
                 // extend their start to include the range start.
                 for &scope_id in &active_scopes {
-                    let scope = &mut env.scopes[scope_id.index()];
+                    let scope = &mut env.scopes[scope_id];
                     scope.range.start = min(scope.range.start, top.range.start);
                 }
             }
@@ -182,7 +182,7 @@ pub fn align_reactive_scopes_to_block_scopes_hir(func: &mut HirFunction, env: &m
                 let next_id = block_first_id(func, ft);
 
                 for &scope_id in &active_scopes {
-                    let scope = &mut env.scopes[scope_id.index()];
+                    let scope = &mut env.scopes[scope_id];
                     if scope.range.end > terminal_eval_order {
                         scope.range.end = max(scope.range.end, next_id);
                     }
@@ -216,7 +216,7 @@ pub fn align_reactive_scopes_to_block_scopes_hir(func: &mut HirFunction, env: &m
                     let first_id = block_first_id(func, start_range.fallthrough);
 
                     for &scope_id in &active_scopes {
-                        let scope = &mut env.scopes[scope_id.index()];
+                        let scope = &mut env.scopes[scope_id];
                         if scope.range.end <= terminal_eval_order {
                             continue;
                         }
@@ -271,7 +271,7 @@ pub fn align_reactive_scopes_to_block_scopes_hir(func: &mut HirFunction, env: &m
         if let Some(scope_id) = ident.scope {
             let original = &original_scope_ranges[scope_id.index()];
             if ident.mutable_range.same_range(original) {
-                let scope_range = &env.scopes[scope_id.index()].range;
+                let scope_range = &env.scopes[scope_id].range;
                 ident.mutable_range.start = scope_range.start;
                 ident.mutable_range.end = scope_range.end;
             }
@@ -291,9 +291,9 @@ fn record_place_id(
     seen: &mut FxHashSet<ScopeId>,
 ) {
     // Get the scope for this identifier, if active at this instruction
-    let scope_id = match env.identifiers[identifier_id.index()].scope {
+    let scope_id = match env.identifiers[identifier_id].scope {
         Some(scope_id) => {
-            let scope = &env.scopes[scope_id.index()];
+            let scope = &env.scopes[scope_id];
             if id >= scope.range.start && id < scope.range.end { Some(scope_id) } else { None }
         }
         None => None,
@@ -308,7 +308,7 @@ fn record_place_id(
         seen.insert(scope_id);
 
         if let Some(n) = node {
-            let scope = &mut env.scopes[scope_id.index()];
+            let scope = &mut env.scopes[scope_id];
             scope.range.start = min(n.value_range.start, scope.range.start);
             scope.range.end = max(n.value_range.end, scope.range.end);
         }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/analyse_functions.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/analyse_functions.rs
@@ -68,13 +68,13 @@ where
     // Process each inner function
     for func_id in inner_func_ids {
         // Take the inner function out of the arena to avoid borrow conflicts
-        let mut inner_func = replace(&mut env.functions[func_id.index()], placeholder_function());
+        let mut inner_func = replace(&mut env.functions[func_id], placeholder_function());
 
         lower_with_mutation_aliasing(&mut inner_func, env, debug_logger)?;
 
         // If an invariant error was recorded, put the function back and stop processing
         if env.has_invariant_errors() {
-            env.functions[func_id.index()] = inner_func;
+            env.functions[func_id] = inner_func;
             return Ok(());
         }
 
@@ -86,13 +86,13 @@ where
         // and clear its scope.
         for operand in &inner_func.context {
             let new_range = env.new_mutable_range(EvaluationOrder::UNSET, EvaluationOrder::UNSET);
-            let ident = &mut env.identifiers[operand.identifier.index()];
+            let ident = &mut env.identifiers[operand.identifier];
             ident.mutable_range = new_range;
             ident.scope = None;
         }
 
         // Put the function back
-        env.functions[func_id.index()] = inner_func;
+        env.functions[func_id] = inner_func;
     }
 
     Ok(())
@@ -206,7 +206,7 @@ fn placeholder_function<'a>() -> HirFunction<'a> {
             span: None,
         },
         context: Vec::new(),
-        body: HIR { entry: BlockId::from_usize(0), blocks: FxIndexMap::default() },
+        body: HIR { entry: BlockId::ENTRY, blocks: FxIndexMap::default() },
         instructions: Vec::new(),
         generator: false,
         is_async: false,

--- a/crates/oxc_react_compiler/src/react_compiler_inference/build_reactive_scope_terminals_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/build_reactive_scope_terminals_hir.rs
@@ -45,8 +45,8 @@ fn get_scopes(func: &HirFunction, env: &Environment) -> Vec<ScopeId> {
     let mut scope_ids: FxHashSet<ScopeId> = FxHashSet::default();
 
     let mut visit_place = |identifier_id: IdentifierId| {
-        if let Some(scope_id) = env.identifiers[identifier_id.index()].scope {
-            let range = &env.scopes[scope_id.index()].range;
+        if let Some(scope_id) = env.identifiers[identifier_id].scope {
+            let range = &env.scopes[scope_id].range;
             if range.start != range.end {
                 scope_ids.insert(scope_id);
             }
@@ -111,8 +111,8 @@ fn collect_scope_rewrites(func: &HirFunction, env: &mut Environment) -> Vec<Term
     // Sort: ascending by start, descending by end for ties
     let mut items: Vec<ScopeId> = scope_ids;
     items.sort_by(|a, b| {
-        let a_range = &env.scopes[a.index()].range;
-        let b_range = &env.scopes[b.index()].range;
+        let a_range = &env.scopes[*a].range;
+        let b_range = &env.scopes[*b].range;
         let start_diff = a_range.start.cmp(&b_range.start);
         if start_diff != Ordering::Equal {
             return start_diff;
@@ -125,15 +125,15 @@ fn collect_scope_rewrites(func: &HirFunction, env: &mut Environment) -> Vec<Term
     let mut active_items: Vec<ScopeId> = Vec::new();
 
     for &curr in &items {
-        let curr_start = env.scopes[curr.index()].range.start;
-        let curr_end = env.scopes[curr.index()].range.end;
+        let curr_start = env.scopes[curr].range.start;
+        let curr_end = env.scopes[curr].range.end;
 
         // Pop active items that are disjoint with current
         let mut j = active_items.len();
         while j > 0 {
             j -= 1;
             let maybe_parent = active_items[j];
-            let parent_end = env.scopes[maybe_parent.index()].range.end;
+            let parent_end = env.scopes[maybe_parent].range.end;
             let disjoint = curr_start >= parent_end;
             let nested = curr_end <= parent_end;
             assert!(disjoint || nested, "Invalid nesting in program blocks or scopes");
@@ -141,7 +141,7 @@ fn collect_scope_rewrites(func: &HirFunction, env: &mut Environment) -> Vec<Term
                 // Exit this scope
                 let fallthrough_id =
                     *fallthroughs.get(&maybe_parent).expect("Expected scope to exist");
-                let end_instr_id = env.scopes[maybe_parent.index()].range.end;
+                let end_instr_id = env.scopes[maybe_parent].range.end;
                 rewrites
                     .push(TerminalRewriteInfo::EndScope { instr_id: end_instr_id, fallthrough_id });
                 active_items.truncate(j);
@@ -153,7 +153,7 @@ fn collect_scope_rewrites(func: &HirFunction, env: &mut Environment) -> Vec<Term
         // Enter scope
         let block_id = env.next_block_id();
         let fallthrough_id = env.next_block_id();
-        let start_instr_id = env.scopes[curr.index()].range.start;
+        let start_instr_id = env.scopes[curr].range.start;
         rewrites.push(TerminalRewriteInfo::StartScope {
             block_id,
             fallthrough_id,
@@ -167,7 +167,7 @@ fn collect_scope_rewrites(func: &HirFunction, env: &mut Environment) -> Vec<Term
     // Exit remaining active items
     while let Some(curr) = active_items.pop() {
         let fallthrough_id = *fallthroughs.get(&curr).expect("Expected scope to exist");
-        let end_instr_id = env.scopes[curr.index()].range.end;
+        let end_instr_id = env.scopes[curr].range.end;
         rewrites.push(TerminalRewriteInfo::EndScope { instr_id: end_instr_id, fallthrough_id });
     }
 
@@ -369,8 +369,8 @@ fn fix_scope_and_identifier_ranges(func: &HirFunction, env: &mut Environment) {
                 } else {
                     fallthrough_block.terminal.evaluation_order()
                 };
-                env.scopes[scope.index()].range.start = *id;
-                env.scopes[scope.index()].range.end = first_id;
+                env.scopes[*scope].range.start = *id;
+                env.scopes[*scope].range.end = first_id;
             }
             _ => {}
         }
@@ -388,7 +388,7 @@ fn fix_scope_and_identifier_ranges(func: &HirFunction, env: &mut Environment) {
         if let Some(scope_id) = ident.scope {
             let original = &original_scope_ranges[scope_id.index()];
             if ident.mutable_range.same_range(original) {
-                let scope_range = &env.scopes[scope_id.index()].range;
+                let scope_range = &env.scopes[scope_id].range;
                 ident.mutable_range.start = scope_range.start;
                 ident.mutable_range.end = scope_range.end;
             }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/flatten_scopes_with_hooks_or_use_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/flatten_scopes_with_hooks_or_use_hir.rs
@@ -59,8 +59,7 @@ pub fn flatten_scopes_with_hooks_or_use_hir(
             let instr = &func.instructions[instr_id.index()];
             match &instr.value {
                 InstructionValue::CallExpression { callee, .. } => {
-                    let callee_ty =
-                        &env.types[env.identifiers[callee.identifier.index()].type_.index()];
+                    let callee_ty = &env.types[env.identifiers[callee.identifier].type_];
                     if is_hook_or_use(env, callee_ty)? {
                         // All active scopes must be pruned
                         prune.extend(active_scopes.iter().map(|s| s.block));
@@ -68,8 +67,7 @@ pub fn flatten_scopes_with_hooks_or_use_hir(
                     }
                 }
                 InstructionValue::MethodCall { property, .. } => {
-                    let property_ty =
-                        &env.types[env.identifiers[property.identifier.index()].type_.index()];
+                    let property_ty = &env.types[env.identifiers[property.identifier].type_];
                     if is_hook_or_use(env, property_ty)? {
                         prune.extend(active_scopes.iter().map(|s| s.block));
                         active_scopes.clear();

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
@@ -197,7 +197,7 @@ pub fn infer_mutation_aliasing_effects(
             // Check for uninitialized identifier access (matches TS invariant:
             // "Expected value kind to be initialized")
             if let Some((uninitialized_id, usage_span)) = state.uninitialized_access.get() {
-                let ident_info = env.identifiers.get(uninitialized_id.index());
+                let ident_info = env.identifiers.get(uninitialized_id);
                 let name = ident_info
                     .and_then(|ident| ident.name.as_ref())
                     .map(|n| n.value().to_string())
@@ -207,7 +207,7 @@ pub fn infer_mutation_aliasing_effects(
                 // Match TS printPlace format: "<unknown> name$id:type"
                 let type_str = ident_info
                     .map(|ident| {
-                        let ty = &env.types[ident.type_.index()];
+                        let ty = &env.types[ident.type_];
                         format_type_for_print(ty)
                     })
                     .unwrap_or_default();
@@ -430,7 +430,7 @@ impl InferenceState {
         env: &Environment,
         usage_span: Option<Span>,
     ) -> MutationResult {
-        let ty = &env.types[env.identifiers[place_id.index()].type_.index()];
+        let ty = &env.types[env.identifiers[place_id].type_];
         if is_ref_or_ref_value(ty) {
             return MutationResult::MutateRef;
         }
@@ -738,7 +738,7 @@ fn find_hoisted_context_declarations(
         place: &Place,
         env: &Environment,
     ) {
-        let decl_id = env.identifiers[place.identifier.index()].declaration_id;
+        let decl_id = env.identifiers[place.identifier].declaration_id;
         if hoisted.contains_key(&decl_id) && hoisted.get(&decl_id).unwrap().is_none() {
             hoisted.insert(decl_id, Some(place.clone()));
         }
@@ -754,8 +754,7 @@ fn find_hoisted_context_declarations(
                         || kind == InstructionKind::HoistedFunction
                         || kind == InstructionKind::HoistedLet
                     {
-                        let decl_id =
-                            env.identifiers[lvalue.place.identifier.index()].declaration_id;
+                        let decl_id = env.identifiers[lvalue.place.identifier].declaration_id;
                         hoisted.insert(decl_id, None);
                     }
                 }
@@ -852,8 +851,7 @@ fn find_non_mutated_destructure_spreads(
                 }
                 InstructionValue::CallExpression { callee, .. }
                 | InstructionValue::MethodCall { property: callee, .. } => {
-                    let callee_ty =
-                        &env.types[env.identifiers[callee.identifier.index()].type_.index()];
+                    let callee_ty = &env.types[env.identifiers[callee.identifier].type_];
                     if get_hook_kind_for_type(env, callee_ty).ok().flatten().is_some() {
                         if !is_ref_or_ref_value_for_id(env, lvalue_id) {
                             known_frozen.insert(lvalue_id);
@@ -1048,7 +1046,7 @@ fn apply_signature(
     match &instr.value {
         InstructionValue::FunctionExpression { lowered_func, .. }
         | InstructionValue::ObjectMethod { lowered_func, .. } => {
-            let inner_func = &env.functions[lowered_func.func.index()];
+            let inner_func = &env.functions[lowered_func.func];
             if let Some(ref aliasing_effects) = inner_func.aliasing_effects {
                 let context_ids: FxHashSet<IdentifierId> =
                     inner_func.context.iter().map(|p| p.identifier).collect();
@@ -1067,7 +1065,7 @@ fn apply_signature(
                     let value_abstract = state.kind(mutate_value.identifier);
                     if value_abstract.kind == ValueKind::Frozen {
                         let reason_str = get_write_error_reason(&value_abstract);
-                        let ident = &env.identifiers[mutate_value.identifier.index()];
+                        let ident = &env.identifiers[mutate_value.identifier];
                         let variable = match &ident.name {
                             Some(IdentifierName::Named(n)) => {
                                 format!("`{}`", n)
@@ -1136,7 +1134,7 @@ fn freeze_function_captures_transitive(
 ) {
     if let Some(&func_id) = context.function_values.get(&value_id) {
         let ctx_ids: Vec<IdentifierId> =
-            env.functions[func_id.index()].context.iter().map(|p| p.identifier).collect();
+            env.functions[func_id].context.iter().map(|p| p.identifier).collect();
         for ctx_id in ctx_ids {
             // Replicate InferenceState::freeze() logic inline —
             // we need to recurse with context/env which freeze() doesn't have.
@@ -1280,7 +1278,7 @@ fn apply_effect(
                 k == ValueKind::Context || k == ValueKind::Mutable
             });
 
-            let inner_func = &env.functions[function_id.index()];
+            let inner_func = &env.functions[function_id];
             let has_tracked_side_effects = inner_func
                 .aliasing_effects
                 .as_ref()
@@ -1318,7 +1316,7 @@ fn apply_effect(
                     || kind == ValueKind::Global
                 {
                     // Downgrade to Read - we need to mutate the inner function
-                    let inner_func_mut = &mut env.functions[function_id.index()];
+                    let inner_func_mut = &mut env.functions[function_id];
                     for ctx in &mut inner_func_mut.context {
                         if ctx.identifier == operand.identifier && ctx.effect == Effect::Capture {
                             ctx.effect = Effect::Read;
@@ -1477,7 +1475,7 @@ fn apply_effect(
                 if function_values.len() == 1 {
                     let value_id = function_values[0];
                     if let Some(func_id) = context.function_values.get(&value_id).copied() {
-                        let inner_func = &env.functions[func_id.index()];
+                        let inner_func = &env.functions[func_id];
                         if inner_func.aliasing_effects.is_some() {
                             // Build or retrieve the signature from the function expression
                             context.function_signature_cache.entry(func_id).or_insert_with(|| {
@@ -1485,7 +1483,7 @@ fn apply_effect(
                             });
                             let sig =
                                 context.function_signature_cache.get(&func_id).unwrap().clone();
-                            let inner_func = &env.functions[func_id.index()];
+                            let inner_func = &env.functions[func_id];
                             let context_places: Vec<Place> = inner_func.context.clone();
                             let sig_effects = compute_effects_for_aliasing_signature(
                                 env,
@@ -1623,8 +1621,7 @@ fn apply_effect(
                     }
 
                     if *is_spread {
-                        let ty =
-                            &env.types[env.identifiers[operand.identifier.index()].type_.index()];
+                        let ty = &env.types[env.identifiers[operand.identifier].type_];
                         if let Some(mutate_iter) = conditionally_mutate_iterator(operand, ty) {
                             apply_effect(
                                 context,
@@ -1700,7 +1697,7 @@ fn apply_effect(
             {
                 let abstract_value = state.kind(value.identifier);
 
-                let ident = &env.identifiers[value.identifier.index()];
+                let ident = &env.identifiers[value.identifier];
                 let decl_id = ident.declaration_id;
 
                 if mutation_kind == MutationResult::MutateFrozen
@@ -1806,8 +1803,7 @@ fn compute_signature_for_instruction(
                         });
                     }
                     ArrayElement::Spread(s) => {
-                        let ty =
-                            &env.types[env.identifiers[s.place.identifier.index()].type_.index()];
+                        let ty = &env.types[env.identifiers[s.place.identifier].type_];
                         if let Some(mutate_iter) = conditionally_mutate_iterator(&s.place, ty) {
                             effects.push(mutate_iter);
                         }
@@ -1901,7 +1897,7 @@ fn compute_signature_for_instruction(
         }
         InstructionValue::PropertyLoad { object, .. }
         | InstructionValue::ComputedLoad { object, .. } => {
-            let ty = &env.types[env.identifiers[lvalue.identifier.index()].type_.index()];
+            let ty = &env.types[env.identifiers[lvalue.identifier].type_];
             if is_primitive_type(ty) {
                 effects.push(AliasingEffect::Create {
                     into: lvalue.clone(),
@@ -1917,7 +1913,7 @@ fn compute_signature_for_instruction(
         }
         InstructionValue::PropertyStore { object, property, value: store_value, .. } => {
             let mutation_reason: Option<MutationReason> = {
-                let obj_ty = &env.types[env.identifiers[object.identifier.index()].type_.index()];
+                let obj_ty = &env.types[env.identifiers[object.identifier].type_];
                 if let PropertyLiteral::String(prop_name) = property {
                     if prop_name == "current" && matches!(obj_ty, Type::TypeVar { .. }) {
                         Some(MutationReason::AssignCurrentProperty)
@@ -1949,7 +1945,7 @@ fn compute_signature_for_instruction(
         }
         InstructionValue::FunctionExpression { lowered_func, .. }
         | InstructionValue::ObjectMethod { lowered_func, .. } => {
-            let inner_func = &env.functions[lowered_func.func.index()];
+            let inner_func = &env.functions[lowered_func.func];
             let captures: Vec<Place> = inner_func
                 .context
                 .iter()
@@ -1968,7 +1964,7 @@ fn compute_signature_for_instruction(
                 value: ValueKind::Mutable,
                 reason: ValueReason::Other,
             });
-            let ty = &env.types[env.identifiers[collection.identifier.index()].type_.index()];
+            let ty = &env.types[env.identifiers[collection.identifier].type_];
             if is_builtin_collection_type(ty) {
                 effects.push(AliasingEffect::Capture {
                     from: collection.clone(),
@@ -2020,8 +2016,7 @@ fn compute_signature_for_instruction(
             }
             for prop in props {
                 if let JsxAttribute::Attribute { place: prop_place, .. } = prop {
-                    let prop_ty =
-                        &env.types[env.identifiers[prop_place.identifier.index()].type_.index()];
+                    let prop_ty = &env.types[env.identifiers[prop_place.identifier].type_];
                     if let Type::Function { return_type, .. } = prop_ty {
                         if is_jsx_type(return_type) || is_phi_with_jsx(return_type) {
                             effects.push(AliasingEffect::Render { place: prop_place.clone() });
@@ -2061,8 +2056,7 @@ fn compute_signature_for_instruction(
             for pat_item in each_pattern_items(&dl.pattern) {
                 match pat_item {
                     PatternItem::Place(place) => {
-                        let ty =
-                            &env.types[env.identifiers[place.identifier.index()].type_.index()];
+                        let ty = &env.types[env.identifiers[place.identifier].type_];
                         if is_primitive_type(ty) {
                             effects.push(AliasingEffect::Create {
                                 into: place.clone(),
@@ -2101,7 +2095,7 @@ fn compute_signature_for_instruction(
             effects.push(AliasingEffect::CreateFrom { from: place.clone(), into: lvalue.clone() });
         }
         InstructionValue::DeclareContext { lvalue: dcl, .. } => {
-            let decl_id = env.identifiers[dcl.place.identifier.index()].declaration_id;
+            let decl_id = env.identifiers[dcl.place.identifier].declaration_id;
             let kind = dcl.kind;
             if !context.hoisted_context_declarations.contains_key(&decl_id)
                 || kind == InstructionKind::HoistedConst
@@ -2123,7 +2117,7 @@ fn compute_signature_for_instruction(
             });
         }
         InstructionValue::StoreContext { lvalue: scl, value: sc_value, .. } => {
-            let decl_id = env.identifiers[scl.place.identifier.index()].declaration_id;
+            let decl_id = env.identifiers[scl.place.identifier].declaration_id;
             if scl.kind == InstructionKind::Reassign
                 || context.hoisted_context_declarations.contains_key(&decl_id)
             {
@@ -2300,7 +2294,7 @@ fn compute_effects_for_legacy_signature(
             effects.push(AliasingEffect::MutateTransitiveConditionally { value: place.clone() });
         }
         Effect::ConditionallyMutateIterator => {
-            let ty = &env.types[env.identifiers[place.identifier.index()].type_.index()];
+            let ty = &env.types[env.identifiers[place.identifier].type_];
             if let Some(mutate_iter) = conditionally_mutate_iterator(place, ty) {
                 effects.push(mutate_iter);
             }
@@ -2408,7 +2402,7 @@ fn are_arguments_immutable_and_non_mutating(
                 // Check if it's a function type with a known signature
                 let is_place = matches!(arg, PlaceOrSpreadOrHole::Place(_));
                 if is_place {
-                    let ty = &env.types[env.identifiers[place.identifier.index()].type_.index()];
+                    let ty = &env.types[env.identifiers[place.identifier].type_];
                     if let Type::Function { .. } = ty {
                         let fn_shape = env.get_function_signature(ty).ok().flatten();
                         if let Some(fn_sig) = fn_shape {
@@ -2438,13 +2432,13 @@ fn are_arguments_immutable_and_non_mutating(
                 let value_ids = state.values_for(place.identifier);
                 for vid in &value_ids {
                     if let Some(&func_id) = function_values.get(vid) {
-                        let inner_func = &env.functions[func_id.index()];
+                        let inner_func = &env.functions[func_id];
                         let mutates_params = inner_func.params.iter().any(|param| {
                             let param_id = match param {
                                 ParamPattern::Place(p) => p.identifier,
                                 ParamPattern::Spread(s) => s.place.identifier,
                             };
-                            let ident = &env.identifiers[param_id.index()];
+                            let ident = &env.identifiers[param_id];
                             ident.mutable_range.end > ident.mutable_range.start + 1
                         });
                         if mutates_params {
@@ -2504,7 +2498,7 @@ fn compute_effects_for_aliasing_signature_config(
                 }
 
                 if matches!(arg, PlaceOrSpreadOrHole::Spread(_)) {
-                    let ty = &env.types[env.identifiers[place.identifier.index()].type_.index()];
+                    let ty = &env.types[env.identifiers[place.identifier].type_];
                     let mutate_iterator = conditionally_mutate_iterator(place, ty);
                     if mutate_iterator.is_some() {
                         mutable_spreads.insert(place.identifier);
@@ -2515,7 +2509,7 @@ fn compute_effects_for_aliasing_signature_config(
     }
 
     for operand in context {
-        let ident = &env.identifiers[operand.identifier.index()];
+        let ident = &env.identifiers[operand.identifier];
         if let Some(ref name) = ident.name {
             substitutions.insert(format!("@{}", name.value()), vec![operand.clone()]);
         }
@@ -2690,7 +2684,7 @@ fn build_signature_from_function_expression(
     env: &mut Environment,
     func_id: FunctionId,
 ) -> AliasingSignature {
-    let inner_func = &env.functions[func_id.index()];
+    let inner_func = &env.functions[func_id];
     let mut params: Vec<IdentifierId> = Vec::new();
     let mut rest: Option<IdentifierId> = None;
     for param in &inner_func.params {
@@ -2755,7 +2749,7 @@ fn compute_effects_for_aliasing_signature(
                 }
 
                 if is_spread {
-                    let ty = &env.types[env.identifiers[place.identifier.index()].type_.index()];
+                    let ty = &env.types[env.identifiers[place.identifier].type_];
                     let mutate_iterator = conditionally_mutate_iterator(place, ty);
                     if mutate_iterator.is_some() {
                         mutable_spreads.insert(place.identifier);
@@ -3007,12 +3001,12 @@ fn get_function_call_signature(
     env: &Environment,
     callee_id: IdentifierId,
 ) -> Result<Option<FunctionSignature>, OxcDiagnostic> {
-    let ty = &env.types[env.identifiers[callee_id.index()].type_.index()];
+    let ty = &env.types[env.identifiers[callee_id].type_];
     Ok(env.get_function_signature(ty)?.cloned())
 }
 
 fn is_ref_or_ref_value_for_id(env: &Environment, id: IdentifierId) -> bool {
-    let ty = &env.types[env.identifiers[id.index()].type_.index()];
+    let ty = &env.types[env.identifiers[id].type_];
     is_ref_or_ref_value(ty)
 }
 
@@ -3085,7 +3079,7 @@ fn build_apply_operands(
 
 fn create_temp_place(env: &mut Environment, span: Option<Span>) -> Place {
     let id = env.next_identifier_id();
-    env.identifiers[id.index()].span = span;
+    env.identifiers[id].span = span;
     Place { identifier: id, effect: Effect::Unknown, reactive: false, span }
 }
 

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_ranges.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_ranges.rs
@@ -269,7 +269,7 @@ impl AliasingState {
             node.last_mutated = node.last_mutated.max(index);
 
             if let Some(end_val) = end {
-                let ident = &mut env.identifiers[node.id.index()];
+                let ident = &mut env.identifiers[node.id];
                 ident.mutable_range.end = ident.mutable_range.end.max(end_val);
             }
 
@@ -398,7 +398,7 @@ impl AliasingState {
 // =============================================================================
 
 fn append_function_errors(env: &mut Environment, function_id: FunctionId) {
-    let func = &env.functions[function_id.index()];
+    let func = &env.functions[function_id];
     if let Some(ref effects) = func.aliasing_effects {
         // Collect errors first to avoid borrow conflict
         let errors: Vec<_> = effects
@@ -746,8 +746,7 @@ pub fn infer_mutation_aliasing_ranges(
                     .unwrap_or_else(|| block.terminal.evaluation_order());
 
                 let is_mutated_after_creation =
-                    env.identifiers[phi.place.identifier.index()].mutable_range.end
-                        > first_instr_id;
+                    env.identifiers[phi.place.identifier].mutable_range.end > first_instr_id;
 
                 (
                     phi.place.identifier,
@@ -774,7 +773,7 @@ pub fn infer_mutation_aliasing_ranges(
             }
 
             if *is_mutated_after_creation {
-                let ident = &mut env.identifiers[phi_id.index()];
+                let ident = &mut env.identifiers[*phi_id];
                 if ident.mutable_range.start == EvaluationOrder::UNSET {
                     ident.mutable_range.start =
                         EvaluationOrder::from_usize(first_instr_id.index().saturating_sub(1));
@@ -793,7 +792,7 @@ pub fn infer_mutation_aliasing_ranges(
             // This covers the top-level lvalue
             let lvalue_id = instr.lvalue.identifier;
             {
-                let ident = &mut env.identifiers[lvalue_id.index()];
+                let ident = &mut env.identifiers[lvalue_id];
                 if ident.mutable_range.start == EvaluationOrder::UNSET {
                     ident.mutable_range.start = eval_order;
                 }
@@ -810,7 +809,7 @@ pub fn infer_mutation_aliasing_ranges(
                     .map(|p| p.identifier)
                     .collect();
             for vlid in &value_lvalue_ids {
-                let ident = &mut env.identifiers[vlid.index()];
+                let ident = &mut env.identifiers[*vlid];
                 if ident.mutable_range.start == EvaluationOrder::UNSET {
                     ident.mutable_range.start = eval_order;
                 }
@@ -850,7 +849,7 @@ pub fn infer_mutation_aliasing_ranges(
                     | AliasingEffect::CreateFrom { from, into }
                     | AliasingEffect::MaybeAlias { from, into } => {
                         let is_mutated_or_reassigned =
-                            env.identifiers[into.identifier.index()].mutable_range.end > eval_order;
+                            env.identifiers[into.identifier].mutable_range.end > eval_order;
                         if is_mutated_or_reassigned {
                             operand_effects.insert(from.identifier, Effect::Capture);
                             operand_effects.insert(into.identifier, Effect::Store);
@@ -907,11 +906,11 @@ pub fn infer_mutation_aliasing_ranges(
             {
                 let mut apply = |place: &mut Place| {
                     // Fix up mutable range start
-                    let ident = &env.identifiers[place.identifier.index()];
+                    let ident = &env.identifiers[place.identifier];
                     if ident.mutable_range.end > eval_order
                         && ident.mutable_range.start == EvaluationOrder::UNSET
                     {
-                        env.identifiers[place.identifier.index()].mutable_range.start = eval_order;
+                        env.identifiers[place.identifier].mutable_range.start = eval_order;
                     }
                     // Apply effect
                     if let Some(&effect) = operand_effects.get(&place.identifier) {
@@ -926,20 +925,17 @@ pub fn infer_mutation_aliasing_ranges(
                 | InstructionValue::ObjectMethod { lowered_func, .. } = &instr.value
                 {
                     let func_id = lowered_func.func;
-                    let ctx_ids: Vec<IdentifierId> = env.functions[func_id.index()]
-                        .context
-                        .iter()
-                        .map(|c| c.identifier)
-                        .collect();
+                    let ctx_ids: Vec<IdentifierId> =
+                        env.functions[func_id].context.iter().map(|c| c.identifier).collect();
                     for ctx_id in &ctx_ids {
-                        let ident = &env.identifiers[ctx_id.index()];
+                        let ident = &env.identifiers[*ctx_id];
                         if ident.mutable_range.end > eval_order
                             && ident.mutable_range.start == EvaluationOrder::UNSET
                         {
-                            env.identifiers[ctx_id.index()].mutable_range.start = eval_order;
+                            env.identifiers[*ctx_id].mutable_range.start = eval_order;
                         }
                         let effect = operand_effects.get(ctx_id).copied().unwrap_or(Effect::Read);
-                        let inner_func = &mut env.functions[func_id.index()];
+                        let inner_func = &mut env.functions[func_id];
                         for ctx_place in &mut inner_func.context {
                             if ctx_place.identifier == *ctx_id {
                                 ctx_place.effect = effect;
@@ -953,9 +949,9 @@ pub fn infer_mutation_aliasing_ranges(
             let instr = &func.instructions[instr_id.index()];
             if let InstructionValue::StoreContext { value, .. } = &instr.value {
                 let val_id = value.identifier;
-                let val_range_end = env.identifiers[val_id.index()].mutable_range.end;
+                let val_range_end = env.identifiers[val_id].mutable_range.end;
                 if val_range_end <= eval_order {
-                    env.identifiers[val_id.index()].mutable_range.end = eval_order + 1;
+                    env.identifiers[val_id].mutable_range.end = eval_order + 1;
                 }
             }
         }
@@ -978,8 +974,8 @@ pub fn infer_mutation_aliasing_ranges(
     // Part 3: Finish populating the externally visible effects
     // =========================================================================
     let returns_id = func.returns.identifier;
-    let returns_type_id = env.identifiers[returns_id.index()].type_;
-    let returns_type = &env.types[returns_type_id.index()];
+    let returns_type_id = env.identifiers[returns_id].type_;
+    let returns_type = &env.types[returns_type_id];
     let return_value_kind = if is_primitive_type(returns_type) {
         ValueKind::Primitive
     } else if is_jsx_type(returns_type) {

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_places.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_places.rs
@@ -138,8 +138,7 @@ pub fn infer_reactive_places(
                 // Hooks and `use` operator are sources of reactivity
                 match value {
                     InstructionValue::CallExpression { callee, .. } => {
-                        let callee_ty =
-                            &env.types[env.identifiers[callee.identifier.index()].type_.index()];
+                        let callee_ty = &env.types[env.identifiers[callee.identifier].type_];
                         if get_hook_kind_for_type(env, callee_ty)?.is_some()
                             || is_use_operator_type(callee_ty)
                         {
@@ -147,8 +146,7 @@ pub fn infer_reactive_places(
                         }
                     }
                     InstructionValue::MethodCall { property, .. } => {
-                        let property_ty =
-                            &env.types[env.identifiers[property.identifier.index()].type_.index()];
+                        let property_ty = &env.types[env.identifiers[property.identifier].type_];
                         if get_hook_kind_for_type(env, property_ty)?.is_some()
                             || is_use_operator_type(property_ty)
                         {
@@ -182,8 +180,7 @@ pub fn infer_reactive_places(
                             | Effect::ConditionallyMutate
                             | Effect::ConditionallyMutateIterator
                             | Effect::Mutate => {
-                                let op_range =
-                                    &env.identifiers[op_place.identifier.index()].mutable_range;
+                                let op_range = &env.identifiers[op_place.identifier].mutable_range;
                                 if op_range.contains(instr.id) {
                                     reactive_map.mark_reactive(op_place.identifier);
                                 }
@@ -282,10 +279,9 @@ impl StableSidemap {
 
         match value {
             InstructionValue::CallExpression { callee, .. } => {
-                let callee_ty =
-                    &env.types[env.identifiers[callee.identifier.index()].type_.index()];
+                let callee_ty = &env.types[env.identifiers[callee.identifier].type_];
                 if evaluates_to_stable_type_or_container(env, callee_ty) {
-                    let lvalue_ty = &env.types[env.identifiers[lvalue_id.index()].type_.index()];
+                    let lvalue_ty = &env.types[env.identifiers[lvalue_id].type_];
                     if is_stable_type(lvalue_ty) {
                         self.map.insert(lvalue_id, true);
                     } else {
@@ -294,10 +290,9 @@ impl StableSidemap {
                 }
             }
             InstructionValue::MethodCall { property, .. } => {
-                let property_ty =
-                    &env.types[env.identifiers[property.identifier.index()].type_.index()];
+                let property_ty = &env.types[env.identifiers[property.identifier].type_];
                 if evaluates_to_stable_type_or_container(env, property_ty) {
-                    let lvalue_ty = &env.types[env.identifiers[lvalue_id.index()].type_.index()];
+                    let lvalue_ty = &env.types[env.identifiers[lvalue_id].type_];
                     if is_stable_type(lvalue_ty) {
                         self.map.insert(lvalue_id, true);
                     } else {
@@ -308,7 +303,7 @@ impl StableSidemap {
             InstructionValue::PropertyLoad { object, .. } => {
                 let source_id = object.identifier;
                 if self.map.contains_key(&source_id) {
-                    let lvalue_ty = &env.types[env.identifiers[lvalue_id.index()].type_.index()];
+                    let lvalue_ty = &env.types[env.identifiers[lvalue_id].type_];
                     if is_stable_type_container(lvalue_ty) {
                         self.map.insert(lvalue_id, false);
                     } else if is_stable_type(lvalue_ty) {
@@ -324,7 +319,7 @@ impl StableSidemap {
                         .map(|p| p.identifier)
                         .collect();
                     for lid in lvalue_ids {
-                        let lid_ty = &env.types[env.identifiers[lid.index()].type_.index()];
+                        let lid_ty = &env.types[env.identifiers[lid].type_];
                         if is_stable_type_container(lid_ty) {
                             self.map.insert(lid, false);
                         } else if is_stable_type(lid_ty) {
@@ -486,7 +481,7 @@ fn propagate_reactivity_to_inner_functions_inner(
     env: &Environment,
     reactive_map: &mut ReactivityMap,
 ) {
-    let inner_func = &env.functions[func_id.index()];
+    let inner_func = &env.functions[func_id];
 
     for (_block_id, block) in &inner_func.body.blocks {
         for instr_id in &block.instructions {
@@ -586,8 +581,7 @@ fn apply_reactive_flags_replay(
             // Check hooks/use
             match &instr.value {
                 InstructionValue::CallExpression { callee, .. } => {
-                    let callee_ty =
-                        &env.types[env.identifiers[callee.identifier.index()].type_.index()];
+                    let callee_ty = &env.types[env.identifiers[callee.identifier].type_];
                     if get_hook_kind_for_type(env, callee_ty).ok().flatten().is_some()
                         || is_use_operator_type(callee_ty)
                     {
@@ -595,8 +589,7 @@ fn apply_reactive_flags_replay(
                     }
                 }
                 InstructionValue::MethodCall { property, .. } => {
-                    let property_ty =
-                        &env.types[env.identifiers[property.identifier.index()].type_.index()];
+                    let property_ty = &env.types[env.identifiers[property.identifier].type_];
                     if get_hook_kind_for_type(env, property_ty).ok().flatten().is_some()
                         || is_use_operator_type(property_ty)
                     {
@@ -617,7 +610,7 @@ fn apply_reactive_flags_replay(
             if let InstructionValue::FunctionExpression { lowered_func, .. }
             | InstructionValue::ObjectMethod { lowered_func, .. } = &mut instr.value
             {
-                let inner_func = &mut env.functions[lowered_func.func.index()];
+                let inner_func = &mut env.functions[lowered_func.func];
                 for ctx in &mut inner_func.context {
                     if reactive_ids.contains(&ctx.identifier) {
                         ctx.reactive = true;
@@ -717,7 +710,7 @@ fn apply_reactive_flags_to_inner_func(
 ) {
     // Collect nested function IDs first to avoid borrow issues
     let nested_func_ids: Vec<FunctionId> = {
-        let func = &env.functions[func_id.index()];
+        let func = &env.functions[func_id];
         let mut ids = Vec::new();
         for (_block_id, block) in &func.body.blocks {
             for instr_id in &block.instructions {
@@ -735,7 +728,7 @@ fn apply_reactive_flags_to_inner_func(
     };
 
     // Apply reactive flags using canonical visitors
-    let inner_func = &mut env.functions[func_id.index()];
+    let inner_func = &mut env.functions[func_id];
     for (_block_id, block) in &mut inner_func.body.blocks {
         for instr_id in &block.instructions {
             let instr = &mut inner_func.instructions[instr_id.index()];
@@ -754,7 +747,7 @@ fn apply_reactive_flags_to_inner_func(
 
     // Recurse into nested functions, and set reactive on their context variables
     for nested_id in nested_func_ids {
-        let nested_func = &mut env.functions[nested_id.index()];
+        let nested_func = &mut env.functions[nested_id];
         for ctx in &mut nested_func.context {
             if reactive_ids.contains(&ctx.identifier) {
                 ctx.reactive = true;

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_scope_variables.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_scope_variables.rs
@@ -50,19 +50,19 @@ pub fn infer_reactive_scope_variables(
     let mut scopes: FxHashMap<IdentifierId, ScopeState> = FxHashMap::default();
 
     scope_identifiers.for_each(|identifier_id, group_id| {
-        let ident_range = env.identifiers[identifier_id.index()].mutable_range.clone();
-        let ident_span = env.identifiers[identifier_id.index()].span;
+        let ident_range = env.identifiers[identifier_id].mutable_range.clone();
+        let ident_span = env.identifiers[identifier_id].span;
 
         let state = scopes.entry(group_id).or_insert_with(|| {
             let scope_id = env.next_scope_id();
             // Initialize scope range from the first member
-            let scope = &mut env.scopes[scope_id.index()];
+            let scope = &mut env.scopes[scope_id];
             scope.range = ident_range.clone();
             ScopeState { scope_id, span: ident_span }
         });
 
         // Update scope range
-        let scope = &mut env.scopes[state.scope_id.index()];
+        let scope = &mut env.scopes[state.scope_id];
 
         // If this is not the first identifier (scope was already created), merge ranges
         if scope.range.start != ident_range.start || scope.range.end != ident_range.end {
@@ -79,17 +79,17 @@ pub fn infer_reactive_scope_variables(
 
         // Assign the scope to this identifier
         let scope_id = state.scope_id;
-        env.identifiers[identifier_id.index()].scope = Some(scope_id);
+        env.identifiers[identifier_id].scope = Some(scope_id);
     });
 
     // Set span on each scope
     for state in scopes.values() {
-        env.scopes[state.scope_id.index()].span = state.span;
+        env.scopes[state.scope_id].span = state.span;
     }
 
     // Update each identifier's mutable_range to match its scope's range
     for (&_identifier_id, state) in &scopes {
-        let scope_range = env.scopes[state.scope_id.index()].range.clone();
+        let scope_range = env.scopes[state.scope_id].range.clone();
         // Find all identifiers with this scope and update their mutable_range
         // We iterate through all identifiers and check their scope
         for ident in &mut env.identifiers {
@@ -110,7 +110,7 @@ pub fn infer_reactive_scope_variables(
     }
 
     for state in scopes.values() {
-        let scope = &env.scopes[state.scope_id.index()];
+        let scope = &env.scopes[state.scope_id];
         if scope.range.start == EvaluationOrder::UNSET
             || scope.range.end == EvaluationOrder::UNSET
             || max_instruction == EvaluationOrder::UNSET
@@ -241,8 +241,8 @@ pub(crate) fn find_disjoint_mutable_values(
         // Handle phi nodes
         for phi in &block.phis {
             let phi_id = phi.place.identifier;
-            let phi_range = &env.identifiers[phi_id.index()].mutable_range;
-            let phi_decl_id = env.identifiers[phi_id.index()].declaration_id;
+            let phi_range = &env.identifiers[phi_id].mutable_range;
+            let phi_decl_id = env.identifiers[phi_id].declaration_id;
 
             let first_instr_id = block
                 .instructions
@@ -264,8 +264,7 @@ pub(crate) fn find_disjoint_mutable_values(
             // compared at the top of the scope).
             let is_loop_carried_reassignment = !is_phi_mutated_after_creation
                 && phi.operands.iter().any(|(_pred_id, operand)| {
-                    env.identifiers[operand.identifier.index()].mutable_range.start
-                        >= first_instr_id
+                    env.identifiers[operand.identifier].mutable_range.start >= first_instr_id
                 });
             if is_phi_mutated_after_creation || is_loop_carried_reassignment {
                 let mut operands = vec![phi_id];
@@ -289,8 +288,8 @@ pub(crate) fn find_disjoint_mutable_values(
             let mut operands: Vec<IdentifierId> = Vec::new();
 
             let lvalue_id = instr.lvalue.identifier;
-            let lvalue_range = &env.identifiers[lvalue_id.index()].mutable_range;
-            let lvalue_type = &env.types[env.identifiers[lvalue_id.index()].type_.index()];
+            let lvalue_range = &env.identifiers[lvalue_id].mutable_range;
+            let lvalue_type = &env.types[env.identifiers[lvalue_id].type_];
             let lvalue_type_is_primitive = is_primitive_type(lvalue_type);
 
             if lvalue_range.end > lvalue_range.start + 1
@@ -303,21 +302,21 @@ pub(crate) fn find_disjoint_mutable_values(
                 InstructionValue::DeclareLocal { lvalue, .. }
                 | InstructionValue::DeclareContext { lvalue, .. } => {
                     let place_id = lvalue.place.identifier;
-                    let decl_id = env.identifiers[place_id.index()].declaration_id;
+                    let decl_id = env.identifiers[place_id].declaration_id;
                     declarations.entry(decl_id).or_insert(place_id);
                 }
                 InstructionValue::StoreLocal { lvalue, value, .. }
                 | InstructionValue::StoreContext { lvalue, value, .. } => {
                     let place_id = lvalue.place.identifier;
-                    let decl_id = env.identifiers[place_id.index()].declaration_id;
+                    let decl_id = env.identifiers[place_id].declaration_id;
                     declarations.entry(decl_id).or_insert(place_id);
 
-                    let place_range = &env.identifiers[place_id.index()].mutable_range;
+                    let place_range = &env.identifiers[place_id].mutable_range;
                     if place_range.end > place_range.start + 1 {
                         operands.push(place_id);
                     }
 
-                    let value_range = &env.identifiers[value.identifier.index()].mutable_range;
+                    let value_range = &env.identifiers[value.identifier].mutable_range;
                     if value_range.contains(instr.id) && value_range.start > 0 {
                         operands.push(value.identifier);
                     }
@@ -325,16 +324,16 @@ pub(crate) fn find_disjoint_mutable_values(
                 InstructionValue::Destructure { lvalue, value, .. } => {
                     let pattern_places = each_pattern_operand(&lvalue.pattern);
                     for place_id in &pattern_places {
-                        let decl_id = env.identifiers[place_id.index()].declaration_id;
+                        let decl_id = env.identifiers[*place_id].declaration_id;
                         declarations.entry(decl_id).or_insert(*place_id);
 
-                        let place_range = &env.identifiers[place_id.index()].mutable_range;
+                        let place_range = &env.identifiers[*place_id].mutable_range;
                         if place_range.end > place_range.start + 1 {
                             operands.push(*place_id);
                         }
                     }
 
-                    let value_range = &env.identifiers[value.identifier.index()].mutable_range;
+                    let value_range = &env.identifiers[value.identifier].mutable_range;
                     if value_range.contains(instr.id) && value_range.start > 0 {
                         operands.push(value.identifier);
                     }
@@ -343,7 +342,7 @@ pub(crate) fn find_disjoint_mutable_values(
                     // For MethodCall: include all mutable operands plus the computed property
                     let all_operands = each_instruction_value_operand(&instr.value, env);
                     for op_id in &all_operands {
-                        let op_range = &env.identifiers[op_id.index()].mutable_range;
+                        let op_range = &env.identifiers[*op_id].mutable_range;
                         if op_range.contains(instr.id) && op_range.start > 0 {
                             operands.push(*op_id);
                         }
@@ -355,7 +354,7 @@ pub(crate) fn find_disjoint_mutable_values(
                     // For all other instructions: include mutable operands
                     let all_operands = each_instruction_value_operand(&instr.value, env);
                     for op_id in &all_operands {
-                        let op_range = &env.identifiers[op_id.index()].mutable_range;
+                        let op_range = &env.identifiers[*op_id].mutable_range;
                         if op_range.contains(instr.id) && op_range.start > 0 {
                             operands.push(*op_id);
                         }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/memoize_fbt_and_macro_operands_in_same_scope.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/memoize_fbt_and_macro_operands_in_same_scope.rs
@@ -192,7 +192,7 @@ fn merge_macro_arguments(
 
                 InstructionValue::CallExpression { callee, .. }
                 | InstructionValue::MethodCall { property: callee, .. } => {
-                    let scope_id = match env.identifiers[lvalue_id.index()].scope {
+                    let scope_id = match env.identifiers[lvalue_id].scope {
                         Some(s) => s,
                         None => continue,
                     };
@@ -216,7 +216,7 @@ fn merge_macro_arguments(
                 }
 
                 InstructionValue::JsxExpression { tag, .. } => {
-                    let scope_id = match env.identifiers[lvalue_id.index()].scope {
+                    let scope_id = match env.identifiers[lvalue_id].scope {
                         Some(s) => s,
                         None => continue,
                     };
@@ -243,7 +243,7 @@ fn merge_macro_arguments(
 
                 // Default case: check if lvalue is a macro tag
                 _ => {
-                    let scope_id = match env.identifiers[lvalue_id.index()].scope {
+                    let scope_id = match env.identifiers[lvalue_id].scope {
                         Some(s) => s,
                         None => continue,
                     };
@@ -267,7 +267,7 @@ fn merge_macro_arguments(
         // Handle phis
         let block = &func.body.blocks[&block_id];
         for phi in &block.phis {
-            let scope_id = match env.identifiers[phi.place.identifier.index()].scope {
+            let scope_id = match env.identifiers[phi.place.identifier].scope {
                 Some(s) => s,
                 None => continue,
             };
@@ -291,7 +291,7 @@ fn merge_macro_arguments(
                 .collect();
 
             for (operand_id, def) in operand_updates {
-                env.identifiers[operand_id.index()].scope = Some(scope_id);
+                env.identifiers[operand_id].scope = Some(scope_id);
                 expand_fbt_scope_range(env, scope_id, operand_id);
                 macro_tags.insert(operand_id, def);
                 macro_values.insert(operand_id);
@@ -308,18 +308,18 @@ fn merge_macro_arguments(
 /// scope.range, so mutations are automatically visible; in Rust we must propagate.
 /// Equivalent to TS `expandFbtScopeRange`.
 fn expand_fbt_scope_range(env: &mut Environment, scope_id: ScopeId, operand_id: IdentifierId) {
-    let extend_start = env.identifiers[operand_id.index()].mutable_range.start;
+    let extend_start = env.identifiers[operand_id].mutable_range.start;
     if extend_start == 0 {
         return;
     }
-    let old_range_id = env.scopes[scope_id.index()].range.id;
-    let old_start = env.scopes[scope_id.index()].range.start;
+    let old_range_id = env.scopes[scope_id].range.id;
+    let old_start = env.scopes[scope_id].range.start;
     let new_start = old_start.min(extend_start);
     if new_start == old_start {
         return;
     }
-    env.scopes[scope_id.index()].range.start = new_start;
-    let new_range = env.scopes[scope_id.index()].range.clone();
+    env.scopes[scope_id].range.start = new_start;
+    let new_range = env.scopes[scope_id].range.clone();
     for ident in &mut env.identifiers {
         if ident.scope == Some(scope_id) && ident.mutable_range.id == old_range_id {
             ident.mutable_range = new_range.clone();
@@ -348,7 +348,7 @@ fn visit_operands(
 
     for operand_id in operand_ids {
         if matches!(macro_def.level, InlineLevel::Transitive) {
-            env.identifiers[operand_id.index()].scope = Some(scope_id);
+            env.identifiers[operand_id].scope = Some(scope_id);
             expand_fbt_scope_range(env, scope_id, operand_id);
             macro_tags.insert(operand_id, macro_def.clone());
         }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/merge_overlapping_reactive_scopes_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/merge_overlapping_reactive_scopes_hir.rs
@@ -68,7 +68,7 @@ struct TraversalState {
 /// Check if a scope is active at the given instruction id.
 /// Corresponds to TS `isScopeActive(scope, id)`.
 fn is_scope_active(env: &Environment, scope_id: ScopeId, id: EvaluationOrder) -> bool {
-    env.scopes[scope_id.index()].range.contains(id)
+    env.scopes[scope_id].range.contains(id)
 }
 
 /// Get the scope for a place if it's active at the given instruction.
@@ -78,14 +78,14 @@ fn get_place_scope(
     id: EvaluationOrder,
     identifier_id: IdentifierId,
 ) -> Option<ScopeId> {
-    let scope_id = env.identifiers[identifier_id.index()].scope?;
+    let scope_id = env.identifiers[identifier_id].scope?;
     if is_scope_active(env, scope_id, id) { Some(scope_id) } else { None }
 }
 
 /// Check if a place is mutable at the given instruction.
 /// Corresponds to TS `isMutable({id}, place)`.
 fn is_mutable(env: &Environment, id: EvaluationOrder, identifier_id: IdentifierId) -> bool {
-    let range = &env.identifiers[identifier_id.index()].mutable_range;
+    let range = &env.identifiers[identifier_id].mutable_range;
     range.contains(id)
 }
 
@@ -99,12 +99,12 @@ fn collect_scope_info(func: &HirFunction, env: &Environment) -> ScopeInfo {
     let mut place_scopes: FxHashMap<IdentifierId, ScopeId> = FxHashMap::default();
 
     let mut collect_place_scope = |identifier_id: IdentifierId, env: &Environment| {
-        let scope_id = match env.identifiers[identifier_id.index()].scope {
+        let scope_id = match env.identifiers[identifier_id].scope {
             Some(s) => s,
             None => return,
         };
         place_scopes.insert(identifier_id, scope_id);
-        let range = &env.scopes[scope_id.index()].range;
+        let range = &env.scopes[scope_id].range;
         if range.start != range.end {
             scope_starts_map.entry(range.start).or_default().push(scope_id);
             scope_ends_map.entry(range.end).or_default().push(scope_id);
@@ -177,8 +177,8 @@ fn visit_instruction_id(
         // Sort scopes by start descending (matching active_scopes order)
         let mut scopes_sorted = scope_end_entry.scopes;
         scopes_sorted.sort_by(|a, b| {
-            let a_start = env.scopes[a.index()].range.start;
-            let b_start = env.scopes[b.index()].range.start;
+            let a_start = env.scopes[*a].range.start;
+            let b_start = env.scopes[*b].range.start;
             b_start.cmp(&a_start)
         });
 
@@ -201,8 +201,8 @@ fn visit_instruction_id(
         // Sort by end descending
         let mut scopes_sorted = scope_start_entry.scopes;
         scopes_sorted.sort_by(|a, b| {
-            let a_end = env.scopes[a.index()].range.end;
-            let b_end = env.scopes[b.index()].range.end;
+            let a_end = env.scopes[*a].range.end;
+            let b_end = env.scopes[*b].range.end;
             b_end.cmp(&a_end)
         });
 
@@ -212,7 +212,7 @@ fn visit_instruction_id(
         for i in 1..scopes_sorted.len() {
             let prev = scopes_sorted[i - 1];
             let curr = scopes_sorted[i];
-            if env.scopes[prev.index()].range.end == env.scopes[curr.index()].range.end {
+            if env.scopes[prev].range.end == env.scopes[curr].range.end {
                 state.joined.union(&[prev, curr]);
             }
         }
@@ -329,16 +329,16 @@ pub fn merge_overlapping_reactive_scopes_hir(func: &mut HirFunction, env: &mut E
     let mut original_root_range_ids: FxHashMap<ScopeId, MutableRangeId> = FxHashMap::default();
     for (_, root_id) in &scope_groups {
         if !original_root_range_ids.contains_key(root_id) {
-            let range_id = env.scopes[root_id.index()].range.id;
+            let range_id = env.scopes[*root_id].range.id;
             original_root_range_ids.insert(*root_id, range_id);
         }
     }
 
     // Update root scope ranges
     for (scope_id, root_id) in &scope_groups {
-        let scope_start = env.scopes[scope_id.index()].range.start;
-        let scope_end = env.scopes[scope_id.index()].range.end;
-        let root_range = &mut env.scopes[root_id.index()].range;
+        let scope_start = env.scopes[*scope_id].range.start;
+        let scope_end = env.scopes[*scope_id].range.end;
+        let root_range = &mut env.scopes[*root_id].range;
         root_range.start = cmp::min(root_range.start, scope_start);
         root_range.end = cmp::max(root_range.end, scope_end);
     }
@@ -350,7 +350,7 @@ pub fn merge_overlapping_reactive_scopes_hir(func: &mut HirFunction, env: &mut E
     for ident in &mut env.identifiers {
         for (root_id, orig_range_id) in &original_root_range_ids {
             if ident.mutable_range.id == *orig_range_id {
-                let new_range = &env.scopes[root_id.index()].range;
+                let new_range = &env.scopes[*root_id].range;
                 ident.mutable_range.start = new_range.start;
                 ident.mutable_range.end = new_range.end;
                 break;
@@ -365,7 +365,7 @@ pub fn merge_overlapping_reactive_scopes_hir(func: &mut HirFunction, env: &mut E
     for (identifier_id, original_scope) in &place_scopes {
         let next_scope = joined_scopes.find(*original_scope);
         if next_scope != *original_scope {
-            env.identifiers[identifier_id.index()].scope = Some(next_scope);
+            env.identifiers[*identifier_id].scope = Some(next_scope);
         }
     }
 }
@@ -383,7 +383,7 @@ fn each_instruction_operand_ids_with_types<'a>(
     visitors::each_instruction_operand(instr, env)
         .into_iter()
         .map(|p| {
-            let type_ = env.types[env.identifiers[p.identifier.index()].type_.index()].clone();
+            let type_ = env.types[env.identifiers[p.identifier].type_].clone();
             (p.identifier, type_)
         })
         .collect()

--- a/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
@@ -90,13 +90,11 @@ pub fn propagate_scope_dependencies_hir<'a>(func: &mut HirFunction<'a>, env: &mu
 
         // Step 3: Reduce dependencies to a minimal set.
         let candidates = tree.derive_minimal_dependencies();
-        let scope = &mut env.scopes[scope_id.index()];
+        let scope = &mut env.scopes[*scope_id];
         for candidate_dep in candidates {
             let already_exists = scope.dependencies.iter().any(|existing_dep| {
-                let existing_decl_id =
-                    env.identifiers[existing_dep.identifier.index()].declaration_id;
-                let candidate_decl_id =
-                    env.identifiers[candidate_dep.identifier.index()].declaration_id;
+                let existing_decl_id = env.identifiers[existing_dep.identifier].declaration_id;
+                let candidate_decl_id = env.identifiers[candidate_dep.identifier].declaration_id;
                 existing_decl_id == candidate_decl_id
                     && are_equal_paths(&existing_dep.path, &candidate_dep.path)
             });
@@ -134,7 +132,7 @@ fn find_temporaries_used_outside_declaring_scope(
                         pruned_scopes: &FxHashSet<ScopeId>,
                         used_outside: &mut FxHashSet<DeclarationId>,
                         env: &Environment| {
-        let decl_id = env.identifiers[place_id.index()].declaration_id;
+        let decl_id = env.identifiers[place_id].declaration_id;
         if let Some(&declaring_scope) = declarations.get(&decl_id) {
             if !traversal.is_scope_active(declaring_scope)
                 && !pruned_scopes.contains(&declaring_scope)
@@ -178,8 +176,7 @@ fn find_temporaries_used_outside_declaring_scope(
                         InstructionValue::LoadLocal { .. }
                         | InstructionValue::LoadContext { .. }
                         | InstructionValue::PropertyLoad { .. } => {
-                            let decl_id =
-                                env.identifiers[instr.lvalue.identifier.index()].declaration_id;
+                            let decl_id = env.identifiers[instr.lvalue.identifier].declaration_id;
                             declarations.insert(decl_id, scope);
                         }
                         _ => {}
@@ -236,8 +233,8 @@ fn is_load_context_mutable(
     env: &Environment,
 ) -> bool {
     if let InstructionValue::LoadContext { place, .. } = value {
-        if let Some(scope_id) = env.identifiers[place.identifier.index()].scope {
-            let scope_range = &env.scopes[scope_id.index()].range;
+        if let Some(scope_id) = env.identifiers[place.identifier].scope {
+            let scope_range = &env.scopes[scope_id].range;
             return id >= scope_range.end;
         }
     }
@@ -267,7 +264,7 @@ fn collect_temporaries_sidemap_impl<'a>(
             let instr = &func.instructions[instr_id.index()];
             let instr_eval_order =
                 if let Some(outer_id) = inner_fn_context { outer_id } else { instr.id };
-            let lvalue_decl_id = env.identifiers[instr.lvalue.identifier.index()].declaration_id;
+            let lvalue_decl_id = env.identifiers[instr.lvalue.identifier].declaration_id;
             let used_outside = used_outside_declaring_scope.contains(&lvalue_decl_id);
 
             match &instr.value {
@@ -278,8 +275,8 @@ fn collect_temporaries_sidemap_impl<'a>(
                     }
                 }
                 InstructionValue::LoadLocal { place, span, .. }
-                    if env.identifiers[instr.lvalue.identifier.index()].name.is_none()
-                        && env.identifiers[place.identifier.index()].name.is_some()
+                    if env.identifiers[instr.lvalue.identifier].name.is_none()
+                        && env.identifiers[place.identifier].name.is_some()
                         && !used_outside =>
                 {
                     if inner_fn_context.is_none()
@@ -298,8 +295,8 @@ fn collect_temporaries_sidemap_impl<'a>(
                 }
                 value @ InstructionValue::LoadContext { place, span, .. }
                     if is_load_context_mutable(value, instr_eval_order, env)
-                        && env.identifiers[instr.lvalue.identifier.index()].name.is_none()
-                        && env.identifiers[place.identifier.index()].name.is_some()
+                        && env.identifiers[instr.lvalue.identifier].name.is_none()
+                        && env.identifiers[place.identifier].name.is_some()
                         && !used_outside =>
                 {
                     if inner_fn_context.is_none()
@@ -318,7 +315,7 @@ fn collect_temporaries_sidemap_impl<'a>(
                 }
                 InstructionValue::FunctionExpression { lowered_func, .. }
                 | InstructionValue::ObjectMethod { lowered_func, .. } => {
-                    let inner_func = &env.functions[lowered_func.func.index()];
+                    let inner_func = &env.functions[lowered_func.func];
                     let ctx = inner_fn_context.unwrap_or(instr.id);
                     collect_temporaries_sidemap_impl(
                         inner_func,
@@ -421,7 +418,7 @@ fn traverse_function_optional<'a>(
             match &instr.value {
                 InstructionValue::FunctionExpression { lowered_func, .. }
                 | InstructionValue::ObjectMethod { lowered_func, .. } => {
-                    let inner_func = &env.functions[lowered_func.func.index()];
+                    let inner_func = &env.functions[lowered_func.func];
                     traverse_function_optional(inner_func, env, ctx);
                 }
                 _ => {}
@@ -886,10 +883,10 @@ fn is_immutable_at_instr(
     if let Some(nested_ctx) = ctx.nested_fn_immutable_context {
         return nested_ctx.contains(&identifier_id);
     }
-    let ident = &env.identifiers[identifier_id.index()];
+    let ident = &env.identifiers[identifier_id];
     let mutable_at_instr =
         ident.mutable_range.end > ident.mutable_range.start + 1 && ident.scope.is_some() && {
-            let scope = &env.scopes[ident.scope.unwrap().index()];
+            let scope = &env.scopes[ident.scope.unwrap()];
             in_range(instr_id, &scope.range)
         };
     !mutable_at_instr || ctx.known_immutable_identifiers.contains(&identifier_id)
@@ -971,8 +968,7 @@ fn get_assumed_invoked_functions_impl(
             let instr = &func.instructions[instr_id.index()];
             match &instr.value {
                 InstructionValue::CallExpression { callee, args, .. } => {
-                    let callee_ty =
-                        &env.types[env.identifiers[callee.identifier.index()].type_.index()];
+                    let callee_ty = &env.types[env.identifiers[callee.identifier].type_];
                     let maybe_hook = env.get_hook_kind_for_type(callee_ty).ok().flatten();
                     if let Some(entry) = temporaries.get(&callee.identifier) {
                         // Direct calls
@@ -1015,7 +1011,7 @@ fn get_assumed_invoked_functions_impl(
                 InstructionValue::FunctionExpression { lowered_func, .. } => {
                     // Recursively traverse into other function expressions
                     // TS passes the shared temporaries map to the recursive call
-                    let inner_func = &env.functions[lowered_func.func.index()];
+                    let inner_func = &env.functions[lowered_func.func];
                     let lambdas_called =
                         get_assumed_invoked_functions_impl(inner_func, env, temporaries);
                     if let Some(entry) = temporaries.get_mut(&instr.lvalue.identifier) {
@@ -1128,7 +1124,7 @@ fn collect_non_nulls_in_blocks<'a>(
             // Handle assumed-invoked inner functions
             if let InstructionValue::FunctionExpression { lowered_func, .. } = &instr.value {
                 if ctx.assumed_invoked_fns.contains(&lowered_func.func) {
-                    let inner_func = &env.functions[lowered_func.func.index()];
+                    let inner_func = &env.functions[lowered_func.func];
                     // Build nested fn immutable context
                     let nested_fn_immutable_context: FxHashSet<IdentifierId> =
                         if ctx.nested_fn_immutable_context.is_some() {
@@ -1639,19 +1635,19 @@ impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
         if self.inner_fn_context.is_some() {
             return;
         }
-        let decl_id = env.identifiers[identifier_id.index()].declaration_id;
+        let decl_id = env.identifiers[identifier_id].declaration_id;
         self.declarations.entry(decl_id).or_insert_with(|| decl.clone());
         self.reassignments.insert(identifier_id, decl);
     }
 
     fn has_declared(&self, identifier_id: IdentifierId, env: &Environment) -> bool {
-        let decl_id = env.identifiers[identifier_id.index()].declaration_id;
+        let decl_id = env.identifiers[identifier_id].declaration_id;
         self.declarations.contains_key(&decl_id)
     }
 
     fn check_valid_dependency(&self, dep: &ReactiveScopeDependency, env: &Environment) -> bool {
         // Ref value is not a valid dep
-        let ty = &env.types[env.identifiers[dep.identifier.index()].type_.index()];
+        let ty = &env.types[env.identifiers[dep.identifier].type_];
         if is_ref_value_type(ty) {
             return false;
         }
@@ -1660,7 +1656,7 @@ impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
             return false;
         }
 
-        let ident = &env.identifiers[dep.identifier.index()];
+        let ident = &env.identifiers[dep.identifier];
         let current_declaration = self
             .reassignments
             .get(&dep.identifier)
@@ -1668,7 +1664,7 @@ impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
 
         if let Some(current_scope) = self.current_scope() {
             if let Some(decl) = current_declaration {
-                let scope_range_start = env.scopes[current_scope.index()].range.start;
+                let scope_range_start = env.scopes[current_scope].range.start;
                 return decl.id < scope_range_start;
             }
         }
@@ -1700,7 +1696,7 @@ impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
     }
 
     fn visit_dependency(&mut self, dep: ReactiveScopeDependency<'a>, env: &mut Environment) {
-        let ident = &env.identifiers[dep.identifier.index()];
+        let ident = &env.identifiers[dep.identifier];
         let decl_id = ident.declaration_id;
 
         // Record scope declarations for values used outside their declaring scope
@@ -1710,19 +1706,18 @@ impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
                 for &scope_id in &orig_scope_stack {
                     if !self.scope_stack.contains(&scope_id) {
                         // Check if already declared in this scope
-                        let scope = &env.scopes[scope_id.index()];
-                        let already_declared = scope.declarations.iter().any(|(_, d)| {
-                            env.identifiers[d.identifier.index()].declaration_id == decl_id
-                        });
+                        let scope = &env.scopes[scope_id];
+                        let already_declared = scope
+                            .declarations
+                            .iter()
+                            .any(|(_, d)| env.identifiers[d.identifier].declaration_id == decl_id);
                         if !already_declared {
                             let orig_scope_id = *orig_scope_stack.last().unwrap();
                             let new_decl = ReactiveScopeDeclaration {
                                 identifier: dep.identifier,
                                 scope: orig_scope_id,
                             };
-                            env.scopes[scope_id.index()]
-                                .declarations
-                                .push((dep.identifier, new_decl));
+                            env.scopes[scope_id].declarations.push((dep.identifier, new_decl));
                         }
                     }
                 }
@@ -1730,19 +1725,18 @@ impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
         }
 
         // Handle ref.current access
-        let dep =
-            if is_use_ref_type(&env.types[env.identifiers[dep.identifier.index()].type_.index()])
-                && dep.path.first().map(|p| p.property.is_string("current")).unwrap_or(false)
-            {
-                ReactiveScopeDependency {
-                    identifier: dep.identifier,
-                    reactive: dep.reactive,
-                    path: vec![],
-                    span: dep.span,
-                }
-            } else {
-                dep
-            };
+        let dep = if is_use_ref_type(&env.types[env.identifiers[dep.identifier].type_])
+            && dep.path.first().map(|p| p.property.is_string("current")).unwrap_or(false)
+        {
+            ReactiveScopeDependency {
+                identifier: dep.identifier,
+                reactive: dep.reactive,
+                path: vec![],
+                span: dep.span,
+            }
+        } else {
+            dep
+        };
 
         if self.check_valid_dependency(&dep, env) {
             if let Some(top) = self.dep_stack.last_mut() {
@@ -1753,10 +1747,10 @@ impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
 
     fn visit_reassignment(&mut self, place: &Place, env: &mut Environment) {
         if let Some(current_scope) = self.current_scope() {
-            let scope = &env.scopes[current_scope.index()];
+            let scope = &env.scopes[current_scope];
             let already = scope.reassignments.iter().any(|id| {
-                env.identifiers[id.index()].declaration_id
-                    == env.identifiers[place.identifier.index()].declaration_id
+                env.identifiers[*id].declaration_id
+                    == env.identifiers[place.identifier].declaration_id
             });
             if !already
                 && self.check_valid_dependency(
@@ -1769,7 +1763,7 @@ impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
                     env,
                 )
             {
-                env.scopes[current_scope.index()].reassignments.push(place.identifier);
+                env.scopes[current_scope].reassignments.push(place.identifier);
             }
         }
     }
@@ -1795,9 +1789,9 @@ fn visit_inner_function_blocks<'a>(
 ) {
     // Clone inner function's instructions and block structure to avoid
     // borrow conflicts when mutating env through handle_instruction.
-    let inner_instrs: Vec<Instruction> = env.functions[func_id.index()].instructions.clone();
+    let inner_instrs: Vec<Instruction> = env.functions[func_id].instructions.clone();
     type InnerBlockSnapshot = (BlockId, Vec<InstructionId>, Vec<(BlockId, IdentifierId)>, Terminal);
-    let inner_blocks: Vec<InnerBlockSnapshot> = env.functions[func_id.index()]
+    let inner_blocks: Vec<InnerBlockSnapshot> = env.functions[func_id]
         .body
         .blocks
         .iter()

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -72,8 +72,8 @@ fn build_temporary_place(builder: &mut HirBuilder<'_, '_>, span: Option<Span>) -
 /// Corresponds to TS `promoteTemporary(identifier)`.
 fn promote_temporary(builder: &mut HirBuilder<'_, '_>, identifier_id: IdentifierId) {
     let env = builder.environment_mut();
-    let decl_id = env.identifiers[identifier_id.index()].declaration_id;
-    env.identifiers[identifier_id.index()].name =
+    let decl_id = env.identifiers[identifier_id].declaration_id;
+    env.identifiers[identifier_id].name =
         Some(IdentifierName::Promoted(format_ident!(env.allocator, "#t{}", decl_id.index())));
 }
 
@@ -83,7 +83,7 @@ fn lower_value_to_temporary<'a>(
 ) -> Result<Place, OxcDiagnostic> {
     // Optimization: if loading an unnamed temporary, skip creating a new instruction
     if let InstructionValue::LoadLocal { ref place, .. } = value {
-        let ident = &builder.environment().identifiers[place.identifier.index()];
+        let ident = &builder.environment().identifiers[place.identifier];
         if ident.name.is_none() {
             return Ok(place.clone());
         }

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/hir_builder.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/hir_builder.rs
@@ -542,7 +542,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
     pub fn make_temporary(&mut self, span: Option<Span>) -> IdentifierId {
         let id = self.env.next_identifier_id();
         // Update the span on the allocated identifier
-        self.env.identifiers[id.index()].span = span;
+        self.env.identifiers[id].span = span;
         id
     }
 
@@ -662,7 +662,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
             let should_record_fbt_error =
                 if let Some(&identifier_id) = self.bindings.get(&symbol_id) {
                     // Already resolved - check if the resolved name is still "fbt"
-                    match &self.env.identifiers[identifier_id.index()].name {
+                    match &self.env.identifiers[identifier_id].name {
                         Some(IdentifierName::Named(resolved_name)) => resolved_name == "fbt",
                         _ => false,
                     }
@@ -715,15 +715,15 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
         // Allocate identifier in the arena
         let id = self.env.next_identifier_id();
         // Update the name and span on the allocated identifier
-        self.env.identifiers[id.index()].name = Some(IdentifierName::Named(candidate));
+        self.env.identifiers[id].name = Some(IdentifierName::Named(candidate));
         // Prefer the binding's declaration span over the reference span.
         // This matches TS behavior where Babel's resolveBinding returns the
         // binding identifier's original span (the declaration site).
         let decl_span = self.declaration_span(symbol_id);
         if let Some(ref dl) = decl_span {
-            self.env.identifiers[id.index()].span = Some(*dl);
+            self.env.identifiers[id].span = Some(*dl);
         } else if let Some(ref span) = span {
-            self.env.identifiers[id.index()].span = Some(*span);
+            self.env.identifiers[id].span = Some(*span);
         }
 
         self.used_names.insert(candidate, symbol_id);
@@ -734,7 +734,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
     /// Set the span on an identifier to the declaration-site span.
     /// This overrides any previously-set span (which may have come from a reference site).
     pub fn set_identifier_declaration_span(&mut self, id: IdentifierId, span: Span) {
-        self.env.identifiers[id.index()].span = Some(span);
+        self.env.identifiers[id].span = Some(span);
     }
 
     /// Resolve an identifier reference to a VariableBinding.
@@ -848,7 +848,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
         // None = unresolved binding; Some(matches) = resolved, current name comparison
         let resolved_name_matches = |sid: SymbolId| -> Option<bool> {
             let &identifier_id = self.bindings.get(&sid)?;
-            match &self.env.identifiers[identifier_id.index()].name {
+            match &self.env.identifiers[identifier_id].name {
                 Some(IdentifierName::Named(n)) => Some(n == name),
                 _ => Some(false),
             }
@@ -1127,6 +1127,6 @@ pub fn mark_predecessors(hir: &mut HIR) {
 pub fn create_temporary_place(env: &mut Environment<'_>, span: Option<Span>) -> Place {
     let id = env.next_identifier_id();
     // Update the span on the allocated identifier
-    env.identifiers[id.index()].span = span;
+    env.identifiers[id].span = span;
     Place { identifier: id, reactive: false, effect: Effect::Unknown, span: None }
 }

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
@@ -628,9 +628,9 @@ fn process_inner_function<'a>(
     env: &mut Environment<'a>,
     constants: &mut Constants<'a>,
 ) {
-    let mut inner = replace(&mut env.functions[func_id.index()], placeholder_function());
+    let mut inner = replace(&mut env.functions[func_id], placeholder_function());
     constant_propagation_impl(&mut inner, env, constants);
-    env.functions[func_id.index()] = inner;
+    env.functions[func_id] = inner;
 }
 
 // =============================================================================

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/dead_code_elimination.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/dead_code_elimination.rs
@@ -11,6 +11,7 @@
 //!
 //! Ported from TypeScript `src/Optimization/DeadCodeElimination.ts`.
 
+use oxc_index::IndexSlice;
 use oxc_str::IdentHashSet;
 use rustc_hash::FxHashSet;
 
@@ -85,11 +86,11 @@ impl State<'_> {
 /// Mark an identifier as being referenced (not dead code).
 fn reference<'a>(
     state: &mut State<'a>,
-    identifiers: &[Identifier<'a>],
+    identifiers: &IndexSlice<IdentifierId, [Identifier<'a>]>,
     identifier_id: IdentifierId,
 ) {
     state.identifiers.insert(identifier_id);
-    let ident = &identifiers[identifier_id.index()];
+    let ident = &identifiers[identifier_id];
     if let Some(IdentifierName::Named(name) | IdentifierName::Promoted(name)) = ident.name {
         state.named.insert(name);
     }
@@ -99,13 +100,13 @@ fn reference<'a>(
 /// Checks both the specific SSA id and (for named identifiers) any usage of that name.
 fn is_id_or_name_used(
     state: &State,
-    identifiers: &[Identifier],
+    identifiers: &IndexSlice<IdentifierId, [Identifier]>,
     identifier_id: IdentifierId,
 ) -> bool {
     if state.identifiers.contains(&identifier_id) {
         return true;
     }
-    let ident = &identifiers[identifier_id.index()];
+    let ident = &identifiers[identifier_id];
     if let Some(ref name) = ident.name { state.named.contains(name.value()) } else { false }
 }
 
@@ -308,8 +309,7 @@ fn pruneable_value(value: &InstructionValue, state: &State, env: &Environment) -
         }
         InstructionValue::CallExpression { callee, .. } => {
             if env.output_mode == OutputMode::Ssr {
-                let callee_ty =
-                    &env.types[env.identifiers[callee.identifier.index()].type_.index()];
+                let callee_ty = &env.types[env.identifiers[callee.identifier].type_];
                 if let Some(HookKind::UseState | HookKind::UseReducer | HookKind::UseRef) =
                     env.get_hook_kind_for_type(callee_ty).ok().flatten()
                 {
@@ -320,8 +320,7 @@ fn pruneable_value(value: &InstructionValue, state: &State, env: &Environment) -
         }
         InstructionValue::MethodCall { property, .. } => {
             if env.output_mode == OutputMode::Ssr {
-                let callee_ty =
-                    &env.types[env.identifiers[property.identifier.index()].type_.index()];
+                let callee_ty = &env.types[env.identifiers[property.identifier].type_];
                 if let Some(HookKind::UseState | HookKind::UseReducer | HookKind::UseRef) =
                     env.get_hook_kind_for_type(callee_ty).ok().flatten()
                 {

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/drop_manual_memoization.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/drop_manual_memoization.rs
@@ -394,7 +394,7 @@ pub fn collect_maybe_memo_dependencies<'a>(
             if let Some(source) = maybe_deps.get(&place.identifier) {
                 Some(source.clone())
             } else if matches!(
-                &env.identifiers[place.identifier.index()].name,
+                &env.identifiers[place.identifier].name,
                 Some(IdentifierName::Named(_))
             ) {
                 Some(ManualMemoDependency {
@@ -416,7 +416,7 @@ pub fn collect_maybe_memo_dependencies<'a>(
             let lvalue_id = lvalue.place.identifier;
             let rvalue_id = val.identifier;
             if let Some(aliased) = maybe_deps.get(&rvalue_id) {
-                let lvalue_name = &env.identifiers[lvalue_id.index()].name;
+                let lvalue_name = &env.identifiers[lvalue_id].name;
                 if !matches!(lvalue_name, Some(IdentifierName::Named(_))) {
                     // Note: we can't insert into maybe_deps here since we only have
                     // a shared reference. The caller handles insertion.

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/inline_iifes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/inline_iifes.rs
@@ -99,7 +99,7 @@ pub fn inline_immediately_invoked_function_expressions<'a>(
             match &instr.value {
                 InstructionValue::FunctionExpression { lowered_func, .. } => {
                     let identifier_id = instr.lvalue.identifier;
-                    if env.identifiers[identifier_id.index()].name.is_none() {
+                    if env.identifiers[identifier_id].name.is_none() {
                         functions.insert(identifier_id, lowered_func.func);
                     }
                     continue;
@@ -116,7 +116,7 @@ pub fn inline_immediately_invoked_function_expressions<'a>(
                         None => continue, // Not invoking a local function expression
                     };
 
-                    let inner_func = &env.functions[inner_func_id.index()];
+                    let inner_func = &env.functions[inner_func_id];
                     if !inner_func.params.is_empty() || inner_func.is_async || inner_func.generator
                     {
                         // Can't inline functions with params, or async/generator functions
@@ -152,8 +152,8 @@ pub fn inline_immediately_invoked_function_expressions<'a>(
                     func.body.blocks.get_mut(&block_id).unwrap().instructions.truncate(ii);
 
                     let has_single_return =
-                        has_single_exit_return_terminal(&env.functions[inner_func_id.index()]);
-                    let inner_entry = env.functions[inner_func_id.index()].body.entry;
+                        has_single_exit_return_terminal(&env.functions[inner_func_id]);
+                    let inner_entry = env.functions[inner_func_id].body.entry;
 
                     if has_single_return {
                         // Single-return path: simple goto replacement
@@ -165,7 +165,7 @@ pub fn inline_immediately_invoked_function_expressions<'a>(
                         };
 
                         // Take blocks and instructions from inner function
-                        let inner_func = &mut env.functions[inner_func_id.index()];
+                        let inner_func = &mut env.functions[inner_func_id];
                         let inner_blocks: Vec<(BlockId, BasicBlock)> =
                             inner_func.body.blocks.drain(..).collect();
                         let inner_instructions: Vec<Instruction> =
@@ -230,12 +230,12 @@ pub fn inline_immediately_invoked_function_expressions<'a>(
 
                         // Promote the temporary with a name as we require this to persist
                         let identifier_id = result.identifier;
-                        if env.identifiers[identifier_id.index()].name.is_none() {
+                        if env.identifiers[identifier_id].name.is_none() {
                             promote_temporary(env, identifier_id);
                         }
 
                         // Take blocks and instructions from inner function
-                        let inner_func = &mut env.functions[inner_func_id.index()];
+                        let inner_func = &mut env.functions[inner_func_id];
                         let inner_blocks: Vec<(BlockId, BasicBlock)> =
                             inner_func.body.blocks.drain(..).collect();
                         let inner_instructions: Vec<Instruction> =
@@ -386,7 +386,7 @@ fn declare_temporary<'a>(
 
 /// Promote a temporary identifier to a named identifier.
 fn promote_temporary(env: &mut Environment<'_>, identifier_id: IdentifierId) {
-    let decl_id = env.identifiers[identifier_id.index()].declaration_id;
-    env.identifiers[identifier_id.index()].name =
+    let decl_id = env.identifiers[identifier_id].declaration_id;
+    env.identifiers[identifier_id].name =
         Some(IdentifierName::Promoted(format_ident!(env.allocator, "#t{}", decl_id.index())));
 }

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/merge_consecutive_blocks.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/merge_consecutive_blocks.rs
@@ -15,20 +15,24 @@
 
 use std::mem::replace;
 
+use oxc_index::IndexSlice;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::react_compiler_hir::visitors;
 use crate::react_compiler_hir::{
-    AliasingEffect, BlockId, BlockKind, Effect, GENERATED_SOURCE, HirFunction, Instruction,
-    InstructionId, InstructionValue, Place, Terminal,
+    AliasingEffect, BlockId, BlockKind, Effect, FunctionId, GENERATED_SOURCE, HirFunction,
+    Instruction, InstructionId, InstructionValue, Place, Terminal,
 };
 use crate::react_compiler_lowering::mark_predecessors;
 use crate::react_compiler_ssa::enter_ssa::placeholder_function;
 
 /// Merge consecutive blocks in the function's CFG, including inner functions.
-pub fn merge_consecutive_blocks(func: &mut HirFunction, functions: &mut [HirFunction]) {
+pub fn merge_consecutive_blocks(
+    func: &mut HirFunction,
+    functions: &mut IndexSlice<FunctionId, [HirFunction]>,
+) {
     // Collect inner function IDs for recursive processing
-    let inner_func_ids: Vec<usize> = func
+    let inner_func_ids: Vec<FunctionId> = func
         .body
         .blocks
         .values()
@@ -37,9 +41,7 @@ pub fn merge_consecutive_blocks(func: &mut HirFunction, functions: &mut [HirFunc
             let instr = &func.instructions[instr_id.index()];
             match &instr.value {
                 InstructionValue::FunctionExpression { lowered_func, .. }
-                | InstructionValue::ObjectMethod { lowered_func, .. } => {
-                    Some(lowered_func.func.index())
-                }
+                | InstructionValue::ObjectMethod { lowered_func, .. } => Some(lowered_func.func),
                 _ => None,
             }
         })

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/name_anonymous_functions.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/name_anonymous_functions.rs
@@ -72,7 +72,7 @@ pub fn name_anonymous_functions<'a>(func: &mut HirFunction<'a>, env: &mut Enviro
 
     // Apply name updates to the inner HirFunction in the arena
     for (function_id, name) in &updates {
-        env.functions[function_id.index()].name_hint = Some(*name);
+        env.functions[*function_id].name_hint = Some(*name);
     }
 
     // Update name_hint on FunctionExpression instruction values in the outer function
@@ -81,9 +81,10 @@ pub fn name_anonymous_functions<'a>(func: &mut HirFunction<'a>, env: &mut Enviro
     // Update name_hint on FunctionExpression instruction values in all arena functions
     for i in 0..env.functions.len() {
         // We need to temporarily take the instructions to avoid borrow issues
-        let mut instructions = take(&mut env.functions[i].instructions);
+        let func_id = FunctionId::from_usize(i);
+        let mut instructions = take(&mut env.functions[func_id].instructions);
         apply_name_hints_to_instructions(&mut instructions, &update_map);
-        env.functions[i].instructions = instructions;
+        env.functions[func_id].instructions = instructions;
     }
 }
 
@@ -137,7 +138,7 @@ fn name_anonymous_functions_impl<'a>(
                 }
                 InstructionValue::LoadContext { place, .. }
                 | InstructionValue::LoadLocal { place, .. } => {
-                    let ident = &env.identifiers[place.identifier.index()];
+                    let ident = &env.identifiers[place.identifier];
                     if let Some(IdentifierName::Named(name)) = ident.name {
                         names.insert(lvalue_id, name);
                     }
@@ -153,7 +154,7 @@ fn name_anonymous_functions_impl<'a>(
                     }
                 }
                 InstructionValue::FunctionExpression { name, lowered_func, .. } => {
-                    let inner_func = &env.functions[lowered_func.func.index()];
+                    let inner_func = &env.functions[lowered_func.func];
                     let inner = name_anonymous_functions_impl(inner_func, env);
                     let node = Node {
                         function_id: lowered_func.func,
@@ -173,7 +174,7 @@ fn name_anonymous_functions_impl<'a>(
                 | InstructionValue::StoreLocal { lvalue: store_lvalue, value, .. } => {
                     if let Some(&node_idx) = functions.get(&value.identifier) {
                         let node = &mut nodes[node_idx];
-                        let var_ident = &env.identifiers[store_lvalue.place.identifier.index()];
+                        let var_ident = &env.identifiers[store_lvalue.place.identifier];
                         if node.generated_name.is_none() {
                             if let Some(IdentifierName::Named(var_name)) = var_ident.name {
                                 node.generated_name = Some(var_name);
@@ -236,8 +237,8 @@ fn handle_call<'a>(
     names: &FxHashMap<IdentifierId, Ident<'a>>,
     nodes: &mut [Node<'a>],
 ) {
-    let callee_ident = &env.identifiers[callee_id.index()];
-    let callee_ty = &env.types[callee_ident.type_.index()];
+    let callee_ident = &env.identifiers[callee_id];
+    let callee_ty = &env.types[callee_ident.type_];
     let hook_kind = env.get_hook_kind_for_type(callee_ty).ok().flatten();
 
     let callee_name: Cow<'_, str> = if let Some(hk) = hook_kind {

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/optimize_for_ssr.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/optimize_for_ssr.rs
@@ -52,7 +52,7 @@ pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
             let instr = &func.instructions[instr_id.index()];
             match &instr.value {
                 InstructionValue::Destructure { value, lvalue, .. } => {
-                    if inlined_state.contains_key(&env.identifiers[value.identifier.index()].id) {
+                    if inlined_state.contains_key(&env.identifiers[value.identifier].id) {
                         if let Pattern::Array(arr) = &lvalue.pattern {
                             if !arr.items.is_empty() {
                                 if let ArrayPatternElement::Place(_) = &arr.items[0] {
@@ -74,8 +74,7 @@ pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
                                 if let (PlaceOrSpread::Place(_), PlaceOrSpread::Place(arg)) =
                                     (&args[0], &args[1])
                                 {
-                                    let lvalue_id =
-                                        env.identifiers[instr.lvalue.identifier.index()].id;
+                                    let lvalue_id = env.identifiers[instr.lvalue.identifier].id;
                                     inlined_state.insert(
                                         lvalue_id,
                                         InlinedStateReplacement::LoadLocal {
@@ -91,8 +90,7 @@ pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
                                     PlaceOrSpread::Place(initializer),
                                 ) = (&args[0], &args[1], &args[2])
                                 {
-                                    let lvalue_id =
-                                        env.identifiers[instr.lvalue.identifier.index()].id;
+                                    let lvalue_id = env.identifiers[instr.lvalue.identifier].id;
                                     let call_span = instr.value.span().copied();
                                     inlined_state.insert(
                                         lvalue_id,
@@ -107,14 +105,12 @@ pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
                         }
                         Some(HookKind::UseState) if args.len() == 1 => {
                             if let PlaceOrSpread::Place(arg) = &args[0] {
-                                let arg_type = &env.types
-                                    [env.identifiers[arg.identifier.index()].type_.index()];
+                                let arg_type = &env.types[env.identifiers[arg.identifier].type_];
                                 if is_primitive_type(arg_type)
                                     || is_plain_object_type(arg_type)
                                     || is_array_type(arg_type)
                                 {
-                                    let lvalue_id =
-                                        env.identifiers[instr.lvalue.identifier.index()].id;
+                                    let lvalue_id = env.identifiers[instr.lvalue.identifier].id;
                                     inlined_state.insert(
                                         lvalue_id,
                                         InlinedStateReplacement::LoadLocal {
@@ -135,7 +131,7 @@ pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
             if !inlined_state.is_empty() {
                 let operands = each_instruction_value_operand(&instr.value, env);
                 for operand in &operands {
-                    let id = env.identifiers[operand.identifier.index()].id;
+                    let id = env.identifiers[operand.identifier].id;
                     inlined_state.remove(&id);
                 }
             }
@@ -143,7 +139,7 @@ pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
         if !inlined_state.is_empty() {
             let operands = each_terminal_operand(&block.terminal);
             for operand in &operands {
-                let id = env.identifiers[operand.identifier.index()].id;
+                let id = env.identifiers[operand.identifier].id;
                 inlined_state.remove(&id);
             }
         }
@@ -162,7 +158,7 @@ pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
             let instr = &mut func.instructions[instr_id.index()];
             match &instr.value {
                 InstructionValue::FunctionExpression { lowered_func, span, .. } => {
-                    let inner_func = &env.functions[lowered_func.func.index()];
+                    let inner_func = &env.functions[lowered_func.func];
                     if has_known_non_render_call(inner_func, env) {
                         let span = *span;
                         instr.value =
@@ -184,7 +180,7 @@ pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
                     }
                 }
                 InstructionValue::Destructure { value, lvalue, span } => {
-                    let value_id = env.identifiers[value.identifier.index()].id;
+                    let value_id = env.identifiers[value.identifier].id;
                     if inlined_state.contains_key(&value_id) {
                         // Invariant: destructuring pattern must be ArrayPattern with at least one Identifier item
                         if let Pattern::Array(arr) = &lvalue.pattern {
@@ -229,7 +225,7 @@ pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
                             };
                         }
                         Some(HookKind::UseReducer | HookKind::UseState) => {
-                            let lvalue_id = env.identifiers[instr.lvalue.identifier.index()].id;
+                            let lvalue_id = env.identifiers[instr.lvalue.identifier].id;
                             if let Some(replacement) = inlined_state.get(&lvalue_id) {
                                 instr.value = match replacement {
                                     InlinedStateReplacement::LoadLocal { place, span } => {
@@ -278,8 +274,7 @@ fn has_known_non_render_call(func: &HirFunction, env: &Environment) -> bool {
         for &instr_id in &block.instructions {
             let instr = &func.instructions[instr_id.index()];
             if let InstructionValue::CallExpression { callee, .. } = &instr.value {
-                let callee_type =
-                    &env.types[env.identifiers[callee.identifier.index()].type_.index()];
+                let callee_type = &env.types[env.identifiers[callee.identifier].type_];
                 if is_set_state_type(callee_type) || is_start_transition_type(callee_type) {
                     return true;
                 }

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/optimize_props_method_calls.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/optimize_props_method_calls.rs
@@ -27,8 +27,8 @@ pub fn optimize_props_method_calls(func: &mut HirFunction, env: &Environment) {
                 &instr.value,
                 InstructionValue::MethodCall { receiver, .. }
                     if {
-                        let identifier = &env.identifiers[receiver.identifier.index()];
-                        let ty = &env.types[identifier.type_.index()];
+                        let identifier = &env.identifiers[receiver.identifier];
+                        let ty = &env.types[identifier.type_];
                         is_props_type(ty)
                     }
             );

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/outline_functions.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/outline_functions.rs
@@ -49,7 +49,7 @@ pub fn outline_functions<'a>(
 
             match &instr.value {
                 InstructionValue::FunctionExpression { lowered_func, .. } => {
-                    let inner_func = &env.functions[lowered_func.func.index()];
+                    let inner_func = &env.functions[lowered_func.func];
 
                     // Check outlining conditions (TS only checks func.id === null, not name):
                     // 1. No captured context variables
@@ -83,27 +83,27 @@ pub fn outline_functions<'a>(
         match action {
             Action::Recurse(function_id) => {
                 let mut inner_func =
-                    replace(&mut env.functions[function_id.index()], placeholder_function());
+                    replace(&mut env.functions[function_id], placeholder_function());
                 outline_functions(&mut inner_func, env, fbt_operands);
-                env.functions[function_id.index()] = inner_func;
+                env.functions[function_id] = inner_func;
             }
             Action::RecurseAndOutline { instr_idx, function_id } => {
                 // First recurse into the inner function (depth-first)
                 let mut inner_func =
-                    replace(&mut env.functions[function_id.index()], placeholder_function());
+                    replace(&mut env.functions[function_id], placeholder_function());
                 outline_functions(&mut inner_func, env, fbt_operands);
-                env.functions[function_id.index()] = inner_func;
+                env.functions[function_id] = inner_func;
 
                 // Then generate the name and outline (after recursion, matching TS order)
-                let inner = &env.functions[function_id.index()];
+                let inner = &env.functions[function_id];
                 let hint: Option<Ident<'a>> = inner.id.or(inner.name_hint);
                 let generated_name = env.generate_globally_unique_identifier_name(hint.as_deref());
 
                 // Set the id on the inner function
-                env.functions[function_id.index()].id = Some(generated_name);
+                env.functions[function_id].id = Some(generated_name);
 
                 // Outline the function
-                let outlined_func = env.functions[function_id.index()].clone();
+                let outlined_func = env.functions[function_id].clone();
                 env.outline_function(outlined_func, None);
 
                 // Replace the instruction value with LoadGlobal

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/outline_jsx.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/outline_jsx.rs
@@ -9,6 +9,7 @@
 //! This pass is conditional on `env.config.enable_jsx_outlining` (defaults to false).
 
 use crate::react_compiler_utils::FxIndexSet;
+use oxc_index::IndexVec;
 use oxc_str::{Ident, IdentHashSet, format_ident};
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -29,7 +30,7 @@ use std::mem::replace;
 ///
 /// Ported from TS `outlineJSX` in `Optimization/OutlineJsx.ts`.
 pub fn outline_jsx<'a>(func: &mut HirFunction<'a>, env: &mut Environment<'a>) {
-    let mut outlined_fns: Vec<HirFunction<'a>> = Vec::new();
+    let mut outlined_fns: IndexVec<FunctionId, HirFunction<'a>> = IndexVec::new();
     outline_jsx_impl(func, env, &mut outlined_fns);
 
     for outlined_fn in outlined_fns {
@@ -58,7 +59,7 @@ struct OutlinedResult<'a> {
 fn outline_jsx_impl<'a>(
     func: &mut HirFunction<'a>,
     env: &mut Environment<'a>,
-    outlined_fns: &mut Vec<HirFunction<'a>>,
+    outlined_fns: &mut IndexVec<FunctionId, HirFunction<'a>>,
 ) {
     // Collect LoadGlobal instructions (tag -> instr)
     let mut globals: FxHashMap<IdentifierId, usize> = FxHashMap::default(); // id -> instr_idx
@@ -131,9 +132,9 @@ fn outline_jsx_impl<'a>(
                 }
                 InstrAction::FunctionExpr { func_id } => {
                     let mut inner_func =
-                        replace(&mut env.functions[func_id.index()], placeholder_function());
+                        replace(&mut env.functions[func_id], placeholder_function());
                     outline_jsx_impl(&mut inner_func, env, outlined_fns);
-                    env.functions[func_id.index()] = inner_func;
+                    env.functions[func_id] = inner_func;
                 }
                 InstrAction::JsxExpr { lvalue_id, instr_idx, eval_order, child_ids } => {
                     if !children_ids.contains(&lvalue_id) {
@@ -197,7 +198,7 @@ fn process_and_outline_jsx<'a>(
     jsx_group: &mut [JsxInstrInfo],
     globals: &FxHashMap<IdentifierId, usize>,
     rewrite_instr: &mut FxHashMap<EvaluationOrder, Vec<Instruction<'a>>>,
-    outlined_fns: &mut Vec<HirFunction<'a>>,
+    outlined_fns: &mut IndexVec<FunctionId, HirFunction<'a>>,
 ) {
     if jsx_group.len() <= 1 {
         return;
@@ -288,14 +289,14 @@ fn collect_props<'a>(
                     }
                     // Promote the child's identifier to a named temporary
                     let child_id = child.identifier;
-                    let decl_id = env.identifiers[child_id.index()].declaration_id;
-                    if env.identifiers[child_id.index()].name.is_none() {
-                        env.identifiers[child_id.index()].name = Some(IdentifierName::Promoted(
+                    let decl_id = env.identifiers[child_id].declaration_id;
+                    if env.identifiers[child_id].name.is_none() {
+                        env.identifiers[child_id].name = Some(IdentifierName::Promoted(
                             format_ident!(allocator, "#t{}", decl_id.index()),
                         ));
                     }
 
-                    let child_name = match env.identifiers[child_id.index()].name {
+                    let child_name = match env.identifiers[child_id].name {
                         Some(IdentifierName::Named(n)) => n,
                         Some(IdentifierName::Promoted(n)) => n,
                         None => format_ident!(allocator, "#t{}", decl_id.index()),
@@ -329,8 +330,8 @@ fn emit_outlined_jsx<'a>(
     // Create LoadGlobal for the outlined component
     let load_id = env.next_identifier_id();
     // Promote it as a JSX tag temporary
-    let decl_id = env.identifiers[load_id.index()].declaration_id;
-    env.identifiers[load_id.index()].name =
+    let decl_id = env.identifiers[load_id].declaration_id;
+    env.identifiers[load_id].name =
         Some(IdentifierName::Promoted(format_ident!(env.allocator, "#T{}", decl_id.index())));
 
     let load_place =
@@ -379,8 +380,8 @@ fn emit_outlined_fn<'a>(
 
     // Create props parameter
     let props_obj_id = env.next_identifier_id();
-    let decl_id = env.identifiers[props_obj_id.index()].declaration_id;
-    env.identifiers[props_obj_id.index()].name =
+    let decl_id = env.identifiers[props_obj_id].declaration_id;
+    env.identifiers[props_obj_id].name =
         Some(IdentifierName::Promoted(format_ident!(env.allocator, "#t{}", decl_id.index())));
     let props_obj =
         Place { identifier: props_obj_id, effect: Effect::Unknown, reactive: false, span: None };
@@ -419,7 +420,7 @@ fn emit_outlined_fn<'a>(
 
     let block = BasicBlock {
         kind: BlockKind::Block,
-        id: BlockId::from_usize(0),
+        id: BlockId::ENTRY,
         instructions: instr_ids,
         preds: FxIndexSet::default(),
         terminal: Terminal::Return {
@@ -433,7 +434,7 @@ fn emit_outlined_fn<'a>(
     };
 
     let mut blocks = FxIndexMap::default();
-    blocks.insert(BlockId::from_usize(0), block);
+    blocks.insert(BlockId::ENTRY, block);
 
     let outlined_fn = HirFunction {
         id: None,
@@ -442,7 +443,7 @@ fn emit_outlined_fn<'a>(
         params: vec![ParamPattern::Place(props_obj)],
         returns: returns_place,
         context: Vec::new(),
-        body: HIR { entry: BlockId::from_usize(0), blocks },
+        body: HIR { entry: BlockId::ENTRY, blocks },
         instructions: instr_table,
         generator: false,
         is_async: false,
@@ -561,7 +562,7 @@ fn create_old_to_new_props_mapping<'a>(
         }
 
         let new_id = env.next_identifier_id();
-        env.identifiers[new_id.index()].name = Some(IdentifierName::Named(old_prop.new_name));
+        env.identifiers[new_id].name = Some(IdentifierName::Named(old_prop.new_name));
 
         let new_place =
             Place { identifier: new_id, effect: Effect::Unknown, reactive: false, span: None };

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/prune_maybe_throws.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/prune_maybe_throws.rs
@@ -12,10 +12,14 @@
 
 use rustc_hash::FxHashMap;
 
+use oxc_index::IndexSlice;
+
 use oxc_diagnostics::OxcDiagnostic;
 
 use crate::diagnostics::ErrorCategory;
-use crate::react_compiler_hir::{BlockId, HirFunction, Instruction, InstructionValue, Terminal};
+use crate::react_compiler_hir::{
+    BlockId, FunctionId, HirFunction, Instruction, InstructionValue, Terminal,
+};
 use crate::react_compiler_lowering::{
     get_reverse_postordered_blocks, mark_instruction_ids, remove_dead_do_while_statements,
     remove_unnecessary_try_catch, remove_unreachable_for_updates,
@@ -26,7 +30,7 @@ use crate::react_compiler_optimization::merge_consecutive_blocks::merge_consecut
 /// Prune `MaybeThrow` terminals for blocks that cannot throw, then clean up the CFG.
 pub fn prune_maybe_throws(
     func: &mut HirFunction,
-    functions: &mut [HirFunction],
+    functions: &mut IndexSlice<FunctionId, [HirFunction]>,
 ) -> Result<(), OxcDiagnostic> {
     let terminal_mapping = prune_maybe_throws_impl(func);
     if let Some(terminal_mapping) = terminal_mapping {

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/assert_scope_instructions_within_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/assert_scope_instructions_within_scopes.rs
@@ -89,9 +89,9 @@ impl<'a, 'e> ReactiveFunctionVisitor<'a> for CheckInstructionsAgainstScopesVisit
 
     fn visit_place(&self, id: EvaluationOrder, place: &Place, state: &mut CheckState) {
         // getPlaceScope: check if the place's identifier has a scope that is active at this id
-        let identifier = &self.env.identifiers[place.identifier.index()];
+        let identifier = &self.env.identifiers[place.identifier];
         if let Some(scope_id) = identifier.scope {
-            let scope = &self.env.scopes[scope_id.index()];
+            let scope = &self.env.scopes[scope_id];
             // isScopeActive: id >= scope.range.start && id < scope.range.end
             let is_active_at_id = id >= scope.range.start && id < scope.range.end;
             if is_active_at_id

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/build_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/build_reactive_function.rs
@@ -1129,7 +1129,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
         // convert it to a LoadLocal of the value being stored, matching the TS behavior.
         let (value, place) = match &last_instr.value {
             InstructionValue::StoreLocal { lvalue, value: store_value, .. } => {
-                let ident = &self.env.identifiers[lvalue.place.identifier.index()];
+                let ident = &self.env.identifiers[lvalue.place.identifier];
                 if ident.name.is_none() {
                     (
                         ReactiveValue::Instruction(InstructionValue::LoadLocal {

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
@@ -300,12 +300,12 @@ impl<'a, 'env> OxcContext<'a, 'env> {
     }
 
     fn declare(&mut self, identifier_id: IdentifierId) {
-        let ident = &self.env.identifiers[identifier_id.index()];
+        let ident = &self.env.identifiers[identifier_id];
         self.declarations.insert(ident.declaration_id);
     }
 
     fn has_declared(&self, identifier_id: IdentifierId) -> bool {
-        let ident = &self.env.identifiers[identifier_id.index()];
+        let ident = &self.env.identifiers[identifier_id];
         self.declarations.contains(&ident.declaration_id)
     }
 
@@ -451,7 +451,7 @@ fn ox_codegen_reactive_function<'a>(
             ParamPattern::Place(p) => p,
             ParamPattern::Spread(sp) => &sp.place,
         };
-        let ident = &cx.env.identifiers[place.identifier.index()];
+        let ident = &cx.env.identifiers[place.identifier];
         cx.temp.insert(ident.declaration_id, None);
         cx.declare(place.identifier);
     }
@@ -555,7 +555,7 @@ fn ox_identifier_name<'a>(
     env: &Environment<'a>,
     identifier_id: IdentifierId,
 ) -> Result<Ident<'a>, OxcDiagnostic> {
-    let ident = &env.identifiers[identifier_id.index()];
+    let ident = &env.identifiers[identifier_id];
     match ident.name {
         Some(crate::react_compiler_hir::IdentifierName::Named(n))
         | Some(crate::react_compiler_hir::IdentifierName::Promoted(n)) => Ok(n),
@@ -670,9 +670,9 @@ fn ox_codegen_reactive_scope<'a>(
     scope_id: ScopeId,
     block: &ReactiveBlock<'a>,
 ) -> Result<(), OxcDiagnostic> {
-    let scope_deps = cx.env.scopes[scope_id.index()].dependencies.clone();
-    let scope_decls = cx.env.scopes[scope_id.index()].declarations.clone();
-    let scope_reassignments = cx.env.scopes[scope_id.index()].reassignments.clone();
+    let scope_deps = cx.env.scopes[scope_id].dependencies.clone();
+    let scope_decls = cx.env.scopes[scope_id].declarations.clone();
+    let scope_reassignments = cx.env.scopes[scope_id].reassignments.clone();
 
     let mut cache_store_stmts: oxc_allocator::Vec<'a, oxc::Statement<'a>> =
         oxc_allocator::ArenaVec::new_in(&cx.ast);
@@ -832,9 +832,9 @@ fn ox_codegen_reactive_scope<'a>(
     statements.push(memo_stmt);
 
     // Early return
-    let early_return_value = cx.env.scopes[scope_id.index()].early_return_value.clone();
+    let early_return_value = cx.env.scopes[scope_id].early_return_value.clone();
     if let Some(ref early_return) = early_return_value {
-        let early_ident = &cx.env.identifiers[early_return.value.index()];
+        let early_ident = &cx.env.identifiers[early_return.value];
         let name = match &early_ident.name {
             Some(
                 crate::react_compiler_hir::IdentifierName::Named(n)
@@ -1041,7 +1041,7 @@ fn ox_codegen_terminal<'a>(
         ReactiveTerminal::Try { block, handler_binding, handler, .. } => {
             let catch_param = match handler_binding.as_ref() {
                 Some(binding) => {
-                    let ident = &cx.env.identifiers[binding.identifier.index()];
+                    let ident = &cx.env.identifiers[binding.identifier];
                     cx.temp.insert(ident.declaration_id, None);
                     let pattern = ox_binding_for_identifier(cx, binding.identifier)?;
                     Some(oxc_ast::ast::CatchParameter::new(
@@ -1383,7 +1383,7 @@ fn ox_codegen_store_or_declare<'a>(
             let kind = lvalue.kind;
             for place in crate::react_compiler_hir::visitors::each_pattern_operand(&lvalue.pattern)
             {
-                let ident = &cx.env.identifiers[place.identifier.index()];
+                let ident = &cx.env.identifiers[place.identifier];
                 if kind != InstructionKind::Reassign && ident.name.is_none() {
                     cx.temp.insert(ident.declaration_id, None);
                 }
@@ -1483,7 +1483,7 @@ fn ox_emit_store<'a>(
                     ReactiveValue::Instruction(InstructionValue::StoreContext { .. })
                 );
                 if !is_store_context {
-                    let ident = &cx.env.identifiers[lvalue_place.identifier.index()];
+                    let ident = &cx.env.identifiers[lvalue_place.identifier];
                     cx.temp.insert(ident.declaration_id, Some(OxValue::Expression(expr)));
                     return Ok(None);
                 }
@@ -1541,7 +1541,7 @@ fn ox_codegen_instruction<'a>(
         let expr = ox_convert_value_to_expression(&cx.ast, value);
         return Ok(oxc_ast::ast::Statement::new_expression_statement(SPAN, expr, &cx.ast));
     };
-    let ident = &cx.env.identifiers[lvalue.identifier.index()];
+    let ident = &cx.env.identifiers[lvalue.identifier];
     if ident.name.is_none() {
         cx.temp.insert(ident.declaration_id, Some(value));
         return Ok(oxc_ast::ast::Statement::new_empty_statement(SPAN, &cx.ast));
@@ -2201,7 +2201,7 @@ fn ox_codegen_place<'a>(
     cx: &mut OxcContext<'a, '_>,
     place: &Place,
 ) -> Result<OxValue<'a>, OxcDiagnostic> {
-    let ident = &cx.env.identifiers[place.identifier.index()];
+    let ident = &cx.env.identifiers[place.identifier];
     let declaration_id = ident.declaration_id;
     if let Some(tmp) = cx.temp.get(&declaration_id) {
         if let Some(val) = tmp {
@@ -2548,7 +2548,7 @@ fn ox_codegen_function_expression<'a>(
     lowered_func: &crate::react_compiler_hir::LoweredFunction,
     expr_type: &FunctionExpressionType,
 ) -> Result<OxValue<'a>, OxcDiagnostic> {
-    let func = cx.env.functions[lowered_func.func.index()].clone();
+    let func = cx.env.functions[lowered_func.func].clone();
     let mut reactive_fn = build_reactive_function(&func, cx.env)?;
     prune_unused_labels(&mut reactive_fn, cx.env)?;
     prune_unused_lvalues(&mut reactive_fn, cx.env);
@@ -2734,7 +2734,7 @@ fn ox_codegen_object_expression<'a>(
                             return Err(invariant_err("Expected ObjectMethod instruction", None));
                         };
 
-                        let func = cx.env.functions[lowered_func.func.index()].clone();
+                        let func = cx.env.functions[lowered_func.func].clone();
                         let mut reactive_fn = build_reactive_function(&func, cx.env)?;
                         prune_unused_labels(&mut reactive_fn, cx.env)?;
                         prune_unused_lvalues(&mut reactive_fn, cx.env);
@@ -3321,7 +3321,7 @@ impl<'a, 'e> ReactiveFunctionVisitor<'a> for CountMemoBlockVisitor<'a, 'e> {
 
     fn visit_scope(&self, scope_block: &ReactiveScopeBlock<'a>, state: &mut CountMemoBlockState) {
         state.memo_blocks += 1;
-        let scope = &self.env.scopes[scope_block.scope.index()];
+        let scope = &self.env.scopes[scope_block.scope];
         state.memo_values += scope.declarations.len() as u32;
         self.traverse_scope(scope_block, state);
     }
@@ -3332,7 +3332,7 @@ impl<'a, 'e> ReactiveFunctionVisitor<'a> for CountMemoBlockVisitor<'a, 'e> {
         state: &mut CountMemoBlockState,
     ) {
         state.pruned_memo_blocks += 1;
-        let scope = &self.env.scopes[scope_block.scope.index()];
+        let scope = &self.env.scopes[scope_block.scope];
         state.pruned_memo_values += scope.declarations.len() as u32;
         self.traverse_pruned_scope(scope_block, state);
     }
@@ -3398,7 +3398,7 @@ fn dep_to_sort_key(
     dep: &crate::react_compiler_hir::ReactiveScopeDependency,
     env: &Environment,
 ) -> String {
-    let ident = &env.identifiers[dep.identifier.index()];
+    let ident = &env.identifiers[dep.identifier];
     let base = match ident.name {
         Some(name) => name.value().to_string(),
         None => format!("_t{}", dep.identifier.index()),
@@ -3426,7 +3426,7 @@ fn compare_scope_declaration(
 }
 
 fn ident_sort_key(id: IdentifierId, env: &Environment) -> String {
-    let ident = &env.identifiers[id.index()];
+    let ident = &env.identifiers[id];
     match ident.name {
         Some(name) => name.value().to_string(),
         None => format!("_t{}", id.index()),

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/extract_scope_declarations_from_destructuring.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/extract_scope_declarations_from_destructuring.rs
@@ -40,7 +40,7 @@ pub fn extract_scope_declarations_from_destructuring<'a>(
             ParamPattern::Place(p) => p,
             ParamPattern::Spread(s) => &s.place,
         };
-        let identifier = &env.identifiers[place.identifier.index()];
+        let identifier = &env.identifiers[place.identifier];
         declared.insert(identifier.declaration_id);
     }
     let mut transform = Transform { env };
@@ -68,12 +68,12 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
         scope: &mut ReactiveScopeBlock<'a>,
         state: &mut ExtractState,
     ) -> Result<(), OxcDiagnostic> {
-        let scope_data = &self.env.scopes[scope.scope.index()];
+        let scope_data = &self.env.scopes[scope.scope];
         let decl_ids: Vec<DeclarationId> = scope_data
             .declarations
             .iter()
             .map(|(_, d)| {
-                let identifier = &self.env.identifiers[d.identifier.index()];
+                let identifier = &self.env.identifiers[d.identifier];
                 identifier.declaration_id
             })
             .collect();
@@ -103,7 +103,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
             let mut has_declaration = false;
 
             for place in visitors::each_pattern_operand(&lvalue.pattern) {
-                let identifier = &self.env.identifiers[place.identifier.index()];
+                let identifier = &self.env.identifiers[place.identifier];
                 if state.declared.contains(&identifier.declaration_id) {
                     reassigned.insert(place.identifier);
                 } else {
@@ -127,17 +127,19 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
                     }
                     // Create a temporary place (matches TS clonePlaceToTemporary)
                     let temp_id = env.next_identifier_id();
-                    let decl_id = env.identifiers[temp_id.index()].declaration_id;
+                    let decl_id = env.identifiers[temp_id].declaration_id;
                     // Copy type from original identifier to temporary
-                    let original_type = env.identifiers[place.identifier.index()].type_;
-                    env.identifiers[temp_id.index()].type_ = original_type;
+                    let original_type = env.identifiers[place.identifier].type_;
+                    env.identifiers[temp_id].type_ = original_type;
                     // Set identifier span to the place's source location
                     // (matches TS makeTemporaryIdentifier which receives place.span)
-                    env.identifiers[temp_id.index()].span = place.span;
+                    env.identifiers[temp_id].span = place.span;
                     // Promote the temporary
-                    env.identifiers[temp_id.index()].name = Some(IdentifierName::Promoted(
-                        format_ident!(env.allocator, "#t{}", decl_id.index()),
-                    ));
+                    env.identifiers[temp_id].name = Some(IdentifierName::Promoted(format_ident!(
+                        env.allocator,
+                        "#t{}",
+                        decl_id.index()
+                    )));
                     let temporary = Place {
                         identifier: temp_id,
                         effect: place.effect,
@@ -205,7 +207,7 @@ fn update_declared_from_instruction<'a>(
             | InstructionValue::DeclareLocal { lvalue, .. }
             | InstructionValue::StoreLocal { lvalue, .. } => {
                 if lvalue.kind != InstructionKind::Reassign {
-                    let identifier = &env.identifiers[lvalue.place.identifier.index()];
+                    let identifier = &env.identifiers[lvalue.place.identifier];
                     state.declared.insert(identifier.declaration_id);
                 }
             }
@@ -213,7 +215,7 @@ fn update_declared_from_instruction<'a>(
                 if lvalue.kind != InstructionKind::Reassign =>
             {
                 for place in visitors::each_pattern_operand(&lvalue.pattern) {
-                    let identifier = &env.identifiers[place.identifier.index()];
+                    let identifier = &env.identifiers[place.identifier];
                     state.declared.insert(identifier.declaration_id);
                 }
             }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/merge_reactive_scopes_that_invalidate_together.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/merge_reactive_scopes_that_invalidate_together.rs
@@ -66,7 +66,7 @@ impl<'a, 'e> ReactiveFunctionVisitor<'a> for FindLastUsageVisitor<'a, 'e> {
     }
 
     fn visit_place(&self, id: EvaluationOrder, place: &Place, state: &mut Self::State) {
-        let decl_id = self.env.identifiers[place.identifier.index()].declaration_id;
+        let decl_id = self.env.identifiers[place.identifier].declaration_id;
         let entry = state.entry(decl_id).or_insert(id);
         if id > *entry {
             *entry = id;
@@ -98,7 +98,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for MergeTransform<'a, 'e> {
         scope: &mut ReactiveScopeBlock<'a>,
         state: &mut Self::State,
     ) -> Result<Transformed<ReactiveStatement<'a>>, OxcDiagnostic> {
-        let scope_deps = self.env.scopes[scope.scope.index()].dependencies.clone();
+        let scope_deps = self.env.scopes[scope.scope].dependencies.clone();
         // Save parent state and recurse with this scope's deps as state
         let parent_state = state.take();
         *state = Some(scope_deps.clone());
@@ -180,14 +180,13 @@ impl<'a, 'e> MergeTransform<'a, 'e> {
                                 | InstructionValue::UnaryExpression { .. } => {
                                     if let Some(ref mut c) = current {
                                         if let Some(lvalue) = &instr.lvalue {
-                                            let decl_id = self.env.identifiers
-                                                [lvalue.identifier.index()]
-                                            .declaration_id;
+                                            let decl_id = self.env.identifiers[lvalue.identifier]
+                                                .declaration_id;
                                             c.lvalues.insert(decl_id);
                                             if let InstructionValue::LoadLocal { place, .. } = iv {
                                                 let src_decl = self.env.identifiers
-                                                    [place.identifier.index()]
-                                                .declaration_id;
+                                                    [place.identifier]
+                                                    .declaration_id;
                                                 self.temporaries.insert(decl_id, src_decl);
                                             }
                                         }
@@ -199,19 +198,18 @@ impl<'a, 'e> MergeTransform<'a, 'e> {
                                             // Add the instruction lvalue (if any)
                                             if let Some(instr_lvalue) = &instr.lvalue {
                                                 let decl_id = self.env.identifiers
-                                                    [instr_lvalue.identifier.index()]
-                                                .declaration_id;
+                                                    [instr_lvalue.identifier]
+                                                    .declaration_id;
                                                 c.lvalues.insert(decl_id);
                                             }
                                             // Add the StoreLocal's lvalue place
                                             let store_decl = self.env.identifiers
-                                                [lvalue.place.identifier.index()]
-                                            .declaration_id;
+                                                [lvalue.place.identifier]
+                                                .declaration_id;
                                             c.lvalues.insert(store_decl);
                                             // Track temporary mapping
-                                            let value_decl = self.env.identifiers
-                                                [value.identifier.index()]
-                                            .declaration_id;
+                                            let value_decl = self.env.identifiers[value.identifier]
+                                                .declaration_id;
                                             let mapped = self
                                                 .temporaries
                                                 .get(&value_decl)
@@ -263,18 +261,16 @@ impl<'a, 'e> MergeTransform<'a, 'e> {
                             self.env,
                         ) {
                             // Merge: extend the current scope's range
-                            let next_range_end = self.env.scopes[next_scope_id.index()].range.end;
-                            let current_range_end =
-                                self.env.scopes[current_scope_id.index()].range.end;
-                            self.env.scopes[current_scope_id.index()].range.end =
+                            let next_range_end = self.env.scopes[next_scope_id].range.end;
+                            let current_range_end = self.env.scopes[current_scope_id].range.end;
+                            self.env.scopes[current_scope_id].range.end =
                                 current_range_end.max(next_range_end);
 
                             // Merge declarations from next into current
-                            let next_decls =
-                                self.env.scopes[next_scope_id.index()].declarations.clone();
+                            let next_decls = self.env.scopes[next_scope_id].declarations.clone();
                             for (key, value) in next_decls {
                                 let current_decls =
-                                    &mut self.env.scopes[current_scope_id.index()].declarations;
+                                    &mut self.env.scopes[current_scope_id].declarations;
                                 if let Some(existing) =
                                     current_decls.iter_mut().find(|(k, _)| *k == key)
                                 {
@@ -363,7 +359,7 @@ impl<'a, 'e> MergeTransform<'a, 'e> {
                 match stmt {
                     ReactiveStatement::Scope(inner_scope) => {
                         merged_scope.instructions.extend(inner_scope.instructions.clone());
-                        self.env.scopes[merged_scope.scope.index()].merged.push(inner_scope.scope);
+                        self.env.scopes[merged_scope.scope].merged.push(inner_scope.scope);
                     }
                     _ => {
                         merged_scope.instructions.push(stmt.clone());
@@ -393,9 +389,9 @@ fn update_scope_declarations<'a>(
     last_usage: &FxHashMap<DeclarationId, EvaluationOrder>,
     env: &mut Environment<'a>,
 ) {
-    let range_end = env.scopes[scope_id.index()].range.end;
-    env.scopes[scope_id.index()].declarations.retain(|(_id, decl)| {
-        let decl_declaration_id = env.identifiers[decl.identifier.index()].declaration_id;
+    let range_end = env.scopes[scope_id].range.end;
+    env.scopes[scope_id].declarations.retain(|(_id, decl)| {
+        let decl_declaration_id = env.identifiers[decl.identifier].declaration_id;
         match last_usage.get(&decl_declaration_id) {
             Some(last_used_at) => *last_used_at >= range_end,
             // If not tracked, keep the declaration (conservative)
@@ -411,7 +407,7 @@ fn are_lvalues_last_used_by_scope<'a>(
     last_usage: &FxHashMap<DeclarationId, EvaluationOrder>,
     env: &Environment<'a>,
 ) -> bool {
-    let range_end = env.scopes[scope_id.index()].range.end;
+    let range_end = env.scopes[scope_id].range.end;
     for lvalue in lvalues {
         if let Some(&last_used_at) = last_usage.get(lvalue) {
             if last_used_at >= range_end {
@@ -429,8 +425,8 @@ fn can_merge_scopes<'a>(
     env: &Environment<'a>,
     temporaries: &FxHashMap<DeclarationId, DeclarationId>,
 ) -> bool {
-    let current = &env.scopes[current_id.index()];
-    let next = &env.scopes[next_id.index()];
+    let current = &env.scopes[current_id];
+    let next = &env.scopes[next_id];
 
     // Don't merge scopes with reassignments
     if !current.reassignments.is_empty() || !next.reassignments.is_empty() {
@@ -466,13 +462,13 @@ fn can_merge_scopes<'a>(
             if !dep.path.is_empty() {
                 return false;
             }
-            let dep_type = &env.types[env.identifiers[dep.identifier.index()].type_.index()];
+            let dep_type = &env.types[env.identifiers[dep.identifier].type_];
             if !is_always_invalidating_type(dep_type) {
                 return false;
             }
-            let dep_decl = env.identifiers[dep.identifier.index()].declaration_id;
+            let dep_decl = env.identifiers[dep.identifier].declaration_id;
             current.declarations.iter().any(|(_key, decl)| {
-                let decl_decl_id = env.identifiers[decl.identifier.index()].declaration_id;
+                let decl_decl_id = env.identifiers[decl.identifier].declaration_id;
                 decl_decl_id == dep_decl
                     || temporaries.get(&dep_decl).copied() == Some(decl_decl_id)
             })
@@ -510,9 +506,9 @@ fn are_equal_dependencies<'a>(
         return false;
     }
     for a_val in a {
-        let a_decl = env.identifiers[a_val.identifier.index()].declaration_id;
+        let a_decl = env.identifiers[a_val.identifier].declaration_id;
         let found = b.iter().any(|b_val| {
-            let b_decl = env.identifiers[b_val.identifier.index()].declaration_id;
+            let b_decl = env.identifiers[b_val.identifier].declaration_id;
             a_decl == b_decl && are_equal_paths(&a_val.path, &b_val.path)
         });
         if !found {
@@ -532,13 +528,13 @@ fn are_equal_paths(a: &[DependencyPathEntry], b: &[DependencyPathEntry]) -> bool
 
 /// Check if a scope is eligible for merging with subsequent scopes.
 fn scope_is_eligible_for_merging<'a>(scope_id: ScopeId, env: &Environment<'a>) -> bool {
-    let scope = &env.scopes[scope_id.index()];
+    let scope = &env.scopes[scope_id];
     if scope.dependencies.is_empty() {
         // No dependencies means output never changes — eligible
         return true;
     }
     scope.declarations.iter().any(|(_key, decl)| {
-        let ty = &env.types[env.identifiers[decl.identifier.index()].type_.index()];
+        let ty = &env.types[env.identifiers[decl.identifier].type_];
         is_always_invalidating_type(ty)
     })
 }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/promote_used_temporaries.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/promote_used_temporaries.rs
@@ -71,7 +71,7 @@ pub fn promote_used_temporaries(func: &mut ReactiveFunction, env: &mut Environme
             ParamPattern::Place(p) => p,
             ParamPattern::Spread(s) => &s.place,
         };
-        let identifier = &env.identifiers[place.identifier.index()];
+        let identifier = &env.identifiers[place.identifier];
         if identifier.name.is_none() {
             promote_identifier(place.identifier, &mut state, env);
         }
@@ -130,9 +130,9 @@ fn collect_promotable_block(
                 active_scopes.pop();
             }
             ReactiveStatement::PrunedScope(scope) => {
-                let scope_data = &env.scopes[scope.scope.index()];
+                let scope_data = &env.scopes[scope.scope];
                 for (_id, decl) in &scope_data.declarations {
-                    let identifier = &env.identifiers[decl.identifier.index()];
+                    let identifier = &env.identifiers[decl.identifier];
                     state.pruned.insert(
                         identifier.declaration_id,
                         PrunedInfo {
@@ -157,7 +157,7 @@ fn collect_promotable_place(
     env: &Environment,
 ) {
     if !active_scopes.is_empty() {
-        let identifier = &env.identifiers[place.identifier.index()];
+        let identifier = &env.identifiers[place.identifier];
         if let Some(pruned) = state.pruned.get_mut(&identifier.declaration_id) {
             if let Some(last) = active_scopes.last() {
                 if !pruned.active_scopes.contains(last) {
@@ -191,7 +191,7 @@ fn collect_promotable_value(
             }
             // Check for JSX tag
             if let InstructionValue::JsxExpression { tag: JsxTag::Place(place), .. } = instr_value {
-                let identifier = &env.identifiers[place.identifier.index()];
+                let identifier = &env.identifiers[place.identifier];
                 state.tags.insert(identifier.declaration_id);
             }
         }
@@ -295,13 +295,13 @@ fn promote_temporaries_block(block: &ReactiveBlock, state: &mut State, env: &mut
             }
             ReactiveStatement::Scope(scope) => {
                 let scope_id = scope.scope;
-                let scope_data = &env.scopes[scope_id.index()];
+                let scope_data = &env.scopes[scope_id];
                 // Collect all IDs to promote first
                 let mut ids_to_check: Vec<IdentifierId> = Vec::new();
                 ids_to_check.extend(scope_data.dependencies.iter().map(|d| d.identifier));
                 ids_to_check.extend(scope_data.declarations.iter().map(|(_, d)| d.identifier));
                 for id in ids_to_check {
-                    let identifier = &env.identifiers[id.index()];
+                    let identifier = &env.identifiers[id];
                     if identifier.name.is_none() {
                         promote_identifier(id, state, env);
                     }
@@ -310,17 +310,17 @@ fn promote_temporaries_block(block: &ReactiveBlock, state: &mut State, env: &mut
             }
             ReactiveStatement::PrunedScope(scope) => {
                 let scope_id = scope.scope;
-                let scope_data = &env.scopes[scope_id.index()];
+                let scope_data = &env.scopes[scope_id];
                 let decls: Vec<(IdentifierId, DeclarationId)> = scope_data
                     .declarations
                     .iter()
                     .map(|(_, d)| {
-                        let identifier = &env.identifiers[d.identifier.index()];
+                        let identifier = &env.identifiers[d.identifier];
                         (d.identifier, identifier.declaration_id)
                     })
                     .collect();
                 for (id, decl_id) in decls {
-                    let identifier = &env.identifiers[id.index()];
+                    let identifier = &env.identifiers[id];
                     if identifier.name.is_none() {
                         if let Some(pruned) = state.pruned.get(&decl_id) {
                             if pruned.used_outside_scope {
@@ -440,7 +440,7 @@ fn promote_temporaries_terminal(
 fn visit_hir_function_for_promotion(func_id: FunctionId, state: &mut State, env: &mut Environment) {
     // Promote params of this function
     let param_ids: Vec<IdentifierId> = {
-        let func = &env.functions[func_id.index()];
+        let func = &env.functions[func_id];
         func.params
             .iter()
             .map(|param| match param {
@@ -450,7 +450,7 @@ fn visit_hir_function_for_promotion(func_id: FunctionId, state: &mut State, env:
             .collect()
     };
     for id in param_ids {
-        let identifier = &env.identifiers[id.index()];
+        let identifier = &env.identifiers[id];
         if identifier.name.is_none() {
             promote_identifier(id, state, env);
         }
@@ -458,7 +458,7 @@ fn visit_hir_function_for_promotion(func_id: FunctionId, state: &mut State, env:
 
     // Find nested FunctionExpression/ObjectMethod in body instructions
     let nested_func_ids: Vec<FunctionId> = {
-        let func = &env.functions[func_id.index()];
+        let func = &env.functions[func_id];
         let mut nested = Vec::new();
         for (_, block) in &func.body.blocks {
             for &instr_id in &block.instructions {
@@ -531,7 +531,7 @@ fn promote_interposed_place(
     env: &mut Environment,
 ) {
     if let Some(&(id, needs_promotion)) = inter_state.get(&place.identifier) {
-        let identifier = &env.identifiers[id.index()];
+        let identifier = &env.identifiers[id];
         if needs_promotion && identifier.name.is_none() && !consts.contains(&id) {
             promote_identifier(id, state, env);
         }
@@ -600,7 +600,7 @@ fn promote_interposed_instruction(
 
                     if !const_store
                         && (instr.lvalue.is_none()
-                            || env.identifiers[instr.lvalue.as_ref().unwrap().identifier.index()]
+                            || env.identifiers[instr.lvalue.as_ref().unwrap().identifier]
                                 .name
                                 .is_some())
                     {
@@ -613,7 +613,7 @@ fn promote_interposed_instruction(
                         }
                     }
                     if let Some(lvalue) = &instr.lvalue {
-                        let identifier = &env.identifiers[lvalue.identifier.index()];
+                        let identifier = &env.identifiers[lvalue.identifier];
                         if identifier.name.is_none() {
                             inter_state.insert(lvalue.identifier, (lvalue.identifier, false));
                         }
@@ -634,7 +634,7 @@ fn promote_interposed_instruction(
                 InstructionValue::LoadContext { place: load_place, .. }
                 | InstructionValue::LoadLocal { place: load_place, .. } => {
                     if let Some(lvalue) = &instr.lvalue {
-                        let identifier = &env.identifiers[lvalue.identifier.index()];
+                        let identifier = &env.identifiers[lvalue.identifier];
                         if identifier.name.is_none() {
                             if consts.contains(&load_place.identifier) {
                                 consts.insert(lvalue.identifier);
@@ -654,7 +654,7 @@ fn promote_interposed_instruction(
                             globals.insert(lvalue.identifier);
                             consts.insert(lvalue.identifier);
                         }
-                        let identifier = &env.identifiers[lvalue.identifier.index()];
+                        let identifier = &env.identifiers[lvalue.identifier];
                         if identifier.name.is_none() {
                             inter_state.insert(lvalue.identifier, (lvalue.identifier, false));
                         }
@@ -816,7 +816,7 @@ fn promote_all_instances_params(func: &ReactiveFunction, state: &mut State, env:
             ParamPattern::Place(p) => p,
             ParamPattern::Spread(s) => &s.place,
         };
-        let identifier = &env.identifiers[place.identifier.index()];
+        let identifier = &env.identifiers[place.identifier];
         if identifier.name.is_none() && state.promoted.contains(&identifier.declaration_id) {
             promote_identifier(place.identifier, state, env);
         }
@@ -849,7 +849,7 @@ fn promote_all_instances_scope_identifiers(
     state: &mut State,
     env: &mut Environment,
 ) {
-    let scope_data = &env.scopes[scope_id.index()];
+    let scope_data = &env.scopes[scope_id];
 
     // Collect identifiers to promote
     let decl_ids: Vec<IdentifierId> =
@@ -858,19 +858,19 @@ fn promote_all_instances_scope_identifiers(
     let reassign_ids: Vec<IdentifierId> = scope_data.reassignments.clone();
 
     for id in decl_ids {
-        let identifier = &env.identifiers[id.index()];
+        let identifier = &env.identifiers[id];
         if identifier.name.is_none() && state.promoted.contains(&identifier.declaration_id) {
             promote_identifier(id, state, env);
         }
     }
     for id in dep_ids {
-        let identifier = &env.identifiers[id.index()];
+        let identifier = &env.identifiers[id];
         if identifier.name.is_none() && state.promoted.contains(&identifier.declaration_id) {
             promote_identifier(id, state, env);
         }
     }
     for id in reassign_ids {
-        let identifier = &env.identifiers[id.index()];
+        let identifier = &env.identifiers[id];
         if identifier.name.is_none() && state.promoted.contains(&identifier.declaration_id) {
             promote_identifier(id, state, env);
         }
@@ -878,7 +878,7 @@ fn promote_all_instances_scope_identifiers(
 }
 
 fn promote_all_instances_place(place: &Place, state: &mut State, env: &mut Environment) {
-    let identifier = &env.identifiers[place.identifier.index()];
+    let identifier = &env.identifiers[place.identifier];
     if identifier.name.is_none() && state.promoted.contains(&identifier.declaration_id) {
         promote_identifier(place.identifier, state, env);
     }
@@ -906,7 +906,7 @@ fn promote_all_instances_value(value: &ReactiveValue, state: &mut State, env: &m
                 InstructionValue::FunctionExpression { lowered_func, .. }
                 | InstructionValue::ObjectMethod { lowered_func, .. } => {
                     let func_id = lowered_func.func;
-                    let inner_func = &env.functions[func_id.index()];
+                    let inner_func = &env.functions[func_id];
                     let param_ids: Vec<IdentifierId> = inner_func
                         .params
                         .iter()
@@ -916,7 +916,7 @@ fn promote_all_instances_value(value: &ReactiveValue, state: &mut State, env: &m
                         })
                         .collect();
                     for id in param_ids {
-                        let identifier = &env.identifiers[id.index()];
+                        let identifier = &env.identifiers[id];
                         if identifier.name.is_none()
                             && state.promoted.contains(&identifier.declaration_id)
                         {
@@ -1019,7 +1019,7 @@ fn promote_all_instances_terminal(
 // =============================================================================
 
 fn promote_identifier(identifier_id: IdentifierId, state: &mut State, env: &mut Environment) {
-    let identifier = &env.identifiers[identifier_id.index()];
+    let identifier = &env.identifiers[identifier_id];
     assert!(
         identifier.name.is_none(),
         "promoteTemporary: Expected to be called only for temporary variables"
@@ -1027,10 +1027,10 @@ fn promote_identifier(identifier_id: IdentifierId, state: &mut State, env: &mut 
     let decl_id = identifier.declaration_id;
     if state.tags.contains(&decl_id) {
         // JSX tag temporary: use capitalized name
-        env.identifiers[identifier_id.index()].name =
+        env.identifiers[identifier_id].name =
             Some(IdentifierName::Promoted(format_ident!(env.allocator, "#T{}", decl_id.index())));
     } else {
-        env.identifiers[identifier_id.index()].name =
+        env.identifiers[identifier_id].name =
             Some(IdentifierName::Promoted(format_ident!(env.allocator, "#t{}", decl_id.index())));
     }
     state.promoted.insert(decl_id);

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/propagate_early_returns.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/propagate_early_returns.rs
@@ -85,7 +85,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
         let scope_id = scope_block.scope;
 
         // Exit early if an earlier pass has already created an early return
-        if self.env.scopes[scope_id.index()].early_return_value.is_some() {
+        if self.env.scopes[scope_id].early_return_value.is_some() {
             return Ok(());
         }
 
@@ -184,14 +184,14 @@ fn apply_early_return_to_scope<'a>(
     let span = early_return.span;
 
     // Set early return value on the scope
-    env.scopes[scope_id.index()].early_return_value = Some(ReactiveScopeEarlyReturn {
+    env.scopes[scope_id].early_return_value = Some(ReactiveScopeEarlyReturn {
         value: early_return.value,
         span: early_return.span,
         label: early_return.label,
     });
 
     // Add the early return identifier as a scope declaration
-    env.scopes[scope_id.index()].declarations.push((
+    env.scopes[scope_id].declarations.push((
         early_return.value,
         ReactiveScopeDeclaration { identifier: early_return.value, scope: scope_id },
     ));
@@ -329,12 +329,12 @@ fn apply_early_return_to_scope<'a>(
 
 fn create_temporary_place_id(env: &mut Environment, span: Option<Span>) -> IdentifierId {
     let id = env.next_identifier_id();
-    env.identifiers[id.index()].span = span;
+    env.identifiers[id].span = span;
     id
 }
 
 fn promote_temporary<'a>(env: &mut Environment<'a>, identifier_id: IdentifierId) {
-    let decl_id = env.identifiers[identifier_id.index()].declaration_id;
-    env.identifiers[identifier_id.index()].name =
+    let decl_id = env.identifiers[identifier_id].declaration_id;
+    env.identifiers[identifier_id].name =
         Some(IdentifierName::Promoted(format_ident!(env.allocator, "#t{}", decl_id.index())));
 }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_always_invalidating_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_always_invalidating_scopes.rs
@@ -115,7 +115,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
         self.visit_scope(scope, &mut within_scope)?;
 
         let scope_id = scope.scope;
-        let scope_data = &self.env.scopes[scope_id.index()];
+        let scope_data = &self.env.scopes[scope_id];
 
         for dep in &scope_data.dependencies {
             if self.unmemoized_values.contains(&dep.identifier) {

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_hoisted_contexts.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_hoisted_contexts.rs
@@ -81,7 +81,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
         scope: &mut ReactiveScopeBlock<'a>,
         state: &mut VisitorState,
     ) -> Result<(), OxcDiagnostic> {
-        let scope_data = &self.env.scopes[scope.scope.index()];
+        let scope_data = &self.env.scopes[scope.scope];
         let decl_ids: FxHashSet<IdentifierId> =
             scope_data.declarations.iter().map(|(id, _)| *id).collect();
 
@@ -95,7 +95,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
         state.active_scopes.pop();
 
         // Clean up uninitialized after scope
-        let scope_data = &self.env.scopes[scope.scope.index()];
+        let scope_data = &self.env.scopes[scope.scope];
         for (_, decl) in &scope_data.declarations {
             state.uninitialized.remove(&decl.identifier);
         }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_escaping_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_escaping_scopes.rs
@@ -70,7 +70,7 @@ pub fn prune_non_escaping_scopes<'a>(
             ParamPattern::Place(p) => p,
             ParamPattern::Spread(s) => &s.place,
         };
-        let identifier = &env.identifiers[place.identifier.index()];
+        let identifier = &env.identifiers[place.identifier];
         state.declare(identifier.declaration_id);
     }
     let visitor = CollectDependenciesVisitor::new(env);
@@ -188,11 +188,11 @@ impl CollectState {
     ) {
         if let Some(scope_id) = get_place_scope(env, id, place.identifier) {
             self.scopes.entry(scope_id).or_insert_with(|| {
-                let scope_data = &env.scopes[scope_id.index()];
+                let scope_data = &env.scopes[scope_id];
                 let dependencies = scope_data
                     .dependencies
                     .iter()
-                    .map(|dep| env.identifiers[dep.identifier.index()].declaration_id)
+                    .map(|dep| env.identifiers[dep.identifier].declaration_id)
                     .collect();
                 ScopeNode { dependencies, seen: false }
             });
@@ -237,8 +237,8 @@ fn get_place_scope<'a>(
     id: EvaluationOrder,
     identifier_id: IdentifierId,
 ) -> Option<ScopeId> {
-    let scope_id = env.identifiers[identifier_id.index()].scope?;
-    if env.scopes[scope_id.index()].range.contains(id) { Some(scope_id) } else { None }
+    let scope_id = env.identifiers[identifier_id].scope?;
+    if env.scopes[scope_id].range.contains(id) { Some(scope_id) } else { None }
 }
 
 // =============================================================================
@@ -792,7 +792,7 @@ impl<'a, 'e> CollectDependenciesVisitor<'a, 'e> {
         let rvalue_data: Vec<(IdentifierId, DeclarationId)> = aliasing_rvalues
             .iter()
             .map(|(identifier_id, _)| {
-                let decl_id = env.identifiers[identifier_id.index()].declaration_id;
+                let decl_id = env.identifiers[*identifier_id].declaration_id;
                 let operand_id = state.resolve(decl_id);
                 (*identifier_id, operand_id)
             })
@@ -815,7 +815,7 @@ impl<'a, 'e> CollectDependenciesVisitor<'a, 'e> {
 
         // Add the operands as dependencies of all lvalues
         for lv in &aliasing_lvalues {
-            let lvalue_decl_id = env.identifiers[lv.place_identifier.index()].declaration_id;
+            let lvalue_decl_id = env.identifiers[lv.place_identifier].declaration_id;
             let lvalue_id = state.resolve(lvalue_decl_id);
             let node = state.identifiers.entry(lvalue_id).or_insert_with(|| IdentifierNode {
                 level: MemoizationLevel::Never,
@@ -849,8 +849,8 @@ impl<'a, 'e> CollectDependenciesVisitor<'a, 'e> {
         if let ReactiveValue::Instruction(instr_value) = value {
             if let InstructionValue::LoadLocal { place, .. } = instr_value {
                 if let Some(lv_id) = lvalue {
-                    let lv_decl = env.identifiers[lv_id.index()].declaration_id;
-                    let place_decl = env.identifiers[place.identifier.index()].declaration_id;
+                    let lv_decl = env.identifiers[lv_id].declaration_id;
+                    let place_decl = env.identifiers[place.identifier].declaration_id;
                     state.definitions.insert(lv_decl, place_decl);
                 }
             } else if let InstructionValue::CallExpression { callee, args, .. } = instr_value {
@@ -862,7 +862,7 @@ impl<'a, 'e> CollectDependenciesVisitor<'a, 'e> {
                                 PlaceOrSpread::Spread(spread) => &spread.place,
                                 PlaceOrSpread::Place(place) => place,
                             };
-                            let decl = env.identifiers[place.identifier.index()].declaration_id;
+                            let decl = env.identifiers[place.identifier].declaration_id;
                             state.escaping_values.insert(decl);
                         }
                     }
@@ -876,7 +876,7 @@ impl<'a, 'e> CollectDependenciesVisitor<'a, 'e> {
                                 PlaceOrSpread::Spread(spread) => &spread.place,
                                 PlaceOrSpread::Place(place) => place,
                             };
-                            let decl = env.identifiers[place.identifier.index()].declaration_id;
+                            let decl = env.identifiers[place.identifier].declaration_id;
                             state.escaping_values.insert(decl);
                         }
                     }
@@ -913,7 +913,7 @@ impl<'a, 'e> ReactiveFunctionVisitor<'a> for CollectDependenciesVisitor<'a, 'e> 
         // Handle return terminals
         if let ReactiveTerminal::Return { value, .. } = &stmt.terminal {
             let env = self.env;
-            let decl = env.identifiers[value.identifier.index()].declaration_id;
+            let decl = env.identifiers[value.identifier].declaration_id;
             state.0.escaping_values.insert(decl);
 
             // If the return is within a scope, associate those scopes with the returned value
@@ -928,12 +928,12 @@ impl<'a, 'e> ReactiveFunctionVisitor<'a> for CollectDependenciesVisitor<'a, 'e> 
     fn visit_scope(&self, scope: &ReactiveScopeBlock<'a>, state: &mut Self::State) {
         let env = self.env;
         let scope_id = scope.scope;
-        let scope_data = &env.scopes[scope_id.index()];
+        let scope_data = &env.scopes[scope_id];
 
         // If a scope reassigns any variables, set the chain of active scopes as a dependency
         // of those variables.
         for reassignment_id in &scope_data.reassignments {
-            let decl = env.identifiers[reassignment_id.index()].declaration_id;
+            let decl = env.identifiers[*reassignment_id].declaration_id;
             let identifier_node =
                 state.0.identifiers.get_mut(&decl).expect("Expected identifier to be initialized");
             for s in &state.1 {
@@ -1075,7 +1075,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for PruneScopesTransform<'a, 'e> {
         self.visit_scope(scope, state)?;
 
         let scope_id = scope.scope;
-        let scope_data = &self.env.scopes[scope_id.index()];
+        let scope_data = &self.env.scopes[scope_id];
 
         // Keep scopes that appear empty (value being memoized may be early-returned)
         // or have early return values
@@ -1086,10 +1086,10 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for PruneScopesTransform<'a, 'e> {
         }
 
         let has_memoized_output = scope_data.declarations.iter().any(|(_, decl)| {
-            let decl_id = self.env.identifiers[decl.identifier.index()].declaration_id;
+            let decl_id = self.env.identifiers[decl.identifier].declaration_id;
             state.contains(&decl_id)
         }) || scope_data.reassignments.iter().any(|reassign_id| {
-            let decl_id = self.env.identifiers[reassign_id.index()].declaration_id;
+            let decl_id = self.env.identifiers[*reassign_id].declaration_id;
             state.contains(&decl_id)
         });
 
@@ -1114,21 +1114,20 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for PruneScopesTransform<'a, 'e> {
                 lvalue: store_lvalue,
                 ..
             }) if store_lvalue.kind == InstructionKind::Reassign => {
-                let decl_id =
-                    self.env.identifiers[store_lvalue.place.identifier.index()].declaration_id;
+                let decl_id = self.env.identifiers[store_lvalue.place.identifier].declaration_id;
                 let ids = self.reassignments.entry(decl_id).or_default();
                 ids.insert(store_value.identifier);
             }
             ReactiveValue::Instruction(InstructionValue::LoadLocal { place, .. }) => {
-                let has_scope = self.env.identifiers[place.identifier.index()].scope.is_some();
+                let has_scope = self.env.identifiers[place.identifier].scope.is_some();
                 let lvalue_no_scope = instruction
                     .lvalue
                     .as_ref()
-                    .map(|lv| self.env.identifiers[lv.identifier.index()].scope.is_none())
+                    .map(|lv| self.env.identifiers[lv.identifier].scope.is_none())
                     .unwrap_or(false);
                 if has_scope && lvalue_no_scope {
                     if let Some(lv) = &instruction.lvalue {
-                        let decl_id = self.env.identifiers[lv.identifier.index()].declaration_id;
+                        let decl_id = self.env.identifiers[lv.identifier].declaration_id;
                         let ids = self.reassignments.entry(decl_id).or_default();
                         ids.insert(place.identifier);
                     }
@@ -1137,11 +1136,11 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for PruneScopesTransform<'a, 'e> {
             ReactiveValue::Instruction(InstructionValue::FinishMemoize {
                 decl, pruned, ..
             }) => {
-                let decl_has_scope = self.env.identifiers[decl.identifier.index()].scope.is_some();
+                let decl_has_scope = self.env.identifiers[decl.identifier].scope.is_some();
                 if !decl_has_scope {
                     // If the manual memo was a useMemo that got inlined, iterate through
                     // all reassignments to the iife temporary to ensure they're memoized.
-                    let decl_id = self.env.identifiers[decl.identifier.index()].declaration_id;
+                    let decl_id = self.env.identifiers[decl.identifier].declaration_id;
                     let decls: Vec<IdentifierId> = self
                         .reassignments
                         .get(&decl_id)
@@ -1149,13 +1148,13 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for PruneScopesTransform<'a, 'e> {
                         .unwrap_or_else(|| vec![decl.identifier]);
 
                     if decls.iter().all(|d| {
-                        let scope = self.env.identifiers[d.index()].scope;
+                        let scope = self.env.identifiers[*d].scope;
                         scope.is_none() || self.pruned_scopes.contains(&scope.unwrap())
                     }) {
                         *pruned = true;
                     }
                 } else {
-                    let scope = self.env.identifiers[decl.identifier.index()].scope;
+                    let scope = self.env.identifiers[decl.identifier].scope;
                     if let Some(scope_id) = scope {
                         if self.pruned_scopes.contains(&scope_id) {
                             *pruned = true;

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_reactive_dependencies.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_reactive_dependencies.rs
@@ -64,10 +64,10 @@ impl<'a, 'e> ReactiveFunctionVisitor<'a> for CollectVisitor<'a, 'e> {
     fn visit_pruned_scope(&self, scope: &PrunedReactiveScopeBlock<'a>, state: &mut Self::State) {
         self.traverse_pruned_scope(scope, state);
 
-        let scope_data = &self.env.scopes[scope.scope.index()];
+        let scope_data = &self.env.scopes[scope.scope];
         for (_id, decl) in &scope_data.declarations {
-            let identifier = &self.env.identifiers[decl.identifier.index()];
-            let ty = &self.env.types[identifier.type_.index()];
+            let identifier = &self.env.identifiers[decl.identifier];
+            let ty = &self.env.types[identifier.type_];
             if !is_primitive_type(ty) && !is_stable_ref_type(ty, state, identifier.id) {
                 state.insert(*_id);
             }
@@ -181,8 +181,8 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for PruneVisitor<'a, 'e> {
             }) => {
                 if state.contains(&destr_value.identifier) {
                     for operand in hir_visitors::each_pattern_operand(&destr_lvalue.pattern) {
-                        let ident = &self.env.identifiers[operand.identifier.index()];
-                        let ty = &self.env.types[ident.type_.index()];
+                        let ident = &self.env.identifiers[operand.identifier];
+                        let ty = &self.env.types[ident.type_];
                         if is_stable_type(ty) {
                             continue;
                         }
@@ -195,8 +195,8 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for PruneVisitor<'a, 'e> {
             }
             ReactiveValue::Instruction(InstructionValue::PropertyLoad { object, .. }) => {
                 if let Some(lv) = lvalue {
-                    let ident = &self.env.identifiers[lv.identifier.index()];
-                    let ty = &self.env.types[ident.type_.index()];
+                    let ident = &self.env.identifiers[lv.identifier];
+                    let ty = &self.env.types[ident.type_];
                     if state.contains(&object.identifier) && !is_stable_type(ty) {
                         state.insert(lv.identifier);
                     }
@@ -224,7 +224,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for PruneVisitor<'a, 'e> {
         self.traverse_scope(scope, state)?;
 
         let scope_id = scope.scope;
-        let scope_data = &mut self.env.scopes[scope_id.index()];
+        let scope_data = &mut self.env.scopes[scope_id];
 
         // Remove non-reactive dependencies
         scope_data.dependencies.retain(|dep| state.contains(&dep.identifier));

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_unused_lvalues.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_unused_lvalues.rs
@@ -64,7 +64,7 @@ impl<'a, 'e> ReactiveFunctionVisitor<'a> for Visitor<'a, 'e> {
 
     /// TS: `visitPlace(_id, place, state) { state.delete(place.identifier.declarationId) }`
     fn visit_place(&self, _id: EvaluationOrder, place: &Place, state: &mut LValues) {
-        let ident = &self.env.identifiers[place.identifier.index()];
+        let ident = &self.env.identifiers[place.identifier];
         state.remove(&ident.declaration_id);
     }
 
@@ -74,7 +74,7 @@ impl<'a, 'e> ReactiveFunctionVisitor<'a> for Visitor<'a, 'e> {
     fn visit_instruction(&self, instruction: &ReactiveInstruction<'a>, state: &mut LValues) {
         self.traverse_instruction(instruction, state);
         if let Some(lv) = &instruction.lvalue {
-            let ident = &self.env.identifiers[lv.identifier.index()];
+            let ident = &self.env.identifiers[lv.identifier];
             if ident.name.is_none() {
                 state.insert(ident.declaration_id);
             }
@@ -113,7 +113,7 @@ fn null_unused_in_instruction<'a>(
     unused: &FxHashSet<DeclarationId>,
 ) {
     if let Some(lv) = &instr.lvalue {
-        let ident = &env.identifiers[lv.identifier.index()];
+        let ident = &env.identifiers[lv.identifier];
         if unused.contains(&ident.declaration_id) {
             instr.lvalue = None;
         }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_unused_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_unused_scopes.rs
@@ -68,7 +68,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
         self.visit_scope(scope, &mut scope_state)?;
 
         let scope_id = scope.scope;
-        let scope_data = &self.env.scopes[scope_id.index()];
+        let scope_data = &self.env.scopes[scope_id];
 
         if !scope_state.has_return_statement
             && scope_data.reassignments.is_empty()

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/rename_variables.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/rename_variables.rs
@@ -55,7 +55,7 @@ impl<'a> Scopes<'a> {
     }
 
     fn visit_identifier(&mut self, identifier_id: IdentifierId, env: &Environment<'a>) {
-        let identifier = &env.identifiers[identifier_id.index()];
+        let identifier = &env.identifiers[identifier_id];
         let original_name = match &identifier.name {
             Some(name) => *name,
             None => return,
@@ -166,7 +166,7 @@ impl<'a, 'e> ReactiveFunctionVisitor<'a> for Visitor<'a, 'e> {
 
     /// TS: `visitScope(scope, state) { for (const [_, decl] of scope.scope.declarations) state.visit(decl.identifier); this.traverseScope(scope, state) }`
     fn visit_scope(&self, scope: &ReactiveScopeBlock<'a>, state: &mut Scopes<'a>) {
-        let scope_data = &self.env.scopes[scope.scope.index()];
+        let scope_data = &self.env.scopes[scope.scope];
         let decl_ids: Vec<IdentifierId> =
             scope_data.declarations.iter().map(|(_, d)| d.identifier).collect();
         for id in decl_ids {
@@ -343,10 +343,10 @@ fn collect_globals_hir_function<'a>(
     globals: &mut IdentHashSet<'a>,
     env: &Environment<'a>,
 ) {
-    let inner_func = &env.functions[func_id.index()];
+    let inner_func = &env.functions[func_id];
     let block_ids: Vec<_> = inner_func.body.blocks.keys().copied().collect();
     for block_id in block_ids {
-        let inner_func = &env.functions[func_id.index()];
+        let inner_func = &env.functions[func_id];
         let block = &inner_func.body.blocks[&block_id];
         for instr_id in &block.instructions {
             let instr = &inner_func.instructions[instr_id.index()];

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/stabilize_block_ids.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/stabilize_block_ids.rs
@@ -61,7 +61,7 @@ impl<'a, 'e> ReactiveFunctionVisitor<'a> for CollectReferencedLabels<'a, 'e> {
     }
 
     fn visit_scope(&self, scope: &ReactiveScopeBlock<'a>, state: &mut Self::State) {
-        let scope_data = &self.env.scopes[scope.scope.index()];
+        let scope_data = &self.env.scopes[scope.scope];
         if let Some(ref early_return) = scope_data.early_return_value {
             state.insert(early_return.label);
         }
@@ -104,7 +104,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for RewriteBlockIds<'a, 'e> {
         scope: &mut ReactiveScopeBlock<'a>,
         state: &mut Self::State,
     ) -> Result<(), OxcDiagnostic> {
-        let scope_data = &mut self.env.scopes[scope.scope.index()];
+        let scope_data = &mut self.env.scopes[scope.scope];
         if let Some(ref mut early_return) = scope_data.early_return_value {
             early_return.label = get_or_insert_mapping(state, early_return.label);
         }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/visitors.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/visitors.rs
@@ -50,7 +50,7 @@ pub trait ReactiveFunctionVisitor<'a> {
     /// value-lvalues, operands, and nested functions), and terminal operands.
     /// TS: `visitHirFunction`
     fn visit_hir_function(&self, func_id: FunctionId, state: &mut Self::State) {
-        let inner_func = &self.env().functions[func_id.index()];
+        let inner_func = &self.env().functions[func_id];
         for param in &inner_func.params {
             let place = match param {
                 ParamPattern::Place(p) => p,
@@ -60,14 +60,14 @@ pub trait ReactiveFunctionVisitor<'a> {
         }
         let block_ids: Vec<_> = inner_func.body.blocks.keys().copied().collect();
         for block_id in block_ids {
-            let inner_func = &self.env().functions[func_id.index()];
+            let inner_func = &self.env().functions[func_id];
             let block = &inner_func.body.blocks[&block_id];
             let instr_ids: Vec<_> = block.instructions.clone();
             let terminal_operands: Vec<Place> = each_terminal_operand(&block.terminal);
             let terminal_id = block.terminal.evaluation_order();
 
             for instr_id in &instr_ids {
-                let inner_func = &self.env().functions[func_id.index()];
+                let inner_func = &self.env().functions[func_id];
                 let instr = &inner_func.instructions[instr_id.index()];
                 // Build a temporary ReactiveInstruction for the visitor
                 let reactive_instr = ReactiveInstruction {

--- a/crates/oxc_react_compiler/src/react_compiler_ssa/eliminate_redundant_phi.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_ssa/eliminate_redundant_phi.rs
@@ -127,18 +127,17 @@ fn eliminate_redundant_phi_impl(
 
                 if let Some(fid) = func_expr_id {
                     // Rewrite context places
-                    let context = &mut env.functions[fid.index()].context;
+                    let context = &mut env.functions[fid].context;
                     for place in context.iter_mut() {
                         rewrite_place(place, rewrites);
                     }
 
                     // Take inner function out, process it, put it back
-                    let mut inner_func =
-                        replace(&mut env.functions[fid.index()], placeholder_function());
+                    let mut inner_func = replace(&mut env.functions[fid], placeholder_function());
 
                     eliminate_redundant_phi_impl(&mut inner_func, env, rewrites);
 
-                    env.functions[fid.index()] = inner_func;
+                    env.functions[fid] = inner_func;
                 }
             }
 

--- a/crates/oxc_react_compiler/src/react_compiler_ssa/enter_ssa.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_ssa/enter_ssa.rs
@@ -66,11 +66,11 @@ impl SSABuilder {
 
     fn make_id(&mut self, old_id: IdentifierId, env: &mut Environment) -> IdentifierId {
         let new_id = env.next_identifier_id();
-        let old = &env.identifiers[old_id.index()];
+        let old = &env.identifiers[old_id];
         let declaration_id = old.declaration_id;
         let name = old.name;
         let span = old.span;
-        let new_ident = &mut env.identifiers[new_id.index()];
+        let new_ident = &mut env.identifiers[new_id];
         new_ident.declaration_id = declaration_id;
         new_ident.name = name;
         new_ident.span = span;
@@ -85,7 +85,7 @@ impl SSABuilder {
         let old_id = old_place.identifier;
 
         if self.unknown.contains(&old_id) {
-            let ident = &env.identifiers[old_id.index()];
+            let ident = &env.identifiers[old_id];
             let name = match &ident.name {
                 Some(name) => format!("{}${}", name.value(), old_id.index()),
                 None => format!("${}", old_id.index()),
@@ -253,8 +253,8 @@ fn apply_pending_phis(func: &mut HirFunction, env: &mut Environment, builder: &m
             block.phis.extend(phis);
         }
     }
-    for fid in &builder.processed_functions.clone() {
-        let inner_func = &mut env.functions[fid.index()];
+    for &fid in &builder.processed_functions.clone() {
+        let inner_func = &mut env.functions[fid];
         for (block_id, block) in inner_func.body.blocks.iter_mut() {
             if let Some(phis) = builder.pending_phis.remove(block_id) {
                 block.phis.extend(phis);
@@ -323,8 +323,8 @@ fn enter_ssa_impl(
 
             // Map context places for function expressions before other operands
             if let Some(fid) = func_expr_id {
-                let context = take(&mut env.functions[fid.index()].context);
-                env.functions[fid.index()].context =
+                let context = take(&mut env.functions[fid].context);
+                env.functions[fid].context =
                     context.into_iter().map(|place| builder.get_place(&place, env)).collect();
             }
 
@@ -351,16 +351,13 @@ fn enter_ssa_impl(
 
             // Handle inner function SSA
             if let Some(fid) = func_expr_id {
-                let context_ids: Vec<IdentifierId> = env.functions[fid.index()]
-                    .context
-                    .iter()
-                    .map(|place| place.identifier)
-                    .collect();
+                let context_ids: Vec<IdentifierId> =
+                    env.functions[fid].context.iter().map(|place| place.identifier).collect();
                 for id in context_ids {
                     builder.unmark_unknown(id);
                 }
                 builder.processed_functions.push(fid);
-                let inner_func = &mut env.functions[fid.index()];
+                let inner_func = &mut env.functions[fid];
                 let inner_entry = inner_func.body.entry;
                 let entry_block = inner_func.body.blocks.get_mut(&inner_entry).unwrap();
 
@@ -376,7 +373,7 @@ fn enter_ssa_impl(
                 let saved_current = builder.current;
 
                 // Map inner function params
-                let inner_params = take(&mut env.functions[fid.index()].params);
+                let inner_params = take(&mut env.functions[fid].params);
                 let mut new_inner_params = Vec::with_capacity(inner_params.len());
                 for param in inner_params {
                     new_inner_params.push(match param {
@@ -388,21 +385,20 @@ fn enter_ssa_impl(
                         }),
                     });
                 }
-                env.functions[fid.index()].params = new_inner_params;
+                env.functions[fid].params = new_inner_params;
 
                 // Take the inner function out of the arena to process it
-                let mut inner_func =
-                    replace(&mut env.functions[fid.index()], placeholder_function());
+                let mut inner_func = replace(&mut env.functions[fid], placeholder_function());
 
                 enter_ssa_impl(&mut inner_func, builder, env, root_entry)?;
 
                 // Put it back
-                env.functions[fid.index()] = inner_func;
+                env.functions[fid] = inner_func;
 
                 builder.current = saved_current;
 
                 // Clear entry preds
-                env.functions[fid.index()].body.blocks.get_mut(&inner_entry).unwrap().preds.clear();
+                env.functions[fid].body.blocks.get_mut(&inner_entry).unwrap().preds.clear();
                 builder.block_preds.insert(inner_entry, Vec::new());
             }
         }
@@ -453,7 +449,7 @@ pub fn placeholder_function<'a>() -> HirFunction<'a> {
             span: None,
         },
         context: Vec::new(),
-        body: HIR { entry: BlockId::from_usize(0), blocks: FxIndexMap::default() },
+        body: HIR { entry: BlockId::ENTRY, blocks: FxIndexMap::default() },
         instructions: Vec::new(),
         generator: false,
         is_async: false,

--- a/crates/oxc_react_compiler/src/react_compiler_ssa/rewrite_instruction_kinds_based_on_reassignment.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_ssa/rewrite_instruction_kinds_based_on_reassignment.rs
@@ -67,7 +67,7 @@ fn format_kind(kind: Option<InstructionKind>) -> &'static str {
 
 /// Format a Place like TS `printPlace()`: `<effect> <name>$<id>[<range>]{reactive}`
 fn format_place(place: &Place, env: &Environment) -> String {
-    let ident = &env.identifiers[place.identifier.index()];
+    let ident = &env.identifiers[place.identifier];
     let name = ident.name.as_ref().map_or("", |name| name.value());
     let scope = ident
         .scope
@@ -130,7 +130,7 @@ pub fn rewrite_instruction_kinds_based_on_reassignment(
             ParamPattern::Place(p) => p,
             ParamPattern::Spread(s) => &s.place,
         };
-        let ident = &env.identifiers[place.identifier.index()];
+        let ident = &env.identifiers[place.identifier];
         if ident.name.is_some() {
             declarations.insert(ident.declaration_id, DeclarationLoc::ParamOrContext);
         }
@@ -138,7 +138,7 @@ pub fn rewrite_instruction_kinds_based_on_reassignment(
 
     // Seed with context variables
     for place in &func.context {
-        let ident = &env.identifiers[place.identifier.index()];
+        let ident = &env.identifiers[place.identifier];
         if ident.name.is_some() {
             declarations.insert(ident.declaration_id, DeclarationLoc::ParamOrContext);
         }
@@ -153,7 +153,7 @@ pub fn rewrite_instruction_kinds_based_on_reassignment(
             let instr = &func.instructions[instr_id.index()];
             match &instr.value {
                 InstructionValue::DeclareLocal { lvalue, .. } => {
-                    let decl_id = env.identifiers[lvalue.place.identifier.index()].declaration_id;
+                    let decl_id = env.identifiers[lvalue.place.identifier].declaration_id;
                     if declarations.contains_key(&decl_id) {
                         return Err(invariant_error_with_span(
                             "Expected variable not to be defined prior to declaration",
@@ -170,7 +170,7 @@ pub fn rewrite_instruction_kinds_based_on_reassignment(
                     );
                 }
                 InstructionValue::StoreLocal { lvalue, .. } => {
-                    let ident = &env.identifiers[lvalue.place.identifier.index()];
+                    let ident = &env.identifiers[lvalue.place.identifier];
                     if ident.name.is_some() {
                         let decl_id = ident.declaration_id;
                         if let Some(existing) = declarations.get(&decl_id) {
@@ -214,7 +214,7 @@ pub fn rewrite_instruction_kinds_based_on_reassignment(
                 InstructionValue::Destructure { lvalue, .. } => {
                     let mut kind: Option<InstructionKind> = None;
                     for place in each_pattern_operand(&lvalue.pattern) {
-                        let ident = &env.identifiers[place.identifier.index()];
+                        let ident = &env.identifiers[place.identifier];
                         if ident.name.is_none() {
                             if !(kind.is_none() || kind == Some(InstructionKind::Const)) {
                                 return Err(invariant_error_with_span(
@@ -292,7 +292,7 @@ pub fn rewrite_instruction_kinds_based_on_reassignment(
                 }
                 InstructionValue::PostfixUpdate { lvalue, .. }
                 | InstructionValue::PrefixUpdate { lvalue, .. } => {
-                    let ident = &env.identifiers[lvalue.identifier.index()];
+                    let ident = &env.identifiers[lvalue.identifier];
                     let decl_id = ident.declaration_id;
                     let Some(existing) = declarations.get(&decl_id) else {
                         return Err(invariant_error_with_span(

--- a/crates/oxc_react_compiler/src/react_compiler_typeinference/infer_types.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_typeinference/infer_types.rs
@@ -14,6 +14,7 @@ use rustc_hash::FxHashMap;
 
 use oxc_allocator::Allocator;
 use oxc_diagnostics::OxcDiagnostic;
+use oxc_index::{IndexSlice, IndexVec};
 use oxc_str::{Ident, format_ident};
 
 use crate::diagnostics::ErrorCategory;
@@ -64,13 +65,16 @@ pub fn infer_types<'a>(
 // =============================================================================
 
 /// Get the type for an identifier as a TypeVar referencing its type slot.
-fn get_type<'a>(id: IdentifierId, identifiers: &[Identifier<'a>]) -> Type<'a> {
-    let type_id = identifiers[id.index()].type_;
+fn get_type<'a>(
+    id: IdentifierId,
+    identifiers: &IndexSlice<IdentifierId, [Identifier<'a>]>,
+) -> Type<'a> {
+    let type_id = identifiers[id].type_;
     Type::TypeVar { id: type_id }
 }
 
 /// Allocate a new TypeVar in the types arena (standalone, no &mut Environment needed).
-fn make_type<'a>(types: &mut Vec<Type<'a>>) -> Type<'a> {
+fn make_type<'a>(types: &mut IndexVec<TypeId, Type<'a>>) -> Type<'a> {
     let id = TypeId::from_usize(types.len());
     types.push(Type::TypeVar { id });
     Type::TypeVar { id }
@@ -79,9 +83,9 @@ fn make_type<'a>(types: &mut Vec<Type<'a>>) -> Type<'a> {
 /// Pre-resolve LoadGlobal types for a single function's instructions.
 fn pre_resolve_globals<'a>(
     func: &HirFunction<'a>,
-    function_key: u32,
+    function_key: Option<FunctionId>,
     env: &mut Environment<'a>,
-    global_types: &mut FxHashMap<(u32, InstructionId), Type<'a>>,
+    global_types: &mut FxHashMap<(Option<FunctionId>, InstructionId), Type<'a>>,
 ) {
     for &instr_id in func.body.blocks.values().flat_map(|b| &b.instructions) {
         let instr = &func.instructions[instr_id.index()];
@@ -97,12 +101,12 @@ fn pre_resolve_globals<'a>(
 fn pre_resolve_globals_recursive<'a>(
     func_id: FunctionId,
     env: &mut Environment<'a>,
-    global_types: &mut FxHashMap<(u32, InstructionId), Type<'a>>,
+    global_types: &mut FxHashMap<(Option<FunctionId>, InstructionId), Type<'a>>,
 ) {
     // Collect LoadGlobal bindings and child function IDs in one pass to avoid
     // borrow conflicts (we need &env.functions to read, then &mut env for
     // get_global_declaration).
-    let inner = &env.functions[func_id.index()];
+    let inner = &env.functions[func_id];
     let mut load_globals: Vec<(InstructionId, NonLocalBinding, Option<Span>)> = Vec::new();
     let mut child_func_ids: Vec<FunctionId> = Vec::new();
 
@@ -131,7 +135,7 @@ fn pre_resolve_globals_recursive<'a>(
     // Now resolve globals (no longer borrowing env.functions)
     for (instr_id, binding, span) in load_globals {
         if let Some(global_type) = env.get_global_declaration(&binding, span).ok().flatten() {
-            global_types.insert((func_id.index() as u32, instr_id), global_type);
+            global_types.insert((Some(func_id), instr_id), global_type);
         }
     }
 
@@ -305,10 +309,11 @@ fn generate<'a>(
     // Pre-resolve LoadGlobal types for all functions (outer + inner). We do
     // this before the instruction loop because get_global_declaration needs
     // &mut env, but generate_instruction_types takes split borrows on env fields.
-    // The key is (function_key, InstructionId) where function_key is u32::MAX
-    // for the outer function and the FunctionId index for inner functions.
-    let mut global_types: FxHashMap<(u32, InstructionId), Type<'a>> = FxHashMap::default();
-    pre_resolve_globals(func, u32::MAX, env, &mut global_types);
+    // The key is (function_key, InstructionId) where function_key is None for the
+    // outer function and Some(FunctionId) for inner functions.
+    let mut global_types: FxHashMap<(Option<FunctionId>, InstructionId), Type<'a>> =
+        FxHashMap::default();
+    pre_resolve_globals(func, None, env, &mut global_types);
     // Also pre-resolve inner functions recursively
     for &instr_id in func.body.blocks.values().flat_map(|b| &b.instructions) {
         let instr = &func.instructions[instr_id.index()];
@@ -346,7 +351,7 @@ fn generate<'a>(
             generate_instruction_types(
                 instr,
                 instr_id,
-                u32::MAX,
+                None,
                 &env.identifiers,
                 &mut env.types,
                 &mut env.functions,
@@ -378,16 +383,16 @@ fn generate<'a>(
 #[allow(clippy::too_many_arguments)]
 fn generate_for_function_id<'a>(
     func_id: FunctionId,
-    identifiers: &[Identifier<'a>],
-    types: &mut Vec<Type<'a>>,
-    functions: &mut Vec<HirFunction<'a>>,
-    global_types: &FxHashMap<(u32, InstructionId), Type<'a>>,
+    identifiers: &IndexSlice<IdentifierId, [Identifier<'a>]>,
+    types: &mut IndexVec<TypeId, Type<'a>>,
+    functions: &mut IndexVec<FunctionId, HirFunction<'a>>,
+    global_types: &FxHashMap<(Option<FunctionId>, InstructionId), Type<'a>>,
     shapes: &ShapeRegistry<'a>,
     unifier: &mut Unifier<'a>,
     allocator: &'a Allocator,
 ) -> Result<(), OxcDiagnostic> {
     // Take the function out temporarily to avoid borrow conflicts
-    let inner = replace(&mut functions[func_id.index()], placeholder_function());
+    let inner = replace(&mut functions[func_id], placeholder_function());
 
     // Process params for component inner functions
     if inner.fn_type == ReactFunctionType::Component {
@@ -419,7 +424,7 @@ fn generate_for_function_id<'a>(
             generate_instruction_types(
                 instr,
                 instr_id,
-                func_id.index() as u32,
+                Some(func_id),
                 identifiers,
                 types,
                 functions,
@@ -444,7 +449,7 @@ fn generate_for_function_id<'a>(
     }
 
     // Put the function back
-    functions[func_id.index()] = inner;
+    functions[func_id] = inner;
     Ok(())
 }
 
@@ -452,12 +457,12 @@ fn generate_for_function_id<'a>(
 fn generate_instruction_types<'a>(
     instr: &Instruction<'a>,
     instr_id: InstructionId,
-    function_key: u32,
-    identifiers: &[Identifier<'a>],
-    types: &mut Vec<Type<'a>>,
-    functions: &mut Vec<HirFunction<'a>>,
+    function_key: Option<FunctionId>,
+    identifiers: &IndexSlice<IdentifierId, [Identifier<'a>]>,
+    types: &mut IndexVec<TypeId, Type<'a>>,
+    functions: &mut IndexVec<FunctionId, HirFunction<'a>>,
     names: &mut FxHashMap<IdentifierId, Ident<'a>>,
-    global_types: &FxHashMap<(u32, InstructionId), Type<'a>>,
+    global_types: &FxHashMap<(Option<FunctionId>, InstructionId), Type<'a>>,
     shapes: &ShapeRegistry<'a>,
     unifier: &mut Unifier<'a>,
     allocator: &'a Allocator,
@@ -476,7 +481,7 @@ fn generate_instruction_types<'a>(
         }
 
         InstructionValue::LoadLocal { place, .. } => {
-            set_name(names, instr.lvalue.identifier, &identifiers[place.identifier.index()]);
+            set_name(names, instr.lvalue.identifier, &identifiers[place.identifier]);
             let place_type = get_type(place.identifier, identifiers);
             unifier.unify(left, place_type, shapes)?;
         }
@@ -718,7 +723,7 @@ fn generate_instruction_types<'a>(
                 allocator,
             )?;
             // Get the inner function's return type
-            let inner_func = &functions[func_id.index()];
+            let inner_func = &functions[*func_id];
             let inner_return_type = get_type(inner_func.returns.identifier, identifiers);
             unifier.unify(
                 left,
@@ -828,9 +833,9 @@ fn generate_instruction_types<'a>(
 
 fn apply_function<'a>(
     func: &HirFunction<'a>,
-    functions: &[HirFunction<'a>],
-    identifiers: &mut [Identifier<'a>],
-    types: &mut [Type<'a>],
+    functions: &IndexSlice<FunctionId, [HirFunction<'a>]>,
+    identifiers: &mut IndexSlice<IdentifierId, [Identifier<'a>]>,
+    types: &mut IndexSlice<TypeId, [Type<'a>]>,
     unifier: &Unifier<'a>,
 ) {
     for (_block_id, block) in &func.body.blocks {
@@ -861,7 +866,7 @@ fn apply_function<'a>(
                     lowered_func: LoweredFunction { func: func_id },
                     ..
                 } => {
-                    let inner_func = &functions[func_id.index()];
+                    let inner_func = &functions[*func_id];
                     // Resolve types for captured context variable places (matching TS
                     // where eachInstructionValueOperand yields func.context places)
                     for ctx in &inner_func.context {
@@ -880,21 +885,21 @@ fn apply_function<'a>(
 
 fn resolve_identifier<'a>(
     id: IdentifierId,
-    identifiers: &mut [Identifier<'a>],
-    types: &mut [Type<'a>],
+    identifiers: &mut IndexSlice<IdentifierId, [Identifier<'a>]>,
+    types: &mut IndexSlice<TypeId, [Type<'a>]>,
     unifier: &Unifier<'a>,
 ) {
-    let type_id = identifiers[id.index()].type_;
-    let current_type = types[type_id.index()].clone();
+    let type_id = identifiers[id].type_;
+    let current_type = types[type_id].clone();
     let resolved = unifier.get(&current_type);
-    types[type_id.index()] = resolved;
+    types[type_id] = resolved;
 }
 
 /// Resolve types for instruction lvalues (mirrors TS eachInstructionLValue).
 fn apply_instruction_lvalues<'a>(
     value: &InstructionValue<'a>,
-    identifiers: &mut [Identifier<'a>],
-    types: &mut [Type<'a>],
+    identifiers: &mut IndexSlice<IdentifierId, [Identifier<'a>]>,
+    types: &mut IndexSlice<TypeId, [Type<'a>]>,
     unifier: &Unifier<'a>,
 ) {
     match value {
@@ -955,8 +960,8 @@ fn apply_instruction_lvalues<'a>(
 /// Resolve types for instruction operands (mirrors TS eachInstructionOperand).
 fn apply_instruction_operands<'a>(
     value: &InstructionValue<'a>,
-    identifiers: &mut [Identifier<'a>],
-    types: &mut [Type<'a>],
+    identifiers: &mut IndexSlice<IdentifierId, [Identifier<'a>]>,
+    types: &mut IndexSlice<TypeId, [Type<'a>]>,
     unifier: &Unifier<'a>,
 ) {
     match value {

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_context_variable_lvalues.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_context_variable_lvalues.rs
@@ -2,6 +2,8 @@ use rustc_hash::FxHashMap;
 use std::fmt::Display;
 use std::fmt::Formatter;
 
+use oxc_index::IndexSlice;
+
 use oxc_diagnostics::{Diagnostics, OxcDiagnostic};
 
 use crate::diagnostics::ErrorCategory;
@@ -51,8 +53,8 @@ pub fn validate_context_variable_lvalues(
 /// discard the diagnostics (e.g. when lowering is incomplete).
 pub fn validate_context_variable_lvalues_with_errors(
     func: &HirFunction,
-    functions: &[HirFunction],
-    identifiers: &[Identifier],
+    functions: &IndexSlice<FunctionId, [HirFunction]>,
+    identifiers: &IndexSlice<IdentifierId, [Identifier]>,
     errors: &mut Diagnostics,
 ) -> Result<(), OxcDiagnostic> {
     let mut identifier_kinds: IdentifierKinds = FxHashMap::default();
@@ -68,8 +70,8 @@ pub fn validate_context_variable_lvalues_with_errors(
 fn validate_context_variable_lvalues_impl(
     func: &HirFunction,
     identifier_kinds: &mut IdentifierKinds,
-    functions: &[HirFunction],
-    identifiers: &[Identifier],
+    functions: &IndexSlice<FunctionId, [HirFunction]>,
+    identifiers: &IndexSlice<IdentifierId, [Identifier]>,
     errors: &mut Diagnostics,
 ) -> Result<(), OxcDiagnostic> {
     let mut inner_function_ids: Vec<FunctionId> = Vec::new();
@@ -136,7 +138,7 @@ fn validate_context_variable_lvalues_impl(
 
     // Process inner functions after the block loop to avoid borrow conflicts
     for func_id in inner_function_ids {
-        let inner_func = &functions[func_id.index()];
+        let inner_func = &functions[func_id];
         validate_context_variable_lvalues_impl(
             inner_func,
             identifier_kinds,
@@ -150,9 +152,9 @@ fn validate_context_variable_lvalues_impl(
 }
 
 /// Format a place like TS `printPlace()`: `<effect> <name>$<id>`
-fn format_place(place: &Place, identifiers: &[Identifier]) -> String {
+fn format_place(place: &Place, identifiers: &IndexSlice<IdentifierId, [Identifier]>) -> String {
     let id = place.identifier;
-    let ident = &identifiers[id.index()];
+    let ident = &identifiers[id];
     let name = ident.name.as_ref().map_or("", |name| name.value());
     format!("{} {}${}", place.effect, name, id.index())
 }
@@ -161,7 +163,7 @@ fn visit(
     identifiers: &mut IdentifierKinds,
     place: &Place,
     kind: VarRefKind,
-    env_identifiers: &[Identifier],
+    env_identifiers: &IndexSlice<IdentifierId, [Identifier]>,
     errors: &mut Diagnostics,
 ) -> Result<(), OxcDiagnostic> {
     if let Some((prev_place, prev_kind)) = identifiers.get(&place.identifier) {

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_exhaustive_dependencies.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_exhaustive_dependencies.rs
@@ -4,6 +4,7 @@ use std::mem::{replace, take};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use oxc_diagnostics::OxcDiagnostic;
+use oxc_index::IndexSlice;
 use oxc_str::Ident;
 
 use crate::diagnostics::ErrorCategory;
@@ -14,10 +15,10 @@ use crate::react_compiler_hir::visitors::{
     each_terminal_operand,
 };
 use crate::react_compiler_hir::{
-    ArrayElement, BlockId, DependencyPathEntry, Effect, HirFunction, Identifier, IdentifierId,
-    IdentifierName, InstructionKind, InstructionValue, ManualMemoDependency,
+    ArrayElement, BlockId, DependencyPathEntry, Effect, FunctionId, HirFunction, Identifier,
+    IdentifierId, IdentifierName, InstructionKind, InstructionValue, ManualMemoDependency,
     ManualMemoDependencyRoot, NonLocalBinding, ParamPattern, Place, PlaceOrSpread, PropertyLiteral,
-    Terminal, Type,
+    Terminal, Type, TypeId,
 };
 use oxc_span::Span;
 
@@ -216,15 +217,18 @@ fn is_use_ref_type(ty: &Type) -> bool {
 
 fn get_identifier_type<'a>(
     id: IdentifierId,
-    identifiers: &'a [Identifier<'a>],
-    types: &'a [Type<'a>],
+    identifiers: &'a IndexSlice<IdentifierId, [Identifier<'a>]>,
+    types: &'a IndexSlice<TypeId, [Type<'a>]>,
 ) -> &'a Type<'a> {
-    let ident = &identifiers[id.index()];
-    &types[ident.type_.index()]
+    let ident = &identifiers[id];
+    &types[ident.type_]
 }
 
-fn get_identifier_name<'a>(id: IdentifierId, identifiers: &[Identifier<'a>]) -> Option<&'a str> {
-    identifiers[id.index()].name.as_ref().map(IdentifierName::value)
+fn get_identifier_name<'a>(
+    id: IdentifierId,
+    identifiers: &IndexSlice<IdentifierId, [Identifier<'a>]>,
+) -> Option<&'a str> {
+    identifiers[id].name.as_ref().map(IdentifierName::value)
 }
 
 // =============================================================================
@@ -260,7 +264,7 @@ fn is_sub_path_ignoring_optionals(
 
 fn collect_reactive_identifiers(
     func: &HirFunction,
-    functions: &[HirFunction],
+    functions: &IndexSlice<FunctionId, [HirFunction]>,
 ) -> FxHashSet<IdentifierId> {
     let mut reactive = FxHashSet::default();
     for (_block_id, block) in &func.body.blocks {
@@ -448,9 +452,9 @@ fn visit_candidate_dependency<'a>(
 
 fn collect_dependencies<'a>(
     func: &HirFunction<'a>,
-    identifiers: &[Identifier<'a>],
-    types: &[Type<'a>],
-    functions: &[HirFunction<'a>],
+    identifiers: &IndexSlice<IdentifierId, [Identifier<'a>]>,
+    types: &IndexSlice<TypeId, [Type<'a>]>,
+    functions: &IndexSlice<FunctionId, [HirFunction<'a>]>,
     temporaries: &mut FxHashMap<IdentifierId, Temporary<'a>>,
     callbacks: &mut Option<&mut Callbacks<'_, 'a>>,
     is_function_expression: bool,
@@ -577,7 +581,7 @@ fn collect_dependencies<'a>(
                     locals.insert(decl_lv.place.identifier);
                 }
                 InstructionValue::StoreLocal { lvalue: store_lv, value: store_val, .. } => {
-                    let has_name = identifiers[store_lv.place.identifier.index()].name.is_some();
+                    let has_name = identifiers[store_lv.place.identifier].name.is_some();
                     if !has_name {
                         // Unnamed: propagate temporary
                         if let Some(temp) = temporaries.get(&store_val.identifier).cloned() {
@@ -702,7 +706,7 @@ fn collect_dependencies<'a>(
                 }
                 InstructionValue::FunctionExpression { lowered_func, .. }
                 | InstructionValue::ObjectMethod { lowered_func, .. } => {
-                    let inner_func = &functions[lowered_func.func.index()];
+                    let inner_func = &functions[lowered_func.func];
                     let function_deps = collect_dependencies(
                         inner_func,
                         identifiers,
@@ -1102,8 +1106,8 @@ fn validate_dependencies(
     manual_memo_span: Option<Span>,
     category: ErrorCategory,
     exhaustive_deps_report_mode: &str,
-    identifiers: &[Identifier<'_>],
-    types: &[Type<'_>],
+    identifiers: &IndexSlice<IdentifierId, [Identifier<'_>]>,
+    types: &IndexSlice<TypeId, [Type<'_>]>,
 ) -> Result<Option<OxcDiagnostic>, OxcDiagnostic> {
     // Sort dependencies by name and path
     inferred.sort_by(|a, b| {
@@ -1383,7 +1387,10 @@ fn validate_dependencies(
 // Printing helpers
 // =============================================================================
 
-fn print_inferred_dependency(dep: &InferredDependency, identifiers: &[Identifier]) -> String {
+fn print_inferred_dependency(
+    dep: &InferredDependency,
+    identifiers: &IndexSlice<IdentifierId, [Identifier]>,
+) -> String {
     match dep {
         InferredDependency::Global { binding } => binding.name().to_string(),
         InferredDependency::Local { identifier, path, .. } => {
@@ -1397,7 +1404,10 @@ fn print_inferred_dependency(dep: &InferredDependency, identifiers: &[Identifier
     }
 }
 
-fn print_manual_memo_dependency(dep: &ManualMemoDependency, identifiers: &[Identifier]) -> String {
+fn print_manual_memo_dependency(
+    dep: &ManualMemoDependency,
+    identifiers: &IndexSlice<IdentifierId, [Identifier]>,
+) -> String {
     let name = match &dep.root {
         ManualMemoDependencyRoot::Global { identifier_name } => identifier_name.as_str(),
         ManualMemoDependencyRoot::NamedLocal { value, .. } => {
@@ -1419,8 +1429,8 @@ fn print_manual_memo_dependency(dep: &ManualMemoDependency, identifiers: &[Ident
 fn is_optional_dependency(
     identifier: IdentifierId,
     reactive: &FxHashSet<IdentifierId>,
-    identifiers: &[Identifier],
-    types: &[Type],
+    identifiers: &IndexSlice<IdentifierId, [Identifier]>,
+    types: &IndexSlice<TypeId, [Type]>,
 ) -> bool {
     if reactive.contains(&identifier) {
         return false;
@@ -1432,8 +1442,8 @@ fn is_optional_dependency(
 fn is_optional_dependency_inferred(
     dep: &InferredDependency,
     reactive: &FxHashSet<IdentifierId>,
-    identifiers: &[Identifier],
-    types: &[Type],
+    identifiers: &IndexSlice<IdentifierId, [Identifier]>,
+    types: &IndexSlice<TypeId, [Type]>,
 ) -> bool {
     match dep {
         InferredDependency::Local { identifier, .. } => {

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_hooks_usage.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_hooks_usage.rs
@@ -23,9 +23,10 @@ use crate::react_compiler_hir::object_shape::HookKind;
 use crate::react_compiler_hir::visitors::{each_pattern_operand, each_terminal_operand};
 use crate::react_compiler_hir::{
     FunctionId, HirFunction, Identifier, IdentifierId, InstructionValue, ParamPattern, Place,
-    PlaceOrSpread, PropertyLiteral, Type, visitors,
+    PlaceOrSpread, PropertyLiteral, Type, TypeId, visitors,
 };
 use crate::react_compiler_utils::FxIndexMap;
+use oxc_index::IndexSlice;
 use oxc_span::Span;
 
 /// Value classification for hook validation.
@@ -55,10 +56,10 @@ fn join_kinds(a: Kind, b: Kind) -> Kind {
 fn get_kind_for_place(
     place: &Place,
     value_kinds: &FxHashMap<IdentifierId, Kind>,
-    identifiers: &[Identifier],
+    identifiers: &IndexSlice<IdentifierId, [Identifier]>,
 ) -> Kind {
     let known_kind = value_kinds.get(&place.identifier).copied();
-    let ident = &identifiers[place.identifier.index()];
+    let ident = &identifiers[place.identifier];
     if let Some(ref name) = ident.name {
         if is_hook_name(name.value()) {
             return join_kinds(known_kind.unwrap_or(Kind::Local), Kind::PotentialHook);
@@ -67,19 +68,22 @@ fn get_kind_for_place(
     known_kind.unwrap_or(Kind::Local)
 }
 
-fn ident_is_hook_name(identifier_id: IdentifierId, identifiers: &[Identifier]) -> bool {
-    let ident = &identifiers[identifier_id.index()];
+fn ident_is_hook_name(
+    identifier_id: IdentifierId,
+    identifiers: &IndexSlice<IdentifierId, [Identifier]>,
+) -> bool {
+    let ident = &identifiers[identifier_id];
     if let Some(ref name) = ident.name { is_hook_name(name.value()) } else { false }
 }
 
 fn get_hook_kind_for_id<'a>(
     identifier_id: IdentifierId,
-    identifiers: &[Identifier],
-    types: &[Type],
+    identifiers: &IndexSlice<IdentifierId, [Identifier]>,
+    types: &IndexSlice<TypeId, [Type]>,
     env: &'a Environment,
 ) -> Result<Option<&'a HookKind>, OxcDiagnostic> {
-    let identifier = &identifiers[identifier_id.index()];
-    let ty = &types[identifier.type_.index()];
+    let identifier = &identifiers[identifier_id];
+    let ty = &types[identifier.type_];
     env.get_hook_kind_for_type(ty)
 }
 
@@ -380,7 +384,7 @@ fn visit_function_expression(
         NestedFunc(FunctionId),
     }
 
-    let func = &env.functions[func_id.index()];
+    let func = &env.functions[func_id];
     let mut items: Vec<Item> = Vec::new();
 
     for (_block_id, block) in &func.body.blocks {
@@ -407,8 +411,8 @@ fn visit_function_expression(
     for item in items {
         match item {
             Item::Call(identifier_id, span) => {
-                let identifier = &env.identifiers[identifier_id.index()];
-                let ty = &env.types[identifier.type_.index()];
+                let identifier = &env.identifiers[identifier_id];
+                let ty = &env.types[identifier.type_];
                 let hook_kind = env.get_hook_kind_for_type(ty).ok().flatten().cloned();
                 if let Some(hook_kind) = hook_kind {
                     let description = format!(

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_locals_not_reassigned_after_render.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_locals_not_reassigned_after_render.rs
@@ -8,6 +8,7 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use oxc_diagnostics::OxcDiagnostic;
+use oxc_index::IndexSlice;
 
 use crate::diagnostics::ErrorCategory;
 use crate::react_compiler_hir::environment::Environment;
@@ -15,7 +16,8 @@ use crate::react_compiler_hir::visitors::{
     each_instruction_lvalue_ids, each_instruction_value_operand, each_terminal_operand,
 };
 use crate::react_compiler_hir::{
-    Effect, HirFunction, Identifier, IdentifierId, IdentifierName, InstructionValue, Place, Type,
+    Effect, FunctionId, HirFunction, Identifier, IdentifierId, IdentifierName, InstructionValue,
+    Place, Type, TypeId,
 };
 
 /// Validates that local variables cannot be reassigned after render.
@@ -62,8 +64,11 @@ pub fn validate_locals_not_reassigned_after_render(func: &HirFunction, env: &mut
 
 /// Format a variable name for error messages. Uses the named identifier if
 /// available, otherwise falls back to "variable".
-fn format_variable_name(place: &Place, identifiers: &[Identifier]) -> String {
-    let identifier = &identifiers[place.identifier.index()];
+fn format_variable_name(
+    place: &Place,
+    identifiers: &IndexSlice<IdentifierId, [Identifier]>,
+) -> String {
+    let identifier = &identifiers[place.identifier];
     match &identifier.name {
         Some(IdentifierName::Named(name)) => format!("`{}`", name),
         _ => "variable".to_string(),
@@ -77,9 +82,9 @@ fn format_variable_name(place: &Place, identifiers: &[Identifier]) -> String {
 #[allow(clippy::only_used_in_recursion, clippy::too_many_arguments)]
 fn get_context_reassignment(
     func: &HirFunction,
-    identifiers: &[Identifier],
-    types: &[Type],
-    functions: &[HirFunction],
+    identifiers: &IndexSlice<IdentifierId, [Identifier]>,
+    types: &IndexSlice<TypeId, [Type]>,
+    functions: &IndexSlice<FunctionId, [HirFunction]>,
     env: &Environment,
     context_variables: &mut FxHashSet<IdentifierId>,
     is_function_expression: bool,
@@ -96,7 +101,7 @@ fn get_context_reassignment(
             match &instr.value {
                 InstructionValue::FunctionExpression { lowered_func, .. }
                 | InstructionValue::ObjectMethod { lowered_func, .. } => {
-                    let inner_function = &functions[lowered_func.func.index()];
+                    let inner_function = &functions[lowered_func.func];
                     let inner_is_async = is_async || inner_function.is_async;
 
                     // Recursively check the inner function

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_derived_computations_in_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_derived_computations_in_effects.rs
@@ -15,6 +15,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use oxc_allocator::IdentBuildHasher;
 use oxc_diagnostics::{Diagnostics, OxcDiagnostic};
+use oxc_index::IndexSlice;
 use oxc_str::{Ident, IdentHashSet};
 
 use crate::diagnostics::ErrorCategory;
@@ -28,7 +29,7 @@ use crate::react_compiler_hir::visitors::{
 use crate::react_compiler_hir::{
     ArrayElement, BlockId, Effect, EvaluationOrder, FunctionId, HirFunction, Identifier,
     IdentifierId, IdentifierName, InstructionValue, ParamPattern, PlaceOrSpread, ReactFunctionType,
-    ReturnVariant, Type, is_set_state_type, is_use_effect_hook_type, is_use_ref_type,
+    ReturnVariant, Type, TypeId, is_set_state_type, is_use_effect_hook_type, is_use_ref_type,
     is_use_state_type,
 };
 use oxc_span::Span;
@@ -240,16 +241,16 @@ fn maybe_record_set_state_for_instr(
                 set_state_loads.insert(lvalue_id, Some(place.identifier));
             } else {
                 // Only check root setState if not a LoadLocal from a known chain
-                let lvalue_ident = &identifiers[lvalue_id.index()];
-                let lvalue_ty = &types[lvalue_ident.type_.index()];
+                let lvalue_ident = &identifiers[lvalue_id];
+                let lvalue_ty = &types[lvalue_ident.type_];
                 if is_set_state_type(lvalue_ty) {
                     set_state_loads.insert(lvalue_id, None);
                 }
             }
         } else {
             // Check if lvalue is a setState type (root setState)
-            let lvalue_ident = &identifiers[lvalue_id.index()];
-            let lvalue_ty = &types[lvalue_ident.type_.index()];
+            let lvalue_ident = &identifiers[lvalue_id];
+            let lvalue_ty = &types[lvalue_ident.type_];
             if is_set_state_type(lvalue_ty) {
                 set_state_loads.insert(lvalue_id, None);
             }
@@ -271,7 +272,7 @@ fn is_mutable_at(
     eval_order: EvaluationOrder,
     identifier_id: IdentifierId,
 ) -> bool {
-    env.identifiers[identifier_id.index()].mutable_range.contains(eval_order)
+    env.identifiers[identifier_id].mutable_range.contains(eval_order)
 }
 
 pub fn validate_no_derived_computations_in_effects_exp(
@@ -293,7 +294,7 @@ pub fn validate_no_derived_computations_in_effects_exp(
     if func.fn_type == ReactFunctionType::Hook {
         for param in &func.params {
             if let ParamPattern::Place(place) = param {
-                let name = identifiers[place.identifier.index()].name;
+                let name = identifiers[place.identifier].name;
                 context.derivation_cache.cache.insert(
                     place.identifier,
                     DerivationMetadata {
@@ -308,7 +309,7 @@ pub fn validate_no_derived_computations_in_effects_exp(
         }
     } else if func.fn_type == ReactFunctionType::Component {
         if let Some(ParamPattern::Place(place)) = func.params.first() {
-            let name = identifiers[place.identifier.index()].name;
+            let name = identifiers[place.identifier].name;
             context.derivation_cache.cache.insert(
                 place.identifier,
                 DerivationMetadata {
@@ -383,7 +384,7 @@ fn record_phi_derivations<'a>(
         }
 
         if type_of_value != TypeOfValue::Ignored {
-            let name = identifiers[phi.place.identifier.index()].name;
+            let name = identifiers[phi.place.identifier].name;
             context.derivation_cache.add_derivation_entry(
                 phi.place.identifier,
                 name,
@@ -423,7 +424,7 @@ fn record_instruction_derivations<'a>(
         InstructionValue::FunctionExpression { lowered_func, .. } => {
             context.functions.insert(lvalue_id, lowered_func.func);
             // Recurse into the inner function
-            let inner_func = &functions[lowered_func.func.index()];
+            let inner_func = &functions[lowered_func.func];
             for (_block_id, block) in &inner_func.body.blocks {
                 record_phi_derivations(block, context, env);
                 for &inner_instr_id in &block.instructions {
@@ -433,7 +434,7 @@ fn record_instruction_derivations<'a>(
             }
         }
         InstructionValue::CallExpression { callee, args, .. } => {
-            let callee_type = &types[identifiers[callee.identifier.index()].type_.index()];
+            let callee_type = &types[identifiers[callee.identifier].type_];
             if is_use_effect_hook_type(callee_type) && args.len() == 2 {
                 if let (PlaceOrSpread::Place(arg0), PlaceOrSpread::Place(arg1)) =
                     (&args[0], &args[1])
@@ -450,9 +451,9 @@ fn record_instruction_derivations<'a>(
             }
 
             // Check if lvalue is useState type
-            let lvalue_type = &types[identifiers[lvalue_id.index()].type_.index()];
+            let lvalue_type = &types[identifiers[lvalue_id].type_];
             if is_use_state_type(lvalue_type) {
-                let name = identifiers[lvalue_id.index()].name;
+                let name = identifiers[lvalue_id].name;
                 context.derivation_cache.add_derivation_entry(
                     lvalue_id,
                     name,
@@ -464,7 +465,7 @@ fn record_instruction_derivations<'a>(
             }
         }
         InstructionValue::MethodCall { property, args, .. } => {
-            let prop_type = &types[identifiers[property.identifier.index()].type_.index()];
+            let prop_type = &types[identifiers[property.identifier].type_];
             if is_use_effect_hook_type(prop_type) && args.len() == 2 {
                 if let (PlaceOrSpread::Place(arg0), PlaceOrSpread::Place(arg1)) =
                     (&args[0], &args[1])
@@ -481,9 +482,9 @@ fn record_instruction_derivations<'a>(
             }
 
             // Check if lvalue is useState type
-            let lvalue_type = &types[identifiers[lvalue_id.index()].type_.index()];
+            let lvalue_type = &types[identifiers[lvalue_id].type_];
             if is_use_state_type(lvalue_type) {
-                let name = identifiers[lvalue_id.index()].name;
+                let name = identifiers[lvalue_id].name;
                 context.derivation_cache.add_derivation_entry(
                     lvalue_id,
                     name,
@@ -534,7 +535,7 @@ fn record_instruction_derivations<'a>(
 
     // Record derivation for ALL lvalue places (including destructured variables)
     for &lv_id in &each_instruction_lvalue_ids(instr) {
-        let name = identifiers[lv_id.index()].name;
+        let name = identifiers[lv_id].name;
         context.derivation_cache.add_derivation_entry(
             lv_id,
             name,
@@ -556,7 +557,7 @@ fn record_instruction_derivations<'a>(
                 if let Some(existing) = context.derivation_cache.cache.get_mut(&operand.id) {
                     existing.type_of_value = join_value(type_of_value, existing.type_of_value);
                 } else {
-                    let name = identifiers[operand.id.index()].name;
+                    let name = identifiers[operand.id].name;
                     context.derivation_cache.add_derivation_entry(
                         operand.id,
                         name,
@@ -726,7 +727,7 @@ fn get_fn_local_deps(
     env: &Environment,
 ) -> Option<FxHashSet<IdentifierId>> {
     let func_id = func_id?;
-    let inner = &env.functions[func_id.index()];
+    let inner = &env.functions[func_id];
     let mut deps: FxHashSet<IdentifierId> = FxHashSet::default();
 
     for (_block_id, block) in &inner.body.blocks {
@@ -751,7 +752,7 @@ fn validate_effect<'a>(
     let identifiers = &env.identifiers;
     let types = &env.types;
     let functions = &env.functions;
-    let effect_function = &functions[effect_func_id.index()];
+    let effect_function = &functions[effect_func_id];
     let mut seen_blocks: FxHashSet<BlockId> = FxHashSet::default();
 
     struct DerivedSetStateCall {
@@ -797,7 +798,7 @@ fn validate_effect<'a>(
             let instr = &effect_function.instructions[instr_id.index()];
 
             // Early return if any instruction derives from a ref
-            let lvalue_type = &types[identifiers[instr.lvalue.identifier.index()].type_.index()];
+            let lvalue_type = &types[identifiers[instr.lvalue.identifier].type_];
             if is_use_ref_type(lvalue_type) {
                 return;
             }
@@ -828,7 +829,7 @@ fn validate_effect<'a>(
 
             match &instr.value {
                 InstructionValue::CallExpression { callee, args, .. } => {
-                    let callee_type = &types[identifiers[callee.identifier.index()].type_.index()];
+                    let callee_type = &types[identifiers[callee.identifier].type_];
                     if is_set_state_type(callee_type) && args.len() == 1 {
                         if let PlaceOrSpread::Place(arg0) = &args[0] {
                             let callee_metadata =
@@ -1018,7 +1019,7 @@ pub fn validate_no_derived_computations_in_effects(
                         functions_map.insert(instr.lvalue.identifier, lowered_func.func);
                     }
                     InstructionValue::CallExpression { callee, args, .. } => {
-                        let callee_ty = &tys[ids[callee.identifier.index()].type_.index()];
+                        let callee_ty = &tys[ids[callee.identifier].type_];
                         if is_use_effect_hook_type(callee_ty) && args.len() == 2 {
                             if let (PlaceOrSpread::Place(arg0), PlaceOrSpread::Place(arg1)) =
                                 (&args[0], &args[1])
@@ -1039,7 +1040,7 @@ pub fn validate_no_derived_computations_in_effects(
                         }
                     }
                     InstructionValue::MethodCall { property, args, .. } => {
-                        let callee_ty = &tys[ids[property.identifier.index()].type_.index()];
+                        let callee_ty = &tys[ids[property.identifier].type_];
                         if is_use_effect_hook_type(callee_ty) && args.len() == 2 {
                             if let (PlaceOrSpread::Place(arg0), PlaceOrSpread::Place(arg1)) =
                                 (&args[0], &args[1])
@@ -1070,7 +1071,7 @@ pub fn validate_no_derived_computations_in_effects(
     // Matches TS behavior where env.recordError(new CompilerErrorDetail({...})) is used.
     for (func_id, resolved_deps) in effects_to_validate {
         let details = validate_effect_non_exp(
-            &env.functions[func_id.index()],
+            &env.functions[func_id],
             &resolved_deps,
             &env.identifiers,
             &env.types,
@@ -1085,12 +1086,12 @@ pub fn validate_no_derived_computations_in_effects(
 fn validate_effect_non_exp(
     effect_func: &HirFunction,
     effect_deps: &[IdentifierId],
-    ids: &[Identifier],
-    tys: &[Type],
+    ids: &IndexSlice<IdentifierId, [Identifier]>,
+    tys: &IndexSlice<TypeId, [Type]>,
 ) -> Vec<OxcDiagnostic> {
     // Check that the effect function only captures effect deps and setState
     for ctx in &effect_func.context {
-        let ctx_ty = &tys[ids[ctx.identifier.index()].type_.index()];
+        let ctx_ty = &tys[ids[ctx.identifier].type_];
         if is_set_state_type(ctx_ty) || effect_deps.contains(&ctx.identifier) {
             continue;
         } else {
@@ -1164,7 +1165,7 @@ fn validate_effect_non_exp(
                     }
 
                     if let InstructionValue::CallExpression { callee, args, .. } = &instr.value {
-                        let callee_ty = &tys[ids[callee.identifier.index()].type_.index()];
+                        let callee_ty = &tys[ids[callee.identifier].type_];
                         if is_set_state_type(callee_ty) && args.len() == 1 {
                             if let PlaceOrSpread::Place(arg) = &args[0] {
                                 if let Some(deps) = dep_values.get(&arg.identifier) {

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_freezing_known_mutable_functions.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_freezing_known_mutable_functions.rs
@@ -8,13 +8,14 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use oxc_diagnostics::OxcDiagnostic;
+use oxc_index::IndexSlice;
 
 use crate::diagnostics::ErrorCategory;
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::visitors::{each_instruction_value_operand, each_terminal_operand};
 use crate::react_compiler_hir::{
-    AliasingEffect, Effect, HirFunction, Identifier, IdentifierId, IdentifierName,
-    InstructionValue, Place, Type,
+    AliasingEffect, Effect, FunctionId, HirFunction, Identifier, IdentifierId, IdentifierName,
+    InstructionValue, Place, Type, TypeId,
 };
 use oxc_span::Span;
 
@@ -48,9 +49,9 @@ pub fn validate_no_freezing_known_mutable_functions(func: &HirFunction, env: &mu
 
 fn check_no_freezing_known_mutable_functions(
     func: &HirFunction,
-    identifiers: &[Identifier],
-    types: &[Type],
-    functions: &[HirFunction],
+    identifiers: &IndexSlice<IdentifierId, [Identifier]>,
+    types: &IndexSlice<TypeId, [Type]>,
+    functions: &IndexSlice<FunctionId, [HirFunction]>,
     env: &Environment,
 ) -> Vec<OxcDiagnostic> {
     // Maps an identifier to the mutation effect that makes it "known mutable"
@@ -82,7 +83,7 @@ fn check_no_freezing_known_mutable_functions(
                 }
 
                 InstructionValue::FunctionExpression { lowered_func, .. } => {
-                    let inner_function = &functions[lowered_func.func.index()];
+                    let inner_function = &functions[lowered_func.func];
                     if let Some(ref aliasing_effects) = inner_function.aliasing_effects {
                         let context_ids: FxHashSet<IdentifierId> =
                             inner_function.context.iter().map(|place| place.identifier).collect();
@@ -169,12 +170,12 @@ fn check_no_freezing_known_mutable_functions(
 fn check_operand_for_freeze_violation(
     operand: &Place,
     context_mutation_effects: &FxHashMap<IdentifierId, MutationInfo>,
-    identifiers: &[Identifier],
+    identifiers: &IndexSlice<IdentifierId, [Identifier]>,
     diagnostics: &mut Vec<OxcDiagnostic>,
 ) {
     if operand.effect == Effect::Freeze {
         if let Some(mutation_info) = context_mutation_effects.get(&operand.identifier) {
-            let identifier = &identifiers[mutation_info.value_identifier.index()];
+            let identifier = &identifiers[mutation_info.value_identifier];
             let variable_name = match &identifier.name {
                 Some(IdentifierName::Named(name)) => format!("`{}`", name),
                 _ => "a local variable".to_string(),
@@ -208,9 +209,9 @@ fn check_operand_for_freeze_violation(
 /// Check if an identifier's type is a ref or ref-like mutable type.
 fn is_ref_or_ref_like_mutable_type(
     identifier_id: IdentifierId,
-    identifiers: &[Identifier],
-    types: &[Type],
+    identifiers: &IndexSlice<IdentifierId, [Identifier]>,
+    types: &IndexSlice<TypeId, [Type]>,
 ) -> bool {
-    let identifier = &identifiers[identifier_id.index()];
-    crate::react_compiler_hir::is_ref_or_ref_like_mutable_type(&types[identifier.type_.index()])
+    let identifier = &identifiers[identifier_id];
+    crate::react_compiler_hir::is_ref_or_ref_like_mutable_type(&types[identifier.type_])
 }

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_ref_access_in_render.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_ref_access_in_render.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use oxc_diagnostics::OxcDiagnostic;
+use oxc_index::IndexSlice;
 
 use crate::diagnostics::ErrorCategory;
 use crate::react_compiler_hir::environment::Environment;
@@ -12,8 +13,8 @@ use crate::react_compiler_hir::visitors::{
     each_pattern_operand, each_terminal_operand,
 };
 use crate::react_compiler_hir::{
-    AliasingEffect, BlockId, HirFunction, Identifier, IdentifierId, InstructionValue, ParamPattern,
-    Place, PrimitiveValue, Terminal, Type, UnaryOperator, is_use_ref_type,
+    AliasingEffect, BlockId, FunctionId, HirFunction, Identifier, IdentifierId, InstructionValue,
+    ParamPattern, Place, PrimitiveValue, Terminal, Type, TypeId, UnaryOperator, is_use_ref_type,
 };
 use oxc_span::Span;
 
@@ -257,9 +258,13 @@ impl Env {
 
 // --- Helper functions ---
 
-fn ref_type_of_type(id: IdentifierId, identifiers: &[Identifier], types: &[Type]) -> RefAccessType {
-    let identifier = &identifiers[id.index()];
-    let ty = &types[identifier.type_.index()];
+fn ref_type_of_type(
+    id: IdentifierId,
+    identifiers: &IndexSlice<IdentifierId, [Identifier]>,
+    types: &IndexSlice<TypeId, [Type]>,
+) -> RefAccessType {
+    let identifier = &identifiers[id];
+    let ty = &types[identifier.type_];
     if crate::react_compiler_hir::is_ref_value_type(ty) {
         RefAccessType::RefValue { span: None, ref_id: None }
     } else if is_use_ref_type(ty) {
@@ -269,14 +274,22 @@ fn ref_type_of_type(id: IdentifierId, identifiers: &[Identifier], types: &[Type]
     }
 }
 
-fn is_ref_type(id: IdentifierId, identifiers: &[Identifier], types: &[Type]) -> bool {
-    let identifier = &identifiers[id.index()];
-    is_use_ref_type(&types[identifier.type_.index()])
+fn is_ref_type(
+    id: IdentifierId,
+    identifiers: &IndexSlice<IdentifierId, [Identifier]>,
+    types: &IndexSlice<TypeId, [Type]>,
+) -> bool {
+    let identifier = &identifiers[id];
+    is_use_ref_type(&types[identifier.type_])
 }
 
-fn is_ref_value_type(id: IdentifierId, identifiers: &[Identifier], types: &[Type]) -> bool {
-    let identifier = &identifiers[id.index()];
-    crate::react_compiler_hir::is_ref_value_type(&types[identifier.type_.index()])
+fn is_ref_value_type(
+    id: IdentifierId,
+    identifiers: &IndexSlice<IdentifierId, [Identifier]>,
+    types: &IndexSlice<TypeId, [Type]>,
+) -> bool {
+    let identifier = &identifiers[id];
+    crate::react_compiler_hir::is_ref_value_type(&types[identifier.type_])
 }
 
 fn destructure(ty: &RefAccessType) -> RefAccessType {
@@ -445,8 +458,8 @@ pub fn validate_no_ref_access_in_render(func: &HirFunction, env: &mut Environmen
 fn collect_temporaries_sidemap(
     func: &HirFunction,
     env: &mut Env,
-    identifiers: &[Identifier],
-    types: &[Type],
+    identifiers: &IndexSlice<IdentifierId, [Identifier]>,
+    types: &IndexSlice<TypeId, [Type]>,
 ) {
     for (_, block) in &func.body.blocks {
         for &instr_id in &block.instructions {
@@ -490,9 +503,9 @@ fn collect_temporaries_sidemap(
 
 fn validate_no_ref_access_in_render_impl(
     func: &HirFunction,
-    identifiers: &[Identifier],
-    types: &[Type],
-    functions: &[HirFunction],
+    identifiers: &IndexSlice<IdentifierId, [Identifier]>,
+    types: &IndexSlice<TypeId, [Type]>,
+    functions: &IndexSlice<FunctionId, [HirFunction]>,
     env: &Environment,
     ref_env: &mut Env,
     errors: &mut Vec<OxcDiagnostic>,
@@ -660,7 +673,7 @@ fn validate_no_ref_access_in_render_impl(
                     }
                     InstructionValue::ObjectMethod { lowered_func, .. }
                     | InstructionValue::FunctionExpression { lowered_func, .. } => {
-                        let inner = &functions[lowered_func.func.index()];
+                        let inner = &functions[lowered_func.func];
                         let mut inner_errors: Vec<OxcDiagnostic> = Vec::new();
                         let result = validate_no_ref_access_in_render_impl(
                             inner,
@@ -718,8 +731,8 @@ fn validate_no_ref_access_in_render_impl(
                         if !did_error {
                             let is_ref_lvalue =
                                 is_ref_type(instr.lvalue.identifier, identifiers, types);
-                            let callee_identifier = &identifiers[callee.identifier.index()];
-                            let callee_type = &types[callee_identifier.type_.index()];
+                            let callee_identifier = &identifiers[callee.identifier];
+                            let callee_type = &types[callee_identifier.type_];
                             let hook_kind = env.get_hook_kind_for_type(callee_type).ok().flatten();
 
                             if is_ref_lvalue

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_set_state_in_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_set_state_in_effects.rs
@@ -15,6 +15,7 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use oxc_diagnostics::{Diagnostics, OxcDiagnostic};
+use oxc_index::IndexSlice;
 
 use crate::diagnostics::ErrorCategory;
 use crate::react_compiler_hir::ArrayPatternElement;
@@ -23,9 +24,10 @@ use crate::react_compiler_hir::Pattern;
 use crate::react_compiler_hir::dominator::{compute_post_dominator_tree, post_dominator_frontier};
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::{
-    BlockId, HirFunction, Identifier, IdentifierId, InstructionValue, PlaceOrSpread, Terminal,
-    Type, is_ref_value_type, is_set_state_type, is_use_effect_event_type, is_use_effect_hook_type,
-    is_use_insertion_effect_hook_type, is_use_layout_effect_hook_type, is_use_ref_type, visitors,
+    BlockId, FunctionId, HirFunction, Identifier, IdentifierId, InstructionValue, PlaceOrSpread,
+    Terminal, Type, TypeId, is_ref_value_type, is_set_state_type, is_use_effect_event_type,
+    is_use_effect_hook_type, is_use_insertion_effect_hook_type, is_use_layout_effect_hook_type,
+    is_use_ref_type, visitors,
 };
 use oxc_span::Span;
 
@@ -60,7 +62,7 @@ pub fn validate_no_set_state_in_effects(
                 }
                 InstructionValue::FunctionExpression { lowered_func, .. } => {
                     // Check if any context capture references a setState
-                    let inner_func = &functions[lowered_func.func.index()];
+                    let inner_func = &functions[lowered_func.func];
                     let has_set_state_operand = inner_func.context.iter().any(|ctx_place| {
                         is_set_state_type_by_id(ctx_place.identifier, identifiers, types)
                             || set_state_functions.contains_key(&ctx_place.identifier)
@@ -82,7 +84,7 @@ pub fn validate_no_set_state_in_effects(
                     }
                 }
                 InstructionValue::MethodCall { property, args, .. } => {
-                    let prop_type = &types[identifiers[property.identifier.index()].type_.index()];
+                    let prop_type = &types[identifiers[property.identifier].type_];
                     if is_use_effect_event_type(prop_type) {
                         if let Some(PlaceOrSpread::Place(arg_place)) = args.first() {
                             if let Some(info) = set_state_functions.get(&arg_place.identifier) {
@@ -105,7 +107,7 @@ pub fn validate_no_set_state_in_effects(
                     }
                 }
                 InstructionValue::CallExpression { callee, args, .. } => {
-                    let callee_type = &types[identifiers[callee.identifier.index()].type_.index()];
+                    let callee_type = &types[identifiers[callee.identifier].type_];
                     if is_use_effect_event_type(callee_type) {
                         if let Some(PlaceOrSpread::Place(arg_place)) = args.first() {
                             if let Some(info) = set_state_functions.get(&arg_place.identifier) {
@@ -142,11 +144,11 @@ struct SetStateInfo {
 
 fn is_set_state_type_by_id(
     identifier_id: IdentifierId,
-    identifiers: &[Identifier],
-    types: &[Type],
+    identifiers: &IndexSlice<IdentifierId, [Identifier]>,
+    types: &IndexSlice<TypeId, [Type]>,
 ) -> bool {
-    let ident = &identifiers[identifier_id.index()];
-    let ty = &types[ident.type_.index()];
+    let ident = &identifiers[identifier_id];
+    let ty = &types[ident.type_];
     is_set_state_type(ty)
 }
 
@@ -233,20 +235,23 @@ fn collect_destructure_places(pattern: &Pattern, ref_derived_values: &mut FxHash
 fn is_derived_from_ref(
     id: IdentifierId,
     ref_derived_values: &FxHashSet<IdentifierId>,
-    identifiers: &[Identifier],
-    types: &[Type],
+    identifiers: &IndexSlice<IdentifierId, [Identifier]>,
+    types: &IndexSlice<TypeId, [Type]>,
 ) -> bool {
     if ref_derived_values.contains(&id) {
         return true;
     }
-    let ident = &identifiers[id.index()];
-    let ty = &types[ident.type_.index()];
+    let ident = &identifiers[id];
+    let ty = &types[ident.type_];
     is_use_ref_type(ty) || is_ref_value_type(ty)
 }
 
 /// Collects all operand IdentifierIds from an instruction value.
 /// Uses the canonical `each_instruction_value_operand_with_functions` from visitors.
-fn collect_operands(value: &InstructionValue, functions: &[HirFunction]) -> Vec<IdentifierId> {
+fn collect_operands(
+    value: &InstructionValue,
+    functions: &IndexSlice<FunctionId, [HirFunction]>,
+) -> Vec<IdentifierId> {
     visitors::each_instruction_value_operand_with_functions(value, functions)
         .into_iter()
         .map(|p| p.identifier)
@@ -260,8 +265,8 @@ fn create_ref_controlled_block_checker(
     func: &HirFunction,
     next_block_id_counter: u32,
     ref_derived_values: &FxHashSet<IdentifierId>,
-    identifiers: &[Identifier],
-    types: &[Type],
+    identifiers: &IndexSlice<IdentifierId, [Identifier]>,
+    types: &IndexSlice<TypeId, [Type]>,
 ) -> Result<FxHashMap<BlockId, bool>, OxcDiagnostic> {
     let post_dominators = compute_post_dominator_tree(func, next_block_id_counter, false)?;
     let mut cache: FxHashMap<BlockId, bool> = FxHashMap::default();
@@ -320,9 +325,9 @@ fn create_ref_controlled_block_checker(
 fn get_set_state_call(
     func: &HirFunction,
     set_state_functions: &mut FxHashMap<IdentifierId, SetStateInfo>,
-    identifiers: &[Identifier],
-    types: &[Type],
-    functions: &[HirFunction],
+    identifiers: &IndexSlice<IdentifierId, [Identifier]>,
+    types: &IndexSlice<TypeId, [Type]>,
+    functions: &IndexSlice<FunctionId, [HirFunction]>,
     enable_allow_set_state_from_refs: bool,
     next_block_id_counter: u32,
 ) -> Result<Option<SetStateInfo>, OxcDiagnostic> {
@@ -361,8 +366,8 @@ fn get_set_state_call(
 
                 if let InstructionValue::PropertyLoad { object, property, .. } = &instr.value {
                     if property.is_string("current") {
-                        let obj_ident = &identifiers[object.identifier.index()];
-                        let obj_ty = &types[obj_ident.type_.index()];
+                        let obj_ident = &identifiers[object.identifier];
+                        let obj_ty = &types[obj_ident.type_];
                         if is_use_ref_type(obj_ty) || is_ref_value_type(obj_ty) {
                             ref_derived_values.insert(instr.lvalue.identifier);
                         }
@@ -451,8 +456,8 @@ fn get_set_state_call(
                 // Special case: PropertyLoad of .current on ref/refValue
                 if let InstructionValue::PropertyLoad { object, property, .. } = &instr.value {
                     if property.is_string("current") {
-                        let obj_ident = &identifiers[object.identifier.index()];
-                        let obj_ty = &types[obj_ident.type_.index()];
+                        let obj_ident = &identifiers[object.identifier];
+                        let obj_ty = &types[obj_ident.type_];
                         if is_use_ref_type(obj_ty) || is_ref_value_type(obj_ty) {
                             ref_derived_values.insert(instr.lvalue.identifier);
                         }

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_set_state_in_render.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_set_state_in_render.rs
@@ -10,13 +10,14 @@
 use rustc_hash::FxHashSet;
 
 use oxc_diagnostics::OxcDiagnostic;
+use oxc_index::IndexSlice;
 
 use crate::diagnostics::ErrorCategory;
 use crate::react_compiler_hir::dominator::compute_unconditional_blocks;
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::is_set_state_type;
 use crate::react_compiler_hir::{
-    BlockId, HirFunction, Identifier, IdentifierId, InstructionValue, Type,
+    BlockId, FunctionId, HirFunction, Identifier, IdentifierId, InstructionValue, Type, TypeId,
 };
 
 pub fn validate_no_set_state_in_render(
@@ -42,19 +43,19 @@ pub fn validate_no_set_state_in_render(
 
 fn is_set_state_id(
     identifier_id: IdentifierId,
-    identifiers: &[Identifier],
-    types: &[Type],
+    identifiers: &IndexSlice<IdentifierId, [Identifier]>,
+    types: &IndexSlice<TypeId, [Type]>,
 ) -> bool {
-    let ident = &identifiers[identifier_id.index()];
-    let ty = &types[ident.type_.index()];
+    let ident = &identifiers[identifier_id];
+    let ty = &types[ident.type_];
     is_set_state_type(ty)
 }
 
 fn validate_impl(
     func: &HirFunction,
-    identifiers: &[Identifier],
-    types: &[Type],
-    functions: &[HirFunction],
+    identifiers: &IndexSlice<IdentifierId, [Identifier]>,
+    types: &IndexSlice<TypeId, [Type]>,
+    functions: &IndexSlice<FunctionId, [HirFunction]>,
     next_block_id_counter: u32,
     enable_use_keyed_state: bool,
     unconditional_set_state_functions: &mut FxHashSet<IdentifierId>,
@@ -81,7 +82,7 @@ fn validate_impl(
                 }
                 InstructionValue::ObjectMethod { lowered_func, .. }
                 | InstructionValue::FunctionExpression { lowered_func, .. } => {
-                    let inner_func = &functions[lowered_func.func.index()];
+                    let inner_func = &functions[lowered_func.func];
 
                     // Check if any operand references a setState.
                     // For FunctionExpression/ObjectMethod, operands are the context captures.

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_preserved_manual_memoization.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_preserved_manual_memoization.rs
@@ -23,6 +23,7 @@ use crate::react_compiler_hir::{
     ReactiveFunction, ReactiveInstruction, ReactiveScopeBlock, ReactiveStatement, ReactiveTerminal,
     ReactiveValue, ScopeId,
 };
+use oxc_index::IndexSlice;
 use oxc_span::Span;
 
 /// State tracked during manual memo validation within a StartMemoize..FinishMemoize range.
@@ -139,7 +140,7 @@ fn visit_scope<'h>(scope_block: &ReactiveScopeBlock<'h>, state: &mut VisitorStat
     // After traversing, validate scope dependencies against manual memo deps
     if let Some(ref memo_state) = state.manual_memo_state {
         if let Some(ref deps_from_source) = memo_state.deps_from_source {
-            let scope = &state.env.scopes[scope_block.scope.index()];
+            let scope = &state.env.scopes[scope_block.scope];
             let deps = scope.dependencies.clone();
             let memo_span = memo_state.span;
             let decls = memo_state.decls.clone();
@@ -160,7 +161,7 @@ fn visit_scope<'h>(scope_block: &ReactiveScopeBlock<'h>, state: &mut VisitorStat
     }
 
     // Mark scope and merged scopes as completed
-    let scope = &state.env.scopes[scope_block.scope.index()];
+    let scope = &state.env.scopes[scope_block.scope];
     let merged = scope.merged.clone();
     state.scopes.insert(scope_block.scope);
     for merged_id in merged {
@@ -208,7 +209,7 @@ fn visit_instruction<'h>(instr: &ReactiveInstruction<'h>, state: &mut VisitorSta
             // TS: for (const {identifier, span} of eachInstructionValueOperand(value))
             let operand_places = start_memoize_operands(deps);
             for place in &operand_places {
-                let ident = &state.env.identifiers[place.identifier.index()];
+                let ident = &state.env.identifiers[place.identifier];
                 if let Some(scope_id) = ident.scope {
                     if !state.scopes.contains(&scope_id) && !state.pruned_scopes.contains(&scope_id)
                     {
@@ -250,7 +251,7 @@ fn visit_instruction<'h>(instr: &ReactiveInstruction<'h>, state: &mut VisitorSta
 
             if !pruned {
                 // Check if the declared value is unmemoized
-                let decl_ident = &state.env.identifiers[decl.identifier.index()];
+                let decl_ident = &state.env.identifiers[decl.identifier];
 
                 if decl_ident.scope.is_none() {
                     // If the manual memo was inlined (useMemo -> IIFE), check reassignments
@@ -278,16 +279,16 @@ fn visit_instruction<'h>(instr: &ReactiveInstruction<'h>, state: &mut VisitorSta
             if let Some(memo_state) = &mut state.manual_memo_state
                 && lvalue.kind == InstructionKind::Reassign
             {
-                let decl_id = state.env.identifiers[lvalue.place.identifier.index()].declaration_id;
+                let decl_id = state.env.identifiers[lvalue.place.identifier].declaration_id;
                 memo_state.reassignments.entry(decl_id).or_default().insert(value.identifier);
             }
         }
         ReactiveValue::Instruction(InstructionValue::LoadLocal { place, .. })
             if let Some(memo_state) = &mut state.manual_memo_state =>
         {
-            let place_ident = &state.env.identifiers[place.identifier.index()];
+            let place_ident = &state.env.identifiers[place.identifier];
             if let Some(ref lvalue) = instr.lvalue {
-                let lvalue_ident = &state.env.identifiers[lvalue.identifier.index()];
+                let lvalue_ident = &state.env.identifiers[lvalue.identifier];
                 if place_ident.scope.is_some() && lvalue_ident.scope.is_none() {
                     memo_state
                         .reassignments
@@ -323,7 +324,7 @@ fn record_temporaries<'h>(instr: &ReactiveInstruction<'h>, state: &mut VisitorSt
     }
 
     if let Some(ref lvalue) = instr.lvalue {
-        let lv_ident = &state.env.identifiers[lvalue.identifier.index()];
+        let lv_ident = &state.env.identifiers[lvalue.identifier];
         if is_named(lv_ident) && state.manual_memo_state.is_some() {
             state.manual_memo_state.as_mut().unwrap().decls.insert(lv_ident.declaration_id);
         }
@@ -384,7 +385,7 @@ fn record_deps_in_value<'h>(value: &ReactiveValue<'h>, state: &mut VisitorState<
                 InstructionValue::StoreLocal { lvalue, .. }
                 | InstructionValue::StoreContext { lvalue, .. } => {
                     if let Some(ref mut memo_state) = state.manual_memo_state {
-                        let ident = &state.env.identifiers[lvalue.place.identifier.index()];
+                        let ident = &state.env.identifiers[lvalue.place.identifier];
                         memo_state.decls.insert(ident.declaration_id);
                         if is_named(ident) {
                             state.temporaries.insert(
@@ -404,7 +405,7 @@ fn record_deps_in_value<'h>(value: &ReactiveValue<'h>, state: &mut VisitorState<
                 InstructionValue::Destructure { lvalue, .. } => {
                     if let Some(ref mut memo_state) = state.manual_memo_state {
                         for place in destructure_lvalue_places(&lvalue.pattern) {
-                            let ident = &state.env.identifiers[place.identifier.index()];
+                            let ident = &state.env.identifiers[place.identifier];
                             memo_state.decls.insert(ident.declaration_id);
                             if is_named(ident) {
                                 state.temporaries.insert(
@@ -478,9 +479,9 @@ fn destructure_lvalue_places<'p>(pattern: &'p Pattern<'_>) -> Vec<&'p Place> {
 fn is_unmemoized(
     id: IdentifierId,
     completed_scopes: &FxHashSet<ScopeId>,
-    identifiers: &[Identifier],
+    identifiers: &IndexSlice<IdentifierId, [Identifier]>,
 ) -> bool {
-    let ident = &identifiers[id.index()];
+    let ident = &identifiers[id];
     if let Some(scope_id) = ident.scope { !completed_scopes.contains(&scope_id) } else { false }
 }
 
@@ -550,9 +551,9 @@ fn compare_deps(
 fn pretty_print_scope_dependency(
     dep_id: IdentifierId,
     dep_path: &[DependencyPathEntry],
-    identifiers: &[Identifier],
+    identifiers: &IndexSlice<IdentifierId, [Identifier]>,
 ) -> String {
-    let ident = &identifiers[dep_id.index()];
+    let ident = &identifiers[dep_id];
     let root_str = match &ident.name {
         Some(IdentifierName::Named(n) | IdentifierName::Promoted(n)) => n.as_str(),
         None => "[unnamed]",
@@ -573,12 +574,12 @@ fn pretty_print_scope_dependency(
 /// Pretty-print a manual memo dependency for error messages.
 fn print_manual_memo_dependency(
     dep: &ManualMemoDependency,
-    identifiers: &[Identifier],
+    identifiers: &IndexSlice<IdentifierId, [Identifier]>,
     with_optional: bool,
 ) -> String {
     let root_str = match &dep.root {
         ManualMemoDependencyRoot::NamedLocal { value, .. } => {
-            let ident = &identifiers[value.identifier.index()];
+            let ident = &identifiers[value.identifier];
             match &ident.name {
                 Some(IdentifierName::Named(n) | IdentifierName::Promoted(n)) => n.as_str(),
                 None => "[unnamed]",
@@ -628,7 +629,7 @@ fn validate_inferred_dep<'h>(
         path.extend_from_slice(dep_path);
         ManualMemoDependency { root: temp.root.clone(), path, span: temp.span }
     } else {
-        let ident = &env.identifiers[dep_id.index()];
+        let ident = &env.identifiers[dep_id];
         // TS: Diagnostics.invariant(dep.identifier.name?.kind === 'named', ...)
         if !is_named(ident) {
             return;
@@ -650,7 +651,7 @@ fn validate_inferred_dep<'h>(
 
     // Check if the dep was declared within the memo block
     if let ManualMemoDependencyRoot::NamedLocal { value, .. } = &normalized_dep.root {
-        let ident = &env.identifiers[value.identifier.index()];
+        let ident = &env.identifiers[value.identifier];
         if decls_within_memo_block.contains(&ident.declaration_id) {
             return;
         }
@@ -669,7 +670,7 @@ fn validate_inferred_dep<'h>(
         });
     }
 
-    let ident = &env.identifiers[dep_id.index()];
+    let ident = &env.identifiers[dep_id];
 
     let extra = if is_named(ident) {
         // Use the original dep_id/dep_path (matching TS prettyPrintScopeDependency(dep))

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_use_memo.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_use_memo.rs
@@ -1,5 +1,7 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 
+use oxc_index::IndexSlice;
+
 use oxc_diagnostics::Diagnostics;
 
 use crate::diagnostics::ErrorCategory;
@@ -34,7 +36,7 @@ struct FuncExprInfo {
 
 fn validate_use_memo_impl(
     func: &HirFunction,
-    functions: &[HirFunction],
+    functions: &IndexSlice<FunctionId, [HirFunction]>,
     errors: &mut Diagnostics,
     validate_no_void_use_memo: bool,
 ) -> Diagnostics {
@@ -141,7 +143,7 @@ fn validate_use_memo_impl(
 
 #[allow(clippy::too_many_arguments)]
 fn handle_possible_use_memo_call(
-    functions: &[HirFunction],
+    functions: &IndexSlice<FunctionId, [HirFunction]>,
     errors: &mut Diagnostics,
     void_memo_errors: &mut Diagnostics,
     use_memos: &FxHashSet<IdentifierId>,
@@ -167,7 +169,7 @@ fn handle_possible_use_memo_call(
         None => return,
     };
 
-    let body_func = &functions[body_info.func_id.index()];
+    let body_func = &functions[body_info.func_id];
 
     // Validate no parameters
     if !body_func.params.is_empty() {
@@ -267,7 +269,7 @@ fn has_non_void_return(func: &HirFunction) -> bool {
 /// Thin wrapper around canonical `each_instruction_value_operand_with_functions` that maps to ids.
 fn each_instruction_value_operand_ids(
     value: &InstructionValue,
-    functions: &[HirFunction],
+    functions: &IndexSlice<FunctionId, [HirFunction]>,
 ) -> Vec<IdentifierId> {
     each_instruction_value_operand_with_functions(value, functions)
         .into_iter()


### PR DESCRIPTION
Follow-up to #24442 (the id → `oxc_index` nonmax migration, now merged). Now that the HIR ids are `oxc_index` index types, this puts them to use as indices.

## What

- Convert the four **append-only** `Environment` arenas — `identifiers`, `types`, `scopes`, `functions` — from `Vec<T>` to `IndexVec<Id, T>`. They're now indexed by their typed id, and the factories use `next_idx()` / `push`.
- Helper params that took `&[T]` / `&mut Vec<T>` of these element types become `&IndexSlice<Id, [T]>` / `&mut IndexVec<Id, T>`; callers pass `&env.<arena>`, which deref-coerces.
- Replace the global-types map key `(u32, InstructionId)` — where `u32::MAX` meant "outer function" — with `(Option<FunctionId>, InstructionId)`, deleting the `u32::MAX` sentinel and the `index()`-as-`u32` casts.
- Add a named `BlockId::ENTRY` for the "entry block is 0" construction sites.

## Why

Type-safe indexing: a `ScopeId` can no longer index the `identifiers` arena (previously `arena[id.index()]` accepted any id's `usize`). `push` returns the id, so the id factories read straight. And the `Option<FunctionId>` key makes the outer/inner-function distinction typed instead of a magic `u32::MAX`.

## Notes

- The **instruction table stays `Vec`** (`HirFunction.instructions`, `BasicBlock.instructions`): it's `drain`-ed during IIFE inlining, so it isn't a clean append-only arena. Instruction indexing keeps `.index()`.
- Behavior-preserving: the insta snapshot corpus and all 15 transform tests are byte-identical.
