### PR TITLE
fix(formatter_css): keep more value comments before comma

### DIFF
--- a/crates/oxc_formatter_css/AGENTS.md
+++ b/crates/oxc_formatter_css/AGENTS.md
@@ -85,7 +85,7 @@ this section records their CSS translation:
   - Declaration value lists (`write_value_groups`) and function arguments (`write_function`) route every comma through `write_group_comma` with the comma offset paired to its group
   - `split_comma_groups` returns `(group, Option<comma_start>)`; SCSS/Less lists pair `comma_spans`
   - A new comma site must take the pair, the shape makes taking the groups without the commas a visible choice, not an accident
-    - TODO: not every comma writer has adopted this yet
+  - Adopted by every comma writer (function/include args, maps, paren/sass lists, `@mixin` params, `@each` bindings, keyframe selectors)
 - `;` is a declaration TERMINATOR, but unlike JS statements Prettier does NOT move comments behind it:
   - `value /* c */;` keeps the comment before `;` (measured behavior, not principle, may change in the future)
 - The positional cursor makes ownership a bounds discipline, not an attachment one:
@@ -217,6 +217,9 @@ Deliberate divergences from Prettier. Two admission reasons:
 
 Notable divergences are:
 
+- A COMMENTED keyframe selector list is formatted structurally (one selector per line, comments per the separator rule: `60% /* mid */,`)
+  - Prettier keeps the whole list verbatim on one line, interior spacing included (`60%   /* mid */  ,   70%` survives untouched)
+  - Ours prints commented and uncommented lists with the same layout; layout-only, rare trigger
 - Broken `:not(...)` selector args indent at +2
   - Prettier lands at +4 (arg) / +2 (`)`)
   - Layout-only, rare trigger (selector longer than line width)

