### PR TITLE
refactor(linter/typescript/no-extraneous-class): remove unsafe span conversion

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/no_extraneous_class.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_extraneous_class.rs
@@ -134,16 +134,11 @@ impl Rule for NoExtraneousClass {
             [] => {
                 if !self.allow_empty {
                     let mut span = class.span;
-                    #[expect(clippy::checked_conversions, clippy::cast_possible_truncation)]
                     if let Some(decorator) = class.decorators.last() {
                         span = Span::new(decorator.span.end, span.end);
                         // NOTE: there will always be a 'c' because of 'class' keyword.
                         let start = ctx.source_range(span).find('c').unwrap();
-                        // SAFETY: source files are guaranteed to be less than
-                        // 2^32 characters, so conversion will never fail. Using
-                        // unchecked assert here removes a useless bounds check.
-                        unsafe { std::hint::assert_unchecked(start <= u32::MAX as usize) };
-                        span = span.shrink_left(start as u32);
+                        span = span.shrink_left(u32::try_from(start).unwrap());
                     }
                     let has_decorators = !class.decorators.is_empty();
                     ctx.diagnostic_with_suggestion(


### PR DESCRIPTION
## Summary
- replace the unsafe assertion and truncating cast with a checked u32 conversion
- remove the obsolete safety annotation
