### PR TITLE
perf(parser): build AST node lists in a reusable scratch stack

### DIFF
--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -1,6 +1,6 @@
 //! Code related to navigating `Token`s from the lexer
 
-use oxc_allocator::{ArenaBox, ArenaVec};
+use oxc_allocator::{ArenaBox, ArenaVec, GetAllocator};
 use oxc_ast::ast::{BindingRestElement, RegExpFlags};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::{GetSpan, Span};
@@ -390,7 +390,10 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     {
         let opening_span = self.cur_token().span();
         self.expect(open);
-        let mut list = ArenaVec::new_in(self);
+        // Accumulate elements in the reusable scratch stack (see [`ScratchStack`]) rather than
+        // growing an arena `Vec`, then move them into the arena in one exact-size allocation.
+        let allocator = self.allocator();
+        let mark = self.scratch.mark();
         loop {
             let kind = self.cur_kind();
             if kind == close
@@ -399,8 +402,10 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             {
                 break;
             }
-            list.push(f(self));
+            let element = f(self);
+            self.scratch.push(element);
         }
+        let list = self.scratch.drain_into::<T>(mark, allocator);
         self.expect_closing(close, opening_span);
         list
     }
@@ -416,17 +421,19 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     {
         let opening_span = self.cur_token().span();
         self.expect(open);
-        let mut list = ArenaVec::new_in(self);
+        let allocator = self.allocator();
+        let mark = self.scratch.mark();
         loop {
             if self.at(close) || self.has_fatal_error() {
                 break;
             }
             if let Some(e) = f(self) {
-                list.push(e);
+                self.scratch.push(e);
             } else {
                 break;
             }
         }
+        let list = self.scratch.drain_into::<T>(mark, allocator);
         self.expect_closing(close, opening_span);
         list
     }
@@ -436,28 +443,52 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         close: Kind,
         separator: Kind,
         opening_span: Span,
-        mut f: F,
+        f: F,
     ) -> (ArenaVec<'a, T>, Option<u32>)
     where
         F: FnMut(&mut Self) -> T,
     {
-        let mut list = ArenaVec::new_in(self);
+        // Accumulate elements in the reusable scratch stack (see [`ScratchStack`]), then move
+        // them into the arena in one exact-size allocation. The element loop is a separate
+        // method so that its several early exits all funnel through the single `drain_into`
+        // below — draining on every path keeps the scratch stack balanced.
+        let allocator = self.allocator();
+        let mark = self.scratch.mark();
+        let trailing_separator =
+            self.parse_delimited_list_elements::<F, T>(close, separator, opening_span, f);
+        let list = self.scratch.drain_into::<T>(mark, allocator);
+        (list, trailing_separator)
+    }
+
+    /// Parse the elements of a delimited list into the scratch stack, returning the trailing
+    /// separator position (if any). The caller is responsible for draining the scratch stack.
+    fn parse_delimited_list_elements<F, T>(
+        &mut self,
+        close: Kind,
+        separator: Kind,
+        opening_span: Span,
+        mut f: F,
+    ) -> Option<u32>
+    where
+        F: FnMut(&mut Self) -> T,
+    {
         // Cache cur_kind() to avoid redundant calls in compound checks
         let kind = self.cur_kind();
         if kind == close
             || matches!(kind, Kind::Eof | Kind::Undetermined)
             || self.fatal_error.is_some()
         {
-            return (list, None);
+            return None;
         }
-        list.push(f(self));
+        let element = f(self);
+        self.scratch.push(element);
         loop {
             let kind = self.cur_kind();
             if kind == close
                 || matches!(kind, Kind::Eof | Kind::Undetermined)
                 || self.fatal_error.is_some()
             {
-                return (list, None);
+                return None;
             }
             if kind != separator {
                 self.set_fatal_error(diagnostics::expect_closing_or_separator(
@@ -467,14 +498,15 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     self.cur_token().span(),
                     opening_span,
                 ));
-                return (list, None);
+                return None;
             }
             self.advance(separator);
             if self.cur_kind() == close {
                 let trailing_separator = self.prev_token_end - 1;
-                return (list, Some(trailing_separator));
+                return Some(trailing_separator);
             }
-            list.push(f(self));
+            let element = f(self);
+            self.scratch.push(element);
         }
     }
 
@@ -538,7 +570,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         R: Fn(&mut Self) -> ArenaBox<'a, BindingRestElement<'a>>,
         D: Fn(Span) -> OxcDiagnostic,
     {
-        let mut list = ArenaVec::new_in(self);
+        let allocator = self.allocator();
+        let mark = self.scratch.mark();
         let mut rest: Option<ArenaBox<'a, BindingRestElement<'a>>> = None;
         let mut first = true;
         loop {
@@ -585,10 +618,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             if kind == Kind::Dot3 {
                 rest.replace(parse_rest(self));
             } else {
-                list.push(parse_element(self));
+                let element = parse_element(self);
+                self.scratch.push(element);
             }
         }
 
+        let list = self.scratch.drain_into::<A>(mark, allocator);
         (list, rest)
     }
 }

