### PR TITLE
perf(semantic): count AST nodes, scopes, symbols, references during parsing to replace the `Stats::count` walk

### DIFF
--- a/apps/oxlint/src/js_plugins/parse.rs
+++ b/apps/oxlint/src/js_plugins/parse.rs
@@ -204,8 +204,14 @@ unsafe fn parse_raw_impl(
             })
             .with_config(RuntimeParserConfig::new(true))
             .parse();
-        let ParserReturn { program: parsed_program, diagnostics, mut tokens, panicked, .. } =
-            parser_ret;
+        let ParserReturn {
+            program: parsed_program,
+            diagnostics,
+            mut tokens,
+            ast_counts,
+            panicked,
+            ..
+        } = parser_ret;
         let program = allocator.alloc(parsed_program);
 
         let mut parsing_failed = panicked || (!diagnostics.is_empty() && !ignore_non_fatal_errors);
@@ -213,7 +219,8 @@ unsafe fn parse_raw_impl(
         // Check for semantic errors.
         // If `ignore_non_fatal_errors` is `true`, skip running semantic, as any errors will be ignored anyway.
         if !parsing_failed && !ignore_non_fatal_errors {
-            let semantic_ret = SemanticBuilder::new_compiler().build(program);
+            let semantic_ret =
+                SemanticBuilder::new_compiler().with_stats(ast_counts.into()).build(program);
             parsing_failed = !semantic_ret.diagnostics.is_empty();
         }
 

--- a/crates/oxc/src/compiler.rs
+++ b/crates/oxc/src/compiler.rs
@@ -146,7 +146,7 @@ pub trait CompilerInterface {
 
         /* Semantic */
 
-        let mut semantic_return = self.semantic(&program);
+        let mut semantic_return = self.semantic(&program, parser_return.ast_counts.into());
         if !semantic_return.diagnostics.is_empty() {
             self.handle_errors(semantic_return.diagnostics);
             return;
@@ -252,15 +252,19 @@ pub trait CompilerInterface {
         Parser::new(allocator, source_text, source_type).with_options(self.parse_options()).parse()
     }
 
-    fn semantic<'a>(&self, program: &'a Program<'a>) -> SemanticBuilderReturn<'a> {
+    fn semantic<'a>(&self, program: &'a Program<'a>, stats: Stats) -> SemanticBuilderReturn<'a> {
         let mut builder = SemanticBuilder::new_compiler();
 
-        if self.transform_options().is_some() {
+        let stats = if self.transform_options().is_some() {
+            builder = builder.with_enum_eval(true);
             // Estimate transformer will triple scopes, symbols, references
-            builder = builder.with_excess_capacity(2.0).with_enum_eval(true);
-        }
+            stats.increase_by(2.0)
+        } else {
+            stats
+        };
 
         builder
+            .with_stats(stats)
             .with_check_syntax_error(self.check_semantic_error())
             .with_build_nodes(self.build_semantic_nodes())
             .build(program)

--- a/crates/oxc_ast/src/builder/mod.rs
+++ b/crates/oxc_ast/src/builder/mod.rs
@@ -95,8 +95,10 @@
 //! `disable_old_builder` Cargo feature is enabled in all Oxc crates which utilize `AstBuilder`.
 //! Where those crates expose the `AstBuilder` they use to user code, the feature is only enabled in tests.
 
+use std::ops::{AddAssign, Sub};
+
 use oxc_allocator::{Allocator, ArenaBox, FromIn, GetAllocator};
-use oxc_syntax::node::NodeId;
+use oxc_syntax::{node::NodeId, reference::ReferenceId, scope::ScopeId, symbol::SymbolId};
 
 mod custom;
 
@@ -112,13 +114,75 @@ mod methods;
 /// builder directly, or with a type which exposes one by implementing [`GetAstBuilder`]
 /// (e.g. parser or traverse context).
 ///
+/// The parser wraps [`AstBuilder`] in an [`AstBuild`]er which counts AST nodes, scopes, symbols,
+/// and references via these hooks (to accurately pre-allocate `Vec`s in `SemanticBuilder`).
+/// See [`AstCounts`].
+///
 /// Further [`AstBuild`] implementations will be added later:
 ///
-/// * Version for parser which counts AST nodes (to accurately pre-allocate `Vec`s in `SemanticBuilder`).
 /// * Version for transformer/minifier which assigns unique [`NodeId`]s to all AST nodes.
 pub trait AstBuild<'a>: GetAllocator<'a> {
     /// Get [`NodeId`] to assign to an AST node.
     fn node_id(&self) -> NodeId;
+
+    /// Get [`ScopeId`] to assign to an AST node's `scope_id` field.
+    #[inline]
+    fn scope_id(&self) -> Option<ScopeId> {
+        None
+    }
+
+    /// Get [`SymbolId`] to assign to a `BindingIdentifier`'s `symbol_id` field.
+    #[inline]
+    fn symbol_id(&self) -> Option<SymbolId> {
+        None
+    }
+
+    /// Get [`ReferenceId`] to assign to an `IdentifierReference`'s `reference_id` field.
+    #[inline]
+    fn reference_id(&self) -> Option<ReferenceId> {
+        None
+    }
+}
+
+/// Counts of AST nodes, scopes, symbols, and references created by an [`AstBuild`]er.
+///
+/// Produced by the parser while building the AST, and used to pre-allocate sufficient capacity
+/// in `AstNodes`, `ScopeTree`, and `SymbolTable` in `oxc_semantic`, without traversing the AST.
+///
+/// Counts are upper bounds: the parser may build nodes which don't end up in the AST
+/// (e.g. cover grammar conversions).
+#[derive(Clone, Copy, Default, Debug)]
+pub struct AstCounts {
+    /// Number of AST nodes.
+    pub nodes: u32,
+    /// Number of scopes.
+    pub scopes: u32,
+    /// Number of symbols.
+    pub symbols: u32,
+    /// Number of identifier references.
+    pub references: u32,
+}
+
+impl Sub for AstCounts {
+    type Output = Self;
+
+    fn sub(self, other: Self) -> Self {
+        Self {
+            nodes: self.nodes - other.nodes,
+            scopes: self.scopes - other.scopes,
+            symbols: self.symbols - other.symbols,
+            references: self.references - other.references,
+        }
+    }
+}
+
+impl AddAssign for AstCounts {
+    fn add_assign(&mut self, other: Self) {
+        self.nodes += other.nodes;
+        self.scopes += other.scopes;
+        self.symbols += other.symbols;
+        self.references += other.references;
+    }
 }
 
 /// Trait for types which provide access to an [`AstBuild`]er.

--- a/crates/oxc_ast/src/generated/builder_methods.rs
+++ b/crates/oxc_ast/src/generated/builder_methods.rs
@@ -3,8 +3,6 @@
 
 //! AST node builder methods.
 
-#![expect(clippy::default_trait_access)]
-
 use std::cell::Cell;
 
 use oxc_allocator::{ArenaBox, ArenaVec, GetAllocator, IntoIn};
@@ -48,7 +46,7 @@ impl<'a> Program<'a> {
             hashbang,
             directives,
             body,
-            scope_id: Default::default(),
+            scope_id: Cell::new(builder.scope_id()),
         }
     }
 
@@ -1379,7 +1377,7 @@ impl<'a> IdentifierReference<'a> {
             node_id: Cell::new(builder.node_id()),
             span,
             name: name.into(),
-            reference_id: Default::default(),
+            reference_id: Cell::new(builder.reference_id()),
         }
     }
 
@@ -1472,7 +1470,7 @@ impl<'a> BindingIdentifier<'a> {
             node_id: Cell::new(builder.node_id()),
             span,
             name: name.into(),
-            symbol_id: Default::default(),
+            symbol_id: Cell::new(builder.symbol_id()),
         }
     }
 
@@ -9197,7 +9195,7 @@ impl<'a> BlockStatement<'a> {
             node_id: Cell::new(builder.node_id()),
             span,
             body,
-            scope_id: Default::default(),
+            scope_id: Cell::new(builder.scope_id()),
         }
     }
 
@@ -10120,7 +10118,7 @@ impl<'a> ForStatement<'a> {
             test,
             update,
             body,
-            scope_id: Default::default(),
+            scope_id: Cell::new(builder.scope_id()),
         }
     }
 
