### PR TITLE
fix(minifier): keep reads of never-assigned uninitialized bindings

### DIFF
--- a/crates/oxc_minifier/src/peephole/inline.rs
+++ b/crates/oxc_minifier/src/peephole/inline.rs
@@ -34,7 +34,7 @@ impl<'a> PeepholeOptimizations {
             decl.init.as_ref().map_or(Some(ConstantValue::Undefined), |_| init_constant)
         };
         let kind = decl.init.as_ref().map_or(FreshValueKind::None, Self::fresh_value_kind);
-        ctx.init_value(symbol_id, value, kind, falsy_init);
+        ctx.init_value(symbol_id, value, kind, falsy_init, decl.init.is_none());
     }
 
     /// A `ConstantValue` that coerces to `false` (`false`, `0`/`-0`/`NaN`, `""`,
@@ -206,7 +206,7 @@ impl<'a> PeepholeOptimizations {
     ) {
         let Some(id) = id else { return };
         let Some(symbol_id) = id.symbol_id.get() else { return };
-        ctx.init_value(symbol_id, None, FreshValueKind::Function, false);
+        ctx.init_value(symbol_id, None, FreshValueKind::Function, false, false);
     }
 
     /// Initialize symbol value for class declarations.
@@ -220,7 +220,7 @@ impl<'a> PeepholeOptimizations {
         } else {
             FreshValueKind::Class
         };
-        ctx.init_value(symbol_id, None, kind, false);
+        ctx.init_value(symbol_id, None, kind, false, false);
     }
 
     fn is_for_statement_init(ctx: &TraverseCtx<'a>) -> bool {
@@ -239,6 +239,11 @@ impl<'a> PeepholeOptimizations {
             return;
         }
         let Some(cv) = &symbol_value.initialized_constant else { return };