--- a/crates/oxc_parser/src/js/declaration.rs
+++ b/crates/oxc_parser/src/js/declaration.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{ArenaBox, ArenaVec};
+use oxc_allocator::{ArenaBox, GetAllocator};
 use oxc_ast::ast::*;
 use oxc_span::{GetSpan, Span};
 
@@ -83,14 +83,16 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         decl_parent: VariableDeclarationParent,
         declare: bool,
     ) -> ArenaBox<'a, VariableDeclaration<'a>> {
-        let mut declarations = ArenaVec::new_in(self);
+        let allocator = self.allocator();
+        let mark = self.scratch.mark();
         loop {
             let declaration = self.parse_variable_declarator(decl_parent, kind);
-            declarations.push(declaration);
+            self.scratch.push(declaration);
             if !self.eat(Kind::Comma) {
                 break;
             }
         }
+        let declarations = self.scratch.drain_into::<VariableDeclarator>(mark, allocator);
 
         if matches!(decl_parent, VariableDeclarationParent::Statement) {
             self.asi();
@@ -204,7 +206,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
 
         // BindingList[?In, ?Yield, ?Await, ~Pattern]
-        let mut declarations = ArenaVec::new_in(self);
+        let allocator = self.allocator();
+        let mark = self.scratch.mark();
         loop {
             let decl_parent = if matches!(statement_ctx, StatementContext::For) {
                 VariableDeclarationParent::For
@@ -219,11 +222,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 ));
             }
 
-            declarations.push(declaration);
+            self.scratch.push(declaration);
             if !self.eat(Kind::Comma) {
                 break;
             }
         }
+        let declarations = self.scratch.drain_into::<VariableDeclarator>(mark, allocator);
 
         VariableDeclaration::boxed(self.end_span(span), kind, declarations, false, self)
     }

--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{ArenaBox, ArenaVec};
+use oxc_allocator::{ArenaBox, ArenaVec, GetAllocator};
 use oxc_ast::ast::*;
 use oxc_span::{GetSpan, Span};
 
@@ -70,7 +70,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         func_kind: FunctionKind,
         opening_span: Span,
     ) -> (ArenaVec<'a, FormalParameter<'a>>, Option<ArenaBox<'a, FormalParameterRest<'a>>>) {
-        let mut list = ArenaVec::new_in(self);
+        let allocator = self.allocator();
+        let mark = self.scratch.mark();
         let mut rest: Option<ArenaBox<'a, FormalParameterRest<'a>>> = None;
         let mut first = true;
 
@@ -143,10 +144,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     self,
                 ));
             } else {
-                list.push(self.parse_formal_parameter_with_decorators(func_kind, span, decorators));
+                let param =
+                    self.parse_formal_parameter_with_decorators(func_kind, span, decorators);
+                self.scratch.push(param);
             }
         }
 
+        let list = self.scratch.drain_into::<FormalParameter>(mark, allocator);
         (list, rest)
     }
 

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{ArenaBox, ArenaVec};
+use oxc_allocator::{ArenaBox, ArenaVec, GetAllocator};
 use oxc_ast::ast::*;
 use oxc_span::{GetSpan, Span};
 use oxc_str::Str;
@@ -35,7 +35,10 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         in_ts_namespace_body: bool,
     ) -> (ArenaVec<'a, Directive<'a>>, ArenaVec<'a, Statement<'a>>) {
         let mut directives = ArenaVec::new_in(self);
-        let mut statements = ArenaVec::new_in(self);
+        // Accumulate statements in the reusable scratch stack (see [`ScratchStack`]) rather than
+        // growing an arena `Vec`, then move them into the arena in one exact-size allocation.
+        let allocator = self.allocator();
+        let statements_mark = self.scratch.mark();
 
         let is_top_level = self.ctx.has_top_level();
         let stmt_ctx = StatementContext::StatementList;
@@ -62,7 +65,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     None
                 } else {
                     self.state.encountered_await_identifier = false;
-                    Some((statements.len(), self.checkpoint()))
+                    // Index is relative to `statements_mark` (the start of this list's run in
+                    // the scratch stack). At true top level the mark is 0, so this equals the
+                    // index into the finalized statements `Vec` that the reparse patches.
+                    Some((
+                        self.scratch.count_since::<Statement>(statements_mark),
+                        self.checkpoint(),
+                    ))
                 }
             } else {
                 None
@@ -112,9 +121,10 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 self.error(diagnostics::statement_in_ambient_context(stmt.span()));
                 reported_ambient_statement = true;
             }