@@ -11497,7 +11495,7 @@ impl<'a> ForInStatement<'a> {
             left,
             right,
             body,
-            scope_id: Default::default(),
+            scope_id: Cell::new(builder.scope_id()),
         }
     }
 
@@ -11865,7 +11863,7 @@ impl<'a> ForOfStatement<'a> {
             left,
             right,
             body,
-            scope_id: Default::default(),
+            scope_id: Cell::new(builder.scope_id()),
         }
     }
 
@@ -12089,7 +12087,7 @@ impl<'a> WithStatement<'a> {
             span,
             object,
             body,
-            scope_id: Default::default(),
+            scope_id: Cell::new(builder.scope_id()),
         }
     }
 
@@ -12188,7 +12186,7 @@ impl<'a> SwitchStatement<'a> {
             span,
             discriminant,
             cases,
-            scope_id: Default::default(),
+            scope_id: Cell::new(builder.scope_id()),
         }
     }
 
@@ -12444,7 +12442,7 @@ impl<'a> CatchClause<'a> {
             span,
             param,
             body: body.into_in(builder.allocator()),
-            scope_id: Default::default(),
+            scope_id: Cell::new(builder.scope_id()),
         }
     }
 
@@ -12953,7 +12951,7 @@ impl<'a> Function<'a> {
             params: params.into_in(builder.allocator()),
             return_type: return_type.into_in(builder.allocator()),
             body: body.into_in(builder.allocator()),
-            scope_id: Default::default(),
+            scope_id: Cell::new(builder.scope_id()),
             pure: Default::default(),
             pife: Default::default(),
         }
@@ -13395,7 +13393,7 @@ impl<'a> ArrowFunctionExpression<'a> {
             params: params.into_in(builder.allocator()),
             return_type: return_type.into_in(builder.allocator()),
             body: body.into_in(builder.allocator()),
-            scope_id: Default::default(),
+            scope_id: Cell::new(builder.scope_id()),
             pure: Default::default(),
             pife: Default::default(),
         }
@@ -13646,7 +13644,7 @@ impl<'a> Class<'a> {
             body: body.into_in(builder.allocator()),
             r#abstract,
             declare,
-            scope_id: Default::default(),
+            scope_id: Cell::new(builder.scope_id()),
         }
     }
 
