### PR TITLE
feat(linter/import/consistent-type-specifier-style): support `prefer-top-level-if-only-type-imports` option

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -86,7 +86,7 @@ export type FuncNamesConfigType = "always" | "as-needed" | "never";
 export type Style = "expression" | "declaration";
 export type NamedExports = "ignore" | "expression" | "declaration";
 export type PairOrder = "anyOrder" | "getBeforeSet" | "setBeforeGet";
-export type Mode = "prefer-top-level" | "prefer-inline";
+export type Mode = "prefer-top-level" | "prefer-inline" | "prefer-top-level-if-only-type-imports";
 /**
  * Extension rule configuration; Copy to avoid extra indirection.
  */

--- a/crates/oxc_linter/src/rules/import/consistent_type_specifier_style.rs
+++ b/crates/oxc_linter/src/rules/import/consistent_type_specifier_style.rs
@@ -30,28 +30,36 @@ fn use_top_level_for_declaration_file_import_diagnostic(span: Span) -> OxcDiagno
 }
 
 fn consistent_type_specifier_style_diagnostic(span: Span, mode: &Mode) -> OxcDiagnostic {
-    let (warn_msg, help_msg) = if *mode == Mode::PreferInline {
-        (
+    let (warn_msg, help_msg) = match mode {
+        Mode::Inline => (
             "Prefer using inline type specifiers instead of a top-level type-only import.",
             "Replace top‐level import type with an inline type specifier.",
-        )
-    } else {
-        (
+        ),
+        Mode::TopLevel => (
             "Prefer using a top-level type-only import instead of inline type specifiers.",
             "Replace inline type specifiers with a top‐level import type statement.",
-        )
+        ),
+        Mode::TopLevelIfOnlyTypeImports => (
+            "Prefer using a top-level type-only import instead of inline type specifiers when there are only type imports.",
+            "Replace inline type specifiers with a top‐level import type statement.",
+        ),
     };
     OxcDiagnostic::warn(warn_msg).with_help(help_msg).with_label(span)
 }
 
 #[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "kebab-case")]
 enum Mode {
     /// Prefer `import type { Foo } from 'foo'` for type imports.
     #[default]
-    PreferTopLevel,
+    #[serde(rename = "prefer-top-level")]
+    TopLevel,
     /// Prefer `import { type Foo } from 'foo'` for type imports.
-    PreferInline,
+    #[serde(rename = "prefer-inline")]
+    Inline,
+    /// Prefer `import type { Foo } from 'foo'` when all named imports are types, but allow
+    /// `import { type Foo, bar } from 'foo'` when value imports are present.
+    #[serde(rename = "prefer-top-level-if-only-type-imports")]
+    TopLevelIfOnlyTypeImports,
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
@@ -79,6 +87,19 @@ declare_oxc_lint!(
     /// Examples of correct code for the default option:
     /// ```typescript
     /// import type { Foo } from 'Foo';
+    /// import type Foo, { Bar } from 'Foo';
+    /// ```
+    ///
+    /// Examples of incorrect code for the `prefer-top-level-if-only-type-imports` option:
+    /// ```typescript
+    /// import { type Foo } from 'Foo';
+    /// import { type Foo, type Bar } from 'Foo';
+    /// ```
+    ///
+    /// Examples of correct code for the `prefer-top-level-if-only-type-imports` option:
+    /// ```typescript
+    /// import type { Foo } from 'Foo';
+    /// import { type Foo, someValue } from 'Foo';
     /// import type Foo, { Bar } from 'Foo';
     /// ```
     ///
@@ -122,21 +143,26 @@ impl Rule for ConsistentTypeSpecifierStyle {
             return;
         }
 
-        // Declaration file imports should always be top-level type imports
-        if (self.0 == Mode::PreferTopLevel || is_declaration_file_import(import_decl))
-            && import_decl.import_kind.is_value()
-        {
+        // Declaration file imports should always be top-level type imports.
+        if import_decl.import_kind.is_value() {
+            let is_declaration_file_import = is_declaration_file_import(import_decl);
+            if self.0 == Mode::Inline && !is_declaration_file_import {
+                return;
+            }
+
             let (value_specifiers, type_specifiers) = split_import_specifiers_by_kind(specifiers);
             if type_specifiers.is_empty() {
                 return;
             }
 
-            for item in &type_specifiers {
-                let diagnostic = if is_declaration_file_import(import_decl) {
-                    use_top_level_for_declaration_file_import_diagnostic(item.span())
-                } else {
-                    consistent_type_specifier_style_diagnostic(item.span(), &self.0)
-                };
+            let should_use_top_level = is_declaration_file_import
+                || self.0 == Mode::TopLevel
+                || (self.0 == Mode::TopLevelIfOnlyTypeImports && value_specifiers.is_empty());
+            if !should_use_top_level {
+                return;
+            }
+
+            let report = |diagnostic| {
                 ctx.diagnostic_with_fix(diagnostic, |fixer| {
                     let mut import_source = String::new();
 
@@ -154,8 +180,21 @@ impl Rule for ConsistentTypeSpecifierStyle {
                         .replace(import_decl.span, import_source.trim_end().to_string())
                         .with_message("Convert to a `top-level` type import")
                 });
+            };
+
+            if self.0 == Mode::TopLevelIfOnlyTypeImports && !is_declaration_file_import {
+                report(consistent_type_specifier_style_diagnostic(import_decl.span, &self.0));
+            } else {
+                for item in &type_specifiers {
+                    let diagnostic = if is_declaration_file_import {
+                        use_top_level_for_declaration_file_import_diagnostic(item.span())
+                    } else {
+                        consistent_type_specifier_style_diagnostic(item.span(), &self.0)
+                    };
+                    report(diagnostic);
+                }
             }
-        } else if self.0 == Mode::PreferInline && import_decl.import_kind.is_type() {
+        } else if self.0 == Mode::Inline && import_decl.import_kind.is_type() {
             if is_declaration_file_import(import_decl) {
                 return;
             }
@@ -305,6 +344,42 @@ fn test() {
         ("import type { Foo as Bar } from 'Foo';", Some(json!(["prefer-top-level"]))),
         ("import type { Foo, Bar, Baz, Bam } from 'Foo';", Some(json!(["prefer-top-level"]))),
         ("import type {Foo} from 'Foo'", Some(json!(["prefer-top-level"]))),
+        ("import Foo from 'Foo';", Some(json!(["prefer-top-level-if-only-type-imports"]))),
+        ("import type Foo from 'Foo';", Some(json!(["prefer-top-level-if-only-type-imports"]))),
+        ("import { Foo } from 'Foo';", Some(json!(["prefer-top-level-if-only-type-imports"]))),
+        (
+            "import { Foo as Bar } from 'Foo';",
+            Some(json!(["prefer-top-level-if-only-type-imports"])),
+        ),
+        ("import * as Foo from 'Foo';", Some(json!(["prefer-top-level-if-only-type-imports"]))),
+        ("import 'Foo';", Some(json!(["prefer-top-level-if-only-type-imports"]))),
+        ("import {} from 'Foo';", Some(json!(["prefer-top-level-if-only-type-imports"]))),
+        ("import type {} from 'Foo';", Some(json!(["prefer-top-level-if-only-type-imports"]))),
+        ("import type { Foo } from 'Foo';", Some(json!(["prefer-top-level-if-only-type-imports"]))),
+        (
+            "import type { Foo as Bar } from 'Foo';",
+            Some(json!(["prefer-top-level-if-only-type-imports"])),
+        ),
+        (
+            "import type { Foo, Bar, Baz, Bam } from 'Foo';",
+            Some(json!(["prefer-top-level-if-only-type-imports"])),
+        ),
+        (
+            "import { Foo, type Bar } from 'Foo';",
+            Some(json!(["prefer-top-level-if-only-type-imports"])),
+        ),
+        (
+            "import { type Foo, Bar } from 'Foo';",
+            Some(json!(["prefer-top-level-if-only-type-imports"])),
+        ),
+        (
+            "import Foo, { type Bar } from 'Foo';",
+            Some(json!(["prefer-top-level-if-only-type-imports"])),
+        ),
+        (
+            "import Foo, { type Bar, Baz } from 'Foo';",
+            Some(json!(["prefer-top-level-if-only-type-imports"])),
+        ),
         ("import {type Foo} from 'Foo'", Some(json!(["prefer-inline"]))),
         ("import Foo from 'Foo';", Some(json!(["prefer-inline"]))),
         ("import type Foo from 'Foo';", Some(json!(["prefer-inline"]))),
@@ -327,6 +402,10 @@ fn test() {
         ("import type { Foo } from './index.d.cts';", Some(json!(["prefer-inline"]))),
         ("import type { Foo } from './app.d.css.ts';", Some(json!(["prefer-top-level"]))),
         ("import type { Foo } from './app.d.css.ts';", Some(json!(["prefer-inline"]))),
+        (
+            "import type { Foo } from './index.d.ts';",
+            Some(json!(["prefer-top-level-if-only-type-imports"])),
+        ),
     ];
 
     let fail = vec![
@@ -340,6 +419,15 @@ fn test() {
         ("import Foo, { type Bar, Baz } from 'Foo';", None),
         ("import { Component, type ComponentProps } from 'package-1';", None),
         ("import type { Foo, Bar, Baz } from 'Foo';", Some(json!(["prefer-inline"]))),
+        ("import { type Foo } from 'Foo';", Some(json!(["prefer-top-level-if-only-type-imports"]))),
+        (
+            "import { type Foo as Bar } from 'Foo';",
+            Some(json!(["prefer-top-level-if-only-type-imports"])),
+        ),
+        (
+            "import { type Foo, type Bar } from 'Foo';",
+            Some(json!(["prefer-top-level-if-only-type-imports"])),
+        ),
         // declaration files always require `import type` syntax
         ("import { type Foo } from './index.d.ts';", Some(json!(["prefer-top-level"]))),
         ("import { type Foo } from './index.d.ts';", Some(json!(["prefer-inline"]))),
@@ -349,6 +437,10 @@ fn test() {
         ("import { type Foo } from './index.d.cts';", Some(json!(["prefer-inline"]))),
         ("import { type Foo } from './app.d.css.ts';", Some(json!(["prefer-top-level"]))),
         ("import { type Foo } from './app.d.css.ts';", Some(json!(["prefer-inline"]))),
+        (
+            "import { Foo, type Bar } from './index.d.ts';",
+            Some(json!(["prefer-top-level-if-only-type-imports"])),
+        ),
     ];
 
     let fix = vec![
@@ -439,6 +531,26 @@ fn test() {
             "import { type Foo } from 'index.d.ts';",
             "import type { Foo } from 'index.d.ts';",
             Some(json!(["prefer-inline"])),
+        ),
+        (
+            "import { type Foo } from 'Foo';",
+            "import type { Foo } from 'Foo';",
+            Some(json!(["prefer-top-level-if-only-type-imports"])),
+        ),
+        (
+            "import { type Foo as Bar } from 'Foo';",
+            "import type { Foo as Bar } from 'Foo';",
+            Some(json!(["prefer-top-level-if-only-type-imports"])),
+        ),
+        (
+            "import { type Foo, type Bar } from 'Foo';",
+            "import type { Foo, Bar } from 'Foo';",
+            Some(json!(["prefer-top-level-if-only-type-imports"])),
+        ),
+        (
+            "import { Foo, type Bar } from './index.d.ts';",
+            "import { Foo } from './index.d.ts';\nimport type { Bar } from './index.d.ts';",
+            Some(json!(["prefer-top-level-if-only-type-imports"])),
         ),
     ];
 

--- a/crates/oxc_linter/src/snapshots/import_consistent_type_specifier_style.snap
+++ b/crates/oxc_linter/src/snapshots/import_consistent_type_specifier_style.snap
@@ -86,6 +86,27 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Replace top‐level import type with an inline type specifier.
 
+  ⚠ import(consistent-type-specifier-style): Prefer using a top-level type-only import instead of inline type specifiers when there are only type imports.
+   ╭─[consistent_type_specifier_style.tsx:1:1]
+ 1 │ import { type Foo } from 'Foo';
+   · ───────────────────────────────
+   ╰────
+  help: Replace inline type specifiers with a top‐level import type statement.
+
+  ⚠ import(consistent-type-specifier-style): Prefer using a top-level type-only import instead of inline type specifiers when there are only type imports.
+   ╭─[consistent_type_specifier_style.tsx:1:1]
+ 1 │ import { type Foo as Bar } from 'Foo';
+   · ──────────────────────────────────────
+   ╰────
+  help: Replace inline type specifiers with a top‐level import type statement.
+
+  ⚠ import(consistent-type-specifier-style): Prefer using a top-level type-only import instead of inline type specifiers when there are only type imports.
+   ╭─[consistent_type_specifier_style.tsx:1:1]
+ 1 │ import { type Foo, type Bar } from 'Foo';
+   · ─────────────────────────────────────────
+   ╰────
+  help: Replace inline type specifiers with a top‐level import type statement.
+
   ⚠ import(consistent-type-specifier-style): Type imports from declaration files must use top-level `import type` syntax.
    ╭─[consistent_type_specifier_style.tsx:1:10]
  1 │ import { type Foo } from './index.d.ts';
@@ -139,5 +160,12 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[consistent_type_specifier_style.tsx:1:10]
  1 │ import { type Foo } from './app.d.css.ts';
    ·          ────────
+   ╰────
+  help: Replace inline type specifiers with a top-level import type statement.
+
+  ⚠ import(consistent-type-specifier-style): Type imports from declaration files must use top-level `import type` syntax.
+   ╭─[consistent_type_specifier_style.tsx:1:15]
+ 1 │ import { Foo, type Bar } from './index.d.ts';
+   ·               ────────
    ╰────
   help: Replace inline type specifiers with a top-level import type statement.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -12903,6 +12903,14 @@
             "prefer-inline"
           ],
           "markdownDescription": "Prefer `import { type Foo } from 'foo'` for type imports."
+        },
+        {
+          "description": "Prefer `import type { Foo } from 'foo'` when all named imports are types, but allow\n`import { type Foo, bar } from 'foo'` when value imports are present.",
+          "type": "string",
+          "enum": [
+            "prefer-top-level-if-only-type-imports"
+          ],
+          "markdownDescription": "Prefer `import type { Foo } from 'foo'` when all named imports are types, but allow\n`import { type Foo, bar } from 'foo'` when value imports are present."
         }
       ]
     },


### PR DESCRIPTION
## Summary

- Re-port upstream support for prefer-top-level-if-only-type-imports.
- Allow mixed value/type imports while requiring top-level syntax for imports containing only types.
- Preserve Oxlint's existing default and declaration-file behavior.
- Regenerate the JSON schema and TypeScript configuration types.

## Reference

https://github.com/oxc-project/oxc/issues/1117#issuecomment-4966827537

