### PR TITLE
fix(formatter): suppressed trailing semi

### DIFF
--- a/crates/oxc_formatter/AGENTS.md
+++ b/crates/oxc_formatter/AGENTS.md
@@ -73,6 +73,13 @@ Above all, prioritize consistency, and always consider whether the divergence is
 
 ### Comment placement invariants
 
+Two layers of rules, know which one you are editing:
+
+- Invariants hold uniformly
+  - violating one is a bug even where Prettier disagrees (the "Never let it cross" list below, and the content/terminator ownership split)
+- Compat tables record measured Prettier behavior that is not derivable from principle (the variant tables below)
+  - extend them by measuring Prettier, never by analogy, and pin every entry in a fixture
+
 Repositioning a comment is allowed only relative to formatter-owned punctuation
 (e.g. printing `;` before a same-line trailing comment, see `FormatContentWithSemicolon`).
 
@@ -107,12 +114,12 @@ so pin every position change in a fixture.
 The move-behind-the-terminator policy has four deliberate variants.
 When extending to a new node, pick by measuring Prettier, not by analogy:
 
-| Site                                                        | Source `;` required?      | Own-line comment before `;`              |
-| ----------------------------------------------------------- | ------------------------- | ---------------------------------------- |
-| Statements (`FormatContentWithSemicolon`)                   | yes (ASI: no move)        | deferred to the next node's leading pass |
-| return/throw (`ReturnAndThrowStatement`)                    | no (moves even under ASI) | printed as dangling                      |
-| Class property/accessor (`FormatClassElementWithSemicolon`) | yes                       | cancels the move (stays own-line)        |
-| Bodyless methods (`MethodDefinition`)                       | yes                       | cancels the move                         |
+| Site                                                        | Source `;` required?      | Own-line comment before `;`                                                           |
+| ----------------------------------------------------------- | ------------------------- | ------------------------------------------------------------------------------------- |
+| Statements (`FormatContentWithSemicolon`)                   | yes (ASI: no move)        | deferred to the next node's leading pass                                              |
+| return/throw (`ReturnAndThrowStatement`)                    | no (moves even under ASI) | deferred to the next node's leading pass (only the same-line prefix moves behind `;`) |
+| Class property/accessor (`FormatClassElementWithSemicolon`) | yes                       | cancels the move (stays own-line)                                                     |
+| Bodyless methods (`MethodDefinition`)                       | yes                       | cancels the move                                                                      |
 
 Never let it cross:
 
@@ -129,6 +136,29 @@ Never let it cross:
 Prettier's comment _attachment_ is position-heuristic and sometimes asymmetric
 (e.g. it moves `export type T = string /* c */;`'s comment behind the semicolon but not the non-exported form).
 When that happens, prefer one uniform rule over emulating the asymmetry, and pin the intentional divergence in a fixture with a note.
+
+### Statement terminators and suppression
+
+The formatter owns statement terminators (and the trivia up to them); the user owns content.
+Prettier encodes "the trailing `;` is outside the statement" once, in `locEnd`;
+deciding on the spot, we encode the same policy per site, so keep them in step:
+
+- print side: `FormatContentWithSemicolon` and the move-behind table above
+- return/throw: the same-line-prefix dangling split in `ReturnAndThrowStatement`
+- capture side: `Comments::get_trailing_comments` lets deferred own-line comments escape when the statement shares its distant `;` with the enclosing statement
+  (a single-statement body, `if (1) foo\n// c\n;`); a block's last statement keeps them inside instead
+- suppressed side: `suppressed_statement_content_end` (`print/mod.rs`) ends the ignored range at the content,
+  so even a `prettier-ignore`d statement gets the formatter's terminator (per `semi`) instead of its source one
+
+Accepted edges (byte-identical to Prettier, semantically inert, idempotent):
+
+- Whether a suppressed statement re-adds `;` is a compat table, not a principle:
+  keyword statements (`debugger`/`break`/`continue`) always re-add,
+  content-terminated ones only when a source `;` was stripped — the asymmetry is observable only for a suppressed keyword statement relying on ASI
+- The `semi: false` ASI guard is decided from the guarded statement alone,
+  never from the previous statement's output;
+  sound because no statement leaves its own trailing `;`,
+  except a verbatim empty-statement body (`with (1) ;`, that `;` IS the body, i.e. content), where guard plus verbatim `;` re-parse as one extra inert `EmptyStatement`
 
 ## Verification
 

--- a/crates/oxc_formatter/src/ast_nodes/generated/format.rs
+++ b/crates/oxc_formatter/src/ast_nodes/generated/format.rs
@@ -1945,7 +1945,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, IfStatement<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            self.write_suppressed(f);
         } else {
             self.write(f);
         }
@@ -1971,7 +1971,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, WhileStatement<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            self.write_suppressed(f);
         } else {
             self.write(f);
         }
