### PR TITLE
feat(parser): add `ParseOptions::parse_comment_annotations`

### DIFF
--- a/crates/oxc_formatter/src/lib.rs
+++ b/crates/oxc_formatter/src/lib.rs
@@ -210,6 +210,7 @@ pub fn parse_for_format<'a>(
         allow_return_outside_function: true, // accept all syntax the formatter may be handed
         allow_v8_intrinsics: true,
         preserve_parens: false, // MUST be false: the formatter panics otherwise
+        ..ParseOptions::default()
     };
     Parser::new(allocator, source_text, source_type).with_options(options).parse()
 }

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -125,7 +125,19 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         // from source text without going through `get_string`'s kind matching.
         let name = if token.escaped() { self.cur_string() } else { self.token_source(&token) };
         self.advance(kind);
-        (span, Ident::from(name))
+        (span, self.ident(name))
+    }
+
+    /// Create an [`Ident`], respecting [`ParseOptions::precompute_ident_hashes`].
+    ///
+    /// [`ParseOptions::precompute_ident_hashes`]: crate::ParseOptions::precompute_ident_hashes
+    #[inline]
+    pub(crate) fn ident(&self, name: &'a str) -> Ident<'a> {
+        if self.options.precompute_ident_hashes {
+            Ident::from(name)
+        } else {
+            Ident::new_unhashed(name)
+        }
     }
 
     pub(crate) fn check_identifier(&mut self, kind: Kind, ctx: Context) {

--- a/crates/oxc_parser/src/lexer/trivia_builder.rs
+++ b/crates/oxc_parser/src/lexer/trivia_builder.rs
@@ -33,6 +33,10 @@ pub struct TriviaBuilder<'a> {
     pub(super) pure_comment: Option<usize>,
 
     pub(super) has_no_side_effects_comment: bool,
+
+    /// Whether to classify comment contents into annotations.
+    /// Set from [`ParseOptions::parse_comment_annotations`](crate::ParseOptions::parse_comment_annotations).
+    pub(crate) parse_annotations: bool,
 }
 
 impl<'a> TriviaBuilder<'a> {
@@ -46,6 +50,7 @@ impl<'a> TriviaBuilder<'a> {
             previous_kind: Kind::Undetermined,
             pure_comment: None,
             has_no_side_effects_comment: false,
+            parse_annotations: true,
         }
     }
 
@@ -199,7 +204,9 @@ impl<'a> TriviaBuilder<'a> {
     }
 
     fn add_comment(&mut self, mut comment: Comment, source_text: &str) {
-        Self::parse_annotation(&mut comment, source_text);
+        if self.parse_annotations {
+            Self::parse_annotation(&mut comment, source_text);
+        }
         // The comments array is an ordered vec, only add the comment if its not added before,
         // to avoid situations where the parser needs to rewind and tries to reinsert the comment.
         if let Some(last_comment) = self.comments.last()

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -231,6 +231,18 @@ pub struct ParseOptions {
     ///
     /// [`V8IntrinsicExpression`]: oxc_ast::ast::V8IntrinsicExpression
     pub allow_v8_intrinsics: bool,
+
+    /// Precompute hashes for identifier names (`Ident`s) in the AST.
+    ///
+    /// Precomputed hashes speed up `Ident`-keyed hash map operations in semantic analysis
+    /// and later compilation stages, at a small cost to parsing speed.
+    ///
+    /// Only disable this for parse-only pipelines (e.g. parse + serialize). Unhashed `Ident`s
+    /// do not compare equal to hashed ones, so semantic analysis and anything else relying on
+    /// `Ident` hashing must not run on an AST parsed with this option disabled.
+    ///
+    /// Default: `true`
+    pub precompute_ident_hashes: bool,
 }
 
 impl Default for ParseOptions {
@@ -241,6 +253,7 @@ impl Default for ParseOptions {
             allow_return_outside_function: false,
             preserve_parens: true,
             allow_v8_intrinsics: false,
+            precompute_ident_hashes: true,
         }
     }
 }

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -243,6 +243,20 @@ pub struct ParseOptions {
     ///
     /// Default: `true`
     pub precompute_ident_hashes: bool,
+
+    /// Classify comment contents into annotations while parsing.
+    ///
+    /// Annotation classification reads comment bodies to detect `@__PURE__` /
+    /// `@__NO_SIDE_EFFECTS__` markers (minifier), legal comments such as `//!` and
+    /// `@license` / `@preserve` (codegen), and webpack / vite magic comments.
+    /// It also determines how such comments attach to surrounding tokens.
+    ///
+    /// Only disable this for parse-only pipelines that do not run the minifier, codegen,
+    /// or formatter on the resulting AST: all comments are then classified as plain text,
+    /// and annotation-dependent comment attachment is not computed.
+    ///
+    /// Default: `true`
+    pub parse_comment_annotations: bool,
 }
 
 impl Default for ParseOptions {
@@ -254,6 +268,7 @@ impl Default for ParseOptions {
             preserve_parens: true,
             allow_v8_intrinsics: false,
             precompute_ident_hashes: true,
+            parse_comment_annotations: true,
         }
     }
 }
