### PR TITLE
fix(linter/unicorn/prefer-string-raw): skip fix for `TSPropertySignature` keys

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_raw.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_raw.rs
@@ -107,6 +107,20 @@ impl Rule for PreferStringRaw {
                     return;
                 }
             }
+            AstKind::TSPropertySignature(prop) => {
+                if let PropertyKey::StringLiteral(key) = &prop.key
+                    && string_literal.span == key.span
+                {
+                    return;
+                }
+            }
+            AstKind::TSMethodSignature(method) => {
+                if let PropertyKey::StringLiteral(key) = &method.key
+                    && string_literal.span == key.span
+                {
+                    return;
+                }
+            }
             AstKind::JSXAttribute(attr) => {
                 let Some(JSXAttributeValue::StringLiteral(value)) = &attr.value else {
                     return;
@@ -246,6 +260,8 @@ fn test() {
         r#"declare const POSIX_REGEX_SOURCE: { ascii: "\\x00-\\x7F"; };"#,
         r#"type Foo = { path: "C:\\windows\\path"; };"#,
         r#"interface Bar { regex: "foo\\.bar"; }"#,
+        r#"interface EventSchemas { "foo\\bar": Record<string, any>; }"#,
+        r#"interface Methods { "foo\\bar"(): void; }"#,
         r#"let x: "a\\b";"#,
     ];
 


### PR DESCRIPTION
## Summary

- prevent unicorn/prefer-string-raw from rewriting TypeScript property signature keys into invalid tagged-template syntax
- add a regression case based on the PostHog ecosystem CI failure
- preserve existing behavior for runtime string expressions