@@ -1984,7 +1984,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ForStatement<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            self.write_suppressed(f);
         } else {
             self.write(f);
         }
@@ -2028,7 +2028,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ForInStatement<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            self.write_suppressed(f);
         } else {
             self.write(f);
         }
@@ -2072,7 +2072,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ForOfStatement<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            self.write_suppressed(f);
         } else {
             self.write(f);
         }
@@ -2111,7 +2111,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ReturnStatement<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            self.write_suppressed(f);
         } else {
             self.write(f);
         }
@@ -2124,7 +2124,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, WithStatement<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            self.write_suppressed(f);
         } else {
             self.write(f);
         }
@@ -2163,7 +2163,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, LabeledStatement<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            self.write_suppressed(f);
         } else {
             self.write(f);
         }
@@ -2176,7 +2176,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ThrowStatement<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            self.write_suppressed(f);
         } else {
             self.write(f);
         }
@@ -2228,7 +2228,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, DebuggerStatement> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            self.write_suppressed(f);
         } else {
             self.write(f);
         }

--- a/crates/oxc_formatter/src/formatter/comments.rs
+++ b/crates/oxc_formatter/src/formatter/comments.rs
@@ -427,6 +427,51 @@ impl<'a> Comments<'a> {
         if following_span_start == 0 {
             // Find dangling comments at the end of the enclosing node
             let comments = self.comments_before(enclosing_span.end);
+
+            // When the enclosing statement ends at the very position the preceding node does
+            // (a single-statement body sharing its distant `;`),
+            // ```js
+            // if (1) foo
+            // // c
+            // ;
+            // ```
+            // every comment here sits inside the preceding node,
+            // and own-line comments the preceding statement deferred must escape the enclosing statement
+            // to stay own-line for a later pass (the next statement's leading comments),
+            // like Prettier whose statement `locEnd` excludes the trailing `;`.
+            // When the enclosing node continues past the preceding one (e.g. a block's last statement),
+            // the loop below keeps them inside as trailing comments instead.
+            if enclosing_span.end == preceding_span.end {
+                for (idx, comment) in comments.iter().enumerate() {
+                    if !comment.preceded_by_newline() {
+                        continue;
+                    }
+                    // Everything from here to the terminator must be trivia:
+                    // a run of own-line comments separated by whitespace, then the `;`.
+                    let mut pos = comment.span.end;
+                    let mut deferrable = true;
+                    for next in &comments[idx + 1..] {
+                        if !next.preceded_by_newline()
+                            || !source_text
+                                .all_bytes_match(pos, next.span.start, |b| b.is_ascii_whitespace())
+                        {
+                            deferrable = false;
+                            break;
+                        }
+                        pos = next.span.end;
+                    }
+                    if deferrable
+                        && source_text.all_bytes_match(pos, preceding_span.end, |b| {
+                            b.is_ascii_whitespace() || b == b';'
+                        })
+                        && source_text.bytes_contain(pos, preceding_span.end, b';')
+                    {
+                        return &comments[..idx];
+                    }
+                }
+                return comments;
+            }
+
             let mut start = preceding_span.end;
             for (idx, comment) in comments.iter().enumerate() {
                 // Comments inside the preceding node, which should be printed without checking

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -625,12 +625,106 @@ fn write_suppressed_statement_with_semicolon(
     write!(f, [FormatSuppressedNode(Span::new(start, content_end)), OptionalSemicolon]);
 }
 
+/// Prints a suppressed statement whose ignored range may or may not have had
+/// its trailing `;` stripped (see [`suppressed_statement_content_end`]).
+fn write_suppressed_statement(
+    span: Span,
+    content_end: u32,
+    print_semicolon: bool,
+    f: &mut JsFormatter<'_, '_>,
+) {
+    if print_semicolon {
+        write_suppressed_statement_with_semicolon(span.start, content_end, f);
+    } else {
+        debug_assert_eq!(content_end, span.end);
+        FormatSuppressedNode(span).fmt(f);
+    }
+}
+
+/// The ignored range end for a statement terminated by a (possibly distant) source `;`,
+/// and whether one was actually stripped (so the formatter must print its own).
+fn semicolon_terminated_content_end(
+    content_end: u32,
+    span: Span,
+    f: &JsFormatter<'_, '_>,
+) -> (u32, bool) {
+    let end = f.comments().end_including_source_parens(content_end, span.end);
+    (end, end < span.end)
+}
+
+#[expect(clippy::cast_possible_truncation)]
+const RETURN_KEYWORD_LEN: u32 = "return".len() as u32;
+#[expect(clippy::cast_possible_truncation)]
+const DEBUGGER_KEYWORD_LEN: u32 = "debugger".len() as u32;
+#[expect(clippy::cast_possible_truncation)]
+const BREAK_KEYWORD_LEN: u32 = "break".len() as u32;
+#[expect(clippy::cast_possible_truncation)]
+const CONTINUE_KEYWORD_LEN: u32 = "continue".len() as u32;
+
+/// The ignored range end for `return` (the argument or the keyword),
+/// and whether a source `;` was stripped.
+fn return_statement_content_end(s: &ReturnStatement<'_>, f: &JsFormatter<'_, '_>) -> (u32, bool) {
+    s.argument.as_ref().map_or_else(
+        || {
+            let keyword_end = s.span.start + RETURN_KEYWORD_LEN;
+            (keyword_end, keyword_end < s.span.end)
+        },
+        |argument| semicolon_terminated_content_end(argument.span().end, s.span, f),
+    )
+}
+
+/// The ignored range end for `break`/`continue`: the label, or the keyword.
+fn break_or_continue_content_end(
+    span: Span,
+    keyword_len: u32,
+    label: Option<&LabelIdentifier<'_>>,
+) -> u32 {
+    label.map_or(span.start + keyword_len, |label| label.span.end)
+}
+
+/// The ignored range end of a suppressed statement and whether the formatter prints its own terminator after it,
+/// mirroring Prettier's `locEnd` overrides (`language-js/location/overrides.js`) + `shouldIgnoredNodePrintSemicolon`:
+/// the trailing `;` (and anything between it and the content) is excluded from the verbatim range,
+/// keyword statements (`debugger`/`break`/`continue`) always re-add `;`,
+/// content-terminated ones only when a source `;` was stripped, and statements ending in a body recurse into the rightmost body.
+fn suppressed_statement_content_end(stmt: &Statement<'_>, f: &JsFormatter<'_, '_>) -> (u32, bool) {
+    match stmt {
+        Statement::ExpressionStatement(s) => {
+            semicolon_terminated_content_end(s.expression.span().end, s.span, f)
+        }
+        Statement::ReturnStatement(s) => return_statement_content_end(s, f),
+        Statement::ThrowStatement(s) => {
+            semicolon_terminated_content_end(s.argument.span().end, s.span, f)
+        }
+        Statement::DoWhileStatement(s) => {
+            semicolon_terminated_content_end(s.test.span().end, s.span, f)
+        }
+        Statement::DebuggerStatement(s) => (s.span.start + DEBUGGER_KEYWORD_LEN, true),
+        Statement::BreakStatement(s) => {
+            (break_or_continue_content_end(s.span, BREAK_KEYWORD_LEN, s.label.as_ref()), true)
+        }
+        Statement::ContinueStatement(s) => {
+            (break_or_continue_content_end(s.span, CONTINUE_KEYWORD_LEN, s.label.as_ref()), true)
+        }
+        Statement::IfStatement(s) => {
+            suppressed_statement_content_end(s.alternate.as_ref().unwrap_or(&s.consequent), f)
+        }
+        Statement::WhileStatement(s) => suppressed_statement_content_end(&s.body, f),
+        Statement::WithStatement(s) => suppressed_statement_content_end(&s.body, f),
+        Statement::ForStatement(s) => suppressed_statement_content_end(&s.body, f),
+        Statement::ForInStatement(s) => suppressed_statement_content_end(&s.body, f),
+        Statement::ForOfStatement(s) => suppressed_statement_content_end(&s.body, f),
+        Statement::LabeledStatement(s) => suppressed_statement_content_end(&s.body, f),
+        _ => (stmt.span().end, false),
+    }
+}
+
 impl<'a> FormatWrite<'a> for AstNode<'a, DoWhileStatement<'a>> {
     fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
         // The ignored range ends at the closing paren
-        let rparen_end =
-            f.comments().end_including_source_parens(self.test().span().end, self.span().end);
-        write_suppressed_statement_with_semicolon(self.span().start, rparen_end, f);
+        let (content_end, print_semicolon) =
+            semicolon_terminated_content_end(self.test().span().end, self.span(), f);
+        write_suppressed_statement(self.span(), content_end, print_semicolon, f);
     }
 
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
@@ -706,6 +800,11 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatTestOfIfAndWhileStatement<'a,
     }
 }
 impl<'a> FormatWrite<'a> for AstNode<'a, WhileStatement<'a>> {
+    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
+        let (content_end, print_semicolon) = suppressed_statement_content_end(&self.body, f);
+        write_suppressed_statement(self.span(), content_end, print_semicolon, f);
+    }
+
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         let body = self.body();
         write!(
@@ -726,6 +825,11 @@ impl<'a> FormatWrite<'a> for AstNode<'a, WhileStatement<'a>> {
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ForStatement<'a>> {
+    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
+        let (content_end, print_semicolon) = suppressed_statement_content_end(&self.body, f);
+        write_suppressed_statement(self.span(), content_end, print_semicolon, f);
+    }
+
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         let init = self.init();
         let test = self.test();
@@ -766,6 +870,11 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForStatement<'a>> {
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ForInStatement<'a>> {
+    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
+        let (content_end, print_semicolon) = suppressed_statement_content_end(&self.body, f);
+        write_suppressed_statement(self.span(), content_end, print_semicolon, f);
+    }
+
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         let comments = f.context().comments().own_line_comments_before(self.right.span().start);
         let left = self.left();
@@ -797,6 +906,11 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForInStatement<'a>> {
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ForOfStatement<'a>> {
+    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
+        let (content_end, print_semicolon) = suppressed_statement_content_end(&self.body, f);
+        write_suppressed_statement(self.span(), content_end, print_semicolon, f);
+    }
+
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         let comments = f.context().comments().own_line_comments_before(self.right.span().start);
 