--- a/crates/oxc_formatter_css/src/print/scss.rs
+++ b/crates/oxc_formatter_css/src/print/scss.rs
@@ -197,7 +197,10 @@ pub(super) fn write_sass_map<'a>(
             write!(f, soft_line_break());
             for (i, item) in map.items.iter().enumerate() {
                 if i > 0 {
-                    write!(f, ",");
+                    value::write_group_comma(
+                        map.comma_spans.get(i - 1).map(|sp| to_span(sp).start),
+                        f,
+                    );
                     // A blank line between items in the source is preserved
                     // (Prettier's isNextLineEmpty → hardline).
                     let prev_end = to_span(map.items[i - 1].span()).end;
@@ -252,7 +255,7 @@ pub(super) fn write_sass_map<'a>(
         let mut first_item_has_leading_comment = false;
         for (i, item) in map.items.iter().enumerate() {
             if i > 0 {
-                write!(f, ",");
+                value::write_group_comma(map.comma_spans.get(i - 1).map(|sp| to_span(sp).start), f);
                 write!(f, hard_line_break());
                 // Preserve one blank line between items
                 let prev_end = to_span(map.items[i - 1].span()).end;
@@ -418,6 +421,7 @@ pub(super) fn write_sass_list<'a>(
     f: &mut CssFormatter<'_, 'a>,
 ) {
     if list.comma_spans.is_some() {
+        let comma_spans = list.comma_spans.as_ref();
         let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
             let mut filler = f.fill();
             for (i, el) in list.elements.iter().enumerate() {
@@ -425,7 +429,10 @@ pub(super) fn write_sass_list<'a>(
                 let content = format_with(move |f: &mut CssFormatter<'_, 'a>| {
                     value::write_component_value(el, ctx, f);
                     if !is_last {
-                        write!(f, ",");
+                        value::write_group_comma(
+                            comma_spans.and_then(|s| s.get(i)).map(|sp| to_span(sp).start),
+                            f,
+                        );
                     }
                 });
                 filler.entry(&soft_line_break_or_space(), &content);
@@ -447,10 +454,14 @@ pub(super) fn write_sass_each<'a>(each: &SassEach<'a>, f: &mut CssFormatter<'_, 
 
     // Comma-list expr: the first element joins the `... in` entry,
     // the rest are separate fill entries (mirrors postcss's flat comma groups).
-    let expr_elements: &[ComponentValue<'a>] = match &each.expr {
-        ComponentValue::SassList(list) if list.comma_spans.is_some() => &list.elements,
-        expr => std::slice::from_ref(expr),
+    let (expr_elements, expr_comma_spans): (&[ComponentValue<'a>], _) = match &each.expr {
+        ComponentValue::SassList(list) if list.comma_spans.is_some() => {
+            (&list.elements, list.comma_spans.as_ref())
+        }
+        expr => (std::slice::from_ref(expr), None),
     };
+    let expr_comma_start =
+        move |i: usize| expr_comma_spans.and_then(|s| s.get(i)).map(|sp| to_span(sp).start);
 
     let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
         let mut filler = f.fill();
@@ -478,7 +489,7 @@ pub(super) fn write_sass_each<'a>(each: &SassEach<'a>, f: &mut CssFormatter<'_, 
                                 f,
                             );
                             if expr_elements.len() > 1 {
-                                write!(f, ",");
+                                value::write_group_comma(expr_comma_start(0), f);
                             }
                         });
                         inner.entry(&soft_line_break_or_space(), &binding);
@@ -493,7 +504,10 @@ pub(super) fn write_sass_each<'a>(each: &SassEach<'a>, f: &mut CssFormatter<'_, 
                     write!(f, group(&indent(&tail)));
                 } else {
                     write!(f, text(source.text_for(&span)));
-                    write!(f, ",");
+                    value::write_group_comma(
+                        each.comma_spans.get(i).map(|sp| to_span(sp).start),
+                        f,
+                    );
                 }
             });
             filler.entry(&soft_line_break_or_space(), &content);
@@ -503,7 +517,7 @@ pub(super) fn write_sass_each<'a>(each: &SassEach<'a>, f: &mut CssFormatter<'_, 
             let content = format_with(move |f: &mut CssFormatter<'_, 'a>| {
                 value::write_component_value(el, ValueContext::default(), f);
                 if !is_last {
-                    write!(f, ",");
+                    value::write_group_comma(expr_comma_start(i), f);
                 }
             });
             filler.entry(&soft_line_break_or_space(), &content);
@@ -547,15 +561,15 @@ pub(super) fn write_sass_function<'a>(function: &SassFunction<'a>, f: &mut CssFo
 
 fn write_sass_parameters<'a>(parameters: &SassParameters<'a>, f: &mut CssFormatter<'_, 'a>) {
     let source = f.context().source_text();
+    let comma_start =
+        |i: usize| parameters.comma_spans.get(i).map(|sp: &oxc_css_parser::Span| to_span(sp).start);
     let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
         write!(f, soft_line_break());
-        let mut first = true;
-        for param in &parameters.params {
-            if !first {
-                write!(f, ",");
+        for (i, param) in parameters.params.iter().enumerate() {
+            if i > 0 {
+                value::write_group_comma(comma_start(i - 1), f);
                 write!(f, soft_line_break_or_space());
             }
-            first = false;
             let name_span = to_span(param.name.span());
             write!(f, text(source.text_for(&name_span)));
             if let Some(default) = &param.default_value {
@@ -564,8 +578,8 @@ fn write_sass_parameters<'a>(parameters: &SassParameters<'a>, f: &mut CssFormatt
             }
         }
         if let Some(arbitrary) = &parameters.arbitrary_param {
-            if !first {
-                write!(f, ",");
+            if !parameters.params.is_empty() {
+                value::write_group_comma(comma_start(parameters.params.len() - 1), f);
                 write!(f, soft_line_break_or_space());
             }
             let span = to_span(arbitrary.name.span());
@@ -590,6 +604,7 @@ pub(super) fn write_sass_include<'a>(include: &SassInclude<'a>, f: &mut CssForma
     write!(f, text(source.text_for(&name_span)));
     if let Some(arguments) = &include.arguments {
         let args = &arguments.args;
+        let comma_spans = &arguments.comma_spans;
         // Same first-argument gate as `write_function` (which see), over typed args
         let first_arg_is_kw =
             args.first().is_some_and(|a| matches!(a, ComponentValue::SassKeywordArgument(_)));
@@ -598,7 +613,7 @@ pub(super) fn write_sass_include<'a>(include: &SassInclude<'a>, f: &mut CssForma
             write!(f, soft_line_break());
             for (i, arg) in args.iter().enumerate() {
                 if i > 0 {
-                    write!(f, ",");
+                    value::write_group_comma(comma_spans.get(i - 1).map(|sp| to_span(sp).start), f);
                     // Preserve a blank line, but only after a multi-part argument
                     // (Prettier checks `value-comma_group`s only).
                     let prev = &args[i - 1];

--- a/crates/oxc_formatter_css/src/print/statement.rs
+++ b/crates/oxc_formatter_css/src/print/statement.rs
@@ -238,13 +238,21 @@ pub(super) fn write_statement<'a>(stmt: &Statement<'a>, f: &mut CssFormatter<'_,
             );
         }
         Statement::KeyframeBlock(keyframe_block) => {
+            // Comments follow the list-separator rule (pre-comma stays before the comma, post-comma leads the next selector).
+            // Prettier instead keeps a COMMENTED selector list verbatim on one line.
             for (i, sel) in keyframe_block.selectors.iter().enumerate() {
                 if i > 0 {
-                    write!(f, ",");
+                    value::write_group_comma(
+                        keyframe_block.comma_spans.get(i - 1).map(|sp| to_span(sp).start),
+                        f,
+                    );
                     write!(f, hard_line_break());
                 }
+                value::flush_value_comments(to_span(sel.span()).start, f);
                 selector::write_keyframe_selector(sel, f);
             }
+            // Trailing comments before `{` stay on the selector line
+            value::flush_trailing_value_comments(to_span(keyframe_block.block.span()).start, f);
             write!(f, space());
             write_block(&keyframe_block.block, f);
         }

--- a/crates/oxc_formatter_css/src/print/value.rs
+++ b/crates/oxc_formatter_css/src/print/value.rs
@@ -577,7 +577,7 @@ pub(super) fn comma_group_is_multi(group: &[ComponentValue<'_>], is_first: bool)
 /// A group's separator comma:
 /// comments between the group and its comma stay before the comma (`a /* c */, b`);
 /// only comments past it lead the next group.
-fn write_group_comma(comma_start: Option<u32>, f: &mut CssFormatter<'_, '_>) {
+pub(super) fn write_group_comma(comma_start: Option<u32>, f: &mut CssFormatter<'_, '_>) {
     if let Some(comma) = comma_start {
         flush_trailing_value_comments(comma, f);
     }
@@ -1355,11 +1355,15 @@ pub(super) fn write_component_value<'a>(
                 let inner_ctx = ValueContext { paren_break: false, ..ctx };
                 let trailing = f.options().allow_trailing_comma();
                 let elements = &list.elements;
+                let comma_spans = list.comma_spans.as_ref();
                 let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
                     write!(f, hard_line_break());
                     for (i, el) in elements.iter().enumerate() {
                         if i > 0 {
-                            write!(f, ",");
+                            write_group_comma(
+                                comma_spans.and_then(|s| s.get(i - 1)).map(|sp| to_span(sp).start),
+                                f,
+                            );
                             write!(f, hard_line_break());
                         }
                         write_component_value(el, inner_ctx, f);
@@ -1381,9 +1385,13 @@ pub(super) fn write_component_value<'a>(
                 if let ComponentValue::SassList(list) = &*paren.expr
                     && list.comma_spans.is_some()
                 {
+                    let comma_spans = list.comma_spans.as_ref();
                     for (i, el) in list.elements.iter().enumerate() {
                         if i > 0 {
-                            write!(f, ",");
+                            write_group_comma(
+                                comma_spans.and_then(|s| s.get(i - 1)).map(|sp| to_span(sp).start),
+                                f,
+                            );
                             write!(f, soft_line_break_or_space());
                         }
                         write_component_value(el, inner_ctx, f);

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/keyframe-selector-comment.css
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/keyframe-selector-comment.css
@@ -1,0 +1,23 @@
+/* KNOWN DIVERGENCE (see AGENTS.md): every output block below deviates from Prettier.
+   Prettier keeps a COMMENTED keyframe selector list verbatim on one line
+   (`60% /+ mid +/, 70%, 80% /+ late +/ {`, interior spacing included — a postcss
+   raws artifact); we format it structurally, same layout as uncommented lists:
+   one selector per line, comment-before-comma per the separator rule. */
+@keyframes k {
+  0%, 50% {
+    top: 0;
+  }
+  60% /* mid */, 70%, 80% /* late */ {
+    top: 1px;
+  }
+}
+@keyframes spaced {
+  60%   /* mid */  ,   70% ,  80%   {
+    top: 1px;
+  }
+}
+@keyframes after-comma {
+  0%, /* c2 */ 50% /* tail */ {
+    top: 0;
+  }
+}

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/keyframe-selector-comment.css.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/keyframe-selector-comment.css.snap
@@ -1,0 +1,96 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+/* KNOWN DIVERGENCE (see AGENTS.md): every output block below deviates from Prettier.
+   Prettier keeps a COMMENTED keyframe selector list verbatim on one line
+   (`60% /+ mid +/, 70%, 80% /+ late +/ {`, interior spacing included — a postcss
+   raws artifact); we format it structurally, same layout as uncommented lists:
+   one selector per line, comment-before-comma per the separator rule. */
+@keyframes k {
+  0%, 50% {
+    top: 0;
+  }
+  60% /* mid */, 70%, 80% /* late */ {
+    top: 1px;
+  }
+}
+@keyframes spaced {
+  60%   /* mid */  ,   70% ,  80%   {
+    top: 1px;
+  }
+}
+@keyframes after-comma {
+  0%, /* c2 */ 50% /* tail */ {
+    top: 0;
+  }
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+/* KNOWN DIVERGENCE (see AGENTS.md): every output block below deviates from Prettier.
+   Prettier keeps a COMMENTED keyframe selector list verbatim on one line
+   (`60% /+ mid +/, 70%, 80% /+ late +/ {`, interior spacing included — a postcss
+   raws artifact); we format it structurally, same layout as uncommented lists:
+   one selector per line, comment-before-comma per the separator rule. */
+@keyframes k {
+  0%,
+  50% {
+    top: 0;
+  }
+  60% /* mid */,
+  70%,
+  80% /* late */ {
+    top: 1px;
+  }
+}
+@keyframes spaced {
+  60% /* mid */,
+  70%,
+  80% {
+    top: 1px;
+  }
+}
+@keyframes after-comma {
+  0%,
+  /* c2 */ 50% /* tail */ {
+    top: 0;
+  }
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+/* KNOWN DIVERGENCE (see AGENTS.md): every output block below deviates from Prettier.
+   Prettier keeps a COMMENTED keyframe selector list verbatim on one line
+   (`60% /+ mid +/, 70%, 80% /+ late +/ {`, interior spacing included — a postcss
+   raws artifact); we format it structurally, same layout as uncommented lists:
+   one selector per line, comment-before-comma per the separator rule. */
+@keyframes k {
+  0%,
+  50% {
+    top: 0;
+  }
+  60% /* mid */,
+  70%,
+  80% /* late */ {
+    top: 1px;
+  }
+}
+@keyframes spaced {
+  60% /* mid */,
+  70%,
+  80% {
+    top: 1px;
+  }
+}
+@keyframes after-comma {
+  0%,
+  /* c2 */ 50% /* tail */ {
+    top: 0;
+  }
+}
+
+===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/list-comment-before-comma.scss
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/list-comment-before-comma.scss
@@ -1,0 +1,16 @@
+// A comment between a list element and its comma stays BEFORE the comma,
+// across every comma site: include args, paren lists, maps, params, each bindings.
+a {
+  @include mx($a /* c */, $b);
+}
+$paren: (a /* c */, b);
+$map: (k1: 1 /* c */, k2: 2);
+@mixin mx($p1 /* c */, $p2) {
+  color: red;
+}
+@each $k /* c */, $v in $m {
+  a: $k;
+}
+@each $v in aa /* c1 */, bb /* c2 */, cc {
+  b: $v;
+}

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/list-comment-before-comma.scss.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/list-comment-before-comma.scss.snap
@@ -1,0 +1,69 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// A comment between a list element and its comma stays BEFORE the comma,
+// across every comma site: include args, paren lists, maps, params, each bindings.
+a {
+  @include mx($a /* c */, $b);
+}
+$paren: (a /* c */, b);
+$map: (k1: 1 /* c */, k2: 2);
+@mixin mx($p1 /* c */, $p2) {
+  color: red;
+}
+@each $k /* c */, $v in $m {
+  a: $k;
+}
+@each $v in aa /* c1 */, bb /* c2 */, cc {
+  b: $v;
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// A comment between a list element and its comma stays BEFORE the comma,
+// across every comma site: include args, paren lists, maps, params, each bindings.
+a {
+  @include mx($a /* c */, $b);
+}
+$paren: (a /* c */, b);
+$map: (
+  k1: 1 /* c */,
+  k2: 2,
+);
+@mixin mx($p1 /* c */, $p2) {
+  color: red;
+}
+@each $k /* c */, $v in $m {
+  a: $k;
+}
+@each $v in aa /* c1 */, bb /* c2 */, cc {
+  b: $v;
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// A comment between a list element and its comma stays BEFORE the comma,
+// across every comma site: include args, paren lists, maps, params, each bindings.
+a {
+  @include mx($a /* c */, $b);
+}
+$paren: (a /* c */, b);
+$map: (
+  k1: 1 /* c */,
+  k2: 2,
+);
+@mixin mx($p1 /* c */, $p2) {
+  color: red;
+}
+@each $k /* c */, $v in $m {
+  a: $k;
+}
+@each $v in aa /* c1 */, bb /* c2 */, cc {
+  b: $v;
+}
+
+===================== End =====================


### PR DESCRIPTION
Follow up on #24484.

Apply the same rule for all call sites.