### PR TITLE
fix(semantic): report TS2435 for nested ambient modules

### DIFF
--- a/crates/oxc_semantic/src/checker/typescript.rs
+++ b/crates/oxc_semantic/src/checker/typescript.rs
@@ -111,7 +111,40 @@ fn check_duplicate_bound_names<'a, T: BoundNames<'a>>(bound_names: &T, ctx: &Sem
 
 pub fn check_ts_module_declaration<'a>(decl: &TSModuleDeclaration<'a>, ctx: &SemanticBuilder<'a>) {
     check_ts_module_or_global_declaration(decl.span, ctx);
+    check_nested_ambient_module(decl, ctx);
     check_ts_export_assignment_in_module_decl(decl, ctx);
+}
+
+fn check_nested_ambient_module(decl: &TSModuleDeclaration<'_>, ctx: &SemanticBuilder<'_>) {
+    if !decl.id.is_string_literal() {
+        return;
+    }
+
+    // These nodes wrap a module declaration without changing its semantic container.
+    let mut ancestors = ctx.ancestry().ancestor_kinds().filter(|kind| {
+        !matches!(kind, AstKind::ExportNamedDeclaration(_) | AstKind::TSModuleBlock(_))
+    });
+
+    let Some(container) = ancestors.next() else {
+        return;
+    };
+    let container_is_top_level = matches!(ancestors.next(), Some(AstKind::Program(_)));
+
+    // In a script, a quoted module directly inside a top-level ambient module or `global`
+    // declaration is an external module augmentation, not a nested ambient module.
+    let is_top_level_script_augmentation = ctx.source_type.is_script()
+        && container_is_top_level
+        && match container {
+            AstKind::TSModuleDeclaration(parent) => parent.id.is_string_literal(),
+            AstKind::TSGlobalDeclaration(_) => true,
+            _ => false,
+        };
+
+    if matches!(container, AstKind::TSModuleDeclaration(_) | AstKind::TSGlobalDeclaration(_))
+        && !is_top_level_script_augmentation
+    {
+        ctx.error(diagnostics::ambient_module_cannot_be_nested(decl.id.span()));
+    }
 }
 
 pub fn check_ts_global_declaration<'a>(decl: &TSGlobalDeclaration<'a>, ctx: &SemanticBuilder<'a>) {

--- a/crates/oxc_semantic/src/checker/typescript.rs
+++ b/crates/oxc_semantic/src/checker/typescript.rs
@@ -130,9 +130,10 @@ fn check_nested_ambient_module(decl: &TSModuleDeclaration<'_>, ctx: &SemanticBui
     };
     let container_is_top_level = matches!(ancestors.next(), Some(AstKind::Program(_)));
 
