### PR TITLE
refactor(react_compiler): store aliasing signature config as &'static str

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler_hir/globals.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/globals.rs
@@ -177,7 +177,7 @@ fn install_type_config_inner<'a>(
                         .unwrap_or(false),
                     impure: func_config.impure.unwrap_or(false),
                     canonical_name: func_config.canonical_name.clone().map(Into::into),
-                    aliasing: func_config.aliasing.clone(),
+                    aliasing: func_config.aliasing,
                     known_incompatible: func_config.known_incompatible.clone().map(Into::into),
                     ..Default::default()
                 },
@@ -199,7 +199,7 @@ fn install_type_config_inner<'a>(
                     return_type,
                     return_value_kind: hook_config.return_value_kind.unwrap_or(ValueKind::Frozen),
                     no_alias: hook_config.no_alias.unwrap_or(false),
-                    aliasing: hook_config.aliasing.clone(),
+                    aliasing: hook_config.aliasing,
                     known_incompatible: hook_config.known_incompatible.clone().map(Into::into),
                     ..Default::default()
                 },
@@ -374,50 +374,40 @@ fn build_array_shape(shapes: &mut ShapeRegistry) {
             no_alias: true,
             mutable_only_if_operands_are_mutable: true,
             aliasing: Some(AliasingSignatureConfig {
-                receiver: "@receiver".to_string(),
-                params: vec!["@callback".to_string()],
+                receiver: "@receiver",
+                params: &["@callback"],
                 rest: None,
-                returns: "@returns".to_string(),
-                temporaries: vec![
-                    "@item".to_string(),
-                    "@callbackReturn".to_string(),
-                    "@thisArg".to_string(),
-                ],
-                effects: vec![
+                returns: "@returns",
+                temporaries: &["@item", "@callbackReturn", "@thisArg"],
+                effects: &[
                     // Map creates a new mutable array
                     AliasingEffectConfig::Create {
-                        into: "@returns".to_string(),
+                        into: "@returns",
                         value: ValueKind::Mutable,
                         reason: ValueReason::KnownReturnSignature,
                     },
                     // The first arg to the callback is an item extracted from the receiver array
-                    AliasingEffectConfig::CreateFrom {
-                        from: "@receiver".to_string(),
-                        into: "@item".to_string(),
-                    },
+                    AliasingEffectConfig::CreateFrom { from: "@receiver", into: "@item" },
                     // The undefined this for the callback
                     AliasingEffectConfig::Create {
-                        into: "@thisArg".to_string(),
+                        into: "@thisArg",
                         value: ValueKind::Primitive,
                         reason: ValueReason::KnownReturnSignature,
                     },
                     // Calls the callback, returning the result into a temporary
                     AliasingEffectConfig::Apply {
-                        receiver: "@thisArg".to_string(),
-                        function: "@callback".to_string(),
+                        receiver: "@thisArg",
+                        function: "@callback",
                         mutates_function: false,
-                        args: vec![
-                            ApplyArgConfig::Place("@item".to_string()),
+                        args: &[
+                            ApplyArgConfig::Place("@item"),
                             ApplyArgConfig::Hole { kind: ApplyArgHoleKind::Hole },
-                            ApplyArgConfig::Place("@receiver".to_string()),
+                            ApplyArgConfig::Place("@receiver"),
                         ],
-                        into: "@callbackReturn".to_string(),
+                        into: "@callbackReturn",
                     },
                     // Captures the result of the callback into the return array
-                    AliasingEffectConfig::Capture {
-                        from: "@callbackReturn".to_string(),
-                        into: "@returns".to_string(),
-                    },
+                    AliasingEffectConfig::Capture { from: "@callbackReturn", into: "@returns" },
                 ],
             }),
             ..Default::default()
@@ -525,22 +515,19 @@ fn build_array_shape(shapes: &mut ShapeRegistry) {
             return_type: Type::Primitive,
             return_value_kind: ValueKind::Primitive,
             aliasing: Some(AliasingSignatureConfig {
-                receiver: "@receiver".to_string(),
-                params: Vec::new(),
-                rest: Some("@rest".to_string()),
-                returns: "@returns".to_string(),
-                temporaries: Vec::new(),
-                effects: vec![
+                receiver: "@receiver",
+                params: &[],
+                rest: Some("@rest"),
+                returns: "@returns",
+                temporaries: &[],
+                effects: &[
                     // Push directly mutates the array itself
-                    AliasingEffectConfig::Mutate { value: "@receiver".to_string() },
+                    AliasingEffectConfig::Mutate { value: "@receiver" },
                     // The arguments are captured into the array
-                    AliasingEffectConfig::Capture {
-                        from: "@rest".to_string(),
-                        into: "@receiver".to_string(),
-                    },
+                    AliasingEffectConfig::Capture { from: "@rest", into: "@receiver" },
                     // Returns the new length, a primitive
                     AliasingEffectConfig::Create {
-                        into: "@returns".to_string(),
+                        into: "@returns",
                         value: ValueKind::Primitive,
                         reason: ValueReason::KnownReturnSignature,
                     },
@@ -599,24 +586,18 @@ fn build_set_shape(shapes: &mut ShapeRegistry) {
             return_type: Type::Object { shape_id: Some(BUILT_IN_SET_ID) },
             return_value_kind: ValueKind::Mutable,
             aliasing: Some(AliasingSignatureConfig {
-                receiver: "@receiver".to_string(),
-                params: Vec::new(),
-                rest: Some("@rest".to_string()),
-                returns: "@returns".to_string(),
-                temporaries: Vec::new(),
-                effects: vec![
+                receiver: "@receiver",
+                params: &[],
+                rest: Some("@rest"),
+                returns: "@returns",
+                temporaries: &[],
+                effects: &[
                     // Set.add returns the receiver Set
-                    AliasingEffectConfig::Assign {
-                        from: "@receiver".to_string(),
-                        into: "@returns".to_string(),
-                    },
+                    AliasingEffectConfig::Assign { from: "@receiver", into: "@returns" },
                     // Set.add mutates the set itself
-                    AliasingEffectConfig::Mutate { value: "@receiver".to_string() },
+                    AliasingEffectConfig::Mutate { value: "@receiver" },
                     // Captures the rest params into the set
-                    AliasingEffectConfig::Capture {
-                        from: "@rest".to_string(),
-                        into: "@receiver".to_string(),
-                    },
+                    AliasingEffectConfig::Capture { from: "@rest", into: "@receiver" },
                 ],
             }),
             ..Default::default()
@@ -1668,27 +1649,21 @@ fn build_react_apis<'a>(
             return_value_kind: ValueKind::Frozen,
             hook_kind: HookKind::UseEffect,
             aliasing: Some(AliasingSignatureConfig {
-                receiver: "@receiver".to_string(),
-                params: Vec::new(),
-                rest: Some("@rest".to_string()),
-                returns: "@returns".to_string(),
-                temporaries: vec!["@effect".to_string()],
-                effects: vec![
-                    AliasingEffectConfig::Freeze {
-                        value: "@rest".to_string(),
-                        reason: ValueReason::Effect,
-                    },
+                receiver: "@receiver",
+                params: &[],
+                rest: Some("@rest"),
+                returns: "@returns",
+                temporaries: &["@effect"],
+                effects: &[
+                    AliasingEffectConfig::Freeze { value: "@rest", reason: ValueReason::Effect },
                     AliasingEffectConfig::Create {
-                        into: "@effect".to_string(),
+                        into: "@effect",
                         value: ValueKind::Frozen,
                         reason: ValueReason::KnownReturnSignature,
                     },
-                    AliasingEffectConfig::Capture {
-                        from: "@rest".to_string(),
-                        into: "@effect".to_string(),
-                    },
+                    AliasingEffectConfig::Capture { from: "@rest", into: "@effect" },
                     AliasingEffectConfig::Create {
-                        into: "@returns".to_string(),
+                        into: "@returns",
                         value: ValueKind::Primitive,
                         reason: ValueReason::KnownReturnSignature,
                     },
@@ -1814,22 +1789,19 @@ fn build_typed_globals<'a>(
             return_type: Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID) },
             return_value_kind: ValueKind::Mutable,
             aliasing: Some(AliasingSignatureConfig {
-                receiver: "@receiver".to_string(),
-                params: vec!["@object".to_string()],
+                receiver: "@receiver",
+                params: &["@object"],
                 rest: None,
-                returns: "@returns".to_string(),
-                temporaries: Vec::new(),
-                effects: vec![
+                returns: "@returns",
+                temporaries: &[],
+                effects: &[
                     AliasingEffectConfig::Create {
-                        into: "@returns".to_string(),
+                        into: "@returns",
                         value: ValueKind::Mutable,
                         reason: ValueReason::KnownReturnSignature,
                     },
                     // Only keys are captured, and keys are immutable
-                    AliasingEffectConfig::ImmutableCapture {
-                        from: "@object".to_string(),
-                        into: "@returns".to_string(),
-                    },
+                    AliasingEffectConfig::ImmutableCapture { from: "@object", into: "@returns" },
                 ],
             }),
             ..Default::default()
@@ -1857,22 +1829,19 @@ fn build_typed_globals<'a>(
             return_type: Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID) },
             return_value_kind: ValueKind::Mutable,
             aliasing: Some(AliasingSignatureConfig {
-                receiver: "@receiver".to_string(),
-                params: vec!["@object".to_string()],
+                receiver: "@receiver",
+                params: &["@object"],
                 rest: None,
-                returns: "@returns".to_string(),
-                temporaries: Vec::new(),
-                effects: vec![
+                returns: "@returns",
+                temporaries: &[],
+                effects: &[
                     AliasingEffectConfig::Create {
-                        into: "@returns".to_string(),
+                        into: "@returns",
                         value: ValueKind::Mutable,
                         reason: ValueReason::KnownReturnSignature,
                     },
                     // Object values are captured into the return
-                    AliasingEffectConfig::Capture {
-                        from: "@object".to_string(),
-                        into: "@returns".to_string(),
-                    },
+                    AliasingEffectConfig::Capture { from: "@object", into: "@returns" },
                 ],
             }),
             ..Default::default()
@@ -1888,22 +1857,19 @@ fn build_typed_globals<'a>(
             return_type: Type::Object { shape_id: Some(BUILT_IN_ARRAY_ID) },
             return_value_kind: ValueKind::Mutable,
             aliasing: Some(AliasingSignatureConfig {
-                receiver: "@receiver".to_string(),
-                params: vec!["@object".to_string()],
+                receiver: "@receiver",
+                params: &["@object"],
                 rest: None,
-                returns: "@returns".to_string(),
-                temporaries: Vec::new(),
-                effects: vec![
+                returns: "@returns",
+                temporaries: &[],
+                effects: &[
                     AliasingEffectConfig::Create {
-                        into: "@returns".to_string(),
+                        into: "@returns",
                         value: ValueKind::Mutable,
                         reason: ValueReason::KnownReturnSignature,
                     },
                     // Object values are captured into the return
-                    AliasingEffectConfig::Capture {
-                        from: "@object".to_string(),
-                        into: "@returns".to_string(),
-                    },
+                    AliasingEffectConfig::Capture { from: "@object", into: "@returns" },
                 ],
             }),
             ..Default::default()

--- a/crates/oxc_react_compiler/src/react_compiler_hir/object_shape.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/object_shape.rs
@@ -402,28 +402,25 @@ pub fn default_nonmutating_hook<'a>(registry: &mut ShapeRegistry<'a>) -> Type<'a
             return_value_kind: ValueKind::Frozen,
             hook_kind: HookKind::Custom,
             aliasing: Some(AliasingSignatureConfig {
-                receiver: "@receiver".to_string(),
-                params: Vec::new(),
-                rest: Some("@rest".to_string()),
-                returns: "@returns".to_string(),
-                temporaries: Vec::new(),
-                effects: vec![
+                receiver: "@receiver",
+                params: &[],
+                rest: Some("@rest"),
+                returns: "@returns",
+                temporaries: &[],
+                effects: &[
                     // Freeze the arguments
                     AliasingEffectConfig::Freeze {
-                        value: "@rest".to_string(),
+                        value: "@rest",
                         reason: ValueReason::HookCaptured,
                     },
                     // Returns a frozen value
                     AliasingEffectConfig::Create {
-                        into: "@returns".to_string(),
+                        into: "@returns",
                         value: ValueKind::Frozen,
                         reason: ValueReason::HookReturn,
                     },
                     // May alias any arguments into the return
-                    AliasingEffectConfig::Alias {
-                        from: "@rest".to_string(),
-                        into: "@returns".to_string(),
-                    },
+                    AliasingEffectConfig::Alias { from: "@rest", into: "@returns" },
                 ],
             }),
             ..Default::default()

--- a/crates/oxc_react_compiler/src/react_compiler_hir/type_config.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/type_config.rs
@@ -44,62 +44,62 @@ pub enum ValueReason {
 // Aliasing effect config types (from TypeSchema.ts)
 // =============================================================================
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum AliasingEffectConfig {
     Freeze {
-        value: String,
+        value: &'static str,
         reason: ValueReason,
     },
     Create {
-        into: String,
+        into: &'static str,
         value: ValueKind,
         reason: ValueReason,
     },
     CreateFrom {
-        from: String,
-        into: String,
+        from: &'static str,
+        into: &'static str,
     },
     Assign {
-        from: String,
-        into: String,
+        from: &'static str,
+        into: &'static str,
     },
     Alias {
-        from: String,
-        into: String,
+        from: &'static str,
+        into: &'static str,
     },
     Capture {
-        from: String,
-        into: String,
+        from: &'static str,
+        into: &'static str,
     },
     ImmutableCapture {
-        from: String,
-        into: String,
+        from: &'static str,
+        into: &'static str,
     },
     Impure {
-        place: String,
+        place: &'static str,
     },
     Mutate {
-        value: String,
+        value: &'static str,
     },
     MutateTransitiveConditionally {
-        value: String,
+        value: &'static str,
     },
     Apply {
-        receiver: String,
-        function: String,
+        receiver: &'static str,
+        function: &'static str,
         mutates_function: bool,
-        args: Vec<ApplyArgConfig>,
-        into: String,
+        args: &'static [ApplyArgConfig],
+        into: &'static str,
     },
 }
 
 #[derive(Debug, Clone)]
 pub enum ApplyArgConfig {
-    Place(String),
+    Place(&'static str),
     Spread {
         #[allow(dead_code)]
         kind: ApplyArgSpreadKind,
-        place: String,
+        place: &'static str,
     },
     Hole {
         #[allow(dead_code)]
@@ -120,14 +120,14 @@ pub enum ApplyArgHoleKind {
 }
 
 /// Aliasing signature config, the JSON-serializable form.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct AliasingSignatureConfig {
-    pub receiver: String,
-    pub params: Vec<String>,
-    pub rest: Option<String>,
-    pub returns: String,
-    pub temporaries: Vec<String>,
-    pub effects: Vec<AliasingEffectConfig>,
+    pub receiver: &'static str,
+    pub params: &'static [&'static str],
+    pub rest: Option<&'static str>,
+    pub returns: &'static str,
+    pub temporaries: &'static [&'static str],
+    pub effects: &'static [AliasingEffectConfig],
 }
 
 // =============================================================================

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
@@ -2554,8 +2554,8 @@ fn compute_effects_for_aliasing_signature_config(
 ) -> Result<Option<Vec<AliasingEffect>>, OxcDiagnostic> {
     // Build substitutions from config strings to places
     let mut substitutions: FxHashMap<String, Vec<Place>> = FxHashMap::default();
-    substitutions.insert(config.receiver.clone(), vec![receiver.clone()]);
-    substitutions.insert(config.returns.clone(), vec![lvalue.clone()]);
+    substitutions.insert(config.receiver.to_string(), vec![receiver.clone()]);
+    substitutions.insert(config.returns.to_string(), vec![lvalue.clone()]);
 
     let mut mutable_spreads: FxHashSet<IdentifierId> = FxHashSet::default();
 
@@ -2565,9 +2565,9 @@ fn compute_effects_for_aliasing_signature_config(
             PlaceOrSpreadOrHole::Place(place)
             | PlaceOrSpreadOrHole::Spread(SpreadPattern { place }) => {
                 if i < config.params.len() && !matches!(arg, PlaceOrSpreadOrHole::Spread(_)) {
-                    substitutions.insert(config.params[i].clone(), vec![place.clone()]);
-                } else if let Some(ref rest) = config.rest {
-                    substitutions.entry(rest.clone()).or_default().push(place.clone());
+                    substitutions.insert(config.params[i].to_string(), vec![place.clone()]);
+                } else if let Some(rest) = config.rest {
+                    substitutions.entry(rest.to_string()).or_default().push(place.clone());
                 } else {
                     return Ok(None);
                 }
@@ -2591,21 +2591,21 @@ fn compute_effects_for_aliasing_signature_config(
     }
 
     // Create temporaries (cached by lvalue + temp_name to be stable across fixpoint iterations)
-    for temp_name in &config.temporaries {
-        let cache_key = (lvalue.identifier, temp_name.clone());
+    for temp_name in config.temporaries {
+        let cache_key = (lvalue.identifier, temp_name.to_string());
         let temp_place = temp_cache
             .entry(cache_key)
             .or_insert_with(|| create_temp_place(env, receiver.span))
             .clone();
-        substitutions.insert(temp_name.clone(), vec![temp_place]);
+        substitutions.insert(temp_name.to_string(), vec![temp_place]);
     }
 
     let mut effects: Vec<AliasingEffect> = Vec::new();
 
-    for eff_config in &config.effects {
+    for eff_config in config.effects {
         match eff_config {
             AliasingEffectConfig::Freeze { value, reason } => {
-                let values = substitutions.get(value).cloned().unwrap_or_default();
+                let values = substitutions.get(*value).cloned().unwrap_or_default();
                 for v in values {
                     if mutable_spreads.contains(&v.identifier) {
                         return Err(ErrorCategory::Todo
@@ -2616,7 +2616,7 @@ fn compute_effects_for_aliasing_signature_config(
                 }
             }
             AliasingEffectConfig::Create { into, value, reason } => {
-                let intos = substitutions.get(into).cloned().unwrap_or_default();
+                let intos = substitutions.get(*into).cloned().unwrap_or_default();
                 for v in intos {
                     effects.push(AliasingEffect::Create {
                         into: v,
@@ -2626,8 +2626,8 @@ fn compute_effects_for_aliasing_signature_config(
                 }
             }
             AliasingEffectConfig::CreateFrom { from, into } => {
-                let froms = substitutions.get(from).cloned().unwrap_or_default();
-                let intos = substitutions.get(into).cloned().unwrap_or_default();
+                let froms = substitutions.get(*from).cloned().unwrap_or_default();
+                let intos = substitutions.get(*into).cloned().unwrap_or_default();
                 for f in &froms {
                     for t in &intos {
                         effects
@@ -2636,8 +2636,8 @@ fn compute_effects_for_aliasing_signature_config(
                 }
             }
             AliasingEffectConfig::Assign { from, into } => {
-                let froms = substitutions.get(from).cloned().unwrap_or_default();
-                let intos = substitutions.get(into).cloned().unwrap_or_default();
+                let froms = substitutions.get(*from).cloned().unwrap_or_default();
+                let intos = substitutions.get(*into).cloned().unwrap_or_default();
                 for f in &froms {
                     for t in &intos {
                         effects.push(AliasingEffect::Assign { from: f.clone(), into: t.clone() });
@@ -2645,8 +2645,8 @@ fn compute_effects_for_aliasing_signature_config(
                 }
             }
             AliasingEffectConfig::Alias { from, into } => {
-                let froms = substitutions.get(from).cloned().unwrap_or_default();
-                let intos = substitutions.get(into).cloned().unwrap_or_default();
+                let froms = substitutions.get(*from).cloned().unwrap_or_default();
+                let intos = substitutions.get(*into).cloned().unwrap_or_default();
                 for f in &froms {
                     for t in &intos {
                         effects.push(AliasingEffect::Alias { from: f.clone(), into: t.clone() });
@@ -2654,8 +2654,8 @@ fn compute_effects_for_aliasing_signature_config(
                 }
             }
             AliasingEffectConfig::Capture { from, into } => {
-                let froms = substitutions.get(from).cloned().unwrap_or_default();
-                let intos = substitutions.get(into).cloned().unwrap_or_default();
+                let froms = substitutions.get(*from).cloned().unwrap_or_default();
+                let intos = substitutions.get(*into).cloned().unwrap_or_default();
                 for f in &froms {
                     for t in &intos {
                         effects.push(AliasingEffect::Capture { from: f.clone(), into: t.clone() });
@@ -2663,8 +2663,8 @@ fn compute_effects_for_aliasing_signature_config(
                 }
             }
             AliasingEffectConfig::ImmutableCapture { from, into } => {
-                let froms = substitutions.get(from).cloned().unwrap_or_default();
-                let intos = substitutions.get(into).cloned().unwrap_or_default();
+                let froms = substitutions.get(*from).cloned().unwrap_or_default();
+                let intos = substitutions.get(*into).cloned().unwrap_or_default();
                 for f in &froms {
                     for t in &intos {
                         effects.push(AliasingEffect::ImmutableCapture {
@@ -2675,7 +2675,7 @@ fn compute_effects_for_aliasing_signature_config(
                 }
             }
             AliasingEffectConfig::Impure { place } => {
-                let values = substitutions.get(place).cloned().unwrap_or_default();
+                let values = substitutions.get(*place).cloned().unwrap_or_default();
                 for v in values {
                     effects.push(AliasingEffect::Impure {
                         place: v,
@@ -2684,13 +2684,13 @@ fn compute_effects_for_aliasing_signature_config(
                 }
             }
             AliasingEffectConfig::Mutate { value } => {
-                let values = substitutions.get(value).cloned().unwrap_or_default();
+                let values = substitutions.get(*value).cloned().unwrap_or_default();
                 for v in values {
                     effects.push(AliasingEffect::Mutate { value: v, reason: None });
                 }
             }
             AliasingEffectConfig::MutateTransitiveConditionally { value } => {
-                let values = substitutions.get(value).cloned().unwrap_or_default();
+                let values = substitutions.get(*value).cloned().unwrap_or_default();
                 for v in values {
                     effects.push(AliasingEffect::MutateTransitiveConditionally { value: v });
                 }
@@ -2702,25 +2702,25 @@ fn compute_effects_for_aliasing_signature_config(
                 args: a,
                 into: i,
             } => {
-                let recv = substitutions.get(r).and_then(|v| v.first()).cloned();
-                let func = substitutions.get(f).and_then(|v| v.first()).cloned();
-                let into = substitutions.get(i).and_then(|v| v.first()).cloned();
+                let recv = substitutions.get(*r).and_then(|v| v.first()).cloned();
+                let func = substitutions.get(*f).and_then(|v| v.first()).cloned();
+                let into = substitutions.get(*i).and_then(|v| v.first()).cloned();
                 if let (Some(recv), Some(func), Some(into)) = (recv, func, into) {
                     let mut apply_args: Vec<PlaceOrSpreadOrHole> = Vec::new();
-                    for arg in a {
+                    for arg in *a {
                         match arg {
                             ApplyArgConfig::Hole { .. } => {
                                 apply_args.push(PlaceOrSpreadOrHole::Hole);
                             }
                             ApplyArgConfig::Place(name) => {
-                                if let Some(places) = substitutions.get(name)
+                                if let Some(places) = substitutions.get(*name)
                                     && let Some(p) = places.first()
                                 {
                                     apply_args.push(PlaceOrSpreadOrHole::Place(p.clone()));
                                 }
                             }
                             ApplyArgConfig::Spread { place: name, .. } => {
-                                if let Some(places) = substitutions.get(name)
+                                if let Some(places) = substitutions.get(*name)
                                     && let Some(p) = places.first()
                                 {
                                     apply_args.push(PlaceOrSpreadOrHole::Spread(SpreadPattern {


### PR DESCRIPTION
The built-in aliasing signatures in `globals.rs`/`object_shape.rs` are all compile-time string literals, so `AliasingSignatureConfig` (and the `AliasingEffectConfig`/`ApplyArgConfig` it contains) can hold `&'static str` / `&'static [...]` instead of `String`/`Vec`. This removes the 59 `.to_string()` allocations from the once-per-process built-in registry build.

Shrinks the react_compiler-enabled `oxc-transform` `.node` by **~16 KiB** (5,403,088 → 5,386,640 bytes, stripped release). Snapshots unchanged (`cargo test -p oxc_react_compiler`).