### PR TITLE
refactor(react_compiler): drop lint allows and fix clippy warnings

### DIFF
--- a/crates/oxc_react_compiler/Cargo.toml
+++ b/crates/oxc_react_compiler/Cargo.toml
@@ -61,16 +61,11 @@ convert_case = { workspace = true }
 oxc_ast = { workspace = true, features = ["disable_old_builder"] }
 
 # The `src/` conversion modules are vendored close to upstream `react_compiler_oxc`
-# (kept near byte-for-byte to ease re-syncing), so relax the handful of lints they
-# trip here rather than editing the code. Defining `[lints.clippy]` means this crate
-# does not inherit `[lints] workspace = true`, which keeps the in-house restriction
-# lints (`todo!`/`unimplemented!`/...) off the vendored code while clippy's default
-# correctness and perf checks still apply.
+# (kept near byte-for-byte to ease re-syncing). Defining `[lints.clippy]` means this
+# crate does not inherit `[lints] workspace = true`, which keeps the in-house
+# restriction lints (`todo!`/`unimplemented!`/...) off the vendored code while clippy's
+# default correctness and perf checks still apply.
 [lints.clippy]
-disallowed_types = "allow" # `react_compiler_ast`'s `ScopeInfo`/`ScopeData` fields are std `HashMap`
-collapsible_if = "allow"
-needless_return = "allow"
-unnecessary_unwrap = "allow"
 result_large_err = "allow" # `Result<T, OxcDiagnostic>` everywhere; same trade-off as the workspace allow
 
 # The vendored modules' doc comments reference types like `Vec<PatternLike>`

--- a/crates/oxc_react_compiler/src/lib.rs
+++ b/crates/oxc_react_compiler/src/lib.rs
@@ -90,7 +90,7 @@ pub fn compile<'a>(
     }
 
     match compile_program(allocator, semantic, program, options) {
-        CompileResult::Success { output, diagnostics } => (output, diagnostics),
+        CompileResult::Success { output, diagnostics } => (output.map(|b| *b), diagnostics),
         CompileResult::Error { diagnostics } => (None, diagnostics),
     }
 }

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/compile_result.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/compile_result.rs
@@ -8,13 +8,12 @@ use crate::react_compiler_hir::ReactFunctionType;
 use super::program::CompileOutput;
 
 /// Main result type returned by the compile function.
-#[allow(clippy::large_enum_variant)] // built once per compile; `ProgramContext` carries the options
 pub enum CompileResult<'a> {
     /// Compilation succeeded (or no functions needed compilation).
     /// `output` is None if no changes are to be made to the program — always so
     /// in lint output mode.
     Success {
-        output: Option<CompileOutput<'a>>,
+        output: Option<Box<CompileOutput<'a>>>,
         /// Errors and warnings accumulated during compilation.
         diagnostics: Diagnostics,
     },

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/imports.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/imports.rs
@@ -174,10 +174,10 @@ impl<'a> ProgramContext<'a> {
         name_hint: Option<&str>,
     ) -> NonLocalImportSpecifier<'a> {
         // Check if already imported