@@ -836,6 +950,14 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForOfStatement<'a>> {
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, IfStatement<'a>> {
+    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
+        let (content_end, print_semicolon) = suppressed_statement_content_end(
+            self.alternate.as_ref().unwrap_or(&self.consequent),
+            f,
+        );
+        write_suppressed_statement(self.span(), content_end, print_semicolon, f);
+    }
+
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         let test = self.test();
         let consequent = self.consequent();
@@ -907,12 +1029,9 @@ impl<'a> FormatWrite<'a> for AstNode<'a, IfStatement<'a>> {
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ContinueStatement<'a>> {
     fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
-        #[expect(clippy::cast_possible_truncation)]
-        const CONTINUE_KEYWORD_LEN: u32 = "continue".len() as u32;
-
         // The ignored range ends at the label (or the keyword)
         let content_end =
-            self.label().map_or_else(|| self.span().start + CONTINUE_KEYWORD_LEN, |l| l.span().end);
+            break_or_continue_content_end(self.span(), CONTINUE_KEYWORD_LEN, self.label.as_ref());
         write_suppressed_statement_with_semicolon(self.span().start, content_end, f);
     }
 
@@ -928,12 +1047,9 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ContinueStatement<'a>> {
 
 impl<'a> FormatWrite<'a> for AstNode<'a, BreakStatement<'a>> {
     fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
-        #[expect(clippy::cast_possible_truncation)]
-        const BREAK_KEYWORD_LEN: u32 = "break".len() as u32;
-
         // The ignored range ends at the label (or the keyword)
         let content_end =
-            self.label().map_or_else(|| self.span().start + BREAK_KEYWORD_LEN, |l| l.span().end);
+            break_or_continue_content_end(self.span(), BREAK_KEYWORD_LEN, self.label.as_ref());
         write_suppressed_statement_with_semicolon(self.span().start, content_end, f);
     }
 
