### PR TITLE
fix(formatter_css): keep value comments before comma

### DIFF
--- a/crates/oxc_formatter_css/AGENTS.md
+++ b/crates/oxc_formatter_css/AGENTS.md
@@ -60,8 +60,7 @@ Prettier operates on `postcss` + three sub-parsers (`postcss-selector-parser`, `
 ### Comments
 
 `oxc-css-parser` does not attach comments to the AST;
-they are collected via `ParserBuilder::comments()` into a positional cursor over `CssComment { span, inline }`
-(`inline` = `//`).
+they are collected via `ParserBuilder::comments()` into a positional cursor over `CssComment { span, inline }` (`inline` = `//`).
 
 - Statement-level comments: flushed before each statement
   (`flush_leading_comments`); consecutive same-line comments stay glued
@@ -71,6 +70,29 @@ they are collected via `ParserBuilder::comments()` into a positional cursor over
 - Trailing (`value /* c */;`): flushed by `write_declaration` with the source gap before `;` preserved
 - After each statement, the sequence DISCARDS unclaimed comments inside the
   statement span (cursor must never point before a printed position)
+
+#### Placement invariants
+
+The placement rules follow `crates/oxc_formatter/AGENTS.md` "Comment placement invariants"
+(the invariant / compat-table two-layer split, and the terminator vs separator ownership rule);
+
+this section records their CSS translation:
+
+- A comment never crosses user content (other values, other comments):
+  - it stays on its source side of every value/argument
+- `,` is a list SEPARATOR: a comment between an element and its comma stays BEFORE the comma
+  - `a /* c */, b`; comments after it lead the next element
+  - Declaration value lists (`write_value_groups`) and function arguments (`write_function`) route every comma through `write_group_comma` with the comma offset paired to its group
+  - `split_comma_groups` returns `(group, Option<comma_start>)`; SCSS/Less lists pair `comma_spans`
+  - A new comma site must take the pair, the shape makes taking the groups without the commas a visible choice, not an accident
+    - TODO: not every comma writer has adopted this yet
+- `;` is a declaration TERMINATOR, but unlike JS statements Prettier does NOT move comments behind it:
+  - `value /* c */;` keeps the comment before `;` (measured behavior, not principle, may change in the future)
+- The positional cursor makes ownership a bounds discipline, not an attachment one:
+  - a flush's upper bound must never extend past the next piece of user content,
+  - and a declaration's `tail_bound` may only be consumed by the LAST comma group (`write_value_groups` clears it for every other group)
+- Never let a comment cross a line boundary
+  - `//` comments force a hardline after; own-line comments stay own-line, and never move a suppression comment off its target
 
 ### Line endings
 

--- a/crates/oxc_formatter_css/src/print/scss.rs
+++ b/crates/oxc_formatter_css/src/print/scss.rs
@@ -93,9 +93,9 @@ pub(super) fn write_top_level_value<'a>(
     ctx: ValueContext<'a>,
     f: &mut CssFormatter<'_, 'a>,
 ) {
-    let (elements, is_comma) = match value {
-        ComponentValue::SassList(list) => (&list.elements, list.comma_spans.is_some()),
-        ComponentValue::LessList(list) => (&list.elements, list.comma_spans.is_some()),
+    let (elements, comma_spans) = match value {
+        ComponentValue::SassList(list) => (&list.elements, list.comma_spans.as_ref()),
+        ComponentValue::LessList(list) => (&list.elements, list.comma_spans.as_ref()),
         _ => {
             value::write_component_value(value, ctx, f);
             return;
@@ -104,17 +104,22 @@ pub(super) fn write_top_level_value<'a>(
     // `paren_break` only applies to a paren group that IS the whole value,
     // not to parens nested inside lists.
     let ctx = ValueContext { paren_break: false, ..ctx };
-    if is_comma {
-        let groups: Vec<&[ComponentValue<'a>]> = elements
+    if let Some(comma_spans) = comma_spans {
+        // Each element paired with the comma that follows it (see `write_value_groups`)
+        let groups: Vec<(&[ComponentValue<'a>], Option<u32>)> = elements
             .iter()
-            .map(|el| match el {
-                ComponentValue::SassList(inner) if inner.comma_spans.is_none() => {
-                    &inner.elements[..]
-                }
-                ComponentValue::LessList(inner) if inner.comma_spans.is_none() => {
-                    &inner.elements[..]
-                }
-                other => std::slice::from_ref(other),
+            .enumerate()
+            .map(|(i, el)| {
+                let group = match el {
+                    ComponentValue::SassList(inner) if inner.comma_spans.is_none() => {
+                        &inner.elements[..]
+                    }
+                    ComponentValue::LessList(inner) if inner.comma_spans.is_none() => {
+                        &inner.elements[..]
+                    }
+                    other => std::slice::from_ref(other),
+                };
+                (group, comma_spans.get(i).map(|sp| to_span(sp).start))
             })
             .collect();
         let value_span = to_span(value.span());
@@ -124,7 +129,10 @@ pub(super) fn write_top_level_value<'a>(
             .iter_before(value_span.end)
             .any(|c| c.span.start >= value_span.start);
         let force_hard_line = !ctx.decl_prop.is_some_and(|p| p.starts_with("--"))
-            && (groups.iter().enumerate().any(|(i, g)| value::comma_group_is_multi(g, i == 0))
+            && (groups
+                .iter()
+                .enumerate()
+                .any(|(i, (g, _))| value::comma_group_is_multi(g, i == 0))
                 || has_comments);
         value::write_value_groups(&groups, ctx, force_hard_line, true, f);
     } else {

--- a/crates/oxc_formatter_css/src/print/value.rs
+++ b/crates/oxc_formatter_css/src/print/value.rs
@@ -479,19 +479,25 @@ impl ValueContext<'_> {
 }
 
 /// Splits a flat component stream at top-level commas.
+///
 /// A raw `Token::Comma` splits too (postcss value-parses raw token streams the same way):
 /// a declaration value the typed grammar rejected falls back to raw tokens,
 /// and its comma list must still count as a multi-value list
 /// (`background-position: 0 0, 0 spacing(tight), ...` breaks one per line).
 /// Raw parens keep their inner commas out of the split.
-fn split_comma_groups<'b, 'a>(values: &'b [ComponentValue<'a>]) -> Vec<&'b [ComponentValue<'a>]> {
+/// Each group is paired with the start offset of the comma that follows it (`None` for the last group):
+/// comments between a group and its comma stay BEFORE the comma (`a /* c */, b`),
+/// so group printers need the boundary.
+fn split_comma_groups<'b, 'a>(
+    values: &'b [ComponentValue<'a>],
+) -> Vec<(&'b [ComponentValue<'a>], Option<u32>)> {
     let mut groups = vec![];
     let mut start = 0;
     let mut depth = 0i32;
     for (i, v) in values.iter().enumerate() {
         if let ComponentValue::TokenWithSpan(tok) = v {
             if depth == 0 && matches!(&tok.token, Token::Comma(_)) {
-                groups.push(&values[start..i]);
+                groups.push((&values[start..i], Some(to_span(v.span()).start)));
                 start = i + 1;
             } else {
                 depth += token_depth_delta(&tok.token);
@@ -499,13 +505,13 @@ fn split_comma_groups<'b, 'a>(values: &'b [ComponentValue<'a>]) -> Vec<&'b [Comp
             continue;
         }
         if is_comma(v) {
-            groups.push(&values[start..i]);
+            groups.push((&values[start..i], Some(to_span(v.span()).start)));
             start = i + 1;
         }
     }
-    groups.push(&values[start..]);
+    groups.push((&values[start..], None));
     // A trailing comma produces an empty last group; Prettier drops it
-    if groups.len() > 1 && groups.last().is_some_and(|g| g.is_empty()) {
+    if groups.len() > 1 && groups.last().is_some_and(|(g, _)| g.is_empty()) {
         groups.pop();
     }
     groups
@@ -530,7 +536,7 @@ pub(super) fn write_declaration_value<'a>(
 
     if groups.len() == 1 {
         // Flattened to a single comma group
-        write_comma_group(groups[0], ctx, f);
+        write_comma_group(groups[0].0, ctx, f);
         return;
     }
 
@@ -543,7 +549,7 @@ pub(super) fn write_declaration_value<'a>(
     let has_comments =
         f.context().comments().iter_before(value_end).any(|c| c.span.start >= value_start);
     let force_hard_line = !ctx.decl_prop.is_some_and(|p| p.starts_with("--"))
-        && (groups.iter().enumerate().any(|(i, g)| comma_group_is_multi(g, i == 0))
+        && (groups.iter().enumerate().any(|(i, (g, _))| comma_group_is_multi(g, i == 0))
             || has_comments);
 
     write_value_groups(&groups, ctx, force_hard_line, true, f);
@@ -568,10 +574,20 @@ pub(super) fn comma_group_is_multi(group: &[ComponentValue<'_>], is_first: bool)
                 if id.raw.starts_with('-') && !id.raw.starts_with("--"))
 }
 
-/// Top-level comma-group list layout,
-/// shared between flat component streams and SCSS comma lists.
+/// A group's separator comma:
+/// comments between the group and its comma stay before the comma (`a /* c */, b`);
+/// only comments past it lead the next group.
+fn write_group_comma(comma_start: Option<u32>, f: &mut CssFormatter<'_, '_>) {
+    if let Some(comma) = comma_start {
+        flush_trailing_value_comments(comma, f);
+    }
+    write!(f, ",");
+}
+
+/// Top-level comma-group list layout, shared between flat component streams and SCSS comma lists.
+/// Each group comes paired with the start of its trailing comma (see [`split_comma_groups`] / [`write_group_comma`]).
 pub(super) fn write_value_groups<'a>(
-    groups: &[&[ComponentValue<'a>]],
+    groups: &[(&[ComponentValue<'a>], Option<u32>)],
     ctx: ValueContext<'a>,
     force_hard_line: bool,
     _top_level: bool,
@@ -582,17 +598,13 @@ pub(super) fn write_value_groups<'a>(
     if force_hard_line {
         let body = format_with(|f: &mut CssFormatter<'_, 'a>| {
             write!(f, hard_line_break());
-            for (i, group_values) in groups.iter().enumerate() {
+            for (i, &(group_values, comma)) in groups.iter().enumerate() {
                 if i > 0 {
-                    write!(f, ",");
                     write!(f, hard_line_break());
                 }
+                let is_last = i + 1 == groups.len();
                 // The declaration tail belongs to the LAST group only
-                let gctx = if i + 1 < groups.len() {
-                    ValueContext { tail_bound: None, ..ctx }
-                } else {
-                    ctx
-                };
+                let gctx = if is_last { ctx } else { ValueContext { tail_bound: None, ..ctx } };
                 // Comments between groups (e.g. after the previous comma)
                 // fill together with the group they precede;
                 // `//` comments (and leading own-line comments) keep their own line.
@@ -621,7 +633,7 @@ pub(super) fn write_value_groups<'a>(
                     let group_w =
                         group_values.first().zip(group_values.last()).map_or(0, |(first, last)| {
                             to_span(last.span()).end - to_span(first.span()).start
-                        }) + u32::from(i + 1 < groups.len());
+                        }) + u32::from(!is_last);
                     let mut x = 4u32; // hardline indent under the value
                     for (k, &comment) in lead.iter().enumerate() {
                         comments::write_single_comment(comment, f);
@@ -640,6 +652,9 @@ pub(super) fn write_value_groups<'a>(
                     }
                     write_comma_group(group_values, gctx, f);
                 }
+                if !is_last {
+                    write_group_comma(comma, f);
+                }
             }
         });
         write!(f, indent(&body));
@@ -649,15 +664,17 @@ pub(super) fn write_value_groups<'a>(
                 write!(f, soft_line_break());
             }
             let mut filler = f.fill();
-            for (i, group_values) in groups.iter().enumerate() {
+            for (i, &(group_values, comma)) in groups.iter().enumerate() {
                 let is_last = i + 1 == groups.len();
+                // The declaration tail belongs to the LAST group only
+                let gctx = if is_last { ctx } else { ValueContext { tail_bound: None, ..ctx } };
                 let content = format_with(move |f: &mut CssFormatter<'_, 'a>| {
                     if let Some(first) = group_values.first() {
                         flush_value_comments(to_span(first.span()).start, f);
                     }
-                    write_comma_group(group_values, ctx, f);
+                    write_comma_group(group_values, gctx, f);
                     if !is_last {
-                        write!(f, ",");
+                        write_group_comma(comma, f);
                     }
                 });
                 filler.entry(&soft_line_break_or_space(), &content);
@@ -2016,22 +2033,22 @@ pub(super) fn write_function<'a>(
     if function_name_text(func).eq_ignore_ascii_case("url") {
         write!(f, "(");
         // Single plain argument: verbatim (matches the `Url` node path)
-        if groups.len() == 1
-            && groups[0].len() == 1
+        if let [([arg], _)] = groups.as_slice()
             && matches!(
-                groups[0][0],
+                arg,
                 ComponentValue::InterpolableIdent(_) | ComponentValue::TokenWithSpan(_)
             )
         {
-            let span = to_span(groups[0][0].span());
+            let span = to_span(arg.span());
             write!(f, text(source.text_for(&span)));
         } else {
             let url_ctx = ValueContext { in_url: true, ..ctx };
-            for (i, group_values) in groups.iter().enumerate() {
-                if i > 0 {
-                    write!(f, [",", " "]);
-                }
+            for (i, &(group_values, comma)) in groups.iter().enumerate() {
                 write_comma_group(group_values, url_ctx, f);
+                if i + 1 < groups.len() {
+                    write_group_comma(comma, f);
+                    write!(f, " ");
+                }
             }
         }
         write!(f, ")");
@@ -2057,11 +2074,12 @@ pub(super) fn write_function<'a>(
     // no break opportunities, args joined inline.
     if ctx.no_break {
         write!(f, "(");
-        for (i, group_values) in groups.iter().enumerate() {
-            if i > 0 {
-                write!(f, [",", " "]);
-            }
+        for (i, &(group_values, comma)) in groups.iter().enumerate() {
             write_arg_group(group_values, ctx, f);
+            if i + 1 < groups.len() {
+                write_group_comma(comma, f);
+                write!(f, " ");
+            }
         }
         write!(f, ")");
         return;
@@ -2089,16 +2107,15 @@ pub(super) fn write_function<'a>(
     let is_kw_arg = |g: &[ComponentValue<'a>]| {
         g.len() == 1 && matches!(g[0], ComponentValue::SassKeywordArgument(_))
     };
-    let first_arg_is_kw = groups.first().is_some_and(|g| is_kw_arg(g));
+    let first_arg_is_kw = groups.first().is_some_and(|(g, _)| is_kw_arg(g));
     let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
         let source = f.context().source_text();
         write!(f, soft_line_break());
-        for (i, group_values) in groups_ref.iter().enumerate() {
+        for (i, &(group_values, comma)) in groups_ref.iter().enumerate() {
             if i > 0 {
-                write!(f, ",");
                 // Preserve a blank line between argument groups,
                 // but only after a multi-part group (Prettier checks `comma_groups`).
-                let prev_end = groups_ref[i - 1].last().map_or(0, |v| to_span(v.span()).end);
+                let prev_end = groups_ref[i - 1].0.last().map_or(0, |v| to_span(v.span()).end);
                 let next_start = group_values.first().map_or(prev_end, |v| to_span(v.span()).start);
                 let next_start = f
                     .context()
@@ -2106,7 +2123,7 @@ pub(super) fn write_function<'a>(
                     .peek()
                     .map_or(next_start, |c| c.span.start.min(next_start));
                 if prev_end != 0
-                    && groups_ref[i - 1].len() > 1
+                    && groups_ref[i - 1].0.len() > 1
                     && comments::classify_gap(source.bytes_range(prev_end, next_start))
                         == comments::Gap::Blank
                 {
@@ -2118,9 +2135,10 @@ pub(super) fn write_function<'a>(
             let arg_ctx =
                 ValueContext { paren_break: first_arg_is_kw && is_kw_arg(group_values), ..ctx };
             write_arg_group(group_values, arg_ctx, f);
-        }
-        if has_trailing_comma {
-            write!(f, ",");
+            // `has_trailing_comma`: the kept `var(--x /* c */,)` comma counts too
+            if i + 1 < groups_ref.len() || has_trailing_comma {
+                write_group_comma(comma, f);
+            }
         }
         // Comments between the last argument and `)` wrap as fill items;
         // `//` comments stay glued to the argument (their hardline follows).

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/function-arg-comment-before-comma.css
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/function-arg-comment-before-comma.css
@@ -1,0 +1,10 @@
+/* a comment between a function argument and its comma stays BEFORE the comma */
+a {
+  color: rgb(1 /* c */, 2, 3);
+  color: rgb(1, /* c */ 2, 3);
+  background: url(a.png /* c */, b.png);
+  width: var(--x /* c */, 10px);
+  /* the kept var() trailing comma counts too */
+  height: var(--y /* c */,);
+  color: color-mix(in srgb /* space */, red 50% /* half */, blue);
+}

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/function-arg-comment-before-comma.css.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/function-arg-comment-before-comma.css.snap
@@ -1,0 +1,45 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+/* a comment between a function argument and its comma stays BEFORE the comma */
+a {
+  color: rgb(1 /* c */, 2, 3);
+  color: rgb(1, /* c */ 2, 3);
+  background: url(a.png /* c */, b.png);
+  width: var(--x /* c */, 10px);
+  /* the kept var() trailing comma counts too */
+  height: var(--y /* c */,);
+  color: color-mix(in srgb /* space */, red 50% /* half */, blue);
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+/* a comment between a function argument and its comma stays BEFORE the comma */
+a {
+  color: rgb(1 /* c */, 2, 3);
+  color: rgb(1, /* c */ 2, 3);
+  background: url(a.png /* c */, b.png);
+  width: var(--x /* c */, 10px);
+  /* the kept var() trailing comma counts too */
+  height: var(--y /* c */,);
+  color: color-mix(in srgb /* space */, red 50% /* half */, blue);
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+/* a comment between a function argument and its comma stays BEFORE the comma */
+a {
+  color: rgb(1 /* c */, 2, 3);
+  color: rgb(1, /* c */ 2, 3);
+  background: url(a.png /* c */, b.png);
+  width: var(--x /* c */, 10px);
+  /* the kept var() trailing comma counts too */
+  height: var(--y /* c */,);
+  color: color-mix(in srgb /* space */, red 50% /* half */, blue);
+}
+
+===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/value-comment-before-comma.css
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/value-comment-before-comma.css
@@ -1,0 +1,18 @@
+/* issue #24469: a comment between a value group and its comma stays BEFORE the comma */
+@theme {
+  --default-font-feature-settings:
+    "ss01" on /* Open digits */,
+    "ss03" on /* Round quotes & commas */,
+    "cv05" on /* Lower-case L with tail */,
+    "cv06" on /* Simplified u */,
+    "cv08" on /* Upper-case i with serif */,
+    "cv10" on /* Capital G with spur */;
+}
+a {
+  /* comment position relative to the comma is preserved */
+  --x: aa /* c1 */, /* c2 */ bb;
+  /* a declaration-tail comment stays on the LAST group */
+  --y: aa, bb /* tail */;
+  /* non-custom property: forced one-group-per-line list */
+  font-family: Arial /* c1 */, /* c2 */ sans-serif;
+}

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/value-comment-before-comma.css.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/value-comment-before-comma.css.snap
@@ -1,0 +1,67 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+/* issue #24469: a comment between a value group and its comma stays BEFORE the comma */
+@theme {
+  --default-font-feature-settings:
+    "ss01" on /* Open digits */,
+    "ss03" on /* Round quotes & commas */,
+    "cv05" on /* Lower-case L with tail */,
+    "cv06" on /* Simplified u */,
+    "cv08" on /* Upper-case i with serif */,
+    "cv10" on /* Capital G with spur */;
+}
+a {
+  /* comment position relative to the comma is preserved */
+  --x: aa /* c1 */, /* c2 */ bb;
+  /* a declaration-tail comment stays on the LAST group */
+  --y: aa, bb /* tail */;
+  /* non-custom property: forced one-group-per-line list */
+  font-family: Arial /* c1 */, /* c2 */ sans-serif;
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+/* issue #24469: a comment between a value group and its comma stays BEFORE the comma */
+@theme {
+  --default-font-feature-settings:
+    "ss01" on /* Open digits */, "ss03" on /* Round quotes & commas */,
+    "cv05" on /* Lower-case L with tail */, "cv06" on /* Simplified u */,
+    "cv08" on /* Upper-case i with serif */, "cv10" on /* Capital G with spur */;
+}
+a {
+  /* comment position relative to the comma is preserved */
+  --x: aa /* c1 */, /* c2 */ bb;
+  /* a declaration-tail comment stays on the LAST group */
+  --y: aa, bb /* tail */;
+  /* non-custom property: forced one-group-per-line list */
+  font-family:
+    Arial /* c1 */,
+    /* c2 */ sans-serif;
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+/* issue #24469: a comment between a value group and its comma stays BEFORE the comma */
+@theme {
+  --default-font-feature-settings:
+    "ss01" on /* Open digits */, "ss03" on /* Round quotes & commas */,
+    "cv05" on /* Lower-case L with tail */, "cv06" on /* Simplified u */,
+    "cv08" on /* Upper-case i with serif */, "cv10" on /* Capital G with spur */;
+}
+a {
+  /* comment position relative to the comma is preserved */
+  --x: aa /* c1 */, /* c2 */ bb;
+  /* a declaration-tail comment stays on the LAST group */
+  --y: aa, bb /* tail */;
+  /* non-custom property: forced one-group-per-line list */
+  font-family:
+    Arial /* c1 */,
+    /* c2 */ sans-serif;
+}
+
+===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/function-arg-comment-before-comma.scss
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/function-arg-comment-before-comma.scss
@@ -1,0 +1,2 @@
+// A comment between a function argument and its comma stays BEFORE the comma
+$x: foo($a /* c1 */, $b /* c2 */);

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/function-arg-comment-before-comma.scss.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/function-arg-comment-before-comma.scss.snap
@@ -1,0 +1,21 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// A comment between a function argument and its comma stays BEFORE the comma
+$x: foo($a /* c1 */, $b /* c2 */);
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// A comment between a function argument and its comma stays BEFORE the comma
+$x: foo($a /* c1 */, $b /* c2 */);
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// A comment between a function argument and its comma stays BEFORE the comma
+$x: foo($a /* c1 */, $b /* c2 */);
+
+===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/value-comment-before-comma.scss
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/value-comment-before-comma.scss
@@ -1,0 +1,5 @@
+// A comment between a SassList element and its comma stays BEFORE the comma
+$x: aa /* c1 */, bb /* c2 */, cc;
+a {
+  $y: 1px 2px /* c */, 3px 4px;
+}

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/value-comment-before-comma.scss.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/value-comment-before-comma.scss.snap
@@ -1,0 +1,40 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// A comment between a SassList element and its comma stays BEFORE the comma
+$x: aa /* c1 */, bb /* c2 */, cc;
+a {
+  $y: 1px 2px /* c */, 3px 4px;
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// A comment between a SassList element and its comma stays BEFORE the comma
+$x:
+  aa /* c1 */,
+  bb /* c2 */,
+  cc;
+a {
+  $y:
+    1px 2px /* c */,
+    3px 4px;
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// A comment between a SassList element and its comma stays BEFORE the comma
+$x:
+  aa /* c1 */,
+  bb /* c2 */,
+  cc;
+a {
+  $y:
+    1px 2px /* c */,
+    3px 4px;
+}
+
+===================== End =====================


### PR DESCRIPTION
Fixes #24469

This keeps comments before/after `,` stay the same position.