@@ -658,9 +673,12 @@ impl<'a, C: ParserConfig> ParserImpl<'a, C> {
         config: C,
         unique: UniquePromise,
     ) -> Self {
+        let mut lexer =
+            Lexer::new(allocator, source_text, source_type, config.lexer_config(), unique);
+        lexer.trivia_builder.parse_annotations = options.parse_comment_annotations;
         Self {
             options,
-            lexer: Lexer::new(allocator, source_text, source_type, config.lexer_config(), unique),
+            lexer,
             source_type,
             source_text,
             errors: vec![],

--- a/crates/oxc_str/src/ident.rs
+++ b/crates/oxc_str/src/ident.rs
@@ -136,13 +136,28 @@ impl<'a> Ident<'a> {
         new_const_ident(allocator.allocator().alloc_str(s))
     }
 
+    /// Create an [`Ident`] without precomputing its hash (hash field is `0`).
+    ///
+    /// `Eq` and `Hash` include the stored hash, so an unhashed `Ident` does not compare equal to,
+    /// or hash the same as, a hashed `Ident` of the same string. Only use this when nothing
+    /// downstream relies on `Ident` hashing (e.g. parse-only pipelines that skip semantic analysis).
+    #[expect(clippy::cast_possible_truncation)]
+    #[inline]
+    pub const fn new_unhashed(s: &'a str) -> Self {
+        let bytes = s.as_bytes();
+        let ptr = NonNull::from_ref(bytes).cast::<u8>();
+        // SAFETY: `ptr` points to a `&str` with lifetime `'a`, with length `len`.
+        unsafe { Self::from_raw(ptr, bytes.len() as u32, 0) }
+    }
+
     /// Create an [`Ident`] from raw components.
     ///
     /// # SAFETY
     ///
     /// * `ptr` must point to the start of a valid UTF-8 string, of length `len`.
     /// * The memory pointed to `len` bytes starting at `ptr` must be valid for reads and immutable for lifetime `'a`.
-    /// * `hash` must be an accurate hash of the string, calculated with `ident_hash`.
+    /// * `hash` must be an accurate hash of the string, calculated with `ident_hash`,
+    ///   or `0` for an unhashed `Ident` (see [`Ident::new_unhashed`]).
     #[inline]
     const unsafe fn from_raw(ptr: NonNull<u8>, len: u32, hash: u32) -> Self {
         Self { ptr, len_and_hash: LenAndHash::new(len, hash), _marker: PhantomData }

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -222,6 +222,7 @@ impl Oxc {
             allow_return_outside_function: parser_options.allow_return_outside_function,
             preserve_parens: parser_options.preserve_parens,
             allow_v8_intrinsics: parser_options.allow_v8_intrinsics,
+            ..ParseOptions::default()
         };
         let ParserReturn { program, diagnostics, module_record, .. } =
             Parser::new(allocator, source_text, source_type).with_options(parser_options).parse();


### PR DESCRIPTION
Adds `ParseOptions::parse_comment_annotations` (default `true`).

Stacked on #24491 (both add `ParseOptions` fields).

### Why

`TriviaBuilder::parse_annotation` reads comment bodies at parse time: every JSDoc block is scanned with `memchr('@')` for `@license` / `@preserve` (each `@param` tag hits the search), plus `@__PURE__` / webpack / vite magic-comment detection. This classification only matters to the minifier, codegen, and formatter — parse-only consumers pay for it on every comment.

Measured (yuku-style native harness, median, annotation scanning off): typescript.js (31k comments) −1.4%, App.tsx −2.0%.

### Contract

With the option disabled, all comments are classified as plain text: `@__PURE__` / legal-comment / magic-comment metadata is not produced, and annotation-dependent comment attachment (`should_stay_leading`) is not computed. Only disable for pipelines that never run the minifier, codegen, or formatter on the resulting AST. Default behavior is unchanged.

Verified: parser conformance byte-identical, clippy, unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
