### PR TITLE
perf(react_compiler): reduce allocations in reactive-places and mutation-aliasing passes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2447,6 +2447,7 @@ dependencies = [
  "oxc_str",
  "oxc_syntax",
  "rustc-hash",
+ "smallvec",
 ]
 
 [[package]]

--- a/crates/oxc_react_compiler/Cargo.toml
+++ b/crates/oxc_react_compiler/Cargo.toml
@@ -44,6 +44,7 @@ oxc_syntax = { workspace = true, features = ["to_js_string"] }
 indexmap = { workspace = true }
 rustc-hash = { workspace = true }
 cow-utils = { workspace = true }
+smallvec = { workspace = true }
 
 [dev-dependencies]
 # The example and integration tests parse source and print the compiled program; the

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
@@ -62,8 +62,8 @@ use crate::react_compiler_hir::type_config::ApplyArgConfig;
 use crate::react_compiler_hir::type_config::ValueKind;
 use crate::react_compiler_hir::type_config::ValueReason;
 use crate::react_compiler_hir::visitors;
-use crate::react_compiler_utils::FxIndexSet;
 use oxc_span::Span;
+use smallvec::SmallVec;
 use std::cell::Cell;
 use std::rc::Rc;
 
@@ -89,17 +89,20 @@ pub fn infer_mutation_aliasing_effects(
         let value_id = ValueId::new();
         initial_state.initialize(
             value_id,
-            AbstractValue { kind: ValueKind::Context, reason: hashset_of(ValueReason::Other) },
+            AbstractValue {
+                kind: ValueKind::Context,
+                reason: ReasonSet::single(ValueReason::Other),
+            },
         );
         initial_state.define(ctx_place.identifier, value_id);
     }
 
     let param_kind: AbstractValue = if is_function_expression {
-        AbstractValue { kind: ValueKind::Mutable, reason: hashset_of(ValueReason::Other) }
+        AbstractValue { kind: ValueKind::Mutable, reason: ReasonSet::single(ValueReason::Other) }
     } else {
         AbstractValue {
             kind: ValueKind::Frozen,
-            reason: hashset_of(ValueReason::ReactiveFunctionArgument),
+            reason: ReasonSet::single(ValueReason::ReactiveFunctionArgument),
         }
     };
 
@@ -117,7 +120,10 @@ pub fn infer_mutation_aliasing_effects(
             let value_id = ValueId::new();
             initial_state.initialize(
                 value_id,
-                AbstractValue { kind: ValueKind::Mutable, reason: hashset_of(ValueReason::Other) },
+                AbstractValue {
+                    kind: ValueKind::Mutable,
+                    reason: ReasonSet::single(ValueReason::Other),
+                },
             );
             initial_state.define(ref_place.identifier, value_id);
         }
@@ -290,13 +296,38 @@ impl ValueId {
 #[derive(Debug, Clone)]
 struct AbstractValue {
     kind: ValueKind,
-    reason: FxIndexSet<ValueReason>,
+    reason: ReasonSet,
 }
 
-fn hashset_of(r: ValueReason) -> FxIndexSet<ValueReason> {
-    let mut s = FxIndexSet::default();
-    s.insert(r);
-    s
+/// A small, insertion-ordered set of [`ValueReason`]s.
+///
+/// `AbstractValue`s are cloned constantly during the inference fixpoint — once per
+/// entry on every `InferenceState` clone — so `reason` must clone without
+/// allocating. The sets are tiny (usually a single element, never more than one
+/// per `ValueReason` variant), so an inline `SmallVec` avoids the per-clone heap
+/// allocation the previous `IndexSet` required. Insertion order is preserved to
+/// keep [`primary_reason`] (which returns the first non-`Other` reason) unchanged.
+#[derive(Debug, Clone, Default)]
+struct ReasonSet(SmallVec<[ValueReason; 4]>);
+
+impl ReasonSet {
+    fn single(reason: ValueReason) -> Self {
+        Self(smallvec::smallvec![reason])
+    }
+
+    fn insert(&mut self, reason: ValueReason) {
+        if !self.0.contains(&reason) {
+            self.0.push(reason);
+        }
+    }
+
+    fn contains(&self, reason: &ValueReason) -> bool {
+        self.0.contains(reason)
+    }
+
+    fn iter(&self) -> impl Iterator<Item = ValueReason> + '_ {
+        self.0.iter().copied()
+    }
 }
 
 // =============================================================================
@@ -347,7 +378,7 @@ impl InferenceState {
                 }
                 return AbstractValue {
                     kind: ValueKind::Mutable,
-                    reason: hashset_of(ValueReason::Other),
+                    reason: ReasonSet::single(ValueReason::Other),
                 };
             }
         };
