### PR TITLE
fix(parser): reject invalid accessor assertions

### DIFF
--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -426,13 +426,19 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             diagnostics::accessor_modifier,
         );
         if let Some(definite_token_start) = definite
-            && ((self.ctx.has_ambient() && !modifiers.contains(ModifierKind::Declare))
-                || r#type.is_abstract())
+            && !modifiers.contains(ModifierKind::Declare)
         {
-            self.error(diagnostics::definite_assignment_assertion_not_permitted(Span::sized(
-                definite_token_start,
-                1,
-            )));
+            let definite_span = Span::sized(definite_token_start, 1);
+            if value.is_some() {
+                self.error(diagnostics::variable_declarator_definite(definite_span));
+            } else if type_annotation.is_none() {
+                self.error(diagnostics::variable_declarator_definite_type_assertion(definite_span));
+            } else if self.ctx.has_ambient()
+                || modifiers.contains(ModifierKind::Static)
+                || r#type.is_abstract()
+            {
+                self.error(diagnostics::definite_assignment_assertion_not_permitted(definite_span));
+            }
         }
         ClassElement::new_accessor_property(
             self.end_span(span),

--- a/tasks/coverage/misc/fail/oxc-24503.ts
+++ b/tasks/coverage/misc/fail/oxc-24503.ts
@@ -1,0 +1,22 @@
+class Basic {
+    accessor noType!;
+    accessor initialized! = 1;
+    accessor typed!: number;
+    static accessor staticTyped!: number;
+    static accessor staticNoType!;
+    static accessor staticInitialized! = 1;
+}
+
+abstract class Abstract {
+    abstract accessor value!: number;
+}
+
+declare class Ambient {
+    accessor value!: number;
+}
+
+class DeclareMember {
+    declare accessor typed!: number;
+    declare accessor untyped!;
+    declare accessor initialized! = 1;
+}

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -12507,6 +12507,14 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
   help: Private identifiers are enforced at runtime, while accessibility modifiers only affect type checking, so using both is redundant.
 
+  × TS(1264): Declarations with definite assignment assertions must also have type annotations.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/accessor-invalid/input.ts:5:13]
+ 4 │ 
+ 5 │   accessor a!;
+   ·             ─
+ 6 │   abstract accessor #s;
+   ╰────
+
   × TS(1276): An 'accessor' property cannot be declared optional.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/accessor-invalid/input.ts:7:14]
  6 │   abstract accessor #s;
@@ -12866,6 +12874,22 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  4 │   accessor a!: number = 1;
    ╰────
 
+  × TS(1263): Declarations with initializers cannot also have definite assignment assertions.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/invalid-definite-initializer/input.ts:4:13]
+ 3 │   #x!: number = 1;
+ 4 │   accessor a!: number = 1;
+   ·             ─
+ 5 │   accessor #a!: number = 1;
+   ╰────
+
+  × TS(1263): Declarations with initializers cannot also have definite assignment assertions.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/invalid-definite-initializer/input.ts:5:14]
+ 4 │   accessor a!: number = 1;
+ 5 │   accessor #a!: number = 1;
+   ·              ─
+ 6 │ }
+   ╰────
+
   × TS(1264): Declarations with definite assignment assertions must also have type annotations.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/invalid-definite-without-type/input.ts:2:4]
  1 │ class C {
@@ -12880,6 +12904,22 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  3 │   #x!;
    ·     ─
  4 │   accessor a!;
+   ╰────
+
+  × TS(1264): Declarations with definite assignment assertions must also have type annotations.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/invalid-definite-without-type/input.ts:4:13]
+ 3 │   #x!;
+ 4 │   accessor a!;
+   ·             ─
+ 5 │   accessor #a!;
+   ╰────
+
+  × TS(1264): Declarations with definite assignment assertions must also have type annotations.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/invalid-definite-without-type/input.ts:5:14]
+ 4 │   accessor a!;
+ 5 │   accessor #a!;
+   ·              ─
+ 6 │ }
    ╰────
 
   × TS(1029): 'private' modifier must precede 'override' modifier.

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
 AST Parsed     : 71/71 (100.00%)
 Positive Passed: 71/71 (100.00%)
-Negative Passed: 149/149 (100.00%)
+Negative Passed: 150/150 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[misc/fail/arguments-eval.ts:1:10]
@@ -3642,6 +3642,89 @@ Negative Passed: 149/149 (100.00%)
     ·                     ╰── `{` expected
  39 │     & import("pkg", [ {"resolution-mode": "import"} ]).ImportInterface;
     ╰────
