### PR TITLE
docs(formatter_css): update AGENTS.md and examples

### DIFF
--- a/crates/oxc_formatter_css/AGENTS.md
+++ b/crates/oxc_formatter_css/AGENTS.md
@@ -392,11 +392,9 @@ pnpm --dir apps/oxfmt conformance
 ### Manual checks
 
 ```sh
-cargo run -p oxc_formatter_css --example css_formatter file.css
+cargo run -p oxc_formatter_css --example css_formatter file.css                  # defaults to --print-width 80
 cargo run -p oxc_formatter_css --example parse_debug -- --syntax scss file.scss  # dump oxc-css-parser AST
 cargo run -p oxc_formatter_css --example embedded_debug file.scss                # format_to_ir entry
 ```
 
-## Roadmap (TODO: Follow Prettier main)
-
-The guiding axis is Prettier compatibility, matching what is in Prettier's unreleased changelog (main has them, next stable will).
+`DUMP_IR=1` prints the `FormatElement` stream before printing.

--- a/crates/oxc_formatter_css/examples/css_formatter.rs
+++ b/crates/oxc_formatter_css/examples/css_formatter.rs
@@ -26,7 +26,12 @@ fn main() {
         _ => CssVariant::Css,
     };
 
-    let mut options = CssFormatOptions { variant, ..CssFormatOptions::default() };
+    let mut options = CssFormatOptions {
+        variant,
+        // Match Prettier's default print width for side-by-side comparison (default 100)
+        line_width: 80.try_into().unwrap(),
+        ..CssFormatOptions::default()
+    };
     if let Some(width) = line_width {
         options.line_width = width.try_into().unwrap();
     }


### PR DESCRIPTION
Use `printWidth: 80` for examples.