### PR TITLE
refactor(napi): don't force tokio_rt on the napi binding crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,7 +171,7 @@ oxc_tasks_transform_checker = { path = "tasks/transform_checker" } # Transform v
 oxlint = { path = "apps/oxlint" } # Linter CLI
 
 # Relaxed version so the user can decide which version to use.
-napi = { version = "3", features = ["tokio_rt"] } # Node.js native bindings
+napi = { version = "3" } # Node.js native bindings
 napi-build = "2" # NAPI build tool
 napi-derive = "3" # NAPI proc macros
 

--- a/napi/parser/Cargo.toml
+++ b/napi/parser/Cargo.toml
@@ -31,7 +31,7 @@ oxc_str = { workspace = true }
 
 rustc-hash = { workspace = true }
 
-napi = { workspace = true, features = ["async"] }
+napi = { workspace = true }
 napi-derive = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]


### PR DESCRIPTION
## What

Stop forcing `tokio_rt` on oxc's napi binding crates.

`tokio_rt` was enabled as a blanket default on the workspace `napi` dependency, so **every** napi crate pulled in tokio. But the napi binding crates don't use a tokio runtime:

- no `#[napi] async fn` exports and no `tokio::` usage anywhere in the napi crates
- the only async surface is `oxc_parser_napi`'s `parse_async`, which is a libuv-backed `AsyncTask` / `Task` (napi4), **not** a tokio future

## Change (2 lines)

- workspace `Cargo.toml`: `napi = { version = "3", features = ["tokio_rt"] }` → `napi = { version = "3" }` — napi's own `default` already provides `napi4` + `dyn-symbols`, which covers `AsyncTask`
- `napi/parser/Cargo.toml`: drop the now-redundant `features = ["async"]`

## Effect

- oxc's napi crates (`oxc_napi`, `oxc_parser_napi`, `oxc_transform_napi`, `oxc_minify_napi`) no longer link tokio → smaller npm binaries
- downstream consumers that share the same `napi` (e.g. a bundler wiring napi's pluggable async-runtime SPI) are no longer forced to pull tokio in via Cargo feature unification
- crates that genuinely want napi's tokio async (`oxlint`, `oxfmt`) keep opting in explicitly via `features = ["async"]`

## Verification

- `cargo check --workspace` — green
- `cargo tree -i tokio` shows tokio gone from all four napi crates' normal dependency trees; `napi` now resolves to just `default` (`napi4` + `dyn-symbols`)
- CI validates the JS-side async parse (`parse_async`) tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T34fMrYCf2V13Mg8BKmnda

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-feature-only change with explicit opt-in preserved for crates that need napi async; async parse paths use `Task`/`AsyncTask`, not Tokio futures.
> 
> **Overview**
> Removes **`tokio_rt`** from the workspace **`napi`** dependency so NAPI binding crates no longer inherit Tokio through Cargo feature unification. **`napi/parser`** also drops the redundant **`features = ["async"]`** on its **`napi`** line.
> 
> Published NAPI crates (`oxc_parser_napi`, `oxc_transform_napi`, etc.) should link a smaller native addon while **`parse`** / **`parse_raw`** keep using **`AsyncTask`** / **`Task`** (napi4), not napi’s Tokio async runtime. Crates that need napi async (**`oxlint`**, **`oxfmt`**, playground) still enable **`features = ["async"]`** locally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48c63d442bcc2ffa8b88f5aa6f777137bebe8651. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->