+
+  × TS(1264): Declarations with definite assignment assertions must also have type annotations.
+   ╭─[misc/fail/oxc-24503.ts:2:20]
+ 1 │ class Basic {
+ 2 │     accessor noType!;
+   ·                    ─
+ 3 │     accessor initialized! = 1;
+   ╰────
+
+  × TS(1263): Declarations with initializers cannot also have definite assignment assertions.
+   ╭─[misc/fail/oxc-24503.ts:3:25]
+ 2 │     accessor noType!;
+ 3 │     accessor initialized! = 1;
+   ·                         ─
+ 4 │     accessor typed!: number;
+   ╰────
+
+  × TS(1255): A definite assignment assertion '!' is not permitted in this context.
+   ╭─[misc/fail/oxc-24503.ts:5:32]
+ 4 │     accessor typed!: number;
+ 5 │     static accessor staticTyped!: number;
+   ·                                ─
+ 6 │     static accessor staticNoType!;
+   ╰────
+
+  × TS(1264): Declarations with definite assignment assertions must also have type annotations.
+   ╭─[misc/fail/oxc-24503.ts:6:33]
+ 5 │     static accessor staticTyped!: number;
+ 6 │     static accessor staticNoType!;
+   ·                                 ─
+ 7 │     static accessor staticInitialized! = 1;
+   ╰────
+
+  × TS(1263): Declarations with initializers cannot also have definite assignment assertions.
+   ╭─[misc/fail/oxc-24503.ts:7:38]
+ 6 │     static accessor staticNoType!;
+ 7 │     static accessor staticInitialized! = 1;
+   ·                                      ─
+ 8 │ }
+   ╰────
+
+  × TS(1255): A definite assignment assertion '!' is not permitted in this context.
+    ╭─[misc/fail/oxc-24503.ts:11:28]
+ 10 │ abstract class Abstract {
+ 11 │     abstract accessor value!: number;
+    ·                            ─
+ 12 │ }
+    ╰────
+
+  × TS(1255): A definite assignment assertion '!' is not permitted in this context.
+    ╭─[misc/fail/oxc-24503.ts:15:19]
+ 14 │ declare class Ambient {
+ 15 │     accessor value!: number;
+    ·                   ─
+ 16 │ }
+    ╰────
+
+  × TS(1243): 'accessor' modifier cannot be used with 'declare' modifier.
+    ╭─[misc/fail/oxc-24503.ts:19:5]
+ 18 │ class DeclareMember {
+ 19 │     declare accessor typed!: number;
+    ·     ───────
+ 20 │     declare accessor untyped!;
+    ╰────
+  help: Allowed modifiers are: private, protected, public, static, abstract, override
+
+  × TS(1243): 'accessor' modifier cannot be used with 'declare' modifier.
+    ╭─[misc/fail/oxc-24503.ts:20:5]
+ 19 │     declare accessor typed!: number;
+ 20 │     declare accessor untyped!;
+    ·     ───────
+ 21 │     declare accessor initialized! = 1;
+    ╰────
+  help: Allowed modifiers are: private, protected, public, static, abstract, override
+
+  × TS(1243): 'accessor' modifier cannot be used with 'declare' modifier.
+    ╭─[misc/fail/oxc-24503.ts:21:5]
+ 20 │     declare accessor untyped!;
+ 21 │     declare accessor initialized! = 1;
+    ·     ───────
+ 22 │ }
+    ╰────
+  help: Allowed modifiers are: private, protected, public, static, abstract, override
 
   × Expected `:` but found `[`
    ╭─[misc/fail/oxc-3320.tsx:1:8]


### PR DESCRIPTION
## Summary

- Align auto-accessor definite assignment assertions with TypeScript.
- Report TS1263 when an accessor has both `!` and an initializer.
- Report TS1264 when an accessor has `!` but no type annotation.
- Report TS1255 for typed definite assertions in static, abstract, and ambient contexts.
- Highlight only the `!` token, matching TypeScript.

fixes #24503.

## TypeScript behavior

Given:

```ts
class A {
    accessor missingType!;
    // ^: TS1264: Declarations with definite assignment assertions must also have type annotations.
    accessor initialized! = 1;
    // ^: TS1263: Declarations with initializers cannot also have definite assignment assertions.
    accessor typed!: number;
    // ^: valid
    static accessor staticTyped!: number;
    // ^: TS1255: A definite assignment assertion '!' is not permitted in this context.
}
```

TypeScript treats auto-accessors as property declarations and applies the following grammar check:

https://github.com/microsoft/TypeScript/blob/637d5746b70257028fb95aad32ddec6b26ab0a14/src/compiler/checker.ts#L53443-L53452

This establishes the diagnostic precedence:

1. An initializer produces TS1263.
2. Otherwise, a missing type annotation produces TS1264.
3. Otherwise, an invalid context produces TS1255.