@@ -948,6 +1064,11 @@ impl<'a> FormatWrite<'a> for AstNode<'a, BreakStatement<'a>> {
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, WithStatement<'a>> {
+    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
+        let (content_end, print_semicolon) = suppressed_statement_content_end(&self.body, f);
+        write_suppressed_statement(self.span(), content_end, print_semicolon, f);
+    }
+
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         write!(
             f,
@@ -964,6 +1085,11 @@ impl<'a> FormatWrite<'a> for AstNode<'a, WithStatement<'a>> {
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, LabeledStatement<'a>> {
+    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
+        let (content_end, print_semicolon) = suppressed_statement_content_end(&self.body, f);
+        write_suppressed_statement(self.span(), content_end, print_semicolon, f);
+    }
+
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         let comments = f.context().comments().line_comments_before(self.body.span().start);
         FormatLeadingComments::Comments(comments).fmt(f);
@@ -989,6 +1115,15 @@ impl<'a> FormatWrite<'a> for AstNode<'a, LabeledStatement<'a>> {
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, DebuggerStatement> {
+    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
+        // The ignored range ends at the keyword
+        write_suppressed_statement_with_semicolon(
+            self.span.start,
+            self.span.start + DEBUGGER_KEYWORD_LEN,
+            f,
+        );
+    }
+
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         write!(f, ["debugger", OptionalSemicolon]);
     }

--- a/crates/oxc_formatter/src/print/return_or_throw_statement.rs
+++ b/crates/oxc_formatter/src/print/return_or_throw_statement.rs
@@ -5,8 +5,14 @@ use crate::{
     Format,
     ast_nodes::{AstNode, AstNodes},
     format_args,
-    formatter::prelude::*,
-    print::{ExpressionLeftSide, semicolon::OptionalSemicolon},
+    formatter::{
+        prelude::*,
+        trivia::{DanglingIndentMode, FormatDanglingComments},
+    },
+    print::{
+        ExpressionLeftSide, return_statement_content_end, semicolon::OptionalSemicolon,
+        semicolon_terminated_content_end, write_suppressed_statement,
+    },
     utils::{
         format_node_without_trailing_comments::format_content_without_comments_after,
         typecast::format_leading_comments_and_open_paren,
@@ -17,12 +23,25 @@ use crate::{
 use super::FormatWrite;
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ReturnStatement<'a>> {
+    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
+        // The ignored range ends at the argument (or the keyword),
+        // excluding a stripped trailing `;`
+        let (content_end, print_semicolon) = return_statement_content_end(self, f);
+        write_suppressed_statement(self.span, content_end, print_semicolon, f);
+    }
+
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         ReturnAndThrowStatement::ReturnStatement(self).fmt(f);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ThrowStatement<'a>> {
+    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
+        let (content_end, print_semicolon) =
+            semicolon_terminated_content_end(self.argument().span().end, self.span, f);
+        write_suppressed_statement(self.span, content_end, print_semicolon, f);
+    }
+
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         ReturnAndThrowStatement::ThrowStatement(self).fmt(f);
     }
@@ -95,12 +114,27 @@ impl<'a> Format<'a, JsFormatContext<'a>> for ReturnAndThrowStatement<'a, '_> {
 
         // The semicolon goes before the dangling comments, like Prettier:
         // `return foo /* comment */;` -> `return foo; /* comment */`
+        // Own-line comments stay own-line:
+        // from the first one on, comments are left for a later pass (the next node's leading comments),
+        // also like Prettier, whose statement `locEnd` excludes the trailing `;`.
         let dangling_comments = f.context().comments().comments_before(self.span().end);
+        let same_line_count =
+            dangling_comments.iter().take_while(|c| !c.preceded_by_newline()).count();
+        let dangling_comments = &dangling_comments[..same_line_count];
 
         write!(f, OptionalSemicolon);
 
         if !dangling_comments.is_empty() {
-            write!(f, [space(), format_dangling_comments(self.span())]);
+            write!(
+                f,
+                [
+                    space(),
+                    FormatDanglingComments::Comments {
+                        comments: dangling_comments,
+                        indent: DanglingIndentMode::None
+                    }
+                ]
+            );
         }
     }
 }

