### PR TITLE
fix(linter): skip suppression validation with `--type-check-only`

### DIFF
--- a/apps/oxlint/fixtures/suppression/type_check_only_with_regular_rule/.oxlintrc.json
+++ b/apps/oxlint/fixtures/suppression/type_check_only_with_regular_rule/.oxlintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-console": "error"
+  }
+}

--- a/apps/oxlint/fixtures/suppression/type_check_only_with_regular_rule/index.ts
+++ b/apps/oxlint/fixtures/suppression/type_check_only_with_regular_rule/index.ts
@@ -1,0 +1,1 @@
+console.log("still suppressed");

--- a/apps/oxlint/fixtures/suppression/type_check_only_with_regular_rule/oxlint-suppressions.json
+++ b/apps/oxlint/fixtures/suppression/type_check_only_with_regular_rule/oxlint-suppressions.json
@@ -1,0 +1,7 @@
+{
+  "index.ts": {
+    "no-console": {
+      "count": 1
+    }
+  }
+}

--- a/apps/oxlint/fixtures/suppression/type_check_only_with_regular_rule/tsconfig.json
+++ b/apps/oxlint/fixtures/suppression/type_check_only_with_regular_rule/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "strict": true
+  }
+}

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -393,6 +393,15 @@ impl CliRunner {
             );
             return CliRunResult::InvalidOptionTypeCheckOnlyWithFix;
         }
+        if type_check_only
+            && (suppression_options.suppress_all || suppression_options.prune_suppressions)
+        {
+            print_and_flush_stdout(
+                stdout,
+                "The `--type-check-only` option cannot be used with suppression update flags.\nRemove `--suppress-all` and `--prune-suppressions`.\n",
+            );
+            return CliRunResult::InvalidOptionTypeCheckOnlyWithSuppressionUpdate;
+        }
         let deny_warnings = warning_options.deny_warnings || config_store.deny_warnings();
         let max_warnings = warning_options.max_warnings.or(config_store.max_warnings());
 
@@ -516,7 +525,13 @@ impl CliRunner {
             }
         }
 
-        let result = suppression_manager.finalize(diff_manager, &tx_error, &cwd);
+        // A suppression file can contain regular lint rules that were not run in type-check-only
+        // mode, so its runtime diff is incomplete and cannot be used to validate the baseline.
+        let result = if type_check_only {
+            Ok(())
+        } else {
+            suppression_manager.finalize(diff_manager, &tx_error, &cwd)
+        };
         let suppress_all_succeeded = suppression_options.suppress_all && result.is_ok();
 
         drop(tx_error);
@@ -2011,6 +2026,48 @@ mod suppression {
             !matches!(result, CliRunResult::LintFoundErrors),
             "Expected no errors (warnings-only files should not count), got {result:?}"
         );
+    }
+
+    #[test]
+    #[cfg_attr(target_endian = "big", ignore = "disabled on big-endian")]
+    fn test_type_check_only_does_not_validate_regular_rule_suppressions() {
+        let cwd = "fixtures/suppression/type_check_only_with_regular_rule";
+
+        let (stdout, result) = Tester::new().with_cwd(cwd.into()).test_output(&["index.ts"]);
+        assert!(
+            matches!(result, CliRunResult::LintSucceeded),
+            "Expected the suppression fixture to pass regular lint, got {result:?}.\nOutput: {stdout}"
+        );
+
+        let (stdout, result) =
+            Tester::new().with_cwd(cwd.into()).test_output(&["--type-check-only", "index.ts"]);
+
+        assert!(
+            matches!(result, CliRunResult::LintSucceeded),
+            "Expected LintSucceeded, got {result:?}.\nOutput: {stdout}"
+        );
+        assert!(
+            !stdout.contains("suppressions that do not occur anymore"),
+            "Regular lint suppressions must not be validated when their rules did not run.\nOutput: {stdout}"
+        );
+    }
+
+    #[test]
+    fn test_type_check_only_rejects_suppression_update_flags() {
+        for flag in ["--suppress-all", "--prune-suppressions"] {
+            let (stdout, result) = Tester::new()
+                .with_cwd("fixtures/suppression/type_check_only_with_regular_rule".into())
+                .test_output(&["--type-check-only", flag, "index.ts"]);
+
+            assert!(
+                matches!(result, CliRunResult::InvalidOptionTypeCheckOnlyWithSuppressionUpdate),
+                "Expected {flag} to be rejected with --type-check-only, got {result:?}.\nOutput: {stdout}"
+            );
+            assert!(
+                stdout.contains("cannot be used with suppression update flags"),
+                "Expected an invalid option message for {flag}.\nOutput: {stdout}"
+            );
+        }
     }
 
     #[test]

--- a/apps/oxlint/src/result.rs
+++ b/apps/oxlint/src/result.rs
@@ -8,6 +8,7 @@ pub enum CliRunResult {
     InvalidOptionTsConfig,
     InvalidOptionTypeCheckWithoutTypeAware,
     InvalidOptionTypeCheckOnlyWithFix,
+    InvalidOptionTypeCheckOnlyWithSuppressionUpdate,
     InvalidOptionSeverityWithoutFilter,
     InvalidOptionSeverityWithoutPluginName,
     InvalidOptionSeverityWithoutRuleName,
@@ -40,6 +41,7 @@ impl Termination for CliRunResult {
             | Self::InvalidOptionTsConfig
             | Self::InvalidOptionTypeCheckWithoutTypeAware
             | Self::InvalidOptionTypeCheckOnlyWithFix
+            | Self::InvalidOptionTypeCheckOnlyWithSuppressionUpdate
             | Self::InvalidOptionSeverityWithoutFilter
             | Self::InvalidOptionSeverityWithoutPluginName
             | Self::InvalidOptionSeverityWithoutRuleName


### PR DESCRIPTION
## Summary

- skip bulk suppression finalization in `--type-check-only` mode
- reject `--suppress-all` and `--prune-suppressions` when combined with `--type-check-only`
- add a CLI regression fixture for a still-valid regular lint suppression

## Root cause

`--type-check-only` intentionally skips regular lint rules, but bulk suppression finalization still compared the full baseline against the partial runtime rule map. A file processed by type checking was marked as seen without regular rule counts, so valid regular suppressions were interpreted as stale.

Suppression update operations are also unsafe with this partial result because they could remove or replace entries for rules that did not run.

## Validation

- `just ready` with Node.js 24.14.0
- verified the original Dify single-file reproduction with both regular lint and `--type-check-only`

## AI usage

I used OpenAI Codex to help investigate, implement, test, and prepare this pull request. I reviewed the changes and take responsibility for the submission.

Fixes #24460
