### PR TITLE
perf(react_compiler): make aliasing effects cheap to intern and clone

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
@@ -1268,7 +1268,7 @@ pub enum AliasingEffect {
         mutates_function: bool,
         args: Vec<PlaceOrSpreadOrHole>,
         into: Place,
-        signature: Option<FunctionSignature>,
+        signature: Option<std::rc::Rc<FunctionSignature>>,
         span: Option<Span>,
     },
     /// Function expression creation with captures.

--- a/crates/oxc_react_compiler/src/react_compiler_hir/type_config.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/type_config.rs
@@ -13,7 +13,7 @@ use crate::react_compiler_utils::FxIndexMap;
 use crate::react_compiler_hir::Effect;
 
 /// Mirrors TS `ValueKind` enum for use in config.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ValueKind {
     Mutable,
     Frozen,

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
@@ -679,15 +679,15 @@ enum MutationResult {
 // =============================================================================
 
 struct Context {
-    interned_effects: FxHashMap<String, AliasingEffect>,
+    interned_effects: FxHashMap<EffectKey, AliasingEffect>,
     instruction_signature_cache: FxHashMap<u32, InstructionSignature>,
     catch_handlers: FxHashMap<BlockId, Place>,
     is_function_expression: bool,
     hoisted_context_declarations: FxHashMap<DeclarationId, Option<Place>>,
     non_mutating_spreads: FxHashSet<IdentifierId>,
-    /// Cache of ValueIds keyed by effect hash, ensuring stable allocation-site identity
+    /// Cache of ValueIds keyed by effect key, ensuring stable allocation-site identity
     /// across fixpoint iterations. Mirrors TS `effectInstructionValueCache`.
-    effect_value_id_cache: FxHashMap<String, ValueId>,
+    effect_value_id_cache: FxHashMap<EffectKey, ValueId>,
     /// Maps ValueId to FunctionId for function expressions, so we can look up
     /// locally-declared functions when processing Apply effects.
     function_values: FxHashMap<ValueId, FunctionId>,
@@ -701,14 +701,14 @@ struct Context {
 
 impl Context {
     fn intern_effect(&mut self, effect: AliasingEffect) -> AliasingEffect {
-        let hash = hash_effect(&effect);
-        self.interned_effects.entry(hash).or_insert(effect).clone()
+        let key = effect_key(&effect);
+        self.interned_effects.entry(key).or_insert(effect).clone()
     }
 
     /// Get or create a stable ValueId for a given effect, ensuring fixpoint convergence.
     fn get_or_create_value_id(&mut self, effect: &AliasingEffect) -> ValueId {
-        let hash = hash_effect(effect);
-        *self.effect_value_id_cache.entry(hash).or_insert_with(ValueId::new)
+        let key = effect_key(effect);
+        *self.effect_value_id_cache.entry(key).or_insert_with(ValueId::new)
     }
 }
 
@@ -717,84 +717,186 @@ struct InstructionSignature {
 }
 
 // =============================================================================
-// Helper: hash_effect
+// Helper: effect_key
 // =============================================================================
 
-fn hash_effect(effect: &AliasingEffect) -> String {
+/// Interning key for an `AliasingEffect`. Exactly the same fields participate in
+/// identity as in the string key this replaces — everything else (`Apply`'s
+/// `signature`/`span`, `Mutate`'s `reason`, `Impure`'s `error`) is ignored — but
+/// building and hashing the key no longer allocates or runs the formatting
+/// machinery on the hot path (except for the rare error-carrying arms, which
+/// clone their message strings).
+#[derive(PartialEq, Eq, Hash)]
+enum EffectKey {
+    Apply {
+        receiver: IdentifierId,
+        function: IdentifierId,
+        mutates_function: bool,
+        args: Vec<ArgKey>,
+        into: IdentifierId,
+    },
+    CreateFrom {
+        from: IdentifierId,
+        into: IdentifierId,
+    },
+    ImmutableCapture {
+        from: IdentifierId,
+        into: IdentifierId,
+    },
+    Assign {
+        from: IdentifierId,
+        into: IdentifierId,
+    },
+    Alias {
+        from: IdentifierId,
+        into: IdentifierId,
+    },
+    Capture {
+        from: IdentifierId,
+        into: IdentifierId,
+    },
+    MaybeAlias {
+        from: IdentifierId,
+        into: IdentifierId,
+    },
+    Create {
+        into: IdentifierId,
+        value: ValueKind,
+        reason: ValueReason,
+    },
+    Freeze {
+        value: IdentifierId,
+        reason: ValueReason,
+    },
+    Impure {
+        place: IdentifierId,
+    },
+    Render {
+        place: IdentifierId,
+    },
+    MutateFrozen {
+        place: IdentifierId,
+        message: Cow<'static, str>,
+        help: Option<Cow<'static, str>>,
+    },
+    MutateGlobal {
+        place: IdentifierId,
+        message: Cow<'static, str>,
+        help: Option<Cow<'static, str>>,
+    },
+    Mutate {
+        value: IdentifierId,
+    },
+    MutateConditionally {
+        value: IdentifierId,
+    },
+    MutateTransitive {
+        value: IdentifierId,
+    },
+    MutateTransitiveConditionally {
+        value: IdentifierId,
+    },
+    CreateFunction {
+        into: IdentifierId,
+        function_id: FunctionId,
+        captures: Vec<IdentifierId>,
+    },
+    /// Synthetic keys used by the `Assign` handler for kind-preserving copies;
+    /// they share the ValueId cache but never collide with real-effect keys.
+    AssignFrozen {
+        from: IdentifierId,
+        into: IdentifierId,
+    },
+    AssignCopy {
+        from: IdentifierId,
+        into: IdentifierId,
+    },
+}
+
+/// Key form of an `Apply` argument (identifier only, like the string encoding).
+#[derive(PartialEq, Eq, Hash)]
+enum ArgKey {
+    Place(IdentifierId),
+    Spread(IdentifierId),
+    Hole,
+}
+
+fn effect_key(effect: &AliasingEffect) -> EffectKey {
     match effect {
         AliasingEffect::Apply { receiver, function, mutates_function, args, into, .. } => {
-            let args_str: Vec<Cow<'_, str>> = args
+            let mut key_args: Vec<ArgKey> = args
                 .iter()
                 .map(|a| match a {
-                    PlaceOrSpreadOrHole::Hole => Cow::Borrowed(""),
-                    PlaceOrSpreadOrHole::Place(p) => {
-                        Cow::Owned(format!("{}", p.identifier.index()))
-                    }
-                    PlaceOrSpreadOrHole::Spread(s) => {
-                        Cow::Owned(format!("...{}", s.place.identifier.index()))
-                    }
+                    PlaceOrSpreadOrHole::Hole => ArgKey::Hole,
+                    PlaceOrSpreadOrHole::Place(p) => ArgKey::Place(p.identifier),
+                    PlaceOrSpreadOrHole::Spread(s) => ArgKey::Spread(s.place.identifier),
                 })
                 .collect();
-            format!(
-                "Apply:{}:{}:{}:{}:{}",
-                receiver.identifier.index(),
-                function.identifier.index(),
-                mutates_function,
-                args_str.join(","),
-                into.identifier.index()
-            )
+            // The string key joined args with "," and encoded a hole as "", so a
+            // single-hole list was indistinguishable from an empty one. Keep that.
+            if matches!(key_args.as_slice(), [ArgKey::Hole]) {
+                key_args.clear();
+            }
+            EffectKey::Apply {
+                receiver: receiver.identifier,
+                function: function.identifier,
+                mutates_function: *mutates_function,
+                args: key_args,
+                into: into.identifier,
+            }
         }
         AliasingEffect::CreateFrom { from, into } => {
-            format!("CreateFrom:{}:{}", from.identifier.index(), into.identifier.index())
+            EffectKey::CreateFrom { from: from.identifier, into: into.identifier }
         }
         AliasingEffect::ImmutableCapture { from, into } => {
-            format!("ImmutableCapture:{}:{}", from.identifier.index(), into.identifier.index())
+            EffectKey::ImmutableCapture { from: from.identifier, into: into.identifier }
         }
         AliasingEffect::Assign { from, into } => {
-            format!("Assign:{}:{}", from.identifier.index(), into.identifier.index())
+            EffectKey::Assign { from: from.identifier, into: into.identifier }
         }
         AliasingEffect::Alias { from, into } => {
-            format!("Alias:{}:{}", from.identifier.index(), into.identifier.index())
+            EffectKey::Alias { from: from.identifier, into: into.identifier }
         }
         AliasingEffect::Capture { from, into } => {
-            format!("Capture:{}:{}", from.identifier.index(), into.identifier.index())
+            EffectKey::Capture { from: from.identifier, into: into.identifier }
         }
         AliasingEffect::MaybeAlias { from, into } => {
-            format!("MaybeAlias:{}:{}", from.identifier.index(), into.identifier.index())
+            EffectKey::MaybeAlias { from: from.identifier, into: into.identifier }
         }
         AliasingEffect::Create { into, value, reason } => {
-            format!("Create:{}:{:?}:{:?}", into.identifier.index(), value, reason)
+            EffectKey::Create { into: into.identifier, value: *value, reason: *reason }
         }
         AliasingEffect::Freeze { value, reason } => {
-            format!("Freeze:{}:{:?}", value.identifier.index(), reason)
+            EffectKey::Freeze { value: value.identifier, reason: *reason }
         }
-        AliasingEffect::Impure { place, .. } => format!("Impure:{}", place.identifier.index()),
-        AliasingEffect::Render { place } => format!("Render:{}", place.identifier.index()),
-        AliasingEffect::MutateFrozen { place, error } => {
-            format!("MutateFrozen:{}:{}:{:?}", place.identifier.index(), error.message, error.help)
-        }
-        AliasingEffect::MutateGlobal { place, error } => {
-            format!("MutateGlobal:{}:{}:{:?}", place.identifier.index(), error.message, error.help)
-        }
-        AliasingEffect::Mutate { value, .. } => format!("Mutate:{}", value.identifier.index()),
+        AliasingEffect::Impure { place, .. } => EffectKey::Impure { place: place.identifier },
+        AliasingEffect::Render { place } => EffectKey::Render { place: place.identifier },
+        AliasingEffect::MutateFrozen { place, error } => EffectKey::MutateFrozen {
+            place: place.identifier,
+            message: error.message.clone(),
+            help: error.help.clone(),
+        },
+        AliasingEffect::MutateGlobal { place, error } => EffectKey::MutateGlobal {
+            place: place.identifier,
+            message: error.message.clone(),
+            help: error.help.clone(),
+        },
+        AliasingEffect::Mutate { value, .. } => EffectKey::Mutate { value: value.identifier },
         AliasingEffect::MutateConditionally { value } => {
-            format!("MutateConditionally:{}", value.identifier.index())
+            EffectKey::MutateConditionally { value: value.identifier }
         }
         AliasingEffect::MutateTransitive { value } => {
-            format!("MutateTransitive:{}", value.identifier.index())
+            EffectKey::MutateTransitive { value: value.identifier }
         }
         AliasingEffect::MutateTransitiveConditionally { value } => {
-            format!("MutateTransitiveConditionally:{}", value.identifier.index())
+            EffectKey::MutateTransitiveConditionally { value: value.identifier }
         }
         AliasingEffect::CreateFunction { into, function_id, captures } => {
-            let cap_str: Vec<String> =
-                captures.iter().map(|p| format!("{}", p.identifier.index())).collect();
-            format!(
-                "CreateFunction:{}:{}:{}",
-                into.identifier.index(),
-                function_id.index(),
-                cap_str.join(",")
-            )
+            EffectKey::CreateFunction {
+                into: into.identifier,
+                function_id: *function_id,
+                captures: captures.iter().map(|p| p.identifier).collect(),
+            }
         }
     }
 }
@@ -1529,11 +1631,8 @@ fn apply_effect(
                         effects,
                         env,
                     )?;
-                    let cache_key = format!(
-                        "Assign_frozen:{}:{}",
-                        from.identifier.index(),
-                        into.identifier.index()
-                    );
+                    let cache_key =
+                        EffectKey::AssignFrozen { from: from.identifier, into: into.identifier };
                     let value_id = *context
                         .effect_value_id_cache
                         .entry(cache_key)
@@ -1545,11 +1644,8 @@ fn apply_effect(
                     state.define(into.identifier, value_id);
                 }
                 ValueKind::Global | ValueKind::Primitive => {
-                    let cache_key = format!(
-                        "Assign_copy:{}:{}",
-                        from.identifier.index(),
-                        into.identifier.index()
-                    );
+                    let cache_key =
+                        EffectKey::AssignCopy { from: from.identifier, into: into.identifier };
                     let value_id = *context
                         .effect_value_id_cache
                         .entry(cache_key)

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
@@ -680,7 +680,9 @@ enum MutationResult {
 
 struct Context {
     interned_effects: FxHashMap<EffectKey, AliasingEffect>,
-    instruction_signature_cache: FxHashMap<u32, InstructionSignature>,
+    /// `Rc` so `apply_signature` can hold the signature while passing the
+    /// context on mutably, without deep-cloning the effect list every time.
+    instruction_signature_cache: FxHashMap<u32, Rc<InstructionSignature>>,
     catch_handlers: FxHashMap<BlockId, Place>,
     is_function_expression: bool,
     hoisted_context_declarations: FxHashMap<DeclarationId, Option<Place>>,
@@ -1156,7 +1158,7 @@ fn infer_block(
         if !context.instruction_signature_cache.contains_key(instr_idx) {
             let sig =
                 compute_signature_for_instruction(context, env, &func.instructions[instr_index]);
-            context.instruction_signature_cache.insert(*instr_idx, sig);
+            context.instruction_signature_cache.insert(*instr_idx, Rc::new(sig));
         }
 
         // Apply signature
@@ -1308,10 +1310,9 @@ fn apply_signature(
     let mut initialized: FxHashSet<IdentifierId> = FxHashSet::default();
 
     // Get the cached signature effects
-    let sig = context.instruction_signature_cache.get(&instr_idx).unwrap();
-    let sig_effects: Vec<AliasingEffect> = sig.effects.clone();
+    let sig = Rc::clone(context.instruction_signature_cache.get(&instr_idx).unwrap());
 
-    for effect in &sig_effects {
+    for effect in &sig.effects {
         apply_effect(context, state, effect.clone(), &mut initialized, &mut effects, env)?;
     }
 

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
@@ -3181,9 +3181,9 @@ fn is_builtin_collection_type(ty: &Type) -> bool {
 fn get_function_call_signature(
     env: &Environment,
     callee_id: IdentifierId,
-) -> Result<Option<FunctionSignature>, OxcDiagnostic> {
+) -> Result<Option<Rc<FunctionSignature>>, OxcDiagnostic> {
     let ty = &env.types[env.identifiers[callee_id].type_];
-    Ok(env.get_function_signature(ty)?.cloned())
+    Ok(env.get_function_signature(ty)?.map(|s| Rc::new(s.clone())))
 }
 
 fn is_ref_or_ref_value_for_id(env: &Environment, id: IdentifierId) -> bool {


### PR DESCRIPTION
## What

The mutation/aliasing inference interns every effect it applies. Both the interning map and the fixpoint-stable ValueId cache were keyed by a formatted `String`, so every lookup on the `apply_effect` hot path built a fresh string. On top of that, `AliasingEffect::Apply` carried an owned `FunctionSignature`, so cloning an Apply effect meant copying the whole struct including its parameter effect list, and `apply_signature` deep-cloned the cached effect list of every instruction it applied.

## Change

- Replace the `String` key with an `EffectKey` enum carrying exactly the fields the string encoded. `Apply::signature`/`span` and `Mutate::reason` still don't participate in identity, and the one collision the string format had (an empty `Apply` argument list vs a single hole) is reproduced on purpose. Building and hashing a key no longer allocates or formats, except in the rare error-carrying arms, which clone their message strings.
- Put the `FunctionSignature` in `Apply` behind `Rc`. It's still deep-cloned out of the shape registry once per call instruction, but every later clone of the effect is just a refcount bump. The interning key already ignores the signature, and all readers are immutable.
- Put the cached `InstructionSignature` entries behind `Rc` too, so `apply_signature` can hold the signature while passing the context on mutably, instead of cloning the whole effect list each time.

Follow-up to #24117; this PR is based on current main, which includes it.

Numbers from linting cal.com with only `react/react-compiler` enabled, single thread, fat-LTO release build:

| Metric (cal.com, 1 thread) |     main |  this PR | delta |
| -------------------------- | -------: | -------: | ----: |
| instructions               | 19.113 G | 18.086 G | −5.4% |
| wall time                  |  2.907 s |  2.804 s | −3.5% |

## Verification

- Output of the main binary vs this PR's binary is byte-identical (stdout, stderr, exit code) on all 4 corpus/config combinations: cal.com and excalidraw, each with `reportAllBailouts` on and off.
- The `react_compiler` example (parse, compile, codegen) produces identical output on all 1438 corpus files.
- `cargo test -p oxc_react_compiler` passes, including the 1,736-fixture snapshot corpus: compiled output is unchanged on every fixture.
- `cargo clippy` and `cargo fmt` clean.

One note for future re-syncs with the vendored React Compiler sources: `EffectKey` mirrors `AliasingEffect` variant for variant. Adding an identity-relevant field to a variant without updating `effect_key` silently changes interning behavior. Keep the two in sync.

This PR was assisted by Claude Code.