-            statements.push(stmt);
+            self.scratch.push(stmt);
         }
 
+        let statements = self.scratch.drain_into::<Statement>(statements_mark, allocator);
         (directives, statements)
     }
 
@@ -731,7 +741,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             }
         };
         self.expect(Kind::Colon);
-        let mut consequent = ArenaVec::new_in(self);
+        let allocator = self.allocator();
+        let consequent_mark = self.scratch.mark();
         loop {
             let kind = self.cur_kind();
             if matches!(
@@ -751,8 +762,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     stmt.span(),
                 ));
             }
-            consequent.push(stmt);
+            self.scratch.push(stmt);
         }
+        let consequent = self.scratch.drain_into::<Statement>(consequent_mark, allocator);
         SwitchCase::new(self.end_span(span), test, consequent, self)
     }
 

--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -235,12 +235,26 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
         in_jsx_child: bool,
     ) -> (ArenaVec<'a, JSXChild<'a>>, JSXClosing<'a>) {
-        let mut children = ArenaVec::new_in(self);
+        // Accumulate children in the reusable scratch stack; the element loop has several early
+        // exits (each returns the closing tag), so it is a separate method whose result funnels
+        // through the single `drain_into` below.
+        let allocator = self.allocator();
+        let mark = self.scratch.mark();
+        let closing = self.parse_jsx_children_into_scratch(in_jsx_child);
+        let children = self.scratch.drain_into::<JSXChild>(mark, allocator);
+        (children, closing)
+    }
+
+    /// Parse JSX children into the scratch stack, returning the closing tag/fragment. The caller
+    /// is responsible for draining the scratch stack.
+    fn parse_jsx_children_into_scratch(&mut self, in_jsx_child: bool) -> JSXClosing<'a> {
         loop {
             if self.fatal_error.is_some() {
                 // Return dummy closing fragment on fatal error
-                let closing = JSXClosingFragment::new(self.cur_token().span(), self);
-                return (children, JSXClosing::Fragment(closing));
+                return JSXClosing::Fragment(JSXClosingFragment::new(
+                    self.cur_token().span(),
+                    self,
+                ));
             }
 
             match self.cur_kind() {
@@ -251,25 +265,26 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
                     // <> open nested fragment
                     if kind == Kind::RAngle {
-                        children.push(JSXChild::Fragment(self.parse_jsx_fragment(span, true)));
+                        let child = JSXChild::Fragment(self.parse_jsx_fragment(span, true));
+                        self.scratch.push(child);
                         continue;
                     }
 
                     // <ident open nested element
                     if kind == Kind::Ident || kind.is_any_keyword() {
-                        children.push(JSXChild::Element(self.parse_jsx_element(span, true)));
+                        let child = JSXChild::Element(self.parse_jsx_element(span, true));
+                        self.scratch.push(child);
                         continue;
                     }
 
                     // </ closing tag - parse it inline and return
                     if kind == Kind::Slash {
                         self.bump_any(); // bump `/`
-                        let closing = self.parse_jsx_closing_inline(span, in_jsx_child);
-                        return (children, closing);
+                        return self.parse_jsx_closing_inline(span, in_jsx_child);
                     }
 
                     // Unexpected token after `<`
-                    return (children, self.unexpected());
+                    return self.unexpected();
                 }
                 Kind::LCurly => {
                     let span_start = self.start_span();
@@ -277,23 +292,25 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
                     // {...expr}
                     if self.eat(Kind::Dot3) {
-                        children.push(JSXChild::Spread(self.parse_jsx_spread_child(span_start)));
+                        let child = JSXChild::Spread(self.parse_jsx_spread_child(span_start));
+                        self.scratch.push(child);
                         continue;
                     }
                     // {expr}
-                    children.push(JSXChild::ExpressionContainer(
-                        self.parse_jsx_expression_container(
+                    let child =
+                        JSXChild::ExpressionContainer(self.parse_jsx_expression_container(
                             span_start, /* in_jsx_child */ true,
-                        ),
-                    ));
+                        ));
+                    self.scratch.push(child);
                 }
                 // text
                 Kind::JSXText => {
-                    children.push(JSXChild::Text(self.parse_jsx_text()));
+                    let child = JSXChild::Text(self.parse_jsx_text());
+                    self.scratch.push(child);
                 }
                 _ => {
                     // Unexpected token in JSX children
-                    return (children, self.unexpected());
+                    return self.unexpected();
                 }
             }
         }