-    // In a script, a quoted module directly inside a top-level ambient module or `global`
-    // declaration is an external module augmentation, not a nested ambient module.
-    let is_top_level_script_augmentation = ctx.source_type.is_script()
+    // In a script or declaration file, a quoted module directly inside a top-level ambient
+    // module or `global` declaration is not a nested ambient module.
+    let is_top_level_ambient_context = (ctx.source_type.is_script()
+        || ctx.source_type.is_typescript_definition())
         && container_is_top_level
         && match container {
             AstKind::TSModuleDeclaration(parent) => parent.id.is_string_literal(),
@@ -141,7 +142,7 @@ fn check_nested_ambient_module(decl: &TSModuleDeclaration<'_>, ctx: &SemanticBui
         };
 
     if matches!(container, AstKind::TSModuleDeclaration(_) | AstKind::TSGlobalDeclaration(_))
-        && !is_top_level_script_augmentation
+        && !is_top_level_ambient_context
     {
         ctx.error(diagnostics::ambient_module_cannot_be_nested(decl.id.span()));
     }

--- a/crates/oxc_semantic/src/checker/typescript.rs
+++ b/crates/oxc_semantic/src/checker/typescript.rs
@@ -128,13 +128,17 @@ fn check_nested_ambient_module(decl: &TSModuleDeclaration<'_>, ctx: &SemanticBui
     let Some(container) = ancestors.next() else {
         return;
     };
-    let container_is_top_level = matches!(ancestors.next(), Some(AstKind::Program(_)));
+    let top_level_program = match ancestors.next() {
+        Some(AstKind::Program(program)) => Some(program),
+        _ => None,
+    };
+    let is_global_declaration_file = ctx.source_type.is_typescript_definition()
+        && top_level_program.is_some_and(|program| !has_external_module_indicator(program));
 
-    // In a script or declaration file, a quoted module directly inside a top-level ambient
-    // module or `global` declaration is not a nested ambient module.
-    let is_top_level_ambient_context = (ctx.source_type.is_script()
-        || ctx.source_type.is_typescript_definition())
-        && container_is_top_level
+    // In a script or global declaration file, a quoted module directly inside a top-level
+    // ambient module or `global` declaration is not a nested ambient module.
+    let is_top_level_ambient_context = (ctx.source_type.is_script() || is_global_declaration_file)
+        && top_level_program.is_some()
         && match container {
             AstKind::TSModuleDeclaration(parent) => parent.id.is_string_literal(),
             AstKind::TSGlobalDeclaration(_) => true,
@@ -146,6 +150,17 @@ fn check_nested_ambient_module(decl: &TSModuleDeclaration<'_>, ctx: &SemanticBui
     {
         ctx.error(diagnostics::ambient_module_cannot_be_nested(decl.id.span()));
     }
+}
+
+fn has_external_module_indicator(program: &Program<'_>) -> bool {
+    program.body.iter().any(|stmt| {
+        stmt.is_module_declaration()
+            || matches!(
+                stmt,
+                Statement::TSImportEqualsDeclaration(decl)
+                    if decl.module_reference.is_external()
+            )
+    })
 }
 
 pub fn check_ts_global_declaration<'a>(decl: &TSGlobalDeclaration<'a>, ctx: &SemanticBuilder<'a>) {

--- a/crates/oxc_semantic/src/diagnostics.rs
+++ b/crates/oxc_semantic/src/diagnostics.rs
@@ -330,6 +330,12 @@ pub fn global_scope_augmentation_should_have_declare_modifier(span: Span) -> Oxc
 }
 
 #[cold]
+pub fn ambient_module_cannot_be_nested(span: Span) -> OxcDiagnostic {
+    ts_error("2435", "Ambient modules cannot be nested in other modules or namespaces.")
+        .with_label(span)
+}
+
+#[cold]
 pub fn enum_member_must_have_initializer(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Enum member must have initializer.").with_label(span)
 }

--- a/tasks/coverage/misc/fail/nested-ambient-module-external.d.ts
+++ b/tasks/coverage/misc/fail/nested-ambient-module-external.d.ts
@@ -1,0 +1,9 @@
+export {};
+
+declare module "outer" {
+    module "inner" {}
+}
+
+declare global {
+    module "global-inner" {}
+}

--- a/tasks/coverage/misc/pass/nested-ambient-module.d.cts
+++ b/tasks/coverage/misc/pass/nested-ambient-module.d.cts
@@ -1,0 +1,3 @@
+declare module "outer" {
+    module "inner" {}
+}

--- a/tasks/coverage/misc/pass/nested-ambient-module.d.mts
+++ b/tasks/coverage/misc/pass/nested-ambient-module.d.mts
@@ -1,0 +1,3 @@
+declare module "outer" {
+    module "inner" {}
+}

--- a/tasks/coverage/snapshots/codegen_misc.snap
+++ b/tasks/coverage/snapshots/codegen_misc.snap
@@ -1,3 +1,3 @@
 codegen_misc Summary:
-AST Parsed     : 71/71 (100.00%)
-Positive Passed: 71/71 (100.00%)
+AST Parsed     : 73/73 (100.00%)
+Positive Passed: 73/73 (100.00%)

--- a/tasks/coverage/snapshots/formatter_misc.snap
+++ b/tasks/coverage/snapshots/formatter_misc.snap
@@ -1,3 +1,3 @@
 formatter_misc Summary:
-AST Parsed     : 71/71 (100.00%)
-Positive Passed: 71/71 (100.00%)
+AST Parsed     : 73/73 (100.00%)
+Positive Passed: 73/73 (100.00%)

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -2,7 +2,7 @@ commit: c86e9e4b
 
 parser_babel Summary:
 AST Parsed     : 2235/2235 (100.00%)
-Positive Passed: 2221/2235 (99.37%)
+Positive Passed: 2220/2235 (99.33%)
 Negative Passed: 1728/1743 (99.14%)
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/cast/unparenthesized-assert-and-assign/input.ts
 
@@ -246,6 +246,16 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/function/declare-pattern-parameters/input.ts:1:25]
  1 │ declare function f([]?, {})
    ·                         ──
+   ╰────
+
+Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-in-nested-module/input.ts
+
+  × TS(2435): Ambient modules cannot be nested in other modules or namespaces.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-in-nested-module/input.ts:3:10]
+ 2 │   import type { JSONSchema7 } from 'json-schema';
+ 3 │   module 'test/sub2' {
+   ·          ───────────
+ 4 │     export { JSONSchema7 }
    ╰────
 
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/const-type-parameters/input.ts

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
 AST Parsed     : 73/73 (100.00%)
 Positive Passed: 73/73 (100.00%)
-Negative Passed: 149/149 (100.00%)
+Negative Passed: 150/150 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[misc/fail/arguments-eval.ts:1:10]
@@ -473,6 +473,22 @@ Negative Passed: 149/149 (100.00%)
  1 │ const foo = 1 ? 2
    ·               ┬
    ·               ╰── Conditional starts here
+   ╰────
+
+  × TS(2435): Ambient modules cannot be nested in other modules or namespaces.
+   ╭─[misc/fail/nested-ambient-module-external.d.ts:4:12]
+ 3 │ declare module "outer" {
+ 4 │     module "inner" {}
+   ·            ───────
+ 5 │ }
+   ╰────
+
+  × TS(2435): Ambient modules cannot be nested in other modules or namespaces.
+   ╭─[misc/fail/nested-ambient-module-external.d.ts:8:12]
+ 7 │ declare global {
+ 8 │     module "global-inner" {}
+   ·            ──────────────
+ 9 │ }
    ╰────
 
   × Identifier `b` has already been declared

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,6 +1,6 @@
 parser_misc Summary:
-AST Parsed     : 71/71 (100.00%)
-Positive Passed: 71/71 (100.00%)
+AST Parsed     : 73/73 (100.00%)
+Positive Passed: 73/73 (100.00%)
 Negative Passed: 149/149 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -3,7 +3,7 @@ commit: 637d5746
 parser_typescript Summary:
 AST Parsed     : 9779/9779 (100.00%)
 Positive Passed: 9779/9779 (100.00%)
-Negative Passed: 1644/2640 (62.27%)
+Negative Passed: 1645/2640 (62.31%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration4.ts
@@ -947,8 +947,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/voidAsNonAmb
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/widenedTypes.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientDeclarationsPatterns_merging3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientExternalModuleInsideNonAmbient.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientExternalModuleInsideNonAmbientExternalModule.ts
 
@@ -10961,6 +10959,38 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  150 │     }
      ╰────
 
+  × TS(2435): Ambient modules cannot be nested in other modules or namespaces.
+    ╭─[typescript/tests/cases/compiler/privacyGloImportParseErrors.ts:22:27]
+ 21 │ 
+ 22 │     export declare module "m1_M3_public" {
+    ·                           ──────────────
+ 23 │         export function f1();
+    ╰────
+
+  × TS(2435): Ambient modules cannot be nested in other modules or namespaces.
+    ╭─[typescript/tests/cases/compiler/privacyGloImportParseErrors.ts:30:20]
+ 29 │ 
+ 30 │     declare module "m1_M4_private" {
+    ·                    ───────────────
+ 31 │         export function f1();
+    ╰────
+
+  × TS(2435): Ambient modules cannot be nested in other modules or namespaces.
+     ╭─[typescript/tests/cases/compiler/privacyGloImportParseErrors.ts:133:24]
+ 132 │     namespace m2 {
+ 133 │         declare module "abc" {
+     ·                        ─────
+ 134 │         }
+     ╰────
+
+  × TS(2435): Ambient modules cannot be nested in other modules or namespaces.
+     ╭─[typescript/tests/cases/compiler/privacyGloImportParseErrors.ts:138:16]
+ 137 │     namespace m2 {
+ 138 │         module "abc2" {
+     ·                ──────
+ 139 │         }
+     ╰────
+
   × TS(1147): Import declarations in a namespace cannot reference a module.
     ╭─[typescript/tests/cases/compiler/privacyImportParseErrors.ts:59:5]
  58 │ 
@@ -11088,6 +11118,86 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  353 │         import m2 = require("use_glo_M1_public");
      ·         ─────────────────────────────────────────
  354 │     }
+     ╰────
+
+  × TS(2435): Ambient modules cannot be nested in other modules or namespaces.
+    ╭─[typescript/tests/cases/compiler/privacyImportParseErrors.ts:22:27]
+ 21 │ 
+ 22 │     export declare module "m1_M3_public" {
+    ·                           ──────────────
+ 23 │         export function f1();
+    ╰────
+
+  × TS(2435): Ambient modules cannot be nested in other modules or namespaces.
+    ╭─[typescript/tests/cases/compiler/privacyImportParseErrors.ts:30:20]
+ 29 │ 
+ 30 │     declare module "m1_M4_private" {
+    ·                    ───────────────
+ 31 │         export function f1();
+    ╰────
+
+  × TS(2435): Ambient modules cannot be nested in other modules or namespaces.
+     ╭─[typescript/tests/cases/compiler/privacyImportParseErrors.ts:106:27]
+ 105 │ 
+ 106 │     export declare module "m2_M3_public" {
+     ·                           ──────────────
+ 107 │         export function f1();
+     ╰────
+
+  × TS(2435): Ambient modules cannot be nested in other modules or namespaces.
+     ╭─[typescript/tests/cases/compiler/privacyImportParseErrors.ts:114:20]
+ 113 │ 
+ 114 │     declare module "m2_M4_private" {
+     ·                    ───────────────
+ 115 │         export function f1();
+     ╰────
+
+  × TS(2435): Ambient modules cannot be nested in other modules or namespaces.
+     ╭─[typescript/tests/cases/compiler/privacyImportParseErrors.ts:314:24]
+ 313 │     namespace m2 {
+ 314 │         declare module "abc" {
+     ·                        ─────
+ 315 │         }
+     ╰────
+
+  × TS(2435): Ambient modules cannot be nested in other modules or namespaces.
+     ╭─[typescript/tests/cases/compiler/privacyImportParseErrors.ts:319:16]
+ 318 │     namespace m2 {
+ 319 │         module "abc2" {
+     ·                ──────
+ 320 │         }
+     ╰────
+
+  × TS(2435): Ambient modules cannot be nested in other modules or namespaces.
+     ╭─[typescript/tests/cases/compiler/privacyImportParseErrors.ts:322:12]
+ 321 │     }
+ 322 │     module "abc3" {
+     ·            ──────
+ 323 │     }
+     ╰────
+
+  × TS(2435): Ambient modules cannot be nested in other modules or namespaces.
+     ╭─[typescript/tests/cases/compiler/privacyImportParseErrors.ts:328:24]
+ 327 │     namespace m2 {
+ 328 │         declare module "abc" {
+     ·                        ─────
+ 329 │         }
+     ╰────
+
+  × TS(2435): Ambient modules cannot be nested in other modules or namespaces.
+     ╭─[typescript/tests/cases/compiler/privacyImportParseErrors.ts:333:16]
+ 332 │     namespace m2 {
+ 333 │         module "abc2" {
+     ·                ──────
+ 334 │         }
+     ╰────
+
+  × TS(2435): Ambient modules cannot be nested in other modules or namespaces.
+     ╭─[typescript/tests/cases/compiler/privacyImportParseErrors.ts:336:12]
+ 335 │     }
+ 336 │     module "abc3" {
+     ·            ──────
+ 337 │     }
      ╰────
 
   × Unexpected token
@@ -14025,6 +14135,14 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  42 │     }
     ╰────
 
+  × TS(2435): Ambient modules cannot be nested in other modules or namespaces.
+    ╭─[typescript/tests/cases/conformance/ambient/ambientErrors.ts:47:20]
+ 46 │ namespace M2 {
+ 47 │     declare module 'nope' { }
+    ·                    ──────
+ 48 │ }
+    ╰────
+
   × TS(2309): An export assignment cannot be used in a module with other exported elements
     ╭─[typescript/tests/cases/conformance/ambient/ambientErrors.ts:57:5]
  56 │     export var q;
@@ -14033,6 +14151,14 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  58 │ }
     ╰────
   help: If you want to use `export =`, remove other `export`s and put all of them to the right hand value of `export =`. If you want to use `export`s, remove `export =` statement.
+
+  × TS(2435): Ambient modules cannot be nested in other modules or namespaces.
+   ╭─[typescript/tests/cases/conformance/ambient/ambientExternalModuleInsideNonAmbient.ts:2:27]
+ 1 │ namespace M {
+ 2 │     export declare module "M" { }
+   ·                           ───
+ 3 │ }
+   ╰────
 
   × Identifier expected. 'debugger' is a reserved word that cannot be used here.
    ╭─[typescript/tests/cases/conformance/ambient/ambientModuleDeclarationWithReservedIdentifierInDottedPath.ts:3:26]

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -2,7 +2,7 @@ commit: c86e9e4b
 
 semantic_babel Summary:
 AST Parsed     : 2235/2235 (100.00%)
-Positive Passed: 2146/2235 (96.02%)
+Positive Passed: 2145/2235 (95.97%)
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/decorators/decorators-after-export/input.js
 Symbol flags mismatch for "_default":
 after transform: SymbolId(3): SymbolFlags(Class)
@@ -442,6 +442,9 @@ semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescr
 Symbol reference IDs mismatch for "fooBar":
 after transform: SymbolId(1): [ReferenceId(1), ReferenceId(4)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
+
+semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-in-nested-module/input.ts
+Ambient modules cannot be nested in other modules or namespaces.
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-interface-class/input.ts
 Bindings mismatch:

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -1,6 +1,6 @@
 semantic_misc Summary:
-AST Parsed     : 71/71 (100.00%)
-Positive Passed: 66/71 (92.96%)
+AST Parsed     : 73/73 (100.00%)
+Positive Passed: 68/73 (93.15%)
 semantic Error: tasks/coverage/misc/pass/declare-let-private.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["private"]

--- a/tasks/coverage/snapshots/transformer_misc.snap
+++ b/tasks/coverage/snapshots/transformer_misc.snap
@@ -1,3 +1,3 @@
 transformer_misc Summary:
-AST Parsed     : 71/71 (100.00%)
-Positive Passed: 71/71 (100.00%)
+AST Parsed     : 73/73 (100.00%)
+Positive Passed: 73/73 (100.00%)


### PR DESCRIPTION
## Summary
- emit TS2435 from semantic analysis for ambient modules nested in modules or namespaces
- preserve the TypeScript exception for direct module augmentations inside top-level ambient modules in script files
- match the TypeScript diagnostic code, message, and quoted-module-name span

## Examples

### Nested ambient module in a namespace

```ts
namespace Outer {
  declare module "inner" {}
}
```

```text
error TS2435: Ambient modules cannot be nested in other modules or namespaces.
  declare module "inner" {}
                 ~~~~~~~
```

### Nested ambient module in an external module

```ts
export {};

declare module "outer" {
  module "inner" {}
}
```

```text
error TS2435: Ambient modules cannot be nested in other modules or namespaces.
  module "inner" {}
         ~~~~~~~
```

### Allowed script augmentation

```ts
declare module "outer" {
  module "augmentation" {}
}
```

This remains valid because the inner declaration is a direct module augmentation in a script.

## Coverage
- TypeScript negative coverage improves from 1644/2640 to 1645/2640
- all 16 upstream TypeScript TS2435 baseline positions are emitted
- Babel semantic coverage records the module-mode nested declaration as an expected semantic failure