@@ -14376,7 +14374,7 @@ impl<'a> StaticBlock<'a> {
             node_id: Cell::new(builder.node_id()),
             span,
             body,
-            scope_id: Default::default(),
+            scope_id: Cell::new(builder.scope_id()),
         }
     }
 
@@ -19732,7 +19730,7 @@ impl<'a> TSEnumBody<'a> {
             node_id: Cell::new(builder.node_id()),
             span,
             members,
-            scope_id: Default::default(),
+            scope_id: Cell::new(builder.scope_id()),
         }
     }
 
@@ -20957,7 +20955,7 @@ impl<'a> TSConditionalType<'a> {
             extends_type,
             true_type,
             false_type,
-            scope_id: Default::default(),
+            scope_id: Cell::new(builder.scope_id()),
         }
     }
 
@@ -22994,7 +22992,7 @@ impl<'a> TSTypeAliasDeclaration<'a> {
             type_parameters: type_parameters.into_in(builder.allocator()),
             type_annotation,
             declare,
-            scope_id: Default::default(),
+            scope_id: Cell::new(builder.scope_id()),
         }
     }
 
@@ -23167,7 +23165,7 @@ impl<'a> TSInterfaceDeclaration<'a> {
             extends,
             body: body.into_in(builder.allocator()),
             declare,
-            scope_id: Default::default(),
+            scope_id: Cell::new(builder.scope_id()),
         }
     }
 
@@ -23799,7 +23797,7 @@ impl<'a> TSCallSignatureDeclaration<'a> {
             this_param: this_param.into_in(builder.allocator()),
             params: params.into_in(builder.allocator()),
             return_type: return_type.into_in(builder.allocator()),
-            scope_id: Default::default(),
+            scope_id: Cell::new(builder.scope_id()),
         }
     }
 
@@ -23965,7 +23963,7 @@ impl<'a> TSMethodSignature<'a> {
             this_param: this_param.into_in(builder.allocator()),
             params: params.into_in(builder.allocator()),
             return_type: return_type.into_in(builder.allocator()),
-            scope_id: Default::default(),
+            scope_id: Cell::new(builder.scope_id()),
         }
     }
 
@@ -24158,7 +24156,7 @@ impl<'a> TSConstructSignatureDeclaration<'a> {
             type_parameters: type_parameters.into_in(builder.allocator()),
             params: params.into_in(builder.allocator()),
             return_type: return_type.into_in(builder.allocator()),
-            scope_id: Default::default(),
+            scope_id: Cell::new(builder.scope_id()),
         }
     }
 
@@ -24431,7 +24429,7 @@ impl<'a> TSModuleDeclaration<'a> {
             body,
             kind,
             declare,
-            scope_id: Default::default(),
+            scope_id: Cell::new(builder.scope_id()),
         }
     }
 
@@ -24697,7 +24695,7 @@ impl<'a> TSGlobalDeclaration<'a> {
             global_span,
             body,
             declare,
-            scope_id: Default::default(),
+            scope_id: Cell::new(builder.scope_id()),
         }
     }
 
@@ -25240,7 +25238,7 @@ impl<'a> TSFunctionType<'a> {
             this_param: this_param.into_in(builder.allocator()),
             params: params.into_in(builder.allocator()),
             return_type: return_type.into_in(builder.allocator()),
-            scope_id: Default::default(),
+            scope_id: Cell::new(builder.scope_id()),
         }
     }
 
@@ -25393,7 +25391,7 @@ impl<'a> TSConstructorType<'a> {
             type_parameters: type_parameters.into_in(builder.allocator()),
             params: params.into_in(builder.allocator()),
             return_type: return_type.into_in(builder.allocator()),
-            scope_id: Default::default(),
+            scope_id: Cell::new(builder.scope_id()),
         }
     }
 
@@ -25544,7 +25542,7 @@ impl<'a> TSMappedType<'a> {
             type_annotation,
             optional,
             readonly,
-            scope_id: Default::default(),
+            scope_id: Cell::new(builder.scope_id()),
         }
     }
 