@@ -383,7 +400,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ///   `JSXSpreadAttribute` `JSXAttributes_opt`
     ///   `JSXAttribute` `JSXAttributes_opt`
     fn parse_jsx_attributes(&mut self) -> ArenaVec<'a, JSXAttributeItem<'a>> {
-        let mut attributes = ArenaVec::new_in(self);
+        let allocator = self.allocator();
+        let mark = self.scratch.mark();
         loop {
             let kind = self.cur_kind();
             if matches!(kind, Kind::LAngle | Kind::RAngle | Kind::Slash)
@@ -397,9 +415,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 }
                 _ => JSXAttributeItem::Attribute(self.parse_jsx_attribute()),
             };
-            attributes.push(attribute);
+            self.scratch.push(attribute);
         }
-        attributes
+        self.scratch.drain_into::<JSXAttributeItem>(mark, allocator)
     }
 
     /// `JSXAttribute` :

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -72,6 +72,7 @@ mod cursor;
 mod error_handler;
 mod modifiers;
 mod module_record;
+mod scratch;
 mod state;
 
 mod js;
@@ -105,6 +106,7 @@ use crate::{
     error_handler::FatalError,
     lexer::Lexer,
     module_record::ModuleRecordBuilder,
+    scratch::ScratchStack,
     state::ParserState,
 };
 
@@ -628,6 +630,10 @@ struct ParserImpl<'a, C: ParserConfig> {
 
     /// Precomputed typescript detection
     is_ts: bool,
+
+    /// Reusable scratch buffer for building AST node lists without repeated
+    /// arena reallocations. See [`ScratchStack`].
+    scratch: ScratchStack,
 }
 
 impl<'a, C: ParserConfig> ParserImpl<'a, C> {
@@ -660,6 +666,7 @@ impl<'a, C: ParserConfig> ParserImpl<'a, C> {
             ast: AstBuilder::new(allocator),
             module_record_builder: ModuleRecordBuilder::new(allocator, source_type),
             is_ts: source_type.is_typescript(),
+            scratch: ScratchStack::new(),
         }
     }
 

