### PR TITLE
feat(parser): add `ParseOptions::enable_ident_hashes`

### DIFF
--- a/crates/oxc_formatter/src/lib.rs
+++ b/crates/oxc_formatter/src/lib.rs
@@ -210,6 +210,9 @@ pub fn parse_for_format<'a>(
         allow_return_outside_function: true, // accept all syntax the formatter may be handed
         allow_v8_intrinsics: true,
         preserve_parens: false, // MUST be false: the formatter panics otherwise
+        // The formatter does not use `Ident` hashes, but `detect_code_removal` runs semantic
+        // analysis on this AST, and semantic requires hashed `Ident`s.
+        enable_ident_hashes: cfg!(feature = "detect_code_removal"),
     };
     Parser::new(allocator, source_text, source_type).with_options(options).parse()
 }

--- a/crates/oxc_formatter_json/src/parse.rs
+++ b/crates/oxc_formatter_json/src/parse.rs
@@ -53,7 +53,11 @@ pub fn parse_json<'a>(
     // So the JS lexer rules apply uniformly regardless of `variant`.
     // e.g. line terminators (incl. U+2028 / U+2029), trailing commas, single quotes
     // Downstream newline scans must therefore be LS/PS-aware for all variants, not just JSON5.
-    let options = ParseOptions { preserve_parens: false, ..ParseOptions::default() };
+    let options = ParseOptions {
+        preserve_parens: false,
+        enable_ident_hashes: false, // the JSON formatter does not use `Ident` hashes
+        ..ParseOptions::default()
+    };
     let ret =
         Parser::new(allocator, wrapped_source, SourceType::default()).with_options(options).parse();
 

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -125,7 +125,20 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         // from source text without going through `get_string`'s kind matching.
         let name = if token.escaped() { self.cur_string() } else { self.token_source(&token) };
         self.advance(kind);
-        (span, Ident::from(name))
+        (span, self.ident(name))
+    }
+
+    /// Create an [`Ident`], respecting [`ParseOptions::enable_ident_hashes`].
+    ///
+    /// All parser-created [`Ident`]s must be built through this method (or copied from another
+    /// `Ident` that was), so that [`ParseOptions::enable_ident_hashes`] applies uniformly.
+    /// Building an `Ident` from a `&str`/`Str` via `Into` instead would always hash it, producing
+    /// an AST where some `Ident`s are hashed and some are not.
+    ///
+    /// [`ParseOptions::enable_ident_hashes`]: crate::ParseOptions::enable_ident_hashes
+    #[inline]
+    pub(crate) fn ident(&self, name: &'a str) -> Ident<'a> {
+        if self.options.enable_ident_hashes { Ident::from(name) } else { Ident::new_unhashed(name) }
     }
 
     pub(crate) fn check_identifier(&mut self, kind: Kind, ctx: Context) {
@@ -159,7 +172,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     /// # Panics
     pub(crate) fn parse_private_identifier(&mut self) -> PrivateIdentifier<'a> {
         let span = self.cur_token().span();
-        let name = Str::from(self.cur_string());
+        let name = self.ident(self.cur_string());
         self.bump_any();
         PrivateIdentifier::new(span, name, self)
     }

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -887,7 +887,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                         // { type as as }
                         property_name = Some(ModuleExportName::new_identifier_name(
                             type_or_name_token.span(),
-                            self.token_source(&type_or_name_token),
+                            self.ident(self.token_source(&type_or_name_token)),
                             self,
                         ));
                         name = ModuleExportName::new_identifier_name(
@@ -950,7 +950,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 ImportOrExportSpecifier::Import(ImportSpecifier::new(
                     self.end_span(specifier_span),
                     property_name.unwrap_or_else(|| name.clone()),
-                    BindingIdentifier::new(name.span(), name.name(), self),
+                    BindingIdentifier::new(name.span(), self.ident(name.name().as_str()), self),
                     kind,
                     self,
                 ))

--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -178,7 +178,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             };
 
         if is_reference {
-            JSXElementName::new_identifier_reference(identifier.span, identifier.name, self)
+            JSXElementName::new_identifier_reference(
+                identifier.span,
+                self.ident(identifier.name.as_str()),
+                self,
+            )
         } else if name == "this" {
             JSXElementName::new_this_expression(identifier.span, self)
         } else {
@@ -197,7 +201,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let mut object = if object.name == "this" {
             JSXMemberExpressionObject::new_this_expression(object.span, self)
         } else {
-            JSXMemberExpressionObject::new_identifier_reference(object.span, object.name, self)
+            JSXMemberExpressionObject::new_identifier_reference(
+                object.span,
+                self.ident(object.name.as_str()),
+                self,
+            )
         };
 
         let mut span = Span::new(span, 0);

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -231,6 +231,19 @@ pub struct ParseOptions {
     ///
     /// [`V8IntrinsicExpression`]: oxc_ast::ast::V8IntrinsicExpression
     pub allow_v8_intrinsics: bool,
+
+    /// Precompute hashes for identifier names (`Ident`s) in the AST.
+    ///
+    /// Precomputed hashes speed up `Ident`-keyed hash map operations in semantic analysis
+    /// and later compilation stages, at a small cost to parsing speed.
+    ///
+    /// Only disable this for parse-only pipelines that never rely on `Ident` hashing, such as
+    /// parse + serialize or formatting. Unhashed `Ident`s do not compare equal to hashed ones,
+    /// so semantic analysis and anything else relying on `Ident` hashing must not run on an AST
+    /// parsed with this option disabled.
+    ///
+    /// Default: `true`
+    pub enable_ident_hashes: bool,
 }
 
 impl Default for ParseOptions {
@@ -241,6 +254,7 @@ impl Default for ParseOptions {
             allow_return_outside_function: false,
             preserve_parens: true,
             allow_v8_intrinsics: false,
+            enable_ident_hashes: true,
         }
     }
 }

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -153,7 +153,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 // `type something = intrinsic. ...`
                 let left_name = TSTypeName::new_identifier_reference(
                     intrinsic_token.span(),
-                    self.token_source(&intrinsic_token),
+                    self.ident(self.token_source(&intrinsic_token)),
                     self,
                 );
                 let type_name =
@@ -739,7 +739,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.error(diagnostics::identifier_reserved_word(this_span, "this"));
             self.bump_any();
             // Recover by creating an identifier
-            let this = this_span.source_text(self.source_text);
+            let this = self.ident(this_span.source_text(self.source_text));
             debug_assert_eq!(this, "this");
             let ident = IdentifierReference::boxed(this_span, this, self);
             return TSModuleReference::IdentifierReference(ident);

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -1206,7 +1206,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.error(diagnostics::ts_import_type_options_expected_with(key_span));
         }
         // Use the actual string from the source (not a static string) to ensure it's in the arena