--- a/crates/oxc_formatter/tests/fixtures/js/semicolons/statement-terminator-own-line-comment.js
+++ b/crates/oxc_formatter/tests/fixtures/js/semicolons/statement-terminator-own-line-comment.js
@@ -1,0 +1,31 @@
+// An own-line comment between a statement's content and its distant `;`
+// terminator stays own-line: it leads the next statement (or ends the block),
+// and never drags a single-statement body onto its own line.
+
+if (1) foo
+
+// leading of the next statement
+;[].sort()
+
+if (1) foo
+
+// a run of own-line comments
+// escapes as a whole
+;[].sort()
+
+function f() {
+  if (1) foo
+  // stays at the end of the block
+  ;
+}
+
+function g() {
+  return
+  // stays at the end of the block
+  ;
+}
+
+function h() {
+  return; // stays behind the terminator
+  /* stays at the end of the block */
+}

--- a/crates/oxc_formatter/tests/fixtures/js/semicolons/statement-terminator-own-line-comment.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/semicolons/statement-terminator-own-line-comment.js.snap
@@ -1,0 +1,170 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// An own-line comment between a statement's content and its distant `;`
+// terminator stays own-line: it leads the next statement (or ends the block),
+// and never drags a single-statement body onto its own line.
+
+if (1) foo
+
+// leading of the next statement
+;[].sort()
+
+if (1) foo
+
+// a run of own-line comments
+// escapes as a whole
+;[].sort()
+
+function f() {
+  if (1) foo
+  // stays at the end of the block
+  ;
+}
+
+function g() {
+  return
+  // stays at the end of the block
+  ;
+}
+
+function h() {
+  return; // stays behind the terminator
+  /* stays at the end of the block */
+}
+
+==================== Output ====================
+------------------------------
+{ printWidth: 80, semi: true }
+------------------------------
+// An own-line comment between a statement's content and its distant `;`
+// terminator stays own-line: it leads the next statement (or ends the block),
+// and never drags a single-statement body onto its own line.
+
+if (1) foo;
+
+// leading of the next statement
+[].sort();
+
+if (1) foo;
+
+// a run of own-line comments
+// escapes as a whole
+[].sort();
+
+function f() {
+  if (1) foo;
+  // stays at the end of the block
+}
+
+function g() {
+  return;
+  // stays at the end of the block
+}
+
+function h() {
+  return; // stays behind the terminator
+  /* stays at the end of the block */
+}
+
+-------------------------------
+{ printWidth: 100, semi: true }
+-------------------------------
+// An own-line comment between a statement's content and its distant `;`
+// terminator stays own-line: it leads the next statement (or ends the block),
+// and never drags a single-statement body onto its own line.
+
+if (1) foo;
+
+// leading of the next statement
+[].sort();
+
+if (1) foo;
+
+// a run of own-line comments
+// escapes as a whole
+[].sort();
+
+function f() {
+  if (1) foo;
+  // stays at the end of the block
+}
+
+function g() {
+  return;
+  // stays at the end of the block
+}
+
+function h() {
+  return; // stays behind the terminator
+  /* stays at the end of the block */
+}
+
+-------------------------------
+{ printWidth: 80, semi: false }
+-------------------------------
+// An own-line comment between a statement's content and its distant `;`
+// terminator stays own-line: it leads the next statement (or ends the block),
+// and never drags a single-statement body onto its own line.
+
+if (1) foo
+
+// leading of the next statement
+;[].sort()
+
+if (1) foo
+
+// a run of own-line comments
+// escapes as a whole
+;[].sort()
+
+function f() {
+  if (1) foo
+  // stays at the end of the block
+}
+
+function g() {
+  return
+  // stays at the end of the block
+}
+
+function h() {
+  return // stays behind the terminator
+  /* stays at the end of the block */
+}
+
+--------------------------------
+{ printWidth: 100, semi: false }
+--------------------------------
+// An own-line comment between a statement's content and its distant `;`
+// terminator stays own-line: it leads the next statement (or ends the block),
+// and never drags a single-statement body onto its own line.
+
+if (1) foo
+
+// leading of the next statement
+;[].sort()
+
+if (1) foo
+
+// a run of own-line comments
+// escapes as a whole
+;[].sort()
+
+function f() {
+  if (1) foo
+  // stays at the end of the block
+}
+
+function g() {
+  return
+  // stays at the end of the block
+}
+
+function h() {
+  return // stays behind the terminator
+  /* stays at the end of the block */
+}
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-trailing-semicolon.js
+++ b/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-trailing-semicolon.js
@@ -1,0 +1,45 @@
+// The ignored range of a suppressed statement excludes a (possibly distant)
+// trailing `;` — even one owned by a nested single-statement body — and the
+// formatter prints its own terminator only when one was stripped, never
+// doubling it (a doubled `;` would re-parse as an extra EmptyStatement).
+
+// oxfmt-ignore
+debugger
+
+;[].sort()
+
+// oxfmt-ignore
+while   (   1)   foo (   )
+
+;[].sort()
+
+// oxfmt-ignore
+if (   1) ; else    foo
+
+;[].sort()
+
+// oxfmt-ignore
+label: for (   a of   b) while   (   1)   foo (   )
+
+;[].sort()
+
+function f() {
+  // oxfmt-ignore
+  return
+
+  ;[].sort()
+}
+
+function g() {
+  // oxfmt-ignore
+  throw    err
+
+  ;[].sort()
+}
+
+// No source `;` at the end — nothing is stripped, nothing is added.
+// oxfmt-ignore
+while   (   1)   { foo (   ) }
+
+// oxfmt-ignore
+with   (   1)   ;