--- a/crates/oxc_parser/src/scratch.rs
+++ b/crates/oxc_parser/src/scratch.rs
@@ -1,0 +1,338 @@
+//! A reusable scratch stack for building AST node lists.
+//!
+//! The parser builds many lists of AST nodes (statements, array/object elements,
+//! call arguments, class members, ...). Building each list directly in the arena
+//! is expensive: an arena [`Vec`] starts empty and grows `1 → 2 → 4 → 8 → …`, and
+//! **every** grow copies the existing contents (arena reallocation always
+//! `memmove`s, even when the buffer is the last allocation).
+//!
+//! [`ScratchStack`] avoids this. It is a single, persistent, heap-backed buffer,
+//! reused for every list in a parse. A caller records a [`mark`], pushes the
+//! list's elements, then [`drain_into`] moves them into the arena in one
+//! exact-size allocation and rewinds the stack to the mark. Because the buffer is
+//! reused, after a brief warm-up it stops growing, so its own growth cost
+//! amortizes to ~zero across the parse — and no list ever `memmove`s while being
+//! built.
+//!
+//! One buffer serves every element type: elements are stored as raw bytes, packed
+//! by their natural size/alignment. This is sound because the buffer is used
+//! strictly LIFO (recursive-descent nesting marks above its parent's run) and all
+//! AST list-element types are non-[`Drop`] with alignment `<= SCRATCH_ALIGN`.
+//!
+//! [`Vec`]: oxc_allocator::Vec
+//! [`mark`]: ScratchStack::mark
+//! [`drain_into`]: ScratchStack::drain_into
+
+use std::{
+    alloc::{self, Layout},
+    cmp,
+    marker::PhantomData,
+    mem::{align_of, needs_drop, size_of},
+    ptr::{self, NonNull},
+};
+
+use oxc_allocator::{Allocator, ArenaVec};
+
+/// Alignment of the scratch buffer.
+///
+/// All AST node types have alignment `<= 8`; 16 is used to be safe and
+/// future-proof. [`ScratchStack::push`] and [`ScratchStack::drain_into`] assert
+/// `align_of::<T>() <= SCRATCH_ALIGN` at compile time.
+const SCRATCH_ALIGN: usize = 16;
+
+/// Initial capacity of the scratch buffer, in bytes.
+///
+/// Sized so that the buffer rarely (if ever) needs to grow during a parse. Growth
+/// is handled gracefully regardless; this only affects warm-up.
+const INITIAL_CAPACITY: usize = 8192;
+
+const _: () = assert!(INITIAL_CAPACITY > 0 && INITIAL_CAPACITY <= isize::MAX as usize);
+
+/// A reusable, persistent, byte-addressed LIFO stack for accumulating AST node
+/// lists before moving them into the arena.
+///
+/// See the [module documentation](self) for the rationale.
+///
+/// # Usage invariant
+///
+/// Used strictly LIFO. Between a [`mark`] and the matching [`drain_into`], all
+/// pushes must be of the same type `T` (the element type of the list being
+/// built). Nested lists must mark above the parent's run and drain (rewinding to
+/// their own mark) before the parent pushes again. Recursive-descent parsing
+/// satisfies this naturally.
+///
+/// [`mark`]: ScratchStack::mark
+/// [`drain_into`]: ScratchStack::drain_into
+pub struct ScratchStack {
+    /// Start of the allocation. Dangling (and never dereferenced) when `capacity == 0`.
+    ptr: NonNull<u8>,
+    /// Number of bytes currently in use (the stack top).
+    len: usize,
+    /// Number of bytes allocated.
+    capacity: usize,
+}
+
+// `ScratchStack` owns its heap buffer exclusively, like `Vec<u8>`, so it is safe
+// to move across threads. The buffer only ever holds plain bytes.
+// SAFETY: The buffer is owned exclusively and contains no thread-affine state.
+unsafe impl Send for ScratchStack {}
+
+impl ScratchStack {
+    /// Create a new [`ScratchStack`] with the default initial capacity.
+    pub fn new() -> Self {
+        let layout = Self::layout(INITIAL_CAPACITY);
+        // SAFETY: `layout` has non-zero size (`INITIAL_CAPACITY > 0`).
+        let ptr = unsafe { alloc::alloc(layout) };
+        let Some(ptr) = NonNull::new(ptr) else { alloc::handle_alloc_error(layout) };
+        Self { ptr, len: 0, capacity: INITIAL_CAPACITY }
+    }
+
+    #[inline]
+    fn layout(capacity: usize) -> Layout {
+        debug_assert!(capacity > 0);
+        // `SCRATCH_ALIGN` is a valid power-of-two alignment. This only panics if
+        // `capacity` rounded up to `SCRATCH_ALIGN` overflows `isize::MAX`, which
+        // does not happen for the capacities used here.
+        Layout::from_size_align(capacity, SCRATCH_ALIGN).unwrap_or_else(|_| capacity_overflow())
+    }
+
+    /// Record the current stack top. Pass the returned mark to [`drain_into`]
+    /// after pushing this list's elements.
+    ///
+    /// [`drain_into`]: ScratchStack::drain_into
+    #[inline]
+    pub fn mark(&self) -> usize {
+        self.len
+    }
+
+    /// Number of `T` elements pushed since `mark` (without draining).
+    ///
+    /// Used to compute a list-relative index while a list is still being built.
+    #[inline]
+    pub fn count_since<T>(&self, mark: usize) -> usize {
+        let offset = align_up(mark, align_of::<T>());
+        if self.len > offset { (self.len - offset) / size_of::<T>() } else { 0 }
+    }
+
+    /// Push a value onto the stack.
+    #[inline]
+    pub fn push<T>(&mut self, value: T) {
+        const {
+            assert!(align_of::<T>() <= SCRATCH_ALIGN);
+            assert!(size_of::<T>() > 0, "`ScratchStack` does not support zero-sized types");
+            // Non-`Drop` guarantees rewinding / abandoning bytes never leaks a resource.
+            assert!(!needs_drop::<T>(), "`ScratchStack` only holds non-`Drop` types");
+        }
+        let offset = align_up(self.len, align_of::<T>());
+        let new_len = offset + size_of::<T>();
+        if new_len > self.capacity {
+            self.grow(new_len);
+        }
+        // SAFETY: `grow` guarantees `capacity >= new_len`, so `[offset, offset + size_of::<T>())`
+        // is in bounds. `self.ptr` is aligned to `SCRATCH_ALIGN >= align_of::<T>()` and `offset`
+        // is aligned to `align_of::<T>()`, so `self.ptr + offset` is correctly aligned for `T`.
+        unsafe {
+            self.ptr.as_ptr().add(offset).cast::<T>().write(value);
+        }
+        self.len = new_len;
+    }
+
+    /// Move the elements pushed since `mark` into `allocator` as a single
+    /// exact-size arena [`Vec`], then rewind the stack to `mark`.
+    ///
+    /// `T` must be the type that was pushed since `mark`.
+    ///
+    /// [`Vec`]: oxc_allocator::Vec
+    #[inline]
+    pub fn drain_into<'a, T>(
+        &mut self,
+        mark: usize,
+        allocator: &'a Allocator,
+    ) -> ArenaVec<'a, T> {
+        const { assert!(align_of::<T>() <= SCRATCH_ALIGN) };
+        let offset = align_up(mark, align_of::<T>());
+        let count = if self.len > offset { (self.len - offset) / size_of::<T>() } else { 0 };
+
+        let vec = if count == 0 {
+            ArenaVec::new_in(&allocator)
+        } else {
+            // SAFETY: `[offset, offset + count * size_of::<T>())` was written by `push::<T>`
+            // as `count` initialized, aligned `T`s. `ScratchDrain` reads each exactly once,
+            // moving it out; the source bytes are abandoned by the rewind below (`T` is
+            // non-`Drop`, so this leaks nothing).
+            let iter = unsafe {
+                ScratchDrain {
+                    ptr: self.ptr.as_ptr().add(offset).cast::<T>(),
+                    remaining: count,
+                    marker: PhantomData,
+                }
+            };
+            ArenaVec::from_iter_in(iter, &allocator)
+        };
+
+        self.len = mark;
+        vec
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn grow(&mut self, required: usize) {
+        let new_capacity = cmp::max(self.capacity * 2, required);
+        let new_layout = Self::layout(new_capacity);
+        let old_layout = Self::layout(self.capacity);
+        // SAFETY: `self.ptr` was allocated with `old_layout` (capacity is always `> 0`),
+        // `new_layout` has the same alignment, and `new_layout.size() > old_layout.size()`.
+        let new_ptr = unsafe { alloc::realloc(self.ptr.as_ptr(), old_layout, new_layout.size()) };
+        let Some(new_ptr) = NonNull::new(new_ptr) else { alloc::handle_alloc_error(new_layout) };
+        self.ptr = new_ptr;
+        self.capacity = new_capacity;
+    }
+}
+
+impl Drop for ScratchStack {
+    fn drop(&mut self) {
+        // SAFETY: `self.ptr` was allocated with this layout and has not been freed.
+        // `capacity` is always `> 0` (allocated in `new`, only ever grown).
+        unsafe {
+            alloc::dealloc(self.ptr.as_ptr(), Self::layout(self.capacity));
+        }
+    }
+}
+
+/// Iterator that moves `remaining` values out of a raw pointer, one at a time.
+struct ScratchDrain<T> {
+    ptr: *const T,
+    remaining: usize,
+    marker: PhantomData<T>,
+}
+
+impl<T> Iterator for ScratchDrain<T> {
+    type Item = T;
+
+    #[inline]
+    fn next(&mut self) -> Option<T> {
+        if self.remaining == 0 {
+            return None;
+        }
+        // SAFETY: `remaining` elements starting at `ptr` are initialized `T`s. Each is read
+        // exactly once (we advance `ptr` and decrement `remaining`), moving it out.
+        let value = unsafe { ptr::read(self.ptr) };
+        // SAFETY: after reading, advancing by one stays within the initialized run (or reaches
+        // its one-past-the-end, which is never dereferenced because `remaining` hits 0).
+        self.ptr = unsafe { self.ptr.add(1) };
+        self.remaining -= 1;
+        Some(value)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.remaining, Some(self.remaining))
+    }
+}
+
+impl<T> ExactSizeIterator for ScratchDrain<T> {}
+
+/// Round `offset` up to a multiple of `align` (a power of two).
+#[inline]
+const fn align_up(offset: usize, align: usize) -> usize {
+    debug_assert!(align.is_power_of_two());
+    (offset + (align - 1)) & !(align - 1)
+}
+
+#[cold]
+#[inline(never)]
+fn capacity_overflow() -> ! {
+    panic!("`ScratchStack` capacity overflow");
+}
+
+#[cfg(test)]
+mod test {
+    use oxc_allocator::Allocator;
+
+    use super::ScratchStack;
+
+    #[test]
+    fn push_and_drain_single_type() {
+        let allocator = Allocator::default();
+        let mut scratch = ScratchStack::new();
+
+        let mark = scratch.mark();
+        for i in 0..10u32 {
+            scratch.push(i);
+        }
+        assert_eq!(scratch.count_since::<u32>(mark), 10);
+
+        let vec = scratch.drain_into::<u32>(mark, &allocator);
+        assert_eq!(&*vec, &(0..10).collect::<Vec<_>>()[..]);
+        // Stack is rewound.
+        assert_eq!(scratch.mark(), mark);
+    }
+
+    #[test]
+    fn empty_run_drains_to_empty_vec() {
+        let allocator = Allocator::default();
+        let mut scratch = ScratchStack::new();
+
+        let mark = scratch.mark();
+        let vec = scratch.drain_into::<u32>(mark, &allocator);
+        assert!(vec.is_empty());
+        assert_eq!(scratch.mark(), mark);
+    }
+
+    #[test]
+    fn nested_lifo_different_types() {
+        let allocator = Allocator::default();
+        let mut scratch = ScratchStack::new();
+
+        // Outer list of `u64`.
+        let outer = scratch.mark();
+        scratch.push(1u64);
+        scratch.push(2u64);
+
+        // Nested list of `(u8, u32)` built above the outer run, then drained.
+        let inner = scratch.mark();
+        scratch.push((7u8, 700u32));
+        scratch.push((8u8, 800u32));
+        let inner_vec = scratch.drain_into::<(u8, u32)>(inner, &allocator);
+        assert_eq!(&*inner_vec, &[(7u8, 700u32), (8u8, 800u32)][..]);
+        // Draining the inner list rewound the stack to the outer run.
+        assert_eq!(scratch.mark(), inner);
+
+        // Outer list continues, unaffected.
+        scratch.push(3u64);
+        let outer_vec = scratch.drain_into::<u64>(outer, &allocator);
+        assert_eq!(&*outer_vec, &[1u64, 2, 3][..]);
+        assert_eq!(scratch.mark(), outer);
+    }
+
+    #[test]
+    fn grows_past_initial_capacity() {
+        let allocator = Allocator::default();
+        let mut scratch = ScratchStack::new();
+
+        let mark = scratch.mark();
+        let n = super::INITIAL_CAPACITY; // far more elements than the initial byte capacity
+        for i in 0..n {
+            scratch.push(i);
+        }
+        let vec = scratch.drain_into::<usize>(mark, &allocator);
+        assert_eq!(vec.len(), n);
+        assert!(vec.iter().copied().eq(0..n));
+    }
+
+    #[test]
+    fn reuse_across_lists_rewinds() {
+        let allocator = Allocator::default();
+        let mut scratch = ScratchStack::new();
+
+        for round in 0..100u32 {
+            let mark = scratch.mark();
+            assert_eq!(mark, 0, "stack must fully rewind between top-level lists");
+            for i in 0..round {
+                scratch.push(i);
+            }
+            let vec = scratch.drain_into::<u32>(mark, &allocator);
+            assert_eq!(vec.len(), round as usize);
+        }
+    }
+}