+        // Textually inlining the implicit `undefined` of `let x;` can only grow
+        // the output; see `SymbolValue::implicit_undefined` (rolldown#10174).
+        if symbol_value.implicit_undefined {
+            return;
+        }
         if symbol_value.read_references_count == 1
             || match cv {
                 ConstantValue::Number(n) => n.fract() == 0.0 && *n >= -99.0 && *n <= 999.0,

--- a/crates/oxc_minifier/src/symbol_value.rs
+++ b/crates/oxc_minifier/src/symbol_value.rs
@@ -33,6 +33,15 @@ pub struct SymbolValue<'a> {
     /// `None` when the value is not a constant evaluated value.
     pub initialized_constant: Option<ConstantValue<'a>>,
 
+    /// The `initialized_constant` is the implicit `undefined` of a declaration
+    /// with no initializer (`let x;`), not an evaluated initializer. Textually
+    /// inlining such a read prints `void 0` — longer than a mangled identifier
+    /// read — and there is no initializer whose elimination pays for it, so
+    /// `inline_identifier_reference` skips it (rolldown#10174). Constant-driven
+    /// folds (`if (x)`, `x === void 0`, `return x`) are unaffected: they
+    /// resolve the value through `initialized_constant`.
+    pub implicit_undefined: bool,
+
     /// Symbol is exported.
     pub exported: bool,
 

--- a/crates/oxc_minifier/src/traverse_context/ecma_context.rs
+++ b/crates/oxc_minifier/src/traverse_context/ecma_context.rs
@@ -246,6 +246,7 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
         constant: Option<ConstantValue<'a>>,
         kind: FreshValueKind,
         falsy_init: bool,
+        init_absent: bool,
     ) {
         let mut exported = false;
         if self.scoping.current_scope_id() == self.scoping().root_scope_id() {
@@ -293,8 +294,14 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
             && !scope_flags.contains(ScopeFlags::DirectEval)
             && !(self.source_type().is_script() && scope_id == self.scoping().root_scope_id());
 
+        // See `SymbolValue::implicit_undefined` — only meaningful when the
+        // recorded constant is the hoist-produced `undefined` of `let x;`.
+        let implicit_undefined =
+            init_absent && initialized_constant.as_ref().is_some_and(ConstantValue::is_undefined);
+
         let symbol_value = SymbolValue {
             initialized_constant,
+            implicit_undefined,
             exported,
             read_references_count,
             write_references_count,

--- a/crates/oxc_minifier/tests/peephole/inline.rs
+++ b/crates/oxc_minifier/tests/peephole/inline.rs
@@ -292,6 +292,46 @@ fn dead_code_depending_on_const() {
     );
 }
 
+// https://github.com/rolldown/rolldown/issues/10174
+// A never-assigned binding with no initializer reads as `undefined`, but the
+// textual inline prints `void 0` — longer than a mangled identifier read plus
+// its share of a declaration, and with no initializer there is nothing whose
+// removal pays for it. Keep the read; constant-driven folds still see the
+// value through `SymbolValue` tracking.
+#[test]
+fn keep_value_context_read_of_uninitialized_binding() {
+    let options = CompressOptions::smallest();
+    // The exact rolldown#10174 shape: a value-context assignment read.
+    test_options(
+        "let undefinedVar; export let value; export function reset() { value = undefinedVar; }",
+        "let undefinedVar; export let value; export function reset() { value = undefinedVar; }",
+        &options,
+    );
+    // Multi-read value context.
+    test_options(
+        "let u; export function f() { g(u), g(u); }",
+        "let u; export function f() { g(u), g(u); }",
+        &options,
+    );
+
+    // Near-misses: folds that consume the value must keep working without the
+    // textual inline — evaluation resolves the read through `SymbolValue`.
+    test_options("let u; export function f() { return u; }", "export function f() {}", &options);
+    test_options("let u; export function f() { if (u) g(); }", "export function f() {}", &options);
+    test_options(
+        "let u; export function f() { return u === void 0; }",
+        "export function f() { return !0; }",
+        &options,
+    );
+    // Near-miss: an explicit `undefined` initializer still inlines — the inline
+    // eliminates the `= void 0` initializer text along with the declaration.
+    test_options(
+        "const foo = undefined; export function f() { g(foo); }",
+        "export function f() { g(void 0); }",
+        &options,
+    );
+}
+
 #[test]
 fn small_value() {
     let options = CompressOptions::smallest();

--- a/crates/oxc_minifier/tests/peephole/merge_assignments_to_declarations.rs
+++ b/crates/oxc_minifier/tests/peephole/merge_assignments_to_declarations.rs
@@ -34,7 +34,7 @@ fn merge_assignments_to_declarations_let() {
     test("let a, b; a = 0; b = 1", "let a, b; a = 0, b = 1"); // this can be improved to `let a = 0, b = 1`
     test_same("let a, b; a = c()"); // `c()` may access `b`, `let a = c(), b` will cause TDZ error
     test("let a, b; a = c(); b = d()", "let a, b; a = c(), b = d()"); // same as above
-    test("let a, b; a = b", "let a, b; a = void 0"); // `let a = b, b` will cause TDZ error
+    test_same("let a, b; a = b"); // `let a = b, b` will cause TDZ error; `b` reads as the implicit `undefined`, which is not worth inlining (rolldown#10174)
     test_same("let a; a = foo(a)"); // `let a = foo(a)` will cause TDZ error
     test("let a; a = (() => a)()", "let a; a = a;"); // `let a = (() => a)()` will cause TDZ error
     test("let a; a = () => a", "let a = () => a");

--- a/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
@@ -650,7 +650,9 @@ fn remove_unused_assignment_expression() {
 
     // For loops
     test_options("for (let i;;) i = 0", "for (;;);", &options);
-    test_options("for (let i;;) foo(i)", "for (;;) foo(void 0)", &options);
+    // `i` reads as the implicit `undefined`, but `void 0` prints longer than a
+    // mangled identifier read, so the read (and thus the decl) stays (rolldown#10174).
+    test_same_options("for (let i;;) foo(i)", &options);
     test_same_options("for (let i;;) i = 0, foo(i)", &options);
     test_same_options("for (let i in []) foo(i)", &options);
     test_same_options("for (let element of list) element && (element.foo = bar)", &options);


### PR DESCRIPTION
`inline_identifier_reference` counts `undefined` among the constants that are always worth substituting into a read. But it prints as `void 0` — six characters — while a kept read mangles to one or two, and for a binding declared without an initializer (`let x;`) there is no initializer whose elimination pays the difference, so the substitution can only grow mangled output. rolldown hits this on bundled chunks (`minify: true` always mangles): the chunk in rolldown/rolldown#10174 minified to 58 bytes where keeping the binding gives 55.

`SymbolValue` now records that a tracked `undefined` is the implicit value of an initializer-less declaration, and the textual inline skips such reads. Only the byte substitution is affected: constant-driven folds (`if (x)` dead branches, `x === void 0`, `return x` elision) resolve the value through `SymbolValue` during evaluation and behave as before. An explicit `const x = undefined` initializer still inlines — there the substitution deletes the `= void 0` text along with the declaration, so it pays for itself.

The known tradeoff is compress-without-mangle: with `mangle: false` the kept binding prints its full source name, where the old behavior emitted the shorter `void 0`. The small-value thresholds in this heuristic already assume mangled read sites (numbers up to 3 digits, strings up to 3 chars), so the gate follows the same assumption; a CompressOptions hint for compress-only pipelines can be added later if anyone hits it. For comparison, esbuild never models implicit `undefined` (its const-value inlining requires a `const` with a literal initializer) and wins this shape by keeping the binding; terser substitutes like the old behavior and produces the same 58 bytes.

## Example

The rolldown chunk from the issue (`minify: false` output, then minified with mangling):

```js
let undefinedVar;
let value;
function reset() {
	value = undefinedVar;
}
export { reset, value };
```

Before:

```js
let e;function t(){e=void 0}export{t as reset,e as value};
```

After:

```js
let e,t;function n(){t=e}export{n as reset,t as value};
```

Verified with the minifier unit suite (two expectation updates where the kept binding is now smaller or equal), `just minsize` and allocation snapshots unchanged, `--twice` idempotency on the repro, and old-vs-new byte-identical output on real rolldown chunks of vue, svelte, and rxjs.

Fixes rolldown/rolldown#10174.

Implemented with AI assistance (Claude Code); design, review, and verification driven by the author per the repo AI-usage policy.
