### PR TITLE
feat(linter/eslint): implement `one-var` rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -186,6 +186,8 @@ export type CallbackReturn = string[];
 export type HandleCallbackErrConfig = string;
 export type NoMixedRequiresConfig = boolean | NoMixedRequiresOptions;
 export type ShorthandType = "always" | "methods" | "properties" | "consistent" | "consistent-as-needed" | "never";
+export type OneVar = OneVarMode | OneVarOptions;
+export type OneVarMode = "always" | "never" | "consecutive";
 export type Destructuring = "any" | "all";
 export type PreferDestructuringOption = PreferDestructuringTargetOption | PreferDestructuringAssignmentConfig;
 export type TerminationMethod = string | string[];
@@ -1232,6 +1234,7 @@ export interface DummyRuleMap {
   "node/no-sync"?: RuleNoConfig | [AllowWarnDeny, NoSyncConfig];
   "object-shorthand"?:
     RuleNoConfig | [AllowWarnDeny, ShorthandType] | [AllowWarnDeny, ShorthandType, ObjectShorthandOptions];
+  "one-var"?: RuleNoConfig | [AllowWarnDeny, OneVar];
   "operator-assignment"?: RuleNoConfig | [AllowWarnDeny, AlwaysNever];
   "oxc/approx-constant"?: RuleNoConfig;
   "oxc/bad-array-method-on-arguments"?: RuleNoConfig;
@@ -4045,6 +4048,16 @@ export interface ObjectShorthandOptions {
   avoidQuotes?: boolean;
   ignoreConstructors?: boolean;
   methodsIgnorePattern?: string;
+}
+export interface OneVarOptions {
+  awaitUsing?: OneVarMode;
+  const?: OneVarMode;
+  initialized?: OneVarMode;
+  let?: OneVarMode;
+  separateRequires?: boolean;
+  uninitialized?: OneVarMode;
+  using?: OneVarMode;
+  var?: OneVarMode;
 }
 export interface NoAsyncEndpointHandlersConfig {
   /**

--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -189,7 +189,17 @@ export type ExportsStyleMode = "module.exports" | "exports";
 export type HandleCallbackErrConfig = string;
 export type NoMixedRequiresConfig = boolean | NoMixedRequiresOptions;
 export type ShorthandType = "always" | "methods" | "properties" | "consistent" | "consistent-as-needed" | "never";
-export type OneVar = OneVarMode | OneVarOptions;
+/**
+ * Enforces consistent grouping of variable declarations.
+ */
+export type OneVar = OneVarConfig;
+/**
+ * Configuration accepted by the `one-var` rule.
+ */
+export type OneVarConfig = OneVarMode | OneVarOptions;
+/**
+ * Controls how variable declarators are grouped into declarations.
+ */
 export type OneVarMode = "always" | "never" | "consecutive";
 export type Destructuring = "any" | "all";
 export type PreferDestructuringOption = PreferDestructuringTargetOption | PreferDestructuringAssignmentConfig;
@@ -4225,14 +4235,44 @@ export interface ObjectShorthandOptions {
   ignoreConstructors?: boolean;
   methodsIgnorePattern?: string;
 }
+/**
+ * Options for configuring declaration grouping by kind or initialization state.
+ *
+ * `initialized` and `uninitialized` take precedence over the per-kind option for the
+ * corresponding declarators.
+ */
 export interface OneVarOptions {
+  /**
+   * Controls grouping for `await using` declarations.
+   */
   awaitUsing?: OneVarMode;
+  /**
+   * Controls grouping for `const` declarations.
+   */
   const?: OneVarMode;
+  /**
+   * Controls grouping for initialized declarators, overriding per-kind options.
+   */
   initialized?: OneVarMode;
+  /**
+   * Controls grouping for `let` declarations.
+   */
   let?: OneVarMode;
+  /**
+   * Keeps direct `require(...)` initializers separate from other initialized declarations.
+   */
   separateRequires?: boolean;
+  /**
+   * Controls grouping for uninitialized declarators, overriding per-kind options.
+   */
   uninitialized?: OneVarMode;
+  /**
+   * Controls grouping for `using` declarations.
+   */
   using?: OneVarMode;
+  /**
+   * Controls grouping for `var` declarations.
+   */
   var?: OneVarMode;
 }
 export interface NoAsyncEndpointHandlersConfig {

--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -189,6 +189,8 @@ export type ExportsStyleMode = "module.exports" | "exports";
 export type HandleCallbackErrConfig = string;
 export type NoMixedRequiresConfig = boolean | NoMixedRequiresOptions;
 export type ShorthandType = "always" | "methods" | "properties" | "consistent" | "consistent-as-needed" | "never";
+export type OneVar = OneVarMode | OneVarOptions;
+export type OneVarMode = "always" | "never" | "consecutive";
 export type Destructuring = "any" | "all";
 export type PreferDestructuringOption = PreferDestructuringTargetOption | PreferDestructuringAssignmentConfig;
 export type TerminationMethod = string | string[];
@@ -1258,6 +1260,7 @@ export interface DummyRuleMap {
   "node/no-top-level-await"?: RuleNoConfig | [AllowWarnDeny, NoTopLevelAwaitConfig];
   "object-shorthand"?:
     RuleNoConfig | [AllowWarnDeny, ShorthandType] | [AllowWarnDeny, ShorthandType, ObjectShorthandOptions];
+  "one-var"?: RuleNoConfig | [AllowWarnDeny, OneVar];
   "operator-assignment"?: RuleNoConfig | [AllowWarnDeny, AlwaysNever];
   "oxc/approx-constant"?: RuleNoConfig;
   "oxc/bad-array-method-on-arguments"?: RuleNoConfig;
@@ -4221,6 +4224,16 @@ export interface ObjectShorthandOptions {
   avoidQuotes?: boolean;
   ignoreConstructors?: boolean;
   methodsIgnorePattern?: string;
+}
+export interface OneVarOptions {
+  awaitUsing?: OneVarMode;
+  const?: OneVarMode;
+  initialized?: OneVarMode;
+  let?: OneVarMode;
+  separateRequires?: boolean;
+  uninitialized?: OneVarMode;
+  using?: OneVarMode;
+  var?: OneVarMode;
 }
 export interface NoAsyncEndpointHandlersConfig {
   /**

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -1300,6 +1300,11 @@ impl RuleRunner for crate::rules::eslint::object_shorthand::ObjectShorthand {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::eslint::one_var::OneVar {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
 impl RuleRunner for crate::rules::eslint::operator_assignment::OperatorAssignment {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::AssignmentExpression]));

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -1313,6 +1313,11 @@ impl RuleRunner for crate::rules::eslint::object_shorthand::ObjectShorthand {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::eslint::one_var::OneVar {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
 impl RuleRunner for crate::rules::eslint::operator_assignment::OperatorAssignment {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::AssignmentExpression]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -167,6 +167,7 @@ pub use crate::rules::eslint::no_void::NoVoid as EslintNoVoid;
 pub use crate::rules::eslint::no_warning_comments::NoWarningComments as EslintNoWarningComments;
 pub use crate::rules::eslint::no_with::NoWith as EslintNoWith;
 pub use crate::rules::eslint::object_shorthand::ObjectShorthand as EslintObjectShorthand;
+pub use crate::rules::eslint::one_var::OneVar as EslintOneVar;
 pub use crate::rules::eslint::operator_assignment::OperatorAssignment as EslintOperatorAssignment;
 pub use crate::rules::eslint::prefer_arrow_callback::PreferArrowCallback as EslintPreferArrowCallback;
 pub use crate::rules::eslint::prefer_const::PreferConst as EslintPreferConst;
@@ -1051,6 +1052,7 @@ pub enum RuleEnum {
     EslintNoWarningComments(EslintNoWarningComments),
     EslintNoWith(EslintNoWith),
     EslintObjectShorthand(EslintObjectShorthand),
+    EslintOneVar(EslintOneVar),
     EslintOperatorAssignment(EslintOperatorAssignment),
     EslintPreferArrowCallback(EslintPreferArrowCallback),
     EslintPreferConst(EslintPreferConst),
@@ -1901,7 +1903,8 @@ const ESLINT_NO_VOID_ID: usize = ESLINT_NO_VAR_ID + 1usize;
 const ESLINT_NO_WARNING_COMMENTS_ID: usize = ESLINT_NO_VOID_ID + 1usize;
 const ESLINT_NO_WITH_ID: usize = ESLINT_NO_WARNING_COMMENTS_ID + 1usize;
 const ESLINT_OBJECT_SHORTHAND_ID: usize = ESLINT_NO_WITH_ID + 1usize;
-const ESLINT_OPERATOR_ASSIGNMENT_ID: usize = ESLINT_OBJECT_SHORTHAND_ID + 1usize;
+const ESLINT_ONE_VAR_ID: usize = ESLINT_OBJECT_SHORTHAND_ID + 1usize;
+const ESLINT_OPERATOR_ASSIGNMENT_ID: usize = ESLINT_ONE_VAR_ID + 1usize;
 const ESLINT_PREFER_ARROW_CALLBACK_ID: usize = ESLINT_OPERATOR_ASSIGNMENT_ID + 1usize;
 const ESLINT_PREFER_CONST_ID: usize = ESLINT_PREFER_ARROW_CALLBACK_ID + 1usize;
 const ESLINT_PREFER_DESTRUCTURING_ID: usize = ESLINT_PREFER_CONST_ID + 1usize;
@@ -2855,6 +2858,7 @@ impl RuleEnum {
             Self::EslintNoWarningComments(_) => ESLINT_NO_WARNING_COMMENTS_ID,
             Self::EslintNoWith(_) => ESLINT_NO_WITH_ID,
             Self::EslintObjectShorthand(_) => ESLINT_OBJECT_SHORTHAND_ID,
+            Self::EslintOneVar(_) => ESLINT_ONE_VAR_ID,
             Self::EslintOperatorAssignment(_) => ESLINT_OPERATOR_ASSIGNMENT_ID,
             Self::EslintPreferArrowCallback(_) => ESLINT_PREFER_ARROW_CALLBACK_ID,
             Self::EslintPreferConst(_) => ESLINT_PREFER_CONST_ID,
@@ -3828,6 +3832,7 @@ impl RuleEnum {
             Self::EslintNoWarningComments(_) => EslintNoWarningComments::NAME,
             Self::EslintNoWith(_) => EslintNoWith::NAME,
             Self::EslintObjectShorthand(_) => EslintObjectShorthand::NAME,
+            Self::EslintOneVar(_) => EslintOneVar::NAME,
             Self::EslintOperatorAssignment(_) => EslintOperatorAssignment::NAME,
             Self::EslintPreferArrowCallback(_) => EslintPreferArrowCallback::NAME,
             Self::EslintPreferConst(_) => EslintPreferConst::NAME,
@@ -4791,6 +4796,7 @@ impl RuleEnum {
             Self::EslintNoWarningComments(_) => EslintNoWarningComments::CATEGORY,
             Self::EslintNoWith(_) => EslintNoWith::CATEGORY,
             Self::EslintObjectShorthand(_) => EslintObjectShorthand::CATEGORY,
+            Self::EslintOneVar(_) => EslintOneVar::CATEGORY,
             Self::EslintOperatorAssignment(_) => EslintOperatorAssignment::CATEGORY,
             Self::EslintPreferArrowCallback(_) => EslintPreferArrowCallback::CATEGORY,
             Self::EslintPreferConst(_) => EslintPreferConst::CATEGORY,
@@ -5805,6 +5811,7 @@ impl RuleEnum {
             Self::EslintNoWarningComments(_) => EslintNoWarningComments::FIX,
             Self::EslintNoWith(_) => EslintNoWith::FIX,
             Self::EslintObjectShorthand(_) => EslintObjectShorthand::FIX,
+            Self::EslintOneVar(_) => EslintOneVar::FIX,
             Self::EslintOperatorAssignment(_) => EslintOperatorAssignment::FIX,
             Self::EslintPreferArrowCallback(_) => EslintPreferArrowCallback::FIX,
             Self::EslintPreferConst(_) => EslintPreferConst::FIX,
@@ -6793,6 +6800,7 @@ impl RuleEnum {
             Self::EslintNoWarningComments(_) => EslintNoWarningComments::documentation(),
             Self::EslintNoWith(_) => EslintNoWith::documentation(),
             Self::EslintObjectShorthand(_) => EslintObjectShorthand::documentation(),
+            Self::EslintOneVar(_) => EslintOneVar::documentation(),
             Self::EslintOperatorAssignment(_) => EslintOperatorAssignment::documentation(),
             Self::EslintPreferArrowCallback(_) => EslintPreferArrowCallback::documentation(),
             Self::EslintPreferConst(_) => EslintPreferConst::documentation(),
@@ -8281,6 +8289,9 @@ impl RuleEnum {
             }
             Self::EslintObjectShorthand(_) => EslintObjectShorthand::config_schema(generator)
                 .or_else(|| EslintObjectShorthand::schema(generator)),
+            Self::EslintOneVar(_) => {
+                EslintOneVar::config_schema(generator).or_else(|| EslintOneVar::schema(generator))
+            }
             Self::EslintOperatorAssignment(_) => EslintOperatorAssignment::config_schema(generator)
                 .or_else(|| EslintOperatorAssignment::schema(generator)),
             Self::EslintPreferArrowCallback(_) => {
@@ -10411,6 +10422,7 @@ impl RuleEnum {
             Self::EslintNoWarningComments(_) => "eslint",
             Self::EslintNoWith(_) => "eslint",
             Self::EslintObjectShorthand(_) => "eslint",
+            Self::EslintOneVar(_) => "eslint",
             Self::EslintOperatorAssignment(_) => "eslint",
             Self::EslintPreferArrowCallback(_) => "eslint",
             Self::EslintPreferConst(_) => "eslint",
@@ -11636,6 +11648,9 @@ impl RuleEnum {
             }
             Self::EslintObjectShorthand(_) => {
                 Ok(Self::EslintObjectShorthand(EslintObjectShorthand::from_configuration(value)?))
+            }
+            Self::EslintOneVar(_) => {
+                Ok(Self::EslintOneVar(EslintOneVar::from_configuration(value)?))
             }
             Self::EslintOperatorAssignment(_) => Ok(Self::EslintOperatorAssignment(
                 EslintOperatorAssignment::from_configuration(value)?,
@@ -13970,6 +13985,7 @@ impl RuleEnum {
             Self::EslintNoWarningComments(rule) => rule.to_configuration(),
             Self::EslintNoWith(rule) => rule.to_configuration(),
             Self::EslintObjectShorthand(rule) => rule.to_configuration(),
+            Self::EslintOneVar(rule) => rule.to_configuration(),
             Self::EslintOperatorAssignment(rule) => rule.to_configuration(),
             Self::EslintPreferArrowCallback(rule) => rule.to_configuration(),
             Self::EslintPreferConst(rule) => rule.to_configuration(),
@@ -14820,6 +14836,7 @@ impl RuleEnum {
             Self::EslintNoWarningComments(rule) => rule.run(node, ctx),
             Self::EslintNoWith(rule) => rule.run(node, ctx),
             Self::EslintObjectShorthand(rule) => rule.run(node, ctx),
+            Self::EslintOneVar(rule) => rule.run(node, ctx),
             Self::EslintOperatorAssignment(rule) => rule.run(node, ctx),
             Self::EslintPreferArrowCallback(rule) => rule.run(node, ctx),
             Self::EslintPreferConst(rule) => rule.run(node, ctx),
@@ -15678,6 +15695,7 @@ impl RuleEnum {
             Self::EslintNoWarningComments(rule) => rule.run_once(ctx),
             Self::EslintNoWith(rule) => rule.run_once(ctx),
             Self::EslintObjectShorthand(rule) => rule.run_once(ctx),
+            Self::EslintOneVar(rule) => rule.run_once(ctx),
             Self::EslintOperatorAssignment(rule) => rule.run_once(ctx),
             Self::EslintPreferArrowCallback(rule) => rule.run_once(ctx),
             Self::EslintPreferConst(rule) => rule.run_once(ctx),
@@ -16539,6 +16557,7 @@ impl RuleEnum {
             Self::EslintNoWarningComments(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoWith(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintObjectShorthand(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::EslintOneVar(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintOperatorAssignment(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintPreferArrowCallback(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintPreferConst(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -17512,6 +17531,7 @@ impl RuleEnum {
             Self::EslintNoWarningComments(rule) => rule.should_run(ctx),
             Self::EslintNoWith(rule) => rule.should_run(ctx),
             Self::EslintObjectShorthand(rule) => rule.should_run(ctx),
+            Self::EslintOneVar(rule) => rule.should_run(ctx),
             Self::EslintOperatorAssignment(rule) => rule.should_run(ctx),
             Self::EslintPreferArrowCallback(rule) => rule.should_run(ctx),
             Self::EslintPreferConst(rule) => rule.should_run(ctx),
@@ -18385,6 +18405,7 @@ impl RuleEnum {
             Self::EslintNoWarningComments(_) => EslintNoWarningComments::IS_TSGOLINT_RULE,
             Self::EslintNoWith(_) => EslintNoWith::IS_TSGOLINT_RULE,
             Self::EslintObjectShorthand(_) => EslintObjectShorthand::IS_TSGOLINT_RULE,
+            Self::EslintOneVar(_) => EslintOneVar::IS_TSGOLINT_RULE,
             Self::EslintOperatorAssignment(_) => EslintOperatorAssignment::IS_TSGOLINT_RULE,
             Self::EslintPreferArrowCallback(_) => EslintPreferArrowCallback::IS_TSGOLINT_RULE,
             Self::EslintPreferConst(_) => EslintPreferConst::IS_TSGOLINT_RULE,
@@ -19586,6 +19607,7 @@ impl RuleEnum {
             Self::EslintNoWarningComments(_) => EslintNoWarningComments::VERSION,
             Self::EslintNoWith(_) => EslintNoWith::VERSION,
             Self::EslintObjectShorthand(_) => EslintObjectShorthand::VERSION,
+            Self::EslintOneVar(_) => EslintOneVar::VERSION,
             Self::EslintOperatorAssignment(_) => EslintOperatorAssignment::VERSION,
             Self::EslintPreferArrowCallback(_) => EslintPreferArrowCallback::VERSION,
             Self::EslintPreferConst(_) => EslintPreferConst::VERSION,
@@ -20610,6 +20632,7 @@ impl RuleEnum {
             Self::EslintNoWarningComments(_) => EslintNoWarningComments::HAS_CONFIG,
             Self::EslintNoWith(_) => EslintNoWith::HAS_CONFIG,
             Self::EslintObjectShorthand(_) => EslintObjectShorthand::HAS_CONFIG,
+            Self::EslintOneVar(_) => EslintOneVar::HAS_CONFIG,
             Self::EslintOperatorAssignment(_) => EslintOperatorAssignment::HAS_CONFIG,
             Self::EslintPreferArrowCallback(_) => EslintPreferArrowCallback::HAS_CONFIG,
             Self::EslintPreferConst(_) => EslintPreferConst::HAS_CONFIG,
@@ -21657,6 +21680,7 @@ impl RuleEnum {
             Self::EslintNoWarningComments(_) => EslintNoWarningComments::INFO,
             Self::EslintNoWith(_) => EslintNoWith::INFO,
             Self::EslintObjectShorthand(_) => EslintObjectShorthand::INFO,
+            Self::EslintOneVar(_) => EslintOneVar::INFO,
             Self::EslintOperatorAssignment(_) => EslintOperatorAssignment::INFO,
             Self::EslintPreferArrowCallback(_) => EslintPreferArrowCallback::INFO,
             Self::EslintPreferConst(_) => EslintPreferConst::INFO,
@@ -22621,6 +22645,7 @@ impl RuleEnum {
             Self::EslintNoWarningComments(rule) => rule.types_info(),
             Self::EslintNoWith(rule) => rule.types_info(),
             Self::EslintObjectShorthand(rule) => rule.types_info(),
+            Self::EslintOneVar(rule) => rule.types_info(),
             Self::EslintOperatorAssignment(rule) => rule.types_info(),
             Self::EslintPreferArrowCallback(rule) => rule.types_info(),
             Self::EslintPreferConst(rule) => rule.types_info(),
@@ -23466,6 +23491,7 @@ impl RuleEnum {
             Self::EslintNoWarningComments(rule) => rule.run_info(),
             Self::EslintNoWith(rule) => rule.run_info(),
             Self::EslintObjectShorthand(rule) => rule.run_info(),
+            Self::EslintOneVar(rule) => rule.run_info(),
             Self::EslintOperatorAssignment(rule) => rule.run_info(),
             Self::EslintPreferArrowCallback(rule) => rule.run_info(),
             Self::EslintPreferConst(rule) => rule.run_info(),
@@ -24333,6 +24359,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::EslintNoWarningComments(EslintNoWarningComments::default()),
         RuleEnum::EslintNoWith(EslintNoWith::default()),
         RuleEnum::EslintObjectShorthand(EslintObjectShorthand::default()),
+        RuleEnum::EslintOneVar(EslintOneVar::default()),
         RuleEnum::EslintOperatorAssignment(EslintOperatorAssignment::default()),
         RuleEnum::EslintPreferArrowCallback(EslintPreferArrowCallback::default()),
         RuleEnum::EslintPreferConst(EslintPreferConst::default()),

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -168,6 +168,7 @@ pub use crate::rules::eslint::no_void::NoVoid as EslintNoVoid;
 pub use crate::rules::eslint::no_warning_comments::NoWarningComments as EslintNoWarningComments;
 pub use crate::rules::eslint::no_with::NoWith as EslintNoWith;
 pub use crate::rules::eslint::object_shorthand::ObjectShorthand as EslintObjectShorthand;
+pub use crate::rules::eslint::one_var::OneVar as EslintOneVar;
 pub use crate::rules::eslint::operator_assignment::OperatorAssignment as EslintOperatorAssignment;
 pub use crate::rules::eslint::prefer_arrow_callback::PreferArrowCallback as EslintPreferArrowCallback;
 pub use crate::rules::eslint::prefer_const::PreferConst as EslintPreferConst;
@@ -1058,6 +1059,7 @@ pub enum RuleEnum {
     EslintNoWarningComments(EslintNoWarningComments),
     EslintNoWith(EslintNoWith),
     EslintObjectShorthand(EslintObjectShorthand),
+    EslintOneVar(EslintOneVar),
     EslintOperatorAssignment(EslintOperatorAssignment),
     EslintPreferArrowCallback(EslintPreferArrowCallback),
     EslintPreferConst(EslintPreferConst),
@@ -1914,7 +1916,8 @@ const ESLINT_NO_VOID_ID: usize = ESLINT_NO_VAR_ID + 1usize;
 const ESLINT_NO_WARNING_COMMENTS_ID: usize = ESLINT_NO_VOID_ID + 1usize;
 const ESLINT_NO_WITH_ID: usize = ESLINT_NO_WARNING_COMMENTS_ID + 1usize;
 const ESLINT_OBJECT_SHORTHAND_ID: usize = ESLINT_NO_WITH_ID + 1usize;
-const ESLINT_OPERATOR_ASSIGNMENT_ID: usize = ESLINT_OBJECT_SHORTHAND_ID + 1usize;
+const ESLINT_ONE_VAR_ID: usize = ESLINT_OBJECT_SHORTHAND_ID + 1usize;
+const ESLINT_OPERATOR_ASSIGNMENT_ID: usize = ESLINT_ONE_VAR_ID + 1usize;
 const ESLINT_PREFER_ARROW_CALLBACK_ID: usize = ESLINT_OPERATOR_ASSIGNMENT_ID + 1usize;
 const ESLINT_PREFER_CONST_ID: usize = ESLINT_PREFER_ARROW_CALLBACK_ID + 1usize;
 const ESLINT_PREFER_DESTRUCTURING_ID: usize = ESLINT_PREFER_CONST_ID + 1usize;
@@ -2875,6 +2878,7 @@ impl RuleEnum {
             Self::EslintNoWarningComments(_) => ESLINT_NO_WARNING_COMMENTS_ID,
             Self::EslintNoWith(_) => ESLINT_NO_WITH_ID,
             Self::EslintObjectShorthand(_) => ESLINT_OBJECT_SHORTHAND_ID,
+            Self::EslintOneVar(_) => ESLINT_ONE_VAR_ID,
             Self::EslintOperatorAssignment(_) => ESLINT_OPERATOR_ASSIGNMENT_ID,
             Self::EslintPreferArrowCallback(_) => ESLINT_PREFER_ARROW_CALLBACK_ID,
             Self::EslintPreferConst(_) => ESLINT_PREFER_CONST_ID,
@@ -3854,6 +3858,7 @@ impl RuleEnum {
             Self::EslintNoWarningComments(_) => EslintNoWarningComments::NAME,
             Self::EslintNoWith(_) => EslintNoWith::NAME,
             Self::EslintObjectShorthand(_) => EslintObjectShorthand::NAME,
+            Self::EslintOneVar(_) => EslintOneVar::NAME,
             Self::EslintOperatorAssignment(_) => EslintOperatorAssignment::NAME,
             Self::EslintPreferArrowCallback(_) => EslintPreferArrowCallback::NAME,
             Self::EslintPreferConst(_) => EslintPreferConst::NAME,
@@ -4823,6 +4828,7 @@ impl RuleEnum {
             Self::EslintNoWarningComments(_) => EslintNoWarningComments::CATEGORY,
             Self::EslintNoWith(_) => EslintNoWith::CATEGORY,
             Self::EslintObjectShorthand(_) => EslintObjectShorthand::CATEGORY,
+            Self::EslintOneVar(_) => EslintOneVar::CATEGORY,
             Self::EslintOperatorAssignment(_) => EslintOperatorAssignment::CATEGORY,
             Self::EslintPreferArrowCallback(_) => EslintPreferArrowCallback::CATEGORY,
             Self::EslintPreferConst(_) => EslintPreferConst::CATEGORY,
@@ -5843,6 +5849,7 @@ impl RuleEnum {
             Self::EslintNoWarningComments(_) => EslintNoWarningComments::FIX,
             Self::EslintNoWith(_) => EslintNoWith::FIX,
             Self::EslintObjectShorthand(_) => EslintObjectShorthand::FIX,
+            Self::EslintOneVar(_) => EslintOneVar::FIX,
             Self::EslintOperatorAssignment(_) => EslintOperatorAssignment::FIX,
             Self::EslintPreferArrowCallback(_) => EslintPreferArrowCallback::FIX,
             Self::EslintPreferConst(_) => EslintPreferConst::FIX,
@@ -6837,6 +6844,7 @@ impl RuleEnum {
             Self::EslintNoWarningComments(_) => EslintNoWarningComments::documentation(),
             Self::EslintNoWith(_) => EslintNoWith::documentation(),
             Self::EslintObjectShorthand(_) => EslintObjectShorthand::documentation(),
+            Self::EslintOneVar(_) => EslintOneVar::documentation(),
             Self::EslintOperatorAssignment(_) => EslintOperatorAssignment::documentation(),
             Self::EslintPreferArrowCallback(_) => EslintPreferArrowCallback::documentation(),
             Self::EslintPreferConst(_) => EslintPreferConst::documentation(),
@@ -8336,6 +8344,9 @@ impl RuleEnum {
             }
             Self::EslintObjectShorthand(_) => EslintObjectShorthand::config_schema(generator)
                 .or_else(|| EslintObjectShorthand::schema(generator)),
+            Self::EslintOneVar(_) => {
+                EslintOneVar::config_schema(generator).or_else(|| EslintOneVar::schema(generator))
+            }
             Self::EslintOperatorAssignment(_) => EslintOperatorAssignment::config_schema(generator)
                 .or_else(|| EslintOperatorAssignment::schema(generator)),
             Self::EslintPreferArrowCallback(_) => {
@@ -10481,6 +10492,7 @@ impl RuleEnum {
             Self::EslintNoWarningComments(_) => "eslint",
             Self::EslintNoWith(_) => "eslint",
             Self::EslintObjectShorthand(_) => "eslint",
+            Self::EslintOneVar(_) => "eslint",
             Self::EslintOperatorAssignment(_) => "eslint",
             Self::EslintPreferArrowCallback(_) => "eslint",
             Self::EslintPreferConst(_) => "eslint",
@@ -11714,6 +11726,9 @@ impl RuleEnum {
             }
             Self::EslintObjectShorthand(_) => {
                 Ok(Self::EslintObjectShorthand(EslintObjectShorthand::from_configuration(value)?))
+            }
+            Self::EslintOneVar(_) => {
+                Ok(Self::EslintOneVar(EslintOneVar::from_configuration(value)?))
             }
             Self::EslintOperatorAssignment(_) => Ok(Self::EslintOperatorAssignment(
                 EslintOperatorAssignment::from_configuration(value)?,
@@ -14066,6 +14081,7 @@ impl RuleEnum {
             Self::EslintNoWarningComments(rule) => rule.to_configuration(),
             Self::EslintNoWith(rule) => rule.to_configuration(),
             Self::EslintObjectShorthand(rule) => rule.to_configuration(),
+            Self::EslintOneVar(rule) => rule.to_configuration(),
             Self::EslintOperatorAssignment(rule) => rule.to_configuration(),
             Self::EslintPreferArrowCallback(rule) => rule.to_configuration(),
             Self::EslintPreferConst(rule) => rule.to_configuration(),
@@ -14922,6 +14938,7 @@ impl RuleEnum {
             Self::EslintNoWarningComments(rule) => rule.run(node, ctx),
             Self::EslintNoWith(rule) => rule.run(node, ctx),
             Self::EslintObjectShorthand(rule) => rule.run(node, ctx),
+            Self::EslintOneVar(rule) => rule.run(node, ctx),
             Self::EslintOperatorAssignment(rule) => rule.run(node, ctx),
             Self::EslintPreferArrowCallback(rule) => rule.run(node, ctx),
             Self::EslintPreferConst(rule) => rule.run(node, ctx),
@@ -15786,6 +15803,7 @@ impl RuleEnum {
             Self::EslintNoWarningComments(rule) => rule.run_once(ctx),
             Self::EslintNoWith(rule) => rule.run_once(ctx),
             Self::EslintObjectShorthand(rule) => rule.run_once(ctx),
+            Self::EslintOneVar(rule) => rule.run_once(ctx),
             Self::EslintOperatorAssignment(rule) => rule.run_once(ctx),
             Self::EslintPreferArrowCallback(rule) => rule.run_once(ctx),
             Self::EslintPreferConst(rule) => rule.run_once(ctx),
@@ -16653,6 +16671,7 @@ impl RuleEnum {
             Self::EslintNoWarningComments(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoWith(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintObjectShorthand(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::EslintOneVar(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintOperatorAssignment(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintPreferArrowCallback(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintPreferConst(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -17632,6 +17651,7 @@ impl RuleEnum {
             Self::EslintNoWarningComments(rule) => rule.should_run(ctx),
             Self::EslintNoWith(rule) => rule.should_run(ctx),
             Self::EslintObjectShorthand(rule) => rule.should_run(ctx),
+            Self::EslintOneVar(rule) => rule.should_run(ctx),
             Self::EslintOperatorAssignment(rule) => rule.should_run(ctx),
             Self::EslintPreferArrowCallback(rule) => rule.should_run(ctx),
             Self::EslintPreferConst(rule) => rule.should_run(ctx),
@@ -18511,6 +18531,7 @@ impl RuleEnum {
             Self::EslintNoWarningComments(_) => EslintNoWarningComments::IS_TSGOLINT_RULE,
             Self::EslintNoWith(_) => EslintNoWith::IS_TSGOLINT_RULE,
             Self::EslintObjectShorthand(_) => EslintObjectShorthand::IS_TSGOLINT_RULE,
+            Self::EslintOneVar(_) => EslintOneVar::IS_TSGOLINT_RULE,
             Self::EslintOperatorAssignment(_) => EslintOperatorAssignment::IS_TSGOLINT_RULE,
             Self::EslintPreferArrowCallback(_) => EslintPreferArrowCallback::IS_TSGOLINT_RULE,
             Self::EslintPreferConst(_) => EslintPreferConst::IS_TSGOLINT_RULE,
@@ -19722,6 +19743,7 @@ impl RuleEnum {
             Self::EslintNoWarningComments(_) => EslintNoWarningComments::VERSION,
             Self::EslintNoWith(_) => EslintNoWith::VERSION,
             Self::EslintObjectShorthand(_) => EslintObjectShorthand::VERSION,
+            Self::EslintOneVar(_) => EslintOneVar::VERSION,
             Self::EslintOperatorAssignment(_) => EslintOperatorAssignment::VERSION,
             Self::EslintPreferArrowCallback(_) => EslintPreferArrowCallback::VERSION,
             Self::EslintPreferConst(_) => EslintPreferConst::VERSION,
@@ -20752,6 +20774,7 @@ impl RuleEnum {
             Self::EslintNoWarningComments(_) => EslintNoWarningComments::HAS_CONFIG,
             Self::EslintNoWith(_) => EslintNoWith::HAS_CONFIG,
             Self::EslintObjectShorthand(_) => EslintObjectShorthand::HAS_CONFIG,
+            Self::EslintOneVar(_) => EslintOneVar::HAS_CONFIG,
             Self::EslintOperatorAssignment(_) => EslintOperatorAssignment::HAS_CONFIG,
             Self::EslintPreferArrowCallback(_) => EslintPreferArrowCallback::HAS_CONFIG,
             Self::EslintPreferConst(_) => EslintPreferConst::HAS_CONFIG,
@@ -21807,6 +21830,7 @@ impl RuleEnum {
             Self::EslintNoWarningComments(_) => EslintNoWarningComments::INFO,
             Self::EslintNoWith(_) => EslintNoWith::INFO,
             Self::EslintObjectShorthand(_) => EslintObjectShorthand::INFO,
+            Self::EslintOneVar(_) => EslintOneVar::INFO,
             Self::EslintOperatorAssignment(_) => EslintOperatorAssignment::INFO,
             Self::EslintPreferArrowCallback(_) => EslintPreferArrowCallback::INFO,
             Self::EslintPreferConst(_) => EslintPreferConst::INFO,
@@ -22777,6 +22801,7 @@ impl RuleEnum {
             Self::EslintNoWarningComments(rule) => rule.types_info(),
             Self::EslintNoWith(rule) => rule.types_info(),
             Self::EslintObjectShorthand(rule) => rule.types_info(),
+            Self::EslintOneVar(rule) => rule.types_info(),
             Self::EslintOperatorAssignment(rule) => rule.types_info(),
             Self::EslintPreferArrowCallback(rule) => rule.types_info(),
             Self::EslintPreferConst(rule) => rule.types_info(),
@@ -23628,6 +23653,7 @@ impl RuleEnum {
             Self::EslintNoWarningComments(rule) => rule.run_info(),
             Self::EslintNoWith(rule) => rule.run_info(),
             Self::EslintObjectShorthand(rule) => rule.run_info(),
+            Self::EslintOneVar(rule) => rule.run_info(),
             Self::EslintOperatorAssignment(rule) => rule.run_info(),
             Self::EslintPreferArrowCallback(rule) => rule.run_info(),
             Self::EslintPreferConst(rule) => rule.run_info(),
@@ -24501,6 +24527,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::EslintNoWarningComments(EslintNoWarningComments::default()),
         RuleEnum::EslintNoWith(EslintNoWith::default()),
         RuleEnum::EslintObjectShorthand(EslintObjectShorthand::default()),
+        RuleEnum::EslintOneVar(EslintOneVar::default()),
         RuleEnum::EslintOperatorAssignment(EslintOperatorAssignment::default()),
         RuleEnum::EslintPreferArrowCallback(EslintPreferArrowCallback::default()),
         RuleEnum::EslintPreferConst(EslintPreferConst::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -200,6 +200,7 @@ pub(crate) mod eslint {
     pub mod no_warning_comments;
     pub mod no_with;
     pub mod object_shorthand;
+    pub mod one_var;
     pub mod operator_assignment;
     pub mod prefer_arrow_callback;
     pub mod prefer_const;

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -199,6 +199,7 @@ pub(crate) mod eslint {
     pub mod no_warning_comments;
     pub mod no_with;
     pub mod object_shorthand;
+    pub mod one_var;
     pub mod operator_assignment;
     pub mod prefer_arrow_callback;
     pub mod prefer_const;

--- a/crates/oxc_linter/src/rules/eslint/one_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/one_var.rs
@@ -1,0 +1,1925 @@
+use oxc_ast::{
+    AstKind,
+    ast::{Expression, VariableDeclaration, VariableDeclarationKind},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+use oxc_syntax::{node::NodeId, scope::ScopeId};
+use rustc_hash::FxHashMap;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    fixer::{Fix, RuleFix},
+    rule::{DefaultRuleConfig, Rule},
+};
+
+fn one_var_diagnostic(span: Span, message: String) -> OxcDiagnostic {
+    OxcDiagnostic::warn(message).with_label(span)
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+enum OneVarMode {
+    #[default]
+    Always,
+    Never,
+    Consecutive,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+struct OneVarOptions {
+    r#const: Option<OneVarMode>,
+    separate_requires: bool,
+    var: Option<OneVarMode>,
+    await_using: Option<OneVarMode>,
+    r#let: Option<OneVarMode>,
+    using: Option<OneVarMode>,
+    initialized: Option<OneVarMode>,
+    uninitialized: Option<OneVarMode>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+enum OneVarConfig {
+    Mode(OneVarMode),
+    Options(OneVarOptions),
+}
+
+impl Default for OneVarConfig {
+    fn default() -> Self {
+        Self::Mode(OneVarMode::Always)
+    }
+}
+
+#[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct OneVar(OneVarConfig);
+
+// See <https://github.com/oxc-project/oxc/issues/6050> for documentation details.
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces variables to be declared either together or separately.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Consistent declaration grouping makes variable lifetimes and initialization patterns easier
+    /// to scan. This rule can require one declaration per scope, one declarator per statement, or
+    /// grouping only consecutive declarations.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// var foo = 1;
+    /// var bar = 2;
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// var foo = 1, bar = 2;
+    /// ```
+    OneVar,
+    eslint,
+    style,
+    conditional_fix,
+    config = OneVar,
+    version = "next",
+    short_description = "Enforce variables to be declared either together or separately in functions.",
+);
+
+impl Rule for OneVar {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let mut scopes: FxHashMap<(ScopeId, u8), ScopeState> = FxHashMap::default();
+        let previous_statements = previous_statement_ids(ctx);
+
+        for node in ctx.nodes().iter() {
+            let AstKind::VariableDeclaration(declaration) = node.kind() else {
+                continue;
+            };
+            let modes = self.modes(declaration.kind);
+            if modes.initialized.is_none() && modes.uninitialized.is_none() {
+                continue;
+            }
+
+            let counts = DeclarationCounts::new(declaration);
+            let requires = declaration
+                .declarations
+                .iter()
+                .filter(|decl| is_require(decl.init.as_ref()))
+                .count();
+            if self.separate_requires()
+                && modes.initialized == Some(OneVarMode::Always)
+                && requires > 0
+                && requires != declaration.declarations.len()
+            {
+                ctx.diagnostic(one_var_diagnostic(
+                    declaration.span,
+                    "Split requires to be separated into a single block.".to_string(),
+                ));
+            }
+
+            if let Some(previous) = previous_declaration(node, ctx, &previous_statements)
+                && previous.kind == declaration.kind
+                && !mixed_requires(previous, declaration)
+            {
+                let previous_counts = DeclarationCounts::new(previous);
+                if modes.initialized == Some(OneVarMode::Consecutive)
+                    && modes.uninitialized == Some(OneVarMode::Consecutive)
+                {
+                    report_join(
+                        ctx,
+                        declaration,
+                        previous,
+                        format!(
+                            "Combine this with the previous '{}' statement.",
+                            declaration.kind.as_str()
+                        ),
+                    );
+                } else {
+                    if modes.initialized == Some(OneVarMode::Consecutive)
+                        && counts.initialized > 0
+                        && previous_counts.initialized > 0
+                    {
+                        report_join(
+                            ctx,
+                            declaration,
+                            previous,
+                            format!(
+                                "Combine this with the previous '{}' statement with initialized variables.",
+                                declaration.kind.as_str()
+                            ),
+                        );
+                    }
+                    if modes.uninitialized == Some(OneVarMode::Consecutive)
+                        && counts.uninitialized > 0
+                        && previous_counts.uninitialized > 0
+                    {
+                        report_join(
+                            ctx,
+                            declaration,
+                            previous,
+                            format!(
+                                "Combine this with the previous '{}' statement with uninitialized variables.",
+                                declaration.kind.as_str()
+                            ),
+                        );
+                    }
+                }
+            }
+
+            let scope_id = declaration_scope(node, ctx);
+            let state = scopes.entry((scope_id, declaration.kind as u8)).or_default();
+            let has_requires = requires > 0;
+            let should_join_initialized = modes.initialized == Some(OneVarMode::Always)
+                && counts.initialized > 0
+                && state.initialized
+                && !has_requires;
+            let should_join_uninitialized = modes.uninitialized == Some(OneVarMode::Always)
+                && counts.uninitialized > 0
+                && state.uninitialized;
+            let should_join_all = modes.initialized == Some(OneVarMode::Always)
+                && modes.uninitialized == Some(OneVarMode::Always)
+                && (state.initialized || state.uninitialized)
+                && !has_requires;
+            let should_join_require = self.separate_requires() && has_requires && state.required;
+
+            if should_join_all || should_join_require {
+                report_join_with_optional_previous(
+                    ctx,
+                    node,
+                    declaration,
+                    &previous_statements,
+                    format!(
+                        "Combine this with the previous '{}' statement.",
+                        declaration.kind.as_str()
+                    ),
+                );
+            } else {
+                if should_join_initialized {
+                    report_join_with_optional_previous(
+                        ctx,
+                        node,
+                        declaration,
+                        &previous_statements,
+                        format!(
+                            "Combine this with the previous '{}' statement with initialized variables.",
+                            declaration.kind.as_str()
+                        ),
+                    );
+                }
+                if should_join_uninitialized && !is_for_in_or_of_left(node, ctx) {
+                    report_join_with_optional_previous(
+                        ctx,
+                        node,
+                        declaration,
+                        &previous_statements,
+                        format!(
+                            "Combine this with the previous '{}' statement with uninitialized variables.",
+                            declaration.kind.as_str()
+                        ),
+                    );
+                }
+            }
+
+            if modes.initialized == Some(OneVarMode::Always) && counts.initialized > 0 {
+                if self.separate_requires() && has_requires {
+                    state.required = true;
+                } else {
+                    state.initialized = true;
+                }
+            }
+            if modes.uninitialized == Some(OneVarMode::Always) && counts.uninitialized > 0 {
+                state.uninitialized = true;
+            }
+
+            if !is_for_statement_init(node, ctx) && declaration.declarations.len() > 1 {
+                if modes.initialized == Some(OneVarMode::Never)
+                    && modes.uninitialized == Some(OneVarMode::Never)
+                {
+                    report_split(
+                        ctx,
+                        node,
+                        declaration,
+                        format!(
+                            "Split '{}' declarations into multiple statements.",
+                            declaration.kind.as_str()
+                        ),
+                    );
+                } else {
+                    if modes.initialized == Some(OneVarMode::Never) && counts.initialized > 0 {
+                        report_split(
+                            ctx,
+                            node,
+                            declaration,
+                            format!(
+                                "Split initialized '{}' declarations into multiple statements.",
+                                declaration.kind.as_str()
+                            ),
+                        );
+                    }
+                    if modes.uninitialized == Some(OneVarMode::Never) && counts.uninitialized > 0 {
+                        report_split(
+                            ctx,
+                            node,
+                            declaration,
+                            format!(
+                                "Split uninitialized '{}' declarations into multiple statements.",
+                                declaration.kind.as_str()
+                            ),
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct EffectiveModes {
+    initialized: Option<OneVarMode>,
+    uninitialized: Option<OneVarMode>,
+}
+
+impl OneVar {
+    fn modes(&self, kind: VariableDeclarationKind) -> EffectiveModes {
+        match &self.0 {
+            OneVarConfig::Mode(mode) => {
+                EffectiveModes { initialized: Some(*mode), uninitialized: Some(*mode) }
+            }
+            OneVarConfig::Options(options) => {
+                let per_kind = match kind {
+                    VariableDeclarationKind::Var => options.var,
+                    VariableDeclarationKind::Let => options.r#let,
+                    VariableDeclarationKind::Const => options.r#const,
+                    VariableDeclarationKind::Using => options.using,
+                    VariableDeclarationKind::AwaitUsing => options.await_using,
+                };
+                EffectiveModes {
+                    initialized: options.initialized.or(per_kind),
+                    uninitialized: options.uninitialized.or(per_kind),
+                }
+            }
+        }
+    }
+
+    fn separate_requires(&self) -> bool {
+        matches!(&self.0, OneVarConfig::Options(options) if options.separate_requires)
+    }
+}
+
+#[derive(Default)]
+struct ScopeState {
+    initialized: bool,
+    uninitialized: bool,
+    required: bool,
+}
+
+struct DeclarationCounts {
+    initialized: usize,
+    uninitialized: usize,
+}
+
+impl DeclarationCounts {
+    fn new(declaration: &VariableDeclaration<'_>) -> Self {
+        let initialized =
+            declaration.declarations.iter().filter(|decl| decl.init.is_some()).count();
+        Self { initialized, uninitialized: declaration.declarations.len() - initialized }
+    }
+}
+
+fn is_require(expression: Option<&Expression<'_>>) -> bool {
+    matches!(expression, Some(Expression::CallExpression(call)) if call.callee_name() == Some("require"))
+}
+
+fn mixed_requires(left: &VariableDeclaration<'_>, right: &VariableDeclaration<'_>) -> bool {
+    let declarations = left.declarations.iter().chain(&right.declarations);
+    let mut require = false;
+    let mut other = false;
+    for declaration in declarations {
+        if is_require(declaration.init.as_ref()) {
+            require = true;
+        } else {
+            other = true;
+        }
+    }
+    require && other
+}
+
+fn declaration_scope(node: &AstNode<'_>, ctx: &LintContext<'_>) -> ScopeId {
+    if let AstKind::VariableDeclaration(declaration) = node.kind()
+        && declaration.kind == VariableDeclarationKind::Var
+    {
+        return ctx
+            .scoping()
+            .scope_ancestors(node.scope_id())
+            .find(|&scope_id| ctx.scoping().scope_flags(scope_id).is_var())
+            .unwrap_or_else(|| ctx.scoping().root_scope_id());
+    }
+    node.scope_id()
+}
+
+fn is_statement_list_parent(kind: AstKind<'_>) -> bool {
+    matches!(
+        kind,
+        AstKind::Program(_)
+            | AstKind::BlockStatement(_)
+            | AstKind::FunctionBody(_)
+            | AstKind::StaticBlock(_)
+            | AstKind::SwitchCase(_)
+            | AstKind::TSModuleBlock(_)
+    )
+}
+
+fn statement_node_id(node: &AstNode<'_>, ctx: &LintContext<'_>) -> Option<NodeId> {
+    let parent = ctx.nodes().parent_node(node.id());
+    if is_statement_list_parent(parent.kind()) {
+        Some(node.id())
+    } else if matches!(parent.kind(), AstKind::ExportNamedDeclaration(_)) {
+        let grandparent = ctx.nodes().parent_node(parent.id());
+        is_statement_list_parent(grandparent.kind()).then_some(parent.id())
+    } else {
+        None
+    }
+}
+
+fn previous_statement_ids(ctx: &LintContext<'_>) -> FxHashMap<NodeId, NodeId> {
+    let mut statement_lists: FxHashMap<NodeId, Vec<(u32, NodeId)>> = FxHashMap::default();
+    for node in ctx.nodes().iter() {
+        let parent = ctx.nodes().parent_node(node.id());
+        if is_statement_list_parent(parent.kind()) {
+            statement_lists.entry(parent.id()).or_default().push((node.span().start, node.id()));
+        }
+    }
+
+    let mut previous = FxHashMap::default();
+    for statements in statement_lists.values_mut() {
+        statements.sort_unstable_by_key(|&(start, _)| start);
+        for pair in statements.windows(2) {
+            previous.insert(pair[1].1, pair[0].1);
+        }
+    }
+    previous
+}
+
+fn previous_statement<'a, 'c>(
+    node: &AstNode<'a>,
+    ctx: &'c LintContext<'a>,
+    previous_statements: &FxHashMap<NodeId, NodeId>,
+) -> Option<&'c AstNode<'a>> {
+    let statement_id = statement_node_id(node, ctx)?;
+    previous_statements.get(&statement_id).map(|&previous_id| ctx.nodes().get_node(previous_id))
+}
+
+fn previous_declaration<'a, 'c>(
+    node: &AstNode<'a>,
+    ctx: &'c LintContext<'a>,
+    previous_statements: &FxHashMap<NodeId, NodeId>,
+) -> Option<&'c VariableDeclaration<'a>> {
+    match previous_statement(node, ctx, previous_statements)?.kind() {
+        AstKind::VariableDeclaration(declaration) => Some(declaration),
+        _ => None,
+    }
+}
+
+fn is_for_statement_init(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
+    matches!(ctx.nodes().parent_kind(node.id()), AstKind::ForStatement(statement) if statement.init.as_ref().is_some_and(|init| init.span() == node.span()))
+}
+
+fn is_for_in_or_of_left(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
+    matches!(
+        ctx.nodes().parent_kind(node.id()),
+        AstKind::ForInStatement(_) | AstKind::ForOfStatement(_)
+    )
+}
+
+fn report_join_with_optional_previous<'a>(
+    ctx: &LintContext<'a>,
+    node: &AstNode<'a>,
+    declaration: &VariableDeclaration<'a>,
+    previous_statements: &FxHashMap<NodeId, NodeId>,
+    message: String,
+) {
+    if let Some(previous) = previous_declaration(node, ctx, previous_statements)
+        .filter(|previous| previous.kind == declaration.kind)
+    {
+        report_join(ctx, declaration, previous, message);
+    } else {
+        ctx.diagnostic(one_var_diagnostic(declaration.span, message));
+    }
+}
+
+fn report_join(
+    ctx: &LintContext<'_>,
+    declaration: &VariableDeclaration<'_>,
+    previous: &VariableDeclaration<'_>,
+    message: String,
+) {
+    ctx.diagnostic_with_fix(one_var_diagnostic(declaration.span, message), |_fixer| {
+        let source = ctx.source_text();
+        let previous_source = previous.span.source_text(source);
+        let mut fixes = Vec::with_capacity(3);
+        if let Some(index) = previous_source.rfind(';') {
+            let start = previous.span.start + u32::try_from(index).unwrap();
+            fixes.push(Fix::new(",", Span::sized(start, 1)));
+        } else {
+            fixes.push(Fix::new(",", Span::empty(previous.span.end)));
+        }
+        let keyword = declaration.kind.as_str();
+        let declaration_source = declaration.span.source_text(source);
+        if declaration.kind == VariableDeclarationKind::AwaitUsing {
+            fixes.push(Fix::delete(Span::sized(declaration.span.start, 5)));
+            let using_offset = declaration_source.find("using").unwrap();
+            fixes.push(Fix::delete(Span::sized(
+                declaration.span.start + u32::try_from(using_offset).unwrap(),
+                5,
+            )));
+        } else if let Some(offset) = declaration_source.find(keyword) {
+            fixes.push(Fix::delete(Span::sized(
+                declaration.span.start + u32::try_from(offset).unwrap(),
+                u32::try_from(keyword.len()).unwrap(),
+            )));
+        }
+        fixes.into_iter().collect::<RuleFix>().with_message("Combine variable declarations")
+    });
+}
+
+fn report_split(
+    ctx: &LintContext<'_>,
+    node: &AstNode<'_>,
+    declaration: &VariableDeclaration<'_>,
+    message: String,
+) {
+    let diagnostic = one_var_diagnostic(declaration.span, message);
+    if statement_node_id(node, ctx).is_none() {
+        ctx.diagnostic(diagnostic);
+        return;
+    }
+    ctx.diagnostic_with_fix(diagnostic, |_fixer| {
+        let source = ctx.source_text();
+        let keyword = declaration.kind.as_str();
+        let exported =
+            matches!(ctx.nodes().parent_kind(node.id()), AstKind::ExportNamedDeclaration(_));
+        let prefix = if exported { format!("export {keyword} ") } else { format!("{keyword} ") };
+        let mut fixes = Vec::with_capacity((declaration.declarations.len() - 1) * 2);
+        for pair in declaration.declarations.windows(2) {
+            let left = &pair[0];
+            let right = &pair[1];
+            let gap = &source[left.span.end as usize..right.span.start as usize];
+            if let Some(index) = gap.find(',') {
+                let comma = left.span.end + u32::try_from(index).unwrap();
+                let separator = if comma + 1 == right.span.start { "; " } else { ";" };
+                fixes.push(Fix::new(separator, Span::sized(comma, 1)));
+                fixes.push(Fix::new(prefix.clone(), Span::empty(right.span.start)));
+            }
+        }
+        fixes.into_iter().collect::<RuleFix>().with_message("Split variable declarations")
+    });
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        ("function foo() { var bar = true; }", None),
+        ("function foo() { var bar = true, baz = 1; if (qux) { bar = false; } }", None),
+        ("var foo = function() { var bar = true; baz(); }", None),
+        ("function foo() { var bar = true, baz = false; }", Some(serde_json::json!(["always"]))),
+        ("function foo() { var bar = true; var baz = false; }", Some(serde_json::json!(["never"]))),
+        ("for (var i = 0, len = arr.length; i < len; i++) {}", Some(serde_json::json!(["never"]))),
+        ("var bar = true; var baz = false;", Some(serde_json::json!([{ "initialized": "never" }]))),
+        ("var bar = true, baz = false;", Some(serde_json::json!([{ "initialized": "always" }]))),
+        ("var bar, baz;", Some(serde_json::json!([{ "initialized": "never" }]))),
+        ("var bar; var baz;", Some(serde_json::json!([{ "uninitialized": "never" }]))),
+        ("var bar, baz;", Some(serde_json::json!([{ "uninitialized": "always" }]))),
+        ("var bar = true, baz = false;", Some(serde_json::json!([{ "uninitialized": "never" }]))),
+        (
+            "var bar = true, baz = false, a, b;",
+            Some(serde_json::json!([{ "uninitialized": "always", "initialized": "always" }])),
+        ),
+        (
+            "var bar = true; var baz = false; var a; var b;",
+            Some(serde_json::json!([{ "uninitialized": "never", "initialized": "never" }])),
+        ),
+        (
+            "var bar, baz; var a = true; var b = false;",
+            Some(serde_json::json!([{ "uninitialized": "always", "initialized": "never" }])),
+        ),
+        (
+            "var bar = true, baz = false; var a; var b;",
+            Some(serde_json::json!([{ "uninitialized": "never", "initialized": "always" }])),
+        ),
+        (
+            "var bar; var baz; var a = true, b = false;",
+            Some(serde_json::json!([{ "uninitialized": "never", "initialized": "always" }])),
+        ),
+        (
+            "function foo() { var a = [1, 2, 3]; var [b, c, d] = a; }",
+            Some(serde_json::json!(["never"])),
+        ),
+        (
+            "function foo() { let a = 1; var c = true; if (a) {let c = true; } }",
+            Some(serde_json::json!(["always"])),
+        ),
+        (
+            "function foo() { const a = 1; var c = true; if (a) {const c = true; } }",
+            Some(serde_json::json!(["always"])),
+        ),
+        (
+            "function foo() { if (true) { const a = 1; }; if (true) {const a = true; } }",
+            Some(serde_json::json!(["always"])),
+        ),
+        ("function foo() { let a = 1; let b = true; }", Some(serde_json::json!(["never"]))),
+        ("function foo() { const a = 1; const b = true; }", Some(serde_json::json!(["never"]))),
+        (
+            "function foo() { let a = 1; const b = false; var c = true; }",
+            Some(serde_json::json!(["always"])),
+        ),
+        (
+            "function foo() { let a = 1, b = false; var c = true; }",
+            Some(serde_json::json!(["always"])),
+        ),
+        (
+            "function foo() { let a = 1; let b = 2; const c = false; const d = true; var e = true, f = false; }",
+            Some(serde_json::json!([{ "var": "always", "let": "never", "const": "never" }])),
+        ),
+        (
+            "let foo = true; for (let i = 0; i < 1; i++) { let foo = false; }",
+            Some(serde_json::json!([{ "var": "always", "let": "always", "const": "never" }])),
+        ),
+        (
+            "let foo = true; for (let i = 0; i < 1; i++) { let foo = false; }",
+            Some(serde_json::json!([{ "var": "always" }])),
+        ),
+        ("let foo = true, bar = false;", Some(serde_json::json!([{ "var": "never" }]))),
+        ("let foo = true, bar = false;", Some(serde_json::json!([{ "const": "never" }]))),
+        ("let foo = true, bar = false;", Some(serde_json::json!([{ "uninitialized": "never" }]))),
+        ("let foo, bar", Some(serde_json::json!([{ "initialized": "never" }]))),
+        (
+            "let foo = true, bar = false; let a; let b;",
+            Some(serde_json::json!([{ "uninitialized": "never" }])),
+        ),
+        (
+            "let foo, bar; let a = true; let b = true;",
+            Some(serde_json::json!([{ "initialized": "never" }])),
+        ),
+        (
+            "var foo, bar; const a=1; const b=2; let c, d",
+            Some(serde_json::json!([{ "var": "always", "let": "always" }])),
+        ),
+        (
+            "var foo; var bar; const a=1, b=2; let c; let d",
+            Some(serde_json::json!([{ "const": "always" }])),
+        ),
+        (
+            "for (let x of foo) {}; for (let y of foo) {}",
+            Some(serde_json::json!([{ "uninitialized": "always" }])),
+        ),
+        (
+            "for (let x in foo) {}; for (let y in foo) {}",
+            Some(serde_json::json!([{ "uninitialized": "always" }])),
+        ),
+        (
+            "var x; for (var y in foo) {}",
+            Some(serde_json::json!([{ "initialized": "never", "uninitialized": "always" }])),
+        ),
+        (
+            "var x, y; for (y in foo) {}",
+            Some(serde_json::json!([{ "initialized": "never", "uninitialized": "always" }])),
+        ),
+        (
+            "var x, y; for (var z in foo) {}",
+            Some(serde_json::json!([{ "initialized": "never", "uninitialized": "always" }])),
+        ),
+        (
+            "var x; for (var y in foo) {var bar = y; for (var z in bar) {}}",
+            Some(serde_json::json!([{ "initialized": "never", "uninitialized": "always" }])),
+        ),
+        (
+            "var a = 1; var b = 2; var x, y; for (var z in foo) {var baz = z; for (var d in baz) {}}",
+            Some(serde_json::json!([{ "initialized": "never", "uninitialized": "always" }])),
+        ),
+        (
+            "var x; for (var y of foo) {}",
+            Some(serde_json::json!([{ "initialized": "never", "uninitialized": "always" }])),
+        ),
+        (
+            "var x, y; for (y of foo) {}",
+            Some(serde_json::json!([{ "initialized": "never", "uninitialized": "always" }])),
+        ),
+        (
+            "var x, y; for (var z of foo) {}",
+            Some(serde_json::json!([{ "initialized": "never", "uninitialized": "always" }])),
+        ),
+        (
+            "var x; for (var y of foo) {var bar = y; for (var z of bar) {}}",
+            Some(serde_json::json!([{ "initialized": "never", "uninitialized": "always" }])),
+        ),
+        (
+            "var a = 1; var b = 2; var x, y; for (var z of foo) {var baz = z; for (var d of baz) {}}",
+            Some(serde_json::json!([{ "initialized": "never", "uninitialized": "always" }])),
+        ),
+        (
+            "var foo = require('foo'), bar;",
+            Some(serde_json::json!([{ "separateRequires": false, "var": "always" }])),
+        ),
+        (
+            "var foo = require('foo'), bar = require('bar');",
+            Some(serde_json::json!([{ "separateRequires": true, "var": "always" }])),
+        ),
+        (
+            "var bar = 'bar'; var foo = require('foo');",
+            Some(serde_json::json!([{ "separateRequires": true, "var": "always" }])),
+        ),
+        (
+            "var foo = require('foo'); var bar = 'bar';",
+            Some(serde_json::json!([{ "separateRequires": true, "var": "always" }])),
+        ),
+        ("var a = 0, b, c;", Some(serde_json::json!(["consecutive"]))),
+        ("var a = 0, b = 1, c = 2;", Some(serde_json::json!(["consecutive"]))),
+        ("var a = 0, b = 1; foo(); var c = 2;", Some(serde_json::json!(["consecutive"]))),
+        ("let a = 0, b, c;", Some(serde_json::json!(["consecutive"]))), // { "ecmaVersion": 6 },
+        ("let a = 0, b = 1, c = 2;", Some(serde_json::json!(["consecutive"]))), // { "ecmaVersion": 6 },
+        ("let a = 0, b = 1; foo(); let c = 2;", Some(serde_json::json!(["consecutive"]))), // { "ecmaVersion": 6 },
+        ("const a = 0, b = 1; foo(); const c = 2;", Some(serde_json::json!(["consecutive"]))), // { "ecmaVersion": 6 },
+        ("const a = 0; var b = 1;", Some(serde_json::json!(["consecutive"]))), // { "ecmaVersion": 6 },
+        ("const a = 0; let b = 1;", Some(serde_json::json!(["consecutive"]))), // { "ecmaVersion": 6 },
+        ("let a = 0; const b = 1; var c = 2;", Some(serde_json::json!(["consecutive"]))), // { "ecmaVersion": 6 },
+        (
+            "const foo = require('foo'); const bar = 'bar';",
+            Some(serde_json::json!([{ "const": "consecutive", "separateRequires": true }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "var a = 0, b = 1; var c, d;",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "always" }])),
+        ),
+        (
+            "var a = 0; var b, c; var d = 1;",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "always" }])),
+        ),
+        (
+            "let a = 0, b = 1; let c, d;",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "always" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "let a = 0; let b, c; let d = 1;",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "always" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "const a = 0, b = 1; let c, d;",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "always" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "const a = 0; let b, c; const d = 1;",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "always" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "var a = 0, b = 1; var c; var d;",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "never" }])),
+        ),
+        (
+            "var a = 0; var b; var c; var d = 1;",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "never" }])),
+        ),
+        (
+            "let a = 0, b = 1; let c; let d;",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "never" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "let a = 0; let b; let c; let d = 1;",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "never" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "const a = 0, b = 1; let c; let d;",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "never" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "const a = 0; let b; let c; const d = 1;",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "never" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "var a, b; var c = 0, d = 1;",
+            Some(serde_json::json!([{ "uninitialized": "consecutive", "initialized": "always" }])),
+        ),
+        (
+            "var a; var b = 0, c = 1; var d;",
+            Some(serde_json::json!([{ "uninitialized": "consecutive", "initialized": "always" }])),
+        ),
+        (
+            "let a, b; let c = 0, d = 1;",
+            Some(serde_json::json!([{ "uninitialized": "consecutive", "initialized": "always" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "let a; let b = 0, c = 1; let d;",
+            Some(serde_json::json!([{ "uninitialized": "consecutive", "initialized": "always" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "let a, b; const c = 0, d = 1;",
+            Some(serde_json::json!([{ "uninitialized": "consecutive", "initialized": "always" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "let a; const b = 0, c = 1; let d;",
+            Some(serde_json::json!([{ "uninitialized": "consecutive", "initialized": "always" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "var a, b; var c = 0; var d = 1;",
+            Some(serde_json::json!([{ "uninitialized": "consecutive", "initialized": "never" }])),
+        ),
+        (
+            "var a; var b = 0; var c = 1; var d;",
+            Some(serde_json::json!([{ "uninitialized": "consecutive", "initialized": "never" }])),
+        ),
+        (
+            "let a, b; let c = 0; let d = 1;",
+            Some(serde_json::json!([{ "uninitialized": "consecutive", "initialized": "never" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "let a; let b = 0; let c = 1; let d;",
+            Some(serde_json::json!([{ "uninitialized": "consecutive", "initialized": "never" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "let a, b; const c = 0; const d = 1;",
+            Some(serde_json::json!([{ "uninitialized": "consecutive", "initialized": "never" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "let a; const b = 0; const c = 1; let d;",
+            Some(serde_json::json!([{ "uninitialized": "consecutive", "initialized": "never" }])),
+        ), // { "ecmaVersion": 6 },
+        ("var a = 0, b = 1;", Some(serde_json::json!([{ "var": "consecutive" }]))),
+        ("var a = 0; foo; var b = 1;", Some(serde_json::json!([{ "var": "consecutive" }]))),
+        ("let a = 0, b = 1;", Some(serde_json::json!([{ "let": "consecutive" }]))), // { "ecmaVersion": 6 },
+        ("let a = 0; foo; let b = 1;", Some(serde_json::json!([{ "let": "consecutive" }]))), // { "ecmaVersion": 6 },
+        ("const a = 0, b = 1;", Some(serde_json::json!([{ "const": "consecutive" }]))), // { "ecmaVersion": 6 },
+        ("const a = 0; foo; const b = 1;", Some(serde_json::json!([{ "const": "consecutive" }]))), // { "ecmaVersion": 6 },
+        (
+            "let a, b; const c = 0, d = 1;",
+            Some(serde_json::json!([{ "let": "consecutive", "const": "always" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "let a; const b = 0, c = 1; let d;",
+            Some(serde_json::json!([{ "let": "consecutive", "const": "always" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "let a, b; const c = 0; const d = 1;",
+            Some(serde_json::json!([{ "let": "consecutive", "const": "never" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "let a; const b = 0; const c = 1; let d;",
+            Some(serde_json::json!([{ "let": "consecutive", "const": "never" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "const a = 0, b = 1; let c, d;",
+            Some(serde_json::json!([{ "const": "consecutive", "let": "always" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "const a = 0; let b, c; const d = 1;",
+            Some(serde_json::json!([{ "const": "consecutive", "let": "always" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "const a = 0, b = 1; let c; let d;",
+            Some(serde_json::json!([{ "const": "consecutive", "let": "never" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "const a = 0; let b; let c; const d = 1;",
+            Some(serde_json::json!([{ "const": "consecutive", "let": "never" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "var a = 1, b = 2; foo(); var c = 3, d = 4;",
+            Some(serde_json::json!([{ "initialized": "consecutive" }])),
+        ),
+        ("var bar, baz;", Some(serde_json::json!(["consecutive"]))),
+        (
+            "var bar = 1, baz = 2; qux(); var qux = 3, quux;",
+            Some(serde_json::json!(["consecutive"])),
+        ),
+        (
+            "let a, b; var c; var d; let e;",
+            Some(
+                serde_json::json!([ { "var": "never", "let": "consecutive", "const": "consecutive" }, ]),
+            ),
+        ), // { "ecmaVersion": 6 },
+        (
+            "const a = 1, b = 2; var d; var e; const f = 3;",
+            Some(
+                serde_json::json!([ { "var": "never", "let": "consecutive", "const": "consecutive" }, ]),
+            ),
+        ), // { "ecmaVersion": 6 },
+        (
+            "var a, b; const c = 1; const d = 2; let e; let f; ",
+            Some(serde_json::json!([{ "var": "consecutive" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "var a = 1, b = 2; var c; var d; var e = 3, f = 4;",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "never" }])),
+        ),
+        ("var a; somethingElse(); var b;", Some(serde_json::json!([{ "var": "never" }]))),
+        (
+            "var foo = 1;
+            let bar = function() { var x; };
+            var baz = 2;",
+            Some(serde_json::json!([{ "var": "never" }])),
+        ),
+        ("class C { static { var a; let b; const c = 0; } }", Some(serde_json::json!(["always"]))), // { "ecmaVersion": 2022 },
+        ("const a = 0; class C { static { const b = 0; } }", Some(serde_json::json!(["always"]))), // { "ecmaVersion": 2022 },
+        ("class C { static { const b = 0; } } const a = 0; ", Some(serde_json::json!(["always"]))), // { "ecmaVersion": 2022 },
+        ("let a; class C { static { let b; } }", Some(serde_json::json!(["always"]))), // { "ecmaVersion": 2022 },
+        ("class C { static { let b; } } let a;", Some(serde_json::json!(["always"]))), // { "ecmaVersion": 2022 },
+        ("var a; class C { static { var b; } }", Some(serde_json::json!(["always"]))), // { "ecmaVersion": 2022 },
+        ("class C { static { var b; } } var a; ", Some(serde_json::json!(["always"]))), // { "ecmaVersion": 2022 },
+        ("var a; class C { static { if (foo) { var b; } } }", Some(serde_json::json!(["always"]))), // { "ecmaVersion": 2022 },
+        ("class C { static { if (foo) { var b; } } } var a; ", Some(serde_json::json!(["always"]))), // { "ecmaVersion": 2022 },
+        (
+            "class C { static { const a = 0; if (foo) { const b = 0; } } }",
+            Some(serde_json::json!(["always"])),
+        ), // { "ecmaVersion": 2022 },
+        ("class C { static { let a; if (foo) { let b; } } }", Some(serde_json::json!(["always"]))), // { "ecmaVersion": 2022 },
+        ("class C { static { const a = 0; const b = 0; } }", Some(serde_json::json!(["never"]))), // { "ecmaVersion": 2022 },
+        ("class C { static { let a; let b; } }", Some(serde_json::json!(["never"]))), // { "ecmaVersion": 2022 },
+        ("class C { static { var a; var b; } }", Some(serde_json::json!(["never"]))), // { "ecmaVersion": 2022 },
+        ("class C { static { let a; foo; let b; } }", Some(serde_json::json!(["consecutive"]))), // { "ecmaVersion": 2022 },
+        (
+            "class C { static { let a; const b = 0; let c; } }",
+            Some(serde_json::json!(["consecutive"])),
+        ), // { "ecmaVersion": 2022 },
+        ("class C { static { var a; foo; var b; } }", Some(serde_json::json!(["consecutive"]))), // { "ecmaVersion": 2022 },
+        ("class C { static { var a; let b; var c; } }", Some(serde_json::json!(["consecutive"]))), // { "ecmaVersion": 2022 },
+        (
+            "class C { static { let a; if (foo) { let b; } } }",
+            Some(serde_json::json!(["consecutive"])),
+        ), // { "ecmaVersion": 2022 },
+        (
+            "class C { static { if (foo) { let b; } let a;  } }",
+            Some(serde_json::json!(["consecutive"])),
+        ), // { "ecmaVersion": 2022 },
+        (
+            "class C { static { const a = 0; if (foo) { const b = 0; } } }",
+            Some(serde_json::json!(["consecutive"])),
+        ), // { "ecmaVersion": 2022 },
+        (
+            "class C { static { if (foo) { const b = 0; } const a = 0; } }",
+            Some(serde_json::json!(["consecutive"])),
+        ), // { "ecmaVersion": 2022 },
+        ("class C { static { var a; if (foo) var b; } }", Some(serde_json::json!(["consecutive"]))), // { "ecmaVersion": 2022 },
+        ("class C { static { if (foo) var b; var a; } }", Some(serde_json::json!(["consecutive"]))), // { "ecmaVersion": 2022 },
+        (
+            "class C { static { if (foo) { var b; } var a; } }",
+            Some(serde_json::json!(["consecutive"])),
+        ), // { "ecmaVersion": 2022 },
+        (
+            "class C { static { let a; let b = 0; } }",
+            Some(serde_json::json!([{ "initialized": "consecutive" }])),
+        ), // { "ecmaVersion": 2022 },
+        (
+            "class C { static { var a; var b = 0; } }",
+            Some(serde_json::json!([{ "initialized": "consecutive" }])),
+        ), // { "ecmaVersion": 2022 },
+        ("using a = 0; let b = 1; const c = 2;", None), // { "ecmaVersion": 2026, "sourceType": "module", },
+        ("await using a = 0; let b = 1; const c = 2;", None), // { "ecmaVersion": 2026, "sourceType": "module", },
+        ("using a = 0, b = 1;", None), // { "ecmaVersion": 2026, "sourceType": "module", },
+        ("await using a = 0, b = 1;", None), // { "ecmaVersion": 2026, "sourceType": "module", },
+        ("function fn() { { using a = 0; } using b = 1; }", None), // { "ecmaVersion": 2026, "sourceType": "module", },
+        ("using a = 0; using b = 1;", Some(serde_json::json!(["never"]))), // { "ecmaVersion": 2026, "sourceType": "module", },
+        ("await using a = 0; await using b = 1;", Some(serde_json::json!(["never"]))), // { "ecmaVersion": 2026, "sourceType": "module", },
+        ("using a = 0, b = 1;", Some(serde_json::json!(["consecutive"]))), // { "ecmaVersion": 2026, "sourceType": "module", },
+        ("await using a = 0, b = 1;", Some(serde_json::json!(["consecutive"]))), // { "ecmaVersion": 2026, "sourceType": "module", },
+        ("using a = 0, b = 1;", Some(serde_json::json!([{ "initialized": "always" }]))), // { "ecmaVersion": 2026, "sourceType": "module", },
+        ("await using a = 0, b = 1;", Some(serde_json::json!([{ "initialized": "always" }]))), // { "ecmaVersion": 2026, "sourceType": "module", },
+        ("using a = 0; using b = 1;", Some(serde_json::json!([{ "initialized": "never" }]))), // { "ecmaVersion": 2026, "sourceType": "module", },
+        (
+            "await using a = 0; await using b = 1;",
+            Some(serde_json::json!([{ "initialized": "never" }])),
+        ), // { "ecmaVersion": 2026, "sourceType": "module", },
+        (
+            "using a = 0, b = 1; foo(); using c = 2, d = 3;",
+            Some(serde_json::json!([{ "initialized": "consecutive" }])),
+        ), // { "ecmaVersion": 2026, "sourceType": "module", },
+        (
+            "await using a = 0, b = 1; foo(); await using c = 2, d = 3;",
+            Some(serde_json::json!([{ "initialized": "consecutive" }])),
+        ), // { "ecmaVersion": 2026, "sourceType": "module", }
+    ];
+    let fail = vec![
+        ("var bar = true, baz = false;", Some(serde_json::json!(["never"]))),
+        ("function foo() { var bar = true, baz = false; }", Some(serde_json::json!(["never"]))),
+        ("if (foo) { var bar = true, baz = false; }", Some(serde_json::json!(["never"]))),
+        (
+            "switch (foo) { case bar: var baz = true, quux = false; }",
+            Some(serde_json::json!(["never"])),
+        ),
+        (
+            "switch (foo) { default: var baz = true, quux = false; }",
+            Some(serde_json::json!(["never"])),
+        ),
+        (
+            "function foo() { var bar = true; var baz = false; }",
+            Some(serde_json::json!(["always"])),
+        ),
+        ("var a = 1; for (var b = 2;;) {}", Some(serde_json::json!(["always"]))),
+        (
+            "function foo() { var foo = true, bar = false; }",
+            Some(serde_json::json!([{ "initialized": "never" }])),
+        ),
+        (
+            "function foo() { var foo, bar; }",
+            Some(serde_json::json!([{ "uninitialized": "never" }])),
+        ),
+        (
+            "function foo() { var bar, baz; var a = true; var b = false; var c, d;}",
+            Some(serde_json::json!([{ "uninitialized": "always", "initialized": "never" }])),
+        ),
+        (
+            "function foo() { var bar = true, baz = false; var a; var b; var c = true, d = false; }",
+            Some(serde_json::json!([{ "uninitialized": "never", "initialized": "always" }])),
+        ),
+        (
+            "function foo() { var bar = true, baz = false; var a, b;}",
+            Some(serde_json::json!([{ "uninitialized": "never", "initialized": "never" }])),
+        ),
+        (
+            "function foo() { var bar = true; var baz = false; var a; var b;}",
+            Some(serde_json::json!([{ "uninitialized": "always", "initialized": "always" }])),
+        ),
+        (
+            "function foo() { var a = [1, 2, 3]; var [b, c, d] = a; }",
+            Some(serde_json::json!(["always"])),
+        ),
+        ("function foo() { let a = 1; let b = 2; }", Some(serde_json::json!(["always"]))),
+        ("function foo() { const a = 1; const b = 2; }", Some(serde_json::json!(["always"]))),
+        (
+            "function foo() { let a = 1; let b = 2; }",
+            Some(serde_json::json!([{ "let": "always" }])),
+        ),
+        (
+            "function foo() { const a = 1; const b = 2; }",
+            Some(serde_json::json!([{ "const": "always" }])),
+        ),
+        ("function foo() { let a = 1, b = 2; }", Some(serde_json::json!([{ "let": "never" }]))),
+        (
+            "function foo() { let a = 1, b = 2; }",
+            Some(serde_json::json!([{ "initialized": "never" }])),
+        ),
+        ("function foo() { let a, b; }", Some(serde_json::json!([{ "uninitialized": "never" }]))),
+        (
+            "function foo() { const a = 1, b = 2; }",
+            Some(serde_json::json!([{ "initialized": "never" }])),
+        ),
+        ("function foo() { const a = 1, b = 2; }", Some(serde_json::json!([{ "const": "never" }]))),
+        (
+            "let foo = true; switch(foo) { case true: let bar = 2; break; case false: let baz = 3; break; }",
+            Some(serde_json::json!([{ "var": "always", "let": "always", "const": "never" }])),
+        ),
+        (
+            "var one = 1, two = 2;
+            var three;",
+            Some(serde_json::json!(["always"])),
+        ),
+        ("var i = [0], j;", Some(serde_json::json!([{ "initialized": "never" }]))),
+        ("var i = [0], j;", Some(serde_json::json!([{ "uninitialized": "never" }]))),
+        ("for (var x of foo) {}; for (var y of foo) {}", Some(serde_json::json!(["always"]))),
+        ("for (var x in foo) {}; for (var y in foo) {}", Some(serde_json::json!(["always"]))),
+        ("var foo = function() { var bar = true; var baz = false; }", None),
+        (
+            "function foo() { var bar = true; if (qux) { var baz = false; } else { var quxx = 42; } }",
+            None,
+        ),
+        ("var foo = () => { var bar = true; var baz = false; }", None), // { "ecmaVersion": 6 },
+        ("var foo = function() { var bar = true; if (qux) { var baz = false; } }", None),
+        ("var foo; var bar;", None),
+        (
+            "var x = 1, y = 2; for (var z in foo) {}",
+            Some(serde_json::json!([{ "initialized": "never", "uninitialized": "always" }])),
+        ),
+        (
+            "var x = 1, y = 2; for (var z of foo) {}",
+            Some(serde_json::json!([{ "initialized": "never", "uninitialized": "always" }])),
+        ),
+        (
+            "var x; var y; for (var z in foo) {}",
+            Some(serde_json::json!([{ "initialized": "never", "uninitialized": "always" }])),
+        ),
+        (
+            "var x; var y; for (var z of foo) {}",
+            Some(serde_json::json!([{ "initialized": "never", "uninitialized": "always" }])),
+        ),
+        (
+            "var x; for (var y in foo) {var bar = y; var a; for (var z of bar) {}}",
+            Some(serde_json::json!([{ "initialized": "never", "uninitialized": "always" }])),
+        ),
+        (
+            "var a = 1; var b = 2; var x, y; for (var z of foo) {var c = 3, baz = z; for (var d in baz) {}}",
+            Some(serde_json::json!([{ "initialized": "never", "uninitialized": "always" }])),
+        ),
+        ("var {foo} = 1, [bar] = 2;", Some(serde_json::json!([{ "initialized": "never" }]))), // { "ecmaVersion": 6 },
+        (
+            "const foo = 1,
+                bar = 2;",
+            Some(serde_json::json!([{ "initialized": "never" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "var foo = 1,
+                bar = 2;",
+            Some(serde_json::json!([{ "initialized": "never" }])),
+        ),
+        (
+            "var foo = 1, // comment
+                bar = 2;",
+            Some(serde_json::json!([{ "initialized": "never" }])),
+        ),
+        ("var f, k /* test */, l;", Some(serde_json::json!(["never"]))),
+        ("var f,          /* test */ l;", Some(serde_json::json!(["never"]))),
+        (
+            "var f, k /* test 
+             some more comment 
+             even more */, l = 1, P;",
+            Some(serde_json::json!(["never"])),
+        ),
+        ("var a = 1, b = 2", Some(serde_json::json!(["never"]))),
+        (
+            "var foo = require('foo'), bar;",
+            Some(serde_json::json!([{ "separateRequires": true, "var": "always" }])),
+        ),
+        (
+            "var foo, bar = require('bar');",
+            Some(serde_json::json!([{ "separateRequires": true, "var": "always" }])),
+        ),
+        (
+            "let foo, bar = require('bar');",
+            Some(serde_json::json!([{ "separateRequires": true, "let": "always" }])),
+        ),
+        (
+            "const foo = 0, bar = require('bar');",
+            Some(serde_json::json!([{ "separateRequires": true, "const": "always" }])),
+        ),
+        (
+            "const foo = require('foo'); const bar = require('bar');",
+            Some(serde_json::json!([{ "separateRequires": true, "const": "always" }])),
+        ),
+        ("var a = 1, b; var c;", Some(serde_json::json!(["consecutive"]))),
+        ("var a = 0, b = 1; var c = 2;", Some(serde_json::json!(["consecutive"]))),
+        ("let a = 1, b; let c;", Some(serde_json::json!(["consecutive"]))), // { "ecmaVersion": 6 },
+        ("let a = 0, b = 1; let c = 2;", Some(serde_json::json!(["consecutive"]))), // { "ecmaVersion": 6 },
+        ("const a = 0, b = 1; const c = 2;", Some(serde_json::json!(["consecutive"]))), // { "ecmaVersion": 6 },
+        (
+            "const a = 0; var b = 1; var c = 2; const d = 3;",
+            Some(serde_json::json!(["consecutive"])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "var a = true; var b = false;",
+            Some(serde_json::json!([{ "separateRequires": true, "var": "always" }])),
+        ),
+        (
+            "const a = 0; let b = 1; let c = 2; const d = 3;",
+            Some(serde_json::json!(["consecutive"])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "let a = 0; const b = 1; const c = 1; var d = 2;",
+            Some(serde_json::json!(["consecutive"])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "var a = 0; var b; var c; var d = 1",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "always" }])),
+        ),
+        (
+            "var a = 0; var b = 1; var c; var d;",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "always" }])),
+        ),
+        (
+            "let a = 0; let b; let c; let d = 1;",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "always" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "let a = 0; let b = 1; let c; let d;",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "always" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "const a = 0; let b; let c; const d = 1;",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "always" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "const a = 0; const b = 1; let c; let d;",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "always" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "var a = 0; var b = 1; var c, d;",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "never" }])),
+        ),
+        (
+            "var a = 0; var b, c; var d = 1;",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "never" }])),
+        ),
+        (
+            "let a = 0; let b = 1; let c, d;",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "never" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "let a = 0; let b, c; let d = 1;",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "never" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "const a = 0; const b = 1; let c, d;",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "never" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "const a = 0; let b, c; const d = 1;",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "never" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "var a; var b; var c = 0; var d = 1;",
+            Some(serde_json::json!([{ "uninitialized": "consecutive", "initialized": "always" }])),
+        ),
+        (
+            "var a; var b = 0; var c = 1; var d;",
+            Some(serde_json::json!([{ "uninitialized": "consecutive", "initialized": "always" }])),
+        ),
+        (
+            "let a; let b; let c = 0; let d = 1;",
+            Some(serde_json::json!([{ "uninitialized": "consecutive", "initialized": "always" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "let a; let b = 0; let c = 1; let d;",
+            Some(serde_json::json!([{ "uninitialized": "consecutive", "initialized": "always" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "let a; let b; const c = 0; const d = 1;",
+            Some(serde_json::json!([{ "uninitialized": "consecutive", "initialized": "always" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "let a; const b = 0; const c = 1; let d;",
+            Some(serde_json::json!([{ "uninitialized": "consecutive", "initialized": "always" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "var a; var b; var c = 0, d = 1;",
+            Some(serde_json::json!([{ "uninitialized": "consecutive", "initialized": "never" }])),
+        ),
+        (
+            "var a; var b = 0, c = 1; var d;",
+            Some(serde_json::json!([{ "uninitialized": "consecutive", "initialized": "never" }])),
+        ),
+        (
+            "let a; let b; let c = 0, d = 1;",
+            Some(serde_json::json!([{ "uninitialized": "consecutive", "initialized": "never" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "let a; let b = 0, c = 1; let d;",
+            Some(serde_json::json!([{ "uninitialized": "consecutive", "initialized": "never" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "let a; let b; const c = 0, d = 1;",
+            Some(serde_json::json!([{ "uninitialized": "consecutive", "initialized": "never" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "let a; const b = 0, c = 1; let d;",
+            Some(serde_json::json!([{ "uninitialized": "consecutive", "initialized": "never" }])),
+        ), // { "ecmaVersion": 6 },
+        ("var a = 0; var b = 1;", Some(serde_json::json!([{ "var": "consecutive" }]))),
+        ("let a = 0; let b = 1;", Some(serde_json::json!([{ "let": "consecutive" }]))), // { "ecmaVersion": 6 },
+        ("const a = 0; const b = 1;", Some(serde_json::json!([{ "const": "consecutive" }]))), // { "ecmaVersion": 6 },
+        (
+            "let a; let b; const c = 0; const d = 1;",
+            Some(serde_json::json!([{ "let": "consecutive", "const": "always" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "let a; const b = 0; const c = 1; let d;",
+            Some(serde_json::json!([{ "let": "consecutive", "const": "always" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "let a; let b; const c = 0, d = 1;",
+            Some(serde_json::json!([{ "let": "consecutive", "const": "never" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "let a; const b = 0, c = 1; let d;",
+            Some(serde_json::json!([{ "let": "consecutive", "const": "never" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "const a = 0; const b = 1; let c; let d;",
+            Some(serde_json::json!([{ "const": "consecutive", "let": "always" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "const a = 0; let b; let c; const d = 1;",
+            Some(serde_json::json!([{ "const": "consecutive", "let": "always" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "const a = 0; const b = 1; let c, d;",
+            Some(serde_json::json!([{ "const": "consecutive", "let": "never" }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "const a = 0; let b, c; const d = 1;",
+            Some(serde_json::json!([{ "const": "consecutive", "let": "never" }])),
+        ), // { "ecmaVersion": 6 },
+        ("var bar; var baz;", Some(serde_json::json!(["consecutive"]))),
+        (
+            "var bar = 1; var baz = 2; qux(); var qux = 3; var quux;",
+            Some(serde_json::json!(["consecutive"])),
+        ),
+        (
+            "let a, b; let c; var d, e;",
+            Some(
+                serde_json::json!([ { "var": "never", "let": "consecutive", "const": "consecutive" }, ]),
+            ),
+        ), // { "ecmaVersion": 6 },
+        ("var a; var b;", Some(serde_json::json!([{ "var": "consecutive" }]))),
+        (
+            "var a = 1; var b = 2; var c, d; var e = 3; var f = 4;",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "never" }])),
+        ),
+        (
+            "var a = 1; var b = 2; foo(); var c = 3; var d = 4;",
+            Some(serde_json::json!([{ "initialized": "consecutive" }])),
+        ),
+        (
+            "var a
+            var b",
+            Some(serde_json::json!(["always"])),
+        ),
+        ("export const foo=1, bar=2;", Some(serde_json::json!(["never"]))), // { "ecmaVersion": 2021, "sourceType": "module" },
+        (
+            "const foo=1,
+             bar=2;",
+            Some(serde_json::json!(["never"])),
+        ), // { "ecmaVersion": 2021, "sourceType": "module" },
+        (
+            "export const foo=1,
+             bar=2;",
+            Some(serde_json::json!(["never"])),
+        ), // { "ecmaVersion": 2021, "sourceType": "module" },
+        (
+            "export const foo=1
+            , bar=2;",
+            Some(serde_json::json!(["never"])),
+        ), // { "ecmaVersion": 2021, "sourceType": "module" },
+        ("export const foo= a, bar=2;", Some(serde_json::json!(["never"]))), // { "ecmaVersion": 2021, "sourceType": "module" },
+        ("export const foo=() => a, bar=2;", Some(serde_json::json!(["never"]))), // { "ecmaVersion": 2021, "sourceType": "module" },
+        ("export const foo= a, bar=2, bar2=2;", Some(serde_json::json!(["never"]))), // { "ecmaVersion": 2021, "sourceType": "module" },
+        ("export const foo = 1,bar = 2;", Some(serde_json::json!(["never"]))), // { "ecmaVersion": 2021, "sourceType": "module" },
+        ("if (foo) var x, y;", Some(serde_json::json!(["never"]))),
+        ("if (foo) var x, y;", Some(serde_json::json!([{ "var": "never" }]))),
+        ("if (foo) var x, y;", Some(serde_json::json!([{ "uninitialized": "never" }]))),
+        ("if (foo) var x = 1, y = 1;", Some(serde_json::json!([{ "initialized": "never" }]))),
+        ("if (foo) {} else var x, y;", Some(serde_json::json!(["never"]))),
+        ("while (foo) var x, y;", Some(serde_json::json!(["never"]))),
+        ("do var x, y; while (foo);", Some(serde_json::json!(["never"]))),
+        ("do var x = f(), y = b(); while (x < y);", Some(serde_json::json!(["never"]))),
+        ("for (;;) var x, y;", Some(serde_json::json!(["never"]))),
+        ("for (foo in bar) var x, y;", Some(serde_json::json!(["never"]))),
+        ("for (foo of bar) var x, y;", Some(serde_json::json!(["never"]))),
+        ("with (foo) var x, y;", Some(serde_json::json!(["never"]))),
+        ("label: var x, y;", Some(serde_json::json!(["never"]))),
+        ("class C { static { let x, y; } }", Some(serde_json::json!(["never"]))), // { "ecmaVersion": 2022 },
+        ("class C { static { var x, y; } }", Some(serde_json::json!(["never"]))), // { "ecmaVersion": 2022 },
+        ("class C { static { let x; let y; } }", Some(serde_json::json!(["always"]))), // { "ecmaVersion": 2022 },
+        ("class C { static { var x; var y; } }", Some(serde_json::json!(["always"]))), // { "ecmaVersion": 2022 },
+        ("class C { static { let x; foo; let y; } }", Some(serde_json::json!(["always"]))), // { "ecmaVersion": 2022 },
+        ("class C { static { var x; foo; var y; } }", Some(serde_json::json!(["always"]))), // { "ecmaVersion": 2022 },
+        ("class C { static { var x; if (foo) { var y; } } }", Some(serde_json::json!(["always"]))), // { "ecmaVersion": 2022 },
+        ("class C { static { let x; let y; } }", Some(serde_json::json!(["consecutive"]))), // { "ecmaVersion": 2022 },
+        ("class C { static { var x; var y; } }", Some(serde_json::json!(["consecutive"]))), // { "ecmaVersion": 2022 },
+        (
+            "class C { static { let a = 0; let b = 1; } }",
+            Some(serde_json::json!([{ "initialized": "consecutive" }])),
+        ), // { "ecmaVersion": 2022 },
+        (
+            "class C { static { var a = 0; var b = 1; } }",
+            Some(serde_json::json!([{ "initialized": "consecutive" }])),
+        ), // { "ecmaVersion": 2022 },
+        ("using a = 0; using b = 1;", Some(serde_json::json!(["always"]))), // { "ecmaVersion": 2026, "sourceType": "module", },
+        ("await using a = 0; await using b = 1;", Some(serde_json::json!(["always"]))), // { "ecmaVersion": 2026, "sourceType": "module", },
+        ("using a = 0, b = 1;", Some(serde_json::json!(["never"]))), // { "ecmaVersion": 2026, "sourceType": "module", },
+        ("await using a = 0, b = 1;", Some(serde_json::json!(["never"]))), // { "ecmaVersion": 2026, "sourceType": "module", },
+        ("using a = 0; using b = 1;", Some(serde_json::json!(["consecutive"]))), // { "ecmaVersion": 2026, "sourceType": "module", },
+        ("await using a = 0; await using b = 1;", Some(serde_json::json!(["consecutive"]))), // { "ecmaVersion": 2026, "sourceType": "module", },
+        ("using a = 0, b = 1;", Some(serde_json::json!([{ "initialized": "never" }]))), // { "ecmaVersion": 2026, "sourceType": "module", },
+        ("await using a = 0, b = 1;", Some(serde_json::json!([{ "initialized": "never" }]))), // { "ecmaVersion": 2026, "sourceType": "module", }
+    ];
+    let fix = vec![
+        (
+            "var bar = true, baz = false;",
+            "var bar = true; var baz = false;",
+            Some(serde_json::json!(["never"])),
+        ),
+        (
+            "function foo() { var bar = true, baz = false; }",
+            "function foo() { var bar = true; var baz = false; }",
+            Some(serde_json::json!(["never"])),
+        ),
+        (
+            "if (foo) { var bar = true, baz = false; }",
+            "if (foo) { var bar = true; var baz = false; }",
+            Some(serde_json::json!(["never"])),
+        ),
+        (
+            "switch (foo) { case bar: var baz = true, quux = false; }",
+            "switch (foo) { case bar: var baz = true; var quux = false; }",
+            Some(serde_json::json!(["never"])),
+        ),
+        (
+            "switch (foo) { default: var baz = true, quux = false; }",
+            "switch (foo) { default: var baz = true; var quux = false; }",
+            Some(serde_json::json!(["never"])),
+        ),
+        (
+            "function foo() { var bar = true; var baz = false; }",
+            "function foo() { var bar = true,  baz = false; }",
+            Some(serde_json::json!(["always"])),
+        ),
+        (
+            "function foo() { var foo = true, bar = false; }",
+            "function foo() { var foo = true; var bar = false; }",
+            Some(serde_json::json!([{ "initialized": "never" }])),
+        ),
+        (
+            "function foo() { var foo, bar; }",
+            "function foo() { var foo; var bar; }",
+            Some(serde_json::json!([{ "uninitialized": "never" }])),
+        ),
+        (
+            "function foo() { var bar, baz; var a = true; var b = false; var c, d;}",
+            "function foo() { var bar, baz; var a = true; var b = false,  c, d;}",
+            Some(serde_json::json!([{ "uninitialized": "always", "initialized": "never" }])),
+        ),
+        (
+            "function foo() { var bar = true, baz = false; var a; var b; var c = true, d = false; }",
+            "function foo() { var bar = true, baz = false; var a; var b,  c = true, d = false; }",
+            Some(serde_json::json!([{ "uninitialized": "never", "initialized": "always" }])),
+        ),
+        (
+            "function foo() { var bar = true, baz = false; var a, b;}",
+            "function foo() { var bar = true; var baz = false; var a; var b;}",
+            Some(serde_json::json!([{ "uninitialized": "never", "initialized": "never" }])),
+        ),
+        (
+            "function foo() { var bar = true; var baz = false; var a; var b;}",
+            "function foo() { var bar = true,  baz = false,  a,  b;}",
+            Some(serde_json::json!([{ "uninitialized": "always", "initialized": "always" }])),
+        ),
+        (
+            "function foo() { var a = [1, 2, 3]; var [b, c, d] = a; }",
+            "function foo() { var a = [1, 2, 3],  [b, c, d] = a; }",
+            Some(serde_json::json!(["always"])),
+        ),
+        (
+            "function foo() { let a = 1; let b = 2; }",
+            "function foo() { let a = 1,  b = 2; }",
+            Some(serde_json::json!(["always"])),
+        ),
+        (
+            "function foo() { const a = 1; const b = 2; }",
+            "function foo() { const a = 1,  b = 2; }",
+            Some(serde_json::json!(["always"])),
+        ),
+        (
+            "function foo() { let a = 1; let b = 2; }",
+            "function foo() { let a = 1,  b = 2; }",
+            Some(serde_json::json!([{ "let": "always" }])),
+        ),
+        (
+            "function foo() { const a = 1; const b = 2; }",
+            "function foo() { const a = 1,  b = 2; }",
+            Some(serde_json::json!([{ "const": "always" }])),
+        ),
+        (
+            "function foo() { let a = 1, b = 2; }",
+            "function foo() { let a = 1; let b = 2; }",
+            Some(serde_json::json!([{ "let": "never" }])),
+        ),
+        (
+            "function foo() { let a = 1, b = 2; }",
+            "function foo() { let a = 1; let b = 2; }",
+            Some(serde_json::json!([{ "initialized": "never" }])),
+        ),
+        (
+            "function foo() { let a, b; }",
+            "function foo() { let a; let b; }",
+            Some(serde_json::json!([{ "uninitialized": "never" }])),
+        ),
+        (
+            "function foo() { const a = 1, b = 2; }",
+            "function foo() { const a = 1; const b = 2; }",
+            Some(serde_json::json!([{ "initialized": "never" }])),
+        ),
+        (
+            "function foo() { const a = 1, b = 2; }",
+            "function foo() { const a = 1; const b = 2; }",
+            Some(serde_json::json!([{ "const": "never" }])),
+        ),
+        (
+            "var one = 1, two = 2;
+            var three;",
+            "var one = 1, two = 2,
+             three;",
+            Some(serde_json::json!(["always"])),
+        ),
+        (
+            "var i = [0], j;",
+            "var i = [0]; var j;",
+            Some(serde_json::json!([{ "initialized": "never" }])),
+        ),
+        (
+            "var i = [0], j;",
+            "var i = [0]; var j;",
+            Some(serde_json::json!([{ "uninitialized": "never" }])),
+        ),
+        (
+            "var foo = function() { var bar = true; var baz = false; }",
+            "var foo = function() { var bar = true,  baz = false; }",
+            None,
+        ),
+        (
+            "var foo = () => { var bar = true; var baz = false; }",
+            "var foo = () => { var bar = true,  baz = false; }",
+            None,
+        ),
+        ("var foo; var bar;", "var foo,  bar;", None),
+        (
+            "var x = 1, y = 2; for (var z in foo) {}",
+            "var x = 1; var y = 2; for (var z in foo) {}",
+            Some(serde_json::json!([{ "initialized": "never", "uninitialized": "always" }])),
+        ),
+        (
+            "var x = 1, y = 2; for (var z of foo) {}",
+            "var x = 1; var y = 2; for (var z of foo) {}",
+            Some(serde_json::json!([{ "initialized": "never", "uninitialized": "always" }])),
+        ),
+        (
+            "var x; var y; for (var z in foo) {}",
+            "var x,  y; for (var z in foo) {}",
+            Some(serde_json::json!([{ "initialized": "never", "uninitialized": "always" }])),
+        ),
+        (
+            "var x; var y; for (var z of foo) {}",
+            "var x,  y; for (var z of foo) {}",
+            Some(serde_json::json!([{ "initialized": "never", "uninitialized": "always" }])),
+        ),
+        (
+            "var x; for (var y in foo) {var bar = y; var a; for (var z of bar) {}}",
+            "var x; for (var y in foo) {var bar = y,  a; for (var z of bar) {}}",
+            Some(serde_json::json!([{ "initialized": "never", "uninitialized": "always" }])),
+        ),
+        (
+            "var a = 1; var b = 2; var x, y; for (var z of foo) {var c = 3, baz = z; for (var d in baz) {}}",
+            "var a = 1; var b = 2; var x, y; for (var z of foo) {var c = 3; var baz = z; for (var d in baz) {}}",
+            Some(serde_json::json!([{ "initialized": "never", "uninitialized": "always" }])),
+        ),
+        (
+            "var {foo} = 1, [bar] = 2;",
+            "var {foo} = 1; var [bar] = 2;",
+            Some(serde_json::json!([{ "initialized": "never" }])),
+        ),
+        (
+            "const foo = 1,
+                bar = 2;",
+            "const foo = 1;
+                const bar = 2;",
+            Some(serde_json::json!([{ "initialized": "never" }])),
+        ),
+        (
+            "var foo = 1,
+                bar = 2;",
+            "var foo = 1;
+                var bar = 2;",
+            Some(serde_json::json!([{ "initialized": "never" }])),
+        ),
+        (
+            "var foo = 1, // comment
+                bar = 2;",
+            "var foo = 1; // comment
+                var bar = 2;",
+            Some(serde_json::json!([{ "initialized": "never" }])),
+        ),
+        (
+            "var f, k /* test */, l;",
+            "var f; var k /* test */; var l;",
+            Some(serde_json::json!(["never"])),
+        ),
+        (
+            "var f,          /* test */ l;",
+            "var f;          /* test */ var l;",
+            Some(serde_json::json!(["never"])),
+        ),
+        (
+            "var f, k /* test 
+             some more comment 
+             even more */, l = 1, P;",
+            "var f; var k /* test 
+             some more comment 
+             even more */; var l = 1; var P;",
+            Some(serde_json::json!(["never"])),
+        ),
+        ("var a = 1, b = 2", "var a = 1; var b = 2", Some(serde_json::json!(["never"]))),
+        (
+            "const foo = require('foo'); const bar = require('bar');",
+            "const foo = require('foo'),  bar = require('bar');",
+            Some(serde_json::json!([{ "separateRequires": true, "const": "always" }])),
+        ),
+        ("var a = 1, b; var c;", "var a = 1, b,  c;", Some(serde_json::json!(["consecutive"]))),
+        (
+            "var a = 0, b = 1; var c = 2;",
+            "var a = 0, b = 1,  c = 2;",
+            Some(serde_json::json!(["consecutive"])),
+        ),
+        ("let a = 1, b; let c;", "let a = 1, b,  c;", Some(serde_json::json!(["consecutive"]))),
+        (
+            "let a = 0, b = 1; let c = 2;",
+            "let a = 0, b = 1,  c = 2;",
+            Some(serde_json::json!(["consecutive"])),
+        ),
+        (
+            "const a = 0, b = 1; const c = 2;",
+            "const a = 0, b = 1,  c = 2;",
+            Some(serde_json::json!(["consecutive"])),
+        ),
+        (
+            "const a = 0; var b = 1; var c = 2; const d = 3;",
+            "const a = 0; var b = 1,  c = 2; const d = 3;",
+            Some(serde_json::json!(["consecutive"])),
+        ),
+        (
+            "var a = true; var b = false;",
+            "var a = true,  b = false;",
+            Some(serde_json::json!([{ "separateRequires": true, "var": "always" }])),
+        ),
+        (
+            "const a = 0; let b = 1; let c = 2; const d = 3;",
+            "const a = 0; let b = 1,  c = 2; const d = 3;",
+            Some(serde_json::json!(["consecutive"])),
+        ),
+        (
+            "let a = 0; const b = 1; const c = 1; var d = 2;",
+            "let a = 0; const b = 1,  c = 1; var d = 2;",
+            Some(serde_json::json!(["consecutive"])),
+        ),
+        (
+            "var a = 0; var b; var c; var d = 1",
+            "var a = 0; var b,  c; var d = 1",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "always" }])),
+        ),
+        (
+            "var a = 0; var b = 1; var c; var d;",
+            "var a = 0,  b = 1; var c,  d;",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "always" }])),
+        ),
+        (
+            "let a = 0; let b; let c; let d = 1;",
+            "let a = 0; let b,  c; let d = 1;",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "always" }])),
+        ),
+        (
+            "let a = 0; let b = 1; let c; let d;",
+            "let a = 0,  b = 1; let c,  d;",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "always" }])),
+        ),
+        (
+            "const a = 0; let b; let c; const d = 1;",
+            "const a = 0; let b,  c; const d = 1;",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "always" }])),
+        ),
+        (
+            "const a = 0; const b = 1; let c; let d;",
+            "const a = 0,  b = 1; let c,  d;",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "always" }])),
+        ),
+        (
+            "var a = 0; var b = 1; var c, d;",
+            "var a = 0,  b = 1; var c; var d;",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "never" }])),
+        ),
+        (
+            "var a = 0; var b, c; var d = 1;",
+            "var a = 0; var b; var c; var d = 1;",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "never" }])),
+        ),
+        (
+            "let a = 0; let b = 1; let c, d;",
+            "let a = 0,  b = 1; let c; let d;",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "never" }])),
+        ),
+        (
+            "let a = 0; let b, c; let d = 1;",
+            "let a = 0; let b; let c; let d = 1;",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "never" }])),
+        ),
+        (
+            "const a = 0; const b = 1; let c, d;",
+            "const a = 0,  b = 1; let c; let d;",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "never" }])),
+        ),
+        (
+            "const a = 0; let b, c; const d = 1;",
+            "const a = 0; let b; let c; const d = 1;",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "never" }])),
+        ),
+        (
+            "var a; var b; var c = 0; var d = 1;",
+            "var a,  b; var c = 0,  d = 1;",
+            Some(serde_json::json!([{ "uninitialized": "consecutive", "initialized": "always" }])),
+        ),
+        (
+            "var a; var b = 0; var c = 1; var d;",
+            "var a; var b = 0,  c = 1; var d;",
+            Some(serde_json::json!([{ "uninitialized": "consecutive", "initialized": "always" }])),
+        ),
+        (
+            "let a; let b; let c = 0; let d = 1;",
+            "let a,  b; let c = 0,  d = 1;",
+            Some(serde_json::json!([{ "uninitialized": "consecutive", "initialized": "always" }])),
+        ),
+        (
+            "let a; let b = 0; let c = 1; let d;",
+            "let a; let b = 0,  c = 1; let d;",
+            Some(serde_json::json!([{ "uninitialized": "consecutive", "initialized": "always" }])),
+        ),
+        (
+            "let a; let b; const c = 0; const d = 1;",
+            "let a,  b; const c = 0,  d = 1;",
+            Some(serde_json::json!([{ "uninitialized": "consecutive", "initialized": "always" }])),
+        ),
+        (
+            "let a; const b = 0; const c = 1; let d;",
+            "let a; const b = 0,  c = 1; let d;",
+            Some(serde_json::json!([{ "uninitialized": "consecutive", "initialized": "always" }])),
+        ),
+        (
+            "var a; var b; var c = 0, d = 1;",
+            "var a,  b; var c = 0; var d = 1;",
+            Some(serde_json::json!([{ "uninitialized": "consecutive", "initialized": "never" }])),
+        ),
+        (
+            "var a; var b = 0, c = 1; var d;",
+            "var a; var b = 0; var c = 1; var d;",
+            Some(serde_json::json!([{ "uninitialized": "consecutive", "initialized": "never" }])),
+        ),
+        (
+            "let a; let b; let c = 0, d = 1;",
+            "let a,  b; let c = 0; let d = 1;",
+            Some(serde_json::json!([{ "uninitialized": "consecutive", "initialized": "never" }])),
+        ),
+        (
+            "let a; let b = 0, c = 1; let d;",
+            "let a; let b = 0; let c = 1; let d;",
+            Some(serde_json::json!([{ "uninitialized": "consecutive", "initialized": "never" }])),
+        ),
+        (
+            "let a; let b; const c = 0, d = 1;",
+            "let a,  b; const c = 0; const d = 1;",
+            Some(serde_json::json!([{ "uninitialized": "consecutive", "initialized": "never" }])),
+        ),
+        (
+            "let a; const b = 0, c = 1; let d;",
+            "let a; const b = 0; const c = 1; let d;",
+            Some(serde_json::json!([{ "uninitialized": "consecutive", "initialized": "never" }])),
+        ),
+        (
+            "var a = 0; var b = 1;",
+            "var a = 0,  b = 1;",
+            Some(serde_json::json!([{ "var": "consecutive" }])),
+        ),
+        (
+            "let a = 0; let b = 1;",
+            "let a = 0,  b = 1;",
+            Some(serde_json::json!([{ "let": "consecutive" }])),
+        ),
+        (
+            "const a = 0; const b = 1;",
+            "const a = 0,  b = 1;",
+            Some(serde_json::json!([{ "const": "consecutive" }])),
+        ),
+        (
+            "let a; let b; const c = 0; const d = 1;",
+            "let a,  b; const c = 0,  d = 1;",
+            Some(serde_json::json!([{ "let": "consecutive", "const": "always" }])),
+        ),
+        (
+            "let a; const b = 0; const c = 1; let d;",
+            "let a; const b = 0,  c = 1; let d;",
+            Some(serde_json::json!([{ "let": "consecutive", "const": "always" }])),
+        ),
+        (
+            "let a; let b; const c = 0, d = 1;",
+            "let a,  b; const c = 0; const d = 1;",
+            Some(serde_json::json!([{ "let": "consecutive", "const": "never" }])),
+        ),
+        (
+            "let a; const b = 0, c = 1; let d;",
+            "let a; const b = 0; const c = 1; let d;",
+            Some(serde_json::json!([{ "let": "consecutive", "const": "never" }])),
+        ),
+        (
+            "const a = 0; const b = 1; let c; let d;",
+            "const a = 0,  b = 1; let c,  d;",
+            Some(serde_json::json!([{ "const": "consecutive", "let": "always" }])),
+        ),
+        (
+            "const a = 0; let b; let c; const d = 1;",
+            "const a = 0; let b,  c; const d = 1;",
+            Some(serde_json::json!([{ "const": "consecutive", "let": "always" }])),
+        ),
+        (
+            "const a = 0; const b = 1; let c, d;",
+            "const a = 0,  b = 1; let c; let d;",
+            Some(serde_json::json!([{ "const": "consecutive", "let": "never" }])),
+        ),
+        (
+            "const a = 0; let b, c; const d = 1;",
+            "const a = 0; let b; let c; const d = 1;",
+            Some(serde_json::json!([{ "const": "consecutive", "let": "never" }])),
+        ),
+        ("var bar; var baz;", "var bar,  baz;", Some(serde_json::json!(["consecutive"]))),
+        (
+            "var bar = 1; var baz = 2; qux(); var qux = 3; var quux;",
+            "var bar = 1,  baz = 2; qux(); var qux = 3,  quux;",
+            Some(serde_json::json!(["consecutive"])),
+        ),
+        (
+            "let a, b; let c; var d, e;",
+            "let a, b,  c; var d; var e;",
+            Some(
+                serde_json::json!([ { "var": "never", "let": "consecutive", "const": "consecutive" }, ]),
+            ),
+        ),
+        ("var a; var b;", "var a,  b;", Some(serde_json::json!([{ "var": "consecutive" }]))),
+        (
+            "var a = 1; var b = 2; var c, d; var e = 3; var f = 4;",
+            "var a = 1,  b = 2; var c; var d; var e = 3,  f = 4;",
+            Some(serde_json::json!([{ "initialized": "consecutive", "uninitialized": "never" }])),
+        ),
+        (
+            "var a = 1; var b = 2; foo(); var c = 3; var d = 4;",
+            "var a = 1,  b = 2; foo(); var c = 3,  d = 4;",
+            Some(serde_json::json!([{ "initialized": "consecutive" }])),
+        ),
+        (
+            "var a
+            var b",
+            "var a,
+             b",
+            Some(serde_json::json!(["always"])),
+        ),
+        (
+            "export const foo=1, bar=2;",
+            "export const foo=1; export const bar=2;",
+            Some(serde_json::json!(["never"])),
+        ),
+        (
+            "const foo=1,
+             bar=2;",
+            "const foo=1;
+             const bar=2;",
+            Some(serde_json::json!(["never"])),
+        ),
+        (
+            "export const foo=1,
+             bar=2;",
+            "export const foo=1;
+             export const bar=2;",
+            Some(serde_json::json!(["never"])),
+        ),
+        (
+            "export const foo=1
+            , bar=2;",
+            "export const foo=1
+            ; export const bar=2;",
+            Some(serde_json::json!(["never"])),
+        ),
+        (
+            "export const foo= a, bar=2;",
+            "export const foo= a; export const bar=2;",
+            Some(serde_json::json!(["never"])),
+        ),
+        (
+            "export const foo=() => a, bar=2;",
+            "export const foo=() => a; export const bar=2;",
+            Some(serde_json::json!(["never"])),
+        ),
+        (
+            "export const foo= a, bar=2, bar2=2;",
+            "export const foo= a; export const bar=2; export const bar2=2;",
+            Some(serde_json::json!(["never"])),
+        ),
+        (
+            "export const foo = 1,bar = 2;",
+            "export const foo = 1; export const bar = 2;",
+            Some(serde_json::json!(["never"])),
+        ),
+        (
+            "class C { static { let x, y; } }",
+            "class C { static { let x; let y; } }",
+            Some(serde_json::json!(["never"])),
+        ),
+        (
+            "class C { static { var x, y; } }",
+            "class C { static { var x; var y; } }",
+            Some(serde_json::json!(["never"])),
+        ),
+        (
+            "class C { static { let x; let y; } }",
+            "class C { static { let x,  y; } }",
+            Some(serde_json::json!(["always"])),
+        ),
+        (
+            "class C { static { var x; var y; } }",
+            "class C { static { var x,  y; } }",
+            Some(serde_json::json!(["always"])),
+        ),
+        (
+            "class C { static { let x; let y; } }",
+            "class C { static { let x,  y; } }",
+            Some(serde_json::json!(["consecutive"])),
+        ),
+        (
+            "class C { static { var x; var y; } }",
+            "class C { static { var x,  y; } }",
+            Some(serde_json::json!(["consecutive"])),
+        ),
+        (
+            "class C { static { let a = 0; let b = 1; } }",
+            "class C { static { let a = 0,  b = 1; } }",
+            Some(serde_json::json!([{ "initialized": "consecutive" }])),
+        ),
+        (
+            "class C { static { var a = 0; var b = 1; } }",
+            "class C { static { var a = 0,  b = 1; } }",
+            Some(serde_json::json!([{ "initialized": "consecutive" }])),
+        ),
+        ("using a = 0; using b = 1;", "using a = 0,  b = 1;", Some(serde_json::json!(["always"]))),
+        (
+            "await using a = 0; await using b = 1;",
+            "await using a = 0,   b = 1;",
+            Some(serde_json::json!(["always"])),
+        ),
+        ("using a = 0, b = 1;", "using a = 0; using b = 1;", Some(serde_json::json!(["never"]))),
+        (
+            "await using a = 0, b = 1;",
+            "await using a = 0; await using b = 1;",
+            Some(serde_json::json!(["never"])),
+        ),
+        (
+            "using a = 0; using b = 1;",
+            "using a = 0,  b = 1;",
+            Some(serde_json::json!(["consecutive"])),
+        ),
+        (
+            "await using a = 0; await using b = 1;",
+            "await using a = 0,   b = 1;",
+            Some(serde_json::json!(["consecutive"])),
+        ),
+        (
+            "using a = 0, b = 1;",
+            "using a = 0; using b = 1;",
+            Some(serde_json::json!([{ "initialized": "never" }])),
+        ),
+        (
+            "await using a = 0, b = 1;",
+            "await using a = 0; await using b = 1;",
+            Some(serde_json::json!([{ "initialized": "never" }])),
+        ),
+    ];
+    Tester::new(OneVar::NAME, OneVar::PLUGIN, pass, fail).expect_fix(fix).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/eslint/one_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/one_var.rs
@@ -1,12 +1,11 @@
 use oxc_ast::{
-    AstKind,
-    ast::{Declaration, Expression, VariableDeclaration, VariableDeclarationKind},
+    AstKind, AstType,
+    ast::{Expression, Statement, VariableDeclaration, VariableDeclarationKind},
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::{node::NodeId, scope::ScopeId};
-use rustc_hash::FxHashMap;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -98,12 +97,14 @@ impl Rule for OneVar {
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {
-        let mut scopes: FxHashMap<(ScopeId, u8), ScopeState> = FxHashMap::default();
-        let mut previous_statements = PreviousStatementTracker::default();
+        if !ctx.nodes().contains(AstType::VariableDeclaration) {
+            return;
+        }
+
+        let mut scopes = vec![[ScopeState::default(); 5]; ctx.scoping().scopes_len()];
         let separate_requires = self.separate_requires();
 
         for node in ctx.nodes().iter() {
-            let previous_statement_id = previous_statements.visit(node, ctx);
             let AstKind::VariableDeclaration(declaration) = node.kind() else {
                 continue;
             };
@@ -124,15 +125,9 @@ impl Rule for OneVar {
                 ));
             }
 
-            let previous_declaration = previous_statement_id
-                .map(|id| ctx.nodes().get_node(id))
-                .and_then(|node| match node.kind() {
-                    AstKind::VariableDeclaration(declaration) => Some(declaration),
-                    _ => None,
-                });
             if (modes.initialized == Some(OneVarMode::Consecutive)
                 || modes.uninitialized == Some(OneVarMode::Consecutive))
-                && let Some(previous) = previous_declaration
+                && let Some(previous) = previous_declaration(node, ctx)
                 && previous.kind == declaration.kind
             {
                 let previous_facts = DeclarationFacts::new(previous);
@@ -183,7 +178,7 @@ impl Rule for OneVar {
             }
 
             let scope_id = declaration_scope(node, ctx);
-            let state = scopes.entry((scope_id, declaration.kind as u8)).or_default();
+            let state = &mut scopes[scope_id.index()][declaration.kind as usize];
             let has_requires = facts.requires > 0;
             let should_join_initialized = modes.initialized == Some(OneVarMode::Always)
                 && facts.initialized > 0
@@ -201,8 +196,8 @@ impl Rule for OneVar {
             if should_join_all || should_join_require {
                 report_join_with_optional_previous(
                     ctx,
+                    node,
                     declaration,
-                    previous_declaration,
                     format!(
                         "Combine this with the previous '{}' statement.",
                         declaration.kind.as_str()
@@ -212,8 +207,8 @@ impl Rule for OneVar {
                 if should_join_initialized {
                     report_join_with_optional_previous(
                         ctx,
+                        node,
                         declaration,
-                        previous_declaration,
                         format!(
                             "Combine this with the previous '{}' statement with initialized variables.",
                             declaration.kind.as_str()
@@ -223,8 +218,8 @@ impl Rule for OneVar {
                 if should_join_uninitialized && !is_for_in_or_of_left(node, ctx) {
                     report_join_with_optional_previous(
                         ctx,
+                        node,
                         declaration,
-                        previous_declaration,
                         format!(
                             "Combine this with the previous '{}' statement with uninitialized variables.",
                             declaration.kind.as_str()
@@ -319,7 +314,7 @@ impl OneVar {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone, Copy)]
 struct ScopeState {
     initialized: bool,
     uninitialized: bool,
@@ -339,7 +334,7 @@ impl DeclarationFacts {
         for declarator in &declaration.declarations {
             if let Some(initializer) = &declarator.init {
                 initialized += 1;
-                requires += usize::from(is_require(Some(initializer)));
+                requires += usize::from(is_require(initializer));
             }
         }
         Self { initialized, uninitialized: declaration.declarations.len() - initialized, requires }
@@ -353,8 +348,12 @@ impl DeclarationFacts {
     }
 }
 
-fn is_require(expression: Option<&Expression<'_>>) -> bool {
-    matches!(expression, Some(Expression::CallExpression(call)) if call.callee_name() == Some("require"))
+fn is_require(expression: &Expression<'_>) -> bool {
+    matches!(
+        expression,
+        Expression::CallExpression(call)
+            if matches!(&call.callee, Expression::Identifier(identifier) if identifier.name == "require")
+    )
 }
 
 fn declaration_scope(node: &AstNode<'_>, ctx: &LintContext<'_>) -> ScopeId {
@@ -394,36 +393,39 @@ fn statement_node_id(node: &AstNode<'_>, ctx: &LintContext<'_>) -> Option<NodeId
     }
 }
 
-#[derive(Default)]
-struct PreviousStatementTracker {
-    last_by_parent: FxHashMap<NodeId, NodeId>,
-    exported_variable_previous: FxHashMap<NodeId, NodeId>,
-}
-
-impl PreviousStatementTracker {
-    fn visit(&mut self, node: &AstNode<'_>, ctx: &LintContext<'_>) -> Option<NodeId> {
-        let parent = ctx.nodes().parent_node(node.id());
-        if is_statement_list_parent(parent.kind()) {
-            let previous = self.last_by_parent.insert(parent.id(), node.id());
-            debug_assert!(
-                previous.is_none_or(|id| {
-                    ctx.nodes().get_node(id).span().start <= node.span().start
-                })
-            );
-            if matches!(
-                node.kind(),
-                AstKind::ExportNamedDeclaration(export)
-                    if matches!(export.declaration.as_ref(), Some(Declaration::VariableDeclaration(_)))
-            ) && let Some(previous) = previous
-            {
-                self.exported_variable_previous.insert(node.id(), previous);
-            }
-            previous
-        } else if matches!(parent.kind(), AstKind::ExportNamedDeclaration(_)) {
-            self.exported_variable_previous.remove(&parent.id())
-        } else {
-            None
+fn previous_declaration<'a, 'c>(
+    node: &AstNode<'a>,
+    ctx: &'c LintContext<'a>,
+) -> Option<&'c VariableDeclaration<'a>> {
+    let nodes = ctx.nodes();
+    let parent = nodes.parent_node(node.id());
+    let (statement_span, statement_parent) = if is_statement_list_parent(parent.kind()) {
+        (node.span(), parent)
+    } else if matches!(parent.kind(), AstKind::ExportNamedDeclaration(_)) {
+        let grandparent = nodes.parent_node(parent.id());
+        if !is_statement_list_parent(grandparent.kind()) {
+            return None;
         }
+        (parent.span(), grandparent)
+    } else {
+        return None;
+    };
+
+    let statements: &[Statement<'a>] = match statement_parent.kind() {
+        AstKind::Program(program) => &program.body,
+        AstKind::BlockStatement(block) => &block.body,
+        AstKind::FunctionBody(body) => &body.statements,
+        AstKind::StaticBlock(block) => &block.body,
+        AstKind::SwitchCase(case) => &case.consequent,
+        AstKind::TSModuleBlock(block) => &block.body,
+        _ => unreachable!(),
+    };
+    let index = statements
+        .binary_search_by_key(&statement_span.start, |statement| statement.span().start)
+        .ok()?;
+    match index.checked_sub(1).and_then(|index| statements.get(index))? {
+        Statement::VariableDeclaration(declaration) => Some(declaration),
+        _ => None,
     }
 }
 
@@ -440,11 +442,13 @@ fn is_for_in_or_of_left(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
 
 fn report_join_with_optional_previous<'a>(
     ctx: &LintContext<'a>,
+    node: &AstNode<'a>,
     declaration: &VariableDeclaration<'a>,
-    previous: Option<&VariableDeclaration<'a>>,
     message: String,
 ) {
-    if let Some(previous) = previous.filter(|previous| previous.kind == declaration.kind) {
+    if let Some(previous) =
+        previous_declaration(node, ctx).filter(|previous| previous.kind == declaration.kind)
+    {
         report_join(ctx, declaration, previous, message);
     } else {
         ctx.diagnostic(one_var_diagnostic(declaration.span, message));
@@ -1551,6 +1555,11 @@ fn test() {
         (
             "const foo = require('foo'); const bar = require('bar');",
             "const foo = require('foo'),  bar = require('bar');",
+            Some(serde_json::json!([{ "separateRequires": true, "const": "always" }])),
+        ),
+        (
+            "const foo = obj.require('foo'); const bar = 1;",
+            "const foo = obj.require('foo'),  bar = 1;",
             Some(serde_json::json!([{ "separateRequires": true, "const": "always" }])),
         ),
         ("var a = 1, b; var c;", "var a = 1, b,  c;", Some(serde_json::json!(["consecutive"]))),

--- a/crates/oxc_linter/src/rules/eslint/one_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/one_var.rs
@@ -1,6 +1,6 @@
 use oxc_ast::{
     AstKind,
-    ast::{Expression, VariableDeclaration, VariableDeclarationKind},
+    ast::{Declaration, Expression, VariableDeclaration, VariableDeclarationKind},
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
@@ -99,9 +99,11 @@ impl Rule for OneVar {
 
     fn run_once(&self, ctx: &LintContext<'_>) {
         let mut scopes: FxHashMap<(ScopeId, u8), ScopeState> = FxHashMap::default();
-        let previous_statements = previous_statement_ids(ctx);
+        let mut previous_statements = PreviousStatementTracker::default();
+        let separate_requires = self.separate_requires();
 
         for node in ctx.nodes().iter() {
+            let previous_statement_id = previous_statements.visit(node, ctx);
             let AstKind::VariableDeclaration(declaration) = node.kind() else {
                 continue;
             };
@@ -110,16 +112,11 @@ impl Rule for OneVar {
                 continue;
             }
 
-            let counts = DeclarationCounts::new(declaration);
-            let requires = declaration
-                .declarations
-                .iter()
-                .filter(|decl| is_require(decl.init.as_ref()))
-                .count();
-            if self.separate_requires()
+            let facts = DeclarationFacts::new(declaration);
+            if separate_requires
                 && modes.initialized == Some(OneVarMode::Always)
-                && requires > 0
-                && requires != declaration.declarations.len()
+                && facts.requires > 0
+                && facts.requires != declaration.declarations.len()
             {
                 ctx.diagnostic(one_var_diagnostic(
                     declaration.span,
@@ -127,77 +124,85 @@ impl Rule for OneVar {
                 ));
             }
 
-            if let Some(previous) = previous_declaration(node, ctx, &previous_statements)
+            let previous_declaration = previous_statement_id
+                .map(|id| ctx.nodes().get_node(id))
+                .and_then(|node| match node.kind() {
+                    AstKind::VariableDeclaration(declaration) => Some(declaration),
+                    _ => None,
+                });
+            if (modes.initialized == Some(OneVarMode::Consecutive)
+                || modes.uninitialized == Some(OneVarMode::Consecutive))
+                && let Some(previous) = previous_declaration
                 && previous.kind == declaration.kind
-                && !mixed_requires(previous, declaration)
             {
-                let previous_counts = DeclarationCounts::new(previous);
-                if modes.initialized == Some(OneVarMode::Consecutive)
-                    && modes.uninitialized == Some(OneVarMode::Consecutive)
-                {
-                    report_join(
-                        ctx,
-                        declaration,
-                        previous,
-                        format!(
-                            "Combine this with the previous '{}' statement.",
-                            declaration.kind.as_str()
-                        ),
-                    );
-                } else {
+                let previous_facts = DeclarationFacts::new(previous);
+                if !facts.mixed_requires_with(&previous_facts) {
                     if modes.initialized == Some(OneVarMode::Consecutive)
-                        && counts.initialized > 0
-                        && previous_counts.initialized > 0
+                        && modes.uninitialized == Some(OneVarMode::Consecutive)
                     {
                         report_join(
                             ctx,
                             declaration,
                             previous,
                             format!(
-                                "Combine this with the previous '{}' statement with initialized variables.",
+                                "Combine this with the previous '{}' statement.",
                                 declaration.kind.as_str()
                             ),
                         );
-                    }
-                    if modes.uninitialized == Some(OneVarMode::Consecutive)
-                        && counts.uninitialized > 0
-                        && previous_counts.uninitialized > 0
-                    {
-                        report_join(
-                            ctx,
-                            declaration,
-                            previous,
-                            format!(
-                                "Combine this with the previous '{}' statement with uninitialized variables.",
-                                declaration.kind.as_str()
-                            ),
-                        );
+                    } else {
+                        if modes.initialized == Some(OneVarMode::Consecutive)
+                            && facts.initialized > 0
+                            && previous_facts.initialized > 0
+                        {
+                            report_join(
+                                ctx,
+                                declaration,
+                                previous,
+                                format!(
+                                    "Combine this with the previous '{}' statement with initialized variables.",
+                                    declaration.kind.as_str()
+                                ),
+                            );
+                        }
+                        if modes.uninitialized == Some(OneVarMode::Consecutive)
+                            && facts.uninitialized > 0
+                            && previous_facts.uninitialized > 0
+                        {
+                            report_join(
+                                ctx,
+                                declaration,
+                                previous,
+                                format!(
+                                    "Combine this with the previous '{}' statement with uninitialized variables.",
+                                    declaration.kind.as_str()
+                                ),
+                            );
+                        }
                     }
                 }
             }
 
             let scope_id = declaration_scope(node, ctx);
             let state = scopes.entry((scope_id, declaration.kind as u8)).or_default();
-            let has_requires = requires > 0;
+            let has_requires = facts.requires > 0;
             let should_join_initialized = modes.initialized == Some(OneVarMode::Always)
-                && counts.initialized > 0
+                && facts.initialized > 0
                 && state.initialized
                 && !has_requires;
             let should_join_uninitialized = modes.uninitialized == Some(OneVarMode::Always)
-                && counts.uninitialized > 0
+                && facts.uninitialized > 0
                 && state.uninitialized;
             let should_join_all = modes.initialized == Some(OneVarMode::Always)
                 && modes.uninitialized == Some(OneVarMode::Always)
                 && (state.initialized || state.uninitialized)
                 && !has_requires;
-            let should_join_require = self.separate_requires() && has_requires && state.required;
+            let should_join_require = separate_requires && has_requires && state.required;
 
             if should_join_all || should_join_require {
                 report_join_with_optional_previous(
                     ctx,
-                    node,
                     declaration,
-                    &previous_statements,
+                    previous_declaration,
                     format!(
                         "Combine this with the previous '{}' statement.",
                         declaration.kind.as_str()
@@ -207,9 +212,8 @@ impl Rule for OneVar {
                 if should_join_initialized {
                     report_join_with_optional_previous(
                         ctx,
-                        node,
                         declaration,
-                        &previous_statements,
+                        previous_declaration,
                         format!(
                             "Combine this with the previous '{}' statement with initialized variables.",
                             declaration.kind.as_str()
@@ -219,9 +223,8 @@ impl Rule for OneVar {
                 if should_join_uninitialized && !is_for_in_or_of_left(node, ctx) {
                     report_join_with_optional_previous(
                         ctx,
-                        node,
                         declaration,
-                        &previous_statements,
+                        previous_declaration,
                         format!(
                             "Combine this with the previous '{}' statement with uninitialized variables.",
                             declaration.kind.as_str()
@@ -230,14 +233,14 @@ impl Rule for OneVar {
                 }
             }
 
-            if modes.initialized == Some(OneVarMode::Always) && counts.initialized > 0 {
-                if self.separate_requires() && has_requires {
+            if modes.initialized == Some(OneVarMode::Always) && facts.initialized > 0 {
+                if separate_requires && has_requires {
                     state.required = true;
                 } else {
                     state.initialized = true;
                 }
             }
-            if modes.uninitialized == Some(OneVarMode::Always) && counts.uninitialized > 0 {
+            if modes.uninitialized == Some(OneVarMode::Always) && facts.uninitialized > 0 {
                 state.uninitialized = true;
             }
 
@@ -255,7 +258,7 @@ impl Rule for OneVar {
                         ),
                     );
                 } else {
-                    if modes.initialized == Some(OneVarMode::Never) && counts.initialized > 0 {
+                    if modes.initialized == Some(OneVarMode::Never) && facts.initialized > 0 {
                         report_split(
                             ctx,
                             node,
@@ -266,7 +269,7 @@ impl Rule for OneVar {
                             ),
                         );
                     }
-                    if modes.uninitialized == Some(OneVarMode::Never) && counts.uninitialized > 0 {
+                    if modes.uninitialized == Some(OneVarMode::Never) && facts.uninitialized > 0 {
                         report_split(
                             ctx,
                             node,
@@ -323,35 +326,35 @@ struct ScopeState {
     required: bool,
 }
 
-struct DeclarationCounts {
+struct DeclarationFacts {
     initialized: usize,
     uninitialized: usize,
+    requires: usize,
 }
 
-impl DeclarationCounts {
+impl DeclarationFacts {
     fn new(declaration: &VariableDeclaration<'_>) -> Self {
-        let initialized =
-            declaration.declarations.iter().filter(|decl| decl.init.is_some()).count();
-        Self { initialized, uninitialized: declaration.declarations.len() - initialized }
+        let mut initialized = 0;
+        let mut requires = 0;
+        for declarator in &declaration.declarations {
+            if let Some(initializer) = &declarator.init {
+                initialized += 1;
+                requires += usize::from(is_require(Some(initializer)));
+            }
+        }
+        Self { initialized, uninitialized: declaration.declarations.len() - initialized, requires }
+    }
+
+    fn mixed_requires_with(&self, other: &Self) -> bool {
+        let requires = self.requires + other.requires;
+        requires > 0
+            && requires
+                != self.initialized + self.uninitialized + other.initialized + other.uninitialized
     }
 }
 
 fn is_require(expression: Option<&Expression<'_>>) -> bool {
     matches!(expression, Some(Expression::CallExpression(call)) if call.callee_name() == Some("require"))
-}
-
-fn mixed_requires(left: &VariableDeclaration<'_>, right: &VariableDeclaration<'_>) -> bool {
-    let declarations = left.declarations.iter().chain(&right.declarations);
-    let mut require = false;
-    let mut other = false;
-    for declaration in declarations {
-        if is_require(declaration.init.as_ref()) {
-            require = true;
-        } else {
-            other = true;
-        }
-    }
-    require && other
 }
 
 fn declaration_scope(node: &AstNode<'_>, ctx: &LintContext<'_>) -> ScopeId {
@@ -391,42 +394,36 @@ fn statement_node_id(node: &AstNode<'_>, ctx: &LintContext<'_>) -> Option<NodeId
     }
 }
 
-fn previous_statement_ids(ctx: &LintContext<'_>) -> FxHashMap<NodeId, NodeId> {
-    let mut statement_lists: FxHashMap<NodeId, Vec<(u32, NodeId)>> = FxHashMap::default();
-    for node in ctx.nodes().iter() {
+#[derive(Default)]
+struct PreviousStatementTracker {
+    last_by_parent: FxHashMap<NodeId, NodeId>,
+    exported_variable_previous: FxHashMap<NodeId, NodeId>,
+}
+
+impl PreviousStatementTracker {
+    fn visit(&mut self, node: &AstNode<'_>, ctx: &LintContext<'_>) -> Option<NodeId> {
         let parent = ctx.nodes().parent_node(node.id());
         if is_statement_list_parent(parent.kind()) {
-            statement_lists.entry(parent.id()).or_default().push((node.span().start, node.id()));
+            let previous = self.last_by_parent.insert(parent.id(), node.id());
+            debug_assert!(
+                previous.is_none_or(|id| {
+                    ctx.nodes().get_node(id).span().start <= node.span().start
+                })
+            );
+            if matches!(
+                node.kind(),
+                AstKind::ExportNamedDeclaration(export)
+                    if matches!(export.declaration.as_ref(), Some(Declaration::VariableDeclaration(_)))
+            ) && let Some(previous) = previous
+            {
+                self.exported_variable_previous.insert(node.id(), previous);
+            }
+            previous
+        } else if matches!(parent.kind(), AstKind::ExportNamedDeclaration(_)) {
+            self.exported_variable_previous.remove(&parent.id())
+        } else {
+            None
         }
-    }
-
-    let mut previous = FxHashMap::default();
-    for statements in statement_lists.values_mut() {
-        statements.sort_unstable_by_key(|&(start, _)| start);
-        for pair in statements.windows(2) {
-            previous.insert(pair[1].1, pair[0].1);
-        }
-    }
-    previous
-}
-
-fn previous_statement<'a, 'c>(
-    node: &AstNode<'a>,
-    ctx: &'c LintContext<'a>,
-    previous_statements: &FxHashMap<NodeId, NodeId>,
-) -> Option<&'c AstNode<'a>> {
-    let statement_id = statement_node_id(node, ctx)?;
-    previous_statements.get(&statement_id).map(|&previous_id| ctx.nodes().get_node(previous_id))
-}
-
-fn previous_declaration<'a, 'c>(
-    node: &AstNode<'a>,
-    ctx: &'c LintContext<'a>,
-    previous_statements: &FxHashMap<NodeId, NodeId>,
-) -> Option<&'c VariableDeclaration<'a>> {
-    match previous_statement(node, ctx, previous_statements)?.kind() {
-        AstKind::VariableDeclaration(declaration) => Some(declaration),
-        _ => None,
     }
 }
 
@@ -443,14 +440,11 @@ fn is_for_in_or_of_left(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
 
 fn report_join_with_optional_previous<'a>(
     ctx: &LintContext<'a>,
-    node: &AstNode<'a>,
     declaration: &VariableDeclaration<'a>,
-    previous_statements: &FxHashMap<NodeId, NodeId>,
+    previous: Option<&VariableDeclaration<'a>>,
     message: String,
 ) {
-    if let Some(previous) = previous_declaration(node, ctx, previous_statements)
-        .filter(|previous| previous.kind == declaration.kind)
-    {
+    if let Some(previous) = previous.filter(|previous| previous.kind == declaration.kind) {
         report_join(ctx, declaration, previous, message);
     } else {
         ctx.diagnostic(one_var_diagnostic(declaration.span, message));

--- a/crates/oxc_linter/src/rules/eslint/one_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/one_var.rs
@@ -59,7 +59,6 @@ impl Default for OneVarConfig {
 #[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
 pub struct OneVar(OneVarConfig);
 
-// See <https://github.com/oxc-project/oxc/issues/6050> for documentation details.
 declare_oxc_lint!(
     /// ### What it does
     ///

--- a/crates/oxc_linter/src/rules/eslint/one_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/one_var.rs
@@ -481,10 +481,10 @@ fn report_join(
     previous: &VariableDeclaration<'_>,
     message: String,
 ) {
-    ctx.diagnostic_with_fix(one_var_diagnostic(declaration.span, message), |_fixer| {
+    ctx.diagnostic_with_fix(one_var_diagnostic(declaration.span, message), |fixer| {
         let source = ctx.source_text();
         let previous_source = previous.span.source_text(source);
-        let mut fixes = Vec::with_capacity(3);
+        let mut fixes = fixer.new_fix_with_capacity(3);
         if let Some(index) = previous_source.rfind(';') {
             let start = previous.span.start + u32::try_from(index).unwrap();
             fixes.push(Fix::new(",", Span::sized(start, 1)));
@@ -506,7 +506,7 @@ fn report_join(
                 u32::try_from(keyword.len()).unwrap(),
             )));
         }
-        fixes.into_iter().collect::<RuleFix>().with_message("Combine variable declarations")
+        fixes.with_message("Combine variable declarations")
     });
 }
 

--- a/crates/oxc_linter/src/rules/eslint/one_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/one_var.rs
@@ -1,3 +1,6 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
 use oxc_ast::{
     AstKind, AstType,
     ast::{Expression, Statement, VariableDeclaration, VariableDeclarationKind},
@@ -6,8 +9,6 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::{node::NodeId, scope::ScopeId};
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 
 use crate::{
     AstNode,

--- a/crates/oxc_linter/src/rules/eslint/one_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/one_var.rs
@@ -522,7 +522,6 @@ fn report_split(
         return;
     }
     ctx.diagnostic_with_fix(diagnostic, |fixer| {
-        let source = ctx.source_text();
         let keyword = declaration.kind.as_str();
         let exported =
             matches!(ctx.nodes().parent_kind(node.id()), AstKind::ExportNamedDeclaration(_));
@@ -531,9 +530,8 @@ fn report_split(
         for pair in declaration.declarations.windows(2) {
             let left = &pair[0];
             let right = &pair[1];
-            let gap = &source[left.span.end as usize..right.span.start as usize];
-            if let Some(index) = gap.find(',') {
-                let comma = left.span.end + u32::try_from(index).unwrap();
+            if let Some(offset) = ctx.find_next_token_within(left.span.end, right.span.start, ",") {
+                let comma = left.span.end + offset;
                 let separator = if comma + 1 == right.span.start { "; " } else { ";" };
                 fixes.push(Fix::new(separator, Span::sized(comma, 1)));
                 fixes.push(Fix::new(prefix.clone(), Span::empty(right.span.start)));

--- a/crates/oxc_linter/src/rules/eslint/one_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/one_var.rs
@@ -23,30 +23,49 @@ fn one_var_diagnostic(span: Span, message: String) -> OxcDiagnostic {
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
+/// Controls how variable declarators are grouped into declarations.
 enum OneVarMode {
+    /// Requires one declaration per variable kind in each applicable scope.
     #[default]
     Always,
+    /// Requires each declarator to have its own declaration statement.
     Never,
+    /// Requires adjacent declarations of the same kind to be combined.
     Consecutive,
 }
 
+/// Options for configuring declaration grouping by kind or initialization state.
+///
+/// `initialized` and `uninitialized` take precedence over the per-kind option for the
+/// corresponding declarators.
 #[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 struct OneVarOptions {
+    /// Controls grouping for `const` declarations.
     r#const: Option<OneVarMode>,
+    /// Keeps direct `require(...)` initializers separate from other initialized declarations.
     separate_requires: bool,
+    /// Controls grouping for `var` declarations.
     var: Option<OneVarMode>,
+    /// Controls grouping for `await using` declarations.
     await_using: Option<OneVarMode>,
+    /// Controls grouping for `let` declarations.
     r#let: Option<OneVarMode>,
+    /// Controls grouping for `using` declarations.
     using: Option<OneVarMode>,
+    /// Controls grouping for initialized declarators, overriding per-kind options.
     initialized: Option<OneVarMode>,
+    /// Controls grouping for uninitialized declarators, overriding per-kind options.
     uninitialized: Option<OneVarMode>,
 }
 
+/// Configuration accepted by the `one-var` rule.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(untagged)]
 enum OneVarConfig {
+    /// Applies one grouping mode to every declaration kind and initialization state.
     Mode(OneVarMode),
+    /// Configures grouping by declaration kind or initialization state.
     Options(OneVarOptions),
 }
 
@@ -57,6 +76,7 @@ impl Default for OneVarConfig {
 }
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
+/// Enforces consistent grouping of variable declarations.
 pub struct OneVar(OneVarConfig);
 
 declare_oxc_lint!(

--- a/crates/oxc_linter/src/rules/eslint/one_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/one_var.rs
@@ -475,6 +475,7 @@ fn report_join_with_optional_previous<'a>(
     }
 }
 
+#[expect(clippy::cast_possible_truncation)]
 fn report_join(
     ctx: &LintContext<'_>,
     declaration: &VariableDeclaration<'_>,
@@ -486,7 +487,7 @@ fn report_join(
         let previous_source = previous.span.source_text(source);
         let mut fixes = fixer.new_fix_with_capacity(3);
         if let Some(index) = previous_source.rfind(';') {
-            let start = previous.span.start + u32::try_from(index).unwrap();
+            let start = previous.span.start + index as u32;
             fixes.push(Fix::new(",", Span::sized(start, 1)));
         } else {
             fixes.push(Fix::new(",", Span::empty(previous.span.end)));
@@ -496,14 +497,11 @@ fn report_join(
         if declaration.kind == VariableDeclarationKind::AwaitUsing {
             fixes.push(Fix::delete(Span::sized(declaration.span.start, 5)));
             let using_offset = declaration_source.find("using").unwrap();
-            fixes.push(Fix::delete(Span::sized(
-                declaration.span.start + u32::try_from(using_offset).unwrap(),
-                5,
-            )));
+            fixes.push(Fix::delete(Span::sized(declaration.span.start + using_offset as u32, 5)));
         } else if let Some(offset) = declaration_source.find(keyword) {
             fixes.push(Fix::delete(Span::sized(
-                declaration.span.start + u32::try_from(offset).unwrap(),
-                u32::try_from(keyword.len()).unwrap(),
+                declaration.span.start + offset as u32,
+                keyword.len() as u32,
             )));
         }
         fixes.with_message("Combine variable declarations")

--- a/crates/oxc_linter/src/rules/eslint/one_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/one_var.rs
@@ -405,7 +405,7 @@ fn statement_node_id(node: &AstNode<'_>, ctx: &LintContext<'_>) -> Option<NodeId
     let parent = ctx.nodes().parent_node(node.id());
     if is_statement_list_parent(parent.kind()) {
         Some(node.id())
-    } else if matches!(parent.kind(), AstKind::ExportNamedDeclaration(_)) {
+    } else if matches!(parent.kind(), AstKind::ExportDeclaration(_)) {
         let grandparent = ctx.nodes().parent_node(parent.id());
         is_statement_list_parent(grandparent.kind()).then_some(parent.id())
     } else {
@@ -421,7 +421,7 @@ fn previous_declaration<'a, 'c>(
     let parent = nodes.parent_node(node.id());
     let (statement_span, statement_parent) = if is_statement_list_parent(parent.kind()) {
         (node.span(), parent)
-    } else if matches!(parent.kind(), AstKind::ExportNamedDeclaration(_)) {
+    } else if matches!(parent.kind(), AstKind::ExportDeclaration(_)) {
         let grandparent = nodes.parent_node(parent.id());
         if !is_statement_list_parent(grandparent.kind()) {
             return None;
@@ -525,8 +525,7 @@ fn report_split(
     }
     ctx.diagnostic_with_fix(diagnostic, |fixer| {
         let keyword = declaration.kind.as_str();
-        let exported =
-            matches!(ctx.nodes().parent_kind(node.id()), AstKind::ExportNamedDeclaration(_));
+        let exported = matches!(ctx.nodes().parent_kind(node.id()), AstKind::ExportDeclaration(_));
         let prefix = if exported { format!("export {keyword} ") } else { format!("{keyword} ") };
         let mut fixes = fixer.new_fix_with_capacity((declaration.declarations.len() - 1) * 2);
         for [left, right] in declaration.declarations.array_windows() {

--- a/crates/oxc_linter/src/rules/eslint/one_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/one_var.rs
@@ -527,9 +527,7 @@ fn report_split(
             matches!(ctx.nodes().parent_kind(node.id()), AstKind::ExportNamedDeclaration(_));
         let prefix = if exported { format!("export {keyword} ") } else { format!("{keyword} ") };
         let mut fixes = fixer.new_fix_with_capacity((declaration.declarations.len() - 1) * 2);
-        for pair in declaration.declarations.windows(2) {
-            let left = &pair[0];
-            let right = &pair[1];
+        for [left, right] in declaration.declarations.array_windows() {
             if let Some(offset) = ctx.find_next_token_within(left.span.end, right.span.start, ",") {
                 let comma = left.span.end + offset;
                 let separator = if comma + 1 == right.span.start { "; " } else { ";" };

--- a/crates/oxc_linter/src/rules/eslint/one_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/one_var.rs
@@ -501,13 +501,13 @@ fn report_split(
         ctx.diagnostic(diagnostic);
         return;
     }
-    ctx.diagnostic_with_fix(diagnostic, |_fixer| {
+    ctx.diagnostic_with_fix(diagnostic, |fixer| {
         let source = ctx.source_text();
         let keyword = declaration.kind.as_str();
         let exported =
             matches!(ctx.nodes().parent_kind(node.id()), AstKind::ExportNamedDeclaration(_));
         let prefix = if exported { format!("export {keyword} ") } else { format!("{keyword} ") };
-        let mut fixes = Vec::with_capacity((declaration.declarations.len() - 1) * 2);
+        let mut fixes = fixer.new_fix_with_capacity((declaration.declarations.len() - 1) * 2);
         for pair in declaration.declarations.windows(2) {
             let left = &pair[0];
             let right = &pair[1];
@@ -519,7 +519,7 @@ fn report_split(
                 fixes.push(Fix::new(prefix.clone(), Span::empty(right.span.start)));
             }
         }
-        fixes.into_iter().collect::<RuleFix>().with_message("Split variable declarations")
+        fixes.with_message("Split variable declarations")
     });
 }
 

--- a/crates/oxc_linter/src/rules/eslint/one_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/one_var.rs
@@ -13,7 +13,7 @@ use oxc_syntax::{node::NodeId, scope::ScopeId};
 use crate::{
     AstNode,
     context::LintContext,
-    fixer::{Fix, RuleFix},
+    fixer::Fix,
     rule::{DefaultRuleConfig, Rule},
 };
 
@@ -483,24 +483,28 @@ fn report_join(
     message: String,
 ) {
     ctx.diagnostic_with_fix(one_var_diagnostic(declaration.span, message), |fixer| {
-        let source = ctx.source_text();
-        let previous_source = previous.span.source_text(source);
         let mut fixes = fixer.new_fix_with_capacity(3);
-        if let Some(index) = previous_source.rfind(';') {
-            let start = previous.span.start + index as u32;
+        if let Some(offset) =
+            ctx.find_next_token_within(previous.span.start, previous.span.end, ";")
+        {
+            let start = previous.span.start + offset;
             fixes.push(Fix::new(",", Span::sized(start, 1)));
         } else {
             fixes.push(Fix::new(",", Span::empty(previous.span.end)));
         }
         let keyword = declaration.kind.as_str();
-        let declaration_source = declaration.span.source_text(source);
         if declaration.kind == VariableDeclarationKind::AwaitUsing {
             fixes.push(Fix::delete(Span::sized(declaration.span.start, 5)));
-            let using_offset = declaration_source.find("using").unwrap();
-            fixes.push(Fix::delete(Span::sized(declaration.span.start + using_offset as u32, 5)));
-        } else if let Some(offset) = declaration_source.find(keyword) {
+            let offset = ctx
+                .find_next_token_within(declaration.span.start, declaration.span.end, "using")
+                .expect("`await using` declaration must contain a `using` keyword");
+            fixes.push(Fix::delete(Span::sized(declaration.span.start + offset, 5)));
+        } else {
+            let offset = ctx
+                .find_next_token_within(declaration.span.start, declaration.span.end, keyword)
+                .expect("variable declaration must contain its declaration keyword");
             fixes.push(Fix::delete(Span::sized(
-                declaration.span.start + offset as u32,
+                declaration.span.start + offset,
                 keyword.len() as u32,
             )));
         }
@@ -526,12 +530,13 @@ fn report_split(
         let prefix = if exported { format!("export {keyword} ") } else { format!("{keyword} ") };
         let mut fixes = fixer.new_fix_with_capacity((declaration.declarations.len() - 1) * 2);
         for [left, right] in declaration.declarations.array_windows() {
-            if let Some(offset) = ctx.find_next_token_within(left.span.end, right.span.start, ",") {
-                let comma = left.span.end + offset;
-                let separator = if comma + 1 == right.span.start { "; " } else { ";" };
-                fixes.push(Fix::new(separator, Span::sized(comma, 1)));
-                fixes.push(Fix::new(prefix.clone(), Span::empty(right.span.start)));
-            }
+            let offset = ctx
+                .find_next_token_within(left.span.end, right.span.start, ",")
+                .expect("variable declarators must be separated by a comma");
+            let comma = left.span.end + offset;
+            let separator = if comma + 1 == right.span.start { "; " } else { ";" };
+            fixes.push(Fix::new(separator, Span::sized(comma, 1)));
+            fixes.push(Fix::new(prefix.clone(), Span::empty(right.span.start)));
         }
         fixes.with_message("Split variable declarations")
     });

--- a/crates/oxc_linter/src/snapshots/eslint_one_var.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_one_var.snap
@@ -1,0 +1,1162 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint(one-var): Split 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:1]
+ 1 │ var bar = true, baz = false;
+   · ────────────────────────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:18]
+ 1 │ function foo() { var bar = true, baz = false; }
+   ·                  ────────────────────────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:12]
+ 1 │ if (foo) { var bar = true, baz = false; }
+   ·            ────────────────────────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:26]
+ 1 │ switch (foo) { case bar: var baz = true, quux = false; }
+   ·                          ─────────────────────────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:25]
+ 1 │ switch (foo) { default: var baz = true, quux = false; }
+   ·                         ─────────────────────────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement.
+   ╭─[one_var.tsx:1:34]
+ 1 │ function foo() { var bar = true; var baz = false; }
+   ·                                  ────────────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement.
+   ╭─[one_var.tsx:1:17]
+ 1 │ var a = 1; for (var b = 2;;) {}
+   ·                 ─────────
+   ╰────
+
+  ⚠ eslint(one-var): Split initialized 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:18]
+ 1 │ function foo() { var foo = true, bar = false; }
+   ·                  ────────────────────────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split uninitialized 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:18]
+ 1 │ function foo() { var foo, bar; }
+   ·                  ─────────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement with uninitialized variables.
+   ╭─[one_var.tsx:1:61]
+ 1 │ function foo() { var bar, baz; var a = true; var b = false; var c, d;}
+   ·                                                             ─────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement with initialized variables.
+   ╭─[one_var.tsx:1:61]
+ 1 │ function foo() { var bar = true, baz = false; var a; var b; var c = true, d = false; }
+   ·                                                             ────────────────────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Split 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:18]
+ 1 │ function foo() { var bar = true, baz = false; var a, b;}
+   ·                  ────────────────────────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:47]
+ 1 │ function foo() { var bar = true, baz = false; var a, b;}
+   ·                                               ─────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement.
+   ╭─[one_var.tsx:1:34]
+ 1 │ function foo() { var bar = true; var baz = false; var a; var b;}
+   ·                                  ────────────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement.
+   ╭─[one_var.tsx:1:51]
+ 1 │ function foo() { var bar = true; var baz = false; var a; var b;}
+   ·                                                   ──────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement.
+   ╭─[one_var.tsx:1:58]
+ 1 │ function foo() { var bar = true; var baz = false; var a; var b;}
+   ·                                                          ──────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement.
+   ╭─[one_var.tsx:1:37]
+ 1 │ function foo() { var a = [1, 2, 3]; var [b, c, d] = a; }
+   ·                                     ──────────────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'let' statement.
+   ╭─[one_var.tsx:1:29]
+ 1 │ function foo() { let a = 1; let b = 2; }
+   ·                             ──────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'const' statement.
+   ╭─[one_var.tsx:1:31]
+ 1 │ function foo() { const a = 1; const b = 2; }
+   ·                               ────────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'let' statement.
+   ╭─[one_var.tsx:1:29]
+ 1 │ function foo() { let a = 1; let b = 2; }
+   ·                             ──────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'const' statement.
+   ╭─[one_var.tsx:1:31]
+ 1 │ function foo() { const a = 1; const b = 2; }
+   ·                               ────────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Split 'let' declarations into multiple statements.
+   ╭─[one_var.tsx:1:18]
+ 1 │ function foo() { let a = 1, b = 2; }
+   ·                  ─────────────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split initialized 'let' declarations into multiple statements.
+   ╭─[one_var.tsx:1:18]
+ 1 │ function foo() { let a = 1, b = 2; }
+   ·                  ─────────────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split uninitialized 'let' declarations into multiple statements.
+   ╭─[one_var.tsx:1:18]
+ 1 │ function foo() { let a, b; }
+   ·                  ─────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split initialized 'const' declarations into multiple statements.
+   ╭─[one_var.tsx:1:18]
+ 1 │ function foo() { const a = 1, b = 2; }
+   ·                  ───────────────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split 'const' declarations into multiple statements.
+   ╭─[one_var.tsx:1:18]
+ 1 │ function foo() { const a = 1, b = 2; }
+   ·                  ───────────────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'let' statement.
+   ╭─[one_var.tsx:1:74]
+ 1 │ let foo = true; switch(foo) { case true: let bar = 2; break; case false: let baz = 3; break; }
+   ·                                                                          ────────────
+   ╰────
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement.
+   ╭─[one_var.tsx:2:13]
+ 1 │ var one = 1, two = 2;
+ 2 │             var three;
+   ·             ──────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Split initialized 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:1]
+ 1 │ var i = [0], j;
+   · ───────────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split uninitialized 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:1]
+ 1 │ var i = [0], j;
+   · ───────────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement.
+   ╭─[one_var.tsx:1:29]
+ 1 │ for (var x of foo) {}; for (var y of foo) {}
+   ·                             ─────
+   ╰────
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement.
+   ╭─[one_var.tsx:1:29]
+ 1 │ for (var x in foo) {}; for (var y in foo) {}
+   ·                             ─────
+   ╰────
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement.
+   ╭─[one_var.tsx:1:40]
+ 1 │ var foo = function() { var bar = true; var baz = false; }
+   ·                                        ────────────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement.
+   ╭─[one_var.tsx:1:45]
+ 1 │ function foo() { var bar = true; if (qux) { var baz = false; } else { var quxx = 42; } }
+   ·                                             ────────────────
+   ╰────
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement.
+   ╭─[one_var.tsx:1:71]
+ 1 │ function foo() { var bar = true; if (qux) { var baz = false; } else { var quxx = 42; } }
+   ·                                                                       ──────────────
+   ╰────
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement.
+   ╭─[one_var.tsx:1:35]
+ 1 │ var foo = () => { var bar = true; var baz = false; }
+   ·                                   ────────────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement.
+   ╭─[one_var.tsx:1:51]
+ 1 │ var foo = function() { var bar = true; if (qux) { var baz = false; } }
+   ·                                                   ────────────────
+   ╰────
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement.
+   ╭─[one_var.tsx:1:10]
+ 1 │ var foo; var bar;
+   ·          ────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Split initialized 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:1]
+ 1 │ var x = 1, y = 2; for (var z in foo) {}
+   · ─────────────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split initialized 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:1]
+ 1 │ var x = 1, y = 2; for (var z of foo) {}
+   · ─────────────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement with uninitialized variables.
+   ╭─[one_var.tsx:1:8]
+ 1 │ var x; var y; for (var z in foo) {}
+   ·        ──────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement with uninitialized variables.
+   ╭─[one_var.tsx:1:8]
+ 1 │ var x; var y; for (var z of foo) {}
+   ·        ──────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement with uninitialized variables.
+   ╭─[one_var.tsx:1:41]
+ 1 │ var x; for (var y in foo) {var bar = y; var a; for (var z of bar) {}}
+   ·                                         ──────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Split initialized 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:53]
+ 1 │ var a = 1; var b = 2; var x, y; for (var z of foo) {var c = 3, baz = z; for (var d in baz) {}}
+   ·                                                     ───────────────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split initialized 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:1]
+ 1 │ var {foo} = 1, [bar] = 2;
+   · ─────────────────────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split initialized 'const' declarations into multiple statements.
+   ╭─[one_var.tsx:1:1]
+ 1 │ ╭─▶ const foo = 1,
+ 2 │ ╰─▶                 bar = 2;
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split initialized 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:1]
+ 1 │ ╭─▶ var foo = 1,
+ 2 │ ╰─▶                 bar = 2;
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split initialized 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:1]
+ 1 │ ╭─▶ var foo = 1, // comment
+ 2 │ ╰─▶                 bar = 2;
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:1]
+ 1 │ var f, k /* test */, l;
+   · ───────────────────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:1]
+ 1 │ var f,          /* test */ l;
+   · ─────────────────────────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:1]
+ 1 │ ╭─▶ var f, k /* test 
+ 2 │ │                some more comment 
+ 3 │ ╰─▶              even more */, l = 1, P;
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:1]
+ 1 │ var a = 1, b = 2
+   · ────────────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split requires to be separated into a single block.
+   ╭─[one_var.tsx:1:1]
+ 1 │ var foo = require('foo'), bar;
+   · ──────────────────────────────
+   ╰────
+
+  ⚠ eslint(one-var): Split requires to be separated into a single block.
+   ╭─[one_var.tsx:1:1]
+ 1 │ var foo, bar = require('bar');
+   · ──────────────────────────────
+   ╰────
+
+  ⚠ eslint(one-var): Split requires to be separated into a single block.
+   ╭─[one_var.tsx:1:1]
+ 1 │ let foo, bar = require('bar');
+   · ──────────────────────────────
+   ╰────
+
+  ⚠ eslint(one-var): Split requires to be separated into a single block.
+   ╭─[one_var.tsx:1:1]
+ 1 │ const foo = 0, bar = require('bar');
+   · ────────────────────────────────────
+   ╰────
+
+  ⚠ eslint(one-var): Combine this with the previous 'const' statement.
+   ╭─[one_var.tsx:1:29]
+ 1 │ const foo = require('foo'); const bar = require('bar');
+   ·                             ───────────────────────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement.
+   ╭─[one_var.tsx:1:15]
+ 1 │ var a = 1, b; var c;
+   ·               ──────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement.
+   ╭─[one_var.tsx:1:19]
+ 1 │ var a = 0, b = 1; var c = 2;
+   ·                   ──────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'let' statement.
+   ╭─[one_var.tsx:1:15]
+ 1 │ let a = 1, b; let c;
+   ·               ──────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'let' statement.
+   ╭─[one_var.tsx:1:19]
+ 1 │ let a = 0, b = 1; let c = 2;
+   ·                   ──────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'const' statement.
+   ╭─[one_var.tsx:1:21]
+ 1 │ const a = 0, b = 1; const c = 2;
+   ·                     ────────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement.
+   ╭─[one_var.tsx:1:25]
+ 1 │ const a = 0; var b = 1; var c = 2; const d = 3;
+   ·                         ──────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement.
+   ╭─[one_var.tsx:1:15]
+ 1 │ var a = true; var b = false;
+   ·               ──────────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'let' statement.
+   ╭─[one_var.tsx:1:25]
+ 1 │ const a = 0; let b = 1; let c = 2; const d = 3;
+   ·                         ──────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'const' statement.
+   ╭─[one_var.tsx:1:25]
+ 1 │ let a = 0; const b = 1; const c = 1; var d = 2;
+   ·                         ────────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement with uninitialized variables.
+   ╭─[one_var.tsx:1:19]
+ 1 │ var a = 0; var b; var c; var d = 1
+   ·                   ──────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement with initialized variables.
+   ╭─[one_var.tsx:1:12]
+ 1 │ var a = 0; var b = 1; var c; var d;
+   ·            ──────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement with uninitialized variables.
+   ╭─[one_var.tsx:1:30]
+ 1 │ var a = 0; var b = 1; var c; var d;
+   ·                              ──────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'let' statement with uninitialized variables.
+   ╭─[one_var.tsx:1:19]
+ 1 │ let a = 0; let b; let c; let d = 1;
+   ·                   ──────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'let' statement with initialized variables.
+   ╭─[one_var.tsx:1:12]
+ 1 │ let a = 0; let b = 1; let c; let d;
+   ·            ──────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'let' statement with uninitialized variables.
+   ╭─[one_var.tsx:1:30]
+ 1 │ let a = 0; let b = 1; let c; let d;
+   ·                              ──────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'let' statement with uninitialized variables.
+   ╭─[one_var.tsx:1:21]
+ 1 │ const a = 0; let b; let c; const d = 1;
+   ·                     ──────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'const' statement with initialized variables.
+   ╭─[one_var.tsx:1:14]
+ 1 │ const a = 0; const b = 1; let c; let d;
+   ·              ────────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'let' statement with uninitialized variables.
+   ╭─[one_var.tsx:1:34]
+ 1 │ const a = 0; const b = 1; let c; let d;
+   ·                                  ──────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement with initialized variables.
+   ╭─[one_var.tsx:1:12]
+ 1 │ var a = 0; var b = 1; var c, d;
+   ·            ──────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Split uninitialized 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:23]
+ 1 │ var a = 0; var b = 1; var c, d;
+   ·                       ─────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split uninitialized 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:12]
+ 1 │ var a = 0; var b, c; var d = 1;
+   ·            ─────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'let' statement with initialized variables.
+   ╭─[one_var.tsx:1:12]
+ 1 │ let a = 0; let b = 1; let c, d;
+   ·            ──────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Split uninitialized 'let' declarations into multiple statements.
+   ╭─[one_var.tsx:1:23]
+ 1 │ let a = 0; let b = 1; let c, d;
+   ·                       ─────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split uninitialized 'let' declarations into multiple statements.
+   ╭─[one_var.tsx:1:12]
+ 1 │ let a = 0; let b, c; let d = 1;
+   ·            ─────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'const' statement with initialized variables.
+   ╭─[one_var.tsx:1:14]
+ 1 │ const a = 0; const b = 1; let c, d;
+   ·              ────────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Split uninitialized 'let' declarations into multiple statements.
+   ╭─[one_var.tsx:1:27]
+ 1 │ const a = 0; const b = 1; let c, d;
+   ·                           ─────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split uninitialized 'let' declarations into multiple statements.
+   ╭─[one_var.tsx:1:14]
+ 1 │ const a = 0; let b, c; const d = 1;
+   ·              ─────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement with uninitialized variables.
+   ╭─[one_var.tsx:1:8]
+ 1 │ var a; var b; var c = 0; var d = 1;
+   ·        ──────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement with initialized variables.
+   ╭─[one_var.tsx:1:26]
+ 1 │ var a; var b; var c = 0; var d = 1;
+   ·                          ──────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement with initialized variables.
+   ╭─[one_var.tsx:1:19]
+ 1 │ var a; var b = 0; var c = 1; var d;
+   ·                   ──────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'let' statement with uninitialized variables.
+   ╭─[one_var.tsx:1:8]
+ 1 │ let a; let b; let c = 0; let d = 1;
+   ·        ──────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'let' statement with initialized variables.
+   ╭─[one_var.tsx:1:26]
+ 1 │ let a; let b; let c = 0; let d = 1;
+   ·                          ──────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'let' statement with initialized variables.
+   ╭─[one_var.tsx:1:19]
+ 1 │ let a; let b = 0; let c = 1; let d;
+   ·                   ──────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'let' statement with uninitialized variables.
+   ╭─[one_var.tsx:1:8]
+ 1 │ let a; let b; const c = 0; const d = 1;
+   ·        ──────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'const' statement with initialized variables.
+   ╭─[one_var.tsx:1:28]
+ 1 │ let a; let b; const c = 0; const d = 1;
+   ·                            ────────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'const' statement with initialized variables.
+   ╭─[one_var.tsx:1:21]
+ 1 │ let a; const b = 0; const c = 1; let d;
+   ·                     ────────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement with uninitialized variables.
+   ╭─[one_var.tsx:1:8]
+ 1 │ var a; var b; var c = 0, d = 1;
+   ·        ──────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Split initialized 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:15]
+ 1 │ var a; var b; var c = 0, d = 1;
+   ·               ─────────────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split initialized 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:8]
+ 1 │ var a; var b = 0, c = 1; var d;
+   ·        ─────────────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'let' statement with uninitialized variables.
+   ╭─[one_var.tsx:1:8]
+ 1 │ let a; let b; let c = 0, d = 1;
+   ·        ──────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Split initialized 'let' declarations into multiple statements.
+   ╭─[one_var.tsx:1:15]
+ 1 │ let a; let b; let c = 0, d = 1;
+   ·               ─────────────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split initialized 'let' declarations into multiple statements.
+   ╭─[one_var.tsx:1:8]
+ 1 │ let a; let b = 0, c = 1; let d;
+   ·        ─────────────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'let' statement with uninitialized variables.
+   ╭─[one_var.tsx:1:8]
+ 1 │ let a; let b; const c = 0, d = 1;
+   ·        ──────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Split initialized 'const' declarations into multiple statements.
+   ╭─[one_var.tsx:1:15]
+ 1 │ let a; let b; const c = 0, d = 1;
+   ·               ───────────────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split initialized 'const' declarations into multiple statements.
+   ╭─[one_var.tsx:1:8]
+ 1 │ let a; const b = 0, c = 1; let d;
+   ·        ───────────────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement.
+   ╭─[one_var.tsx:1:12]
+ 1 │ var a = 0; var b = 1;
+   ·            ──────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'let' statement.
+   ╭─[one_var.tsx:1:12]
+ 1 │ let a = 0; let b = 1;
+   ·            ──────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'const' statement.
+   ╭─[one_var.tsx:1:14]
+ 1 │ const a = 0; const b = 1;
+   ·              ────────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'let' statement.
+   ╭─[one_var.tsx:1:8]
+ 1 │ let a; let b; const c = 0; const d = 1;
+   ·        ──────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'const' statement.
+   ╭─[one_var.tsx:1:28]
+ 1 │ let a; let b; const c = 0; const d = 1;
+   ·                            ────────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'const' statement.
+   ╭─[one_var.tsx:1:21]
+ 1 │ let a; const b = 0; const c = 1; let d;
+   ·                     ────────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'let' statement.
+   ╭─[one_var.tsx:1:8]
+ 1 │ let a; let b; const c = 0, d = 1;
+   ·        ──────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Split 'const' declarations into multiple statements.
+   ╭─[one_var.tsx:1:15]
+ 1 │ let a; let b; const c = 0, d = 1;
+   ·               ───────────────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split 'const' declarations into multiple statements.
+   ╭─[one_var.tsx:1:8]
+ 1 │ let a; const b = 0, c = 1; let d;
+   ·        ───────────────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'const' statement.
+   ╭─[one_var.tsx:1:14]
+ 1 │ const a = 0; const b = 1; let c; let d;
+   ·              ────────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'let' statement.
+   ╭─[one_var.tsx:1:34]
+ 1 │ const a = 0; const b = 1; let c; let d;
+   ·                                  ──────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'let' statement.
+   ╭─[one_var.tsx:1:21]
+ 1 │ const a = 0; let b; let c; const d = 1;
+   ·                     ──────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'const' statement.
+   ╭─[one_var.tsx:1:14]
+ 1 │ const a = 0; const b = 1; let c, d;
+   ·              ────────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Split 'let' declarations into multiple statements.
+   ╭─[one_var.tsx:1:27]
+ 1 │ const a = 0; const b = 1; let c, d;
+   ·                           ─────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split 'let' declarations into multiple statements.
+   ╭─[one_var.tsx:1:14]
+ 1 │ const a = 0; let b, c; const d = 1;
+   ·              ─────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement.
+   ╭─[one_var.tsx:1:10]
+ 1 │ var bar; var baz;
+   ·          ────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement.
+   ╭─[one_var.tsx:1:14]
+ 1 │ var bar = 1; var baz = 2; qux(); var qux = 3; var quux;
+   ·              ────────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement.
+   ╭─[one_var.tsx:1:47]
+ 1 │ var bar = 1; var baz = 2; qux(); var qux = 3; var quux;
+   ·                                               ─────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'let' statement.
+   ╭─[one_var.tsx:1:11]
+ 1 │ let a, b; let c; var d, e;
+   ·           ──────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Split 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:18]
+ 1 │ let a, b; let c; var d, e;
+   ·                  ─────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement.
+   ╭─[one_var.tsx:1:8]
+ 1 │ var a; var b;
+   ·        ──────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement with initialized variables.
+   ╭─[one_var.tsx:1:12]
+ 1 │ var a = 1; var b = 2; var c, d; var e = 3; var f = 4;
+   ·            ──────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Split uninitialized 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:23]
+ 1 │ var a = 1; var b = 2; var c, d; var e = 3; var f = 4;
+   ·                       ─────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement with initialized variables.
+   ╭─[one_var.tsx:1:44]
+ 1 │ var a = 1; var b = 2; var c, d; var e = 3; var f = 4;
+   ·                                            ──────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement with initialized variables.
+   ╭─[one_var.tsx:1:12]
+ 1 │ var a = 1; var b = 2; foo(); var c = 3; var d = 4;
+   ·            ──────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement with initialized variables.
+   ╭─[one_var.tsx:1:41]
+ 1 │ var a = 1; var b = 2; foo(); var c = 3; var d = 4;
+   ·                                         ──────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement.
+   ╭─[one_var.tsx:2:13]
+ 1 │ var a
+ 2 │             var b
+   ·             ─────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Split 'const' declarations into multiple statements.
+   ╭─[one_var.tsx:1:8]
+ 1 │ export const foo=1, bar=2;
+   ·        ───────────────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split 'const' declarations into multiple statements.
+   ╭─[one_var.tsx:1:1]
+ 1 │ ╭─▶ const foo=1,
+ 2 │ ╰─▶              bar=2;
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split 'const' declarations into multiple statements.
+   ╭─[one_var.tsx:1:8]
+ 1 │ ╭─▶ export const foo=1,
+ 2 │ ╰─▶              bar=2;
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split 'const' declarations into multiple statements.
+   ╭─[one_var.tsx:1:8]
+ 1 │ ╭─▶ export const foo=1
+ 2 │ ╰─▶             , bar=2;
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split 'const' declarations into multiple statements.
+   ╭─[one_var.tsx:1:8]
+ 1 │ export const foo= a, bar=2;
+   ·        ────────────────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split 'const' declarations into multiple statements.
+   ╭─[one_var.tsx:1:8]
+ 1 │ export const foo=() => a, bar=2;
+   ·        ─────────────────────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split 'const' declarations into multiple statements.
+   ╭─[one_var.tsx:1:8]
+ 1 │ export const foo= a, bar=2, bar2=2;
+   ·        ────────────────────────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split 'const' declarations into multiple statements.
+   ╭─[one_var.tsx:1:8]
+ 1 │ export const foo = 1,bar = 2;
+   ·        ──────────────────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:10]
+ 1 │ if (foo) var x, y;
+   ·          ─────────
+   ╰────
+
+  ⚠ eslint(one-var): Split 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:10]
+ 1 │ if (foo) var x, y;
+   ·          ─────────
+   ╰────
+
+  ⚠ eslint(one-var): Split uninitialized 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:10]
+ 1 │ if (foo) var x, y;
+   ·          ─────────
+   ╰────
+
+  ⚠ eslint(one-var): Split initialized 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:10]
+ 1 │ if (foo) var x = 1, y = 1;
+   ·          ─────────────────
+   ╰────
+
+  ⚠ eslint(one-var): Split 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:18]
+ 1 │ if (foo) {} else var x, y;
+   ·                  ─────────
+   ╰────
+
+  ⚠ eslint(one-var): Split 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:13]
+ 1 │ while (foo) var x, y;
+   ·             ─────────
+   ╰────
+
+  ⚠ eslint(one-var): Split 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:4]
+ 1 │ do var x, y; while (foo);
+   ·    ─────────
+   ╰────
+
+  ⚠ eslint(one-var): Split 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:4]
+ 1 │ do var x = f(), y = b(); while (x < y);
+   ·    ─────────────────────
+   ╰────
+
+  ⚠ eslint(one-var): Split 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:10]
+ 1 │ for (;;) var x, y;
+   ·          ─────────
+   ╰────
+
+  ⚠ eslint(one-var): Split 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:18]
+ 1 │ for (foo in bar) var x, y;
+   ·                  ─────────
+   ╰────
+
+  ⚠ eslint(one-var): Split 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:18]
+ 1 │ for (foo of bar) var x, y;
+   ·                  ─────────
+   ╰────
+
+  ⚠ eslint(one-var): Split 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:12]
+ 1 │ with (foo) var x, y;
+   ·            ─────────
+   ╰────
+
+  ⚠ eslint(one-var): Split 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:8]
+ 1 │ label: var x, y;
+   ·        ─────────
+   ╰────
+
+  ⚠ eslint(one-var): Split 'let' declarations into multiple statements.
+   ╭─[one_var.tsx:1:20]
+ 1 │ class C { static { let x, y; } }
+   ·                    ─────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split 'var' declarations into multiple statements.
+   ╭─[one_var.tsx:1:20]
+ 1 │ class C { static { var x, y; } }
+   ·                    ─────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'let' statement.
+   ╭─[one_var.tsx:1:27]
+ 1 │ class C { static { let x; let y; } }
+   ·                           ──────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement.
+   ╭─[one_var.tsx:1:27]
+ 1 │ class C { static { var x; var y; } }
+   ·                           ──────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'let' statement.
+   ╭─[one_var.tsx:1:32]
+ 1 │ class C { static { let x; foo; let y; } }
+   ·                                ──────
+   ╰────
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement.
+   ╭─[one_var.tsx:1:32]
+ 1 │ class C { static { var x; foo; var y; } }
+   ·                                ──────
+   ╰────
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement.
+   ╭─[one_var.tsx:1:38]
+ 1 │ class C { static { var x; if (foo) { var y; } } }
+   ·                                      ──────
+   ╰────
+
+  ⚠ eslint(one-var): Combine this with the previous 'let' statement.
+   ╭─[one_var.tsx:1:27]
+ 1 │ class C { static { let x; let y; } }
+   ·                           ──────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement.
+   ╭─[one_var.tsx:1:27]
+ 1 │ class C { static { var x; var y; } }
+   ·                           ──────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'let' statement with initialized variables.
+   ╭─[one_var.tsx:1:31]
+ 1 │ class C { static { let a = 0; let b = 1; } }
+   ·                               ──────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'var' statement with initialized variables.
+   ╭─[one_var.tsx:1:31]
+ 1 │ class C { static { var a = 0; var b = 1; } }
+   ·                               ──────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'using' statement.
+   ╭─[one_var.tsx:1:14]
+ 1 │ using a = 0; using b = 1;
+   ·              ────────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'await using' statement.
+   ╭─[one_var.tsx:1:20]
+ 1 │ await using a = 0; await using b = 1;
+   ·                    ──────────────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Split 'using' declarations into multiple statements.
+   ╭─[one_var.tsx:1:1]
+ 1 │ using a = 0, b = 1;
+   · ───────────────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split 'await using' declarations into multiple statements.
+   ╭─[one_var.tsx:1:1]
+ 1 │ await using a = 0, b = 1;
+   · ─────────────────────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'using' statement.
+   ╭─[one_var.tsx:1:14]
+ 1 │ using a = 0; using b = 1;
+   ·              ────────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Combine this with the previous 'await using' statement.
+   ╭─[one_var.tsx:1:20]
+ 1 │ await using a = 0; await using b = 1;
+   ·                    ──────────────────
+   ╰────
+  help: Combine variable declarations
+
+  ⚠ eslint(one-var): Split initialized 'using' declarations into multiple statements.
+   ╭─[one_var.tsx:1:1]
+ 1 │ using a = 0, b = 1;
+   · ───────────────────
+   ╰────
+  help: Split variable declarations
+
+  ⚠ eslint(one-var): Split initialized 'await using' declarations into multiple statements.
+   ╭─[one_var.tsx:1:1]
+ 1 │ await using a = 0, b = 1;
+   · ─────────────────────────
+   ╰────
+  help: Split variable declarations

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -5749,6 +5749,26 @@
             }
           ]
         },
+        "one-var": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleNoConfig"
+            },
+            {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/AllowWarnDeny"
+                },
+                {
+                  "$ref": "#/definitions/OneVar"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          ]
+        },
         "operator-assignment": {
           "anyOf": [
             {
@@ -16220,6 +16240,93 @@
           }
         }
       ]
+    },
+    "OneVar": {
+      "$ref": "#/definitions/OneVarConfig"
+    },
+    "OneVarConfig": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/OneVarMode"
+        },
+        {
+          "$ref": "#/definitions/OneVarOptions"
+        }
+      ]
+    },
+    "OneVarMode": {
+      "type": "string",
+      "enum": [
+        "always",
+        "never",
+        "consecutive"
+      ]
+    },
+    "OneVarOptions": {
+      "type": "object",
+      "properties": {
+        "awaitUsing": {
+          "default": null,
+          "allOf": [
+            {
+              "$ref": "#/definitions/OneVarMode"
+            }
+          ]
+        },
+        "const": {
+          "default": null,
+          "allOf": [
+            {
+              "$ref": "#/definitions/OneVarMode"
+            }
+          ]
+        },
+        "initialized": {
+          "default": null,
+          "allOf": [
+            {
+              "$ref": "#/definitions/OneVarMode"
+            }
+          ]
+        },
+        "let": {
+          "default": null,
+          "allOf": [
+            {
+              "$ref": "#/definitions/OneVarMode"
+            }
+          ]
+        },
+        "separateRequires": {
+          "default": false,
+          "type": "boolean"
+        },
+        "uninitialized": {
+          "default": null,
+          "allOf": [
+            {
+              "$ref": "#/definitions/OneVarMode"
+            }
+          ]
+        },
+        "using": {
+          "default": null,
+          "allOf": [
+            {
+              "$ref": "#/definitions/OneVarMode"
+            }
+          ]
+        },
+        "var": {
+          "default": null,
+          "allOf": [
+            {
+              "$ref": "#/definitions/OneVarMode"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
     },
     "OnlyExportComponentsConfig": {
       "type": "object",

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -5850,6 +5850,26 @@
             }
           ]
         },
+        "one-var": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleNoConfig"
+            },
+            {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/AllowWarnDeny"
+                },
+                {
+                  "$ref": "#/definitions/OneVar"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          ]
+        },
         "operator-assignment": {
           "anyOf": [
             {
@@ -16583,6 +16603,93 @@
           }
         }
       ]
+    },
+    "OneVar": {
+      "$ref": "#/definitions/OneVarConfig"
+    },
+    "OneVarConfig": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/OneVarMode"
+        },
+        {
+          "$ref": "#/definitions/OneVarOptions"
+        }
+      ]
+    },
+    "OneVarMode": {
+      "type": "string",
+      "enum": [
+        "always",
+        "never",
+        "consecutive"
+      ]
+    },
+    "OneVarOptions": {
+      "type": "object",
+      "properties": {
+        "awaitUsing": {
+          "default": null,
+          "allOf": [
+            {
+              "$ref": "#/definitions/OneVarMode"
+            }
+          ]
+        },
+        "const": {
+          "default": null,
+          "allOf": [
+            {
+              "$ref": "#/definitions/OneVarMode"
+            }
+          ]
+        },
+        "initialized": {
+          "default": null,
+          "allOf": [
+            {
+              "$ref": "#/definitions/OneVarMode"
+            }
+          ]
+        },
+        "let": {
+          "default": null,
+          "allOf": [
+            {
+              "$ref": "#/definitions/OneVarMode"
+            }
+          ]
+        },
+        "separateRequires": {
+          "default": false,
+          "type": "boolean"
+        },
+        "uninitialized": {
+          "default": null,
+          "allOf": [
+            {
+              "$ref": "#/definitions/OneVarMode"
+            }
+          ]
+        },
+        "using": {
+          "default": null,
+          "allOf": [
+            {
+              "$ref": "#/definitions/OneVarMode"
+            }
+          ]
+        },
+        "var": {
+          "default": null,
+          "allOf": [
+            {
+              "$ref": "#/definitions/OneVarMode"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
     },
     "OnlyExportComponentsConfig": {
       "type": "object",

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -16605,91 +16605,151 @@
       ]
     },
     "OneVar": {
-      "$ref": "#/definitions/OneVarConfig"
+      "description": "Enforces consistent grouping of variable declarations.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/OneVarConfig"
+        }
+      ],
+      "markdownDescription": "Enforces consistent grouping of variable declarations."
     },
     "OneVarConfig": {
+      "description": "Configuration accepted by the `one-var` rule.",
       "anyOf": [
         {
-          "$ref": "#/definitions/OneVarMode"
+          "description": "Applies one grouping mode to every declaration kind and initialization state.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/OneVarMode"
+            }
+          ],
+          "markdownDescription": "Applies one grouping mode to every declaration kind and initialization state."
         },
         {
-          "$ref": "#/definitions/OneVarOptions"
+          "description": "Configures grouping by declaration kind or initialization state.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/OneVarOptions"
+            }
+          ],
+          "markdownDescription": "Configures grouping by declaration kind or initialization state."
         }
-      ]
+      ],
+      "markdownDescription": "Configuration accepted by the `one-var` rule."
     },
     "OneVarMode": {
-      "type": "string",
-      "enum": [
-        "always",
-        "never",
-        "consecutive"
-      ]
+      "description": "Controls how variable declarators are grouped into declarations.",
+      "oneOf": [
+        {
+          "description": "Requires one declaration per variable kind in each applicable scope.",
+          "type": "string",
+          "enum": [
+            "always"
+          ],
+          "markdownDescription": "Requires one declaration per variable kind in each applicable scope."
+        },
+        {
+          "description": "Requires each declarator to have its own declaration statement.",
+          "type": "string",
+          "enum": [
+            "never"
+          ],
+          "markdownDescription": "Requires each declarator to have its own declaration statement."
+        },
+        {
+          "description": "Requires adjacent declarations of the same kind to be combined.",
+          "type": "string",
+          "enum": [
+            "consecutive"
+          ],
+          "markdownDescription": "Requires adjacent declarations of the same kind to be combined."
+        }
+      ],
+      "markdownDescription": "Controls how variable declarators are grouped into declarations."
     },
     "OneVarOptions": {
+      "description": "Options for configuring declaration grouping by kind or initialization state.\n\n`initialized` and `uninitialized` take precedence over the per-kind option for the\ncorresponding declarators.",
       "type": "object",
       "properties": {
         "awaitUsing": {
+          "description": "Controls grouping for `await using` declarations.",
           "default": null,
           "allOf": [
             {
               "$ref": "#/definitions/OneVarMode"
             }
-          ]
+          ],
+          "markdownDescription": "Controls grouping for `await using` declarations."
         },
         "const": {
+          "description": "Controls grouping for `const` declarations.",
           "default": null,
           "allOf": [
             {
               "$ref": "#/definitions/OneVarMode"
             }
-          ]
+          ],
+          "markdownDescription": "Controls grouping for `const` declarations."
         },
         "initialized": {
+          "description": "Controls grouping for initialized declarators, overriding per-kind options.",
           "default": null,
           "allOf": [
             {
               "$ref": "#/definitions/OneVarMode"
             }
-          ]
+          ],
+          "markdownDescription": "Controls grouping for initialized declarators, overriding per-kind options."
         },
         "let": {
+          "description": "Controls grouping for `let` declarations.",
           "default": null,
           "allOf": [
             {
               "$ref": "#/definitions/OneVarMode"
             }
-          ]
+          ],
+          "markdownDescription": "Controls grouping for `let` declarations."
         },
         "separateRequires": {
+          "description": "Keeps direct `require(...)` initializers separate from other initialized declarations.",
           "default": false,
-          "type": "boolean"
+          "type": "boolean",
+          "markdownDescription": "Keeps direct `require(...)` initializers separate from other initialized declarations."
         },
         "uninitialized": {
+          "description": "Controls grouping for uninitialized declarators, overriding per-kind options.",
           "default": null,
           "allOf": [
             {
               "$ref": "#/definitions/OneVarMode"
             }
-          ]
+          ],
+          "markdownDescription": "Controls grouping for uninitialized declarators, overriding per-kind options."
         },
         "using": {
+          "description": "Controls grouping for `using` declarations.",
           "default": null,
           "allOf": [
             {
               "$ref": "#/definitions/OneVarMode"
             }
-          ]
+          ],
+          "markdownDescription": "Controls grouping for `using` declarations."
         },
         "var": {
+          "description": "Controls grouping for `var` declarations.",
           "default": null,
           "allOf": [
             {
               "$ref": "#/definitions/OneVarMode"
             }
-          ]
+          ],
+          "markdownDescription": "Controls grouping for `var` declarations."
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "markdownDescription": "Options for configuring declaration grouping by kind or initialization state.\n\n`initialized` and `uninitialized` take precedence over the per-kind option for the\ncorresponding declarators."
     },
     "OnlyExportComponentsConfig": {
       "type": "object",

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -155,6 +155,7 @@ eslint/no-var                                              |  31363
 eslint/no-void                                             |   9106
 eslint/no-warning-comments                                 |      7
 eslint/object-shorthand                                    |  46617
+eslint/one-var                                             |      7
 eslint/operator-assignment                                 |  13005
 eslint/prefer-arrow-callback                               |  14283
 eslint/prefer-const                                        |  31363


### PR DESCRIPTION
## Summary

Adds a native Oxlint implementation of [ESLint's `one-var` rule](https://eslint.org/docs/latest/rules/one-var). This implementation is a port of the [eslint rule source](https://github.com/eslint/eslint/blob/main/lib/rules/one-var.js), test suite, and autofix logic.

Related #479

## AI Disclosure

GPT 5.6 Sol was used to assist with implementation of this rule.