--- a/crates/oxc_parser/src/scratch.rs
+++ b/crates/oxc_parser/src/scratch.rs
@@ -144,11 +144,7 @@ impl ScratchStack {
     ///
     /// [`Vec`]: oxc_allocator::Vec
     #[inline]
-    pub fn drain_into<'a, T>(
-        &mut self,
-        mark: usize,
-        allocator: &'a Allocator,
-    ) -> ArenaVec<'a, T> {
+    pub fn drain_into<'a, T>(&mut self, mark: usize, allocator: &'a Allocator) -> ArenaVec<'a, T> {
         const { assert!(align_of::<T>() <= SCRATCH_ALIGN) };
         let offset = align_up(mark, align_of::<T>());
         let count = if self.len > offset { (self.len - offset) / size_of::<T>() } else { 0 };

--- a/tasks/track_memory_allocations/allocs_parser.snap
+++ b/tasks/track_memory_allocations/allocs_parser.snap
@@ -1,16 +1,16 @@
 File                       | File size      || Sys allocs     | Sys reallocs   || Arena allocs   | Arena reallocs 
 ---------------------------------------------------------------------------------------------------------------------------
-checker.ts                 | 2.92 MB        ||           1818 |             10 ||         264366 |          22860
+checker.ts                 | 2.92 MB        ||           1819 |             13 ||         264366 |           1643
 