--- a/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-trailing-semicolon.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-trailing-semicolon.js.snap
@@ -1,0 +1,248 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// The ignored range of a suppressed statement excludes a (possibly distant)
+// trailing `;` — even one owned by a nested single-statement body — and the
+// formatter prints its own terminator only when one was stripped, never
+// doubling it (a doubled `;` would re-parse as an extra EmptyStatement).
+
+// oxfmt-ignore
+debugger
+
+;[].sort()
+
+// oxfmt-ignore
+while   (   1)   foo (   )
+
+;[].sort()
+
+// oxfmt-ignore
+if (   1) ; else    foo
+
+;[].sort()
+
+// oxfmt-ignore
+label: for (   a of   b) while   (   1)   foo (   )
+
+;[].sort()
+
+function f() {
+  // oxfmt-ignore
+  return
+
+  ;[].sort()
+}
+
+function g() {
+  // oxfmt-ignore
+  throw    err
+
+  ;[].sort()
+}
+
+// No source `;` at the end — nothing is stripped, nothing is added.
+// oxfmt-ignore
+while   (   1)   { foo (   ) }
+
+// oxfmt-ignore
+with   (   1)   ;
+
+==================== Output ====================
+------------------------------
+{ printWidth: 80, semi: true }
+------------------------------
+// The ignored range of a suppressed statement excludes a (possibly distant)
+// trailing `;` — even one owned by a nested single-statement body — and the
+// formatter prints its own terminator only when one was stripped, never
+// doubling it (a doubled `;` would re-parse as an extra EmptyStatement).
+
+// oxfmt-ignore
+debugger;
+
+[].sort();
+
+// oxfmt-ignore
+while   (   1)   foo (   );
+
+[].sort();
+
+// oxfmt-ignore
+if (   1) ; else    foo;
+
+[].sort();
+
+// oxfmt-ignore
+label: for (   a of   b) while   (   1)   foo (   );
+
+[].sort();
+
+function f() {
+  // oxfmt-ignore
+  return;
+
+  [].sort();
+}
+
+function g() {
+  // oxfmt-ignore
+  throw    err;
+
+  [].sort();
+}
+
+// No source `;` at the end — nothing is stripped, nothing is added.
+// oxfmt-ignore
+while   (   1)   { foo (   ) }
+
+// oxfmt-ignore
+with   (   1)   ;
+
+-------------------------------
+{ printWidth: 100, semi: true }
+-------------------------------
+// The ignored range of a suppressed statement excludes a (possibly distant)
+// trailing `;` — even one owned by a nested single-statement body — and the
+// formatter prints its own terminator only when one was stripped, never
+// doubling it (a doubled `;` would re-parse as an extra EmptyStatement).
+
+// oxfmt-ignore
+debugger;
+
+[].sort();
+
+// oxfmt-ignore
+while   (   1)   foo (   );
+
+[].sort();
+
+// oxfmt-ignore
+if (   1) ; else    foo;
+
+[].sort();
+
+// oxfmt-ignore
+label: for (   a of   b) while   (   1)   foo (   );
+
+[].sort();
+
+function f() {
+  // oxfmt-ignore
+  return;
+
+  [].sort();
+}
+
+function g() {
+  // oxfmt-ignore
+  throw    err;
+
+  [].sort();
+}
+
+// No source `;` at the end — nothing is stripped, nothing is added.
+// oxfmt-ignore
+while   (   1)   { foo (   ) }
+
+// oxfmt-ignore
+with   (   1)   ;
+
+-------------------------------
+{ printWidth: 80, semi: false }
+-------------------------------
+// The ignored range of a suppressed statement excludes a (possibly distant)
+// trailing `;` — even one owned by a nested single-statement body — and the
+// formatter prints its own terminator only when one was stripped, never
+// doubling it (a doubled `;` would re-parse as an extra EmptyStatement).
+
+// oxfmt-ignore
+debugger
+
+;[].sort()
+
+// oxfmt-ignore
+while   (   1)   foo (   )
+
+;[].sort()
+
+// oxfmt-ignore
+if (   1) ; else    foo
+
+;[].sort()
+
+// oxfmt-ignore
+label: for (   a of   b) while   (   1)   foo (   )
+
+;[].sort()
+
+function f() {
+  // oxfmt-ignore
+  return
+
+  ;[].sort()
+}
+
+function g() {
+  // oxfmt-ignore
+  throw    err
+
+  ;[].sort()
+}
+
+// No source `;` at the end — nothing is stripped, nothing is added.
+// oxfmt-ignore
+while   (   1)   { foo (   ) }
+
+// oxfmt-ignore
+with   (   1)   ;
+
+--------------------------------
+{ printWidth: 100, semi: false }
+--------------------------------
+// The ignored range of a suppressed statement excludes a (possibly distant)
+// trailing `;` — even one owned by a nested single-statement body — and the
+// formatter prints its own terminator only when one was stripped, never
+// doubling it (a doubled `;` would re-parse as an extra EmptyStatement).
+
+// oxfmt-ignore
+debugger
+
+;[].sort()
+
+// oxfmt-ignore
+while   (   1)   foo (   )
+
+;[].sort()
+
+// oxfmt-ignore
+if (   1) ; else    foo
+
+;[].sort()
+
+// oxfmt-ignore
+label: for (   a of   b) while   (   1)   foo (   )
+
+;[].sort()
+
+function f() {
+  // oxfmt-ignore
+  return
+
+  ;[].sort()
+}
+
+function g() {
+  // oxfmt-ignore
+  throw    err
+
+  ;[].sort()
+}
+
+// No source `;` at the end — nothing is stripped, nothing is added.
+// oxfmt-ignore
+while   (   1)   { foo (   ) }
+
+// oxfmt-ignore
+with   (   1)   ;
+
+===================== End =====================