--- a/crates/oxc_formatter/src/detect_code_removal/mod.rs
+++ b/crates/oxc_formatter/src/detect_code_removal/mod.rs
@@ -23,7 +23,8 @@ pub fn detect_code_removal(
 fn collect(code: &str, source_type: SourceType) -> StatsCollector {
     // Parse the way the formatter does (so the before/after comparison matches the formatter's view).
     let allocator = Allocator::default();
-    let ParserReturn { program, diagnostics, .. } = parse_for_format(&allocator, code, source_type);
+    let ParserReturn { program, diagnostics, ast_counts, .. } =
+        parse_for_format(&allocator, code, source_type);
 
     let mut collector = StatsCollector::default();
 
@@ -35,7 +36,8 @@ fn collect(code: &str, source_type: SourceType) -> StatsCollector {
     }
 
     // Using semantic analysis here only to get parent node
-    let semantic_ret = SemanticBuilder::new().with_build_nodes(true).build(&program);
+    let semantic_ret =
+        SemanticBuilder::new().with_build_nodes(true).with_stats(ast_counts.into()).build(&program);
     collector.collect(&program, &semantic_ret.semantic)
 }
 

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -1146,6 +1146,7 @@ impl Runtime {
 
         let semantic_ret = SemanticBuilder::new_linter()
             .with_check_syntax_error(check_syntax_errors)
+            .with_stats(ret.ast_counts.into())
             .build(allocator.alloc(ret.program));
 
         if !semantic_ret.diagnostics.is_empty() {

--- a/crates/oxc_parser/src/counting_builder.rs
+++ b/crates/oxc_parser/src/counting_builder.rs
@@ -1,0 +1,96 @@
+use std::cell::Cell;
+
+use oxc_allocator::{Allocator, GetAllocator};
+use oxc_ast::builder::{AstBuild, AstBuilder, AstCounts, GetAstBuilder};
+use oxc_syntax::{node::NodeId, reference::ReferenceId, scope::ScopeId, symbol::SymbolId};
+
+/// [`AstBuild`]er which wraps [`AstBuilder`] and counts AST nodes, scopes, symbols,
+/// and references as they are created.
+///
+/// Counts are returned to the caller in `ParserReturn::ast_counts`, so `SemanticBuilder`
+/// can pre-allocate sufficient capacity without traversing the AST to count.
+///
+/// Counts must be saved and restored when the parser rewinds to a checkpoint,
+/// so that speculatively-parsed nodes which are discarded are not counted.
+pub struct CountingAstBuilder<'a> {
+    ast: AstBuilder<'a>,
+    nodes: Cell<u32>,
+    scopes: Cell<u32>,
+    symbols: Cell<u32>,
+    references: Cell<u32>,
+}
+
+impl<'a> CountingAstBuilder<'a> {
+    pub fn new(allocator: &'a Allocator) -> Self {
+        Self {
+            ast: AstBuilder::new(allocator),
+            nodes: Cell::new(0),
+            scopes: Cell::new(0),
+            symbols: Cell::new(0),
+            references: Cell::new(0),
+        }
+    }
+
+    pub fn counts(&self) -> AstCounts {
+        AstCounts {
+            nodes: self.nodes.get(),
+            scopes: self.scopes.get(),
+            symbols: self.symbols.get(),
+            references: self.references.get(),
+        }
+    }
+
+    pub fn set_counts(&self, counts: AstCounts) {
+        self.nodes.set(counts.nodes);
+        self.scopes.set(counts.scopes);
+        self.symbols.set(counts.symbols);
+        self.references.set(counts.references);
+    }
+
+    /// Count a symbol which is not created via a `BindingIdentifier` (enum member names).
+    pub fn count_extra_symbol(&self) {
+        self.symbols.set(self.symbols.get() + 1);
+    }
+}
+
+impl<'a> GetAllocator<'a> for CountingAstBuilder<'a> {
+    #[inline]
+    fn allocator(&self) -> &'a Allocator {
+        self.ast.allocator()
+    }
+}
+
+impl<'a> AstBuild<'a> for CountingAstBuilder<'a> {
+    #[inline]
+    fn node_id(&self) -> NodeId {
+        self.nodes.set(self.nodes.get() + 1);
+        NodeId::DUMMY
+    }
+
+    #[inline]
+    fn scope_id(&self) -> Option<ScopeId> {
+        self.scopes.set(self.scopes.get() + 1);
+        None
+    }
+
+    #[inline]
+    fn symbol_id(&self) -> Option<SymbolId> {
+        self.symbols.set(self.symbols.get() + 1);
+        None
+    }
+
+    #[inline]
+    fn reference_id(&self) -> Option<ReferenceId> {
+        self.references.set(self.references.get() + 1);
+        None
+    }
+}
+
+impl<'a> GetAstBuilder<'a> for CountingAstBuilder<'a> {
+    type Builder = Self;
+
+    #[inline]
+    fn builder(&self) -> &Self {
+        self
+    }
+}

--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -1,7 +1,10 @@
 //! Code related to navigating `Token`s from the lexer
 
 use oxc_allocator::{ArenaBox, ArenaVec};
-use oxc_ast::ast::{BindingRestElement, RegExpFlags};
+use oxc_ast::{
+    ast::{BindingRestElement, RegExpFlags},
+    builder::AstCounts,
+};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::{GetSpan, Span};
 
@@ -18,6 +21,7 @@ pub struct ParserCheckpoint<'a> {
     prev_span_end: u32,
     errors_pos: usize,
     fatal_error: Option<FatalError>,
+    ast_counts: AstCounts,
 }
 
 impl<'a, C: Config> ParserImpl<'a, C> {
@@ -309,6 +313,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             prev_span_end: self.prev_token_end,
             errors_pos: self.errors.len(),
             fatal_error: self.fatal_error.take(),
+            ast_counts: self.ast.counts(),
         }
     }
 
@@ -319,18 +324,26 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             prev_span_end: self.prev_token_end,
             errors_pos: self.errors.len(),
             fatal_error: self.fatal_error.take(),