-App.tsx                    | 415.34 kB      ||            360 |             13 ||          44464 |           3537
+App.tsx                    | 415.34 kB      ||            361 |             13 ||          44464 |            263
 
-RadixUIAdoptionSection.jsx | 2.52 kB        ||              1 |              0 ||            367 |             66
+RadixUIAdoptionSection.jsx | 2.52 kB        ||              2 |              0 ||            367 |              7
 
-pdf.mjs                    | 567.30 kB      ||            337 |             67 ||          90583 |           8153
+pdf.mjs                    | 567.30 kB      ||            338 |             67 ||          90583 |            235
 
-antd.js                    | 6.69 MB        ||           3661 |            221 ||         528577 |          55355
+antd.js                    | 6.69 MB        ||           3662 |            224 ||         528577 |           1303
 
-binder.ts                  | 193.08 kB      ||             85 |              0 ||          16620 |           1476
+binder.ts                  | 193.08 kB      ||             86 |              0 ||          16620 |            139
 
-kitchen-sink.tsx           | 732.90 kB      ||           2051 |            160 ||         138059 |          11905
+kitchen-sink.tsx           | 732.90 kB      ||           2052 |            163 ||         138059 |           1423
 

--- a/tasks/track_memory_allocations/allocs_transformer.snap
+++ b/tasks/track_memory_allocations/allocs_transformer.snap
@@ -4,7 +4,7 @@ checker.ts                 | 2.92 MB        ||             18 |              0 |
 
 App.tsx                    | 415.34 kB      ||             23 |              2 ||            618 |             17
 
