### PR TITLE
feat(linter/react): implement function-component-definition rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -215,6 +215,10 @@ export type ForbidItem2 =
        */
       message?: string;
     };
+export type NamedComponents = NamedComponentStyle | NamedComponentStyle[];
+export type NamedComponentStyle = "function-declaration" | "arrow-function" | "function-expression";
+export type UnnamedComponents = UnnamedComponentStyle | UnnamedComponentStyle[];
+export type UnnamedComponentStyle = "arrow-function" | "function-expression";
 export type EnforceBooleanAttribute = "always" | "never";
 export type JsxCurlyBracePresenceConfig = JsxCurlyBracePresenceMode | JsxCurlyBracePresence;
 export type JsxCurlyBracePresenceMode = "always" | "never" | "ignore";
@@ -1305,6 +1309,7 @@ export interface DummyRuleMap {
   "react/forbid-dom-props"?: RuleNoConfig | [AllowWarnDeny, ForbidDomPropsConfig];
   "react/forbid-elements"?: RuleNoConfig | [AllowWarnDeny, ForbidElementsConfig];
   "react/forward-ref-uses-ref"?: RuleNoConfig;
+  "react/function-component-definition"?: RuleNoConfig | [AllowWarnDeny, FunctionComponentDefinitionConfig];
   "react/hook-use-state"?: RuleNoConfig | [AllowWarnDeny, HookUseStateConfig];
   "react/iframe-missing-sandbox"?: RuleNoConfig;
   "react/jsx-boolean-value"?:
@@ -4507,6 +4512,10 @@ export interface ForbidElementsConfig {
    * - `["error, { "forbid": [{ "element": "input" }] }]`
    */
   forbid?: ForbidItem2[];
+}
+export interface FunctionComponentDefinitionConfig {
+  namedComponents?: NamedComponents;
+  unnamedComponents?: UnnamedComponents;
 }
 export interface HookUseStateConfig {
   /**

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2581,6 +2581,14 @@ impl RuleRunner for crate::rules::react::forward_ref_uses_ref::ForwardRefUsesRef
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner
+    for crate::rules::react::function_component_definition::FunctionComponentDefinition
+{
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ArrowFunctionExpression, AstType::Function]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::react::hook_use_state::HookUseState {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -426,6 +426,7 @@ pub use crate::rules::react::forbid_component_props::ForbidComponentProps as Rea
 pub use crate::rules::react::forbid_dom_props::ForbidDomProps as ReactForbidDomProps;
 pub use crate::rules::react::forbid_elements::ForbidElements as ReactForbidElements;
 pub use crate::rules::react::forward_ref_uses_ref::ForwardRefUsesRef as ReactForwardRefUsesRef;
+pub use crate::rules::react::function_component_definition::FunctionComponentDefinition as ReactFunctionComponentDefinition;
 pub use crate::rules::react::hook_use_state::HookUseState as ReactHookUseState;
 pub use crate::rules::react::iframe_missing_sandbox::IframeMissingSandbox as ReactIframeMissingSandbox;
 pub use crate::rules::react::jsx_boolean_value::JsxBooleanValue as ReactJsxBooleanValue;
@@ -1259,6 +1260,7 @@ pub enum RuleEnum {
     ReactForbidDomProps(ReactForbidDomProps),
     ReactForbidElements(ReactForbidElements),
     ReactForwardRefUsesRef(ReactForwardRefUsesRef),
+    ReactFunctionComponentDefinition(ReactFunctionComponentDefinition),
     ReactHookUseState(ReactHookUseState),
     ReactIframeMissingSandbox(ReactIframeMissingSandbox),
     ReactJsxBooleanValue(ReactJsxBooleanValue),
@@ -2155,7 +2157,8 @@ const REACT_FORBID_COMPONENT_PROPS_ID: usize = REACT_EXHAUSTIVE_DEPS_ID + 1usize
 const REACT_FORBID_DOM_PROPS_ID: usize = REACT_FORBID_COMPONENT_PROPS_ID + 1usize;
 const REACT_FORBID_ELEMENTS_ID: usize = REACT_FORBID_DOM_PROPS_ID + 1usize;
 const REACT_FORWARD_REF_USES_REF_ID: usize = REACT_FORBID_ELEMENTS_ID + 1usize;
-const REACT_HOOK_USE_STATE_ID: usize = REACT_FORWARD_REF_USES_REF_ID + 1usize;
+const REACT_FUNCTION_COMPONENT_DEFINITION_ID: usize = REACT_FORWARD_REF_USES_REF_ID + 1usize;
+const REACT_HOOK_USE_STATE_ID: usize = REACT_FUNCTION_COMPONENT_DEFINITION_ID + 1usize;
 const REACT_IFRAME_MISSING_SANDBOX_ID: usize = REACT_HOOK_USE_STATE_ID + 1usize;
 const REACT_JSX_BOOLEAN_VALUE_ID: usize = REACT_IFRAME_MISSING_SANDBOX_ID + 1usize;
 const REACT_JSX_CURLY_BRACE_PRESENCE_ID: usize = REACT_JSX_BOOLEAN_VALUE_ID + 1usize;
@@ -3131,6 +3134,7 @@ impl RuleEnum {
             Self::ReactForbidDomProps(_) => REACT_FORBID_DOM_PROPS_ID,
             Self::ReactForbidElements(_) => REACT_FORBID_ELEMENTS_ID,
             Self::ReactForwardRefUsesRef(_) => REACT_FORWARD_REF_USES_REF_ID,
+            Self::ReactFunctionComponentDefinition(_) => REACT_FUNCTION_COMPONENT_DEFINITION_ID,
             Self::ReactHookUseState(_) => REACT_HOOK_USE_STATE_ID,
             Self::ReactIframeMissingSandbox(_) => REACT_IFRAME_MISSING_SANDBOX_ID,
             Self::ReactJsxBooleanValue(_) => REACT_JSX_BOOLEAN_VALUE_ID,
@@ -4102,6 +4106,7 @@ impl RuleEnum {
             Self::ReactForbidDomProps(_) => ReactForbidDomProps::NAME,
             Self::ReactForbidElements(_) => ReactForbidElements::NAME,
             Self::ReactForwardRefUsesRef(_) => ReactForwardRefUsesRef::NAME,
+            Self::ReactFunctionComponentDefinition(_) => ReactFunctionComponentDefinition::NAME,
             Self::ReactHookUseState(_) => ReactHookUseState::NAME,
             Self::ReactIframeMissingSandbox(_) => ReactIframeMissingSandbox::NAME,
             Self::ReactJsxBooleanValue(_) => ReactJsxBooleanValue::NAME,
@@ -5085,6 +5090,7 @@ impl RuleEnum {
             Self::ReactForbidDomProps(_) => ReactForbidDomProps::CATEGORY,
             Self::ReactForbidElements(_) => ReactForbidElements::CATEGORY,
             Self::ReactForwardRefUsesRef(_) => ReactForwardRefUsesRef::CATEGORY,
+            Self::ReactFunctionComponentDefinition(_) => ReactFunctionComponentDefinition::CATEGORY,
             Self::ReactHookUseState(_) => ReactHookUseState::CATEGORY,
             Self::ReactIframeMissingSandbox(_) => ReactIframeMissingSandbox::CATEGORY,
             Self::ReactJsxBooleanValue(_) => ReactJsxBooleanValue::CATEGORY,
@@ -6079,6 +6085,7 @@ impl RuleEnum {
             Self::ReactForbidDomProps(_) => ReactForbidDomProps::FIX,
             Self::ReactForbidElements(_) => ReactForbidElements::FIX,
             Self::ReactForwardRefUsesRef(_) => ReactForwardRefUsesRef::FIX,
+            Self::ReactFunctionComponentDefinition(_) => ReactFunctionComponentDefinition::FIX,
             Self::ReactHookUseState(_) => ReactHookUseState::FIX,
             Self::ReactIframeMissingSandbox(_) => ReactIframeMissingSandbox::FIX,
             Self::ReactJsxBooleanValue(_) => ReactJsxBooleanValue::FIX,
@@ -7145,6 +7152,9 @@ impl RuleEnum {
             Self::ReactForbidDomProps(_) => ReactForbidDomProps::documentation(),
             Self::ReactForbidElements(_) => ReactForbidElements::documentation(),
             Self::ReactForwardRefUsesRef(_) => ReactForwardRefUsesRef::documentation(),
+            Self::ReactFunctionComponentDefinition(_) => {
+                ReactFunctionComponentDefinition::documentation()
+            }
             Self::ReactHookUseState(_) => ReactHookUseState::documentation(),
             Self::ReactIframeMissingSandbox(_) => ReactIframeMissingSandbox::documentation(),
             Self::ReactJsxBooleanValue(_) => ReactJsxBooleanValue::documentation(),
@@ -8927,6 +8937,10 @@ impl RuleEnum {
                 .or_else(|| ReactForbidElements::schema(generator)),
             Self::ReactForwardRefUsesRef(_) => ReactForwardRefUsesRef::config_schema(generator)
                 .or_else(|| ReactForwardRefUsesRef::schema(generator)),
+            Self::ReactFunctionComponentDefinition(_) => {
+                ReactFunctionComponentDefinition::config_schema(generator)
+                    .or_else(|| ReactFunctionComponentDefinition::schema(generator))
+            }
             Self::ReactHookUseState(_) => ReactHookUseState::config_schema(generator)
                 .or_else(|| ReactHookUseState::schema(generator)),
             Self::ReactIframeMissingSandbox(_) => {
@@ -10617,6 +10631,7 @@ impl RuleEnum {
             Self::ReactForbidDomProps(_) => "react",
             Self::ReactForbidElements(_) => "react",
             Self::ReactForwardRefUsesRef(_) => "react",
+            Self::ReactFunctionComponentDefinition(_) => "react",
             Self::ReactHookUseState(_) => "react",
             Self::ReactIframeMissingSandbox(_) => "react",
             Self::ReactJsxBooleanValue(_) => "react",
@@ -12346,6 +12361,11 @@ impl RuleEnum {
             }
             Self::ReactForwardRefUsesRef(_) => {
                 Ok(Self::ReactForwardRefUsesRef(ReactForwardRefUsesRef::from_configuration(value)?))
+            }
+            Self::ReactFunctionComponentDefinition(_) => {
+                Ok(Self::ReactFunctionComponentDefinition(
+                    ReactFunctionComponentDefinition::from_configuration(value)?,
+                ))
             }
             Self::ReactHookUseState(_) => {
                 Ok(Self::ReactHookUseState(ReactHookUseState::from_configuration(value)?))
@@ -14178,6 +14198,7 @@ impl RuleEnum {
             Self::ReactForbidDomProps(rule) => rule.to_configuration(),
             Self::ReactForbidElements(rule) => rule.to_configuration(),
             Self::ReactForwardRefUsesRef(rule) => rule.to_configuration(),
+            Self::ReactFunctionComponentDefinition(rule) => rule.to_configuration(),
             Self::ReactHookUseState(rule) => rule.to_configuration(),
             Self::ReactIframeMissingSandbox(rule) => rule.to_configuration(),
             Self::ReactJsxBooleanValue(rule) => rule.to_configuration(),
@@ -15026,6 +15047,7 @@ impl RuleEnum {
             Self::ReactForbidDomProps(rule) => rule.run(node, ctx),
             Self::ReactForbidElements(rule) => rule.run(node, ctx),
             Self::ReactForwardRefUsesRef(rule) => rule.run(node, ctx),
+            Self::ReactFunctionComponentDefinition(rule) => rule.run(node, ctx),
             Self::ReactHookUseState(rule) => rule.run(node, ctx),
             Self::ReactIframeMissingSandbox(rule) => rule.run(node, ctx),
             Self::ReactJsxBooleanValue(rule) => rule.run(node, ctx),
@@ -15884,6 +15906,7 @@ impl RuleEnum {
             Self::ReactForbidDomProps(rule) => rule.run_once(ctx),
             Self::ReactForbidElements(rule) => rule.run_once(ctx),
             Self::ReactForwardRefUsesRef(rule) => rule.run_once(ctx),
+            Self::ReactFunctionComponentDefinition(rule) => rule.run_once(ctx),
             Self::ReactHookUseState(rule) => rule.run_once(ctx),
             Self::ReactIframeMissingSandbox(rule) => rule.run_once(ctx),
             Self::ReactJsxBooleanValue(rule) => rule.run_once(ctx),
@@ -16813,6 +16836,7 @@ impl RuleEnum {
             Self::ReactForbidDomProps(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactForbidElements(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactForwardRefUsesRef(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::ReactFunctionComponentDefinition(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactHookUseState(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactIframeMissingSandbox(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactJsxBooleanValue(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -17718,6 +17742,7 @@ impl RuleEnum {
             Self::ReactForbidDomProps(rule) => rule.should_run(ctx),
             Self::ReactForbidElements(rule) => rule.should_run(ctx),
             Self::ReactForwardRefUsesRef(rule) => rule.should_run(ctx),
+            Self::ReactFunctionComponentDefinition(rule) => rule.should_run(ctx),
             Self::ReactHookUseState(rule) => rule.should_run(ctx),
             Self::ReactIframeMissingSandbox(rule) => rule.should_run(ctx),
             Self::ReactJsxBooleanValue(rule) => rule.should_run(ctx),
@@ -18737,6 +18762,9 @@ impl RuleEnum {
             Self::ReactForbidDomProps(_) => ReactForbidDomProps::IS_TSGOLINT_RULE,
             Self::ReactForbidElements(_) => ReactForbidElements::IS_TSGOLINT_RULE,
             Self::ReactForwardRefUsesRef(_) => ReactForwardRefUsesRef::IS_TSGOLINT_RULE,
+            Self::ReactFunctionComponentDefinition(_) => {
+                ReactFunctionComponentDefinition::IS_TSGOLINT_RULE
+            }
             Self::ReactHookUseState(_) => ReactHookUseState::IS_TSGOLINT_RULE,
             Self::ReactIframeMissingSandbox(_) => ReactIframeMissingSandbox::IS_TSGOLINT_RULE,
             Self::ReactJsxBooleanValue(_) => ReactJsxBooleanValue::IS_TSGOLINT_RULE,
@@ -19880,6 +19908,7 @@ impl RuleEnum {
             Self::ReactForbidDomProps(_) => ReactForbidDomProps::VERSION,
             Self::ReactForbidElements(_) => ReactForbidElements::VERSION,
             Self::ReactForwardRefUsesRef(_) => ReactForwardRefUsesRef::VERSION,
+            Self::ReactFunctionComponentDefinition(_) => ReactFunctionComponentDefinition::VERSION,
             Self::ReactHookUseState(_) => ReactHookUseState::VERSION,
             Self::ReactIframeMissingSandbox(_) => ReactIframeMissingSandbox::VERSION,
             Self::ReactJsxBooleanValue(_) => ReactJsxBooleanValue::VERSION,
@@ -20914,6 +20943,9 @@ impl RuleEnum {
             Self::ReactForbidDomProps(_) => ReactForbidDomProps::HAS_CONFIG,
             Self::ReactForbidElements(_) => ReactForbidElements::HAS_CONFIG,
             Self::ReactForwardRefUsesRef(_) => ReactForwardRefUsesRef::HAS_CONFIG,
+            Self::ReactFunctionComponentDefinition(_) => {
+                ReactFunctionComponentDefinition::HAS_CONFIG
+            }
             Self::ReactHookUseState(_) => ReactHookUseState::HAS_CONFIG,
             Self::ReactIframeMissingSandbox(_) => ReactIframeMissingSandbox::HAS_CONFIG,
             Self::ReactJsxBooleanValue(_) => ReactJsxBooleanValue::HAS_CONFIG,
@@ -21931,6 +21963,7 @@ impl RuleEnum {
             Self::ReactForbidDomProps(_) => ReactForbidDomProps::INFO,
             Self::ReactForbidElements(_) => ReactForbidElements::INFO,
             Self::ReactForwardRefUsesRef(_) => ReactForwardRefUsesRef::INFO,
+            Self::ReactFunctionComponentDefinition(_) => ReactFunctionComponentDefinition::INFO,
             Self::ReactHookUseState(_) => ReactHookUseState::INFO,
             Self::ReactIframeMissingSandbox(_) => ReactIframeMissingSandbox::INFO,
             Self::ReactJsxBooleanValue(_) => ReactJsxBooleanValue::INFO,
@@ -22827,6 +22860,7 @@ impl RuleEnum {
             Self::ReactForbidDomProps(rule) => rule.types_info(),
             Self::ReactForbidElements(rule) => rule.types_info(),
             Self::ReactForwardRefUsesRef(rule) => rule.types_info(),
+            Self::ReactFunctionComponentDefinition(rule) => rule.types_info(),
             Self::ReactHookUseState(rule) => rule.types_info(),
             Self::ReactIframeMissingSandbox(rule) => rule.types_info(),
             Self::ReactJsxBooleanValue(rule) => rule.types_info(),
@@ -23672,6 +23706,7 @@ impl RuleEnum {
             Self::ReactForbidDomProps(rule) => rule.run_info(),
             Self::ReactForbidElements(rule) => rule.run_info(),
             Self::ReactForwardRefUsesRef(rule) => rule.run_info(),
+            Self::ReactFunctionComponentDefinition(rule) => rule.run_info(),
             Self::ReactHookUseState(rule) => rule.run_info(),
             Self::ReactIframeMissingSandbox(rule) => rule.run_info(),
             Self::ReactJsxBooleanValue(rule) => rule.run_info(),
@@ -24607,6 +24642,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::ReactForbidDomProps(ReactForbidDomProps::default()),
         RuleEnum::ReactForbidElements(ReactForbidElements::default()),
         RuleEnum::ReactForwardRefUsesRef(ReactForwardRefUsesRef::default()),
+        RuleEnum::ReactFunctionComponentDefinition(ReactFunctionComponentDefinition::default()),
         RuleEnum::ReactHookUseState(ReactHookUseState::default()),
         RuleEnum::ReactIframeMissingSandbox(ReactIframeMissingSandbox::default()),
         RuleEnum::ReactJsxBooleanValue(ReactJsxBooleanValue::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -417,6 +417,7 @@ pub(crate) mod react {
     pub mod forbid_dom_props;
     pub mod forbid_elements;
     pub mod forward_ref_uses_ref;
+    pub mod function_component_definition;
     pub mod hook_use_state;
     pub mod iframe_missing_sandbox;
     pub mod jsx_boolean_value;

--- a/crates/oxc_linter/src/rules/react/function_component_definition.rs
+++ b/crates/oxc_linter/src/rules/react/function_component_definition.rs
@@ -420,7 +420,8 @@ mod fix {
                     .type_parameters
                     .as_ref()
                     .map_or_else(String::new, |item| ctx.source_range(item.span).to_string()),
-                params: parenthesized_params(&function.params, ctx),
+                // Function parameter spans always include their parentheses.
+                params: ctx.source_range(function.params.span).to_string(),
                 return_type: function
                     .return_type
                     .as_ref()
@@ -451,7 +452,7 @@ mod fix {
                     .type_parameters
                     .as_ref()
                     .map_or_else(String::new, |item| ctx.source_range(item.span).to_string()),
-                params: parenthesized_params(&arrow.params, ctx),
+                params: parenthesized_arrow_params(&arrow.params, ctx),
                 return_type: arrow
                     .return_type
                     .as_ref()
@@ -492,8 +493,9 @@ mod fix {
             .map_or("", |annotation| ctx.source_range(annotation.span))
     }
 
-    fn parenthesized_params(params: &FormalParameters<'_>, ctx: &LintContext<'_>) -> String {
+    fn parenthesized_arrow_params(params: &FormalParameters<'_>, ctx: &LintContext<'_>) -> String {
         let source = ctx.source_range(params.span);
+        // Simple arrow parameter spans omit parentheses; parenthesized arrow spans include them.
         if source.starts_with('(') { source.to_string() } else { format!("({source})") }
     }
 }
@@ -1911,6 +1913,11 @@ fn test() {
             "async function* Hello(props) { yield await load(); return <div/>; }",
             "const Hello = async function*(props) { yield await load(); return <div/>; }",
             Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "const Hello = props => <div/>;",
+            "function Hello(props) {\n return <div/>\n}",
+            Some(serde_json::json!([{ "namedComponents": "function-declaration" }])),
         ),
     ];
 

--- a/crates/oxc_linter/src/rules/react/function_component_definition.rs
+++ b/crates/oxc_linter/src/rules/react/function_component_definition.rs
@@ -1,10 +1,4 @@
-use oxc_ast::{
-    AstKind,
-    ast::{
-        ArrowFunctionExpression, FormalParameters, Function, FunctionType,
-        TSTypeParameterDeclaration, VariableDeclarator,
-    },
-};
+use oxc_ast::{AstKind, ast::FunctionType};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
@@ -148,9 +142,9 @@ impl Rule for FunctionComponentDefinition {
         }
 
         let diagnostic = function_component_definition_diagnostic(node.span(), expected);
-        if can_fix(node, ctx, expected) {
+        if fix::can_fix(node, ctx, expected) {
             ctx.diagnostic_with_suggestion(diagnostic, |fixer| {
-                let (span, replacement) = replacement(node, ctx, expected, named);
+                let (span, replacement) = fix::replacement(node, ctx, expected, named);
                 fixer.replace(span, replacement)
             });
         } else {
@@ -236,244 +230,268 @@ fn is_named(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
         || matches!(ctx.nodes().parent_kind(node.id()), AstKind::VariableDeclarator(_))
 }
 
-fn can_fix<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>, expected: FunctionStyle) -> bool {
-    match node.kind() {
-        AstKind::Function(function) => {
-            if function.r#type == FunctionType::FunctionDeclaration
-                && matches!(
-                    ctx.nodes().parent_kind(node.id()),
-                    AstKind::ExportDefaultDeclaration(_)
-                )
-            {
-                return false;
-            }
-            if function.r#type == FunctionType::FunctionExpression && function.id.is_some() {
-                return false;
-            }
-            if expected == FunctionStyle::Declaration
-                && variable_declarator(node, ctx)
-                    .is_some_and(|declaration| declaration.type_annotation.is_some())
-            {
-                return false;
-            }
-            if expected == FunctionStyle::Arrow
-                && (function.generator
-                    || has_one_unconstrained_type_parameter(function.type_parameters.as_deref()))
-            {
-                return false;
-            }
-        }
-        AstKind::ArrowFunctionExpression(arrow) => {
-            if expected == FunctionStyle::Declaration
-                && variable_declarator(node, ctx)
-                    .is_some_and(|declaration| declaration.type_annotation.is_some())
-            {
-                return false;
-            }
-            if expected == FunctionStyle::Arrow
-                && has_one_unconstrained_type_parameter(arrow.type_parameters.as_deref())
-            {
-                return false;
-            }
-        }
-        _ => return false,
-    }
-    true
-}
-
-fn has_one_unconstrained_type_parameter(
-    parameters: Option<&TSTypeParameterDeclaration<'_>>,
-) -> bool {
-    parameters.is_some_and(|parameters| {
-        parameters.params.len() == 1 && parameters.params[0].constraint.is_none()
-    })
-}
-
-fn variable_declarator<'a, 'c>(
-    node: &AstNode<'a>,
-    ctx: &'c LintContext<'a>,
-) -> Option<&'c VariableDeclarator<'a>> {
-    match ctx.nodes().parent_kind(node.id()) {
-        AstKind::VariableDeclarator(declaration) => Some(declaration),
-        _ => None,
-    }
-}
-
-fn replacement<'a>(
-    node: &AstNode<'a>,
-    ctx: &LintContext<'a>,
-    expected: FunctionStyle,
-    named: bool,
-) -> (Span, String) {
-    let parts = FunctionParts::new(node, ctx);
-    let body = if parts.expression_body {
-        format!("{{\n return {}\n}}", parts.body)
-    } else {
-        parts.body.clone()
+mod fix {
+    use oxc_ast::{
+        AstKind,
+        ast::{
+            ArrowFunctionExpression, FormalParameters, Function, FunctionType,
+            TSTypeParameterDeclaration, VariableDeclarator,
+        },
     };
-    let function = match (expected, named) {
-        (FunctionStyle::Declaration, true) => format!(
-            "{}function{} {}{}{}{} {}",
-            parts.async_prefix,
-            parts.generator_marker,
-            parts.name,
-            parts.type_parameters,
-            parts.params,
-            parts.return_type,
-            body
-        ),
-        (FunctionStyle::Expression, true) => format!(
-            "{} {}{} = {}function{}{}{}{} {}",
-            parts.variable_kind,
-            parts.name,
-            parts.type_annotation,
-            parts.async_prefix,
-            parts.generator_marker,
-            parts.type_parameters,
-            parts.params,
-            parts.return_type,
-            body
-        ),
-        (FunctionStyle::Arrow, true) => format!(
-            "{} {}{} = {}{}{}{} => {}",
-            parts.variable_kind,
-            parts.name,
-            parts.type_annotation,
-            parts.async_prefix,
-            parts.type_parameters,
-            parts.params,
-            parts.return_type,
-            body
-        ),
-        (FunctionStyle::Expression, false) => format!(
-            "{}function{}{}{}{} {}",
-            parts.async_prefix,
-            parts.generator_marker,
-            parts.type_parameters,
-            parts.params,
-            parts.return_type,
-            body
-        ),
-        (FunctionStyle::Arrow, false) => format!(
-            "{}{}{}{} => {}",
-            parts.async_prefix, parts.type_parameters, parts.params, parts.return_type, body
-        ),
-        (FunctionStyle::Declaration, false) => unreachable!(),
-    };
-    (parts.replace_span, function)
-}
+    use oxc_span::{GetSpan, Span};
 
-struct FunctionParts<'a> {
-    replace_span: Span,
-    name: String,
-    variable_kind: &'static str,
-    type_annotation: &'a str,
-    async_prefix: &'static str,
-    generator_marker: &'static str,
-    type_parameters: String,
-    params: String,
-    return_type: String,
-    body: String,
-    expression_body: bool,
-}
+    use super::FunctionStyle;
+    use crate::{AstNode, context::LintContext};
 
-impl<'a> FunctionParts<'a> {
-    fn new(node: &AstNode<'a>, ctx: &LintContext<'a>) -> Self {
-        match node.kind() {
-            AstKind::Function(function) => Self::from_function(function, node, ctx),
-            AstKind::ArrowFunctionExpression(arrow) => Self::from_arrow(arrow, node, ctx),
-            _ => unreachable!(),
-        }
-    }
-
-    fn from_function(function: &Function<'a>, node: &AstNode<'a>, ctx: &LintContext<'a>) -> Self {
-        let declaration = variable_declarator(node, ctx);
-        let (replace_span, variable_kind) = variable_context(node, ctx);
-        Self {
-            replace_span,
-            name: function.id.as_ref().map_or_else(
-                || variable_name(declaration),
-                |identifier| identifier.name.to_string(),
-            ),
-            variable_kind,
-            type_annotation: type_annotation(declaration, ctx),
-            async_prefix: if function.r#async { "async " } else { "" },
-            generator_marker: if function.generator { "*" } else { "" },
-            type_parameters: function
-                .type_parameters
-                .as_ref()
-                .map_or_else(String::new, |item| ctx.source_range(item.span).to_string()),
-            params: parenthesized_params(&function.params, ctx),
-            return_type: function
-                .return_type
-                .as_ref()
-                .map_or_else(String::new, |item| ctx.source_range(item.span).to_string()),
-            body: function
-                .body
-                .as_ref()
-                .map_or_else(String::new, |body| ctx.source_range(body.span).to_string()),
-            expression_body: false,
-        }
-    }
-
-    fn from_arrow(
-        arrow: &ArrowFunctionExpression<'a>,
+    pub(super) fn can_fix<'a>(
         node: &AstNode<'a>,
         ctx: &LintContext<'a>,
-    ) -> Self {
-        let declaration = variable_declarator(node, ctx);
-        let (replace_span, variable_kind) = variable_context(node, ctx);
-        Self {
-            replace_span,
-            name: variable_name(declaration),
-            variable_kind,
-            type_annotation: type_annotation(declaration, ctx),
-            async_prefix: if arrow.r#async { "async " } else { "" },
-            generator_marker: "",
-            type_parameters: arrow
-                .type_parameters
-                .as_ref()
-                .map_or_else(String::new, |item| ctx.source_range(item.span).to_string()),
-            params: parenthesized_params(&arrow.params, ctx),
-            return_type: arrow
-                .return_type
-                .as_ref()
-                .map_or_else(String::new, |item| ctx.source_range(item.span).to_string()),
-            body: ctx.source_range(arrow.body.span).to_string(),
-            expression_body: arrow.expression,
+        expected: FunctionStyle,
+    ) -> bool {
+        match node.kind() {
+            AstKind::Function(function) => {
+                if function.r#type == FunctionType::FunctionDeclaration
+                    && matches!(
+                        ctx.nodes().parent_kind(node.id()),
+                        AstKind::ExportDefaultDeclaration(_)
+                    )
+                {
+                    return false;
+                }
+                if function.r#type == FunctionType::FunctionExpression && function.id.is_some() {
+                    return false;
+                }
+                if expected == FunctionStyle::Declaration
+                    && variable_declarator(node, ctx)
+                        .is_some_and(|declaration| declaration.type_annotation.is_some())
+                {
+                    return false;
+                }
+                if expected == FunctionStyle::Arrow
+                    && (function.generator
+                        || has_one_unconstrained_type_parameter(
+                            function.type_parameters.as_deref(),
+                        ))
+                {
+                    return false;
+                }
+            }
+            AstKind::ArrowFunctionExpression(arrow) => {
+                if expected == FunctionStyle::Declaration
+                    && variable_declarator(node, ctx)
+                        .is_some_and(|declaration| declaration.type_annotation.is_some())
+                {
+                    return false;
+                }
+                if expected == FunctionStyle::Arrow
+                    && has_one_unconstrained_type_parameter(arrow.type_parameters.as_deref())
+                {
+                    return false;
+                }
+            }
+            _ => return false,
+        }
+        true
+    }
+
+    fn has_one_unconstrained_type_parameter(
+        parameters: Option<&TSTypeParameterDeclaration<'_>>,
+    ) -> bool {
+        parameters.is_some_and(|parameters| {
+            parameters.params.len() == 1 && parameters.params[0].constraint.is_none()
+        })
+    }
+
+    fn variable_declarator<'a, 'c>(
+        node: &AstNode<'a>,
+        ctx: &'c LintContext<'a>,
+    ) -> Option<&'c VariableDeclarator<'a>> {
+        match ctx.nodes().parent_kind(node.id()) {
+            AstKind::VariableDeclarator(declaration) => Some(declaration),
+            _ => None,
         }
     }
-}
 
-fn variable_context<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> (Span, &'static str) {
-    if variable_declarator(node, ctx).is_some() {
-        let declaration_node = ctx.nodes().parent_node(node.id());
-        let variable_node = ctx.nodes().parent_node(declaration_node.id());
-        if let AstKind::VariableDeclaration(variable) = variable_node.kind() {
-            return (variable.span, variable.kind.as_str());
+    pub(super) fn replacement<'a>(
+        node: &AstNode<'a>,
+        ctx: &LintContext<'a>,
+        expected: FunctionStyle,
+        named: bool,
+    ) -> (Span, String) {
+        let parts = FunctionParts::new(node, ctx);
+        let body = if parts.expression_body {
+            format!("{{\n return {}\n}}", parts.body)
+        } else {
+            parts.body.clone()
+        };
+        let function = match (expected, named) {
+            (FunctionStyle::Declaration, true) => format!(
+                "{}function{} {}{}{}{} {}",
+                parts.async_prefix,
+                parts.generator_marker,
+                parts.name,
+                parts.type_parameters,
+                parts.params,
+                parts.return_type,
+                body
+            ),
+            (FunctionStyle::Expression, true) => format!(
+                "{} {}{} = {}function{}{}{}{} {}",
+                parts.variable_kind,
+                parts.name,
+                parts.type_annotation,
+                parts.async_prefix,
+                parts.generator_marker,
+                parts.type_parameters,
+                parts.params,
+                parts.return_type,
+                body
+            ),
+            (FunctionStyle::Arrow, true) => format!(
+                "{} {}{} = {}{}{}{} => {}",
+                parts.variable_kind,
+                parts.name,
+                parts.type_annotation,
+                parts.async_prefix,
+                parts.type_parameters,
+                parts.params,
+                parts.return_type,
+                body
+            ),
+            (FunctionStyle::Expression, false) => format!(
+                "{}function{}{}{}{} {}",
+                parts.async_prefix,
+                parts.generator_marker,
+                parts.type_parameters,
+                parts.params,
+                parts.return_type,
+                body
+            ),
+            (FunctionStyle::Arrow, false) => format!(
+                "{}{}{}{} => {}",
+                parts.async_prefix, parts.type_parameters, parts.params, parts.return_type, body
+            ),
+            (FunctionStyle::Declaration, false) => unreachable!(),
+        };
+        (parts.replace_span, function)
+    }
+
+    struct FunctionParts<'a> {
+        replace_span: Span,
+        name: String,
+        variable_kind: &'static str,
+        type_annotation: &'a str,
+        async_prefix: &'static str,
+        generator_marker: &'static str,
+        type_parameters: String,
+        params: String,
+        return_type: String,
+        body: String,
+        expression_body: bool,
+    }
+
+    impl<'a> FunctionParts<'a> {
+        fn new(node: &AstNode<'a>, ctx: &LintContext<'a>) -> Self {
+            match node.kind() {
+                AstKind::Function(function) => Self::from_function(function, node, ctx),
+                AstKind::ArrowFunctionExpression(arrow) => Self::from_arrow(arrow, node, ctx),
+                _ => unreachable!(),
+            }
+        }
+
+        fn from_function(
+            function: &Function<'a>,
+            node: &AstNode<'a>,
+            ctx: &LintContext<'a>,
+        ) -> Self {
+            let declaration = variable_declarator(node, ctx);
+            let (replace_span, variable_kind) = variable_context(node, ctx);
+            Self {
+                replace_span,
+                name: function.id.as_ref().map_or_else(
+                    || variable_name(declaration),
+                    |identifier| identifier.name.to_string(),
+                ),
+                variable_kind,
+                type_annotation: type_annotation(declaration, ctx),
+                async_prefix: if function.r#async { "async " } else { "" },
+                generator_marker: if function.generator { "*" } else { "" },
+                type_parameters: function
+                    .type_parameters
+                    .as_ref()
+                    .map_or_else(String::new, |item| ctx.source_range(item.span).to_string()),
+                params: parenthesized_params(&function.params, ctx),
+                return_type: function
+                    .return_type
+                    .as_ref()
+                    .map_or_else(String::new, |item| ctx.source_range(item.span).to_string()),
+                body: function
+                    .body
+                    .as_ref()
+                    .map_or_else(String::new, |body| ctx.source_range(body.span).to_string()),
+                expression_body: false,
+            }
+        }
+
+        fn from_arrow(
+            arrow: &ArrowFunctionExpression<'a>,
+            node: &AstNode<'a>,
+            ctx: &LintContext<'a>,
+        ) -> Self {
+            let declaration = variable_declarator(node, ctx);
+            let (replace_span, variable_kind) = variable_context(node, ctx);
+            Self {
+                replace_span,
+                name: variable_name(declaration),
+                variable_kind,
+                type_annotation: type_annotation(declaration, ctx),
+                async_prefix: if arrow.r#async { "async " } else { "" },
+                generator_marker: "",
+                type_parameters: arrow
+                    .type_parameters
+                    .as_ref()
+                    .map_or_else(String::new, |item| ctx.source_range(item.span).to_string()),
+                params: parenthesized_params(&arrow.params, ctx),
+                return_type: arrow
+                    .return_type
+                    .as_ref()
+                    .map_or_else(String::new, |item| ctx.source_range(item.span).to_string()),
+                body: ctx.source_range(arrow.body.span).to_string(),
+                expression_body: arrow.expression,
+            }
         }
     }
-    (node.span(), "const")
-}
 
-fn variable_name(declaration: Option<&VariableDeclarator<'_>>) -> String {
-    declaration
-        .and_then(|declaration| declaration.id.get_identifier_name())
-        .map_or_else(String::new, |name| name.to_string())
-}
+    fn variable_context<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> (Span, &'static str) {
+        if variable_declarator(node, ctx).is_some() {
+            let declaration_node = ctx.nodes().parent_node(node.id());
+            let variable_node = ctx.nodes().parent_node(declaration_node.id());
+            if let AstKind::VariableDeclaration(variable) = variable_node.kind() {
+                return (variable.span, variable.kind.as_str());
+            }
+        }
+        (node.span(), "const")
+    }
 
-fn type_annotation<'a>(
-    declaration: Option<&VariableDeclarator<'_>>,
-    ctx: &LintContext<'a>,
-) -> &'a str {
-    declaration
-        .and_then(|declaration| declaration.type_annotation.as_ref())
-        .map_or("", |annotation| ctx.source_range(annotation.span))
-}
+    fn variable_name(declaration: Option<&VariableDeclarator<'_>>) -> String {
+        declaration
+            .and_then(|declaration| declaration.id.get_identifier_name())
+            .map_or_else(String::new, |name| name.to_string())
+    }
 
-fn parenthesized_params(params: &FormalParameters<'_>, ctx: &LintContext<'_>) -> String {
-    let source = ctx.source_range(params.span);
-    if source.starts_with('(') { source.to_string() } else { format!("({source})") }
+    fn type_annotation<'a>(
+        declaration: Option<&VariableDeclarator<'_>>,
+        ctx: &LintContext<'a>,
+    ) -> &'a str {
+        declaration
+            .and_then(|declaration| declaration.type_annotation.as_ref())
+            .map_or("", |annotation| ctx.source_range(annotation.span))
+    }
+
+    fn parenthesized_params(params: &FormalParameters<'_>, ctx: &LintContext<'_>) -> String {
+        let source = ctx.source_range(params.span);
+        if source.starts_with('(') { source.to_string() } else { format!("({source})") }
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/react/function_component_definition.rs
+++ b/crates/oxc_linter/src/rules/react/function_component_definition.rs
@@ -1,6 +1,9 @@
 use oxc_ast::{
     AstKind,
-    ast::{ArrowFunctionExpression, FormalParameters, Function, FunctionType},
+    ast::{
+        ArrowFunctionExpression, FormalParameters, Function, FunctionType,
+        TSTypeParameterDeclaration, VariableDeclarator,
+    },
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
@@ -278,7 +281,7 @@ fn can_fix<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>, expected: FunctionStyl
 }
 
 fn has_one_unconstrained_type_parameter(
-    parameters: Option<&oxc_ast::ast::TSTypeParameterDeclaration<'_>>,
+    parameters: Option<&TSTypeParameterDeclaration<'_>>,
 ) -> bool {
     parameters.is_some_and(|parameters| {
         parameters.params.len() == 1 && parameters.params[0].constraint.is_none()
@@ -288,7 +291,7 @@ fn has_one_unconstrained_type_parameter(
 fn variable_declarator<'a, 'c>(
     node: &AstNode<'a>,
     ctx: &'c LintContext<'a>,
-) -> Option<&'c oxc_ast::ast::VariableDeclarator<'a>> {
+) -> Option<&'c VariableDeclarator<'a>> {
     match ctx.nodes().parent_kind(node.id()) {
         AstKind::VariableDeclarator(declaration) => Some(declaration),
         _ => None,
@@ -435,16 +438,13 @@ fn variable_context<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> (Span, &'s
     (node.span(), "const")
 }
 
-fn variable_name(declaration: Option<&oxc_ast::ast::VariableDeclarator<'_>>) -> String {
+fn variable_name(declaration: Option<&VariableDeclarator<'_>>) -> String {
     declaration
         .and_then(|declaration| declaration.id.get_identifier_name())
         .map_or_else(String::new, |name| name.to_string())
 }
 
-fn type_annotation(
-    declaration: Option<&oxc_ast::ast::VariableDeclarator<'_>>,
-    ctx: &LintContext<'_>,
-) -> String {
+fn type_annotation(declaration: Option<&VariableDeclarator<'_>>, ctx: &LintContext<'_>) -> String {
     declaration
         .and_then(|declaration| declaration.type_annotation.as_ref())
         .map_or_else(String::new, |annotation| ctx.source_range(annotation.span).to_string())

--- a/crates/oxc_linter/src/rules/react/function_component_definition.rs
+++ b/crates/oxc_linter/src/rules/react/function_component_definition.rs
@@ -246,6 +246,16 @@ mod fix {
         ctx: &LintContext<'a>,
         expected: FunctionStyle,
     ) -> bool {
+        let declaration = variable_declarator(node, ctx);
+        if declaration.is_some_and(|declaration| {
+            matches!(
+                ctx.nodes().parent_kind(declaration.node_id()),
+                AstKind::VariableDeclaration(variable) if variable.declarations.len() > 1
+            )
+        }) {
+            return false;
+        }
+
         match node.kind() {
             AstKind::Function(function) => {
                 if function.r#type == FunctionType::FunctionDeclaration
@@ -260,8 +270,7 @@ mod fix {
                     return false;
                 }
                 if expected == FunctionStyle::Declaration
-                    && variable_declarator(node, ctx)
-                        .is_some_and(|declaration| declaration.type_annotation.is_some())
+                    && declaration.is_some_and(|declaration| declaration.type_annotation.is_some())
                 {
                     return false;
                 }
@@ -277,8 +286,7 @@ mod fix {
             }
             AstKind::ArrowFunctionExpression(arrow) => {
                 if expected == FunctionStyle::Declaration
-                    && variable_declarator(node, ctx)
-                        .is_some_and(|declaration| declaration.type_annotation.is_some())
+                    && declaration.is_some_and(|declaration| declaration.type_annotation.is_some())
                 {
                     return false;
                 }
@@ -1320,6 +1328,10 @@ fn test() {
         (
             "function Hello(this: Context, props: Props) { return <div/>; }",
             Some(serde_json::json!([{ "namedComponents": "arrow-function" }])),
+        ),
+        (
+            "const Hello = () => <div/>, keep = sideEffect();",
+            Some(serde_json::json!([{ "namedComponents": "function-declaration" }])),
         ),
     ];
 

--- a/crates/oxc_linter/src/rules/react/function_component_definition.rs
+++ b/crates/oxc_linter/src/rules/react/function_component_definition.rs
@@ -1,8 +1,6 @@
 use oxc_ast::{
     AstKind,
-    ast::{
-        ArrowFunctionExpression, FormalParameters, Function, FunctionType, VariableDeclarationKind,
-    },
+    ast::{ArrowFunctionExpression, FormalParameters, Function, FunctionType},
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
@@ -434,19 +432,7 @@ fn variable_context<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> (Span, &'s
             return (variable.span, variable.kind.as_str());
         }
     }
-    let uses_es6 = ctx.nodes().iter().any(|candidate| match candidate.kind() {
-        AstKind::VariableDeclaration(declaration) => {
-            declaration.kind != VariableDeclarationKind::Var
-        }
-        AstKind::JSXElement(_)
-        | AstKind::JSXFragment(_)
-        | AstKind::ImportDeclaration(_)
-        | AstKind::ExportNamedDeclaration(_)
-        | AstKind::ExportDefaultDeclaration(_)
-        | AstKind::ExportAllDeclaration(_) => true,
-        _ => false,
-    });
-    (node.span(), if uses_es6 { "const" } else { "var" })
+    (node.span(), "const")
 }
 
 fn variable_name(declaration: Option<&oxc_ast::ast::VariableDeclarator<'_>>) -> String {
@@ -1517,7 +1503,7 @@ fn test() {
                     }
                   ",
             "
-                    var Hello = function(props: Test) {
+                    const Hello = function(props: Test) {
                       return React.createElement('div');
                     }
                   ",

--- a/crates/oxc_linter/src/rules/react/function_component_definition.rs
+++ b/crates/oxc_linter/src/rules/react/function_component_definition.rs
@@ -73,7 +73,7 @@ enum UnnamedComponentStyle {
 }
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
-pub struct FunctionComponentDefinition(FunctionComponentDefinitionConfig);
+pub struct FunctionComponentDefinition(Box<FunctionComponentDefinitionConfig>);
 
 // See <https://github.com/oxc-project/oxc/issues/6050> for documentation details.
 declare_oxc_lint!(

--- a/crates/oxc_linter/src/rules/react/function_component_definition.rs
+++ b/crates/oxc_linter/src/rules/react/function_component_definition.rs
@@ -347,11 +347,11 @@ fn replacement<'a>(
     (parts.replace_span, function)
 }
 
-struct FunctionParts {
+struct FunctionParts<'a> {
     replace_span: Span,
     name: String,
     variable_kind: &'static str,
-    type_annotation: String,
+    type_annotation: &'a str,
     type_parameters: String,
     params: String,
     return_type: String,
@@ -359,8 +359,8 @@ struct FunctionParts {
     expression_body: bool,
 }
 
-impl FunctionParts {
-    fn new<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> Self {
+impl<'a> FunctionParts<'a> {
+    fn new(node: &AstNode<'a>, ctx: &LintContext<'a>) -> Self {
         match node.kind() {
             AstKind::Function(function) => Self::from_function(function, node, ctx),
             AstKind::ArrowFunctionExpression(arrow) => Self::from_arrow(arrow, node, ctx),
@@ -368,11 +368,7 @@ impl FunctionParts {
         }
     }
 
-    fn from_function<'a>(
-        function: &Function<'a>,
-        node: &AstNode<'a>,
-        ctx: &LintContext<'a>,
-    ) -> Self {
+    fn from_function(function: &Function<'a>, node: &AstNode<'a>, ctx: &LintContext<'a>) -> Self {
         let declaration = variable_declarator(node, ctx);
         let (replace_span, variable_kind) = variable_context(node, ctx);
         Self {
@@ -400,7 +396,7 @@ impl FunctionParts {
         }
     }
 
-    fn from_arrow<'a>(
+    fn from_arrow(
         arrow: &ArrowFunctionExpression<'a>,
         node: &AstNode<'a>,
         ctx: &LintContext<'a>,
@@ -444,10 +440,13 @@ fn variable_name(declaration: Option<&VariableDeclarator<'_>>) -> String {
         .map_or_else(String::new, |name| name.to_string())
 }
 
-fn type_annotation(declaration: Option<&VariableDeclarator<'_>>, ctx: &LintContext<'_>) -> String {
+fn type_annotation<'a>(
+    declaration: Option<&VariableDeclarator<'_>>,
+    ctx: &LintContext<'a>,
+) -> &'a str {
     declaration
         .and_then(|declaration| declaration.type_annotation.as_ref())
-        .map_or_else(String::new, |annotation| ctx.source_range(annotation.span).to_string())
+        .map_or("", |annotation| ctx.source_range(annotation.span))
 }
 
 fn parenthesized_params(params: &FormalParameters<'_>, ctx: &LintContext<'_>) -> String {

--- a/crates/oxc_linter/src/rules/react/function_component_definition.rs
+++ b/crates/oxc_linter/src/rules/react/function_component_definition.rs
@@ -101,7 +101,7 @@ declare_oxc_lint!(
     FunctionComponentDefinition,
     react,
     style,
-    conditional_fix,
+    conditional_suggestion,
     config = FunctionComponentDefinition,
     version = "next",
     short_description = "Enforce a specific function type for function components.",
@@ -149,7 +149,7 @@ impl Rule for FunctionComponentDefinition {
 
         let diagnostic = function_component_definition_diagnostic(node.span(), expected);
         if can_fix(node, ctx, expected) {
-            ctx.diagnostic_with_fix(diagnostic, |fixer| {
+            ctx.diagnostic_with_suggestion(diagnostic, |fixer| {
                 let (span, replacement) = replacement(node, ctx, expected, named);
                 fixer.replace(span, replacement)
             });

--- a/crates/oxc_linter/src/rules/react/function_component_definition.rs
+++ b/crates/oxc_linter/src/rules/react/function_component_definition.rs
@@ -24,6 +24,7 @@ struct FunctionComponentDefinitionConfig {
     named_components: NamedComponents,
     unnamed_components: UnnamedComponents,
 }
+
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(untagged)]
 enum NamedComponents {

--- a/crates/oxc_linter/src/rules/react/function_component_definition.rs
+++ b/crates/oxc_linter/src/rules/react/function_component_definition.rs
@@ -123,6 +123,7 @@ impl Rule for FunctionComponentDefinition {
             }
             _ => return,
         };
+
         if !is_component || matches!(ctx.nodes().parent_kind(node.id()), AstKind::ObjectProperty(_))
         {
             return;

--- a/crates/oxc_linter/src/rules/react/function_component_definition.rs
+++ b/crates/oxc_linter/src/rules/react/function_component_definition.rs
@@ -405,7 +405,7 @@ mod fix {
             ctx: &LintContext<'a>,
         ) -> Self {
             let declaration = variable_declarator(node, ctx);
-            let (replace_span, variable_kind) = variable_context(node, ctx);
+            let (replace_span, variable_kind) = variable_context(node, declaration, ctx);
             Self {
                 replace_span,
                 name: function.id.as_ref().map_or_else(
@@ -439,7 +439,7 @@ mod fix {
             ctx: &LintContext<'a>,
         ) -> Self {
             let declaration = variable_declarator(node, ctx);
-            let (replace_span, variable_kind) = variable_context(node, ctx);
+            let (replace_span, variable_kind) = variable_context(node, declaration, ctx);
             Self {
                 replace_span,
                 name: variable_name(declaration),
@@ -462,15 +462,19 @@ mod fix {
         }
     }
 
-    fn variable_context<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> (Span, &'static str) {
-        if variable_declarator(node, ctx).is_some() {
-            let declaration_node = ctx.nodes().parent_node(node.id());
-            let variable_node = ctx.nodes().parent_node(declaration_node.id());
-            if let AstKind::VariableDeclaration(variable) = variable_node.kind() {
-                return (variable.span, variable.kind.as_str());
-            }
-        }
-        (node.span(), "const")
+    fn variable_context<'a>(
+        node: &AstNode<'a>,
+        declaration: Option<&VariableDeclarator<'a>>,
+        ctx: &LintContext<'a>,
+    ) -> (Span, &'static str) {
+        let Some(declaration) = declaration else {
+            return (node.span(), "const");
+        };
+        let AstKind::VariableDeclaration(variable) = ctx.nodes().parent_kind(declaration.node_id())
+        else {
+            unreachable!()
+        };
+        (variable.span, variable.kind.as_str())
     }
 
     fn variable_name(declaration: Option<&VariableDeclarator<'_>>) -> String {

--- a/crates/oxc_linter/src/rules/react/function_component_definition.rs
+++ b/crates/oxc_linter/src/rules/react/function_component_definition.rs
@@ -70,7 +70,6 @@ enum UnnamedComponentStyle {
 #[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
 pub struct FunctionComponentDefinition(Box<FunctionComponentDefinitionConfig>);
 
-// See <https://github.com/oxc-project/oxc/issues/6050> for documentation details.
 declare_oxc_lint!(
     /// ### What it does
     ///

--- a/crates/oxc_linter/src/rules/react/function_component_definition.rs
+++ b/crates/oxc_linter/src/rules/react/function_component_definition.rs
@@ -1,0 +1,1872 @@
+use oxc_ast::{
+    AstKind,
+    ast::{
+        ArrowFunctionExpression, FormalParameters, Function, FunctionType, VariableDeclarationKind,
+    },
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+    utils::{function_body_contains_jsx, function_contains_jsx},
+};
+
+fn function_component_definition_diagnostic(span: Span, expected: FunctionStyle) -> OxcDiagnostic {
+    let article = if expected == FunctionStyle::Arrow { "an" } else { "a" };
+    OxcDiagnostic::warn(format!("Function component is not {article} {}", expected.description()))
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+struct FunctionComponentDefinitionConfig {
+    named_components: NamedComponents,
+    unnamed_components: UnnamedComponents,
+}
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+enum NamedComponents {
+    Single(NamedComponentStyle),
+    Multiple(Vec<NamedComponentStyle>),
+}
+
+impl Default for NamedComponents {
+    fn default() -> Self {
+        Self::Single(NamedComponentStyle::FunctionDeclaration)
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+enum NamedComponentStyle {
+    #[default]
+    FunctionDeclaration,
+    ArrowFunction,
+    FunctionExpression,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+enum UnnamedComponents {
+    Single(UnnamedComponentStyle),
+    Multiple(Vec<UnnamedComponentStyle>),
+}
+
+impl Default for UnnamedComponents {
+    fn default() -> Self {
+        Self::Single(UnnamedComponentStyle::FunctionExpression)
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+enum UnnamedComponentStyle {
+    ArrowFunction,
+    #[default]
+    FunctionExpression,
+}
+
+#[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct FunctionComponentDefinition(FunctionComponentDefinitionConfig);
+
+// See <https://github.com/oxc-project/oxc/issues/6050> for documentation details.
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces a consistent function form for React function components.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Mixing declarations, function expressions, and arrow functions makes component definitions
+    /// less predictable and harder to scan.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```jsx
+    /// const Component = () => <div />;
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    /// function Component() { return <div />; }
+    /// ```
+    FunctionComponentDefinition,
+    react,
+    style,
+    conditional_fix,
+    config = FunctionComponentDefinition,
+    version = "next",
+    short_description = "Enforce a specific function type for function components.",
+);
+
+impl Rule for FunctionComponentDefinition {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let (actual, is_component) = match node.kind() {
+            AstKind::Function(function)
+                if matches!(
+                    function.r#type,
+                    FunctionType::FunctionDeclaration | FunctionType::FunctionExpression
+                ) =>
+            {
+                let actual = if function.r#type == FunctionType::FunctionDeclaration {
+                    FunctionStyle::Declaration
+                } else {
+                    FunctionStyle::Expression
+                };
+                (actual, function_contains_jsx(function))
+            }
+            AstKind::ArrowFunctionExpression(arrow) => {
+                (FunctionStyle::Arrow, function_body_contains_jsx(&arrow.body))
+            }
+            _ => return,
+        };
+        if !is_component || matches!(ctx.nodes().parent_kind(node.id()), AstKind::ObjectProperty(_))
+        {
+            return;
+        }
+
+        let named = is_named(node, ctx);
+        let (allowed, expected) = if named {
+            (self.0.named_components.allows(actual), self.0.named_components.preferred())
+        } else {
+            (self.0.unnamed_components.allows(actual), self.0.unnamed_components.preferred())
+        };
+        if allowed {
+            return;
+        }
+
+        let diagnostic = function_component_definition_diagnostic(node.span(), expected);
+        if can_fix(node, ctx, expected) {
+            ctx.diagnostic_with_fix(diagnostic, |fixer| {
+                let (span, replacement) = replacement(node, ctx, expected, named);
+                fixer.replace(span, replacement)
+            });
+        } else {
+            ctx.diagnostic(diagnostic);
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FunctionStyle {
+    Declaration,
+    Expression,
+    Arrow,
+}
+
+impl FunctionStyle {
+    fn description(self) -> &'static str {
+        match self {
+            Self::Declaration => "function declaration",
+            Self::Expression => "function expression",
+            Self::Arrow => "arrow function",
+        }
+    }
+}
+
+impl NamedComponents {
+    fn preferred(&self) -> FunctionStyle {
+        match self {
+            Self::Single(style) => style.style(),
+            Self::Multiple(styles) => {
+                styles.first().map_or(FunctionStyle::Declaration, |style| style.style())
+            }
+        }
+    }
+
+    fn allows(&self, style: FunctionStyle) -> bool {
+        match self {
+            Self::Single(item) => item.style() == style,
+            Self::Multiple(styles) => styles.iter().any(|item| item.style() == style),
+        }
+    }
+}
+
+impl NamedComponentStyle {
+    fn style(self) -> FunctionStyle {
+        match self {
+            Self::FunctionDeclaration => FunctionStyle::Declaration,
+            Self::FunctionExpression => FunctionStyle::Expression,
+            Self::ArrowFunction => FunctionStyle::Arrow,
+        }
+    }
+}
+
+impl UnnamedComponents {
+    fn preferred(&self) -> FunctionStyle {
+        match self {
+            Self::Single(style) => style.style(),
+            Self::Multiple(styles) => {
+                styles.first().map_or(FunctionStyle::Expression, |style| style.style())
+            }
+        }
+    }
+
+    fn allows(&self, style: FunctionStyle) -> bool {
+        match self {
+            Self::Single(item) => item.style() == style,
+            Self::Multiple(styles) => styles.iter().any(|item| item.style() == style),
+        }
+    }
+}
+
+impl UnnamedComponentStyle {
+    fn style(self) -> FunctionStyle {
+        match self {
+            Self::FunctionExpression => FunctionStyle::Expression,
+            Self::ArrowFunction => FunctionStyle::Arrow,
+        }
+    }
+}
+
+fn is_named(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
+    matches!(node.kind(), AstKind::Function(function) if function.r#type == FunctionType::FunctionDeclaration)
+        || matches!(ctx.nodes().parent_kind(node.id()), AstKind::VariableDeclarator(_))
+}
+
+fn can_fix<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>, expected: FunctionStyle) -> bool {
+    match node.kind() {
+        AstKind::Function(function) => {
+            if function.r#type == FunctionType::FunctionDeclaration
+                && matches!(
+                    ctx.nodes().parent_kind(node.id()),
+                    AstKind::ExportDefaultDeclaration(_)
+                )
+            {
+                return false;
+            }
+            if function.r#type == FunctionType::FunctionExpression && function.id.is_some() {
+                return false;
+            }
+            if expected == FunctionStyle::Declaration
+                && variable_declarator(node, ctx)
+                    .is_some_and(|declaration| declaration.type_annotation.is_some())
+            {
+                return false;
+            }
+            if expected == FunctionStyle::Arrow
+                && has_one_unconstrained_type_parameter(function.type_parameters.as_deref())
+            {
+                return false;
+            }
+        }
+        AstKind::ArrowFunctionExpression(arrow) => {
+            if expected == FunctionStyle::Declaration
+                && variable_declarator(node, ctx)
+                    .is_some_and(|declaration| declaration.type_annotation.is_some())
+            {
+                return false;
+            }
+            if expected == FunctionStyle::Arrow
+                && has_one_unconstrained_type_parameter(arrow.type_parameters.as_deref())
+            {
+                return false;
+            }
+        }
+        _ => return false,
+    }
+    true
+}
+
+fn has_one_unconstrained_type_parameter(
+    parameters: Option<&oxc_ast::ast::TSTypeParameterDeclaration<'_>>,
+) -> bool {
+    parameters.is_some_and(|parameters| {
+        parameters.params.len() == 1 && parameters.params[0].constraint.is_none()
+    })
+}
+
+fn variable_declarator<'a, 'c>(
+    node: &AstNode<'a>,
+    ctx: &'c LintContext<'a>,
+) -> Option<&'c oxc_ast::ast::VariableDeclarator<'a>> {
+    match ctx.nodes().parent_kind(node.id()) {
+        AstKind::VariableDeclarator(declaration) => Some(declaration),
+        _ => None,
+    }
+}
+
+fn replacement<'a>(
+    node: &AstNode<'a>,
+    ctx: &LintContext<'a>,
+    expected: FunctionStyle,
+    named: bool,
+) -> (Span, String) {
+    let parts = FunctionParts::new(node, ctx);
+    let body = if parts.expression_body {
+        format!("{{\n return {}\n}}", parts.body)
+    } else {
+        parts.body.clone()
+    };
+    let function = match (expected, named) {
+        (FunctionStyle::Declaration, true) => format!(
+            "function {}{}{}{} {}",
+            parts.name, parts.type_parameters, parts.params, parts.return_type, body
+        ),
+        (FunctionStyle::Expression, true) => format!(
+            "{} {}{} = function{}{}{} {}",
+            parts.variable_kind,
+            parts.name,
+            parts.type_annotation,
+            parts.type_parameters,
+            parts.params,
+            parts.return_type,
+            body
+        ),
+        (FunctionStyle::Arrow, true) => format!(
+            "{} {}{} = {}{}{} => {}",
+            parts.variable_kind,
+            parts.name,
+            parts.type_annotation,
+            parts.type_parameters,
+            parts.params,
+            parts.return_type,
+            body
+        ),
+        (FunctionStyle::Expression, false) => format!(
+            "function{}{}{} {}",
+            parts.type_parameters, parts.params, parts.return_type, body
+        ),
+        (FunctionStyle::Arrow, false) => {
+            format!("{}{}{} => {}", parts.type_parameters, parts.params, parts.return_type, body)
+        }
+        (FunctionStyle::Declaration, false) => unreachable!(),
+    };
+    (parts.replace_span, function)
+}
+
+struct FunctionParts {
+    replace_span: Span,
+    name: String,
+    variable_kind: &'static str,
+    type_annotation: String,
+    type_parameters: String,
+    params: String,
+    return_type: String,
+    body: String,
+    expression_body: bool,
+}
+
+impl FunctionParts {
+    fn new<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> Self {
+        match node.kind() {
+            AstKind::Function(function) => Self::from_function(function, node, ctx),
+            AstKind::ArrowFunctionExpression(arrow) => Self::from_arrow(arrow, node, ctx),
+            _ => unreachable!(),
+        }
+    }
+
+    fn from_function<'a>(
+        function: &Function<'a>,
+        node: &AstNode<'a>,
+        ctx: &LintContext<'a>,
+    ) -> Self {
+        let declaration = variable_declarator(node, ctx);
+        let (replace_span, variable_kind) = variable_context(node, ctx);
+        Self {
+            replace_span,
+            name: function.id.as_ref().map_or_else(
+                || variable_name(declaration),
+                |identifier| identifier.name.to_string(),
+            ),
+            variable_kind,
+            type_annotation: type_annotation(declaration, ctx),
+            type_parameters: function
+                .type_parameters
+                .as_ref()
+                .map_or_else(String::new, |item| ctx.source_range(item.span).to_string()),
+            params: parenthesized_params(&function.params, ctx),
+            return_type: function
+                .return_type
+                .as_ref()
+                .map_or_else(String::new, |item| ctx.source_range(item.span).to_string()),
+            body: function
+                .body
+                .as_ref()
+                .map_or_else(String::new, |body| ctx.source_range(body.span).to_string()),
+            expression_body: false,
+        }
+    }
+
+    fn from_arrow<'a>(
+        arrow: &ArrowFunctionExpression<'a>,
+        node: &AstNode<'a>,
+        ctx: &LintContext<'a>,
+    ) -> Self {
+        let declaration = variable_declarator(node, ctx);
+        let (replace_span, variable_kind) = variable_context(node, ctx);
+        Self {
+            replace_span,
+            name: variable_name(declaration),
+            variable_kind,
+            type_annotation: type_annotation(declaration, ctx),
+            type_parameters: arrow
+                .type_parameters
+                .as_ref()
+                .map_or_else(String::new, |item| ctx.source_range(item.span).to_string()),
+            params: parenthesized_params(&arrow.params, ctx),
+            return_type: arrow
+                .return_type
+                .as_ref()
+                .map_or_else(String::new, |item| ctx.source_range(item.span).to_string()),
+            body: ctx.source_range(arrow.body.span).to_string(),
+            expression_body: arrow.expression,
+        }
+    }
+}
+
+fn variable_context<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> (Span, &'static str) {
+    if variable_declarator(node, ctx).is_some() {
+        let declaration_node = ctx.nodes().parent_node(node.id());
+        let variable_node = ctx.nodes().parent_node(declaration_node.id());
+        if let AstKind::VariableDeclaration(variable) = variable_node.kind() {
+            return (variable.span, variable.kind.as_str());
+        }
+    }
+    let uses_es6 = ctx.nodes().iter().any(|candidate| match candidate.kind() {
+        AstKind::VariableDeclaration(declaration) => {
+            declaration.kind != VariableDeclarationKind::Var
+        }
+        AstKind::JSXElement(_)
+        | AstKind::JSXFragment(_)
+        | AstKind::ImportDeclaration(_)
+        | AstKind::ExportNamedDeclaration(_)
+        | AstKind::ExportDefaultDeclaration(_)
+        | AstKind::ExportAllDeclaration(_) => true,
+        _ => false,
+    });
+    (node.span(), if uses_es6 { "const" } else { "var" })
+}
+
+fn variable_name(declaration: Option<&oxc_ast::ast::VariableDeclarator<'_>>) -> String {
+    declaration
+        .and_then(|declaration| declaration.id.get_identifier_name())
+        .map_or_else(String::new, |name| name.to_string())
+}
+
+fn type_annotation(
+    declaration: Option<&oxc_ast::ast::VariableDeclarator<'_>>,
+    ctx: &LintContext<'_>,
+) -> String {
+    declaration
+        .and_then(|declaration| declaration.type_annotation.as_ref())
+        .map_or_else(String::new, |annotation| ctx.source_range(annotation.span).to_string())
+}
+
+fn parenthesized_params(params: &FormalParameters<'_>, ctx: &LintContext<'_>) -> String {
+    let source = ctx.source_range(params.span);
+    if source.starts_with('(') { source.to_string() } else { format!("({source})") }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (
+            "
+                    class Hello extends React.Component {
+                      render() { return <div>Hello {this.props.name}</div> }
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "arrow-function" }])),
+        ),
+        (
+            "
+                    class Hello extends React.Component {
+                      render() { return <div>Hello {this.props.name}</div> }
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-declaration" }])),
+        ),
+        (
+            "
+                    class Hello extends React.Component {
+                      render() { return <div>Hello {this.props.name}</div> }
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "var Hello = (props) => { return <div/> }",
+            Some(serde_json::json!([{ "namedComponents": "arrow-function" }])),
+        ),
+        (
+            "const Hello = (props) => { return <div/> }",
+            Some(serde_json::json!([{ "namedComponents": "arrow-function" }])),
+        ),
+        (
+            "function Hello(props) { return <div/> }",
+            Some(serde_json::json!([{ "namedComponents": "function-declaration" }])),
+        ),
+        (
+            "var Hello = function(props) { return <div/> }",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "const Hello = function(props) { return <div/> }",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "function Hello() { return function() { return <div/> } }",
+            Some(serde_json::json!([{ "unnamedComponents": "function-expression" }])),
+        ),
+        (
+            "function Hello() { return () => { return <div/> }}",
+            Some(serde_json::json!([{ "unnamedComponents": "arrow-function" }])),
+        ),
+        (
+            "var Foo = React.memo(function Foo() { return <p/> })",
+            Some(serde_json::json!([{ "namedComponents": "function-declaration" }])),
+        ),
+        (
+            "const Foo = React.memo(function Foo() { return <p/> })",
+            Some(serde_json::json!([{ "namedComponents": "function-declaration" }])),
+        ),
+        (
+            "
+                    const selectAvatarByUserId = (state, id) => {
+                      const user = selectUserById(state, id)
+                      return null
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-declaration" }])),
+        ),
+        (
+            "
+                    function ensureValidSourceType(sourceType: string) {
+                      switch (sourceType) {
+                        case 'ALBUM':
+                        case 'PLAYLIST':
+                          return sourceType;
+                        default:
+                          return null;
+                      }
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "arrow-function" }])),
+        ),
+        (
+            "function Hello(props: Test) { return <p/> }",
+            Some(serde_json::json!([{ "namedComponents": "function-declaration" }])),
+        ),
+        (
+            "var Hello = function(props: Test) { return <p/> }",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "var Hello = (props: Test) => { return <p/> }",
+            Some(serde_json::json!([{ "namedComponents": "arrow-function" }])),
+        ),
+        (
+            "var Hello: React.FC<Test> = function(props) { return <p/> }",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "var Hello: React.FC<Test> = (props) => { return <p/> }",
+            Some(serde_json::json!([{ "namedComponents": "arrow-function" }])),
+        ),
+        (
+            "function Hello<Test>(props: Props<Test>) { return <p/> }",
+            Some(serde_json::json!([{ "namedComponents": "function-declaration" }])),
+        ),
+        (
+            "function Hello<Test extends {}>(props: Props<Test>) { return <p/> }",
+            Some(serde_json::json!([{ "namedComponents": "function-declaration" }])),
+        ),
+        (
+            "var Hello = function<Test>(props: Props<Test>) { return <p/> }",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "var Hello = function<Test extends {}>(props: Props<Test>) { return <p/> }",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "var Hello = <Test extends {}>(props: Props<Test>) => { return <p/> }",
+            Some(serde_json::json!([{ "namedComponents": "arrow-function" }])),
+        ),
+        (
+            "function wrapper() { return function<Test>(props: Props<Test>) { return <p/> } } ",
+            Some(serde_json::json!([{ "unnamedComponents": "function-expression" }])),
+        ),
+        (
+            "function wrapper() { return function<Test extends {}>(props: Props<Test>) { return <p/> } } ",
+            Some(serde_json::json!([{ "unnamedComponents": "function-expression" }])),
+        ),
+        (
+            "function wrapper() { return<Test extends {}>(props: Props<Test>) => { return <p/> } } ",
+            Some(serde_json::json!([{ "unnamedComponents": "arrow-function" }])),
+        ),
+        (
+            "var Hello = function(props): ReactNode { return <p/> }",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "var Hello = (props): ReactNode => { return <p/> }",
+            Some(serde_json::json!([{ "namedComponents": "arrow-function" }])),
+        ),
+        (
+            "function wrapper() { return function(props): ReactNode { return <p/> } }",
+            Some(serde_json::json!([{ "unnamedComponents": "function-expression" }])),
+        ),
+        (
+            "function wrapper() { return (props): ReactNode => { return <p/> } }",
+            Some(serde_json::json!([{ "unnamedComponents": "arrow-function" }])),
+        ),
+        (
+            "function Hello(props): ReactNode { return <p/> }",
+            Some(serde_json::json!([{ "namedComponents": "function-declaration" }])),
+        ),
+        (
+            "
+                    const obj = {
+                      serialize: (el) => {
+                        return <p/>
+                      }
+                    };
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-declaration" }])),
+        ),
+        (
+            "
+                    const obj = {
+                      serialize: (el) => {
+                        return <p/>
+                      }
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "arrow-function" }])),
+        ),
+        (
+            "
+                    const obj = {
+                      serialize: (el) => {
+                        return <p/>
+                      }
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    const obj = {
+                      serialize: function (el) {
+                        return <p/>
+                      }
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-declaration" }])),
+        ),
+        (
+            "
+                    const obj = {
+                      serialize: function (el) {
+                        return <p/>
+                      }
+                    };
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "arrow-function" }])),
+        ),
+        (
+            "
+                    const obj = {
+                      serialize: function (el) {
+                        return <p/>
+                      }
+                    };
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    const obj = {
+                      serialize(el) {
+                        return <p/>
+                      }
+                    };
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-declaration" }])),
+        ),
+        (
+            "
+                    const obj = {
+                      serialize(el) {
+                        return <p/>
+                      }
+                    };
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "arrow-function" }])),
+        ),
+        (
+            "
+                    const obj = {
+                      serialize(el) {
+                        return <p/>
+                      }
+                    };
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    const obj = {
+                      serialize(el) {
+                        return <p/>
+                      }
+                    };
+                  ",
+            Some(serde_json::json!([{ "unnamedComponents": "arrow-function" }])),
+        ),
+        (
+            "
+                    const obj = {
+                      serialize(el) {
+                        return <p/>
+                      }
+                    };
+                  ",
+            Some(serde_json::json!([{ "unnamedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    const obj = {
+                      serialize: (el) => {
+                        return <p/>
+                      }
+                    };
+                  ",
+            Some(serde_json::json!([{ "unnamedComponents": "arrow-function" }])),
+        ),
+        (
+            "
+                    const obj = {
+                      serialize: (el) => {
+                        return <p/>
+                      }
+                    };
+                  ",
+            Some(serde_json::json!([{ "unnamedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    const obj = {
+                      serialize: function (el) {
+                        return <p/>
+                      }
+                    };
+                  ",
+            Some(serde_json::json!([{ "unnamedComponents": "arrow-function" }])),
+        ),
+        (
+            "
+                    const obj = {
+                      serialize: function (el) {
+                        return <p/>
+                      }
+                    };
+                  ",
+            Some(serde_json::json!([{ "unnamedComponents": "function-expression" }])),
+        ),
+        (
+            "function Hello(props) { return <div/> }",
+            Some(
+                serde_json::json!([{ "namedComponents": ["function-declaration", "function-expression"] }]),
+            ),
+        ),
+        (
+            "var Hello = function(props) { return <div/> }",
+            Some(
+                serde_json::json!([{ "namedComponents": ["function-declaration", "function-expression"] }]),
+            ),
+        ),
+        (
+            "var Foo = React.memo(function Foo() { return <p/> })",
+            Some(
+                serde_json::json!([{ "namedComponents": ["function-declaration", "function-expression"] }]),
+            ),
+        ),
+        (
+            "function Hello(props: Test) { return <p/> }",
+            Some(
+                serde_json::json!([{ "namedComponents": ["function-declaration", "function-expression"] }]),
+            ),
+        ),
+        (
+            "var Hello = function(props: Test) { return <p/> }",
+            Some(
+                serde_json::json!([{ "namedComponents": ["function-expression", "function-expression"] }]),
+            ),
+        ),
+        (
+            "var Hello = (props: Test) => { return <p/> }",
+            Some(
+                serde_json::json!([{ "namedComponents": ["arrow-function", "function-expression"] }]),
+            ),
+        ),
+        (
+            "
+                    function wrap(Component) {
+                      return function(props) {
+                        return <div><Component {...props}/></div>;
+                      };
+                    }
+                  ",
+            Some(
+                serde_json::json!([{ "unnamedComponents": ["arrow-function", "function-expression"] }]),
+            ),
+        ),
+        (
+            "
+                    function wrap(Component) {
+                      return (props) => {
+                        return <div><Component {...props}/></div>;
+                      };
+                    }
+                  ",
+            Some(
+                serde_json::json!([{ "unnamedComponents": ["arrow-function", "function-expression"] }]),
+            ),
+        ),
+        (
+            "
+                    export default (key, subTree = {}) => {
+                      return (state) => {
+                        const dataInStore = getFromDataModel(key)(state);
+                        const fullPaths = dataInStore.map((item, index) => {
+                          return [key, index];
+                        });
+            
+                        return {
+                          key,
+                          paths: fullPaths.map((p) => [p[1]]),
+                          fullPaths,
+                          subTree: Object.keys(subTree).length ? subTree : null,
+                        }
+                      };
+                    }
+                  ",
+            None,
+        ),
+        (
+            "
+                    function mapStateToProps() {
+                      const internItems = makeInternArray();
+                      const internClassList = makeInternArray();
+            
+                      return (state, props) => {
+                        const { store, bucket, singleCharacter } = props;
+            
+                        return {
+                          store: null,
+                          destinyVersion: store.destinyVersion,
+                          storeId: store.id,
+                        }
+                      }
+                    }
+                  ",
+            None,
+        ),
+    ];
+
+    let fail = vec![
+        (
+            "
+                    function Hello(props) {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "arrow-function" }])),
+        ),
+        (
+            "
+                    var Hello = function(props) {
+                      return <div/>;
+                    };
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "arrow-function" }])),
+        ),
+        (
+            "
+                    var Hello = (props) => {
+                      return <div/>;
+                    };
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-declaration" }])),
+        ),
+        (
+            "
+                    var Hello = function(props) {
+                      return <div/>;
+                    };
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-declaration" }])),
+        ),
+        (
+            "
+                    var Hello = (props) => {
+                      return <div/>;
+                    };
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    let Hello = (props) => {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    let Hello;
+                    Hello = (props) => {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    let Hello = (props) => {
+                      return <div/>;
+                    }
+                    Hello = function(props) {
+                      return <span/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    function Hello(props) {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    function wrap(Component) {
+                      return function(props) {
+                        return <div><Component {...props}/></div>;
+                      };
+                    }
+                  ",
+            Some(serde_json::json!([{ "unnamedComponents": "arrow-function" }])),
+        ),
+        (
+            "
+                    function wrap(Component) {
+                      return (props) => {
+                        return <div><Component {...props}/></div>;
+                      };
+                    }
+                  ",
+            Some(serde_json::json!([{ "unnamedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    var Hello = (props: Test) => {
+                      return <div/>;
+                    };
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-declaration" }])),
+        ),
+        (
+            "
+                    var Hello = function(props: Test) {
+                      return <div/>;
+                    };
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-declaration" }])),
+        ),
+        (
+            "
+                    function Hello(props: Test) {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "arrow-function" }])),
+        ),
+        (
+            "
+                    var Hello = function(props: Test) {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "arrow-function" }])),
+        ),
+        (
+            "
+                    function Hello(props: Test) {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    function Hello(props: Test) {
+                      return React.createElement('div');
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    import * as React from 'react';
+                    function Hello(props: Test) {
+                      return React.createElement('div');
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    export function Hello(props: Test) {
+                      return React.createElement('div');
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    function Hello(props) {
+                      return React.createElement('div');
+                    }
+                    export default Hello;
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    var Hello = (props: Test) => {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    var Hello: React.FC<Test> = (props) => {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    var Hello: React.FC<Test> = function(props) {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "arrow-function" }])),
+        ),
+        (
+            "
+                    var Hello: React.FC<Test> = function(props) {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-declaration" }])),
+        ),
+        (
+            "
+                    var Hello: React.FC<Test> = (props) => {
+                      return <div/>;
+                    };
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-declaration" }])),
+        ),
+        (
+            "
+                    function Hello<Test extends {}>(props: Test) {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "arrow-function" }])),
+        ),
+        (
+            "
+                    function Hello<Test>(props: Test) {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "arrow-function" }])),
+        ),
+        (
+            "
+                    function Hello<Test extends {}>(props: Test) {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    var Hello = function<Test extends {}>(props: Test) {
+                      return <div/>;
+                    };
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-declaration" }])),
+        ),
+        (
+            "
+                    var Hello = <Test extends {}>(props: Test) => {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    var Hello = function<Test extends {}>(props: Test) {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "arrow-function" }])),
+        ),
+        (
+            "
+                    var Hello = function<Test extends {}>(props: Test) {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-declaration" }])),
+        ),
+        (
+            "
+                    function wrap(Component) {
+                      return function<Test extends {}>(props) {
+                        return <div><Component {...props}/></div>
+                      }
+                    }
+                  ",
+            Some(serde_json::json!([{ "unnamedComponents": "arrow-function" }])),
+        ),
+        (
+            "
+                    function wrap(Component) {
+                      return function<Test>(props) {
+                        return <div><Component {...props}/></div>
+                      }
+                    }
+                  ",
+            Some(serde_json::json!([{ "unnamedComponents": "arrow-function" }])),
+        ),
+        (
+            "
+                    function wrap(Component) {
+                      return <Test extends {}>(props) => {
+                        return <div><Component {...props}/></div>
+                      }
+                    }
+                  ",
+            Some(serde_json::json!([{ "unnamedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    function wrap(Component) {
+                      return function(props): ReactNode {
+                        return <div><Component {...props}/></div>
+                      }
+                    }
+                  ",
+            Some(serde_json::json!([{ "unnamedComponents": "arrow-function" }])),
+        ),
+        (
+            "
+                    function wrap(Component) {
+                      return (props): ReactNode => {
+                        return <div><Component {...props}/></div>
+                      }
+                    }
+                  ",
+            Some(serde_json::json!([{ "unnamedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    export function Hello(props) {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "arrow-function" }])),
+        ),
+        (
+            "
+                    export var Hello = function(props) {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "arrow-function" }])),
+        ),
+        (
+            "
+                    export var Hello = (props) => {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-declaration" }])),
+        ),
+        (
+            "
+                    export default function Hello(props) {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "arrow-function" }])),
+        ),
+        (
+            "
+                    module.exports = function Hello(props) {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "unnamedComponents": "arrow-function" }])),
+        ),
+        (
+            "
+                    function Hello(props) {
+                      return <div/>;
+                    }
+                  ",
+            Some(
+                serde_json::json!([{ "namedComponents": ["arrow-function", "function-expression"] }]),
+            ),
+        ),
+        (
+            "
+                    var Hello = (props) => {
+                      return <div/>;
+                    };
+                  ",
+            Some(
+                serde_json::json!([{ "namedComponents": ["function-declaration", "function-expression"] }]),
+            ),
+        ),
+        (
+            "
+                    var Hello = (props) => {
+                      return <div/>;
+                    };
+                  ",
+            Some(
+                serde_json::json!([{ "namedComponents": ["function-expression", "function-declaration"] }]),
+            ),
+        ),
+        (
+            "
+                    const genX = (symbol) => `the symbol is ${symbol}`;
+            
+                    const IndexPage = () => {
+                      return (
+                        <div>
+                          Hello World.{genX('$')}
+                        </div>
+                      )
+                    }
+            
+                    export default IndexPage;
+                  ",
+            Some(serde_json::json!([{ "namedComponents": ["function-declaration"] }])),
+        ),
+    ];
+
+    let fix = vec![
+        (
+            "
+                    function Hello(props) {
+                      return <div/>;
+                    }
+                  ",
+            "
+                    const Hello = (props) => {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "arrow-function" }])),
+        ),
+        (
+            "
+                    var Hello = function(props) {
+                      return <div/>;
+                    };
+                  ",
+            "
+                    var Hello = (props) => {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "arrow-function" }])),
+        ),
+        (
+            "
+                    var Hello = (props) => {
+                      return <div/>;
+                    };
+                  ",
+            "
+                    function Hello(props) {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-declaration" }])),
+        ),
+        (
+            "
+                    var Hello = function(props) {
+                      return <div/>;
+                    };
+                  ",
+            "
+                    function Hello(props) {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-declaration" }])),
+        ),
+        (
+            "
+                    var Hello = (props) => {
+                      return <div/>;
+                    };
+                  ",
+            "
+                    var Hello = function(props) {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    let Hello = (props) => {
+                      return <div/>;
+                    }
+                  ",
+            "
+                    let Hello = function(props) {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    let Hello;
+                    Hello = (props) => {
+                      return <div/>;
+                    }
+                  ",
+            "
+                    let Hello;
+                    Hello = function(props) {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    let Hello = (props) => {
+                      return <div/>;
+                    }
+                    Hello = function(props) {
+                      return <span/>;
+                    }
+                  ",
+            "
+                    let Hello = function(props) {
+                      return <div/>;
+                    }
+                    Hello = function(props) {
+                      return <span/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    function Hello(props) {
+                      return <div/>;
+                    }
+                  ",
+            "
+                    const Hello = function(props) {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    function wrap(Component) {
+                      return function(props) {
+                        return <div><Component {...props}/></div>;
+                      };
+                    }
+                  ",
+            "
+                    function wrap(Component) {
+                      return (props) => {
+                        return <div><Component {...props}/></div>;
+                      };
+                    }
+                  ",
+            Some(serde_json::json!([{ "unnamedComponents": "arrow-function" }])),
+        ),
+        (
+            "
+                    function wrap(Component) {
+                      return (props) => {
+                        return <div><Component {...props}/></div>;
+                      };
+                    }
+                  ",
+            "
+                    function wrap(Component) {
+                      return function(props) {
+                        return <div><Component {...props}/></div>;
+                      };
+                    }
+                  ",
+            Some(serde_json::json!([{ "unnamedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    var Hello = (props: Test) => {
+                      return <div/>;
+                    };
+                  ",
+            "
+                    function Hello(props: Test) {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-declaration" }])),
+        ),
+        (
+            "
+                    var Hello = function(props: Test) {
+                      return <div/>;
+                    };
+                  ",
+            "
+                    function Hello(props: Test) {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-declaration" }])),
+        ),
+        (
+            "
+                    function Hello(props: Test) {
+                      return <div/>;
+                    }
+                  ",
+            "
+                    const Hello = (props: Test) => {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "arrow-function" }])),
+        ),
+        (
+            "
+                    var Hello = function(props: Test) {
+                      return <div/>;
+                    }
+                  ",
+            "
+                    var Hello = (props: Test) => {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "arrow-function" }])),
+        ),
+        (
+            "
+                    function Hello(props: Test) {
+                      return <div/>;
+                    }
+                  ",
+            "
+                    const Hello = function(props: Test) {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    function Hello(props: Test) {
+                      return React.createElement('div');
+                    }
+                  ",
+            "
+                    var Hello = function(props: Test) {
+                      return React.createElement('div');
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    import * as React from 'react';
+                    function Hello(props: Test) {
+                      return React.createElement('div');
+                    }
+                  ",
+            "
+                    import * as React from 'react';
+                    const Hello = function(props: Test) {
+                      return React.createElement('div');
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    export function Hello(props: Test) {
+                      return React.createElement('div');
+                    }
+                  ",
+            "
+                    export const Hello = function(props: Test) {
+                      return React.createElement('div');
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    function Hello(props) {
+                      return React.createElement('div');
+                    }
+                    export default Hello;
+                  ",
+            "
+                    const Hello = function(props) {
+                      return React.createElement('div');
+                    }
+                    export default Hello;
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    var Hello = (props: Test) => {
+                      return <div/>;
+                    }
+                  ",
+            "
+                    var Hello = function(props: Test) {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    var Hello: React.FC<Test> = (props) => {
+                      return <div/>;
+                    }
+                  ",
+            "
+                    var Hello: React.FC<Test> = function(props) {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    var Hello: React.FC<Test> = function(props) {
+                      return <div/>;
+                    }
+                  ",
+            "
+                    var Hello: React.FC<Test> = (props) => {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "arrow-function" }])),
+        ),
+        (
+            "
+                    function Hello<Test extends {}>(props: Test) {
+                      return <div/>;
+                    }
+                  ",
+            "
+                    const Hello = <Test extends {}>(props: Test) => {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "arrow-function" }])),
+        ),
+        (
+            "
+                    function Hello<Test extends {}>(props: Test) {
+                      return <div/>;
+                    }
+                  ",
+            "
+                    const Hello = function<Test extends {}>(props: Test) {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    var Hello = function<Test extends {}>(props: Test) {
+                      return <div/>;
+                    };
+                  ",
+            "
+                    function Hello<Test extends {}>(props: Test) {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-declaration" }])),
+        ),
+        (
+            "
+                    var Hello = <Test extends {}>(props: Test) => {
+                      return <div/>;
+                    }
+                  ",
+            "
+                    var Hello = function<Test extends {}>(props: Test) {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    var Hello = function<Test extends {}>(props: Test) {
+                      return <div/>;
+                    }
+                  ",
+            "
+                    var Hello = <Test extends {}>(props: Test) => {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "arrow-function" }])),
+        ),
+        (
+            "
+                    var Hello = function<Test extends {}>(props: Test) {
+                      return <div/>;
+                    }
+                  ",
+            "
+                    function Hello<Test extends {}>(props: Test) {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-declaration" }])),
+        ),
+        (
+            "
+                    function wrap(Component) {
+                      return function<Test extends {}>(props) {
+                        return <div><Component {...props}/></div>
+                      }
+                    }
+                  ",
+            "
+                    function wrap(Component) {
+                      return <Test extends {}>(props) => {
+                        return <div><Component {...props}/></div>
+                      }
+                    }
+                  ",
+            Some(serde_json::json!([{ "unnamedComponents": "arrow-function" }])),
+        ),
+        (
+            "
+                    function wrap(Component) {
+                      return <Test extends {}>(props) => {
+                        return <div><Component {...props}/></div>
+                      }
+                    }
+                  ",
+            "
+                    function wrap(Component) {
+                      return function<Test extends {}>(props) {
+                        return <div><Component {...props}/></div>
+                      }
+                    }
+                  ",
+            Some(serde_json::json!([{ "unnamedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    function wrap(Component) {
+                      return function(props): ReactNode {
+                        return <div><Component {...props}/></div>
+                      }
+                    }
+                  ",
+            "
+                    function wrap(Component) {
+                      return (props): ReactNode => {
+                        return <div><Component {...props}/></div>
+                      }
+                    }
+                  ",
+            Some(serde_json::json!([{ "unnamedComponents": "arrow-function" }])),
+        ),
+        (
+            "
+                    function wrap(Component) {
+                      return (props): ReactNode => {
+                        return <div><Component {...props}/></div>
+                      }
+                    }
+                  ",
+            "
+                    function wrap(Component) {
+                      return function(props): ReactNode {
+                        return <div><Component {...props}/></div>
+                      }
+                    }
+                  ",
+            Some(serde_json::json!([{ "unnamedComponents": "function-expression" }])),
+        ),
+        (
+            "
+                    export function Hello(props) {
+                      return <div/>;
+                    }
+                  ",
+            "
+                    export const Hello = (props) => {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "arrow-function" }])),
+        ),
+        (
+            "
+                    export var Hello = function(props) {
+                      return <div/>;
+                    }
+                  ",
+            "
+                    export var Hello = (props) => {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "arrow-function" }])),
+        ),
+        (
+            "
+                    export var Hello = (props) => {
+                      return <div/>;
+                    }
+                  ",
+            "
+                    export function Hello(props) {
+                      return <div/>;
+                    }
+                  ",
+            Some(serde_json::json!([{ "namedComponents": "function-declaration" }])),
+        ),
+        (
+            "
+                    function Hello(props) {
+                      return <div/>;
+                    }
+                  ",
+            "
+                    const Hello = (props) => {
+                      return <div/>;
+                    }
+                  ",
+            Some(
+                serde_json::json!([{ "namedComponents": ["arrow-function", "function-expression"] }]),
+            ),
+        ),
+        (
+            "
+                    var Hello = (props) => {
+                      return <div/>;
+                    };
+                  ",
+            "
+                    function Hello(props) {
+                      return <div/>;
+                    }
+                  ",
+            Some(
+                serde_json::json!([{ "namedComponents": ["function-declaration", "function-expression"] }]),
+            ),
+        ),
+        (
+            "
+                    var Hello = (props) => {
+                      return <div/>;
+                    };
+                  ",
+            "
+                    var Hello = function(props) {
+                      return <div/>;
+                    }
+                  ",
+            Some(
+                serde_json::json!([{ "namedComponents": ["function-expression", "function-declaration"] }]),
+            ),
+        ),
+        (
+            "
+                    const genX = (symbol) => `the symbol is ${symbol}`;
+            
+                    const IndexPage = () => {
+                      return (
+                        <div>
+                          Hello World.{genX('$')}
+                        </div>
+                      )
+                    }
+            
+                    export default IndexPage;
+                  ",
+            "
+                    const genX = (symbol) => `the symbol is ${symbol}`;
+            
+                    function IndexPage() {
+                      return (
+                        <div>
+                          Hello World.{genX('$')}
+                        </div>
+                      )
+                    }
+            
+                    export default IndexPage;
+                  ",
+            Some(serde_json::json!([{ "namedComponents": ["function-declaration"] }])),
+        ),
+    ];
+
+    Tester::new(FunctionComponentDefinition::NAME, FunctionComponentDefinition::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/react/function_component_definition.rs
+++ b/crates/oxc_linter/src/rules/react/function_component_definition.rs
@@ -1,9 +1,10 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
 use oxc_ast::{AstKind, ast::FunctionType};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 
 use crate::{
     AstNode,

--- a/crates/oxc_linter/src/rules/react/function_component_definition.rs
+++ b/crates/oxc_linter/src/rules/react/function_component_definition.rs
@@ -286,7 +286,7 @@ mod fix {
                     return false;
                 }
             }
-            _ => return false,
+            _ => unreachable!(),
         }
         true
     }

--- a/crates/oxc_linter/src/rules/react/function_component_definition.rs
+++ b/crates/oxc_linter/src/rules/react/function_component_definition.rs
@@ -266,7 +266,8 @@ mod fix {
                     return false;
                 }
                 if expected == FunctionStyle::Arrow
-                    && (function.generator
+                    && (function.this_param.is_some()
+                        || function.generator
                         || has_one_unconstrained_type_parameter(
                             function.type_parameters.as_deref(),
                         ))
@@ -1314,6 +1315,10 @@ fn test() {
         ),
         (
             "function* Hello(props) { return <div/>; }",
+            Some(serde_json::json!([{ "namedComponents": "arrow-function" }])),
+        ),
+        (
+            "function Hello(this: Context, props: Props) { return <div/>; }",
             Some(serde_json::json!([{ "namedComponents": "arrow-function" }])),
         ),
     ];

--- a/crates/oxc_linter/src/rules/react/function_component_definition.rs
+++ b/crates/oxc_linter/src/rules/react/function_component_definition.rs
@@ -108,17 +108,13 @@ impl Rule for FunctionComponentDefinition {
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let (actual, is_component) = match node.kind() {
-            AstKind::Function(function)
-                if matches!(
-                    function.r#type,
-                    FunctionType::FunctionDeclaration | FunctionType::FunctionExpression
-                ) =>
-            {
-                let actual = if function.r#type == FunctionType::FunctionDeclaration {
-                    FunctionStyle::Declaration
-                } else {
-                    FunctionStyle::Expression
+            AstKind::Function(function) => {
+                let actual = match function.r#type {
+                    FunctionType::FunctionDeclaration => FunctionStyle::Declaration,
+                    FunctionType::FunctionExpression => FunctionStyle::Expression,
+                    _ => return,
                 };
+
                 (actual, function_contains_jsx(function))
             }
             AstKind::ArrowFunctionExpression(arrow) => {

--- a/crates/oxc_linter/src/rules/react/function_component_definition.rs
+++ b/crates/oxc_linter/src/rules/react/function_component_definition.rs
@@ -257,7 +257,8 @@ fn can_fix<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>, expected: FunctionStyl
                 return false;
             }
             if expected == FunctionStyle::Arrow
-                && has_one_unconstrained_type_parameter(function.type_parameters.as_deref())
+                && (function.generator
+                    || has_one_unconstrained_type_parameter(function.type_parameters.as_deref()))
             {
                 return false;
             }
@@ -312,36 +313,51 @@ fn replacement<'a>(
     };
     let function = match (expected, named) {
         (FunctionStyle::Declaration, true) => format!(
-            "function {}{}{}{} {}",
-            parts.name, parts.type_parameters, parts.params, parts.return_type, body
+            "{}function{} {}{}{}{} {}",
+            parts.async_prefix,
+            parts.generator_marker,
+            parts.name,
+            parts.type_parameters,
+            parts.params,
+            parts.return_type,
+            body
         ),
         (FunctionStyle::Expression, true) => format!(
-            "{} {}{} = function{}{}{} {}",
+            "{} {}{} = {}function{}{}{}{} {}",
             parts.variable_kind,
             parts.name,
             parts.type_annotation,
+            parts.async_prefix,
+            parts.generator_marker,
             parts.type_parameters,
             parts.params,
             parts.return_type,
             body
         ),
         (FunctionStyle::Arrow, true) => format!(
-            "{} {}{} = {}{}{} => {}",
+            "{} {}{} = {}{}{}{} => {}",
             parts.variable_kind,
             parts.name,
             parts.type_annotation,
+            parts.async_prefix,
             parts.type_parameters,
             parts.params,
             parts.return_type,
             body
         ),
         (FunctionStyle::Expression, false) => format!(
-            "function{}{}{} {}",
-            parts.type_parameters, parts.params, parts.return_type, body
+            "{}function{}{}{}{} {}",
+            parts.async_prefix,
+            parts.generator_marker,
+            parts.type_parameters,
+            parts.params,
+            parts.return_type,
+            body
         ),
-        (FunctionStyle::Arrow, false) => {
-            format!("{}{}{} => {}", parts.type_parameters, parts.params, parts.return_type, body)
-        }
+        (FunctionStyle::Arrow, false) => format!(
+            "{}{}{}{} => {}",
+            parts.async_prefix, parts.type_parameters, parts.params, parts.return_type, body
+        ),
         (FunctionStyle::Declaration, false) => unreachable!(),
     };
     (parts.replace_span, function)
@@ -352,6 +368,8 @@ struct FunctionParts<'a> {
     name: String,
     variable_kind: &'static str,
     type_annotation: &'a str,
+    async_prefix: &'static str,
+    generator_marker: &'static str,
     type_parameters: String,
     params: String,
     return_type: String,
@@ -379,6 +397,8 @@ impl<'a> FunctionParts<'a> {
             ),
             variable_kind,
             type_annotation: type_annotation(declaration, ctx),
+            async_prefix: if function.r#async { "async " } else { "" },
+            generator_marker: if function.generator { "*" } else { "" },
             type_parameters: function
                 .type_parameters
                 .as_ref()
@@ -408,6 +428,8 @@ impl<'a> FunctionParts<'a> {
             name: variable_name(declaration),
             variable_kind,
             type_annotation: type_annotation(declaration, ctx),
+            async_prefix: if arrow.r#async { "async " } else { "" },
+            generator_marker: "",
             type_parameters: arrow
                 .type_parameters
                 .as_ref()
@@ -1268,6 +1290,10 @@ fn test() {
                   ",
             Some(serde_json::json!([{ "namedComponents": ["function-declaration"] }])),
         ),
+        (
+            "function* Hello(props) { return <div/>; }",
+            Some(serde_json::json!([{ "namedComponents": "arrow-function" }])),
+        ),
     ];
 
     let fix = vec![
@@ -1848,6 +1874,21 @@ fn test() {
                     export default IndexPage;
                   ",
             Some(serde_json::json!([{ "namedComponents": ["function-declaration"] }])),
+        ),
+        (
+            "async function Hello(props) { await load(); return <div/>; }",
+            "const Hello = async (props) => { await load(); return <div/>; }",
+            Some(serde_json::json!([{ "namedComponents": "arrow-function" }])),
+        ),
+        (
+            "const Hello = async (props) => { await load(); return <div/>; }",
+            "async function Hello(props) { await load(); return <div/>; }",
+            Some(serde_json::json!([{ "namedComponents": "function-declaration" }])),
+        ),
+        (
+            "async function* Hello(props) { yield await load(); return <div/>; }",
+            "const Hello = async function*(props) { yield await load(); return <div/>; }",
+            Some(serde_json::json!([{ "namedComponents": "function-expression" }])),
         ),
     ];
 

--- a/crates/oxc_linter/src/snapshots/react_function_component_definition.snap
+++ b/crates/oxc_linter/src/snapshots/react_function_component_definition.snap
@@ -639,3 +639,9 @@ source: crates/oxc_linter/src/tester.rs
  1 │ function Hello(this: Context, props: Props) { return <div/>; }
    · ──────────────────────────────────────────────────────────────
    ╰────
+
+  ⚠ react(function-component-definition): Function component is not a function declaration
+   ╭─[function_component_definition.tsx:1:15]
+ 1 │ const Hello = () => <div/>, keep = sideEffect();
+   ·               ────────────
+   ╰────

--- a/crates/oxc_linter/src/snapshots/react_function_component_definition.snap
+++ b/crates/oxc_linter/src/snapshots/react_function_component_definition.snap
@@ -1,0 +1,629 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ react(function-component-definition): Function component is not an arrow function
+   ╭─[function_component_definition.tsx:2:21]
+ 1 │     
+ 2 │ ╭─▶                     function Hello(props) {
+ 3 │ │                         return <div/>;
+ 4 │ ╰─▶                     }
+ 5 │                       
+   ╰────
+  help: Replace `function Hello(props) {
+                              return <div/>;
+                            }` with `const Hello = (props) => {
+                              return <div/>;
+                            }`.
+
+  ⚠ react(function-component-definition): Function component is not an arrow function
+   ╭─[function_component_definition.tsx:2:33]
+ 1 │     
+ 2 │ ╭─▶                     var Hello = function(props) {
+ 3 │ │                         return <div/>;
+ 4 │ ╰─▶                     };
+ 5 │                       
+   ╰────
+  help: Replace `var Hello = function(props) {
+                              return <div/>;
+                            };` with `var Hello = (props) => {
+                              return <div/>;
+                            }`.
+
+  ⚠ react(function-component-definition): Function component is not a function declaration
+   ╭─[function_component_definition.tsx:2:33]
+ 1 │     
+ 2 │ ╭─▶                     var Hello = (props) => {
+ 3 │ │                         return <div/>;
+ 4 │ ╰─▶                     };
+ 5 │                       
+   ╰────
+  help: Replace `var Hello = (props) => {
+                              return <div/>;
+                            };` with `function Hello(props) {
+                              return <div/>;
+                            }`.
+
+  ⚠ react(function-component-definition): Function component is not a function declaration
+   ╭─[function_component_definition.tsx:2:33]
+ 1 │     
+ 2 │ ╭─▶                     var Hello = function(props) {
+ 3 │ │                         return <div/>;
+ 4 │ ╰─▶                     };
+ 5 │                       
+   ╰────
+  help: Replace `var Hello = function(props) {
+                              return <div/>;
+                            };` with `function Hello(props) {
+                              return <div/>;
+                            }`.
+
+  ⚠ react(function-component-definition): Function component is not a function expression
+   ╭─[function_component_definition.tsx:2:33]
+ 1 │     
+ 2 │ ╭─▶                     var Hello = (props) => {
+ 3 │ │                         return <div/>;
+ 4 │ ╰─▶                     };
+ 5 │                       
+   ╰────
+  help: Replace `var Hello = (props) => {
+                              return <div/>;
+                            };` with `var Hello = function(props) {
+                              return <div/>;
+                            }`.
+
+  ⚠ react(function-component-definition): Function component is not a function expression
+   ╭─[function_component_definition.tsx:2:33]
+ 1 │     
+ 2 │ ╭─▶                     let Hello = (props) => {
+ 3 │ │                         return <div/>;
+ 4 │ ╰─▶                     }
+ 5 │                       
+   ╰────
+  help: Replace `let Hello = (props) => {
+                              return <div/>;
+                            }` with `let Hello = function(props) {
+                              return <div/>;
+                            }`.
+
+  ⚠ react(function-component-definition): Function component is not a function expression
+   ╭─[function_component_definition.tsx:3:29]
+ 2 │                         let Hello;
+ 3 │ ╭─▶                     Hello = (props) => {
+ 4 │ │                         return <div/>;
+ 5 │ ╰─▶                     }
+ 6 │                       
+   ╰────
+  help: Replace `(props) => {
+                              return <div/>;
+                            }` with `function(props) {
+                              return <div/>;
+                            }`.
+
+  ⚠ react(function-component-definition): Function component is not a function expression
+   ╭─[function_component_definition.tsx:2:33]
+ 1 │     
+ 2 │ ╭─▶                     let Hello = (props) => {
+ 3 │ │                         return <div/>;
+ 4 │ ╰─▶                     }
+ 5 │                         Hello = function(props) {
+   ╰────
+  help: Replace `let Hello = (props) => {
+                              return <div/>;
+                            }` with `let Hello = function(props) {
+                              return <div/>;
+                            }`.
+
+  ⚠ react(function-component-definition): Function component is not a function expression
+   ╭─[function_component_definition.tsx:2:21]
+ 1 │     
+ 2 │ ╭─▶                     function Hello(props) {
+ 3 │ │                         return <div/>;
+ 4 │ ╰─▶                     }
+ 5 │                       
+   ╰────
+  help: Replace `function Hello(props) {
+                              return <div/>;
+                            }` with `const Hello = function(props) {
+                              return <div/>;
+                            }`.
+
+  ⚠ react(function-component-definition): Function component is not an arrow function
+   ╭─[function_component_definition.tsx:3:30]
+ 2 │                         function wrap(Component) {
+ 3 │ ╭─▶                       return function(props) {
+ 4 │ │                           return <div><Component {...props}/></div>;
+ 5 │ ╰─▶                       };
+ 6 │                         }
+   ╰────
+  help: Replace `function(props) {
+                                return <div><Component {...props}/></div>;
+                              }` with `(props) => {
+                                return <div><Component {...props}/></div>;
+                              }`.
+
+  ⚠ react(function-component-definition): Function component is not a function expression
+   ╭─[function_component_definition.tsx:3:30]
+ 2 │                         function wrap(Component) {
+ 3 │ ╭─▶                       return (props) => {
+ 4 │ │                           return <div><Component {...props}/></div>;
+ 5 │ ╰─▶                       };
+ 6 │                         }
+   ╰────
+  help: Replace `(props) => {
+                                return <div><Component {...props}/></div>;
+                              }` with `function(props) {
+                                return <div><Component {...props}/></div>;
+                              }`.
+
+  ⚠ react(function-component-definition): Function component is not a function declaration
+   ╭─[function_component_definition.tsx:2:33]
+ 1 │     
+ 2 │ ╭─▶                     var Hello = (props: Test) => {
+ 3 │ │                         return <div/>;
+ 4 │ ╰─▶                     };
+ 5 │                       
+   ╰────
+  help: Replace `var Hello = (props: Test) => {
+                              return <div/>;
+                            };` with `function Hello(props: Test) {
+                              return <div/>;
+                            }`.
+
+  ⚠ react(function-component-definition): Function component is not a function declaration
+   ╭─[function_component_definition.tsx:2:33]
+ 1 │     
+ 2 │ ╭─▶                     var Hello = function(props: Test) {
+ 3 │ │                         return <div/>;
+ 4 │ ╰─▶                     };
+ 5 │                       
+   ╰────
+  help: Replace `var Hello = function(props: Test) {
+                              return <div/>;
+                            };` with `function Hello(props: Test) {
+                              return <div/>;
+                            }`.
+
+  ⚠ react(function-component-definition): Function component is not an arrow function
+   ╭─[function_component_definition.tsx:2:21]
+ 1 │     
+ 2 │ ╭─▶                     function Hello(props: Test) {
+ 3 │ │                         return <div/>;
+ 4 │ ╰─▶                     }
+ 5 │                       
+   ╰────
+  help: Replace `function Hello(props: Test) {
+                              return <div/>;
+                            }` with `const Hello = (props: Test) => {
+                              return <div/>;
+                            }`.
+
+  ⚠ react(function-component-definition): Function component is not an arrow function
+   ╭─[function_component_definition.tsx:2:33]
+ 1 │     
+ 2 │ ╭─▶                     var Hello = function(props: Test) {
+ 3 │ │                         return <div/>;
+ 4 │ ╰─▶                     }
+ 5 │                       
+   ╰────
+  help: Replace `var Hello = function(props: Test) {
+                              return <div/>;
+                            }` with `var Hello = (props: Test) => {
+                              return <div/>;
+                            }`.
+
+  ⚠ react(function-component-definition): Function component is not a function expression
+   ╭─[function_component_definition.tsx:2:21]
+ 1 │     
+ 2 │ ╭─▶                     function Hello(props: Test) {
+ 3 │ │                         return <div/>;
+ 4 │ ╰─▶                     }
+ 5 │                       
+   ╰────
+  help: Replace `function Hello(props: Test) {
+                              return <div/>;
+                            }` with `const Hello = function(props: Test) {
+                              return <div/>;
+                            }`.
+
+  ⚠ react(function-component-definition): Function component is not a function expression
+   ╭─[function_component_definition.tsx:2:21]
+ 1 │     
+ 2 │ ╭─▶                     function Hello(props: Test) {
+ 3 │ │                         return React.createElement('div');
+ 4 │ ╰─▶                     }
+ 5 │                       
+   ╰────
+  help: Replace `function Hello(props: Test) {
+                              return React.createElement('div');
+                            }` with `var Hello = function(props: Test) {
+                              return React.createElement('div');
+                            }`.
+
+  ⚠ react(function-component-definition): Function component is not a function expression
+   ╭─[function_component_definition.tsx:3:21]
+ 2 │                         import * as React from 'react';
+ 3 │ ╭─▶                     function Hello(props: Test) {
+ 4 │ │                         return React.createElement('div');
+ 5 │ ╰─▶                     }
+ 6 │                       
+   ╰────
+  help: Replace `function Hello(props: Test) {
+                              return React.createElement('div');
+                            }` with `const Hello = function(props: Test) {
+                              return React.createElement('div');
+                            }`.
+
+  ⚠ react(function-component-definition): Function component is not a function expression
+   ╭─[function_component_definition.tsx:2:28]
+ 1 │     
+ 2 │ ╭─▶                     export function Hello(props: Test) {
+ 3 │ │                         return React.createElement('div');
+ 4 │ ╰─▶                     }
+ 5 │                       
+   ╰────
+  help: Replace `function Hello(props: Test) {
+                              return React.createElement('div');
+                            }` with `const Hello = function(props: Test) {
+                              return React.createElement('div');
+                            }`.
+
+  ⚠ react(function-component-definition): Function component is not a function expression
+   ╭─[function_component_definition.tsx:2:21]
+ 1 │     
+ 2 │ ╭─▶                     function Hello(props) {
+ 3 │ │                         return React.createElement('div');
+ 4 │ ╰─▶                     }
+ 5 │                         export default Hello;
+   ╰────
+  help: Replace `function Hello(props) {
+                              return React.createElement('div');
+                            }` with `const Hello = function(props) {
+                              return React.createElement('div');
+                            }`.
+
+  ⚠ react(function-component-definition): Function component is not a function expression
+   ╭─[function_component_definition.tsx:2:33]
+ 1 │     
+ 2 │ ╭─▶                     var Hello = (props: Test) => {
+ 3 │ │                         return <div/>;
+ 4 │ ╰─▶                     }
+ 5 │                       
+   ╰────
+  help: Replace `var Hello = (props: Test) => {
+                              return <div/>;
+                            }` with `var Hello = function(props: Test) {
+                              return <div/>;
+                            }`.
+
+  ⚠ react(function-component-definition): Function component is not a function expression
+   ╭─[function_component_definition.tsx:2:49]
+ 1 │     
+ 2 │ ╭─▶                     var Hello: React.FC<Test> = (props) => {
+ 3 │ │                         return <div/>;
+ 4 │ ╰─▶                     }
+ 5 │                       
+   ╰────
+  help: Replace `var Hello: React.FC<Test> = (props) => {
+                              return <div/>;
+                            }` with `var Hello: React.FC<Test> = function(props) {
+                              return <div/>;
+                            }`.
+
+  ⚠ react(function-component-definition): Function component is not an arrow function
+   ╭─[function_component_definition.tsx:2:49]
+ 1 │     
+ 2 │ ╭─▶                     var Hello: React.FC<Test> = function(props) {
+ 3 │ │                         return <div/>;
+ 4 │ ╰─▶                     }
+ 5 │                       
+   ╰────
+  help: Replace `var Hello: React.FC<Test> = function(props) {
+                              return <div/>;
+                            }` with `var Hello: React.FC<Test> = (props) => {
+                              return <div/>;
+                            }`.
+
+  ⚠ react(function-component-definition): Function component is not a function declaration
+   ╭─[function_component_definition.tsx:2:49]
+ 1 │     
+ 2 │ ╭─▶                     var Hello: React.FC<Test> = function(props) {
+ 3 │ │                         return <div/>;
+ 4 │ ╰─▶                     }
+ 5 │                       
+   ╰────
+
+  ⚠ react(function-component-definition): Function component is not a function declaration
+   ╭─[function_component_definition.tsx:2:49]
+ 1 │     
+ 2 │ ╭─▶                     var Hello: React.FC<Test> = (props) => {
+ 3 │ │                         return <div/>;
+ 4 │ ╰─▶                     };
+ 5 │                       
+   ╰────
+
+  ⚠ react(function-component-definition): Function component is not an arrow function
+   ╭─[function_component_definition.tsx:2:21]
+ 1 │     
+ 2 │ ╭─▶                     function Hello<Test extends {}>(props: Test) {
+ 3 │ │                         return <div/>;
+ 4 │ ╰─▶                     }
+ 5 │                       
+   ╰────
+  help: Replace `function Hello<Test extends {}>(props: Test) {
+                              return <div/>;
+                            }` with `const Hello = <Test extends {}>(props: Test) => {
+                              return <div/>;
+                            }`.
+
+  ⚠ react(function-component-definition): Function component is not an arrow function
+   ╭─[function_component_definition.tsx:2:21]
+ 1 │     
+ 2 │ ╭─▶                     function Hello<Test>(props: Test) {
+ 3 │ │                         return <div/>;
+ 4 │ ╰─▶                     }
+ 5 │                       
+   ╰────
+
+  ⚠ react(function-component-definition): Function component is not a function expression
+   ╭─[function_component_definition.tsx:2:21]
+ 1 │     
+ 2 │ ╭─▶                     function Hello<Test extends {}>(props: Test) {
+ 3 │ │                         return <div/>;
+ 4 │ ╰─▶                     }
+ 5 │                       
+   ╰────
+  help: Replace `function Hello<Test extends {}>(props: Test) {
+                              return <div/>;
+                            }` with `const Hello = function<Test extends {}>(props: Test) {
+                              return <div/>;
+                            }`.
+
+  ⚠ react(function-component-definition): Function component is not a function declaration
+   ╭─[function_component_definition.tsx:2:33]
+ 1 │     
+ 2 │ ╭─▶                     var Hello = function<Test extends {}>(props: Test) {
+ 3 │ │                         return <div/>;
+ 4 │ ╰─▶                     };
+ 5 │                       
+   ╰────
+  help: Replace `var Hello = function<Test extends {}>(props: Test) {
+                              return <div/>;
+                            };` with `function Hello<Test extends {}>(props: Test) {
+                              return <div/>;
+                            }`.
+
+  ⚠ react(function-component-definition): Function component is not a function expression
+   ╭─[function_component_definition.tsx:2:33]
+ 1 │     
+ 2 │ ╭─▶                     var Hello = <Test extends {}>(props: Test) => {
+ 3 │ │                         return <div/>;
+ 4 │ ╰─▶                     }
+ 5 │                       
+   ╰────
+  help: Replace `var Hello = <Test extends {}>(props: Test) => {
+                              return <div/>;
+                            }` with `var Hello = function<Test extends {}>(props: Test) {
+                              return <div/>;
+                            }`.
+
+  ⚠ react(function-component-definition): Function component is not an arrow function
+   ╭─[function_component_definition.tsx:2:33]
+ 1 │     
+ 2 │ ╭─▶                     var Hello = function<Test extends {}>(props: Test) {
+ 3 │ │                         return <div/>;
+ 4 │ ╰─▶                     }
+ 5 │                       
+   ╰────
+  help: Replace `var Hello = function<Test extends {}>(props: Test) {
+                              return <div/>;
+                            }` with `var Hello = <Test extends {}>(props: Test) => {
+                              return <div/>;
+                            }`.
+
+  ⚠ react(function-component-definition): Function component is not a function declaration
+   ╭─[function_component_definition.tsx:2:33]
+ 1 │     
+ 2 │ ╭─▶                     var Hello = function<Test extends {}>(props: Test) {
+ 3 │ │                         return <div/>;
+ 4 │ ╰─▶                     }
+ 5 │                       
+   ╰────
+  help: Replace `var Hello = function<Test extends {}>(props: Test) {
+                              return <div/>;
+                            }` with `function Hello<Test extends {}>(props: Test) {
+                              return <div/>;
+                            }`.
+
+  ⚠ react(function-component-definition): Function component is not an arrow function
+   ╭─[function_component_definition.tsx:3:30]
+ 2 │                         function wrap(Component) {
+ 3 │ ╭─▶                       return function<Test extends {}>(props) {
+ 4 │ │                           return <div><Component {...props}/></div>
+ 5 │ ╰─▶                       }
+ 6 │                         }
+   ╰────
+  help: Replace `function<Test extends {}>(props) {
+                                return <div><Component {...props}/></div>
+                              }` with `<Test extends {}>(props) => {
+                                return <div><Component {...props}/></div>
+                              }`.
+
+  ⚠ react(function-component-definition): Function component is not an arrow function
+   ╭─[function_component_definition.tsx:3:30]
+ 2 │                         function wrap(Component) {
+ 3 │ ╭─▶                       return function<Test>(props) {
+ 4 │ │                           return <div><Component {...props}/></div>
+ 5 │ ╰─▶                       }
+ 6 │                         }
+   ╰────
+
+  ⚠ react(function-component-definition): Function component is not a function expression
+   ╭─[function_component_definition.tsx:3:30]
+ 2 │                         function wrap(Component) {
+ 3 │ ╭─▶                       return <Test extends {}>(props) => {
+ 4 │ │                           return <div><Component {...props}/></div>
+ 5 │ ╰─▶                       }
+ 6 │                         }
+   ╰────
+  help: Replace `<Test extends {}>(props) => {
+                                return <div><Component {...props}/></div>
+                              }` with `function<Test extends {}>(props) {
+                                return <div><Component {...props}/></div>
+                              }`.
+
+  ⚠ react(function-component-definition): Function component is not an arrow function
+   ╭─[function_component_definition.tsx:3:30]
+ 2 │                         function wrap(Component) {
+ 3 │ ╭─▶                       return function(props): ReactNode {
+ 4 │ │                           return <div><Component {...props}/></div>
+ 5 │ ╰─▶                       }
+ 6 │                         }
+   ╰────
+  help: Replace `function(props): ReactNode {
+                                return <div><Component {...props}/></div>
+                              }` with `(props): ReactNode => {
+                                return <div><Component {...props}/></div>
+                              }`.
+
+  ⚠ react(function-component-definition): Function component is not a function expression
+   ╭─[function_component_definition.tsx:3:30]
+ 2 │                         function wrap(Component) {
+ 3 │ ╭─▶                       return (props): ReactNode => {
+ 4 │ │                           return <div><Component {...props}/></div>
+ 5 │ ╰─▶                       }
+ 6 │                         }
+   ╰────
+  help: Replace `(props): ReactNode => {
+                                return <div><Component {...props}/></div>
+                              }` with `function(props): ReactNode {
+                                return <div><Component {...props}/></div>
+                              }`.
+
+  ⚠ react(function-component-definition): Function component is not an arrow function
+   ╭─[function_component_definition.tsx:2:28]
+ 1 │     
+ 2 │ ╭─▶                     export function Hello(props) {
+ 3 │ │                         return <div/>;
+ 4 │ ╰─▶                     }
+ 5 │                       
+   ╰────
+  help: Replace `function Hello(props) {
+                              return <div/>;
+                            }` with `const Hello = (props) => {
+                              return <div/>;
+                            }`.
+
+  ⚠ react(function-component-definition): Function component is not an arrow function
+   ╭─[function_component_definition.tsx:2:40]
+ 1 │     
+ 2 │ ╭─▶                     export var Hello = function(props) {
+ 3 │ │                         return <div/>;
+ 4 │ ╰─▶                     }
+ 5 │                       
+   ╰────
+  help: Replace `var Hello = function(props) {
+                              return <div/>;
+                            }` with `var Hello = (props) => {
+                              return <div/>;
+                            }`.
+
+  ⚠ react(function-component-definition): Function component is not a function declaration
+   ╭─[function_component_definition.tsx:2:40]
+ 1 │     
+ 2 │ ╭─▶                     export var Hello = (props) => {
+ 3 │ │                         return <div/>;
+ 4 │ ╰─▶                     }
+ 5 │                       
+   ╰────
+  help: Replace `var Hello = (props) => {
+                              return <div/>;
+                            }` with `function Hello(props) {
+                              return <div/>;
+                            }`.
+
+  ⚠ react(function-component-definition): Function component is not an arrow function
+   ╭─[function_component_definition.tsx:2:36]
+ 1 │     
+ 2 │ ╭─▶                     export default function Hello(props) {
+ 3 │ │                         return <div/>;
+ 4 │ ╰─▶                     }
+ 5 │                       
+   ╰────
+
+  ⚠ react(function-component-definition): Function component is not an arrow function
+   ╭─[function_component_definition.tsx:2:38]
+ 1 │     
+ 2 │ ╭─▶                     module.exports = function Hello(props) {
+ 3 │ │                         return <div/>;
+ 4 │ ╰─▶                     }
+ 5 │                       
+   ╰────
+
+  ⚠ react(function-component-definition): Function component is not an arrow function
+   ╭─[function_component_definition.tsx:2:21]
+ 1 │     
+ 2 │ ╭─▶                     function Hello(props) {
+ 3 │ │                         return <div/>;
+ 4 │ ╰─▶                     }
+ 5 │                       
+   ╰────
+  help: Replace `function Hello(props) {
+                              return <div/>;
+                            }` with `const Hello = (props) => {
+                              return <div/>;
+                            }`.
+
+  ⚠ react(function-component-definition): Function component is not a function declaration
+   ╭─[function_component_definition.tsx:2:33]
+ 1 │     
+ 2 │ ╭─▶                     var Hello = (props) => {
+ 3 │ │                         return <div/>;
+ 4 │ ╰─▶                     };
+ 5 │                       
+   ╰────
+  help: Replace `var Hello = (props) => {
+                              return <div/>;
+                            };` with `function Hello(props) {
+                              return <div/>;
+                            }`.
+
+  ⚠ react(function-component-definition): Function component is not a function expression
+   ╭─[function_component_definition.tsx:2:33]
+ 1 │     
+ 2 │ ╭─▶                     var Hello = (props) => {
+ 3 │ │                         return <div/>;
+ 4 │ ╰─▶                     };
+ 5 │                       
+   ╰────
+  help: Replace `var Hello = (props) => {
+                              return <div/>;
+                            };` with `var Hello = function(props) {
+                              return <div/>;
+                            }`.
+
+  ⚠ react(function-component-definition): Function component is not a function declaration
+    ╭─[function_component_definition.tsx:4:39]
+  3 │                 
+  4 │ ╭─▶                     const IndexPage = () => {
+  5 │ │                         return (
+  6 │ │                           <div>
+  7 │ │                             Hello World.{genX('$')}
+  8 │ │                           </div>
+  9 │ │                         )
+ 10 │ ╰─▶                     }
+ 11 │                 
+    ╰────
+  help: Replace `const IndexPage = () => {
+                              return (
+                                <div>
+                                  Hello World.{genX('$')}
+                                </div>
+                              )
+                            }` with `function IndexPage() {
+                              return (
+                                <div>
+                                  Hello World.{genX('$')}
+                                </div>
+                              )
+                            }`.

--- a/crates/oxc_linter/src/snapshots/react_function_component_definition.snap
+++ b/crates/oxc_linter/src/snapshots/react_function_component_definition.snap
@@ -627,3 +627,9 @@ source: crates/oxc_linter/src/tester.rs
                                 </div>
                               )
                             }`.
+
+  ⚠ react(function-component-definition): Function component is not an arrow function
+   ╭─[function_component_definition.tsx:1:1]
+ 1 │ function* Hello(props) { return <div/>; }
+   · ─────────────────────────────────────────
+   ╰────

--- a/crates/oxc_linter/src/snapshots/react_function_component_definition.snap
+++ b/crates/oxc_linter/src/snapshots/react_function_component_definition.snap
@@ -236,7 +236,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Replace `function Hello(props: Test) {
                               return React.createElement('div');
-                            }` with `var Hello = function(props: Test) {
+                            }` with `const Hello = function(props: Test) {
                               return React.createElement('div');
                             }`.
 

--- a/crates/oxc_linter/src/snapshots/react_function_component_definition.snap
+++ b/crates/oxc_linter/src/snapshots/react_function_component_definition.snap
@@ -633,3 +633,9 @@ source: crates/oxc_linter/src/tester.rs
  1 │ function* Hello(props) { return <div/>; }
    · ─────────────────────────────────────────
    ╰────
+
+  ⚠ react(function-component-definition): Function component is not an arrow function
+   ╭─[function_component_definition.tsx:1:1]
+ 1 │ function Hello(this: Context, props: Props) { return <div/>; }
+   · ──────────────────────────────────────────────────────────────
+   ╰────

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -6506,6 +6506,26 @@
         "react/forward-ref-uses-ref": {
           "$ref": "#/definitions/RuleNoConfig"
         },
+        "react/function-component-definition": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleNoConfig"
+            },
+            {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/AllowWarnDeny"
+                },
+                {
+                  "$ref": "#/definitions/FunctionComponentDefinition"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          ]
+        },
         "react/hook-use-state": {
           "anyOf": [
             {
@@ -11210,6 +11230,31 @@
       },
       "additionalProperties": false
     },
+    "FunctionComponentDefinition": {
+      "$ref": "#/definitions/FunctionComponentDefinitionConfig"
+    },
+    "FunctionComponentDefinitionConfig": {
+      "type": "object",
+      "properties": {
+        "namedComponents": {
+          "default": "function-declaration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NamedComponents"
+            }
+          ]
+        },
+        "unnamedComponents": {
+          "default": "function-expression",
+          "allOf": [
+            {
+              "$ref": "#/definitions/UnnamedComponents"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
     "GetterReturn": {
       "type": "object",
       "properties": {
@@ -13032,6 +13077,27 @@
         }
       ],
       "markdownDescription": "Name specifier that can be a single string or array of strings"
+    },
+    "NamedComponentStyle": {
+      "type": "string",
+      "enum": [
+        "function-declaration",
+        "arrow-function",
+        "function-expression"
+      ]
+    },
+    "NamedComponents": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/NamedComponentStyle"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NamedComponentStyle"
+          }
+        }
+      ]
     },
     "NamedExports": {
       "type": "string",
@@ -18805,6 +18871,26 @@
         }
       },
       "additionalProperties": false
+    },
+    "UnnamedComponentStyle": {
+      "type": "string",
+      "enum": [
+        "arrow-function",
+        "function-expression"
+      ]
+    },
+    "UnnamedComponents": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/UnnamedComponentStyle"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/UnnamedComponentStyle"
+          }
+        }
+      ]
     },
     "UseIsnan": {
       "type": "object",

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -410,6 +410,7 @@ react/display-name                                         |      7
 react/exhaustive-deps                                      |  62606
 react/forbid-component-props                               |    452
 react/forward-ref-uses-ref                                 |  62606
+react/function-component-definition                        |  16812
 react/hook-use-state                                       |  62606
 react/iframe-missing-sandbox                               |  63058
 react/jsx-boolean-value                                    |    452


### PR DESCRIPTION
## Summary

Adds a native Oxlint implementation of the [`eslint-plugin-react` `function-component-definition` rule](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/function-component-definition.md). This implementation is a port of the [rule source](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/function-component-definition.js), test suite, and autofix logic.

Related #1022

## AI Disclosure

GPT 5.6 Sol was used to assist with implementation of this rule.