-        if let Some(module_imports) = self.imports.get(module) {
-            if let Some(existing) = module_imports.get(specifier) {
-                return *existing;
-            }
+        if let Some(module_imports) = self.imports.get(module)
+            && let Some(existing) = module_imports.get(specifier)
+        {
+            return *existing;
         }
 
         let name = self.new_uid(name_hint.unwrap_or(specifier));
@@ -232,14 +232,14 @@ pub fn validate_restricted_imports(
     let mut diagnostics = Diagnostics::new();
 
     for stmt in &program.body {
-        if let Statement::ImportDeclaration(import) = stmt {
-            if restricted.contains(import.source.value.as_str()) {
-                diagnostics.push(
-                    ErrorCategory::Todo
-                        .diagnostic("Bailing out due to blocklisted import")
-                        .with_help(format!("Import from module {}", import.source.value)),
-                );
-            }
+        if let Statement::ImportDeclaration(import) = stmt
+            && restricted.contains(import.source.value.as_str())
+        {
+            diagnostics.push(
+                ErrorCategory::Todo
+                    .diagnostic("Bailing out due to blocklisted import")
+                    .with_help(format!("Import from module {}", import.source.value)),
+            );
         }
     }
 

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -393,10 +393,10 @@ fn calls_hooks_or_creates_jsx_in_stmt(stmt: &Statement) -> bool {
         }
         Statement::VariableDeclaration(var_decl) => {
             for decl in &var_decl.declarations {
-                if let Some(ref init) = decl.init {
-                    if calls_hooks_or_creates_jsx_in_expr(init) {
-                        return true;
-                    }
+                if let Some(ref init) = decl.init
+                    && calls_hooks_or_creates_jsx_in_expr(init)
+                {
+                    return true;
                 }
             }
             false
@@ -415,33 +415,33 @@ fn calls_hooks_or_creates_jsx_in_stmt(stmt: &Statement) -> bool {
                 match init {
                     ForStatementInit::VariableDeclaration(var_decl) => {
                         for decl in &var_decl.declarations {
-                            if let Some(ref init) = decl.init {
-                                if calls_hooks_or_creates_jsx_in_expr(init) {
-                                    return true;
-                                }
+                            if let Some(ref init) = decl.init
+                                && calls_hooks_or_creates_jsx_in_expr(init)
+                            {
+                                return true;
                             }
                         }
                     }
                     // An expression `ForStatementInit` is an `Expression` (the
                     // enum inherits the Expression variants).
                     expr => {
-                        if let Some(expr) = expr.as_expression() {
-                            if calls_hooks_or_creates_jsx_in_expr(expr) {
-                                return true;
-                            }
+                        if let Some(expr) = expr.as_expression()
+                            && calls_hooks_or_creates_jsx_in_expr(expr)
+                        {
+                            return true;
                         }
                     }
                 }
             }
-            if let Some(ref test) = for_stmt.test {
-                if calls_hooks_or_creates_jsx_in_expr(test) {
-                    return true;
-                }
+            if let Some(ref test) = for_stmt.test
+                && calls_hooks_or_creates_jsx_in_expr(test)
+            {
+                return true;
             }
-            if let Some(ref update) = for_stmt.update {
-                if calls_hooks_or_creates_jsx_in_expr(update) {
-                    return true;
-                }
+            if let Some(ref update) = for_stmt.update
+                && calls_hooks_or_creates_jsx_in_expr(update)
+            {
+                return true;
             }
             calls_hooks_or_creates_jsx_in_stmt(&for_stmt.body)
         }
@@ -466,10 +466,10 @@ fn calls_hooks_or_creates_jsx_in_stmt(stmt: &Statement) -> bool {
                 return true;
             }
             for case in &switch.cases {
-                if let Some(ref test) = case.test {
-                    if calls_hooks_or_creates_jsx_in_expr(test) {
-                        return true;
-                    }
+                if let Some(ref test) = case.test
+                    && calls_hooks_or_creates_jsx_in_expr(test)
+                {
+                    return true;
                 }
                 if calls_hooks_or_creates_jsx_in_stmts(&case.consequent) {
                     return true;
@@ -482,15 +482,15 @@ fn calls_hooks_or_creates_jsx_in_stmt(stmt: &Statement) -> bool {
             if calls_hooks_or_creates_jsx_in_stmts(&try_stmt.block.body) {
                 return true;
             }
-            if let Some(ref handler) = try_stmt.handler {
-                if calls_hooks_or_creates_jsx_in_stmts(&handler.body.body) {
-                    return true;
-                }
+            if let Some(ref handler) = try_stmt.handler
+                && calls_hooks_or_creates_jsx_in_stmts(&handler.body.body)
+            {
+                return true;
             }
-            if let Some(ref finalizer) = try_stmt.finalizer {
-                if calls_hooks_or_creates_jsx_in_stmts(&finalizer.body) {
-                    return true;
-                }
+            if let Some(ref finalizer) = try_stmt.finalizer
+                && calls_hooks_or_creates_jsx_in_stmts(&finalizer.body)
+            {
+                return true;
             }
             false
         }
@@ -537,10 +537,10 @@ fn calls_hooks_or_creates_jsx_in_expr(expr: &Expression) -> bool {
                     if calls_hooks_or_creates_jsx_in_expr(arg) {
                         return true;
                     }
-                } else if let Argument::SpreadElement(s) = arg {
-                    if calls_hooks_or_creates_jsx_in_expr(&s.argument) {
-                        return true;
-                    }
+                } else if let Argument::SpreadElement(s) = arg
+                    && calls_hooks_or_creates_jsx_in_expr(&s.argument)
+                {
+                    return true;
                 }
             }
             false
@@ -618,10 +618,10 @@ fn calls_hooks_or_creates_jsx_in_expr(expr: &Expression) -> bool {
             // properties traverse their value (nested functions are skipped).
             ObjectPropertyKind::ObjectProperty(p) => {
                 if p.method || matches!(p.kind, PropertyKind::Get | PropertyKind::Set) {
-                    if let Expression::FunctionExpression(func) = &p.value {
-                        if let Some(body) = &func.body {
-                            return calls_hooks_or_creates_jsx_in_stmts(&body.statements);
-                        }
+                    if let Expression::FunctionExpression(func) = &p.value
+                        && let Some(body) = &func.body
+                    {
+                        return calls_hooks_or_creates_jsx_in_stmts(&body.statements);
                     }
                     false
                 } else {
@@ -734,19 +734,19 @@ fn calls_hooks_or_creates_jsx(params: &FormalParameters, body: &FnBody) -> bool 
 /// nested defaults.
 fn calls_hooks_or_creates_jsx_in_params(params: &FormalParameters) -> bool {
     for param in &params.items {
-        if let Some(init) = &param.initializer {
-            if calls_hooks_or_creates_jsx_in_expr(init) {
-                return true;
-            }
+        if let Some(init) = &param.initializer
+            && calls_hooks_or_creates_jsx_in_expr(init)
+        {
+            return true;
         }
         if calls_hooks_or_creates_jsx_in_binding(&param.pattern) {
             return true;
         }
     }
-    if let Some(rest) = &params.rest {
-        if calls_hooks_or_creates_jsx_in_binding(&rest.rest.argument) {
-            return true;
-        }
+    if let Some(rest) = &params.rest
+        && calls_hooks_or_creates_jsx_in_binding(&rest.rest.argument)
+    {
+        return true;
     }
     false
 }
@@ -947,14 +947,14 @@ fn get_component_or_hook_like(
     }
 
     // For unnamed functions, check if they are forwardRef/memo callbacks
-    if let Some(callee_name) = parent_callee_name {
-        if callee_name == "forwardRef" || callee_name == "memo" {
-            return if calls_hooks_or_creates_jsx(params, body) {
-                Some(ReactFunctionType::Component)
-            } else {
-                None
-            };
-        }
+    if let Some(callee_name) = parent_callee_name
+        && (callee_name == "forwardRef" || callee_name == "memo")
+    {
+        return if calls_hooks_or_creates_jsx(params, body) {
+            Some(ReactFunctionType::Component)
+        } else {
+            None
+        };
     }
 
     None
@@ -972,12 +972,11 @@ fn get_callee_name_if_react_api<'ast>(callee: &Expression<'ast>) -> Option<&'ast
             }
         }
         Expression::StaticMemberExpression(member) => {
-            if let Expression::Identifier(obj) = &member.object {
-                if obj.name == "React"
-                    && (member.property.name == "forwardRef" || member.property.name == "memo")
-                {
-                    return Some(member.property.name.as_str());
-                }
+            if let Expression::Identifier(obj) = &member.object
+                && obj.name == "React"
+                && (member.property.name == "forwardRef" || member.property.name == "memo")
+            {
+                return Some(member.property.name.as_str());
             }
             None
         }
@@ -1896,12 +1895,12 @@ fn may_have_functions_to_compile(semantic: &Semantic, opts: &PluginOptions) -> b
     // callee *names*, not bindings, so unresolved references count too.
     const WRAPPER_NAMES: [&str; 3] = ["memo", "forwardRef", "React"];
     for name in WRAPPER_NAMES {
-        if let Some(reference_ids) = scoping.root_unresolved_references().get(name) {
-            if reference_ids.iter().any(|reference_id| {
+        if let Some(reference_ids) = scoping.root_unresolved_references().get(name)
+            && reference_ids.iter().any(|reference_id| {
                 is_wrapper_callee(nodes, scoping.get_reference(*reference_id).node_id())
-            }) {
-                return true;
-            }
+            })
+        {
+            return true;
         }
     }
 
@@ -2220,12 +2219,12 @@ impl<'a, 'b> oxc_ast_visit::VisitMut<'a> for OxcReplaceFnVisitor<'a, 'b> {
         if self.remaining == 0 {
             return;
         }
-        if let Some(scope_id) = func.scope_id.get() {
-            if let Some(&codegen) = self.replacements.get(&scope_id) {
-                self.replace_function(func, codegen);
-                self.remaining -= 1;
-                return;
-            }
+        if let Some(scope_id) = func.scope_id.get()
+            && let Some(&codegen) = self.replacements.get(&scope_id)
+        {
+            self.replace_function(func, codegen);
+            self.remaining -= 1;
+            return;
         }
         oxc_ast_visit::walk_mut::walk_function(self, func, flags);
     }
@@ -2234,12 +2233,12 @@ impl<'a, 'b> oxc_ast_visit::VisitMut<'a> for OxcReplaceFnVisitor<'a, 'b> {
         if self.remaining == 0 {
             return;
         }
-        if let Some(scope_id) = arrow.scope_id.get() {
-            if let Some(&codegen) = self.replacements.get(&scope_id) {
-                self.replace_arrow(arrow, codegen);
-                self.remaining -= 1;
-                return;
-            }
+        if let Some(scope_id) = arrow.scope_id.get()
+            && let Some(&codegen) = self.replacements.get(&scope_id)
+        {
+            self.replace_arrow(arrow, codegen);
+            self.remaining -= 1;
+            return;
         }
         oxc_ast_visit::walk_mut::walk_arrow_function_expression(self, arrow);
     }
@@ -2325,28 +2324,26 @@ impl<'a, 'b> oxc_ast_visit::VisitMut<'a> for OxcReplaceWithGatedVisitor<'a, 'b> 
                 break;
             }
             // ExportDefaultDeclaration with FunctionDeclaration
-            if let Statement::ExportDefaultDeclaration(e) = &stmts[i] {
-                if let ExportDefaultDeclarationKind::FunctionDeclaration(f) = &e.declaration {
-                    if f.scope_id.get() == Some(self.scope_id) {
-                        if let Some(id) = f.id.as_ref().map(|id| id.name) {
-                            stmts[i] = self.build_const_decl(id.as_str());
-                            self.export_default_name = Some(id);
-                        } else {
-                            stmts[i] = Statement::ExportDefaultDeclaration(
-                                ExportDefaultDeclaration::boxed(
-                                    SPAN,
-                                    ExportDefaultDeclarationKind::from(
-                                        self.gating_expression
-                                            .clone_in_with_semantic_ids(self.ast.allocator()),
-                                    ),
-                                    self.ast,
-                                ),
-                            );
-                        }
-                        self.done = true;
-                        break;
-                    }
+            if let Statement::ExportDefaultDeclaration(e) = &stmts[i]
+                && let ExportDefaultDeclarationKind::FunctionDeclaration(f) = &e.declaration
+                && f.scope_id.get() == Some(self.scope_id)
+            {
+                if let Some(id) = f.id.as_ref().map(|id| id.name) {
+                    stmts[i] = self.build_const_decl(id.as_str());
+                    self.export_default_name = Some(id);
+                } else {
+                    stmts[i] =
+                        Statement::ExportDefaultDeclaration(ExportDefaultDeclaration::boxed(
+                            SPAN,
+                            ExportDefaultDeclarationKind::from(
+                                self.gating_expression
+                                    .clone_in_with_semantic_ids(self.ast.allocator()),
+                            ),
+                            self.ast,
+                        ));
                 }
+                self.done = true;
+                break;
             }
             self.visit_statement(&mut stmts[i]);
             i += 1;
@@ -2643,10 +2640,10 @@ fn ox_add_imports_to_program<'a>(
     // Existing non-namespaced value imports, by module name.
     let mut existing_import_indices: FxHashMap<&str, usize> = FxHashMap::default();
     for (idx, stmt) in program.body.iter().enumerate() {
-        if let Statement::ImportDeclaration(import) = stmt {
-            if ox_is_non_namespaced_import(import) {
-                existing_import_indices.entry(import.source.value.as_str()).or_insert(idx);
-            }
+        if let Statement::ImportDeclaration(import) = stmt
+            && ox_is_non_namespaced_import(import)
+        {
+            existing_import_indices.entry(import.source.value.as_str()).or_insert(idx);
         }
     }
 
@@ -2957,7 +2954,10 @@ pub fn compile_program<'a>(
     // gating imports, so (matching TS `addImportsToProgram`) they're added only
     // when there are replacements.
     let diagnostics = std::mem::take(&mut context.diagnostics);
-    let output =
-        if replacements.is_empty() { None } else { Some(CompileOutput { replacements, context }) };
+    let output = if replacements.is_empty() {
+        None
+    } else {
+        Some(Box::new(CompileOutput { replacements, context }))
+    };
     CompileResult::Success { output, diagnostics }
 }

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/suppression.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/suppression.rs
@@ -101,14 +101,13 @@ pub fn find_program_suppressions(
         let value = comment_value(comment, source_text);
 
         // Check for eslint-disable-next-line (only if not already within a block)
-        if disable_comment.is_none() {
-            if let Some(names) = rule_names {
-                if matches_eslint_disable_next_line(value, names) {
-                    disable_comment = Some(comment);
-                    enable_comment = Some(comment);
-                    source = Some(SuppressionSource::Eslint);
-                }
-            }
+        if disable_comment.is_none()
+            && let Some(names) = rule_names
+            && matches_eslint_disable_next_line(value, names)
+        {
+            disable_comment = Some(comment);
+            enable_comment = Some(comment);
+            source = Some(SuppressionSource::Eslint);
         }
 
         // Check for Flow suppression (only if not already within a block)

--- a/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
@@ -264,7 +264,7 @@ impl<'a> Environment<'a> {
     /// Allocate a new Type in the arena, returns its TypeId.
     pub fn next_type_id(&mut self) -> TypeId {
         let id = self.types.next_idx();
-        self.types.push(Type::TypeVar { id });
+        self.types.push(Type::Var { id });
         id
     }
 
@@ -371,23 +371,22 @@ impl<'a> Environment<'a> {
                 let module_type = self.resolve_module_type(module);
 
                 // Check for module type validation errors (hook-name vs hook-type mismatches)
-                if let Some(errors) = self.module_type_errors.remove(module.as_str()) {
-                    if let Some(first_error) = errors.into_iter().next() {
-                        self.record_error(
-                            ErrorCategory::Config
-                                .diagnostic("Invalid type configuration for module")
-                                .with_help(first_error)
-                                .with_labels(span),
-                        )?;
-                    }
+                if let Some(errors) = self.module_type_errors.remove(module.as_str())
+                    && let Some(first_error) = errors.into_iter().next()
+                {
+                    self.record_error(
+                        ErrorCategory::Config
+                            .diagnostic("Invalid type configuration for module")
+                            .with_help(first_error)
+                            .with_labels(span),
+                    )?;
                 }
 
-                if let Some(module_type) = module_type {
-                    if let Some(imported_type) =
+                if let Some(module_type) = module_type
+                    && let Some(imported_type) =
                         Self::get_property_type_from_shapes(&self.shapes, &module_type, imported)
-                    {
-                        return Ok(Some(imported_type));
-                    }
+                {
+                    return Ok(Some(imported_type));
                 }
 
                 if is_hook_name(imported) || is_hook_name(name) {
@@ -413,15 +412,15 @@ impl<'a> Environment<'a> {
                 let module_type = self.resolve_module_type(module);
 
                 // Check for module type validation errors (hook-name vs hook-type mismatches)
-                if let Some(errors) = self.module_type_errors.remove(module.as_str()) {
-                    if let Some(first_error) = errors.into_iter().next() {
-                        self.record_error(
-                            ErrorCategory::Config
-                                .diagnostic("Invalid type configuration for module")
-                                .with_help(first_error)
-                                .with_labels(span),
-                        )?;
-                    }
+                if let Some(errors) = self.module_type_errors.remove(module.as_str())
+                    && let Some(first_error) = errors.into_iter().next()
+                {
+                    self.record_error(
+                        ErrorCategory::Config
+                            .diagnostic("Invalid type configuration for module")
+                            .with_help(first_error)
+                            .with_labels(span),
+                    )?;
                 }
 
                 if let Some(module_type) = module_type {

--- a/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
@@ -1146,8 +1146,7 @@ pub enum Type<'a> {
     Object {
         shape_id: Option<Ident<'a>>,
     },
-    #[allow(clippy::enum_variant_names)]
-    TypeVar {
+    Var {
         id: TypeId,
     },
     Poly,
@@ -1237,7 +1236,6 @@ pub enum MutationReason {
 /// Describes the aliasing/mutation/data-flow effects of an instruction or terminal.
 /// Ported from TS `AliasingEffect` in `AliasingEffects.ts`.
 #[derive(Debug, Clone)]
-#[allow(clippy::large_enum_variant)]
 pub enum AliasingEffect {
     /// Marks the given value and its direct aliases as frozen.
     Freeze { value: Place, reason: ValueReason },

--- a/crates/oxc_react_compiler/src/react_compiler_hir/reactive.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/reactive.rs
@@ -51,10 +51,9 @@ pub type ReactiveBlock<'a> = Vec<ReactiveStatement<'a>>;
 
 /// TS: ReactiveStatement (discriminated union with 'kind' field)
 #[derive(Debug, Clone)]
-#[allow(clippy::large_enum_variant)]
 pub enum ReactiveStatement<'a> {
     Instruction(ReactiveInstruction<'a>),
-    Terminal(ReactiveTerminalStatement<'a>),
+    Terminal(Box<ReactiveTerminalStatement<'a>>),
     Scope(ReactiveScopeBlock<'a>),
     PrunedScope(PrunedReactiveScopeBlock<'a>),
 }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/align_method_call_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/align_method_call_scopes.rs
@@ -113,14 +113,13 @@ pub fn align_method_call_scopes(func: &mut HirFunction, env: &mut Environment) {
     // Sync identifier mutable_ranges that shared the old scope range.
     // Uses MutableRangeId for exact identity matching instead of value comparison.
     for ident in &mut env.identifiers {
-        if let Some(scope_id) = ident.scope {
-            if let Some(&orig_range_id) = original_range_ids.get(&scope_id) {
-                if ident.mutable_range.id == orig_range_id {
-                    let new_range = &env.scopes[scope_id].range;
-                    ident.mutable_range.start = new_range.start;
-                    ident.mutable_range.end = new_range.end;
-                }
-            }
+        if let Some(scope_id) = ident.scope
+            && let Some(&orig_range_id) = original_range_ids.get(&scope_id)
+            && ident.mutable_range.id == orig_range_id
+        {
+            let new_range = &env.scopes[scope_id].range;
+            ident.mutable_range.start = new_range.start;
+            ident.mutable_range.end = new_range.end;
         }
     }
 

--- a/crates/oxc_react_compiler/src/react_compiler_inference/align_object_method_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/align_object_method_scopes.rs
@@ -133,14 +133,13 @@ pub fn align_object_method_scopes(func: &mut HirFunction, env: &mut Environment)
     // Sync identifier mutable_ranges that shared the old scope range.
     // Uses MutableRangeId for exact identity matching instead of value comparison.
     for ident in &mut env.identifiers {
-        if let Some(scope_id) = ident.scope {
-            if let Some(&orig_range_id) = original_range_ids.get(&scope_id) {
-                if ident.mutable_range.id == orig_range_id {
-                    let new_range = &env.scopes[scope_id].range;
-                    ident.mutable_range.start = new_range.start;
-                    ident.mutable_range.end = new_range.end;
-                }
-            }
+        if let Some(scope_id) = ident.scope
+            && let Some(&orig_range_id) = original_range_ids.get(&scope_id)
+            && ident.mutable_range.id == orig_range_id
+        {
+            let new_range = &env.scopes[scope_id].range;
+            ident.mutable_range.start = new_range.start;
+            ident.mutable_range.end = new_range.end;
         }
     }
 
@@ -157,10 +156,10 @@ pub fn align_object_method_scopes(func: &mut HirFunction, env: &mut Environment)
         for &instr_id in &block.instructions {
             let lvalue_id = func.instructions[instr_id.index()].lvalue.identifier;
 
-            if let Some(current_scope) = env.identifiers[lvalue_id].scope {
-                if let Some(&root) = scope_remap.get(&current_scope) {
-                    env.identifiers[lvalue_id].scope = Some(root);
-                }
+            if let Some(current_scope) = env.identifiers[lvalue_id].scope
+                && let Some(&root) = scope_remap.get(&current_scope)
+            {
+                env.identifiers[lvalue_id].scope = Some(root);
             }
         }
     }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/align_reactive_scopes_to_block_scopes_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/align_reactive_scopes_to_block_scopes_hir.rs
@@ -115,15 +115,15 @@ pub fn align_reactive_scopes_to_block_scopes_hir(func: &mut HirFunction, env: &m
         active_scopes.retain(|&scope_id| env.scopes[scope_id].range.end > starting_id);
 
         // Check if we've reached a fallthrough block
-        if let Some(top) = active_block_fallthrough_ranges.last().cloned() {
-            if top.fallthrough == block_id {
-                active_block_fallthrough_ranges.pop();
-                // All active scopes overlap this block-fallthrough range;
-                // extend their start to include the range start.
-                for &scope_id in &active_scopes {
-                    let scope = &mut env.scopes[scope_id];
-                    scope.range.start = min(scope.range.start, top.range.start);
-                }
+        if let Some(top) = active_block_fallthrough_ranges.last().cloned()
+            && top.fallthrough == block_id
+        {
+            active_block_fallthrough_ranges.pop();
+            // All active scopes overlap this block-fallthrough range;
+            // extend their start to include the range start.
+            for &scope_id in &active_scopes {
+                let scope = &mut env.scopes[scope_id];
+                scope.range.start = min(scope.range.start, top.range.start);
             }
         }
 
@@ -210,19 +210,19 @@ pub fn align_reactive_scopes_to_block_scopes_hir(func: &mut HirFunction, env: &m
             } else {
                 Some(active_block_fallthrough_ranges.len() - 1)
             };
-            if let Some(pos) = start_pos {
-                if top_idx != Some(pos) {
-                    let start_range = active_block_fallthrough_ranges[pos].clone();
-                    let first_id = block_first_id(func, start_range.fallthrough);
+            if let Some(pos) = start_pos
+                && top_idx != Some(pos)
+            {
+                let start_range = active_block_fallthrough_ranges[pos].clone();
+                let first_id = block_first_id(func, start_range.fallthrough);
 
-                    for &scope_id in &active_scopes {
-                        let scope = &mut env.scopes[scope_id];
-                        if scope.range.end <= terminal_eval_order {
-                            continue;
-                        }
-                        scope.range.start = min(start_range.range.start, scope.range.start);
-                        scope.range.end = max(first_id, scope.range.end);
+                for &scope_id in &active_scopes {
+                    let scope = &mut env.scopes[scope_id];
+                    if scope.range.end <= terminal_eval_order {
+                        continue;
                     }
+                    scope.range.start = min(start_range.range.start, scope.range.start);
+                    scope.range.end = max(first_id, scope.range.end);
                 }
             }
         }
@@ -240,14 +240,14 @@ pub fn align_reactive_scopes_to_block_scopes_hir(func: &mut HirFunction, env: &m
             } else if node.is_none() || is_ternary_logical_optional {
                 // Create a new node when transitioning non-value -> value,
                 // or for ternary/logical/optional terminals.
-                let value_range = if node.is_none() {
+                let value_range = if let Some(node) = &node {
+                    // Value -> value transition (ternary/logical/optional): reuse range
+                    node.value_range.clone()
+                } else {
                     // Transition from block -> value block
                     let ft = fallthrough.expect("Expected a fallthrough for value block");
                     let next_id = block_first_id(func, ft);
                     env.new_mutable_range(terminal_eval_order, next_id)
-                } else {
-                    // Value -> value transition (ternary/logical/optional): reuse range
-                    node.as_ref().unwrap().value_range.clone()
                 };
 
                 value_block_nodes.insert(successor, ValueBlockNode { value_range });

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
@@ -937,14 +937,8 @@ fn infer_block(
         }
 
         // Apply signature
-        let effects = apply_signature(
-            context,
-            state,
-            *instr_idx,
-            &func.instructions[instr_index],
-            env,
-            func,
-        )?;
+        let effects =
+            apply_signature(context, state, *instr_idx, &func.instructions[instr_index], env)?;
         func.instructions[instr_index].effects = effects;
     }
 
@@ -975,38 +969,35 @@ fn infer_block(
             context.catch_handlers.insert(handler, binding);
         }
         TerminalAction::MaybeThrow { handler_id } => {
-            if let Some(handler_param) = context.catch_handlers.get(&handler_id).cloned() {
-                if state.is_defined(handler_param.identifier) {
-                    let mut terminal_effects: Vec<AliasingEffect> = Vec::new();
-                    for instr_idx in &instr_ids {
-                        let instr = &func.instructions[*instr_idx as usize];
-                        match &instr.value {
-                            InstructionValue::CallExpression { .. }
-                            | InstructionValue::MethodCall { .. } => {
-                                state.append_alias(
-                                    handler_param.identifier,
-                                    instr.lvalue.identifier,
-                                );
-                                let kind = state.kind(instr.lvalue.identifier).kind;
-                                if kind == ValueKind::Mutable || kind == ValueKind::Context {
-                                    terminal_effects.push(context.intern_effect(
-                                        AliasingEffect::Alias {
-                                            from: instr.lvalue.clone(),
-                                            into: handler_param.clone(),
-                                        },
-                                    ));
-                                }
+            if let Some(handler_param) = context.catch_handlers.get(&handler_id).cloned()
+                && state.is_defined(handler_param.identifier)
+            {
+                let mut terminal_effects: Vec<AliasingEffect> = Vec::new();
+                for instr_idx in &instr_ids {
+                    let instr = &func.instructions[*instr_idx as usize];
+                    match &instr.value {
+                        InstructionValue::CallExpression { .. }
+                        | InstructionValue::MethodCall { .. } => {
+                            state.append_alias(handler_param.identifier, instr.lvalue.identifier);
+                            let kind = state.kind(instr.lvalue.identifier).kind;
+                            if kind == ValueKind::Mutable || kind == ValueKind::Context {
+                                terminal_effects.push(context.intern_effect(
+                                    AliasingEffect::Alias {
+                                        from: instr.lvalue.clone(),
+                                        into: handler_param.clone(),
+                                    },
+                                ));
                             }
-                            _ => {}
                         }
+                        _ => {}
                     }
-                    let block_mut = func.body.blocks.get_mut(&block_id).unwrap();
-                    if let Terminal::MaybeThrow { effects: ref mut term_effects, .. } =
-                        block_mut.terminal
-                    {
-                        *term_effects =
-                            if terminal_effects.is_empty() { None } else { Some(terminal_effects) };
-                    }
+                }
+                let block_mut = func.body.blocks.get_mut(&block_id).unwrap();
+                if let Terminal::MaybeThrow { effects: ref mut term_effects, .. } =
+                    block_mut.terminal
+                {
+                    *term_effects =
+                        if terminal_effects.is_empty() { None } else { Some(terminal_effects) };
                 }
             }
         }
@@ -1038,7 +1029,6 @@ fn apply_signature(
     instr_idx: u32,
     instr: &Instruction,
     env: &mut Environment,
-    func: &HirFunction,
 ) -> Result<Option<Vec<AliasingEffect>>, OxcDiagnostic> {
     let mut effects: Vec<AliasingEffect> = Vec::new();
 
@@ -1099,7 +1089,7 @@ fn apply_signature(
     let sig_effects: Vec<AliasingEffect> = sig.effects.clone();
 
     for effect in &sig_effects {
-        apply_effect(context, state, effect.clone(), &mut initialized, &mut effects, env, func)?;
+        apply_effect(context, state, effect.clone(), &mut initialized, &mut effects, env)?;
     }
 
     // If lvalue is not yet defined, initialize it with a default value.
@@ -1163,7 +1153,6 @@ fn freeze_function_captures_transitive(
 // applyEffect
 // =============================================================================
 
-#[allow(clippy::only_used_in_recursion)]
 fn apply_effect(
     context: &mut Context,
     state: &mut InferenceState,
@@ -1171,7 +1160,6 @@ fn apply_effect(
     initialized: &mut FxHashSet<IdentifierId>,
     effects: &mut Vec<AliasingEffect>,
     env: &mut Environment,
-    func: &HirFunction,
 ) -> Result<(), OxcDiagnostic> {
     let effect = context.intern_effect(effect);
     match effect {
@@ -1253,7 +1241,6 @@ fn apply_effect(
                         initialized,
                         effects,
                         env,
-                        func,
                     )?;
                 }
                 _ => {
@@ -1345,7 +1332,6 @@ fn apply_effect(
                     initialized,
                     effects,
                     env,
-                    func,
                 )?;
             }
         }
@@ -1384,7 +1370,6 @@ fn apply_effect(
                     initialized,
                     effects,
                     env,
-                    func,
                 )?;
             } else if (source_type == Some("mutable") && destination_type == Some("mutable"))
                 || is_maybe_alias
@@ -1400,7 +1385,6 @@ fn apply_effect(
                     initialized,
                     effects,
                     env,
-                    func,
                 )?;
             }
         }
@@ -1420,7 +1404,6 @@ fn apply_effect(
                         initialized,
                         effects,
                         env,
-                        func,
                     )?;
                     let cache_key = format!(
                         "Assign_frozen:{}:{}",
@@ -1505,18 +1488,9 @@ fn apply_effect(
                                     initialized,
                                     effects,
                                     env,
-                                    func,
                                 )?;
                                 for se in sig_effs {
-                                    apply_effect(
-                                        context,
-                                        state,
-                                        se,
-                                        initialized,
-                                        effects,
-                                        env,
-                                        func,
-                                    )?;
+                                    apply_effect(context, state, se, initialized, effects, env)?;
                                 }
                                 return Ok(());
                             }
@@ -1526,9 +1500,10 @@ fn apply_effect(
             }
             if let Some(sig) = signature {
                 // Check known_incompatible (TS line 2351-2370)
-                if let Some(ref incompatible_msg) = sig.known_incompatible {
-                    if env.enable_validations() {
-                        let diagnostic = ErrorCategory::IncompatibleLibrary
+                if let Some(ref incompatible_msg) = sig.known_incompatible
+                    && env.enable_validations()
+                {
+                    let diagnostic = ErrorCategory::IncompatibleLibrary
                             .diagnostic("Use of incompatible library")
                             .with_help(
                                 "This API returns functions which cannot be memoized without leading to stale UI. \
@@ -1539,9 +1514,8 @@ fn apply_effect(
                             .with_labels(
                                 receiver.span.map(|s| s.label(incompatible_msg.clone())),
                             );
-                        // TS throws here, aborting compilation for this function
-                        return Err(diagnostic);
-                    }
+                    // TS throws here, aborting compilation for this function
+                    return Err(diagnostic);
                 }
 
                 if let Some(ref aliasing) = sig.aliasing {
@@ -1557,7 +1531,7 @@ fn apply_effect(
                     )?;
                     if let Some(sig_effs) = sig_effects {
                         for se in sig_effs {
-                            apply_effect(context, state, se, initialized, effects, env, func)?;
+                            apply_effect(context, state, se, initialized, effects, env)?;
                         }
                         return Ok(());
                     }
@@ -1581,7 +1555,7 @@ fn apply_effect(
                     return Err(err_detail);
                 }
                 for le in legacy_effects {
-                    apply_effect(context, state, le, initialized, effects, env, func)?;
+                    apply_effect(context, state, le, initialized, effects, env)?;
                 }
             } else {
                 // No signature: default behavior
@@ -1596,7 +1570,6 @@ fn apply_effect(
                     initialized,
                     effects,
                     env,
-                    func,
                 )?;
 
                 let all_operands = build_apply_operands(receiver, function, args);
@@ -1616,22 +1589,13 @@ fn apply_effect(
                             initialized,
                             effects,
                             env,
-                            func,
                         )?;
                     }
 
                     if *is_spread {
                         let ty = &env.types[env.identifiers[operand.identifier].type_];
                         if let Some(mutate_iter) = conditionally_mutate_iterator(operand, ty) {
-                            apply_effect(
-                                context,
-                                state,
-                                mutate_iter,
-                                initialized,
-                                effects,
-                                env,
-                                func,
-                            )?;
+                            apply_effect(context, state, mutate_iter, initialized, effects, env)?;
                         }
                     }
 
@@ -1642,7 +1606,6 @@ fn apply_effect(
                         initialized,
                         effects,
                         env,
-                        func,
                     )?;
 
                     // In TS, `other === arg` compares the Place extracted from
@@ -1663,7 +1626,6 @@ fn apply_effect(
                             initialized,
                             effects,
                             env,
-                            func,
                         )?;
                     }
                 }
@@ -1715,15 +1677,15 @@ fn apply_effect(
                             "{} is accessed before it is declared, which prevents the earlier access from updating when this value changes over time",
                             variable.as_deref().unwrap_or("This variable")
                         ));
-                    if let Some(ref access) = hoisted_access {
-                        if access.span != value.span {
-                            diagnostic.labels.extend(access.span.map(|s| {
-                                s.label(format!(
-                                    "{} accessed before it is declared",
-                                    variable.as_deref().unwrap_or("variable")
-                                ))
-                            }));
-                        }
+                    if let Some(ref access) = hoisted_access
+                        && access.span != value.span
+                    {
+                        diagnostic.labels.extend(access.span.map(|s| {
+                            s.label(format!(
+                                "{} accessed before it is declared",
+                                variable.as_deref().unwrap_or("variable")
+                            ))
+                        }));
                     }
                     diagnostic.labels.extend(value.span.map(|s| {
                         s.label(format!(
@@ -1738,7 +1700,6 @@ fn apply_effect(
                         initialized,
                         effects,
                         env,
-                        func,
                     )?;
                 } else {
                     let reason_str = get_write_error_reason(&abstract_value);
@@ -1760,7 +1721,7 @@ fn apply_effect(
                     } else {
                         AliasingEffect::MutateGlobal { place: value.clone(), error: diagnostic }
                     };
-                    apply_effect(context, state, error_kind, initialized, effects, env, func)?;
+                    apply_effect(context, state, error_kind, initialized, effects, env)?;
                 }
             }
         }
@@ -1915,7 +1876,7 @@ fn compute_signature_for_instruction(
             let mutation_reason: Option<MutationReason> = {
                 let obj_ty = &env.types[env.identifiers[object.identifier].type_];
                 if let PropertyLiteral::String(prop_name) = property {
-                    if prop_name == "current" && matches!(obj_ty, Type::TypeVar { .. }) {
+                    if prop_name == "current" && matches!(obj_ty, Type::Var { .. }) {
                         Some(MutationReason::AssignCurrentProperty)
                     } else {
                         None
@@ -2017,10 +1978,10 @@ fn compute_signature_for_instruction(
             for prop in props {
                 if let JsxAttribute::Attribute { place: prop_place, .. } = prop {
                     let prop_ty = &env.types[env.identifiers[prop_place.identifier].type_];
-                    if let Type::Function { return_type, .. } = prop_ty {
-                        if is_jsx_type(return_type) || is_phi_with_jsx(return_type) {
-                            effects.push(AliasingEffect::Render { place: prop_place.clone() });
-                        }
+                    if let Type::Function { return_type, .. } = prop_ty
+                        && (is_jsx_type(return_type) || is_phi_with_jsx(return_type))
+                    {
+                        effects.push(AliasingEffect::Render { place: prop_place.clone() });
                     }
                 }
             }
@@ -2638,19 +2599,19 @@ fn compute_effects_for_aliasing_signature_config(
                                 apply_args.push(PlaceOrSpreadOrHole::Hole);
                             }
                             ApplyArgConfig::Place(name) => {
-                                if let Some(places) = substitutions.get(name) {
-                                    if let Some(p) = places.first() {
-                                        apply_args.push(PlaceOrSpreadOrHole::Place(p.clone()));
-                                    }
+                                if let Some(places) = substitutions.get(name)
+                                    && let Some(p) = places.first()
+                                {
+                                    apply_args.push(PlaceOrSpreadOrHole::Place(p.clone()));
                                 }
                             }
                             ApplyArgConfig::Spread { place: name, .. } => {
-                                if let Some(places) = substitutions.get(name) {
-                                    if let Some(p) = places.first() {
-                                        apply_args.push(PlaceOrSpreadOrHole::Spread(
-                                            SpreadPattern { place: p.clone() },
-                                        ));
-                                    }
+                                if let Some(places) = substitutions.get(name)
+                                    && let Some(p) = places.first()
+                                {
+                                    apply_args.push(PlaceOrSpreadOrHole::Spread(SpreadPattern {
+                                        place: p.clone(),
+                                    }));
                                 }
                             }
                         }
@@ -2898,19 +2859,19 @@ fn compute_effects_for_aliasing_signature(
                         match arg {
                             PlaceOrSpreadOrHole::Hole => apply_args.push(PlaceOrSpreadOrHole::Hole),
                             PlaceOrSpreadOrHole::Place(p) => {
-                                if let Some(places) = substitutions.get(&p.identifier) {
-                                    if let Some(place) = places.first() {
-                                        apply_args.push(PlaceOrSpreadOrHole::Place(place.clone()));
-                                    }
+                                if let Some(places) = substitutions.get(&p.identifier)
+                                    && let Some(place) = places.first()
+                                {
+                                    apply_args.push(PlaceOrSpreadOrHole::Place(place.clone()));
                                 }
                             }
                             PlaceOrSpreadOrHole::Spread(sp) => {
-                                if let Some(places) = substitutions.get(&sp.place.identifier) {
-                                    if let Some(place) = places.first() {
-                                        apply_args.push(PlaceOrSpreadOrHole::Spread(
-                                            SpreadPattern { place: place.clone() },
-                                        ));
-                                    }
+                                if let Some(places) = substitutions.get(&sp.place.identifier)
+                                    && let Some(place) = places.first()
+                                {
+                                    apply_args.push(PlaceOrSpreadOrHole::Spread(SpreadPattern {
+                                        place: place.clone(),
+                                    }));
                                 }
                             }
                         }
@@ -3043,7 +3004,7 @@ fn format_type_for_print<'t>(ty: &'t Type) -> Cow<'t, str> {
         Type::Poly => Cow::Borrowed(":TPoly"),
         Type::Phi { .. } => Cow::Borrowed(":TPhi"),
         Type::Property { .. } => Cow::Borrowed(":TProperty"),
-        Type::TypeVar { .. } => Cow::Borrowed(""),
+        Type::Var { .. } => Cow::Borrowed(""),
         Type::ObjectMethod => Cow::Borrowed(":TObjectMethod"),
     }
 }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_ranges.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_ranges.rs
@@ -251,10 +251,10 @@ impl AliasingState {
         while let Some(entry) = queue.pop() {
             let current = entry.place;
             let previous_kind = seen.get(&current).copied();
-            if let Some(prev) = previous_kind {
-                if prev >= entry.kind {
-                    continue;
-                }
+            if let Some(prev) = previous_kind
+                && prev >= entry.kind
+            {
+                continue;
             }
             seen.insert(current, entry.kind);
 
@@ -273,12 +273,12 @@ impl AliasingState {
                 ident.mutable_range.end = ident.mutable_range.end.max(end_val);
             }
 
-            if let NodeValue::Function { function_id } = &node.value {
-                if node.transitive.is_none() && node.local.is_none() {
-                    if should_record_errors {
-                        append_function_errors(env, *function_id);
-                    }
-                }
+            if let NodeValue::Function { function_id } = &node.value
+                && node.transitive.is_none()
+                && node.local.is_none()
+                && should_record_errors
+            {
+                append_function_errors(env, *function_id);
             }
 
             if entry.transitive {
@@ -696,17 +696,17 @@ pub fn infer_mutation_aliasing_ranges(
             ParamPattern::Place(p) => p,
             ParamPattern::Spread(s) => &s.place,
         };
-        if let Some(node) = state.nodes.get(&place.identifier) {
-            if node.local.is_some() || node.transitive.is_some() {
-                captured_params.insert(place.identifier);
-            }
+        if let Some(node) = state.nodes.get(&place.identifier)
+            && (node.local.is_some() || node.transitive.is_some())
+        {
+            captured_params.insert(place.identifier);
         }
     }
     for ctx in &func.context {
-        if let Some(node) = state.nodes.get(&ctx.identifier) {
-            if node.local.is_some() || node.transitive.is_some() {
-                captured_params.insert(ctx.identifier);
-            }
+        if let Some(node) = state.nodes.get(&ctx.identifier)
+            && (node.local.is_some() || node.transitive.is_some())
+        {
+            captured_params.insert(ctx.identifier);
         }
     }
 

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_places.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_places.rs
@@ -372,10 +372,10 @@ fn is_reactive_controlled_block(
                     return true;
                 }
                 for case in cases {
-                    if let Some(ref case_test) = case.test {
-                        if reactive_map.is_reactive(case_test.identifier) {
-                            return true;
-                        }
+                    if let Some(ref case_test) = case.test
+                        && reactive_map.is_reactive(case_test.identifier)
+                    {
+                        return true;
                     }
                 }
             }
@@ -550,10 +550,9 @@ fn apply_reactive_flags_replay(
 
             for (op_idx, (_pred, operand)) in phi.operands.iter_mut().enumerate() {
                 if let Some(&is_reactive) = phi_operand_reactive.get(&(*block_id, phi_idx, op_idx))
+                    && is_reactive
                 {
-                    if is_reactive {
-                        operand.reactive = true;
-                    }
+                    operand.reactive = true;
                 }
             }
         }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/merge_overlapping_reactive_scopes_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/merge_overlapping_reactive_scopes_hir.rs
@@ -232,16 +232,16 @@ fn visit_place(
     // If an instruction mutates an outer scope, flatten all scopes from top
     // of the stack to the mutated outer scope
     let place_scope = get_place_scope(env, id, identifier_id);
-    if let Some(scope_id) = place_scope {
-        if is_mutable(env, id, identifier_id) {
-            let place_scope_idx = state.active_scopes.iter().position(|s| *s == scope_id);
-            if let Some(idx) = place_scope_idx {
-                if idx != state.active_scopes.len() - 1 {
-                    let mut to_union: Vec<ScopeId> = vec![scope_id];
-                    to_union.extend_from_slice(&state.active_scopes[idx + 1..]);
-                    state.joined.union(&to_union);
-                }
-            }
+    if let Some(scope_id) = place_scope
+        && is_mutable(env, id, identifier_id)
+    {
+        let place_scope_idx = state.active_scopes.iter().position(|s| *s == scope_id);
+        if let Some(idx) = place_scope_idx
+            && idx != state.active_scopes.len() - 1
+        {
+            let mut to_union: Vec<ScopeId> = vec![scope_id];
+            to_union.extend_from_slice(&state.active_scopes[idx + 1..]);
+            state.joined.union(&to_union);
         }
     }
 }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
@@ -50,14 +50,12 @@ pub fn propagate_scope_dependencies_hir<'a>(func: &mut HirFunction<'a>, env: &mu
         // Convert to scope-keyed map with full dependency paths
         let mut keyed: FxHashMap<ScopeId, Vec<ReactiveScopeDependency>> = FxHashMap::default();
         for (_block_id, block) in &func.body.blocks {
-            if let Terminal::Scope { scope, block: inner_block, .. } = &block.terminal {
-                if let Some(node_indices) = working.get(inner_block) {
-                    let deps: Vec<ReactiveScopeDependency> = node_indices
-                        .iter()
-                        .map(|&idx| registry.nodes[idx].full_path.clone())
-                        .collect();
-                    keyed.insert(*scope, deps);
-                }
+            if let Terminal::Scope { scope, block: inner_block, .. } = &block.terminal
+                && let Some(node_indices) = working.get(inner_block)
+            {
+                let deps: Vec<ReactiveScopeDependency> =
+                    node_indices.iter().map(|&idx| registry.nodes[idx].full_path.clone()).collect();
+                keyed.insert(*scope, deps);
             }
         }
         keyed
@@ -133,12 +131,11 @@ fn find_temporaries_used_outside_declaring_scope(
                         used_outside: &mut FxHashSet<DeclarationId>,
                         env: &Environment| {
         let decl_id = env.identifiers[place_id].declaration_id;
-        if let Some(&declaring_scope) = declarations.get(&decl_id) {
-            if !traversal.is_scope_active(declaring_scope)
-                && !pruned_scopes.contains(&declaring_scope)
-            {
-                used_outside.insert(decl_id);
-            }
+        if let Some(&declaring_scope) = declarations.get(&decl_id)
+            && !traversal.is_scope_active(declaring_scope)
+            && !pruned_scopes.contains(&declaring_scope)
+        {
+            used_outside.insert(decl_id);
         }
     };
 
@@ -170,17 +167,17 @@ fn find_temporaries_used_outside_declaring_scope(
             }
             // Handle instruction (track declarations)
             let current_scope = traversal.current_scope();
-            if let Some(scope) = current_scope {
-                if !pruned_scopes.contains(&scope) {
-                    match &instr.value {
-                        InstructionValue::LoadLocal { .. }
-                        | InstructionValue::LoadContext { .. }
-                        | InstructionValue::PropertyLoad { .. } => {
-                            let decl_id = env.identifiers[instr.lvalue.identifier].declaration_id;
-                            declarations.insert(decl_id, scope);
-                        }
-                        _ => {}
+            if let Some(scope) = current_scope
+                && !pruned_scopes.contains(&scope)
+            {
+                match &instr.value {
+                    InstructionValue::LoadLocal { .. }
+                    | InstructionValue::LoadContext { .. }
+                    | InstructionValue::PropertyLoad { .. } => {
+                        let decl_id = env.identifiers[instr.lvalue.identifier].declaration_id;
+                        declarations.insert(decl_id, scope);
                     }
+                    _ => {}
                 }
             }
         }
@@ -232,11 +229,11 @@ fn is_load_context_mutable(
     id: EvaluationOrder,
     env: &Environment,
 ) -> bool {
-    if let InstructionValue::LoadContext { place, .. } = value {
-        if let Some(scope_id) = env.identifiers[place.identifier].scope {
-            let scope_range = &env.scopes[scope_id].range;
-            return id >= scope_range.end;
-        }
+    if let InstructionValue::LoadContext { place, .. } = value
+        && let Some(scope_id) = env.identifiers[place.identifier].scope
+    {
+        let scope_range = &env.scopes[scope_id].range;
+        return id >= scope_range.end;
     }
     false
 }
@@ -424,10 +421,10 @@ fn traverse_function_optional<'a>(
                 _ => {}
             }
         }
-        if let Terminal::Optional { .. } = &block.terminal {
-            if !ctx.seen_optionals.contains(&block.id) {
-                traverse_optional_block(block, func, ctx, None);
-            }
+        if let Terminal::Optional { .. } = &block.terminal
+            && !ctx.seen_optionals.contains(&block.id)
+        {
+            traverse_optional_block(block, func, ctx, None);
         }
     }
 }
@@ -976,10 +973,10 @@ fn get_assumed_invoked_functions_impl(
                     } else if maybe_hook.is_some() {
                         // Assume arguments to all hooks are safe to invoke
                         for arg in args {
-                            if let PlaceOrSpread::Place(p) = arg {
-                                if let Some(entry) = temporaries.get(&p.identifier) {
-                                    hoistable.insert(entry.0);
-                                }
+                            if let PlaceOrSpread::Place(p) = arg
+                                && let Some(entry) = temporaries.get(&p.identifier)
+                            {
+                                hoistable.insert(entry.0);
                             }
                         }
                     }
@@ -987,10 +984,10 @@ fn get_assumed_invoked_functions_impl(
                 InstructionValue::JsxExpression { props, children, .. } => {
                     // Assume JSX attributes and children are safe to invoke
                     for prop in props {
-                        if let JsxAttribute::Attribute { place, .. } = prop {
-                            if let Some(entry) = temporaries.get(&place.identifier) {
-                                hoistable.insert(entry.0);
-                            }
+                        if let JsxAttribute::Attribute { place, .. } = prop
+                            && let Some(entry) = temporaries.get(&place.identifier)
+                        {
+                            hoistable.insert(entry.0);
                         }
                     }
                     if let Some(children) = children {
@@ -1025,10 +1022,10 @@ fn get_assumed_invoked_functions_impl(
         }
 
         // Assume directly returned functions are safe to call
-        if let Terminal::Return { value, .. } = &block.terminal {
-            if let Some(entry) = temporaries.get(&value.identifier) {
-                hoistable.insert(entry.0);
-            }
+        if let Terminal::Return { value, .. } = &block.terminal
+            && let Some(entry) = temporaries.get(&value.identifier)
+        {
+            hoistable.insert(entry.0);
         }
     }
 
@@ -1067,11 +1064,12 @@ fn collect_non_nulls_in_blocks<'a>(
 ) -> FxHashMap<BlockId, BlockInfo> {
     // Known non-null identifiers (e.g. component props)
     let mut known_non_null: BTreeSet<usize> = BTreeSet::new();
-    if func.fn_type == ReactFunctionType::Component && !func.params.is_empty() {
-        if let ParamPattern::Place(place) = &func.params[0] {
-            let node_idx = registry.get_or_create_identifier(place.identifier, true, place.span);
-            known_non_null.insert(node_idx);
-        }
+    if func.fn_type == ReactFunctionType::Component
+        && !func.params.is_empty()
+        && let ParamPattern::Place(place) = &func.params[0]
+    {
+        let node_idx = registry.get_or_create_identifier(place.identifier, true, place.span);
+        known_non_null.insert(node_idx);
     }
 
     let mut nodes: FxHashMap<BlockId, BlockInfo> = FxHashMap::default();
@@ -1096,68 +1094,67 @@ fn collect_non_nulls_in_blocks<'a>(
             }
 
             // Handle StartMemoize deps for enablePreserveExistingMemoizationGuarantees
-            if env.enable_preserve_existing_memoization_guarantees {
-                if let InstructionValue::StartMemoize { deps: Some(deps), .. } = &instr.value {
-                    for dep in deps {
-                        if let ManualMemoDependencyRoot::NamedLocal { value: val, .. } = &dep.root {
-                            if !is_immutable_at_instr(val.identifier, instr.id, env, ctx) {
-                                continue;
+            if env.enable_preserve_existing_memoization_guarantees
+                && let InstructionValue::StartMemoize { deps: Some(deps), .. } = &instr.value
+            {
+                for dep in deps {
+                    if let ManualMemoDependencyRoot::NamedLocal { value: val, .. } = &dep.root {
+                        if !is_immutable_at_instr(val.identifier, instr.id, env, ctx) {
+                            continue;
+                        }
+                        for i in 0..dep.path.len() {
+                            if dep.path[i].optional {
+                                break;
                             }
-                            for i in 0..dep.path.len() {
-                                if dep.path[i].optional {
-                                    break;
-                                }
-                                let sub_dep = ReactiveScopeDependency {
-                                    identifier: val.identifier,
-                                    reactive: val.reactive,
-                                    path: dep.path[..i].to_vec(),
-                                    span: dep.span,
-                                };
-                                let node_idx = registry.get_or_create_property(&sub_dep);
-                                assumed.insert(node_idx);
-                            }
+                            let sub_dep = ReactiveScopeDependency {
+                                identifier: val.identifier,
+                                reactive: val.reactive,
+                                path: dep.path[..i].to_vec(),
+                                span: dep.span,
+                            };
+                            let node_idx = registry.get_or_create_property(&sub_dep);
+                            assumed.insert(node_idx);
                         }
                     }
                 }
             }
 
             // Handle assumed-invoked inner functions
-            if let InstructionValue::FunctionExpression { lowered_func, .. } = &instr.value {
-                if ctx.assumed_invoked_fns.contains(&lowered_func.func) {
-                    let inner_func = &env.functions[lowered_func.func];
-                    // Build nested fn immutable context
-                    let nested_fn_immutable_context: FxHashSet<IdentifierId> =
-                        if ctx.nested_fn_immutable_context.is_some() {
-                            // Already in a nested fn context, use existing
-                            ctx.nested_fn_immutable_context.unwrap().clone()
-                        } else {
-                            inner_func
-                                .context
-                                .iter()
-                                .filter(|place| {
-                                    is_immutable_at_instr(place.identifier, instr.id, env, ctx)
-                                })
-                                .map(|place| place.identifier)
-                                .collect()
-                        };
-                    let inner_assumed = get_assumed_invoked_functions(inner_func, env);
-                    let inner_ctx = CollectHoistableContext {
-                        temporaries: ctx.temporaries,
-                        known_immutable_identifiers: &FxHashSet::default(),
-                        hoistable_from_optionals: ctx.hoistable_from_optionals,
-                        nested_fn_immutable_context: Some(&nested_fn_immutable_context),
-                        assumed_invoked_fns: &inner_assumed,
-                    };
-                    let inner_nodes =
-                        collect_non_nulls_in_blocks(inner_func, env, &inner_ctx, registry);
-                    // Propagate non-null from inner function
-                    let inner_working = propagate_non_null(inner_func, &inner_nodes, registry);
-                    // Get hoistables from inner function's entry block (after propagation)
-                    let inner_entry = inner_func.body.entry;
-                    if let Some(inner_set) = inner_working.get(&inner_entry) {
-                        for &node_idx in inner_set {
-                            assumed.insert(node_idx);
-                        }
+            if let InstructionValue::FunctionExpression { lowered_func, .. } = &instr.value
+                && ctx.assumed_invoked_fns.contains(&lowered_func.func)
+            {
+                let inner_func = &env.functions[lowered_func.func];
+                // Build nested fn immutable context
+                let nested_fn_immutable_context: FxHashSet<IdentifierId> = if let Some(existing) =
+                    ctx.nested_fn_immutable_context
+                {
+                    // Already in a nested fn context, use existing
+                    existing.clone()
+                } else {
+                    inner_func
+                        .context
+                        .iter()
+                        .filter(|place| is_immutable_at_instr(place.identifier, instr.id, env, ctx))
+                        .map(|place| place.identifier)
+                        .collect()
+                };
+                let inner_assumed = get_assumed_invoked_functions(inner_func, env);
+                let inner_ctx = CollectHoistableContext {
+                    temporaries: ctx.temporaries,
+                    known_immutable_identifiers: &FxHashSet::default(),
+                    hoistable_from_optionals: ctx.hoistable_from_optionals,
+                    nested_fn_immutable_context: Some(&nested_fn_immutable_context),
+                    assumed_invoked_fns: &inner_assumed,
+                };
+                let inner_nodes =
+                    collect_non_nulls_in_blocks(inner_func, env, &inner_ctx, registry);
+                // Propagate non-null from inner function
+                let inner_working = propagate_non_null(inner_func, &inner_nodes, registry);
+                // Get hoistables from inner function's entry block (after propagation)
+                let inner_entry = inner_func.body.entry;
+                if let Some(inner_set) = inner_working.get(&inner_entry) {
+                    for &node_idx in inner_set {
+                        assumed.insert(node_idx);
                     }
                 }
             }
@@ -1615,10 +1612,10 @@ impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
 
         // Propagate dependencies upward
         for dep in &scoped_deps {
-            if self.check_valid_dependency(dep, env) {
-                if let Some(top) = self.dep_stack.last_mut() {
-                    top.push(dep.clone());
-                }
+            if self.check_valid_dependency(dep, env)
+                && let Some(top) = self.dep_stack.last_mut()
+            {
+                top.push(dep.clone());
             }
         }
 
@@ -1662,11 +1659,11 @@ impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
             .get(&dep.identifier)
             .or_else(|| self.declarations.get(&ident.declaration_id));
 
-        if let Some(current_scope) = self.current_scope() {
-            if let Some(decl) = current_declaration {
-                let scope_range_start = env.scopes[current_scope].range.start;
-                return decl.id < scope_range_start;
-            }
+        if let Some(current_scope) = self.current_scope()
+            && let Some(decl) = current_declaration
+        {
+            let scope_range_start = env.scopes[current_scope].range.start;
+            return decl.id < scope_range_start;
         }
         false
     }
@@ -1700,25 +1697,25 @@ impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
         let decl_id = ident.declaration_id;
 
         // Record scope declarations for values used outside their declaring scope
-        if let Some(original_decl) = self.declarations.get(&decl_id) {
-            if !original_decl.scope_stack.is_empty() {
-                let orig_scope_stack = original_decl.scope_stack.clone();
-                for &scope_id in &orig_scope_stack {
-                    if !self.scope_stack.contains(&scope_id) {
-                        // Check if already declared in this scope
-                        let scope = &env.scopes[scope_id];
-                        let already_declared = scope
-                            .declarations
-                            .iter()
-                            .any(|(_, d)| env.identifiers[d.identifier].declaration_id == decl_id);
-                        if !already_declared {
-                            let orig_scope_id = *orig_scope_stack.last().unwrap();
-                            let new_decl = ReactiveScopeDeclaration {
-                                identifier: dep.identifier,
-                                scope: orig_scope_id,
-                            };
-                            env.scopes[scope_id].declarations.push((dep.identifier, new_decl));
-                        }
+        if let Some(original_decl) = self.declarations.get(&decl_id)
+            && !original_decl.scope_stack.is_empty()
+        {
+            let orig_scope_stack = original_decl.scope_stack.clone();
+            for &scope_id in &orig_scope_stack {
+                if !self.scope_stack.contains(&scope_id) {
+                    // Check if already declared in this scope
+                    let scope = &env.scopes[scope_id];
+                    let already_declared = scope
+                        .declarations
+                        .iter()
+                        .any(|(_, d)| env.identifiers[d.identifier].declaration_id == decl_id);
+                    if !already_declared {
+                        let orig_scope_id = *orig_scope_stack.last().unwrap();
+                        let new_decl = ReactiveScopeDeclaration {
+                            identifier: dep.identifier,
+                            scope: orig_scope_id,
+                        };
+                        env.scopes[scope_id].declarations.push((dep.identifier, new_decl));
                     }
                 }
             }
@@ -1738,10 +1735,10 @@ impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
             dep
         };
 
-        if self.check_valid_dependency(&dep, env) {
-            if let Some(top) = self.dep_stack.last_mut() {
-                top.push(dep);
-            }
+        if self.check_valid_dependency(&dep, env)
+            && let Some(top) = self.dep_stack.last_mut()
+        {
+            top.push(dep);
         }
     }
 

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -355,12 +355,12 @@ fn lower_block_statement_inner<'a>(
             // declaration statement, the declaration site itself counts as a
             // reference (Babel's binding references include the declaration).
             let decl_counts_as_ref = matches!(kind, AstBindingKind::Hoisted) && !is_function_decl;
-            if decl_counts_as_ref {
-                if let Some(decl_span) = builder.identifier_spans().declaration_span(*binding_id) {
-                    if decl_span.start >= stmt_start && decl_span.start < stmt_end {
-                        refs_in_stmt.push(decl_span);
-                    }
-                }
+            if decl_counts_as_ref
+                && let Some(decl_span) = builder.identifier_spans().declaration_span(*binding_id)
+                && decl_span.start >= stmt_start
+                && decl_span.start < stmt_end
+            {
+                refs_in_stmt.push(decl_span);
             }
 
             if refs_in_stmt.is_empty() {
@@ -480,10 +480,10 @@ fn lower_block_statement_inner<'a>(
         // This must cover all statement types that can introduce bindings.
         match body_stmt {
             oxc::Statement::FunctionDeclaration(func) => {
-                if let Some(id) = &func.id {
-                    if let Some(symbol_id) = scope.get_binding(scope_id, id.name.as_str()) {
-                        declared.insert(symbol_id);
-                    }
+                if let Some(id) = &func.id
+                    && let Some(symbol_id) = scope.get_binding(scope_id, id.name.as_str())
+                {
+                    declared.insert(symbol_id);
                 }
             }
             oxc::Statement::VariableDeclaration(var_decl) => {
@@ -492,10 +492,10 @@ fn lower_block_statement_inner<'a>(
                 }
             }
             oxc::Statement::ClassDeclaration(cls) => {
-                if let Some(id) = &cls.id {
-                    if let Some(symbol_id) = scope.get_binding(scope_id, id.name.as_str()) {
-                        declared.insert(symbol_id);
-                    }
+                if let Some(id) = &cls.id
+                    && let Some(symbol_id) = scope.get_binding(scope_id, id.name.as_str())
+                {
+                    declared.insert(symbol_id);
                 }
             }
             _ => {
@@ -664,21 +664,17 @@ fn lower_inner<'a>(
                 param_span,
                 builder.scope().resolve_binding_identifier(ident),
             )?;
-            if !matches!(binding, VariableBinding::Identifier { .. }) {
-                if let Some(symbol_id) = builder
+            if !matches!(binding, VariableBinding::Identifier { .. })
+                && let Some(symbol_id) = builder
                     .scope()
                     .find_binding_in_descendants(ident.name.as_str(), builder.function_scope())
-                {
-                    let binding_kind = crate::react_compiler_lowering::convert_binding_kind(
-                        &builder.scope().binding_kind(symbol_id),
-                    );
-                    let identifier = builder.resolve_binding_with_span(
-                        ident.name,
-                        symbol_id,
-                        Some(param_span),
-                    )?;
-                    binding = VariableBinding::Identifier { identifier, binding_kind };
-                }
+            {
+                let binding_kind = crate::react_compiler_lowering::convert_binding_kind(
+                    &builder.scope().binding_kind(symbol_id),
+                );
+                let identifier =
+                    builder.resolve_binding_with_span(ident.name, symbol_id, Some(param_span))?;
+                binding = VariableBinding::Identifier { identifier, binding_kind };
             }
             match binding {
                 VariableBinding::Identifier { identifier, .. } => {
@@ -842,15 +838,15 @@ fn lower_identifier<'a>(
             Ok(Place { identifier, effect: Effect::Unknown, reactive: false, span: Some(span) })
         }
         _ => {
-            if let VariableBinding::Global { name } = binding {
-                if name == "eval" {
-                    builder.record_error(
+            if let VariableBinding::Global { name } = binding
+                && name == "eval"
+            {
+                builder.record_error(
                         ErrorCategory::UnsupportedSyntax
                             .diagnostic("The 'eval' function is not supported")
                             .with_help("Eval is an anti-pattern in JavaScript, and the code executed cannot be evaluated by React Compiler")
                             .with_label(span),
                     )?;
-                }
             }
             let non_local_binding = match binding {
                 VariableBinding::Global { name } => NonLocalBinding::Global { name },
@@ -1194,17 +1190,16 @@ fn lower_identifier_for_assignment<'a>(
     symbol: Option<SymbolId>,
 ) -> Result<Option<IdentifierForAssignment<'a>>, OxcDiagnostic> {
     let mut binding = builder.resolve_identifier(name, ident_span, symbol)?;
-    if !matches!(binding, VariableBinding::Identifier { .. }) && kind != InstructionKind::Reassign {
-        if let Some(symbol_id) =
+    if !matches!(binding, VariableBinding::Identifier { .. })
+        && kind != InstructionKind::Reassign
+        && let Some(symbol_id) =
             builder.scope().find_binding_in_descendants(name.as_str(), builder.function_scope())
-        {
-            let bk = crate::react_compiler_lowering::convert_binding_kind(
-                &builder.scope().binding_kind(symbol_id),
-            );
-            let identifier =
-                builder.resolve_binding_with_span(name, symbol_id, Some(ident_span))?;
-            binding = VariableBinding::Identifier { identifier, binding_kind: bk };
-        }
+    {
+        let bk = crate::react_compiler_lowering::convert_binding_kind(
+            &builder.scope().binding_kind(symbol_id),
+        );
+        let identifier = builder.resolve_binding_with_span(name, symbol_id, Some(ident_span))?;
+        binding = VariableBinding::Identifier { identifier, binding_kind: bk };
     }
     match binding {
         VariableBinding::Identifier { identifier, binding_kind, .. } => {
@@ -3116,97 +3111,95 @@ fn lower_function_declaration<'a>(
     // todo-repro-named-function-with-shadowed-local-same-name). Fall back to
     // node-based resolution when the scope walk fails (degraded scope info,
     // e.g. synthetic scopes, or backends that split function-body scopes).
-    if let Some(name) = func_name {
-        if let Some(id_node) = &func_decl.id {
-            let ident_span = id_node.span;
-            let scope_binding =
-                builder.get_function_declaration_binding(function_scope, name.as_str());
-            let mut is_context = false;
-            let binding = match scope_binding {
-                Some(symbol_id) => {
-                    is_context = builder.is_context_binding(symbol_id);
-                    let binding_kind = crate::react_compiler_lowering::convert_binding_kind(
-                        &builder.scope().binding_kind(symbol_id),
-                    );
-                    let identifier =
-                        builder.resolve_binding_with_span(name, symbol_id, Some(ident_span))?;
-                    VariableBinding::Identifier { identifier, binding_kind }
-                }
-                None => {
-                    let mut binding = builder.resolve_identifier(
-                        name,
-                        ident_span,
-                        builder.scope().resolve_binding_identifier(id_node),
-                    )?;
-                    if matches!(&binding, VariableBinding::Global { .. }) {
-                        // For function redeclarations (e.g., `function x() {} function x() {}`),
-                        // the redeclaration's identifier does not resolve as a declaration
-                        // site (only the first declaration does). Retry with the binding
-                        // found on the scope chain, resolving through its first declaration.
-                        let fallback = {
-                            let scope = builder.scope();
-                            let scope_id =
-                                func_decl.scope_id.get().unwrap_or_else(|| scope.program_scope());
-                            scope.find_binding(scope_id, name.as_str())
-                        };
-                        if let Some(symbol_id) = fallback {
-                            let symbol =
-                                builder.scope().declaration_ident(symbol_id).map(|_| symbol_id);
-                            binding = builder.resolve_identifier(name, ident_span, symbol)?;
-                        }
-                    }
-                    if matches!(&binding, VariableBinding::Identifier { .. }) {
-                        is_context = builder.is_context_identifier(
-                            builder.scope().resolve_binding_identifier(id_node),
-                        );
-                    }
-                    binding
-                }
-            };
-            match binding {
-                VariableBinding::Identifier { identifier, .. } => {
-                    // Don't override the identifier's declaration span here.
+    if let Some(name) = func_name
+        && let Some(id_node) = &func_decl.id
+    {
+        let ident_span = id_node.span;
+        let scope_binding = builder.get_function_declaration_binding(function_scope, name.as_str());
+        let mut is_context = false;
+        let binding = match scope_binding {
+            Some(symbol_id) => {
+                is_context = builder.is_context_binding(symbol_id);
+                let binding_kind = crate::react_compiler_lowering::convert_binding_kind(
+                    &builder.scope().binding_kind(symbol_id),
+                );
+                let identifier =
+                    builder.resolve_binding_with_span(name, symbol_id, Some(ident_span))?;
+                VariableBinding::Identifier { identifier, binding_kind }
+            }
+            None => {
+                let mut binding = builder.resolve_identifier(
+                    name,
+                    ident_span,
+                    builder.scope().resolve_binding_identifier(id_node),
+                )?;
+                if matches!(&binding, VariableBinding::Global { .. }) {
                     // For function redeclarations (e.g., `function x() {} function x() {}`),
-                    // the identifier's span should remain the first declaration's span,
-                    // which was already set during define_binding.
-                    // Use the full function declaration span for the Place,
-                    // matching the TS behavior where lowerAssignment uses stmt.node.span
-                    let place = Place {
-                        identifier,
-                        reactive: false,
-                        effect: Effect::Unknown,
-                        span: Some(span),
+                    // the redeclaration's identifier does not resolve as a declaration
+                    // site (only the first declaration does). Retry with the binding
+                    // found on the scope chain, resolving through its first declaration.
+                    let fallback = {
+                        let scope = builder.scope();
+                        let scope_id =
+                            func_decl.scope_id.get().unwrap_or_else(|| scope.program_scope());
+                        scope.find_binding(scope_id, name.as_str())
                     };
-                    if is_context {
-                        lower_value_to_temporary(
-                            builder,
-                            InstructionValue::StoreContext {
-                                lvalue: LValue { kind: InstructionKind::Function, place },
-                                value: fn_place,
-                                span: Some(span),
-                            },
-                        )?;
-                    } else {
-                        lower_value_to_temporary(
-                            builder,
-                            InstructionValue::StoreLocal {
-                                lvalue: LValue { kind: InstructionKind::Function, place },
-                                value: fn_place,
-                                span: Some(span),
-                            },
-                        )?;
+                    if let Some(symbol_id) = fallback {
+                        let symbol =
+                            builder.scope().declaration_ident(symbol_id).map(|_| symbol_id);
+                        binding = builder.resolve_identifier(name, ident_span, symbol)?;
                     }
                 }
-                _ => {
-                    builder.record_error(
-                        ErrorCategory::Invariant
-                            .diagnostic(format!(
-                                "Could not find binding for function declaration `{}`",
-                                name
-                            ))
-                            .with_label(span),
+                if matches!(&binding, VariableBinding::Identifier { .. }) {
+                    is_context = builder
+                        .is_context_identifier(builder.scope().resolve_binding_identifier(id_node));
+                }
+                binding
+            }
+        };
+        match binding {
+            VariableBinding::Identifier { identifier, .. } => {
+                // Don't override the identifier's declaration span here.
+                // For function redeclarations (e.g., `function x() {} function x() {}`),
+                // the identifier's span should remain the first declaration's span,
+                // which was already set during define_binding.
+                // Use the full function declaration span for the Place,
+                // matching the TS behavior where lowerAssignment uses stmt.node.span
+                let place = Place {
+                    identifier,
+                    reactive: false,
+                    effect: Effect::Unknown,
+                    span: Some(span),
+                };
+                if is_context {
+                    lower_value_to_temporary(
+                        builder,
+                        InstructionValue::StoreContext {
+                            lvalue: LValue { kind: InstructionKind::Function, place },
+                            value: fn_place,
+                            span: Some(span),
+                        },
+                    )?;
+                } else {
+                    lower_value_to_temporary(
+                        builder,
+                        InstructionValue::StoreLocal {
+                            lvalue: LValue { kind: InstructionKind::Function, place },
+                            value: fn_place,
+                            span: Some(span),
+                        },
                     )?;
                 }
+            }
+            _ => {
+                builder.record_error(
+                    ErrorCategory::Invariant
+                        .diagnostic(format!(
+                            "Could not find binding for function declaration `{}`",
+                            name
+                        ))
+                        .with_label(span),
+                )?;
             }
         }
     }
@@ -4897,15 +4890,15 @@ fn collect_fbt_sub_tags_from_element(
     plural_spans: &mut Vec<Option<Span>>,
     pronoun_spans: &mut Vec<Option<Span>>,
 ) {
-    if let oxc::JSXElementName::NamespacedName(ns) = &el.opening_element.name {
-        if ns.namespace.name == tag_name {
-            let span = Some(ns.span);
-            match ns.name.name.as_str() {
-                "enum" => enum_spans.push(span),
-                "plural" => plural_spans.push(span),
-                "pronoun" => pronoun_spans.push(span),
-                _ => {}
-            }
+    if let oxc::JSXElementName::NamespacedName(ns) = &el.opening_element.name
+        && ns.namespace.name == tag_name
+    {
+        let span = Some(ns.span);
+        match ns.name.name.as_str() {
+            "enum" => enum_spans.push(span),
+            "plural" => plural_spans.push(span),
+            "pronoun" => pronoun_spans.push(span),
+            _ => {}
         }
     }
     collect_fbt_sub_tags(builder, &el.children, tag_name, enum_spans, plural_spans, pronoun_spans);

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/find_context_identifiers.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/find_context_identifiers.rs
@@ -119,11 +119,10 @@ impl<'a> ContextIdentifierVisitor<'a> {
         if let Some(symbol_id) = self.scope.find_binding(current_scope, name) {
             let info = self.binding_info.entry(symbol_id).or_default();
             info.reassigned = true;
-            if let Some(&fn_scope) = self.function_stack.last() {
-                if is_captured_by_function(self.scope, self.scope.symbol_scope(symbol_id), fn_scope)
-                {
-                    info.reassigned_by_inner_fn = true;
-                }
+            if let Some(&fn_scope) = self.function_stack.last()
+                && is_captured_by_function(self.scope, self.scope.symbol_scope(symbol_id), fn_scope)
+            {
+                info.reassigned_by_inner_fn = true;
             }
         }
     }

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/hir_builder.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/hir_builder.rs
@@ -229,7 +229,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
     /// so that TypeIds are consistent with identifier type slots.
     pub fn make_type(&mut self) -> Type<'a> {
         let type_id = self.env.make_type();
-        Type::TypeVar { id: type_id }
+        Type::Var { id: type_id }
     }
 
     /// Access the scope resolver.
@@ -857,12 +857,12 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
         while let Some(id) = current {
             let mut found =
                 self.scope.bindings_in(id).find(|&sid| resolved_name_matches(sid) == Some(true));
-            if found.is_none() {
-                if let Some(sid) = self.scope.get_binding(id, name) {
-                    // Skip bindings that were renamed away from `name`.
-                    if resolved_name_matches(sid) != Some(false) {
-                        found = Some(sid);
-                    }
+            if found.is_none()
+                && let Some(sid) = self.scope.get_binding(id, name)
+            {
+                // Skip bindings that were renamed away from `name`.
+                if resolved_name_matches(sid) != Some(false) {
+                    found = Some(sid);
                 }
             }
             if let Some(sid) = found {
@@ -977,12 +977,11 @@ pub fn get_reverse_postordered_blocks(hir: &HIR) -> FxIndexMap<BlockId, BasicBlo
 pub fn remove_unreachable_for_updates(hir: &mut HIR) {
     let block_ids: FxIndexSet<BlockId> = hir.blocks.keys().copied().collect();
     for block in hir.blocks.values_mut() {
-        if let Terminal::For { update, .. } = &mut block.terminal {
-            if let Some(update_id) = *update {
-                if !block_ids.contains(&update_id) {
-                    *update = None;
-                }
-            }
+        if let Terminal::For { update, .. } = &mut block.terminal
+            && let Some(update_id) = *update
+            && !block_ids.contains(&update_id)
+        {
+            *update = None;
         }
     }
 }
@@ -997,14 +996,14 @@ pub fn remove_dead_do_while_statements(hir: &mut HIR) {
         } else {
             false
         };
-        if should_replace {
-            if let Terminal::DoWhile { loop_block, id, span, .. } = std::mem::replace(
+        if should_replace
+            && let Terminal::DoWhile { loop_block, id, span, .. } = std::mem::replace(
                 &mut block.terminal,
                 Terminal::Unreachable { id: EvaluationOrder::UNSET, span: None },
-            ) {
-                block.terminal =
-                    Terminal::Goto { block: loop_block, variant: GotoVariant::Break, id, span };
-            }
+            )
+        {
+            block.terminal =
+                Terminal::Goto { block: loop_block, variant: GotoVariant::Break, id, span };
         }
     }
 }
@@ -1024,10 +1023,9 @@ pub fn remove_unnecessary_try_catch(hir: &mut HIR) {
         .filter_map(|(&block_id, block)| {
             if let Terminal::Try { block: try_block, handler, fallthrough, span, .. } =
                 &block.terminal
+                && !block_ids.contains(handler)
             {
-                if !block_ids.contains(handler) {
-                    return Some((block_id, *try_block, *handler, *fallthrough, *span));
-                }
+                return Some((block_id, *try_block, *handler, *fallthrough, *span));
             }
             None
         })

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
@@ -453,23 +453,21 @@ fn evaluate_instruction<'a>(
             let object_value = read(constants, object);
             if let Some(Constant::Primitive { value: PrimitiveValue::String(ref s), .. }) =
                 object_value
+                && let PropertyLiteral::String(prop_name) = property
+                && prop_name == "length"
             {
-                if let PropertyLiteral::String(prop_name) = property {
-                    if prop_name == "length" {
-                        // Use UTF-16 code unit count to match JS .length semantics
-                        let len = s.as_str().encode_utf16().count() as f64;
-                        let span = *span;
-                        let result = Constant::Primitive {
-                            value: PrimitiveValue::Number(FloatValue::new(len)),
-                            span,
-                        };
-                        func.instructions[instr_id.index()].value = InstructionValue::Primitive {
-                            value: PrimitiveValue::Number(FloatValue::new(len)),
-                            span,
-                        };
-                        return Some(result);
-                    }
-                }
+                // Use UTF-16 code unit count to match JS .length semantics
+                let len = s.as_str().encode_utf16().count() as f64;
+                let span = *span;
+                let result = Constant::Primitive {
+                    value: PrimitiveValue::Number(FloatValue::new(len)),
+                    span,
+                };
+                func.instructions[instr_id.index()].value = InstructionValue::Primitive {
+                    value: PrimitiveValue::Number(FloatValue::new(len)),
+                    span,
+                };
+                return Some(result);
             }
             None
         }
@@ -577,12 +575,10 @@ fn evaluate_instruction<'a>(
                 for idx in const_dep_indices {
                     if let InstructionValue::StartMemoize { deps: Some(ref mut deps), .. } =
                         func.instructions[instr_id.index()].value
-                    {
-                        if let ManualMemoDependencyRoot::NamedLocal { constant, .. } =
+                        && let ManualMemoDependencyRoot::NamedLocal { constant, .. } =
                             &mut deps[idx].root
-                        {
-                            *constant = true;
-                        }
+                    {
+                        *constant = true;
                     }
                 }
             }

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/drop_manual_memoization.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/drop_manual_memoization.rs
@@ -305,25 +305,22 @@ fn collect_temporaries<'a>(
             }
         }
         InstructionValue::PropertyLoad { object, property, .. } => {
-            if sidemap.react.contains(&object.identifier) {
-                if let PropertyLiteral::String(prop_name) = property {
-                    if prop_name == "useMemo" {
-                        sidemap.manual_memos.insert(
-                            lvalue_id,
-                            ManualMemoCallee {
-                                kind: ManualMemoKind::UseMemo,
-                                load_instr_id: instr_id,
-                            },
-                        );
-                    } else if prop_name == "useCallback" {
-                        sidemap.manual_memos.insert(
-                            lvalue_id,
-                            ManualMemoCallee {
-                                kind: ManualMemoKind::UseCallback,
-                                load_instr_id: instr_id,
-                            },
-                        );
-                    }
+            if sidemap.react.contains(&object.identifier)
+                && let PropertyLiteral::String(prop_name) = property
+            {
+                if prop_name == "useMemo" {
+                    sidemap.manual_memos.insert(
+                        lvalue_id,
+                        ManualMemoCallee { kind: ManualMemoKind::UseMemo, load_instr_id: instr_id },
+                    );
+                } else if prop_name == "useCallback" {
+                    sidemap.manual_memos.insert(
+                        lvalue_id,
+                        ManualMemoCallee {
+                            kind: ManualMemoKind::UseCallback,
+                            load_instr_id: instr_id,
+                        },
+                    );
                 }
             }
         }

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/name_anonymous_functions.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/name_anonymous_functions.rs
@@ -43,10 +43,11 @@ pub fn name_anonymous_functions<'a>(func: &mut HirFunction<'a>, env: &mut Enviro
         updates: &mut Vec<(FunctionId, Ident<'a>)>,
         allocator: &'a Allocator,
     ) {
-        if node.generated_name.is_some() && node.existing_name_hint.is_none() {
+        if let Some(generated_name) = &node.generated_name
+            && node.existing_name_hint.is_none()
+        {
             // Only add the prefix to anonymous functions regardless of nesting depth
-            let name =
-                format_ident!(allocator, "{}{}]", prefix, node.generated_name.as_ref().unwrap());
+            let name = format_ident!(allocator, "{}{}]", prefix, generated_name);
             updates.push((node.function_id, name));
         }
         // Whether or not we generated a name for the function at this node,
@@ -96,10 +97,9 @@ fn apply_name_hints_to_instructions<'a>(
     for instr in instructions.iter_mut() {
         if let InstructionValue::FunctionExpression { lowered_func, name_hint, .. } =
             &mut instr.value
+            && let Some(new_name) = update_map.get(&lowered_func.func)
         {
-            if let Some(new_name) = update_map.get(&lowered_func.func) {
-                *name_hint = Some(*new_name);
-            }
+            *name_hint = Some(*new_name);
         }
     }
 }
@@ -175,11 +175,11 @@ fn name_anonymous_functions_impl<'a>(
                     if let Some(&node_idx) = functions.get(&value.identifier) {
                         let node = &mut nodes[node_idx];
                         let var_ident = &env.identifiers[store_lvalue.place.identifier];
-                        if node.generated_name.is_none() {
-                            if let Some(IdentifierName::Named(var_name)) = var_ident.name {
-                                node.generated_name = Some(var_name);
-                                functions.remove(&value.identifier);
-                            }
+                        if node.generated_name.is_none()
+                            && let Some(IdentifierName::Named(var_name)) = var_ident.name
+                        {
+                            node.generated_name = Some(var_name);
+                            functions.remove(&value.identifier);
                         }
                     }
                 }

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/optimize_for_ssr.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/optimize_for_ssr.rs
@@ -52,15 +52,13 @@ pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
             let instr = &func.instructions[instr_id.index()];
             match &instr.value {
                 InstructionValue::Destructure { value, lvalue, .. } => {
-                    if inlined_state.contains_key(&env.identifiers[value.identifier].id) {
-                        if let Pattern::Array(arr) = &lvalue.pattern {
-                            if !arr.items.is_empty() {
-                                if let ArrayPatternElement::Place(_) = &arr.items[0] {
-                                    // Allow destructuring of inlined states
-                                    continue;
-                                }
-                            }
-                        }
+                    if inlined_state.contains_key(&env.identifiers[value.identifier].id)
+                        && let Pattern::Array(arr) = &lvalue.pattern
+                        && !arr.items.is_empty()
+                        && let ArrayPatternElement::Place(_) = &arr.items[0]
+                    {
+                        // Allow destructuring of inlined states
+                        continue;
                     }
                 }
                 InstructionValue::MethodCall { property, args, .. }
@@ -83,24 +81,23 @@ pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
                                         },
                                     );
                                 }
-                            } else if args.len() == 3 {
-                                if let (
+                            } else if args.len() == 3
+                                && let (
                                     PlaceOrSpread::Place(_),
                                     PlaceOrSpread::Place(arg),
                                     PlaceOrSpread::Place(initializer),
                                 ) = (&args[0], &args[1], &args[2])
-                                {
-                                    let lvalue_id = env.identifiers[instr.lvalue.identifier].id;
-                                    let call_span = instr.value.span().copied();
-                                    inlined_state.insert(
-                                        lvalue_id,
-                                        InlinedStateReplacement::CallExpression {
-                                            callee: initializer.clone(),
-                                            arg: arg.clone(),
-                                            span: call_span,
-                                        },
-                                    );
-                                }
+                            {
+                                let lvalue_id = env.identifiers[instr.lvalue.identifier].id;
+                                let call_span = instr.value.span().copied();
+                                inlined_state.insert(
+                                    lvalue_id,
+                                    InlinedStateReplacement::CallExpression {
+                                        callee: initializer.clone(),
+                                        arg: arg.clone(),
+                                        span: call_span,
+                                    },
+                                );
                             }
                         }
                         Some(HookKind::UseState) if args.len() == 1 => {
@@ -183,19 +180,18 @@ pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
                     let value_id = env.identifiers[value.identifier].id;
                     if inlined_state.contains_key(&value_id) {
                         // Invariant: destructuring pattern must be ArrayPattern with at least one Identifier item
-                        if let Pattern::Array(arr) = &lvalue.pattern {
-                            if !arr.items.is_empty() {
-                                if let ArrayPatternElement::Place(first_place) = &arr.items[0] {
-                                    let span = *span;
-                                    let kind = lvalue.kind;
-                                    let store = InstructionValue::StoreLocal {
-                                        lvalue: LValue { place: first_place.clone(), kind },
-                                        value: value.clone(),
-                                        span,
-                                    };
-                                    instr.value = store;
-                                }
-                            }
+                        if let Pattern::Array(arr) = &lvalue.pattern
+                            && !arr.items.is_empty()
+                            && let ArrayPatternElement::Place(first_place) = &arr.items[0]
+                        {
+                            let span = *span;
+                            let kind = lvalue.kind;
+                            let store = InstructionValue::StoreLocal {
+                                lvalue: LValue { place: first_place.clone(), kind },
+                                value: value.clone(),
+                                span,
+                            };
+                            instr.value = store;
                         }
                     }
                 }
@@ -205,12 +201,12 @@ pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
                     let hook_kind = get_hook_kind(env, callee_id);
                     match hook_kind {
                         Some(HookKind::UseEffectEvent) => {
-                            if args.len() == 1 {
-                                if let PlaceOrSpread::Place(arg) = &args[0] {
-                                    let span = *span;
-                                    instr.value =
-                                        InstructionValue::LoadLocal { place: arg.clone(), span };
-                                }
+                            if args.len() == 1
+                                && let PlaceOrSpread::Place(arg) = &args[0]
+                            {
+                                let span = *span;
+                                instr.value =
+                                    InstructionValue::LoadLocal { place: arg.clone(), span };
                             }
                         }
                         Some(

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/prune_unused_labels_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/prune_unused_labels_hir.rs
@@ -26,13 +26,11 @@ pub fn prune_unused_labels_hir(func: &mut HirFunction) {
             let fallthrough = &func.body.blocks[fallthrough_id];
             if let Terminal::Goto { block: goto_target, variant: GotoVariant::Break, .. } =
                 &next.terminal
+                && goto_target == fallthrough_id
+                && next.kind == BlockKind::Block
+                && fallthrough.kind == BlockKind::Block
             {
-                if goto_target == fallthrough_id
-                    && next.kind == BlockKind::Block
-                    && fallthrough.kind == BlockKind::Block
-                {
-                    merged.push((block_id, *next_id, *fallthrough_id));
-                }
+                merged.push((block_id, *next_id, *fallthrough_id));
             }
         }
     }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/build_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/build_reactive_function.rs
@@ -202,10 +202,8 @@ impl<'a, 'h> Context<'a, 'h> {
                 // (ownsBlock is boolean, so `!== null` is always true)
                 self.scheduled.remove(block);
                 self.scheduled.remove(continue_block);
-                if *owns_loop {
-                    if let Some(lb) = loop_block {
-                        self.scheduled.remove(lb);
-                    }
+                if *owns_loop && let Some(lb) = loop_block {
+                    self.scheduled.remove(lb);
                 }
             }
             _ => {
@@ -258,17 +256,16 @@ impl<'a, 'h> Context<'a, 'h> {
         for i in (0..self.control_flow_stack.len()).rev() {
             let target = &self.control_flow_stack[i];
             if let ControlFlowTarget::Loop { block: fallthrough_block, continue_block, .. } = target
+                && *continue_block == block
             {
-                if *continue_block == block {
-                    let kind = if has_preceding_loop {
-                        ReactiveTerminalTargetKind::Labeled
-                    } else if i == self.control_flow_stack.len() - 1 {
-                        ReactiveTerminalTargetKind::Implicit
-                    } else {
-                        ReactiveTerminalTargetKind::Unlabeled
-                    };
-                    return Some((*fallthrough_block, kind));
-                }
+                let kind = if has_preceding_loop {
+                    ReactiveTerminalTargetKind::Labeled
+                } else if i == self.control_flow_stack.len() - 1 {
+                    ReactiveTerminalTargetKind::Implicit
+                } else {
+                    ReactiveTerminalTargetKind::Unlabeled
+                };
+                return Some((*fallthrough_block, kind));
             }
             has_preceding_loop = has_preceding_loop || target.is_loop();
         }
@@ -369,15 +366,18 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                     };
 
                     self.cx.unschedule_all(&schedule_ids)?;
-                    block_value.push(ReactiveStatement::Terminal(ReactiveTerminalStatement {
-                        terminal: ReactiveTerminal::If {
-                            test: test.clone(),
-                            consequent: consequent_block,
-                            alternate: alternate_block,
-                            id: *id,
+                    block_value.push(ReactiveStatement::Terminal(Box::new(
+                        ReactiveTerminalStatement {
+                            terminal: ReactiveTerminal::If {
+                                test: test.clone(),
+                                consequent: consequent_block,
+                                alternate: alternate_block,
+                                id: *id,
+                            },
+                            label: fallthrough_id
+                                .map(|ft| ReactiveLabel { id: ft, implicit: false }),
                         },
-                        label: fallthrough_id.map(|ft| ReactiveLabel { id: ft, implicit: false }),
-                    }));
+                    )));
 
                     next_block = fallthrough_id;
                 }
@@ -421,14 +421,17 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                     reactive_cases.reverse();
 
                     self.cx.unschedule_all(&schedule_ids)?;
-                    block_value.push(ReactiveStatement::Terminal(ReactiveTerminalStatement {
-                        terminal: ReactiveTerminal::Switch {
-                            test: test.clone(),
-                            cases: reactive_cases,
-                            id: *id,
+                    block_value.push(ReactiveStatement::Terminal(Box::new(
+                        ReactiveTerminalStatement {
+                            terminal: ReactiveTerminal::Switch {
+                                test: test.clone(),
+                                cases: reactive_cases,
+                                id: *id,
+                            },
+                            label: fallthrough_id
+                                .map(|ft| ReactiveLabel { id: ft, implicit: false }),
                         },
-                        label: fallthrough_id.map(|ft| ReactiveLabel { id: ft, implicit: false }),
-                    }));
+                    )));
 
                     next_block = fallthrough_id;
                 }
@@ -459,14 +462,17 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                     let test_result = self.visit_value_block(*test, *span, None)?;
 
                     self.cx.unschedule_all(&schedule_ids)?;
-                    block_value.push(ReactiveStatement::Terminal(ReactiveTerminalStatement {
-                        terminal: ReactiveTerminal::DoWhile {
-                            loop_block: loop_body,
-                            test: test_result.value,
-                            id: *id,
+                    block_value.push(ReactiveStatement::Terminal(Box::new(
+                        ReactiveTerminalStatement {
+                            terminal: ReactiveTerminal::DoWhile {
+                                loop_block: loop_body,
+                                test: test_result.value,
+                                id: *id,
+                            },
+                            label: fallthrough_id
+                                .map(|ft| ReactiveLabel { id: ft, implicit: false }),
                         },
-                        label: fallthrough_id.map(|ft| ReactiveLabel { id: ft, implicit: false }),
-                    }));
+                    )));
 
                     next_block = fallthrough_id;
                 }
@@ -502,14 +508,17 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                     };
 
                     self.cx.unschedule_all(&schedule_ids)?;
-                    block_value.push(ReactiveStatement::Terminal(ReactiveTerminalStatement {
-                        terminal: ReactiveTerminal::While {
-                            test: test_result.value,
-                            loop_block: loop_body,
-                            id: *id,
+                    block_value.push(ReactiveStatement::Terminal(Box::new(
+                        ReactiveTerminalStatement {
+                            terminal: ReactiveTerminal::While {
+                                test: test_result.value,
+                                loop_block: loop_body,
+                                id: *id,
+                            },
+                            label: fallthrough_id
+                                .map(|ft| ReactiveLabel { id: ft, implicit: false }),
                         },
-                        label: fallthrough_id.map(|ft| ReactiveLabel { id: ft, implicit: false }),
-                    }));
+                    )));
 
                     next_block = fallthrough_id;
                 }
@@ -551,16 +560,19 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                     };
 
                     self.cx.unschedule_all(&schedule_ids)?;
-                    block_value.push(ReactiveStatement::Terminal(ReactiveTerminalStatement {
-                        terminal: ReactiveTerminal::For {
-                            init: init_value,
-                            test: test_result.value,
-                            update: update_result.map(|r| r.value),
-                            loop_block: loop_body,
-                            id: *id,
+                    block_value.push(ReactiveStatement::Terminal(Box::new(
+                        ReactiveTerminalStatement {
+                            terminal: ReactiveTerminal::For {
+                                init: init_value,
+                                test: test_result.value,
+                                update: update_result.map(|r| r.value),
+                                loop_block: loop_body,
+                                id: *id,
+                            },
+                            label: fallthrough_id
+                                .map(|ft| ReactiveLabel { id: ft, implicit: false }),
                         },
-                        label: fallthrough_id.map(|ft| ReactiveLabel { id: ft, implicit: false }),
-                    }));
+                    )));
 
                     next_block = fallthrough_id;
                 }
@@ -598,16 +610,19 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                     };
 
                     self.cx.unschedule_all(&schedule_ids)?;
-                    block_value.push(ReactiveStatement::Terminal(ReactiveTerminalStatement {
-                        terminal: ReactiveTerminal::ForOf {
-                            init: init_value,
-                            test: test_value,
-                            loop_block: loop_body,
-                            id: *id,
-                            span: *span,
+                    block_value.push(ReactiveStatement::Terminal(Box::new(
+                        ReactiveTerminalStatement {
+                            terminal: ReactiveTerminal::ForOf {
+                                init: init_value,
+                                test: test_value,
+                                loop_block: loop_body,
+                                id: *id,
+                                span: *span,
+                            },
+                            label: fallthrough_id
+                                .map(|ft| ReactiveLabel { id: ft, implicit: false }),
                         },
-                        label: fallthrough_id.map(|ft| ReactiveLabel { id: ft, implicit: false }),
-                    }));
+                    )));
 
                     next_block = fallthrough_id;
                 }
@@ -641,15 +656,18 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                     };
 
                     self.cx.unschedule_all(&schedule_ids)?;
-                    block_value.push(ReactiveStatement::Terminal(ReactiveTerminalStatement {
-                        terminal: ReactiveTerminal::ForIn {
-                            init: init_value,
-                            loop_block: loop_body,
-                            id: *id,
-                            span: *span,
+                    block_value.push(ReactiveStatement::Terminal(Box::new(
+                        ReactiveTerminalStatement {
+                            terminal: ReactiveTerminal::ForIn {
+                                init: init_value,
+                                loop_block: loop_body,
+                                id: *id,
+                                span: *span,
+                            },
+                            label: fallthrough_id
+                                .map(|ft| ReactiveLabel { id: ft, implicit: false }),
                         },
-                        label: fallthrough_id.map(|ft| ReactiveLabel { id: ft, implicit: false }),
-                    }));
+                    )));
 
                     next_block = fallthrough_id;
                 }
@@ -674,10 +692,13 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                     let label_body = self.traverse_block(*label_block)?;
 
                     self.cx.unschedule_all(&schedule_ids)?;
-                    block_value.push(ReactiveStatement::Terminal(ReactiveTerminalStatement {
-                        terminal: ReactiveTerminal::Label { block: label_body, id: *id },
-                        label: fallthrough_id.map(|ft| ReactiveLabel { id: ft, implicit: false }),
-                    }));
+                    block_value.push(ReactiveStatement::Terminal(Box::new(
+                        ReactiveTerminalStatement {
+                            terminal: ReactiveTerminal::Label { block: label_body, id: *id },
+                            label: fallthrough_id
+                                .map(|ft| ReactiveLabel { id: ft, implicit: false }),
+                        },
+                    )));
 
                     next_block = fallthrough_id;
                 }
@@ -757,15 +778,18 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                     let handler_body = self.traverse_block(*handler)?;
 
                     self.cx.unschedule_all(&schedule_ids)?;
-                    block_value.push(ReactiveStatement::Terminal(ReactiveTerminalStatement {
-                        terminal: ReactiveTerminal::Try {
-                            block: try_body,
-                            handler_binding: handler_binding.clone(),
-                            handler: handler_body,
-                            id: *id,
+                    block_value.push(ReactiveStatement::Terminal(Box::new(
+                        ReactiveTerminalStatement {
+                            terminal: ReactiveTerminal::Try {
+                                block: try_body,
+                                handler_binding: handler_binding.clone(),
+                                handler: handler_body,
+                                id: *id,
+                            },
+                            label: fallthrough_id
+                                .map(|ft| ReactiveLabel { id: ft, implicit: false }),
                         },
-                        label: fallthrough_id.map(|ft| ReactiveLabel { id: ft, implicit: false }),
-                    }));
+                    )));
 
                     next_block = fallthrough_id;
                 }
@@ -819,17 +843,21 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                 }
 
                 Terminal::Return { value, id, .. } => {
-                    block_value.push(ReactiveStatement::Terminal(ReactiveTerminalStatement {
-                        terminal: ReactiveTerminal::Return { value: value.clone(), id: *id },
-                        label: None,
-                    }));
+                    block_value.push(ReactiveStatement::Terminal(Box::new(
+                        ReactiveTerminalStatement {
+                            terminal: ReactiveTerminal::Return { value: value.clone(), id: *id },
+                            label: None,
+                        },
+                    )));
                 }
 
                 Terminal::Throw { value, id, .. } => {
-                    block_value.push(ReactiveStatement::Terminal(ReactiveTerminalStatement {
-                        terminal: ReactiveTerminal::Throw { value: value.clone(), id: *id },
-                        label: None,
-                    }));
+                    block_value.push(ReactiveStatement::Terminal(Box::new(
+                        ReactiveTerminalStatement {
+                            terminal: ReactiveTerminal::Throw { value: value.clone(), id: *id },
+                            label: None,
+                        },
+                    )));
                 }
 
                 Terminal::Unreachable { .. } => {
@@ -854,15 +882,17 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                     }
                     let alternate_block = self.traverse_block(*alternate)?;
 
-                    block_value.push(ReactiveStatement::Terminal(ReactiveTerminalStatement {
-                        terminal: ReactiveTerminal::If {
-                            test: test.clone(),
-                            consequent: consequent_block,
-                            alternate: Some(alternate_block),
-                            id: *id,
+                    block_value.push(ReactiveStatement::Terminal(Box::new(
+                        ReactiveTerminalStatement {
+                            terminal: ReactiveTerminal::If {
+                                test: test.clone(),
+                                consequent: consequent_block,
+                                alternate: Some(alternate_block),
+                                id: *id,
+                            },
+                            label: None,
                         },
-                        label: None,
-                    }));
+                    )));
                 }
             }
             match next_block {
@@ -888,13 +918,13 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
         let instructions: Vec<_> = block.instructions.clone();
 
         // If we've reached the fallthrough, stop
-        if let Some(ft) = fallthrough {
-            if block_id == ft {
-                return Err(ErrorCategory::Invariant.diagnostic(format!(
-                    "Did not expect to reach the fallthrough of a value block (bb{})",
-                    block_id.index()
-                )));
-            }
+        if let Some(ft) = fallthrough
+            && block_id == ft
+        {
+            return Err(ErrorCategory::Invariant.diagnostic(format!(
+                "Did not expect to reach the fallthrough of a value block (bb{})",
+                block_id.index()
+            )));
         }
 
         match &terminal {
@@ -1265,10 +1295,10 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
             }
             return Ok(None);
         }
-        Ok(Some(ReactiveStatement::Terminal(ReactiveTerminalStatement {
+        Ok(Some(ReactiveStatement::Terminal(Box::new(ReactiveTerminalStatement {
             terminal: ReactiveTerminal::Break { target: target_block, id, target_kind },
             label: None,
-        })))
+        }))))
     }
 
     fn visit_continue(
@@ -1286,10 +1316,10 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
             }
         };
 
-        Ok(ReactiveStatement::Terminal(ReactiveTerminalStatement {
+        Ok(ReactiveStatement::Terminal(Box::new(ReactiveTerminalStatement {
             terminal: ReactiveTerminal::Continue { target: target_block, id, target_kind },
             label: None,
-        }))
+        })))
     }
 }
 

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
@@ -473,10 +473,10 @@ fn ox_codegen_reactive_function<'a>(
     );
 
     // Remove trailing `return undefined`
-    if let Some(oxc::Statement::ReturnStatement(ret)) = statements.last() {
-        if ret.argument.is_none() {
-            statements.pop();
-        }
+    if let Some(oxc::Statement::ReturnStatement(ret)) = statements.last()
+        && ret.argument.is_none()
+    {
+        statements.pop();
     }
 
     let (memo_blocks, memo_values, pruned_memo_blocks, pruned_memo_values) =
@@ -927,12 +927,12 @@ fn ox_codegen_terminal<'a>(
         }
         ReactiveTerminal::Return { value, .. } => {
             let expr = ox_codegen_place_to_expression(cx, value)?;
-            if let oxc::Expression::Identifier(ref ident) = expr {
-                if ident.name == "undefined" {
-                    return Ok(Some(oxc_ast::ast::Statement::new_return_statement(
-                        SPAN, None, &cx.ast,
-                    )));
-                }
+            if let oxc::Expression::Identifier(ref ident) = expr
+                && ident.name == "undefined"
+            {
+                return Ok(Some(oxc_ast::ast::Statement::new_return_statement(
+                    SPAN, None, &cx.ast,
+                )));
             }
             Ok(Some(oxc_ast::ast::Statement::new_return_statement(SPAN, Some(expr), &cx.ast)))
         }
@@ -1227,33 +1227,24 @@ fn ox_codegen_for_init<'a>(
         let mut kind = oxc::VariableDeclarationKind::Const;
         for stmt in body {
             // Fold `name = init` assignment into the last declarator when possible.
-            if let oxc::Statement::ExpressionStatement(ref expr_stmt) = stmt {
-                if let oxc::Expression::AssignmentExpression(ref assign) = expr_stmt.expression {
-                    if matches!(assign.operator, oxc::AssignmentOperator::Assign) {
-                        if let oxc::AssignmentTarget::AssignmentTargetIdentifier(ref left_ident) =
-                            assign.left
-                        {
-                            if let Some(top) = declarators.last_mut() {
-                                if let oxc::BindingPattern::BindingIdentifier(ref top_ident) =
-                                    top.id
-                                {
-                                    if top_ident.name == left_ident.name && top.init.is_none() {
-                                        // Move the assignment's right-hand side into the declarator.
-                                        if let oxc::Statement::ExpressionStatement(expr_stmt) = stmt
-                                        {
-                                            if let oxc::Expression::AssignmentExpression(assign) =
-                                                expr_stmt.unbox().expression
-                                            {
-                                                top.init = Some(assign.unbox().right);
-                                            }
-                                        }
-                                        continue;
-                                    }
-                                }
-                            }
-                        }
-                    }
+            if let oxc::Statement::ExpressionStatement(ref expr_stmt) = stmt
+                && let oxc::Expression::AssignmentExpression(ref assign) = expr_stmt.expression
+                && matches!(assign.operator, oxc::AssignmentOperator::Assign)
+                && let oxc::AssignmentTarget::AssignmentTargetIdentifier(ref left_ident) =
+                    assign.left
+                && let Some(top) = declarators.last_mut()
+                && let oxc::BindingPattern::BindingIdentifier(ref top_ident) = top.id
+                && top_ident.name == left_ident.name
+                && top.init.is_none()
+            {
+                // Move the assignment's right-hand side into the declarator.
+                if let oxc::Statement::ExpressionStatement(expr_stmt) = stmt
+                    && let oxc::Expression::AssignmentExpression(assign) =
+                        expr_stmt.unbox().expression
+                {
+                    top.init = Some(assign.unbox().right);
                 }
+                continue;
             }
 
             if let oxc::Statement::VariableDeclaration(var_decl) = stmt {

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/merge_reactive_scopes_that_invalidate_together.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/merge_reactive_scopes_that_invalidate_together.rs
@@ -107,11 +107,11 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for MergeTransform<'a, 'e> {
         *state = parent_state;
 
         // If parent has deps and they match, flatten the inner scope
-        if let Some(parent_deps) = state.as_ref() {
-            if are_equal_dependencies(parent_deps, &scope_deps, self.env) {
-                let instructions = take(&mut scope.instructions);
-                return Ok(Transformed::ReplaceMany(instructions));
-            }
+        if let Some(parent_deps) = state.as_ref()
+            && are_equal_dependencies(parent_deps, &scope_deps, self.env)
+        {
+            let instructions = take(&mut scope.instructions);
+            return Ok(Transformed::ReplaceMany(instructions));
         }
         Ok(Transformed::Keep)
     }
@@ -151,18 +151,18 @@ impl<'a, 'e> MergeTransform<'a, 'e> {
             match statement {
                 ReactiveStatement::Terminal(_) => {
                     // Don't merge across terminals
-                    if let Some(c) = current.take() {
-                        if c.to > c.from + 1 {
-                            merged.push(c);
-                        }
+                    if let Some(c) = current.take()
+                        && c.to > c.from + 1
+                    {
+                        merged.push(c);
                     }
                 }
                 ReactiveStatement::PrunedScope(_) => {
                     // Don't merge across pruned scopes
-                    if let Some(c) = current.take() {
-                        if c.to > c.from + 1 {
-                            merged.push(c);
-                        }
+                    if let Some(c) = current.take()
+                        && c.to > c.from + 1
+                    {
+                        merged.push(c);
                     }
                 }
                 ReactiveStatement::Instruction(instr) => {
@@ -178,17 +178,16 @@ impl<'a, 'e> MergeTransform<'a, 'e> {
                                 | InstructionValue::PropertyLoad { .. }
                                 | InstructionValue::TemplateLiteral { .. }
                                 | InstructionValue::UnaryExpression { .. } => {
-                                    if let Some(ref mut c) = current {
-                                        if let Some(lvalue) = &instr.lvalue {
-                                            let decl_id = self.env.identifiers[lvalue.identifier]
+                                    if let Some(ref mut c) = current
+                                        && let Some(lvalue) = &instr.lvalue
+                                    {
+                                        let decl_id =
+                                            self.env.identifiers[lvalue.identifier].declaration_id;
+                                        c.lvalues.insert(decl_id);
+                                        if let InstructionValue::LoadLocal { place, .. } = iv {
+                                            let src_decl = self.env.identifiers[place.identifier]
                                                 .declaration_id;
-                                            c.lvalues.insert(decl_id);
-                                            if let InstructionValue::LoadLocal { place, .. } = iv {
-                                                let src_decl = self.env.identifiers
-                                                    [place.identifier]
-                                                    .declaration_id;
-                                                self.temporaries.insert(decl_id, src_decl);
-                                            }
+                                            self.temporaries.insert(decl_id, src_decl);
                                         }
                                     }
                                 }
@@ -227,20 +226,20 @@ impl<'a, 'e> MergeTransform<'a, 'e> {
                                 }
                                 _ => {
                                     // Other instructions prevent merging
-                                    if let Some(c) = current.take() {
-                                        if c.to > c.from + 1 {
-                                            merged.push(c);
-                                        }
+                                    if let Some(c) = current.take()
+                                        && c.to > c.from + 1
+                                    {
+                                        merged.push(c);
                                     }
                                 }
                             }
                         }
                         _ => {
                             // Non-Instruction reactive values prevent merging
-                            if let Some(c) = current.take() {
-                                if c.to > c.from + 1 {
-                                    merged.push(c);
-                                }
+                            if let Some(c) = current.take()
+                                && c.to > c.from + 1
+                            {
+                                merged.push(c);
                             }
                         }
                     }
@@ -323,10 +322,10 @@ impl<'a, 'e> MergeTransform<'a, 'e> {
             }
         }
         // Flush remaining
-        if let Some(c) = current.take() {
-            if c.to > c.from + 1 {
-                merged.push(c);
-            }
+        if let Some(c) = current.take()
+            && c.to > c.from + 1
+        {
+            merged.push(c);
         }
 
         // Pass 3: apply merges
@@ -409,10 +408,10 @@ fn are_lvalues_last_used_by_scope<'a>(
 ) -> bool {
     let range_end = env.scopes[scope_id].range.end;
     for lvalue in lvalues {
-        if let Some(&last_used_at) = last_usage.get(lvalue) {
-            if last_used_at >= range_end {
-                return false;
-            }
+        if let Some(&last_used_at) = last_usage.get(lvalue)
+            && last_used_at >= range_end
+        {
+            return false;
         }
     }
     true

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/promote_used_temporaries.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/promote_used_temporaries.rs
@@ -158,12 +158,11 @@ fn collect_promotable_place(
 ) {
     if !active_scopes.is_empty() {
         let identifier = &env.identifiers[place.identifier];
-        if let Some(pruned) = state.pruned.get_mut(&identifier.declaration_id) {
-            if let Some(last) = active_scopes.last() {
-                if !pruned.active_scopes.contains(last) {
-                    pruned.used_outside_scope = true;
-                }
-            }
+        if let Some(pruned) = state.pruned.get_mut(&identifier.declaration_id)
+            && let Some(last) = active_scopes.last()
+            && !pruned.active_scopes.contains(last)
+        {
+            pruned.used_outside_scope = true;
         }
     }
 }
@@ -321,12 +320,11 @@ fn promote_temporaries_block(block: &ReactiveBlock, state: &mut State, env: &mut
                     .collect();
                 for (id, decl_id) in decls {
                     let identifier = &env.identifiers[id];
-                    if identifier.name.is_none() {
-                        if let Some(pruned) = state.pruned.get(&decl_id) {
-                            if pruned.used_outside_scope {
-                                promote_identifier(id, state, env);
-                            }
-                        }
+                    if identifier.name.is_none()
+                        && let Some(pruned) = state.pruned.get(&decl_id)
+                        && pruned.used_outside_scope
+                    {
+                        promote_identifier(id, state, env);
                     }
                 }
                 promote_temporaries_block(&scope.instructions, state, env);
@@ -579,15 +577,14 @@ fn promote_interposed_instruction(
                         }
                         _ => {}
                     }
-                    if let InstructionValue::Destructure { lvalue, .. } = iv {
-                        if lvalue.kind == InstructionKind::Const
-                            || lvalue.kind == InstructionKind::HoistedConst
-                        {
-                            for operand in each_pattern_operand(&lvalue.pattern) {
-                                consts.insert(operand.identifier);
-                            }
-                            const_store = true;
+                    if let InstructionValue::Destructure { lvalue, .. } = iv
+                        && (lvalue.kind == InstructionKind::Const
+                            || lvalue.kind == InstructionKind::HoistedConst)
+                    {
+                        for operand in each_pattern_operand(&lvalue.pattern) {
+                            consts.insert(operand.identifier);
                         }
+                        const_store = true;
                     }
                     if let InstructionValue::MethodCall { property, .. } = iv {
                         consts.insert(property.identifier);

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/propagate_early_returns.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/propagate_early_returns.rs
@@ -114,55 +114,55 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
         stmt: &mut ReactiveTerminalStatement<'a>,
         state: &mut State,
     ) -> Result<Transformed<ReactiveStatement<'a>>, OxcDiagnostic> {
-        if state.within_reactive_scope {
-            if let ReactiveTerminal::Return { value, .. } = &stmt.terminal {
-                let span = value.span;
+        if state.within_reactive_scope
+            && let ReactiveTerminal::Return { value, .. } = &stmt.terminal
+        {
+            let span = value.span;
 
-                let early_return_value = if let Some(ref existing) = state.early_return_value {
-                    existing.clone()
-                } else {
-                    // Create a new early return identifier
-                    let identifier_id = create_temporary_place_id(self.env, span);
-                    promote_temporary(self.env, identifier_id);
-                    let label = self.env.next_block_id();
-                    EarlyReturnInfo { value: identifier_id, span, label }
-                };
+            let early_return_value = if let Some(ref existing) = state.early_return_value {
+                existing.clone()
+            } else {
+                // Create a new early return identifier
+                let identifier_id = create_temporary_place_id(self.env, span);
+                promote_temporary(self.env, identifier_id);
+                let label = self.env.next_block_id();
+                EarlyReturnInfo { value: identifier_id, span, label }
+            };
 
-                state.early_return_value = Some(early_return_value.clone());
+            state.early_return_value = Some(early_return_value.clone());
 
-                let return_value = value.clone();
+            let return_value = value.clone();
 
-                return Ok(Transformed::ReplaceMany(vec![
-                    // StoreLocal: reassign the early return value
-                    ReactiveStatement::Instruction(ReactiveInstruction {
-                        id: EvaluationOrder::UNSET,
-                        lvalue: None,
-                        value: ReactiveValue::Instruction(InstructionValue::StoreLocal {
-                            lvalue: LValue {
-                                kind: InstructionKind::Reassign,
-                                place: Place {
-                                    identifier: early_return_value.value,
-                                    effect: Effect::Capture,
-                                    reactive: true,
-                                    span,
-                                },
+            return Ok(Transformed::ReplaceMany(vec![
+                // StoreLocal: reassign the early return value
+                ReactiveStatement::Instruction(ReactiveInstruction {
+                    id: EvaluationOrder::UNSET,
+                    lvalue: None,
+                    value: ReactiveValue::Instruction(InstructionValue::StoreLocal {
+                        lvalue: LValue {
+                            kind: InstructionKind::Reassign,
+                            place: Place {
+                                identifier: early_return_value.value,
+                                effect: Effect::Capture,
+                                reactive: true,
+                                span,
                             },
-                            value: return_value,
-                            span,
-                        }),
+                        },
+                        value: return_value,
                         span,
                     }),
-                    // Break to the label
-                    ReactiveStatement::Terminal(ReactiveTerminalStatement {
-                        terminal: ReactiveTerminal::Break {
-                            target: early_return_value.label,
-                            id: EvaluationOrder::UNSET,
-                            target_kind: ReactiveTerminalTargetKind::Labeled,
-                        },
-                        label: None,
-                    }),
-                ]));
-            }
+                    span,
+                }),
+                // Break to the label
+                ReactiveStatement::Terminal(Box::new(ReactiveTerminalStatement {
+                    terminal: ReactiveTerminal::Break {
+                        target: early_return_value.label,
+                        id: EvaluationOrder::UNSET,
+                        target_kind: ReactiveTerminalTargetKind::Labeled,
+                    },
+                    label: None,
+                })),
+            ]));
         }
 
         // Default: traverse into the terminal's sub-blocks
@@ -313,13 +313,13 @@ fn apply_early_return_to_scope<'a>(
             span,
         }),
         // Label terminal wrapping the original instructions
-        ReactiveStatement::Terminal(ReactiveTerminalStatement {
+        ReactiveStatement::Terminal(Box::new(ReactiveTerminalStatement {
             label: Some(ReactiveLabel { id: early_return.label, implicit: false }),
             terminal: ReactiveTerminal::Label {
                 block: original_instructions,
                 id: EvaluationOrder::UNSET,
             },
-        }),
+        })),
     ];
 }
 

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_hoisted_contexts.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_hoisted_contexts.rs
@@ -110,12 +110,11 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
     ) -> Result<(), OxcDiagnostic> {
         if let Some(UninitializedKind::Func { definition }) =
             state.uninitialized.get(&place.identifier)
+            && *definition != Some(place.identifier)
         {
-            if *definition != Some(place.identifier) {
-                return Err(ErrorCategory::Todo
-                    .diagnostic("[PruneHoistedContexts] Rewrite hoisted function references")
-                    .with_labels(place.span));
-            }
+            return Err(ErrorCategory::Todo
+                .diagnostic("[PruneHoistedContexts] Rewrite hoisted function references")
+                .with_labels(place.span));
         }
         Ok(())
     }
@@ -145,32 +144,28 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
 
         if let ReactiveValue::Instruction(InstructionValue::StoreContext { lvalue, .. }) =
             &mut instruction.value
+            && lvalue.kind != InstructionKind::Reassign
         {
-            if lvalue.kind != InstructionKind::Reassign {
-                let lvalue_id = lvalue.place.identifier;
-                let is_declared_by_scope = state.find_in_active_scopes(lvalue_id);
-                if is_declared_by_scope {
-                    if lvalue.kind == InstructionKind::Let || lvalue.kind == InstructionKind::Const
-                    {
-                        lvalue.kind = InstructionKind::Reassign;
-                    } else if lvalue.kind == InstructionKind::Function {
-                        if let Some(kind) = state.uninitialized.get(&lvalue_id) {
-                            if !matches!(kind, UninitializedKind::Func { .. }) {
-                                return Err(ErrorCategory::Invariant
-                                    .diagnostic(
-                                        "[PruneHoistedContexts] Unexpected hoisted function",
-                                    )
-                                    .with_labels(instruction.span));
-                            }
-                            // References to hoisted functions are now "safe" as
-                            // variable assignments have finished.
-                            state.uninitialized.remove(&lvalue_id);
+            let lvalue_id = lvalue.place.identifier;
+            let is_declared_by_scope = state.find_in_active_scopes(lvalue_id);
+            if is_declared_by_scope {
+                if lvalue.kind == InstructionKind::Let || lvalue.kind == InstructionKind::Const {
+                    lvalue.kind = InstructionKind::Reassign;
+                } else if lvalue.kind == InstructionKind::Function {
+                    if let Some(kind) = state.uninitialized.get(&lvalue_id) {
+                        if !matches!(kind, UninitializedKind::Func { .. }) {
+                            return Err(ErrorCategory::Invariant
+                                .diagnostic("[PruneHoistedContexts] Unexpected hoisted function")
+                                .with_labels(instruction.span));
                         }
-                    } else {
-                        return Err(ErrorCategory::Todo
-                            .diagnostic("[PruneHoistedContexts] Unexpected kind")
-                            .with_labels(instruction.span));
+                        // References to hoisted functions are now "safe" as
+                        // variable assignments have finished.
+                        state.uninitialized.remove(&lvalue_id);
                     }
+                } else {
+                    return Err(ErrorCategory::Todo
+                        .diagnostic("[PruneHoistedContexts] Unexpected kind")
+                        .with_labels(instruction.span));
                 }
             }
         }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_escaping_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_escaping_scopes.rs
@@ -867,18 +867,18 @@ impl<'a, 'e> CollectDependenciesVisitor<'a, 'e> {
                         }
                     }
                 }
-            } else if let InstructionValue::MethodCall { property, args, .. } = instr_value {
-                if env.get_hook_kind_for_id(property.identifier).ok().flatten().is_some() {
-                    let no_alias = env.has_no_alias_signature(property.identifier);
-                    if !no_alias {
-                        for arg in args {
-                            let place = match arg {
-                                PlaceOrSpread::Spread(spread) => &spread.place,
-                                PlaceOrSpread::Place(place) => place,
-                            };
-                            let decl = env.identifiers[place.identifier].declaration_id;
-                            state.escaping_values.insert(decl);
-                        }
+            } else if let InstructionValue::MethodCall { property, args, .. } = instr_value
+                && env.get_hook_kind_for_id(property.identifier).ok().flatten().is_some()
+            {
+                let no_alias = env.has_no_alias_signature(property.identifier);
+                if !no_alias {
+                    for arg in args {
+                        let place = match arg {
+                            PlaceOrSpread::Spread(spread) => &spread.place,
+                            PlaceOrSpread::Place(place) => place,
+                        };
+                        let decl = env.identifiers[place.identifier].declaration_id;
+                        state.escaping_values.insert(decl);
                     }
                 }
             }
@@ -1125,12 +1125,13 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for PruneScopesTransform<'a, 'e> {
                     .as_ref()
                     .map(|lv| self.env.identifiers[lv.identifier].scope.is_none())
                     .unwrap_or(false);
-                if has_scope && lvalue_no_scope {
-                    if let Some(lv) = &instruction.lvalue {
-                        let decl_id = self.env.identifiers[lv.identifier].declaration_id;
-                        let ids = self.reassignments.entry(decl_id).or_default();
-                        ids.insert(place.identifier);
-                    }
+                if has_scope
+                    && lvalue_no_scope
+                    && let Some(lv) = &instruction.lvalue
+                {
+                    let decl_id = self.env.identifiers[lv.identifier].declaration_id;
+                    let ids = self.reassignments.entry(decl_id).or_default();
+                    ids.insert(place.identifier);
                 }
             }
             ReactiveValue::Instruction(InstructionValue::FinishMemoize {
@@ -1155,10 +1156,10 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for PruneScopesTransform<'a, 'e> {
                     }
                 } else {
                     let scope = self.env.identifiers[decl.identifier].scope;
-                    if let Some(scope_id) = scope {
-                        if self.pruned_scopes.contains(&scope_id) {
-                            *pruned = true;
-                        }
+                    if let Some(scope_id) = scope
+                        && self.pruned_scopes.contains(&scope_id)
+                    {
+                        *pruned = true;
                     }
                 }
             }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_reactive_dependencies.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_reactive_dependencies.rs
@@ -156,10 +156,10 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for PruneVisitor<'a, 'e> {
         let lvalue = &instruction.lvalue;
         match &instruction.value {
             ReactiveValue::Instruction(InstructionValue::LoadLocal { place, .. }) => {
-                if let Some(lv) = lvalue {
-                    if state.contains(&place.identifier) {
-                        state.insert(lv.identifier);
-                    }
+                if let Some(lv) = lvalue
+                    && state.contains(&place.identifier)
+                {
+                    state.insert(lv.identifier);
                 }
             }
             ReactiveValue::Instruction(InstructionValue::StoreLocal {
@@ -205,10 +205,10 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for PruneVisitor<'a, 'e> {
             ReactiveValue::Instruction(InstructionValue::ComputedLoad {
                 object, property, ..
             }) => {
-                if let Some(lv) = lvalue {
-                    if state.contains(&object.identifier) || state.contains(&property.identifier) {
-                        state.insert(lv.identifier);
-                    }
+                if let Some(lv) = lvalue
+                    && (state.contains(&object.identifier) || state.contains(&property.identifier))
+                {
+                    state.insert(lv.identifier);
                 }
             }
             _ => {}

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_unused_labels.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_unused_labels.rs
@@ -72,21 +72,19 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
         // Is this terminal reachable via a break/continue to its label?
         let is_reachable_label = stmt.label.as_ref().is_some_and(|label| state.contains(&label.id));
 
-        if let ReactiveTerminal::Label { block, .. } = &mut stmt.terminal {
-            if !is_reachable_label {
-                // Flatten labeled terminals where the label isn't necessary.
-                // Note: In TS, there's a check for `last.terminal.target === null`
-                // to pop a trailing break, but since target is always a BlockId (number),
-                // that check is always false, so the trailing break is never removed.
-                let flattened = take(block);
-                return Ok(Transformed::ReplaceMany(flattened));
-            }
+        if let ReactiveTerminal::Label { block, .. } = &mut stmt.terminal
+            && !is_reachable_label
+        {
+            // Flatten labeled terminals where the label isn't necessary.
+            // Note: In TS, there's a check for `last.terminal.target === null`
+            // to pop a trailing break, but since target is always a BlockId (number),
+            // that check is always false, so the trailing break is never removed.
+            let flattened = take(block);
+            return Ok(Transformed::ReplaceMany(flattened));
         }
 
-        if !is_reachable_label {
-            if let Some(label) = &mut stmt.label {
-                label.implicit = true;
-            }
+        if !is_reachable_label && let Some(label) = &mut stmt.label {
+            label.implicit = true;
         }
 
         Ok(Transformed::Keep)

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/rename_variables.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/rename_variables.rs
@@ -229,10 +229,10 @@ fn rename_variables_with_parent<'a>(
 
     // Phase 2: Apply the computed renames to all identifiers in env.
     for identifier in env.identifiers.iter_mut() {
-        if let Some(mapped_name) = scopes.seen.get(&identifier.declaration_id) {
-            if identifier.name.is_some() {
-                identifier.name = Some(*mapped_name);
-            }
+        if let Some(mapped_name) = scopes.seen.get(&identifier.declaration_id)
+            && identifier.name.is_some()
+        {
+            identifier.name = Some(*mapped_name);
         }
     }
 

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/stabilize_block_ids.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/stabilize_block_ids.rs
@@ -69,10 +69,10 @@ impl<'a, 'e> ReactiveFunctionVisitor<'a> for CollectReferencedLabels<'a, 'e> {
     }
 
     fn visit_terminal(&self, stmt: &ReactiveTerminalStatement<'a>, state: &mut Self::State) {
-        if let Some(ref label) = stmt.label {
-            if !label.implicit {
-                state.insert(label.id);
-            }
+        if let Some(ref label) = stmt.label
+            && !label.implicit
+        {
+            state.insert(label.id);
         }
         self.traverse_terminal(stmt, state);
     }

--- a/crates/oxc_react_compiler/src/react_compiler_ssa/enter_ssa.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_ssa/enter_ssa.rs
@@ -142,10 +142,10 @@ impl SSABuilder {
         block_id: BlockId,
         env: &mut Environment,
     ) -> IdentifierId {
-        if let Some(state) = self.states.get(&block_id) {
-            if let Some(&new_id) = state.defs.get(&old_place.identifier) {
-                return new_id;
-            }
+        if let Some(state) = self.states.get(&block_id)
+            && let Some(&new_id) = state.defs.get(&old_place.identifier)
+        {
+            return new_id;
         }
 
         let preds = self.block_preds.get(&block_id).cloned().unwrap_or_default();

--- a/crates/oxc_react_compiler/src/react_compiler_typeinference/infer_types.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_typeinference/infer_types.rs
@@ -70,14 +70,14 @@ fn get_type<'a>(
     identifiers: &IndexSlice<IdentifierId, [Identifier<'a>]>,
 ) -> Type<'a> {
     let type_id = identifiers[id].type_;
-    Type::TypeVar { id: type_id }
+    Type::Var { id: type_id }
 }
 
 /// Allocate a new TypeVar in the types arena (standalone, no &mut Environment needed).
 fn make_type<'a>(types: &mut IndexVec<TypeId, Type<'a>>) -> Type<'a> {
     let id = TypeId::from_usize(types.len());
-    types.push(Type::TypeVar { id });
-    Type::TypeVar { id }
+    types.push(Type::Var { id });
+    Type::Var { id }
 }
 
 /// Pre-resolve LoadGlobal types for a single function's instructions.
@@ -89,10 +89,10 @@ fn pre_resolve_globals<'a>(
 ) {
     for &instr_id in func.body.blocks.values().flat_map(|b| &b.instructions) {
         let instr = &func.instructions[instr_id.index()];
-        if let InstructionValue::LoadGlobal { binding, span, .. } = &instr.value {
-            if let Some(global_type) = env.get_global_declaration(binding, *span).ok().flatten() {
-                global_types.insert((function_key, instr_id), global_type);
-            }
+        if let InstructionValue::LoadGlobal { binding, span, .. } = &instr.value
+            && let Some(global_type) = env.get_global_declaration(binding, *span).ok().flatten()
+        {
+            global_types.insert((function_key, instr_id), global_type);
         }
     }
 }
@@ -180,14 +180,12 @@ fn resolve_property_type<'a>(
         Type::Object { shape_id } | Type::Function { shape_id, .. } => shape_id.as_deref(),
         _ => {
             // No shape, but if property name is hook-like, return hook type
-            if let Some(hook_type) = custom_hook_type {
-                if let PropertyNameKind::Literal { value: PropertyLiteral::String(s) } =
+            if let Some(hook_type) = custom_hook_type
+                && let PropertyNameKind::Literal { value: PropertyLiteral::String(s) } =
                     property_name
-                {
-                    if is_hook_name(s) {
-                        return Some(hook_type.clone());
-                    }
-                }
+                && is_hook_name(s)
+            {
+                return Some(hook_type.clone());
             }
             return None;
         }
@@ -197,10 +195,10 @@ fn resolve_property_type<'a>(
         None => {
             // Object/Function with no shapeId: TS getPropertyType falls through
             // to hook-name check, TS getFallthroughPropertyType returns null
-            if let PropertyNameKind::Literal { value: PropertyLiteral::String(s) } = property_name {
-                if is_hook_name(s) {
-                    return custom_hook_type.cloned();
-                }
+            if let PropertyNameKind::Literal { value: PropertyLiteral::String(s) } = property_name
+                && is_hook_name(s)
+            {
+                return custom_hook_type.cloned();
             }
             return None;
         }
@@ -253,7 +251,7 @@ fn is_ref_like_name(object_name: &str, property_name: &PropertyNameKind) -> bool
 /// `if` block, so it unconditionally returns false.
 fn type_equals(a: &Type, b: &Type) -> bool {
     match (a, b) {
-        (Type::TypeVar { id: id_a }, Type::TypeVar { id: id_b }) => id_a == id_b,
+        (Type::Var { id: id_a }, Type::Var { id: id_b }) => id_a == id_b,
         (Type::Primitive, Type::Primitive) => true,
         (Type::Poly, Type::Poly) => true,
         (Type::ObjectMethod, Type::ObjectMethod) => true,
@@ -541,10 +539,10 @@ fn generate_instruction_types<'a>(
         InstructionValue::CallExpression { callee, .. } => {
             let return_type = make_type(types);
             let mut shape_id = None;
-            if unifier.enable_treat_set_identifiers_as_state_setters {
-                if names.get(&callee.identifier).is_some_and(|name| name.starts_with("set")) {
-                    shape_id = Some(BUILT_IN_SET_STATE_ID);
-                }
+            if unifier.enable_treat_set_identifiers_as_state_setters
+                && names.get(&callee.identifier).is_some_and(|name| name.starts_with("set"))
+            {
+                shape_id = Some(BUILT_IN_SET_STATE_ID);
             }
             let callee_type = get_type(callee.identifier, identifiers);
             unifier.unify(
@@ -576,11 +574,11 @@ fn generate_instruction_types<'a>(
 
         InstructionValue::ObjectExpression { properties, .. } => {
             for prop in properties {
-                if let ObjectPropertyOrSpread::Property(obj_prop) = prop {
-                    if let ObjectPropertyKey::Computed { name } = &obj_prop.key {
-                        let name_type = get_type(name.identifier, identifiers);
-                        unifier.unify(name_type, Type::Primitive, shapes)?;
-                    }
+                if let ObjectPropertyOrSpread::Property(obj_prop) = prop
+                    && let ObjectPropertyKey::Computed { name } = &obj_prop.key
+                {
+                    let name_type = get_type(name.identifier, identifiers);
+                    unifier.unify(name_type, Type::Primitive, shapes)?;
                 }
             }
             unifier.unify(left, Type::Object { shape_id: Some(BUILT_IN_OBJECT_ID) }, shapes)?;
@@ -759,15 +757,15 @@ fn generate_instruction_types<'a>(
         InstructionValue::JsxExpression { props, .. } => {
             if unifier.enable_treat_ref_like_identifiers_as_refs {
                 for prop in props {
-                    if let JsxAttribute::Attribute { name, place } = prop {
-                        if name == "ref" {
-                            let ref_type = get_type(place.identifier, identifiers);
-                            unifier.unify(
-                                ref_type,
-                                Type::Object { shape_id: Some(BUILT_IN_USE_REF_ID) },
-                                shapes,
-                            )?;
-                        }
+                    if let JsxAttribute::Attribute { name, place } = prop
+                        && name == "ref"
+                    {
+                        let ref_type = get_type(place.identifier, identifiers);
+                        unifier.unify(
+                            ref_type,
+                            Type::Object { shape_id: Some(BUILT_IN_USE_REF_ID) },
+                            shapes,
+                        )?;
                     }
                 }
             }
@@ -1242,12 +1240,12 @@ impl<'a> Unifier<'a> {
             return Ok(());
         }
 
-        if let Type::TypeVar { .. } = &t_a {
+        if let Type::Var { .. } = &t_a {
             self.bind_variable_to(t_a, t_b, shapes)?;
             return Ok(());
         }
 
-        if let Type::TypeVar { .. } = &t_b {
+        if let Type::Var { .. } = &t_b {
             self.bind_variable_to(t_b, t_a, shapes)?;
             return Ok(());
         }
@@ -1256,10 +1254,9 @@ impl<'a> Unifier<'a> {
             Type::Function { return_type: ret_a, is_constructor: con_a, .. },
             Type::Function { return_type: ret_b, is_constructor: con_b, .. },
         ) = (&t_a, &t_b)
+            && con_a == con_b
         {
-            if con_a == con_b {
-                self.unify_impl(*ret_a.clone(), *ret_b.clone(), shapes)?;
-            }
+            self.unify_impl(*ret_a.clone(), *ret_b.clone(), shapes)?;
         }
         Ok(())
     }
@@ -1271,7 +1268,7 @@ impl<'a> Unifier<'a> {
         shapes: &ShapeRegistry<'a>,
     ) -> Result<(), OxcDiagnostic> {
         let v_id = match &v {
-            Type::TypeVar { id } => *id,
+            Type::Var { id } => *id,
             _ => return Ok(()),
         };
 
@@ -1285,11 +1282,11 @@ impl<'a> Unifier<'a> {
             return Ok(());
         }
 
-        if let Type::TypeVar { id: ty_id } = &ty {
-            if let Some(existing) = self.substitutions.get(ty_id).cloned() {
-                self.unify_impl(v, existing, shapes)?;
-                return Ok(());
-            }
+        if let Type::Var { id: ty_id } = &ty
+            && let Some(existing) = self.substitutions.get(ty_id).cloned()
+        {
+            self.unify_impl(v, existing, shapes)?;
+            return Ok(());
         }
 
         if let Type::Phi { ref operands } = ty {
@@ -1345,19 +1342,18 @@ impl<'a> Unifier<'a> {
             Type::Phi { operands } => {
                 let mut new_operands = Vec::new();
                 for operand in operands {
-                    if let Type::TypeVar { id } = operand {
-                        if let Type::TypeVar { id: v_id } = v {
-                            if id == v_id {
-                                continue; // skip self-reference
-                            }
-                        }
+                    if let Type::Var { id } = operand
+                        && let Type::Var { id: v_id } = v
+                        && id == v_id
+                    {
+                        continue; // skip self-reference
                     }
                     let resolved = self.try_resolve_type(v, operand)?;
                     new_operands.push(resolved);
                 }
                 Some(Type::Phi { operands: new_operands })
             }
-            Type::TypeVar { id } => {
+            Type::Var { id } => {
                 let substitution = self.get(ty);
                 if !type_equals(&substitution, ty) {
                     let resolved = self.try_resolve_type(v, &substitution)?;
@@ -1396,10 +1392,10 @@ impl<'a> Unifier<'a> {
             return true;
         }
 
-        if let Type::TypeVar { id } = ty {
-            if let Some(sub) = self.substitutions.get(id) {
-                return self.occurs_check(v, sub);
-            }
+        if let Type::Var { id } = ty
+            && let Some(sub) = self.substitutions.get(id)
+        {
+            return self.occurs_check(v, sub);
         }
 
         if let Type::Phi { operands } = ty {
@@ -1414,10 +1410,10 @@ impl<'a> Unifier<'a> {
     }
 
     fn get(&self, ty: &Type<'a>) -> Type<'a> {
-        if let Type::TypeVar { id } = ty {
-            if let Some(sub) = self.substitutions.get(id) {
-                return self.get(sub);
-            }
+        if let Type::Var { id } = ty
+            && let Some(sub) = self.substitutions.get(id)
+        {
+            return self.get(sub);
         }
 
         if let Type::Phi { operands } = ty {

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_exhaustive_dependencies.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_exhaustive_dependencies.rs
@@ -81,10 +81,9 @@ pub fn validate_exhaustive_dependencies(
         for instr in func.instructions.iter_mut() {
             if let InstructionValue::StartMemoize { manual_memo_id, has_invalid_deps, .. } =
                 &mut instr.value
+                && callbacks.invalid_memo_ids.contains(manual_memo_id)
             {
-                if callbacks.invalid_memo_ids.contains(manual_memo_id) {
-                    *has_invalid_deps = true;
-                }
+                *has_invalid_deps = true;
             }
         }
     }
@@ -334,10 +333,9 @@ fn find_optional_places(func: &HirFunction) -> FxHashMap<IdentifierId, bool> {
                                 let last_instr = &func.instructions[last_id.index()];
                                 if let InstructionValue::StoreLocal { value, .. } =
                                     &last_instr.value
+                                    && let Some(opt) = is_optional
                                 {
-                                    if let Some(opt) = is_optional {
-                                        optionals.insert(value.identifier, opt);
-                                    }
+                                    optionals.insert(value.identifier, opt);
                                 }
                             }
                             break 'outer;
@@ -836,89 +834,84 @@ fn collect_dependencies<'a>(
                         let callee_ty = get_identifier_type(callee.identifier, identifiers, types);
                         if is_effect_hook(callee_ty)
                             && !matches!(cb.validate_effect, ExhaustiveEffectDepsMode::Off)
+                            && args.len() >= 2
                         {
-                            if args.len() >= 2 {
-                                let fn_arg = match &args[0] {
-                                    PlaceOrSpread::Place(p) => Some(p),
-                                    _ => None,
-                                };
-                                let deps_arg = match &args[1] {
-                                    PlaceOrSpread::Place(p) => Some(p),
-                                    _ => None,
-                                };
-                                if let (Some(fn_place), Some(deps_place)) = (fn_arg, deps_arg) {
-                                    let fn_deps = temporaries.get(&fn_place.identifier).cloned();
-                                    let manual_deps =
-                                        temporaries.get(&deps_place.identifier).cloned();
-                                    if let (
-                                        Some(Temporary::Aggregate {
-                                            dependencies: fn_dep_list,
-                                            ..
-                                        }),
-                                        Some(Temporary::Aggregate {
-                                            dependencies: manual_dep_list,
-                                            span: manual_span,
-                                        }),
-                                    ) = (fn_deps, manual_deps)
-                                    {
-                                        let effect_report_mode = match &cb.validate_effect {
-                                            ExhaustiveEffectDepsMode::All => "all",
-                                            ExhaustiveEffectDepsMode::MissingOnly => "missing-only",
-                                            ExhaustiveEffectDepsMode::ExtraOnly => "extra-only",
-                                            ExhaustiveEffectDepsMode::Off => unreachable!(),
-                                        };
-                                        // Convert manual deps to ManualMemoDependency format
-                                        let manual_memo_deps: Vec<ManualMemoDependency> =
-                                            manual_dep_list
-                                                .iter()
-                                                .map(|dep| match dep {
-                                                    InferredDependency::Local {
-                                                        identifier,
-                                                        path,
-                                                        span,
-                                                        ..
-                                                    } => ManualMemoDependency {
-                                                        root:
-                                                            ManualMemoDependencyRoot::NamedLocal {
-                                                                value: Place {
-                                                                    identifier: *identifier,
-                                                                    effect: Effect::Read,
-                                                                    reactive: cb
-                                                                        .reactive
-                                                                        .contains(identifier),
-                                                                    span: *span,
-                                                                },
-                                                                constant: false,
-                                                            },
-                                                        path: path.clone(),
-                                                        span: *span,
+                            let fn_arg = match &args[0] {
+                                PlaceOrSpread::Place(p) => Some(p),
+                                _ => None,
+                            };
+                            let deps_arg = match &args[1] {
+                                PlaceOrSpread::Place(p) => Some(p),
+                                _ => None,
+                            };
+                            if let (Some(fn_place), Some(deps_place)) = (fn_arg, deps_arg) {
+                                let fn_deps = temporaries.get(&fn_place.identifier).cloned();
+                                let manual_deps = temporaries.get(&deps_place.identifier).cloned();
+                                if let (
+                                    Some(Temporary::Aggregate {
+                                        dependencies: fn_dep_list, ..
+                                    }),
+                                    Some(Temporary::Aggregate {
+                                        dependencies: manual_dep_list,
+                                        span: manual_span,
+                                    }),
+                                ) = (fn_deps, manual_deps)
+                                {
+                                    let effect_report_mode = match &cb.validate_effect {
+                                        ExhaustiveEffectDepsMode::All => "all",
+                                        ExhaustiveEffectDepsMode::MissingOnly => "missing-only",
+                                        ExhaustiveEffectDepsMode::ExtraOnly => "extra-only",
+                                        ExhaustiveEffectDepsMode::Off => unreachable!(),
+                                    };
+                                    // Convert manual deps to ManualMemoDependency format
+                                    let manual_memo_deps: Vec<ManualMemoDependency> =
+                                        manual_dep_list
+                                            .iter()
+                                            .map(|dep| match dep {
+                                                InferredDependency::Local {
+                                                    identifier,
+                                                    path,
+                                                    span,
+                                                    ..
+                                                } => ManualMemoDependency {
+                                                    root: ManualMemoDependencyRoot::NamedLocal {
+                                                        value: Place {
+                                                            identifier: *identifier,
+                                                            effect: Effect::Read,
+                                                            reactive: cb
+                                                                .reactive
+                                                                .contains(identifier),
+                                                            span: *span,
+                                                        },
+                                                        constant: false,
                                                     },
-                                                    InferredDependency::Global { binding } => {
-                                                        ManualMemoDependency {
-                                                            root:
-                                                                ManualMemoDependencyRoot::Global {
-                                                                    identifier_name: binding.name(),
-                                                                },
-                                                            path: Vec::new(),
-                                                            span: None,
-                                                        }
+                                                    path: path.clone(),
+                                                    span: *span,
+                                                },
+                                                InferredDependency::Global { binding } => {
+                                                    ManualMemoDependency {
+                                                        root: ManualMemoDependencyRoot::Global {
+                                                            identifier_name: binding.name(),
+                                                        },
+                                                        path: Vec::new(),
+                                                        span: None,
                                                     }
-                                                })
-                                                .collect();
+                                                }
+                                            })
+                                            .collect();
 
-                                        let diagnostic = validate_dependencies(
-                                            fn_dep_list,
-                                            &manual_memo_deps,
-                                            cb.reactive,
-                                            manual_span,
-                                            ErrorCategory::EffectExhaustiveDependencies,
-                                            effect_report_mode,
-                                            identifiers,
-                                            types,
-                                        )?;
-                                        if let Some(diag) = diagnostic {
-                                            cb.diagnostics.push(diag);
-                                        }
+                                    let diagnostic = validate_dependencies(
+                                        fn_dep_list,
+                                        &manual_memo_deps,
+                                        cb.reactive,
+                                        manual_span,
+                                        ErrorCategory::EffectExhaustiveDependencies,
+                                        effect_report_mode,
+                                        identifiers,
+                                        types,
+                                    )?;
+                                    if let Some(diag) = diagnostic {
+                                        cb.diagnostics.push(diag);
                                     }
                                 }
                             }
@@ -944,88 +937,83 @@ fn collect_dependencies<'a>(
                         let prop_ty = get_identifier_type(property.identifier, identifiers, types);
                         if is_effect_hook(prop_ty)
                             && !matches!(cb.validate_effect, ExhaustiveEffectDepsMode::Off)
+                            && args.len() >= 2
                         {
-                            if args.len() >= 2 {
-                                let fn_arg = match &args[0] {
-                                    PlaceOrSpread::Place(p) => Some(p),
-                                    _ => None,
-                                };
-                                let deps_arg = match &args[1] {
-                                    PlaceOrSpread::Place(p) => Some(p),
-                                    _ => None,
-                                };
-                                if let (Some(fn_place), Some(deps_place)) = (fn_arg, deps_arg) {
-                                    let fn_deps = temporaries.get(&fn_place.identifier).cloned();
-                                    let manual_deps =
-                                        temporaries.get(&deps_place.identifier).cloned();
-                                    if let (
-                                        Some(Temporary::Aggregate {
-                                            dependencies: fn_dep_list,
-                                            ..
-                                        }),
-                                        Some(Temporary::Aggregate {
-                                            dependencies: manual_dep_list,
-                                            span: manual_span,
-                                        }),
-                                    ) = (fn_deps, manual_deps)
-                                    {
-                                        let effect_report_mode = match &cb.validate_effect {
-                                            ExhaustiveEffectDepsMode::All => "all",
-                                            ExhaustiveEffectDepsMode::MissingOnly => "missing-only",
-                                            ExhaustiveEffectDepsMode::ExtraOnly => "extra-only",
-                                            ExhaustiveEffectDepsMode::Off => unreachable!(),
-                                        };
-                                        let manual_memo_deps: Vec<ManualMemoDependency> =
-                                            manual_dep_list
-                                                .iter()
-                                                .map(|dep| match dep {
-                                                    InferredDependency::Local {
-                                                        identifier,
-                                                        path,
-                                                        span,
-                                                        ..
-                                                    } => ManualMemoDependency {
-                                                        root:
-                                                            ManualMemoDependencyRoot::NamedLocal {
-                                                                value: Place {
-                                                                    identifier: *identifier,
-                                                                    effect: Effect::Read,
-                                                                    reactive: cb
-                                                                        .reactive
-                                                                        .contains(identifier),
-                                                                    span: *span,
-                                                                },
-                                                                constant: false,
-                                                            },
-                                                        path: path.clone(),
-                                                        span: *span,
+                            let fn_arg = match &args[0] {
+                                PlaceOrSpread::Place(p) => Some(p),
+                                _ => None,
+                            };
+                            let deps_arg = match &args[1] {
+                                PlaceOrSpread::Place(p) => Some(p),
+                                _ => None,
+                            };
+                            if let (Some(fn_place), Some(deps_place)) = (fn_arg, deps_arg) {
+                                let fn_deps = temporaries.get(&fn_place.identifier).cloned();
+                                let manual_deps = temporaries.get(&deps_place.identifier).cloned();
+                                if let (
+                                    Some(Temporary::Aggregate {
+                                        dependencies: fn_dep_list, ..
+                                    }),
+                                    Some(Temporary::Aggregate {
+                                        dependencies: manual_dep_list,
+                                        span: manual_span,
+                                    }),
+                                ) = (fn_deps, manual_deps)
+                                {
+                                    let effect_report_mode = match &cb.validate_effect {
+                                        ExhaustiveEffectDepsMode::All => "all",
+                                        ExhaustiveEffectDepsMode::MissingOnly => "missing-only",
+                                        ExhaustiveEffectDepsMode::ExtraOnly => "extra-only",
+                                        ExhaustiveEffectDepsMode::Off => unreachable!(),
+                                    };
+                                    let manual_memo_deps: Vec<ManualMemoDependency> =
+                                        manual_dep_list
+                                            .iter()
+                                            .map(|dep| match dep {
+                                                InferredDependency::Local {
+                                                    identifier,
+                                                    path,
+                                                    span,
+                                                    ..
+                                                } => ManualMemoDependency {
+                                                    root: ManualMemoDependencyRoot::NamedLocal {
+                                                        value: Place {
+                                                            identifier: *identifier,
+                                                            effect: Effect::Read,
+                                                            reactive: cb
+                                                                .reactive
+                                                                .contains(identifier),
+                                                            span: *span,
+                                                        },
+                                                        constant: false,
                                                     },
-                                                    InferredDependency::Global { binding } => {
-                                                        ManualMemoDependency {
-                                                            root:
-                                                                ManualMemoDependencyRoot::Global {
-                                                                    identifier_name: binding.name(),
-                                                                },
-                                                            path: Vec::new(),
-                                                            span: None,
-                                                        }
+                                                    path: path.clone(),
+                                                    span: *span,
+                                                },
+                                                InferredDependency::Global { binding } => {
+                                                    ManualMemoDependency {
+                                                        root: ManualMemoDependencyRoot::Global {
+                                                            identifier_name: binding.name(),
+                                                        },
+                                                        path: Vec::new(),
+                                                        span: None,
                                                     }
-                                                })
-                                                .collect();
+                                                }
+                                            })
+                                            .collect();
 
-                                        let diagnostic = validate_dependencies(
-                                            fn_dep_list,
-                                            &manual_memo_deps,
-                                            cb.reactive,
-                                            manual_span,
-                                            ErrorCategory::EffectExhaustiveDependencies,
-                                            effect_report_mode,
-                                            identifiers,
-                                            types,
-                                        )?;
-                                        if let Some(diag) = diagnostic {
-                                            cb.diagnostics.push(diag);
-                                        }
+                                    let diagnostic = validate_dependencies(
+                                        fn_dep_list,
+                                        &manual_memo_deps,
+                                        cb.reactive,
+                                        manual_span,
+                                        ErrorCategory::EffectExhaustiveDependencies,
+                                        effect_report_mode,
+                                        identifiers,
+                                        types,
+                                    )?;
+                                    if let Some(diag) = diagnostic {
+                                        cb.diagnostics.push(diag);
                                     }
                                 }
                             }
@@ -1227,11 +1215,11 @@ fn validate_dependencies(
         match inferred_dep {
             InferredDependency::Global { binding } => {
                 for (i, manual_dep) in manual_dependencies.iter().enumerate() {
-                    if let ManualMemoDependencyRoot::Global { identifier_name } = &manual_dep.root {
-                        if *identifier_name == binding.name() {
-                            matched.insert(i);
-                            extra.push(manual_dep);
-                        }
+                    if let ManualMemoDependencyRoot::Global { identifier_name } = &manual_dep.root
+                        && *identifier_name == binding.name()
+                    {
+                        matched.insert(i);
+                        extra.push(manual_dep);
                     }
                 }
                 continue;
@@ -1245,14 +1233,13 @@ fn validate_dependencies(
 
                 let mut has_matching = false;
                 for (i, manual_dep) in manual_dependencies.iter().enumerate() {
-                    if let ManualMemoDependencyRoot::NamedLocal { value, .. } = &manual_dep.root {
-                        if value.identifier == *identifier
-                            && (are_equal_paths(&manual_dep.path, path)
-                                || is_sub_path_ignoring_optionals(&manual_dep.path, path))
-                        {
-                            has_matching = true;
-                            matched.insert(i);
-                        }
+                    if let ManualMemoDependencyRoot::NamedLocal { value, .. } = &manual_dep.root
+                        && value.identifier == *identifier
+                        && (are_equal_paths(&manual_dep.path, path)
+                            || is_sub_path_ignoring_optionals(&manual_dep.path, path))
+                    {
+                        has_matching = true;
+                        matched.insert(i);
                     }
                 }
 
@@ -1271,13 +1258,13 @@ fn validate_dependencies(
         if matched.contains(&i) {
             continue;
         }
-        if let ManualMemoDependencyRoot::NamedLocal { constant, value, .. } = &dep.root {
-            if *constant {
-                let dep_ty = get_identifier_type(value.identifier, identifiers, types);
-                // Constant-folded primitives: skip
-                if !value.reactive && is_primitive_type(dep_ty) {
-                    continue;
-                }
+        if let ManualMemoDependencyRoot::NamedLocal { constant, value, .. } = &dep.root
+            && *constant
+        {
+            let dep_ty = get_identifier_type(value.identifier, identifiers, types);
+            // Constant-folded primitives: skip
+            if !value.reactive && is_primitive_type(dep_ty) {
+                continue;
             }
         }
         extra.push(dep);

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_hooks_usage.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_hooks_usage.rs
@@ -60,10 +60,10 @@ fn get_kind_for_place(
 ) -> Kind {
     let known_kind = value_kinds.get(&place.identifier).copied();
     let ident = &identifiers[place.identifier];
-    if let Some(ref name) = ident.name {
-        if is_hook_name(name.value()) {
-            return join_kinds(known_kind.unwrap_or(Kind::Local), Kind::PotentialHook);
-        }
+    if let Some(ref name) = ident.name
+        && is_hook_name(name.value())
+    {
+        return join_kinds(known_kind.unwrap_or(Kind::Local), Kind::PotentialHook);
     }
     known_kind.unwrap_or(Kind::Local)
 }

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_locals_not_reassigned_after_render.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_locals_not_reassigned_after_render.rs
@@ -17,7 +17,7 @@ use crate::react_compiler_hir::visitors::{
 };
 use crate::react_compiler_hir::{
     Effect, FunctionId, HirFunction, Identifier, IdentifierId, IdentifierName, InstructionValue,
-    Place, Type, TypeId,
+    Place,
 };
 
 /// Validates that local variables cannot be reassigned after render.
@@ -30,7 +30,6 @@ pub fn validate_locals_not_reassigned_after_render(func: &HirFunction, env: &mut
     let reassignment = get_context_reassignment(
         func,
         &env.identifiers,
-        &env.types,
         &env.functions,
         env,
         &mut context_variables,
@@ -79,11 +78,10 @@ fn format_variable_name(
 /// context variable. Returns the reassigned place if found, or None.
 ///
 /// Side effects: accumulates async-function reassignment diagnostics into `diagnostics`.
-#[allow(clippy::only_used_in_recursion, clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 fn get_context_reassignment(
     func: &HirFunction,
     identifiers: &IndexSlice<IdentifierId, [Identifier]>,
-    types: &IndexSlice<TypeId, [Type]>,
     functions: &IndexSlice<FunctionId, [HirFunction]>,
     env: &Environment,
     context_variables: &mut FxHashSet<IdentifierId>,
@@ -108,7 +106,6 @@ fn get_context_reassignment(
                     let mut reassignment = get_context_reassignment(
                         inner_function,
                         identifiers,
-                        types,
                         functions,
                         env,
                         context_variables,

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_derived_computations_in_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_derived_computations_in_effects.rs
@@ -155,13 +155,12 @@ impl<'a> DerivationCache<'a> {
         let mut final_is_source = is_state_source;
         if !final_is_source {
             for source_id in &source_ids {
-                if let Some(source_metadata) = self.cache.get(source_id) {
-                    if source_metadata.is_state_source
-                        && !matches!(&source_metadata.place_name, Some(IdentifierName::Named(_)))
-                    {
-                        final_is_source = true;
-                        break;
-                    }
+                if let Some(source_metadata) = self.cache.get(source_id)
+                    && source_metadata.is_state_source
+                    && !matches!(&source_metadata.place_name, Some(IdentifierName::Named(_)))
+                {
+                    final_is_source = true;
+                    break;
                 }
             }
         }
@@ -307,24 +306,23 @@ pub fn validate_no_derived_computations_in_effects_exp(
                 );
             }
         }
-    } else if func.fn_type == ReactFunctionType::Component {
-        if let Some(ParamPattern::Place(place)) = func.params.first() {
-            let name = identifiers[place.identifier].name;
-            context.derivation_cache.cache.insert(
-                place.identifier,
-                DerivationMetadata {
-                    place_identifier: place.identifier,
-                    place_name: name,
-                    source_ids: FxIndexSet::default(),
-                    type_of_value: TypeOfValue::FromProps,
-                    is_state_source: true,
-                },
-            );
-        }
+    } else if func.fn_type == ReactFunctionType::Component
+        && let Some(ParamPattern::Place(place)) = func.params.first()
+    {
+        let name = identifiers[place.identifier].name;
+        context.derivation_cache.cache.insert(
+            place.identifier,
+            DerivationMetadata {
+                place_identifier: place.identifier,
+                place_name: name,
+                source_ids: FxIndexSet::default(),
+                type_of_value: TypeOfValue::FromProps,
+                is_state_source: true,
+            },
+        );
     }
 
     // Fixpoint iteration
-    let mut is_first_pass = true;
     let mut iteration_count = 0;
     loop {
         context.derivation_cache.take_snapshot();
@@ -333,12 +331,11 @@ pub fn validate_no_derived_computations_in_effects_exp(
             record_phi_derivations(block, &mut context, env);
             for &instr_id in &block.instructions {
                 let instr = &func.instructions[instr_id.index()];
-                record_instruction_derivations(instr, &mut context, is_first_pass, env)?;
+                record_instruction_derivations(instr, &mut context, env)?;
             }
         }
 
         context.derivation_cache.check_for_changes();
-        is_first_pass = false;
         iteration_count += 1;
         assert!(
             iteration_count < MAX_FIXPOINT_ITERATIONS,
@@ -396,11 +393,9 @@ fn record_phi_derivations<'a>(
     }
 }
 
-#[allow(clippy::only_used_in_recursion)]
 fn record_instruction_derivations<'a>(
     instr: &Instruction,
     context: &mut ValidationContext<'a>,
-    is_first_pass: bool,
     env: &Environment<'a>,
 ) -> Result<(), OxcDiagnostic> {
     let identifiers = &env.identifiers;
@@ -429,24 +424,23 @@ fn record_instruction_derivations<'a>(
                 record_phi_derivations(block, context, env);
                 for &inner_instr_id in &block.instructions {
                     let inner_instr = &inner_func.instructions[inner_instr_id.index()];
-                    record_instruction_derivations(inner_instr, context, is_first_pass, env)?;
+                    record_instruction_derivations(inner_instr, context, env)?;
                 }
             }
         }
         InstructionValue::CallExpression { callee, args, .. } => {
             let callee_type = &types[identifiers[callee.identifier].type_];
-            if is_use_effect_hook_type(callee_type) && args.len() == 2 {
-                if let (PlaceOrSpread::Place(arg0), PlaceOrSpread::Place(arg1)) =
+            if is_use_effect_hook_type(callee_type)
+                && args.len() == 2
+                && let (PlaceOrSpread::Place(arg0), PlaceOrSpread::Place(arg1)) =
                     (&args[0], &args[1])
-                {
-                    let effect_function = context.functions.get(&arg0.identifier).copied();
-                    let deps = context.candidate_dependencies.get(&arg1.identifier).cloned();
-                    if let (Some(effect_func_id), Some(dep_elements)) = (effect_function, deps) {
-                        context.effects_cache.insert(
-                            arg0.identifier,
-                            EffectMetadata { effect_func_id, dep_elements },
-                        );
-                    }
+            {
+                let effect_function = context.functions.get(&arg0.identifier).copied();
+                let deps = context.candidate_dependencies.get(&arg1.identifier).cloned();
+                if let (Some(effect_func_id), Some(dep_elements)) = (effect_function, deps) {
+                    context
+                        .effects_cache
+                        .insert(arg0.identifier, EffectMetadata { effect_func_id, dep_elements });
                 }
             }
 
@@ -466,18 +460,17 @@ fn record_instruction_derivations<'a>(
         }
         InstructionValue::MethodCall { property, args, .. } => {
             let prop_type = &types[identifiers[property.identifier].type_];
-            if is_use_effect_hook_type(prop_type) && args.len() == 2 {
-                if let (PlaceOrSpread::Place(arg0), PlaceOrSpread::Place(arg1)) =
+            if is_use_effect_hook_type(prop_type)
+                && args.len() == 2
+                && let (PlaceOrSpread::Place(arg0), PlaceOrSpread::Place(arg1)) =
                     (&args[0], &args[1])
-                {
-                    let effect_function = context.functions.get(&arg0.identifier).copied();
-                    let deps = context.candidate_dependencies.get(&arg1.identifier).cloned();
-                    if let (Some(effect_func_id), Some(dep_elements)) = (effect_function, deps) {
-                        context.effects_cache.insert(
-                            arg0.identifier,
-                            EffectMetadata { effect_func_id, dep_elements },
-                        );
-                    }
+            {
+                let effect_function = context.functions.get(&arg0.identifier).copied();
+                let deps = context.candidate_dependencies.get(&arg1.identifier).cloned();
+                if let (Some(effect_func_id), Some(dep_elements)) = (effect_function, deps) {
+                    context
+                        .effects_cache
+                        .insert(arg0.identifier, EffectMetadata { effect_func_id, dep_elements });
                 }
             }
 
@@ -516,10 +509,10 @@ fn record_instruction_derivations<'a>(
         if context.set_state_loads.contains_key(&operand_id) {
             let root =
                 get_root_set_state(operand_id, &context.set_state_loads, &mut FxHashSet::default());
-            if let Some(root_id) = root {
-                if let Some(usages) = context.set_state_usages.get_mut(&root_id) {
-                    usages.insert(operand_span.unwrap_or_default());
-                }
+            if let Some(root_id) = root
+                && let Some(usages) = context.set_state_usages.get_mut(&root_id)
+            {
+                usages.insert(operand_span.unwrap_or_default());
             }
         }
 
@@ -625,15 +618,15 @@ fn build_tree_node<'a>(
         None => return Vec::new(),
     };
 
-    if source_metadata.is_state_source {
-        if let Some(IdentifierName::Named(name)) = &source_metadata.place_name {
-            return vec![TreeNode {
-                name: *name,
-                type_of_value: source_metadata.type_of_value,
-                is_source: true,
-                children: Vec::new(),
-            }];
-        }
+    if source_metadata.is_state_source
+        && let Some(IdentifierName::Named(name)) = &source_metadata.place_name
+    {
+        return vec![TreeNode {
+            name: *name,
+            type_of_value: source_metadata.type_of_value,
+            is_source: true,
+            children: Vec::new(),
+        }];
     }
 
     let mut children: Vec<TreeNode> = Vec::new();
@@ -659,15 +652,15 @@ fn build_tree_node<'a>(
         }
     }
 
-    if let Some(IdentifierName::Named(name)) = &source_metadata.place_name {
-        if !visited.contains(name) {
-            return vec![TreeNode {
-                name: *name,
-                type_of_value: source_metadata.type_of_value,
-                is_source: source_metadata.is_state_source,
-                children,
-            }];
-        }
+    if let Some(IdentifierName::Named(name)) = &source_metadata.place_name
+        && !visited.contains(name)
+    {
+        return vec![TreeNode {
+            name: *name,
+            type_of_value: source_metadata.type_of_value,
+            is_source: source_metadata.is_state_source,
+            children,
+        }];
     }
 
     children
@@ -819,10 +812,10 @@ fn validate_effect<'a>(
                         &context.set_state_loads,
                         &mut FxHashSet::default(),
                     );
-                    if let Some(root_id) = root {
-                        if let Some(usages) = effect_set_state_usages.get_mut(&root_id) {
-                            usages.insert(operand_span.unwrap_or_default());
-                        }
+                    if let Some(root_id) = root
+                        && let Some(usages) = effect_set_state_usages.get_mut(&root_id)
+                    {
+                        usages.insert(operand_span.unwrap_or_default());
                     }
                 }
             }
@@ -857,12 +850,11 @@ fn validate_effect<'a>(
                         // Check if callee is from props/propsAndState -> bail
                         let callee_metadata =
                             context.derivation_cache.cache.get(&callee.identifier);
-                        if let Some(cm) = callee_metadata {
-                            if cm.type_of_value == TypeOfValue::FromProps
-                                || cm.type_of_value == TypeOfValue::FromPropsAndState
-                            {
-                                return;
-                            }
+                        if let Some(cm) = callee_metadata
+                            && (cm.type_of_value == TypeOfValue::FromProps
+                                || cm.type_of_value == TypeOfValue::FromPropsAndState)
+                        {
+                            return;
                         }
 
                         if globals.contains(&callee.identifier) {
@@ -1020,44 +1012,40 @@ pub fn validate_no_derived_computations_in_effects(
                     }
                     InstructionValue::CallExpression { callee, args, .. } => {
                         let callee_ty = &tys[ids[callee.identifier].type_];
-                        if is_use_effect_hook_type(callee_ty) && args.len() == 2 {
-                            if let (PlaceOrSpread::Place(arg0), PlaceOrSpread::Place(arg1)) =
+                        if is_use_effect_hook_type(callee_ty)
+                            && args.len() == 2
+                            && let (PlaceOrSpread::Place(arg0), PlaceOrSpread::Place(arg1)) =
                                 (&args[0], &args[1])
-                            {
-                                if let (Some(&func_id), Some(dep_elements)) = (
-                                    functions_map.get(&arg0.identifier),
-                                    candidate_deps.get(&arg1.identifier),
-                                ) {
-                                    if !dep_elements.is_empty() {
-                                        let resolved: Vec<IdentifierId> = dep_elements
-                                            .iter()
-                                            .map(|d| locals_map.get(d).copied().unwrap_or(*d))
-                                            .collect();
-                                        result.push((func_id, resolved));
-                                    }
-                                }
-                            }
+                            && let (Some(&func_id), Some(dep_elements)) = (
+                                functions_map.get(&arg0.identifier),
+                                candidate_deps.get(&arg1.identifier),
+                            )
+                            && !dep_elements.is_empty()
+                        {
+                            let resolved: Vec<IdentifierId> = dep_elements
+                                .iter()
+                                .map(|d| locals_map.get(d).copied().unwrap_or(*d))
+                                .collect();
+                            result.push((func_id, resolved));
                         }
                     }
                     InstructionValue::MethodCall { property, args, .. } => {
                         let callee_ty = &tys[ids[property.identifier].type_];
-                        if is_use_effect_hook_type(callee_ty) && args.len() == 2 {
-                            if let (PlaceOrSpread::Place(arg0), PlaceOrSpread::Place(arg1)) =
+                        if is_use_effect_hook_type(callee_ty)
+                            && args.len() == 2
+                            && let (PlaceOrSpread::Place(arg0), PlaceOrSpread::Place(arg1)) =
                                 (&args[0], &args[1])
-                            {
-                                if let (Some(&func_id), Some(dep_elements)) = (
-                                    functions_map.get(&arg0.identifier),
-                                    candidate_deps.get(&arg1.identifier),
-                                ) {
-                                    if !dep_elements.is_empty() {
-                                        let resolved: Vec<IdentifierId> = dep_elements
-                                            .iter()
-                                            .map(|d| locals_map.get(d).copied().unwrap_or(*d))
-                                            .collect();
-                                        result.push((func_id, resolved));
-                                    }
-                                }
-                            }
+                            && let (Some(&func_id), Some(dep_elements)) = (
+                                functions_map.get(&arg0.identifier),
+                                candidate_deps.get(&arg1.identifier),
+                            )
+                            && !dep_elements.is_empty()
+                        {
+                            let resolved: Vec<IdentifierId> = dep_elements
+                                .iter()
+                                .map(|d| locals_map.get(d).copied().unwrap_or(*d))
+                                .collect();
+                            result.push((func_id, resolved));
                         }
                     }
                     _ => {}
@@ -1166,20 +1154,21 @@ fn validate_effect_non_exp(
 
                     if let InstructionValue::CallExpression { callee, args, .. } = &instr.value {
                         let callee_ty = &tys[ids[callee.identifier].type_];
-                        if is_set_state_type(callee_ty) && args.len() == 1 {
-                            if let PlaceOrSpread::Place(arg) = &args[0] {
-                                if let Some(deps) = dep_values.get(&arg.identifier) {
-                                    let dep_set: FxHashSet<_> = deps.iter().collect();
-                                    if dep_set.len() == effect_deps.len() {
-                                        if let Some(span) = callee.span {
-                                            set_state_spans.push(span);
-                                        }
-                                    } else {
-                                        return Vec::new();
+                        if is_set_state_type(callee_ty)
+                            && args.len() == 1
+                            && let PlaceOrSpread::Place(arg) = &args[0]
+                        {
+                            if let Some(deps) = dep_values.get(&arg.identifier) {
+                                let dep_set: FxHashSet<_> = deps.iter().collect();
+                                if dep_set.len() == effect_deps.len() {
+                                    if let Some(span) = callee.span {
+                                        set_state_spans.push(span);
                                     }
                                 } else {
                                     return Vec::new();
                                 }
+                            } else {
+                                return Vec::new();
                             }
                         }
                     }

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_freezing_known_mutable_functions.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_freezing_known_mutable_functions.rs
@@ -173,36 +173,36 @@ fn check_operand_for_freeze_violation(
     identifiers: &IndexSlice<IdentifierId, [Identifier]>,
     diagnostics: &mut Vec<OxcDiagnostic>,
 ) {
-    if operand.effect == Effect::Freeze {
-        if let Some(mutation_info) = context_mutation_effects.get(&operand.identifier) {
-            let identifier = &identifiers[mutation_info.value_identifier];
-            let variable_name = match &identifier.name {
-                Some(IdentifierName::Named(name)) => format!("`{}`", name),
-                _ => "a local variable".to_string(),
-            };
+    if operand.effect == Effect::Freeze
+        && let Some(mutation_info) = context_mutation_effects.get(&operand.identifier)
+    {
+        let identifier = &identifiers[mutation_info.value_identifier];
+        let variable_name = match &identifier.name {
+            Some(IdentifierName::Named(name)) => format!("`{}`", name),
+            _ => "a local variable".to_string(),
+        };
 
-            diagnostics.push(
-                ErrorCategory::Immutability
-                    .diagnostic("Cannot modify local variables after render completes")
-                    .with_help(format!(
-                        "This argument is a function which may reassign or mutate {} after render, \
+        diagnostics.push(
+            ErrorCategory::Immutability
+                .diagnostic("Cannot modify local variables after render completes")
+                .with_help(format!(
+                    "This argument is a function which may reassign or mutate {} after render, \
                          which can cause inconsistent behavior on subsequent renders. \
                          Consider using state instead",
+                    variable_name
+                ))
+                .with_labels(operand.span.map(|s| {
+                    s.label(format!(
+                        "This function may (indirectly) reassign or modify {} after render",
                         variable_name
                     ))
-                    .with_labels(operand.span.map(|s| {
-                        s.label(format!(
-                            "This function may (indirectly) reassign or modify {} after render",
-                            variable_name
-                        ))
-                    }))
-                    .and_labels(
-                        mutation_info
-                            .value_span
-                            .map(|s| s.label(format!("This modifies {}", variable_name))),
-                    ),
-            );
-        }
+                }))
+                .and_labels(
+                    mutation_info
+                        .value_span
+                        .map(|s| s.label(format!("This modifies {}", variable_name))),
+                ),
+        );
     }
 }
 

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_ref_access_in_render.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_ref_access_in_render.rs
@@ -817,23 +817,23 @@ fn validate_no_ref_access_in_render_impl(
                                             }
                                             _ => (None, "none"),
                                         };
-                                        if let Some(place) = place {
-                                            if validation != "none" {
-                                                let key = format!(
-                                                    "{}:{}",
-                                                    place.identifier.index(),
-                                                    validation
-                                                );
-                                                if visited_effects.insert(key) {
-                                                    if validation == "direct-ref" {
-                                                        validate_no_direct_ref_value_access(
-                                                            errors, place, ref_env,
-                                                        );
-                                                    } else {
-                                                        validate_no_ref_passed_to_function(
-                                                            errors, ref_env, place, place.span,
-                                                        );
-                                                    }
+                                        if let Some(place) = place
+                                            && validation != "none"
+                                        {
+                                            let key = format!(
+                                                "{}:{}",
+                                                place.identifier.index(),
+                                                validation
+                                            );
+                                            if visited_effects.insert(key) {
+                                                if validation == "direct-ref" {
+                                                    validate_no_direct_ref_value_access(
+                                                        errors, place, ref_env,
+                                                    );
+                                                } else {
+                                                    validate_no_ref_passed_to_function(
+                                                        errors, ref_env, place, place.span,
+                                                    );
                                                 }
                                             }
                                         }
@@ -902,14 +902,12 @@ fn validate_no_ref_access_in_render_impl(
                     | InstructionValue::ComputedStore { object, .. } => {
                         let target = ref_env.get(object.identifier).cloned();
                         let mut found_safe = false;
-                        if matches!(&instr.value, InstructionValue::PropertyStore { .. }) {
-                            if let Some(RefAccessType::Ref { ref_id }) = &target {
-                                if let Some(pos) = safe_blocks.iter().position(|(_, r)| r == ref_id)
-                                {
-                                    safe_blocks.remove(pos);
-                                    found_safe = true;
-                                }
-                            }
+                        if matches!(&instr.value, InstructionValue::PropertyStore { .. })
+                            && let Some(RefAccessType::Ref { ref_id }) = &target
+                            && let Some(pos) = safe_blocks.iter().position(|(_, r)| r == ref_id)
+                        {
+                            safe_blocks.remove(pos);
+                            found_safe = true;
                         }
                         if !found_safe {
                             validate_no_ref_update(errors, ref_env, object, instr.span);
@@ -1064,12 +1062,11 @@ fn validate_no_ref_access_in_render_impl(
             }
 
             // Check if terminal is an `if` — push safe block for guard
-            if let Terminal::If { test, fallthrough, .. } = &block.terminal {
-                if let Some(RefAccessType::Guard { ref_id }) = ref_env.get(test.identifier) {
-                    if !safe_blocks.iter().any(|(_, r)| r == ref_id) {
-                        safe_blocks.push((*fallthrough, *ref_id));
-                    }
-                }
+            if let Terminal::If { test, fallthrough, .. } = &block.terminal
+                && let Some(RefAccessType::Guard { ref_id }) = ref_env.get(test.identifier)
+                && !safe_blocks.iter().any(|(_, r)| r == ref_id)
+            {
+                safe_blocks.push((*fallthrough, *ref_id));
             }
 
             // Process terminal operands

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_set_state_in_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_set_state_in_effects.rs
@@ -86,47 +86,43 @@ pub fn validate_no_set_state_in_effects(
                 InstructionValue::MethodCall { property, args, .. } => {
                     let prop_type = &types[identifiers[property.identifier].type_];
                     if is_use_effect_event_type(prop_type) {
-                        if let Some(PlaceOrSpread::Place(arg_place)) = args.first() {
-                            if let Some(info) = set_state_functions.get(&arg_place.identifier) {
-                                set_state_functions.insert(instr.lvalue.identifier, info.clone());
-                            }
+                        if let Some(PlaceOrSpread::Place(arg_place)) = args.first()
+                            && let Some(info) = set_state_functions.get(&arg_place.identifier)
+                        {
+                            set_state_functions.insert(instr.lvalue.identifier, info.clone());
                         }
-                    } else if is_use_effect_hook_type(prop_type)
+                    } else if (is_use_effect_hook_type(prop_type)
                         || is_use_layout_effect_hook_type(prop_type)
-                        || is_use_insertion_effect_hook_type(prop_type)
+                        || is_use_insertion_effect_hook_type(prop_type))
+                        && let Some(PlaceOrSpread::Place(arg_place)) = args.first()
+                        && let Some(info) = set_state_functions.get(&arg_place.identifier)
                     {
-                        if let Some(PlaceOrSpread::Place(arg_place)) = args.first() {
-                            if let Some(info) = set_state_functions.get(&arg_place.identifier) {
-                                push_error(
-                                    &mut errors,
-                                    info,
-                                    env.config.enable_verbose_no_set_state_in_effect,
-                                );
-                            }
-                        }
+                        push_error(
+                            &mut errors,
+                            info,
+                            env.config.enable_verbose_no_set_state_in_effect,
+                        );
                     }
                 }
                 InstructionValue::CallExpression { callee, args, .. } => {
                     let callee_type = &types[identifiers[callee.identifier].type_];
                     if is_use_effect_event_type(callee_type) {
-                        if let Some(PlaceOrSpread::Place(arg_place)) = args.first() {
-                            if let Some(info) = set_state_functions.get(&arg_place.identifier) {
-                                set_state_functions.insert(instr.lvalue.identifier, info.clone());
-                            }
+                        if let Some(PlaceOrSpread::Place(arg_place)) = args.first()
+                            && let Some(info) = set_state_functions.get(&arg_place.identifier)
+                        {
+                            set_state_functions.insert(instr.lvalue.identifier, info.clone());
                         }
-                    } else if is_use_effect_hook_type(callee_type)
+                    } else if (is_use_effect_hook_type(callee_type)
                         || is_use_layout_effect_hook_type(callee_type)
-                        || is_use_insertion_effect_hook_type(callee_type)
+                        || is_use_insertion_effect_hook_type(callee_type))
+                        && let Some(PlaceOrSpread::Place(arg_place)) = args.first()
+                        && let Some(info) = set_state_functions.get(&arg_place.identifier)
                     {
-                        if let Some(PlaceOrSpread::Place(arg_place)) = args.first() {
-                            if let Some(info) = set_state_functions.get(&arg_place.identifier) {
-                                push_error(
-                                    &mut errors,
-                                    info,
-                                    env.config.enable_verbose_no_set_state_in_effect,
-                                );
-                            }
-                        }
+                        push_error(
+                            &mut errors,
+                            info,
+                            env.config.enable_verbose_no_set_state_in_effect,
+                        );
                     }
                 }
                 _ => {}
@@ -292,16 +288,16 @@ fn create_ref_controlled_block_checker(
                         break;
                     }
                     for case in cases {
-                        if let Some(case_test) = &case.test {
-                            if is_derived_from_ref(
+                        if let Some(case_test) = &case.test
+                            && is_derived_from_ref(
                                 case_test.identifier,
                                 ref_derived_values,
                                 identifiers,
                                 types,
-                            ) {
-                                is_controlled = true;
-                                break;
-                            }
+                            )
+                        {
+                            is_controlled = true;
+                            break;
                         }
                     }
                     if is_controlled {
@@ -364,13 +360,13 @@ fn get_set_state_call(
                     }
                 }
 
-                if let InstructionValue::PropertyLoad { object, property, .. } = &instr.value {
-                    if property.is_string("current") {
-                        let obj_ident = &identifiers[object.identifier];
-                        let obj_ty = &types[obj_ident.type_];
-                        if is_use_ref_type(obj_ty) || is_ref_value_type(obj_ty) {
-                            ref_derived_values.insert(instr.lvalue.identifier);
-                        }
+                if let InstructionValue::PropertyLoad { object, property, .. } = &instr.value
+                    && property.is_string("current")
+                {
+                    let obj_ident = &identifiers[object.identifier];
+                    let obj_ty = &types[obj_ident.type_];
+                    if is_use_ref_type(obj_ty) || is_ref_value_type(obj_ty) {
+                        ref_derived_values.insert(instr.lvalue.identifier);
                     }
                 }
             }
@@ -454,13 +450,13 @@ fn get_set_state_call(
                 }
 
                 // Special case: PropertyLoad of .current on ref/refValue
-                if let InstructionValue::PropertyLoad { object, property, .. } = &instr.value {
-                    if property.is_string("current") {
-                        let obj_ident = &identifiers[object.identifier];
-                        let obj_ty = &types[obj_ident.type_];
-                        if is_use_ref_type(obj_ty) || is_ref_value_type(obj_ty) {
-                            ref_derived_values.insert(instr.lvalue.identifier);
-                        }
+                if let InstructionValue::PropertyLoad { object, property, .. } = &instr.value
+                    && property.is_string("current")
+                {
+                    let obj_ident = &identifiers[object.identifier];
+                    let obj_ty = &types[obj_ident.type_];
+                    if is_use_ref_type(obj_ty) || is_ref_value_type(obj_ty) {
+                        ref_derived_values.insert(instr.lvalue.identifier);
                     }
                 }
             }
@@ -485,16 +481,16 @@ fn get_set_state_call(
                 {
                     if enable_allow_set_state_from_refs {
                         // Check if the first argument is ref-derived
-                        if let Some(PlaceOrSpread::Place(arg_place)) = args.first() {
-                            if is_derived_from_ref(
+                        if let Some(PlaceOrSpread::Place(arg_place)) = args.first()
+                            && is_derived_from_ref(
                                 arg_place.identifier,
                                 &ref_derived_values,
                                 identifiers,
                                 types,
-                            ) {
-                                // Allow setState when value is derived from ref
-                                return Ok(None);
-                            }
+                            )
+                        {
+                            // Allow setState when value is derived from ref
+                            return Ok(None);
                         }
                         // Check if the current block is controlled by a ref-derived condition
                         if is_ref_controlled_block(block.id) {

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_preserved_manual_memoization.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_preserved_manual_memoization.rs
@@ -138,25 +138,25 @@ fn visit_scope<'h>(scope_block: &ReactiveScopeBlock<'h>, state: &mut VisitorStat
     visit_block(&scope_block.instructions, state);
 
     // After traversing, validate scope dependencies against manual memo deps
-    if let Some(ref memo_state) = state.manual_memo_state {
-        if let Some(ref deps_from_source) = memo_state.deps_from_source {
-            let scope = &state.env.scopes[scope_block.scope];
-            let deps = scope.dependencies.clone();
-            let memo_span = memo_state.span;
-            let decls = memo_state.decls.clone();
-            let deps_from_source = deps_from_source.clone();
-            let temporaries = state.temporaries.clone();
-            for dep in &deps {
-                validate_inferred_dep(
-                    dep.identifier,
-                    &dep.path,
-                    &temporaries,
-                    &decls,
-                    &deps_from_source,
-                    state.env,
-                    memo_span,
-                );
-            }
+    if let Some(ref memo_state) = state.manual_memo_state
+        && let Some(ref deps_from_source) = memo_state.deps_from_source
+    {
+        let scope = &state.env.scopes[scope_block.scope];
+        let deps = scope.dependencies.clone();
+        let memo_span = memo_state.span;
+        let decls = memo_state.decls.clone();
+        let deps_from_source = deps_from_source.clone();
+        let temporaries = state.temporaries.clone();
+        for dep in &deps {
+            validate_inferred_dep(
+                dep.identifier,
+                &dep.path,
+                &temporaries,
+                &decls,
+                &deps_from_source,
+                state.env,
+                memo_span,
+            );
         }
     }
 
@@ -210,10 +210,11 @@ fn visit_instruction<'h>(instr: &ReactiveInstruction<'h>, state: &mut VisitorSta
             let operand_places = start_memoize_operands(deps);
             for place in &operand_places {
                 let ident = &state.env.identifiers[place.identifier];
-                if let Some(scope_id) = ident.scope {
-                    if !state.scopes.contains(&scope_id) && !state.pruned_scopes.contains(&scope_id)
-                    {
-                        let diag = ErrorCategory::PreserveManualMemo
+                if let Some(scope_id) = ident.scope
+                    && !state.scopes.contains(&scope_id)
+                    && !state.pruned_scopes.contains(&scope_id)
+                {
+                    let diag = ErrorCategory::PreserveManualMemo
                             .diagnostic("Existing memoization could not be preserved")
                             .with_help(
                                 "React Compiler has skipped optimizing this component because the existing manual memoization could not be preserved. \
@@ -224,8 +225,7 @@ fn visit_instruction<'h>(instr: &ReactiveInstruction<'h>, state: &mut VisitorSta
                                     .span
                                     .map(|s| s.label("This dependency may be modified later")),
                             );
-                        state.env.record_diagnostic(diag);
-                    }
+                    state.env.record_diagnostic(diag);
                 }
             }
         }
@@ -317,16 +317,18 @@ fn record_unmemoized_error(span: Option<Span>, env: &mut Environment) {
 fn record_temporaries<'h>(instr: &ReactiveInstruction<'h>, state: &mut VisitorState<'_, 'h>) {
     let lvalue = &instr.lvalue;
     let lv_id = lvalue.as_ref().map(|lv| lv.identifier);
-    if let Some(id) = lv_id {
-        if state.temporaries.contains_key(&id) {
-            return;
-        }
+    if let Some(id) = lv_id
+        && state.temporaries.contains_key(&id)
+    {
+        return;
     }
 
     if let Some(ref lvalue) = instr.lvalue {
         let lv_ident = &state.env.identifiers[lvalue.identifier];
-        if is_named(lv_ident) && state.manual_memo_state.is_some() {
-            state.manual_memo_state.as_mut().unwrap().decls.insert(lv_ident.declaration_id);
+        if is_named(lv_ident)
+            && let Some(manual_memo_state) = state.manual_memo_state.as_mut()
+        {
+            manual_memo_state.decls.insert(lv_ident.declaration_id);
         }
     }
 

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_use_memo.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_use_memo.rs
@@ -70,12 +70,11 @@ fn validate_use_memo_impl(
                     }
                 }
                 InstructionValue::PropertyLoad { object, property, .. } => {
-                    if react.contains(&object.identifier) {
-                        if let PropertyLiteral::String(prop_name) = property {
-                            if prop_name == "useMemo" {
-                                use_memos.insert(lvalue.identifier);
-                            }
-                        }
+                    if react.contains(&object.identifier)
+                        && let PropertyLiteral::String(prop_name) = property
+                        && prop_name == "useMemo"
+                    {
+                        use_memos.insert(lvalue.identifier);
                     }
                 }
                 InstructionValue::FunctionExpression { lowered_func, span, .. } => {
@@ -218,12 +217,10 @@ fn handle_possible_use_memo_call(
                     body_info.span.map(|s| s.label("useMemo() callbacks must return a value")),
                 ),
         );
-    } else if validate_no_void_use_memo {
-        if let Some(callee_span) = callee.span {
-            // The callee is always useMemo/React.useMemo since we checked is_use_memo above.
-            // The identifierName in Babel's AST Span is "useMemo".
-            unused_use_memos.insert(lvalue.identifier, (callee_span, Some("useMemo".to_string())));
-        }
+    } else if validate_no_void_use_memo && let Some(callee_span) = callee.span {
+        // The callee is always useMemo/React.useMemo since we checked is_use_memo above.
+        // The identifierName in Babel's AST Span is "useMemo".
+        unused_use_memos.insert(lvalue.identifier, (callee_span, Some("useMemo".to_string())));
     }
 }
 
@@ -234,9 +231,10 @@ fn validate_no_context_variable_assignment(func: &HirFunction, errors: &mut Diag
     for (_block_id, block) in &func.body.blocks {
         for &instr_id in &block.instructions {
             let instr = &func.instructions[instr_id.index()];
-            if let InstructionValue::StoreContext { lvalue, .. } = &instr.value {
-                if context.contains(&lvalue.place.identifier) {
-                    errors.push(
+            if let InstructionValue::StoreContext { lvalue, .. } = &instr.value
+                && context.contains(&lvalue.place.identifier)
+            {
+                errors.push(
                         ErrorCategory::UseMemo
                             .diagnostic(
                                 "useMemo() callbacks may not reassign variables declared outside of the callback",
@@ -248,7 +246,6 @@ fn validate_no_context_variable_assignment(func: &HirFunction, errors: &mut Diag
                                 lvalue.place.span.map(|s| s.label("Cannot reassign variable")),
                             ),
                     );
-                }
             }
         }
     }
@@ -256,10 +253,10 @@ fn validate_no_context_variable_assignment(func: &HirFunction, errors: &mut Diag
 
 fn has_non_void_return(func: &HirFunction) -> bool {
     for (_block_id, block) in &func.body.blocks {
-        if let Terminal::Return { return_variant, .. } = &block.terminal {
-            if matches!(return_variant, ReturnVariant::Explicit | ReturnVariant::Implicit) {
-                return true;
-            }
+        if let Terminal::Return { return_variant, .. } = &block.terminal
+            && matches!(return_variant, ReturnVariant::Explicit | ReturnVariant::Implicit)
+        {
+            return true;
         }
     }
     false

--- a/crates/oxc_react_compiler/src/scope.rs
+++ b/crates/oxc_react_compiler/src/scope.rs
@@ -151,12 +151,12 @@ impl<'s, 'a> ScopeResolver<'s, 'a> {
             // ObjectMethod extent (which starts at the property, not the function).
             if let AstKind::Function(_) = node.kind() {
                 let parent = nodes.parent_node(node.id());
-                if let AstKind::ObjectProperty(prop) = parent.kind() {
-                    if is_object_method_property(prop) {
-                        let prop_start = parent.kind().span().start;
-                        if prop_start != span.start {
-                            resolver.function_scope_ranges.push((prop_start, span.end));
-                        }
+                if let AstKind::ObjectProperty(prop) = parent.kind()
+                    && is_object_method_property(prop)
+                {
+                    let prop_start = parent.kind().span().start;
+                    if prop_start != span.start {
+                        resolver.function_scope_ranges.push((prop_start, span.end));
                     }
                 }
             }
@@ -497,10 +497,10 @@ impl<'s, 'a> ScopeResolver<'s, 'a> {
         let node = self.nodes.get_node(node_id);
         if let AstKind::Function(_) = node.kind() {
             let parent = self.nodes.parent_node(node_id);
-            if let AstKind::ObjectProperty(prop) = parent.kind() {
-                if is_object_method_property(prop) {
-                    return parent.id();
-                }
+            if let AstKind::ObjectProperty(prop) = parent.kind()
+                && is_object_method_property(prop)
+            {
+                return parent.id();
             }
         }
         node_id
@@ -555,11 +555,11 @@ impl<'s, 'a> ScopeResolver<'s, 'a> {
                 if descendants.contains(&raw) {
                     continue;
                 }
-                if let Some(parent) = scoping.scope_parent_id(scope_id) {
-                    if descendants.contains(&(parent.index() as u32)) {
-                        descendants.insert(raw);
-                        changed = true;
-                    }
+                if let Some(parent) = scoping.scope_parent_id(scope_id)
+                    && descendants.contains(&(parent.index() as u32))
+                {
+                    descendants.insert(raw);
+                    changed = true;
                 }
             }
         }


### PR DESCRIPTION
Follow-up to #24442 / #24448 (now merged). Removes clippy `"allow"`s from `crates/oxc_react_compiler` and fixes the warnings they were hiding.

## Crate-wide allows removed (`[lints.clippy]`)

Only `result_large_err` (the whole-crate `Result<T, OxcDiagnostic>` trade-off) remains.

| lint | warnings | fix |
| --- | --- | --- |
| `collapsible_if` | 197 | `cargo clippy --fix` (nested `if` → `&&` / `if let` chains) |
| `unnecessary_unwrap` | 4 | rewritten as `if let Some(..)` |
| `disallowed_types` | 0 | allow was dead — no `std::HashMap`/`HashSet` in the crate (the `ScopeInfo`/`ScopeData` comment was stale) |
| `needless_return` | 0 | allow was dead — no trailing `return`s |

## Inline allows removed

| lint | fix |
| --- | --- |
| `only_used_in_recursion` (3) | drop the recursion-only params: `func` (`apply_effect` → `apply_signature`), `types` (`get_context_reassignment`), `is_first_pass` (`record_instruction_derivations`) |
| `large_enum_variant` (3) | box `ReactiveStatement::Terminal` and `CompileResult`'s `output` (unboxed at the `lib.rs` boundary, so the public `compile` API is unchanged); `AliasingEffect`'s allow was already dead |
| `enum_variant_names` (1) | rename `Type::TypeVar` → `Type::Var` |

## Notes

- Behavior-preserving: the insta snapshot corpus and all 15 transform tests are byte-identical; `clippy` is clean.
- Deliberately left in place (would need bigger refactors, out of scope): `result_large_err` (whole-crate), `too_many_arguments` (×15 — arg-bundling structs), and `HIR`'s `upper_case_acronyms`.
- This diverges the vendored `src/` modules a bit further from upstream `react_compiler_oxc` (the `collapsible_if` collapses especially) — worth a note for whoever re-syncs.
- One thing the lint surfaced: `is_first_pass` in `record_instruction_derivations` was passed a real value by its fixpoint-loop caller but never read, so both passes were already identical — removing it is behavior-preserving but flags a latent gap if the passes were meant to differ.
