### PR TITLE
fix(formatter): add required parens for conditional type in type parameter constraint

### DIFF
--- a/crates/oxc_formatter/src/parentheses/ts_type.rs
+++ b/crates/oxc_formatter/src/parentheses/ts_type.rs
@@ -180,6 +180,12 @@ impl NeedsParentheses<'_> for AstNode<'_, TSConditionalType<'_>> {
             AstNodes::TSConditionalType(ty) => {
                 ty.extends_type().span() == self.span() || ty.check_type().span() == self.span()
             }
+            // A conditional type is not allowed bare in a type parameter's constraint position:
+            // `<T extends (A extends B ? C : D)>` requires the parentheses.
+            // The default position (`= ...`) does not.
+            AstNodes::TSTypeParameter(param) => {
+                param.constraint().is_some_and(|c| c.span() == self.span())
+            }
             AstNodes::TSUnionType(union) => union.types.len() > 1,
             AstNodes::TSIntersectionType(intersection) => intersection.types.len() > 1,
             _ => operator_type_or_higher_needs_parens(self.span, parent),

--- a/crates/oxc_formatter/tests/fixtures/ts/parenthesis/type-parameter-constraint-conditional.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/parenthesis/type-parameter-constraint-conditional.ts
@@ -1,0 +1,7 @@
+// Conditional type in a type parameter's constraint position requires parentheses;
+// bare `T extends A extends B ? C : D` is a syntax error.
+type F<T extends (A extends B ? C : D)> = T;
+// The default position does not require them.
+type G<T = A extends B ? C : D> = T;
+type H<T extends X, U extends (T extends Y ? P : Q) = T extends Z ? R : S> = U;
+const f = <T extends (A extends B ? C : D)>() => true;

--- a/crates/oxc_formatter/tests/fixtures/ts/parenthesis/type-parameter-constraint-conditional.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/parenthesis/type-parameter-constraint-conditional.ts.snap
@@ -1,0 +1,36 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Conditional type in a type parameter's constraint position requires parentheses;
+// bare `T extends A extends B ? C : D` is a syntax error.
+type F<T extends (A extends B ? C : D)> = T;
+// The default position does not require them.
+type G<T = A extends B ? C : D> = T;
+type H<T extends X, U extends (T extends Y ? P : Q) = T extends Z ? R : S> = U;
+const f = <T extends (A extends B ? C : D)>() => true;
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Conditional type in a type parameter's constraint position requires parentheses;
+// bare `T extends A extends B ? C : D` is a syntax error.
+type F<T extends (A extends B ? C : D)> = T;
+// The default position does not require them.
+type G<T = A extends B ? C : D> = T;
+type H<T extends X, U extends (T extends Y ? P : Q) = T extends Z ? R : S> = U;
+const f = <T extends (A extends B ? C : D)>() => true;
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Conditional type in a type parameter's constraint position requires parentheses;
+// bare `T extends A extends B ? C : D` is a syntax error.
+type F<T extends (A extends B ? C : D)> = T;
+// The default position does not require them.
+type G<T = A extends B ? C : D> = T;
+type H<T extends X, U extends (T extends Y ? P : Q) = T extends Z ? R : S> = U;
+const f = <T extends (A extends B ? C : D)>() => true;
+
+===================== End =====================

--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -25,7 +25,7 @@ ts compatibility: 627/666 (94.14%), 19 files skipped
 | typescript/property-signature/consistent-with-flow/comments.ts | 💥 | 80.00% |
 | typescript/property-signature/consistent-with-flow/union.ts | 💥 | 80.00% |
 | typescript/template-literals/member-expression.ts | 💥 | 65.12% |
-| typescript/type-parameters-arguments/10732.ts | 💥 | 50.00% |
+| typescript/type-parameters-arguments/10732.ts | 💥 | 66.67% |
 | typescript/type-parameters-arguments/18041.ts | 💥 | 91.43% |
 | typescript/type-parameters-arguments/18604.ts | 💥 | 60.00% |
 | typescript/type-parameters-arguments/19505.ts | 💥 | 61.54% |


### PR DESCRIPTION
```ts
type F<T extends (A extends B ? C : D)> = T;
//               ^^^^^^^^^^^^^^^^^^^^^ Keep this parens
```