--- a/tasks/ast_tools/src/generators/formatter/format.rs
+++ b/tasks/ast_tools/src/generators/formatter/format.rs
@@ -41,13 +41,29 @@ const AST_NODE_WITHOUT_PRINTING_LEADING_COMMENTS_LIST: &[&str] =
 // Every node listed here MUST implement `FormatWrite::write_suppressed`
 // (the default implementation panics at runtime).
 //
-// Other semicolon-terminated statements have the same issue in principle,
-// (`ExpressionStatement`, `VariableDeclaration`, ...)
-// but only these three have a confirmed divergence against Prettier 3.9.
-// (return/throw already handle their suppression in their own `write`)
+// Mirrors Prettier's `locEnd` overrides (`language-js/location/overrides.js`) +
+// `shouldIgnoredNodePrintSemicolon`: keyword statements end at their keyword/label,
+// content-terminated ones at their content, body-ended ones recurse into the rightmost body.
+//
+// `ExpressionStatement` and `VariableDeclaration` have the same issue in principle
+// but no confirmed divergence against Prettier 3.9 yet.
+//
 // Extend the list one statement at a time, verifying each against Prettier first.
-const AST_NODE_WITH_CUSTOM_SUPPRESSED_FORMATTING: &[&str] =
-    &["BreakStatement", "ContinueStatement", "DoWhileStatement"];
+const AST_NODE_WITH_CUSTOM_SUPPRESSED_FORMATTING: &[&str] = &[
+    "BreakStatement",
+    "ContinueStatement",
+    "DebuggerStatement",
+    "DoWhileStatement",
+    "ForInStatement",
+    "ForOfStatement",
+    "ForStatement",
+    "IfStatement",
+    "LabeledStatement",
+    "ReturnStatement",
+    "ThrowStatement",
+    "WhileStatement",
+    "WithStatement",
+];
 
 const AST_NODE_NEEDS_PARENTHESES: &[&str] = &[
     "TSTypeAssertion",

--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,4 +1,4 @@
-js compatibility: 764/809 (94.44%), 23 files skipped
+js compatibility: 774/809 (95.67%), 23 files skipped
 
 # Failed
 
@@ -8,7 +8,6 @@ js compatibility: 764/809 (94.44%), 23 files skipped
 | js/assignment-comments/indentable-block-comment.js | 💥 | 12.50% |
 | js/call/no-argument/no-arguments.js | 💥 | 57.53% |
 | js/comments/15661.js | 💥💥 | 43.53% |
-| js/comments/break-continue-statements-2.js | 💥💥 | 87.18% |
 | js/comments/empty-statements.js | 💥💥 | 90.91% |
 | js/comments/if.js | 💥💥 | 97.99% |
 | js/comments/return-statement-2.js | 💥💥 | 77.78% |
@@ -25,7 +24,7 @@ js compatibility: 764/809 (94.44%), 23 files skipped
 | js/comments-closure-typecast/iife.js | 💥 | 76.92% |
 | js/explicit-resource-management/valid-await-using-comments.js | 💥 | 85.71% |
 | js/for/9812-2.js | 💥 | 58.33% |
-| js/for/continue-and-break-comment-without-blocks.js | 💥 | 42.77% |
+| js/for/continue-and-break-comment-without-blocks.js | 💥 | 74.24% |
 | js/for-of/comments.js | 💥 | 50.00% |
 | js/function/iife.js | 💥 | 14.89% |
 | js/function/issue-12967.js | 💥 | 0.00% |
@@ -36,15 +35,6 @@ js compatibility: 764/809 (94.44%), 23 files skipped
 | js/if/condition-break/unary-expression.js | 💥 | 59.59% |
 | js/last-argument-expansion/dangling-comment-in-arrow-function.js | 💥 | 0.00% |
 | js/logical-expressions/in-unary-expression.js | 💥 | 33.33% |
-| js/no-semi/debugger-statement.js | 💥💥 | 91.18% |
-| js/no-semi/for-in-statement.js | 💥💥 | 63.89% |
-| js/no-semi/for-of-statement.js | 💥💥 | 66.67% |
-| js/no-semi/for-statement.js | 💥💥 | 63.89% |
-| js/no-semi/if-statement.js | 💥💥 | 67.50% |
-| js/no-semi/labeled-statement.js | 💥💥 | 63.89% |
-| js/no-semi/return-statement.js | 💥💥 | 67.65% |
-| js/no-semi/while-statement.js | 💥💥 | 63.89% |
-| js/no-semi/with-statement.js | 💥💥 | 63.89% |
 | js/template-literals/expression-break.js | 💥 | 80.00% |
 | js/template-literals/expressions.js | 💥 | 97.64% |
 | js/test-declarations/jest-each.js | 💥💥 | 95.71% |


### PR DESCRIPTION
Fixes suppressed statements (`oxfmt-ignore`) emitting their trailing `;` verbatim, which broke idempotency with `semi: false`.

A suppressed statement's span includes its (possibly distant) trailing `;`, so it was printed verbatim. And with `semi: false`, the formatter also prepends an ASI-guard `;` to the next statement, duplicating it (the doubled `;` = extra `EmptyStatement`):

```js
// oxfmt-ignore
while   (   1)   foo (   )

;[].sort()

// BEFORE

// oxfmt-ignore
while   (   1)   foo (   )

;
;[].sort()

// AFTER
// oxfmt-ignore
while   (   1)   foo (   )

;[].sort()
```