-RadixUIAdoptionSection.jsx | 2.52 kB        ||             19 |              2 ||            258 |             13
+RadixUIAdoptionSection.jsx | 2.52 kB        ||             19 |              2 ||            258 |             14
 
 pdf.mjs                    | 567.30 kB      ||             13 |              0 ||              2 |              0
 
@@ -12,5 +12,5 @@ antd.js                    | 6.69 MB        ||             13 |              0 |
 
 binder.ts                  | 193.08 kB      ||             15 |              0 ||            154 |              0
 
-kitchen-sink.tsx           | 732.90 kB      ||            182 |              3 ||           6132 |            280
+kitchen-sink.tsx           | 732.90 kB      ||            182 |              3 ||           6132 |            316
 


### PR DESCRIPTION
## Summary

Every AST child list (statements, array/object elements, call arguments, class members, JSX children, parameters, …) was built by pushing into an arena `Vec` that starts empty and grows `1 → 2 → 4 → 8 → …`. Every arena grow copies the existing contents — even the `is_last_allocation` fast path does a `memmove` (`arena/alloc_impl.rs`) — so list building spent ~2% of parse time in `memmove` alone.

This introduces **`ScratchStack`** (`crates/oxc_parser/src/scratch.rs`): a single, persistent, heap-backed, byte-addressed LIFO stack held on the parser and shared by every element type. Each list records a mark, pushes its elements, then `drain_into` moves them into the arena in **one exact-size allocation** and rewinds the stack. Because the buffer is reused for the whole parse, it stops growing after a brief warm-up, so no list ever `memmove`s while being built, and every AST list `Vec` ends up exactly sized.

All `unsafe` (alignment, raw move-copy, growth) is contained in the one module. Recursive-descent nesting is naturally LIFO, so nested lists mark above their parent's run and drain before it continues; one shared buffer serves all element types because AST nodes are non-`Drop` with alignment ≤ 8.

Converted sites: the five `cursor.rs` list helpers (blocks, arrays, objects, call args, class bodies, binding patterns) plus the hand-rolled loops for statements (with a mark-relative top-level-`await` reparse index), switch consequents, JSX children/attributes, variable declarators, and formal parameters. Left as-is: `parse_delimited_list_into` (caller-owned vec) and two niche TS type loops (one builds two lists interleaved, incompatible with a single stack).

## Results

Arena reallocations (deterministic, `just allocs`):

| File | Before | After | Δ |
|---|---|---|---|
| checker.ts | 22,860 | 1,643 | −92.8% |
| antd.js (minified) | 55,355 | 1,303 | −97.6% |
| pdf.mjs | 8,153 | 235 | −97.1% |
| kitchen-sink.tsx | 11,905 | 1,423 | −88.0% |
| App.tsx | 3,537 | 263 | −92.6% |
| binder.ts | 1,476 | 139 | −90.6% |

Arena *allocations* stay flat (exact-sizing keeps it one alloc per list); +1 system allocation per parse (the scratch warm-up). Local criterion runs show ~5% faster parsing on large files (clean, non-overlapping CIs on `kitchen-sink.tsx` and `estree/checker.ts`); no file regressed.

### Trade-off

Exact-sizing removes the parser's incidental over-allocation, so the transformer reallocs a few more times when it mutates parser statement `Vec`s (`kitchen-sink.tsx` +36 / 6,132). Net strongly positive, and the dominant oxlint path only parses. Reflected in `allocs_transformer.snap`. `INITIAL_CAPACITY` (8 KiB) is tunable if trading a larger warm-up alloc for zero scratch growth on very large files is preferred.

## Verification

- `just allocs` — arena reallocs −88…−98%, arena allocs flat, +1 sys alloc/parse
- **Miri** clean on `ScratchStack` (alignment / raw move-copy / rewind / growth)
- test262: 47,240 files, 100% AST-parsed, negative-pass unchanged
- codegen (round-trip incl. JSX/TSX) + transformer suites pass; 75 parser + 5 scratch unit tests; clippy clean

---

*Implemented with assistance from Claude Code (Claude Opus); all code reviewed and tested by me.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