-        let key_name = self.cur_string();
+        let key_name = self.ident(self.cur_string());
         let with_key_span = self.start_span();
         self.bump_any();
         let with_key = IdentifierName::boxed(self.end_span(with_key_span), key_name, self);

--- a/crates/oxc_str/src/ident.rs
+++ b/crates/oxc_str/src/ident.rs
@@ -37,6 +37,17 @@ impl LenAndHash {
         Self((len as u64) | ((hash as u64) << 32))
     }
 
+    /// Create a `LenAndHash` with a `0` hash directly from a `usize` `len`.
+    ///
+    /// Converting the `usize` straight to `u64` (rather than truncating to `u32` and widening
+    /// back) is a no-op, because identifier lengths always fit in 32 bits, so the top 32 bits
+    /// (the hash) are `0`. This lets [`Ident::new_unhashed`] compile to a no-op reinterpret of
+    /// `&str`, which has identical layout.
+    #[inline(always)]
+    const fn unhashed(len: usize) -> Self {
+        Self(len as u64)
+    }
+
     #[expect(clippy::cast_possible_truncation)]
     #[inline(always)]
     const fn len(self) -> u32 {
@@ -72,6 +83,15 @@ impl LenAndHash {
     #[inline(always)]
     const fn new(len: u32, hash: u32) -> Self {
         Self { len, hash }
+    }
+
+    /// Create a `LenAndHash` with a `0` hash directly from a `usize` `len`.
+    ///
+    /// See the 64-bit version of this method for why it takes a `usize`.
+    #[expect(clippy::cast_possible_truncation)]
+    #[inline(always)]
+    const fn unhashed(len: usize) -> Self {
+        Self { len: len as u32, hash: 0 }
     }
 
     #[inline(always)]
@@ -136,13 +156,32 @@ impl<'a> Ident<'a> {
         new_const_ident(allocator.allocator().alloc_str(s))
     }
 
+    /// Create an [`Ident`] without precomputing its hash (hash field is `0`).
+    ///
+    /// `Eq` and `Hash` include the stored hash, so an unhashed `Ident` does not compare equal to,
+    /// or hash the same as, a hashed `Ident` of the same string. Only use this when nothing
+    /// downstream relies on `Ident` hashing (e.g. parse-only pipelines that skip semantic analysis).
+    ///
+    /// On 64-bit platforms this compiles to a no-op: an unhashed `Ident` has the same layout and
+    /// bit representation as `&str` (a pointer plus the `usize` length, whose top 32 bits are the
+    /// `0` hash), so no work is done beyond reinterpreting the `&str`.
+    #[inline]
+    pub const fn new_unhashed(s: &'a str) -> Self {
+        let bytes = s.as_bytes();
+        let ptr = NonNull::from_ref(bytes).cast::<u8>();
+        // `ptr` points to a `&str` with lifetime `'a`, of length `bytes.len()`, whose memory is
+        // immutable for lifetime `'a`. The stored hash is `0` (unhashed).
+        Self { ptr, len_and_hash: LenAndHash::unhashed(bytes.len()), _marker: PhantomData }
+    }
+
     /// Create an [`Ident`] from raw components.
     ///
     /// # SAFETY
     ///
     /// * `ptr` must point to the start of a valid UTF-8 string, of length `len`.
     /// * The memory pointed to `len` bytes starting at `ptr` must be valid for reads and immutable for lifetime `'a`.
-    /// * `hash` must be an accurate hash of the string, calculated with `ident_hash`.
+    /// * `hash` must be an accurate hash of the string, calculated with `ident_hash`,
+    ///   or `0` for an unhashed `Ident` (see [`Ident::new_unhashed`]).
     #[inline]
     const unsafe fn from_raw(ptr: NonNull<u8>, len: u32, hash: u32) -> Self {
         Self { ptr, len_and_hash: LenAndHash::new(len, hash), _marker: PhantomData }

--- a/napi/parser/src/lib.rs
+++ b/napi/parser/src/lib.rs
@@ -84,6 +84,9 @@ fn parse_impl<'a>(
 ) -> ParserReturn<'a> {
     let parser = Parser::new(allocator, source_text, source_type).with_options(ParseOptions {
         preserve_parens: options.preserve_parens.unwrap_or(true),
+        // Ident hashes are only consumed by semantic analysis, which this crate runs solely when
+        // semantic errors are requested. Skip hashing otherwise to speed up parse-and-serialize.
+        enable_ident_hashes: options.show_semantic_errors == Some(true),
         ..ParseOptions::default()
     });
 

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -222,6 +222,7 @@ impl Oxc {
             allow_return_outside_function: parser_options.allow_return_outside_function,
             preserve_parens: parser_options.preserve_parens,
             allow_v8_intrinsics: parser_options.allow_v8_intrinsics,
+            ..ParseOptions::default()
         };
         let ParserReturn { program, diagnostics, module_record, .. } =
             Parser::new(allocator, source_text, source_type).with_options(parser_options).parse();


### PR DESCRIPTION
Adds `ParseOptions::enable_ident_hashes` (default `true`) and `Ident::new_unhashed` in `oxc_str`, and turns it off in the parse-only paths of the `oxc-parser` napi crate and the JS/JSON formatters.

### Why

`Ident`'s precomputed hash (#19143) is a parse-time investment that pays off in semantic analysis — but parse-only consumers (parse + serialize, formatting) pay it for nothing. Profiling against other native parsers showed identifier hashing at 3.5-4.6% of parse time.

Measured on M-series (yuku-style native harness, 50 warmup + 300 runs, median):

| fixture | default | option off |
|---|---|---|
| react.development.js | 0.156 ms | 0.152 ms (−2.3%) |
| binder.ts | 0.383 ms | 0.370 ms (−3.5%) |
| App.tsx | 1.140 ms | 1.111 ms (−2.5%) |
| checker.ts | 7.862 ms | 7.499 ms (−4.6%) |
| typescript.js | 25.07 ms | 24.16 ms (−3.6%) |

### Contract

Unhashed `Ident`s store hash `0`; `Eq`/`Hash`/`ContentEq` include the stored hash, so unhashed and hashed `Ident`s of the same string do not compare equal. Semantic analysis (or anything relying on `Ident` hashing) must not run on an AST parsed with the option disabled. Default behavior is unchanged.

Every `Ident` the parser creates funnels through the `ParserImpl::ident()` helper, so the option applies uniformly. This covers identifiers lexed directly (`parse_identifier_kind`, `parse_private_identifier`) as well as those reconstructed from a `&str`/`Str` — import/export specifier locals, JSX element/member names, the TS `intrinsic` type name, TS import-type option keys (`with`/`assert`), and the `import x = this` recovery path — which would otherwise always be hashed through `Into<Ident>`. Exhaustively checked by parsing the test262/babel/typescript/misc/prettier corpora (96.5k files, 5.6M identifiers) in both option states and walking every `Ident` in the AST.

On 64-bit platforms `Ident::new_unhashed` compiles to a no-op: an unhashed `Ident` has the same layout and bit representation as `&str`.

### Opt-outs

- **napi `oxc-parser`** ties `enable_ident_hashes` to whether semantic errors are requested. Both parse entry points run `SemanticBuilder` only when `showSemanticErrors` is set, so the common parse-and-serialize path skips hashing while the semantic-errors path keeps it. Serialized output is unchanged — the hash is internal to `Ident` and never emitted.
- **JS and JSON formatters** turn it off: they never run semantic analysis and only read `Ident::as_str` / compare idents against string literals. Exception: the JS formatter keeps hashes when built with the `detect_code_removal` feature, whose check runs `SemanticBuilder` on the formatter-parsed AST.