@@ -364,7 +395,7 @@ impl InferenceState {
         }
         merged_kind.unwrap_or_else(|| AbstractValue {
             kind: ValueKind::Mutable,
-            reason: hashset_of(ValueReason::Other),
+            reason: ReasonSet::single(ValueReason::Other),
         })
     }
 
@@ -389,7 +420,7 @@ impl InferenceState {
                 set.insert(vid);
                 self.values.entry(vid).or_insert_with(|| AbstractValue {
                     kind: ValueKind::Mutable,
-                    reason: hashset_of(ValueReason::Other),
+                    reason: ReasonSet::single(ValueReason::Other),
                 });
                 Rc::new(set)
             }
@@ -449,7 +480,7 @@ impl InferenceState {
     fn freeze_value(&mut self, value_id: ValueId, reason: ValueReason) {
         self.values.insert(
             value_id,
-            AbstractValue { kind: ValueKind::Frozen, reason: hashset_of(reason) },
+            AbstractValue { kind: ValueKind::Frozen, reason: ReasonSet::single(reason) },
         );
         // Note: In TS, this also transitively freezes FunctionExpression captures
         // if enableTransitivelyFreezeFunctionExpressions is set. We skip that here
@@ -609,8 +640,8 @@ impl InferenceState {
     }
 }
 
-fn is_superset(a: &FxIndexSet<ValueReason>, b: &FxIndexSet<ValueReason>) -> bool {
-    b.iter().all(|x| a.contains(x))
+fn is_superset(a: &ReasonSet, b: &ReasonSet) -> bool {
+    b.iter().all(|x| a.contains(&x))
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -765,8 +796,8 @@ fn merge_abstract_values(a: &AbstractValue, b: &AbstractValue) -> AbstractValue 
         return a.clone();
     }
     let mut reason = a.reason.clone();
-    for r in &b.reason {
-        reason.insert(*r);
+    for r in b.reason.iter() {
+        reason.insert(r);
     }
     AbstractValue { kind, reason }
 }
@@ -1179,7 +1210,10 @@ fn apply_signature(
         let vid = ValueId::from_identifier(instr.lvalue.identifier);
         state.initialize(
             vid,
-            AbstractValue { kind: ValueKind::Mutable, reason: hashset_of(ValueReason::Other) },
+            AbstractValue {
+                kind: ValueKind::Mutable,
+                reason: ReasonSet::single(ValueReason::Other),
+            },
         );
         state.define(instr.lvalue.identifier, vid);
     }
@@ -1270,7 +1304,7 @@ fn apply_effect(
             );
             initialized.insert(into.identifier);
             let value_id = context.get_or_create_value_id(&effect);
-            state.initialize(value_id, AbstractValue { kind, reason: hashset_of(reason) });
+            state.initialize(value_id, AbstractValue { kind, reason: ReasonSet::single(reason) });
             state.define(into.identifier, value_id);
             effects.push(effect.clone());
         }
@@ -1399,7 +1433,7 @@ fn apply_effect(
                 value_id,
                 AbstractValue {
                     kind: if is_mutable { ValueKind::Mutable } else { ValueKind::Frozen },
-                    reason: FxIndexSet::default(),
+                    reason: ReasonSet::default(),
                 },
             );
             state.define(into.identifier, value_id);
@@ -2988,8 +3022,8 @@ fn compute_effects_for_aliasing_signature(
 /// since the primary reason is always inserted first, this effectively
 /// picks the most specific non-Other reason. We replicate this by
 /// preferring any non-Other reason over Other.
-fn primary_reason(reasons: &FxIndexSet<ValueReason>) -> ValueReason {
-    for &r in reasons {
+fn primary_reason(reasons: &ReasonSet) -> ValueReason {
+    for r in reasons.iter() {
         if r != ValueReason::Other {
             return r;
         }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_places.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_places.rs
@@ -18,9 +18,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::diagnostics::ErrorCategory;
-use crate::react_compiler_hir::dominator::{
-    PostDominator, compute_post_dominator_tree, post_dominator_frontier,
-};
+use crate::react_compiler_hir::dominator::{compute_post_dominator_tree, post_dominator_frontier};
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::object_shape::HookKind;
 use crate::react_compiler_hir::visitors;
@@ -64,6 +62,16 @@ pub fn infer_reactive_places(
     // Collect block IDs for iteration
     let block_ids: Vec<BlockId> = func.body.blocks.keys().copied().collect();
 
+    // Post-dominator frontiers depend only on the CFG, which is invariant across
+    // the fixpoint below. Compute each block's frontier once here instead of
+    // re-deriving it (a full reverse-CFG walk that allocates several sets) on every
+    // `is_reactive_controlled_block` call — previously once per block plus once per
+    // phi operand, on every fixpoint iteration.
+    let frontiers: FxHashMap<BlockId, FxHashSet<BlockId>> = block_ids
+        .iter()
+        .map(|&block_id| (block_id, post_dominator_frontier(func, &post_dominators, block_id)))
+        .collect();
+
     // Track phi operand reactive flags during fixpoint.
     // In TS, isReactive() sets place.reactive as a side effect. But when a phi
     // is already reactive, the TS `continue`s and skips operand processing.
@@ -76,7 +84,7 @@ pub fn infer_reactive_places(
         for block_id in &block_ids {
             let block = func.body.blocks.get(block_id).unwrap();
             let has_reactive_control =
-                is_reactive_controlled_block(block.id, func, &post_dominators, &mut reactive_map);
+                is_reactive_controlled_block(block.id, func, &frontiers, &mut reactive_map);
 
             // Process phi nodes
             let block = func.body.blocks.get(block_id).unwrap();
@@ -100,12 +108,8 @@ pub fn infer_reactive_places(
                     reactive_map.mark_reactive(phi.place.identifier);
                 } else {
                     for (pred, _operand) in &phi.operands {
-                        if is_reactive_controlled_block(
-                            *pred,
-                            func,
-                            &post_dominators,
-                            &mut reactive_map,
-                        ) {
+                        if is_reactive_controlled_block(*pred, func, &frontiers, &mut reactive_map)
+                        {
                             reactive_map.mark_reactive(phi.place.identifier);
                             break;
                         }
@@ -355,11 +359,11 @@ impl StableSidemap {
 fn is_reactive_controlled_block(
     block_id: BlockId,
     func: &HirFunction,
-    post_dominators: &PostDominator,
+    frontiers: &FxHashMap<BlockId, FxHashSet<BlockId>>,
     reactive_map: &mut ReactivityMap,
 ) -> bool {
-    let frontier = post_dominator_frontier(func, post_dominators, block_id);
-    for frontier_block_id in &frontier {
+    let Some(frontier) = frontiers.get(&block_id) else { return false };
+    for frontier_block_id in frontier {
         let control_block = func.body.blocks.get(frontier_block_id).unwrap();
         match &control_block.terminal {
             Terminal::If { test, .. } | Terminal::Branch { test, .. } => {


### PR DESCRIPTION
Two allocation-focused optimizations to the React Compiler's two hottest passes. Both are behavior-preserving — the full snapshot suite (`tests/snapshot.rs`, the ~1288 upstream fixtures) is unchanged, and no snapshots were regenerated.

Profiling the compiler on real component files showed ~99% of compile time is the compiler core (parse/semantic/codegen are <1% combined), and the core is allocation-bound: compiling a 35 KB file did ~1.2M heap allocations. These two changes remove most of that.

### 1. Memoize post-dominator frontiers (`infer_reactive_places`)

`is_reactive_controlled_block` recomputed each block's post-dominator frontier — a reverse-CFG walk that allocates several sets — on every call, which happens once per block and once per phi operand on every fixpoint iteration. The frontier depends only on the CFG, which is invariant across the fixpoint, so it is now computed once per block up front and looked up.

### 2. Inline `SmallVec` for `AbstractValue.reason` (`infer_mutation_aliasing_effects`)

`AbstractValue.reason` was an `FxIndexSet<ValueReason>`, which heap-allocates on every clone. During inference these values are cloned constantly (once per entry on every `InferenceState` clone), so the reason sets dominated allocation in the pass. The sets are tiny — usually a single element, never more than one per `ValueReason` variant — so they are now backed by an inline, insertion-ordered `SmallVec`: clones no longer allocate, and `primary_reason` (first non-`Other` reason) keeps its ordering.

### Results

Measured on real-world React component files (from `bluesky-social/social-app`), compile pass only, system allocator:

| File | before | after | allocations |
| --- | ---: | ---: | ---: |
| Explore.tsx (35 KB) | 49.6 ms | 23.5 ms (**2.1×**) | 1.24M → 220K (**−82%**) |
| MessageItem.tsx (30 KB) | 28.4 ms | 20.9 ms (**1.36×**) | 542K → 297K (**−45%**) |
| Drawer.tsx (21 KB) | 9.7 ms | 8.7 ms (1.11×) | 183K → 155K (−15%) |

\#2 is the larger lever — the reason-set clones dominated allocation in the pass. \#1 is a complementary ~6–10% CPU win from avoiding the redundant frontier recomputation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