+            ast_counts: self.ast.counts(),
         }
     }
 
     pub(crate) fn rewind(&mut self, checkpoint: ParserCheckpoint<'a>) {
-        let ParserCheckpoint { lexer, cur_token, prev_span_end, errors_pos, fatal_error } =
-            checkpoint;
+        let ParserCheckpoint {
+            lexer,
+            cur_token,
+            prev_span_end,
+            errors_pos,
+            fatal_error,
+            ast_counts,
+        } = checkpoint;
 
         self.lexer.rewind(lexer);
         self.token = cur_token;
         self.prev_token_end = prev_span_end;
         self.errors.truncate(errors_pos);
         self.fatal_error = fatal_error;
+        self.ast.set_counts(ast_counts);
     }
 
     pub(crate) fn lookahead<U>(&mut self, predicate: impl Fn(&mut ParserImpl<'a, C>) -> U) -> U {

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -68,6 +68,7 @@ use std::any::Any;
 
 pub mod config;
 mod context;
+mod counting_builder;
 mod cursor;
 mod error_handler;
 mod modifiers;
@@ -90,7 +91,7 @@ pub mod lexer;
 use oxc_allocator::{Allocator, ArenaBox, ArenaVec, Dummy, GetAllocator};
 use oxc_ast::{
     ast::{Expression, Program, Statement},
-    builder::{AstBuilder, GetAstBuilder},
+    builder::{AstCounts, GetAstBuilder},
 };
 use oxc_diagnostics::{Diagnostics, OxcDiagnostic};
 use oxc_span::{SourceType, Span};
@@ -102,6 +103,7 @@ use crate::{
         LexerConfig, NoTokensParserConfig, ParserConfig, RuntimeParserConfig, TokensParserConfig,
     },
     context::{Context, StatementContext},
+    counting_builder::CountingAstBuilder,
     error_handler::FatalError,
     lexer::Lexer,
     module_record::ModuleRecordBuilder,
@@ -177,6 +179,17 @@ pub struct ParserReturn<'a> {
     ///
     /// Tokens are only collected when tokens are enabled in [`ParserConfig`].
     pub tokens: ArenaVec<'a, Token>,
+
+    /// Counts of AST nodes, scopes, symbols, and references in the program.
+    ///
+    /// Counts are upper bounds (see [`AstCounts`]). Convert to `oxc_semantic::Stats` and pass to
+    /// `SemanticBuilder::with_stats` to pre-allocate capacity, avoiding a full-AST counting pass.
+    ///
+    /// These describe the AST *as parsed*, so they only size a `SemanticBuilder::build` on an
+    /// AST the parser produced. Passes which mutate the AST (transformer, minifier) add nodes,
+    /// scopes and symbols the parser never saw. To size a semantic rebuild after such a pass,
+    /// use `Semantic::stats()` from the preceding build, which measures actual counts.
+    pub ast_counts: AstCounts,
 
     /// Whether the parser panicked and terminated early.
     ///
@@ -635,7 +648,7 @@ struct ParserImpl<'a, C: ParserConfig> {
     ctx: Context,
 
     /// Ast builder for creating AST nodes
-    ast: AstBuilder<'a>,
+    ast: CountingAstBuilder<'a>,
 
     /// Module Record Builder
     module_record_builder: ModuleRecordBuilder<'a>,
@@ -671,7 +684,7 @@ impl<'a, C: ParserConfig> ParserImpl<'a, C> {
             prev_token_end: 0,
             state: ParserState::new(),
             ctx: Self::default_context(source_type, options),
-            ast: AstBuilder::new(allocator),
+            ast: CountingAstBuilder::new(allocator),
             module_record_builder: ModuleRecordBuilder::new(allocator, source_type),
             is_ts: source_type.is_typescript(),
         }
@@ -698,6 +711,8 @@ impl<'a, C: ParserConfig> ParserImpl<'a, C> {
             program = Program::dummy(self.allocator());
             program.source_type = self.source_type;
             program.source_text = self.source_text;
+            // Counts reflect the aborted partial parse, not the dummy program
+            self.ast.set_counts(AstCounts::default());
         }
 
         self.check_unfinished_errors();
@@ -755,6 +770,7 @@ impl<'a, C: ParserConfig> ParserImpl<'a, C> {
             diagnostics: errors,
             irregular_whitespaces,
             tokens,
+            ast_counts: self.ast.counts(),
             panicked,
             is_flow_language,
         }
@@ -823,21 +839,30 @@ impl<'a, C: ParserConfig> ParserImpl<'a, C> {
         let original_tokens =
             if self.lexer.config.tokens() { Some(self.lexer.take_tokens()) } else { None };
 
+        // The checkpoints hold mid-first-parse count snapshots, so `rewind` would discard
+        // counts for everything parsed after the checkpoint. Accumulate reparse deltas
+        // onto the full first-parse counts instead.
+        let mut counts = self.ast.counts();
+
         let checkpoints = std::mem::take(&mut self.state.potential_await_reparse);
         for (stmt_index, checkpoint) in checkpoints {
             // Rewind to the checkpoint
             self.rewind(checkpoint);
+            let counts_before = self.ast.counts();
 
             // Parse the statement with await context enabled (TopLevel context is already set)
             let stmt = self.context_add(Context::Await, |p| {
                 p.parse_statement_list_item(StatementContext::StatementList)
             });
+            counts += self.ast.counts() - counts_before;
 
             // Replace the statement if the index is valid
             if stmt_index < statements.len() {
                 statements[stmt_index] = stmt;
             }
         }
+
+        self.ast.set_counts(counts);
 
         if let Some(original_tokens) = original_tokens {
             self.lexer.set_tokens(original_tokens);
@@ -909,10 +934,10 @@ impl<'a, C: ParserConfig> GetAllocator<'a> for ParserImpl<'a, C> {
 }
 
 impl<'a, C: ParserConfig> GetAstBuilder<'a> for ParserImpl<'a, C> {
-    type Builder = AstBuilder<'a>;
+    type Builder = CountingAstBuilder<'a>;
 
     #[inline]
-    fn builder(&self) -> &AstBuilder<'a> {
+    fn builder(&self) -> &CountingAstBuilder<'a> {
         &self.ast
     }
 }

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -70,6 +70,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_ts_enum_member_name(&mut self) -> TSEnumMemberName<'a> {
+        // Each enum member name creates a symbol, but has no `BindingIdentifier`
+        self.ast.count_extra_symbol();
         match self.cur_kind() {
             Kind::Str => {
                 let literal = self.parse_literal_string();

--- a/crates/oxc_semantic/src/stats.rs
+++ b/crates/oxc_semantic/src/stats.rs
@@ -3,6 +3,7 @@ use std::cell::Cell;
 use oxc_ast::{
     AstKind,
     ast::{BindingIdentifier, IdentifierReference, Program, TSEnumMemberName},
+    builder::AstCounts,
 };
 use oxc_ast_visit::{Visit, walk::walk_ts_enum_member_name};
 use oxc_syntax::scope::{ScopeFlags, ScopeId};
@@ -45,6 +46,7 @@ macro_rules! assert_ge {
 /// `ScopeTree`, and `SymbolTable` to store info for all these items.
 ///
 /// * Obtain `Stats` from an existing [`Semantic`] with [`Semantic::stats`].
+/// * Convert the parser's counts (`ParserReturn::ast_counts`) with `Stats::from`.
 /// * Use [`Stats::count`] to visit AST and obtain accurate counts.
 ///
 /// # Example
@@ -73,6 +75,27 @@ pub struct Stats {
     pub symbols: u32,
     /// Number of identifier references.
     pub references: u32,
+}
+
+/// Convert [`AstCounts`] produced by the parser (`ParserReturn::ast_counts`) to [`Stats`].
+///
+/// The counts are upper bounds, which is sufficient for pre-allocating capacity.
+///
+/// Only valid for a [`Semantic`] built on the AST the parser produced. Once a pass has mutated
+/// the AST, prefer [`Semantic::stats`] from the preceding build - it measures actual counts,
+/// whereas these describe the AST as parsed.
+///
+/// [`Semantic`]: super::Semantic
+/// [`Semantic::stats`]: super::Semantic::stats
+impl From<AstCounts> for Stats {
+    fn from(counts: AstCounts) -> Self {
+        Stats {
+            nodes: counts.nodes,
+            scopes: counts.scopes,
+            symbols: counts.symbols,
+            references: counts.references,
+        }
+    }
 }
 
 impl Stats {

--- a/napi/parser/src/lib.rs
+++ b/napi/parser/src/lib.rs
@@ -112,7 +112,8 @@ fn parse_with_return(filename: &str, source_text: &str, options: &ParserOptions)
     let mut diagnostics = ret.diagnostics;
 
     if options.show_semantic_errors == Some(true) {
-        let semantic_ret = SemanticBuilder::new_compiler().build(&program);
+        let semantic_ret =
+            SemanticBuilder::new_compiler().with_stats(ret.ast_counts.into()).build(&program);
         diagnostics.extend(semantic_ret.diagnostics);
     }
 

--- a/napi/parser/src/raw_transfer.rs
+++ b/napi/parser/src/raw_transfer.rs
@@ -275,7 +275,8 @@ unsafe fn parse_raw_impl(
         // Note: Avoid calling `Error::from_diagnostics_in` unless there are some errors,
         // because it's fairly expensive (it copies whole of source text into a `String`).
         let mut errors = if options.show_semantic_errors == Some(true) {
-            let semantic_ret = SemanticBuilder::new_compiler().build(&program);
+            let semantic_ret =
+                SemanticBuilder::new_compiler().with_stats(ret.ast_counts.into()).build(&program);
 
             if !ret.diagnostics.is_empty() || !semantic_ret.diagnostics.is_empty() {
                 Error::from_diagnostics_in(

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -12,7 +12,7 @@ use serde::Serialize;
 
 use oxc::{
     allocator::Allocator,
-    ast::ast::Program,
+    ast::{ast::Program, builder::AstCounts},
     ast_visit::Visit,
     codegen::{Codegen, CodegenOptions, CommentOptions, LegalComment},
     diagnostics::OxcDiagnostic,
@@ -21,7 +21,7 @@ use oxc::{
     minifier::{CompressOptions, Minifier, MinifierOptions, MinifierReturn},
     parser::{ParseOptions, Parser, ParserReturn},
     semantic::{
-        ReferenceId, ScopeFlags, ScopeId, Scoping, SemanticBuilder, SymbolFlags, SymbolId,
+        ReferenceId, ScopeFlags, ScopeId, Scoping, SemanticBuilder, Stats, SymbolFlags, SymbolId,
         dot::{DebugDot, DebugDotContext},
     },
     span::{SourceType, Span},
@@ -127,12 +127,17 @@ impl Oxc {
             SourceType::from_path(&path).map_err(|e| napi::Error::from_reason(e.to_string()))?;
 
         // Phase 1: Parse source
-        let (mut program, mut module_record) =
+        let (mut program, mut module_record, ast_counts) =
             self.parse_source(&allocator, &source_text, source_type, parser_options);
 
         // Phase 2: Build semantic analysis
-        let semantic =
-            self.build_semantic(&program, run_options, parser_options, &control_flow_options);
+        let semantic = self.build_semantic(
+            &program,
+            ast_counts,
+            run_options,
+            parser_options,
+            &control_flow_options,
+        );
 
         // Phase 3: Run linter
         let linter_module_record = Arc::new(ModuleRecord::new(&path, &module_record, &semantic));
@@ -216,7 +221,7 @@ impl Oxc {
         source_text: &'a str,
         source_type: SourceType,
         parser_options: &OxcParserOptions,
-    ) -> (Program<'a>, oxc::syntax::module_record::ModuleRecord<'a>) {
+    ) -> (Program<'a>, oxc::syntax::module_record::ModuleRecord<'a>, AstCounts) {
         let parser_options = ParseOptions {
             parse_regular_expression: true,
             allow_return_outside_function: parser_options.allow_return_outside_function,
@@ -224,25 +229,29 @@ impl Oxc {
             allow_v8_intrinsics: parser_options.allow_v8_intrinsics,
             ..ParseOptions::default()
         };
-        let ParserReturn { program, diagnostics, module_record, .. } =
+        let ParserReturn { program, diagnostics, module_record, ast_counts, .. } =
             Parser::new(allocator, source_text, source_type).with_options(parser_options).parse();
         self.diagnostics.extend(diagnostics);
-        (program, module_record)
+        (program, module_record, ast_counts)
     }
 
     fn build_semantic<'a>(
         &mut self,
         program: &'a Program<'a>,
+        ast_counts: AstCounts,
         run_options: &OxcRunOptions,
         parser_options: &OxcParserOptions,
         control_flow_options: &OxcControlFlowOptions,
     ) -> oxc::semantic::Semantic<'a> {
         let mut semantic_builder = SemanticBuilder::new_compiler().with_build_nodes(true);
+        let mut stats = Stats::from(ast_counts);
         if run_options.transform {
             // Estimate transformer will triple scopes, symbols, references
-            semantic_builder = semantic_builder.with_excess_capacity(2.0).with_enum_eval(true);
+            stats = stats.increase_by(2.0);
+            semantic_builder = semantic_builder.with_enum_eval(true);
         }
         let semantic_ret = semantic_builder
+            .with_stats(stats)
             .with_check_syntax_error(parser_options.semantic_errors)
             .with_cfg(run_options.cfg)
             .build(program);

--- a/napi/transform/src/transformer.rs
+++ b/napi/transform/src/transformer.rs
@@ -1081,7 +1081,7 @@ fn module_runner_transform_impl(
     let mut program = parser_ret.program;
 
     let SemanticBuilderReturn { semantic, diagnostics } =
-        SemanticBuilder::new_compiler().build(&program);
+        SemanticBuilder::new_compiler().with_stats(parser_ret.ast_counts.into()).build(&program);
     parser_ret.diagnostics.extend(diagnostics);
 
     let scoping = semantic.into_scoping();

--- a/tasks/ast_tools/src/generators/builder_methods.rs
+++ b/tasks/ast_tools/src/generators/builder_methods.rs
@@ -49,9 +49,6 @@ impl Generator for BuilderMethodsGenerator {
         let output = quote! {
             //! AST node builder methods.
 
-            //!@@line_break
-            #![expect(clippy::default_trait_access)]
-
             ///@@line_break
             use std::cell::Cell;
 
@@ -416,7 +413,15 @@ fn get_struct_fn_params_and_fields(
                 return Some(&param.fn_param);
             }
 
-            fields.push(quote!( #param_ident: Default::default() ));
+            // ID cells (`Cell<Option<ScopeId>>` etc.) are assigned by the builder,
+            // so it can count scopes, symbols, and references
+            let value = match param.field.type_def(schema).innermost_type(schema).name() {
+                "ScopeId" => quote!(Cell::new(builder.scope_id())),
+                "SymbolId" => quote!(Cell::new(builder.symbol_id())),
+                "ReferenceId" => quote!(Cell::new(builder.reference_id())),
+                _ => quote!(Default::default()),
+            };
+            fields.push(quote!( #param_ident: #value ));
             return None;
         }
 

--- a/tasks/benchmark/benches/semantic.rs
+++ b/tasks/benchmark/benches/semantic.rs
@@ -21,15 +21,17 @@ fn bench_semantic(criterion: &mut Criterion) {
                 allocator.reset();
 
                 // Create fresh AST for each iteration, as `SemanticBuilder` alters the AST
-                let program = Parser::new(&allocator, source_text, source_type).parse().program;
-                let program = black_box(program);
+                let parser_ret = Parser::new(&allocator, source_text, source_type).parse();
+                let parser_ret = black_box(parser_ret);
 
                 runner.run(|| {
                     // We drop `Semantic` inside this closure as drop time is part of cost of using this API.
                     // We return `errors` to be dropped outside of the measured section, as usually
                     // real-world code has no errors, so allocating and dropping them is atypical and
                     // we don't want to include it in benchmark time.
-                    let ret = SemanticBuilder::new_compiler().build(&program);
+                    let ret = SemanticBuilder::new_compiler()
+                        .with_stats(parser_ret.ast_counts.into())
+                        .build(&parser_ret.program);
                     let ret = black_box(ret);
                     ret.diagnostics
                 });

--- a/tasks/coverage/src/driver.rs
+++ b/tasks/coverage/src/driver.rs
@@ -8,6 +8,7 @@ use oxc::{
     ast::{
         Comment,
         ast::{Program, RegExpLiteral},
+        builder::AstCounts,
     },
     ast_visit::{VisitJs, walk_js},
     codegen::{CodegenOptions, CodegenReturn},
@@ -39,6 +40,8 @@ pub struct Driver {
     pub errors: Diagnostics,
     pub printed: String,
     pub source_type: Option<SourceType>,
+    /// Parser counts from a clean parse, to check against actual semantic counts
+    pub ast_counts: Option<AstCounts>,
 }
 
 impl CompilerInterface for Driver {
@@ -78,9 +81,10 @@ impl CompilerInterface for Driver {
     }
 
     fn after_parse(&mut self, parser_return: &mut ParserReturn) -> ControlFlow<()> {
-        let ParserReturn { program, panicked, diagnostics, .. } = parser_return;
+        let ParserReturn { program, panicked, diagnostics, ast_counts, .. } = parser_return;
         self.panicked = *panicked;
         self.source_type = Some(program.source_type);
+        self.ast_counts = (!*panicked && diagnostics.is_empty()).then_some(*ast_counts);
         self.check_ast_nodes(program);
         if self.check_comments(&program.comments) {
             return ControlFlow::Break(());
@@ -94,6 +98,20 @@ impl CompilerInterface for Driver {
     }
 
     fn after_semantic(&mut self, ret: &mut SemanticBuilderReturn) -> ControlFlow<()> {
+        // Check parser counts are sufficient to pre-allocate semantic's containers.
+        // Counts are upper bounds - cover grammar conversions may over-count.
+        if let Some(counts) = self.ast_counts.take() {
+            let stats = ret.semantic.stats();
+            if counts.nodes < stats.nodes
+                || counts.scopes < stats.scopes
+                || counts.symbols < stats.symbols
+                || counts.references < stats.references
+            {
+                self.errors.push(OxcDiagnostic::error(format!(
+                    "Parser under-counted AST: {counts:?} < actual {stats:?}"
+                )));
+            }
+        }
         if self.check_semantic {
             let program = ret.semantic.nodes().program();
             if let Some(errors) = check_semantic_ids(program) {


### PR DESCRIPTION
When no stats are provided, `SemanticBuilder::build` runs `Stats::count(program)` — a full AST traversal — purely to pre-allocate `AstNodes` / `ScopeTree` / `SymbolTable`. Every hot path paid it: the oxlint per-file lint path, napi/parser, napi/transform, and the `Compiler`'s initial build.

The parser now counts while building the AST, using the counting `AstBuild` implementation anticipated by the trait's doc comment:

- `ParserImpl` wraps `AstBuilder` in a `CountingAstBuilder`. The existing `builder.node_id()` call in every generated `X::new` counts nodes with **zero codegen change**; new default-bodied `AstBuild` hooks (`scope_id` / `symbol_id` / `reference_id`) are emitted for the 26 ID-cell fields and count scopes/symbols/references. All other `AstBuild`/`GetAstBuilder` users are untouched and compile to exactly the same code as before.
- Counts snapshot/restore through `ParserCheckpoint`, so speculative parses (arrow lookahead, TS type probes, error recovery) don't over-count. The top-level-await reparse loop delta-accumulates instead of naively restoring (its checkpoints are mid-first-parse snapshots).
- `ParserReturn` gains `pub ast_counts: AstCounts` (`#[non_exhaustive]`, non-breaking). Fatal parses reset counts to match the dummy program.
- Consumers pass `.with_stats(ret.ast_counts.into())`: linter runtime, oxlint js_plugins, `CompilerInterface::semantic` (now takes `stats: Stats`; the transform path applies `increase_by(2.0)` in place of `with_excess_capacity`), napi parser/raw_transfer/transform, playground, formatter `detect_code_removal`, and the criterion `semantic` bench.

Only nodes built through the AST builder get counted, so anything bypassing it has to be counted by hand: TS enum member names create a symbol without a `BindingIdentifier`. Counts are otherwise **upper bounds** — cover-grammar conversions legitimately over-count. A new oracle in the coverage driver asserts `counts >= actual` per field over Test262 + Babel + TypeScript.

An earlier revision of this PR also hand-counted the shorthand import/export specifier clones. #24540 has since removed those clones from the parser — imports no longer clone, and exports build through `duplicate_module_export_name` — so the builder counts them automatically and the hand-counting is gone.

## Performance

Semantic build (release, median, direct A/B):

| File | Semantic build | Parser cost |
|---|---|---|
| checker.ts | **−16.5%** (6.72ms → 5.61ms) | +0.4% |
| kitchen-sink.tsx | **−22.2%** (2.09ms → 1.62ms) | +0.7% |
| react.development.js | **−25.4%** (104µs → 77µs) | no change |

Parser cost is one inlined `Cell` increment per node behind the existing `node_id()` hook.

The criterion `semantic` bench now passes `ast_counts` like real consumers do (parse stays in the unmeasured setup phase). CodSpeed confirms: all 5 `semantic[*]` benchmarks improve **+8.6–11.4%** (kitchen-sink.tsx +11.35%, App.tsx +10.3%, RadixUIAdoptionSection.jsx +8.96%, react.development.js +8.63%, binder.ts +8.57%). Instruction-count simulation under-weights the removed walk's cache misses, so wall-clock wins are larger (table above; −22.0% on a local criterion A/B of the bench wiring alone, react.development.js 127.6µs → 98.8µs).

Follow-ups: standalone `Minifier::build`'s first semantic build has no `ParserReturn` to draw from; rolldown can adopt `ast_counts` the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
