### PR TITLE
chore(repo): normalize funding metadata

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,1 @@
-github: [Boshen, Dunqing, camc314, leaysgur]
 open_collective: oxc


### PR DESCRIPTION
Remove personal sponsorship targets from selected funding files and direct sponsorship to the Oxc Open Collective only.