### PR TITLE
perf(react_compiler): use FxHashMap for the lookup-only aliasing node map

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_ranges.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_ranges.rs
@@ -108,12 +108,12 @@ impl Node {
 }
 
 struct AliasingState {
-    nodes: FxIndexMap<IdentifierId, Node>,
+    nodes: FxHashMap<IdentifierId, Node>,
 }
 
 impl AliasingState {
     fn new() -> Self {
-        AliasingState { nodes: FxIndexMap::default() }
+        AliasingState { nodes: FxHashMap::default() }
     }
 
     fn create(&mut self, place: &Place, value: NodeValue) {


### PR DESCRIPTION
`AliasingState.nodes` in `infer_mutation_aliasing_ranges.rs` is only accessed via `get`/`get_mut`/`insert`/`entry`/`contains_key` — never iterated — so its insertion order is never observed. Switching it from `FxIndexMap` to `FxHashMap` drops the entry `Vec` that `IndexMap` maintains, and since `IdentifierId -> Node` is unique to this pass, it also removes the `IndexMap` monomorphization (small binary-size win). The order-critical `created_from`/`captures`/`aliases`/`maybe_aliases` maps (iterated into a worklist that drives diagnostic order) stay `FxIndexMap`.

Snapshots unchanged (`cargo test -p oxc_react_compiler`).