### PR TITLE
fix(minifier): don't fold lexical reads reachable inside their TDZ

### DIFF
--- a/crates/oxc_minifier/src/peephole/inline.rs
+++ b/crates/oxc_minifier/src/peephole/inline.rs
@@ -83,8 +83,9 @@ impl<'a> PeepholeOptimizations {
         // `body_unsafe` is set by a preceding non-declarative statement, and the
         // program root additionally starts unsafe when the module has loaders
         // (see `enter_program`) — so this one check covers the cyclic-import gate.
-        let &(body_scope, body_unsafe) = ctx.state.body_unsafe_stack.last();
-        if body_unsafe || ctx.current_scope_id() != body_scope {
+        let frame = ctx.state.body_unsafe_stack.last();
+        let body_scope = frame.scope;
+        if frame.body_unsafe || ctx.current_scope_id() != frame.scope {
             return false;
         }
         // At least one read, and every read crosses a function boundary.
@@ -236,6 +237,13 @@ impl<'a> PeepholeOptimizations {
         };
         // Skip if there are write references.
         if symbol_value.write_references_count > 0 {
+            return;
+        }
+        // A read inside a hoisted function declaration may run inside the
+        // binding's temporal dead zone (see `SymbolValue::lexical_unsafe_prelude`).
+        if symbol_value.lexical_unsafe_prelude
+            && ctx.inside_hoisted_function_below(ctx.scoping().symbol_scope_id(symbol_id))
+        {
             return;
         }
         let Some(cv) = &symbol_value.initialized_constant else { return };

--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -21,7 +21,7 @@ use oxc_ast_visit::{Visit, VisitJs, walk_js::walk_call_expression};
 use oxc_semantic::Scoping;
 use oxc_syntax::{
     scope::{ScopeFlags, ScopeId},
-    symbol::SymbolId,
+    symbol::{SymbolFlags, SymbolId},
 };
 use rustc_hash::FxHashSet;
 
@@ -30,7 +30,7 @@ use oxc_ast::ast::*;
 
 use crate::{
     ReusableTraverseCtx, Traverse, TraverseCtx, minifier_traverse::traverse_mut_with_ctx,
-    traverse_context::as_direct_eval_call,
+    state::BodyFrame, traverse_context::as_direct_eval_call,
 };
 
 pub use self::normalize::{Normalize, NormalizeOptions};
@@ -136,10 +136,65 @@ impl<'a> PeepholeOptimizations {
     /// prelude. No-op if the flag is already set, or if `current_scope_id` is
     /// some inner scope (a block/for/etc.) — those don't end the prelude.
     fn mark_current_body_unsafe(ctx: &mut TraverseCtx<'a>) {
-        let &(body_scope, body_unsafe) = ctx.state.body_unsafe_stack.last();
-        if !body_unsafe && body_scope == ctx.current_scope_id() {
-            ctx.state.body_unsafe_stack.last_mut().1 = true;
+        let frame = ctx.state.body_unsafe_stack.last();
+        if !frame.body_unsafe && frame.scope == ctx.current_scope_id() {
+            ctx.state.body_unsafe_stack.last_mut().body_unsafe = true;
         }
+    }
+
+    /// Maintains `BodyFrame::hoisted_fn_referenced`; see its doc for the
+    /// reachability model.
+    ///
+    /// Deliberately conservative for closure-contained references: a mention
+    /// inside an arrow or function expression arms the bit at creation even
+    /// though the closure may never run before a later declarator
+    /// (`const expose = () => g; let a = 1;` loses the fold of reads in
+    /// `g`). Distinguishing "created" from "invokable" needs a pending bit
+    /// promoted by a subsequent executable statement at any scope depth —
+    /// the body-scope-only variant is unsound for
+    /// `{ const e = () => g; e(); } let a = 1;` — and the shape is too rare
+    /// to justify that machinery.
+    fn track_hoisted_function_reference(
+        ident: &IdentifierReference<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        let Some(symbol_id) = ctx.scoping().get_reference(ident.reference_id()).symbol_id() else {
+            return;
+        };
+        if !ctx.scoping().symbol_flags(symbol_id).contains(SymbolFlags::Function) {
+            return;
+        }
+        let symbol_scope = ctx.scoping().symbol_scope_id(symbol_id);
+        // No exclusion for a named function expression's self-binding: its
+        // symbol scope is indistinguishable from a declaration nested in a
+        // function body (both are `Function`-flagged), and a self-recursive
+        // call can precede the body's own lexicals anyway — the reference
+        // then sets the bit on its own body's frame, which is exactly right.
+        // The owning frame: the innermost body whose scope contains the
+        // function's declaration scope (equal for body-level declarations,
+        // an ancestor for block-level ones).
+        let Some(owner_index) =
+            ctx.state.body_unsafe_stack.as_slice().iter().enumerate().rev().find_map(
+                |(i, frame)| {
+                    (frame.scope == symbol_scope
+                        || ctx.scoping().scope_is_descendant_of(symbol_scope, frame.scope))
+                    .then_some(i)
+                },
+            )
+        else {
+            return;
+        };
+        let owner = &ctx.state.body_unsafe_stack.as_slice()[owner_index];
+        if owner.hoisted_fn_referenced {
+            return;
+        }
+        let owner_scope = owner.scope;
+        // See `BodyFrame::hoisted_fn_referenced`: references from inside a
+        // hoisted function of the same body don't count.
+        if ctx.inside_hoisted_function_below(owner_scope) {
+            return;
+        }
+        ctx.state.body_unsafe_stack.as_mut_slice()[owner_index].hoisted_fn_referenced = true;
     }
 
     /// Checks if a member expression's base object may be mutated.
@@ -462,14 +517,21 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
         // `enter`/`exit_function_body` are balanced, so the stack is back to its
         // single program-root entry by the next pass; reset it in place rather
         // than reallocating (matching the `reset`/`clear` above).
-        *ctx.state.body_unsafe_stack.last_mut() =
-            (ctx.scoping().root_scope_id(), module_has_loaders);
+        *ctx.state.body_unsafe_stack.last_mut() = BodyFrame {
+            scope: ctx.scoping().root_scope_id(),
+            body_unsafe: module_has_loaders,
+            hoisted_fn_referenced: false,
+        };
         // `PassDirty` is managed by the `Compressor` driver via
         // `flush_pass_dirty`, not reset per traversal.
     }
 
     fn enter_function_body(&mut self, _body: &mut FunctionBody<'a>, ctx: &mut TraverseCtx<'a>) {
-        ctx.state.body_unsafe_stack.push((ctx.current_scope_id(), false));
+        ctx.state.body_unsafe_stack.push(BodyFrame {
+            scope: ctx.current_scope_id(),
+            body_unsafe: false,
+            hoisted_fn_referenced: false,
+        });
     }
 
     fn exit_function_body(&mut self, _body: &mut FunctionBody<'a>, ctx: &mut TraverseCtx<'a>) {
@@ -605,6 +667,15 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
     }
 
     fn exit_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
+        // Runs in both modes: `init_symbol_value` (also both modes) consumes
+        // the bit this maintains — for module sources and for script nested
+        // bodies. Script ROOT frames use the blunt prelude rule instead, so
+        // at script top level (stack depth 1) the tracking is skipped.
+        if (!ctx.source_type().is_script() || ctx.state.body_unsafe_stack.len() > 1)
+            && let Expression::Identifier(ident) = expr
+        {
+            Self::track_hoisted_function_reference(ident, ctx);
+        }
         // Tree-shaking mode: fewer passes than full minify below. Only the ones
         // that remove code, plus the constant folds those removals need. The
         // folds stay on because the removal passes don't evaluate compound

--- a/crates/oxc_minifier/src/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/src/peephole/remove_dead_code.rs
@@ -7,6 +7,7 @@ use oxc_ecmascript::{
     side_effects::MayHaveSideEffects,
 };
 use oxc_span::GetSpan;
+use oxc_syntax::scope::ScopeId;
 
 use crate::{TraverseCtx, keep_var::KeepVar};
 
@@ -439,6 +440,7 @@ impl<'a> PeepholeOptimizations {
                         f.id.as_ref(),
                         &f.params,
                         body,
+                        f.scope_id.get(),
                         f.r#async,
                         f.generator,
                         ctx,
@@ -454,6 +456,7 @@ impl<'a> PeepholeOptimizations {
                                     Some(id),
                                     &a.params,
                                     &a.body,
+                                    a.scope_id.get(),
                                     a.r#async,
                                     false,
                                     ctx,
@@ -465,6 +468,7 @@ impl<'a> PeepholeOptimizations {
                                         Some(id),
                                         &f.params,
                                         body,
+                                        f.scope_id.get(),
                                         f.r#async,
                                         f.generator,
                                         ctx,
@@ -484,6 +488,7 @@ impl<'a> PeepholeOptimizations {
         id: Option<&BindingIdentifier<'a>>,
         params: &FormalParameters<'a>,
         body: &FunctionBody<'a>,
+        scope_id: Option<ScopeId>,
         r#async: bool,
         generator: bool,
         ctx: &mut TraverseCtx<'a>,
@@ -498,6 +503,20 @@ impl<'a> PeepholeOptimizations {
         if body.statements.iter().any(|stmt| stmt.may_have_side_effects(ctx)) {
             return;
         }
+        // The side-effect walk above does not model the temporal dead zone: a
+        // read of an outer `let`/`const`/`class` binding throws when the
+        // function runs before the declarator. `pure_functions` is never
+        // reset, so caching here lets a later pass drop such a call and erase
+        // the ReferenceError. Bail when the body (or a default parameter)
+        // reads an outer lexical whose declarator hasn't been visited yet
+        // (it sits later in source, so a call in between observes the TDZ)
+        // or was recorded as TDZ-hazardous. A visited, unhazardous declarator
+        // precedes this statement with no hoisted-function reference before
+        // it, so no call of this function can run inside the TDZ.
+        let Some(scope_id) = scope_id else { return };
+        if Self::reads_possibly_tdz_lexical(params, body, scope_id, ctx) {
+            return;
+        }
         let Some(symbol_id) = id.and_then(|id| id.symbol_id.get()) else { return };
         if ctx.scoping().get_resolved_references(symbol_id).all(|r| r.flags().is_read_only()) {
             ctx.state.pure_functions.insert(
@@ -505,6 +524,57 @@ impl<'a> PeepholeOptimizations {
                 if body.is_empty() { Some(ConstantValue::Undefined) } else { None },
             );
         }
+    }
+
+    /// See the call site in `try_save_pure_function`.
+    fn reads_possibly_tdz_lexical(
+        params: &FormalParameters<'a>,
+        body: &FunctionBody<'a>,
+        fn_scope: ScopeId,
+        ctx: &TraverseCtx<'a>,
+    ) -> bool {
+        struct TdzReadFinder<'a, 'b> {
+            ctx: &'b TraverseCtx<'a>,
+            fn_scope: ScopeId,
+            found: bool,
+        }
+        impl<'a> VisitJs<'a> for TdzReadFinder<'a, '_> {
+            // Stop descending once a hazard is found.
+            fn visit_statement(&mut self, stmt: &Statement<'a>) {
+                if !self.found {
+                    oxc_ast_visit::walk_js::walk_statement(self, stmt);
+                }
+            }
+            fn visit_expression(&mut self, expr: &Expression<'a>) {
+                if !self.found {
+                    oxc_ast_visit::walk_js::walk_expression(self, expr);
+                }
+            }
+            fn visit_identifier_reference(&mut self, ident: &IdentifierReference<'a>) {
+                if self.found {
+                    return;
+                }
+                let Some(symbol_id) =
+                    self.ctx.scoping().get_reference(ident.reference_id()).symbol_id()
+                else {
+                    return;
+                };
+                // Cheap flag test first; the scope walk below only runs for
+                // hazardous lexicals.
+                if !self.ctx.lexical_read_is_tdz_hazardous(symbol_id) {
+                    return;
+                }
+                let symbol_scope = self.ctx.scoping().symbol_scope_id(symbol_id);
+                // A binding inside the function itself is initialized by the
+                // function's own execution.
+                self.found = symbol_scope != self.fn_scope
+                    && !self.ctx.scoping().scope_is_descendant_of(symbol_scope, self.fn_scope);
+            }
+        }
+        let mut finder = TdzReadFinder { ctx, fn_scope, found: false };
+        finder.visit_formal_parameters(params);
+        finder.visit_function_body(body);
+        finder.found
     }
 
     pub fn remove_dead_code_call_expression(expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {

--- a/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
@@ -43,6 +43,7 @@ impl<'a> PeepholeOptimizations {
                 // a `ReferenceError`, so we must keep it. In all other positions (including
                 // non-derived constructors) `this` is always initialized and can be dropped.
                 Expression::ThisExpression(_) => !Self::this_is_inside_derived_constructor(ctx),
+                Expression::Identifier(ident) => Self::remove_unused_identifier(ident, ctx),
                 _ => unreachable!(
                     "expr_has_specialized_unused_handler is out of sync with this dispatch"
                 ),
@@ -73,6 +74,25 @@ impl<'a> PeepholeOptimizations {
             return false;
         }
         false
+    }
+
+    /// Like the `this`-in-derived-constructor keep above: reading a
+    /// `let`/`const`/`class` binding inside a hoisted function that can run
+    /// before the declarator throws a ReferenceError. Dropping the read
+    /// erases the throw directly — and, by emptying the function, feeds the
+    /// pure-call cache so the caller gets dropped too. Keep the read when
+    /// the declarator is TDZ-hazardous (or not yet visited, i.e. later in
+    /// source) and the read sits inside a hoisted function declaration
+    /// below the binding's scope.
+    fn remove_unused_identifier(ident: &IdentifierReference<'a>, ctx: &TraverseCtx<'a>) -> bool {
+        let Some(symbol_id) = ctx.scoping().get_reference(ident.reference_id()).symbol_id() else {
+            // Unresolved: reading a global can throw or trigger a getter —
+            // defer to the side-effect model.
+            return !ident.may_have_side_effects(ctx);
+        };
+        // A resolved read has no side effect besides a possible TDZ throw.
+        !(ctx.lexical_read_is_tdz_hazardous(symbol_id)
+            && ctx.inside_hoisted_function_below(ctx.scoping().symbol_scope_id(symbol_id)))
     }
 
     fn remove_unused_unary_expr(e: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) -> bool {
@@ -1198,6 +1218,7 @@ impl<'a> PeepholeOptimizations {
                 | Expression::TemplateLiteral(_)
                 | Expression::UnaryExpression(_)
                 | Expression::ThisExpression(_)
+                | Expression::Identifier(_)
         )
     }
 }

--- a/crates/oxc_minifier/src/state.rs
+++ b/crates/oxc_minifier/src/state.rs
@@ -82,15 +82,8 @@ pub struct MinifierState<'a> {
     pub symbol_facts: PersistentSymbolFacts,
 
     /// One frame per enclosing function body (program root at the bottom).
-    /// `(body_scope, body_unsafe)`. While `body_unsafe` is false, the next
-    /// `var x = <literal>;` whose declarator sits at `body_scope` is safe to
-    /// inline despite hoisting. A preceding non-declarative statement sets it;
-    /// the program root additionally starts unsafe when the module has any
-    /// loader (`import` / `export … from` / `export * from`), since a cyclic
-    /// importer could observe a not-yet-assigned binding our exports close over.
-    /// Pushed by `enter_function_body`, popped by `exit_function_body`. See
-    /// `init_symbol_value`.
-    pub body_unsafe_stack: NonEmptyStack<(ScopeId, bool)>,
+    /// Pushed by `enter_function_body`, popped by `exit_function_body`.
+    pub body_unsafe_stack: NonEmptyStack<BodyFrame>,
 
     /// Set when a typed helper mutates the AST. Private by design: the only
     /// writers are the helpers on `MinifierTraverseCtx`; the only reader is
@@ -106,6 +99,27 @@ pub struct MinifierState<'a> {
     /// Scratch buffer reused by `try_fold_concat` to build template literal
     /// quasis without allocating a fresh `String` per call.
     pub concat_scratch: String,
+}
+
+/// Per-function-body streaming state. See `body_unsafe_stack`.
+pub struct BodyFrame {
+    pub scope: ScopeId,
+    /// While false, the next `var x = <literal>;` whose declarator sits at
+    /// `scope` is safe to inline despite hoisting. A preceding
+    /// non-declarative statement sets it; the program root additionally
+    /// starts unsafe when the module has any loader, since a cyclic importer
+    /// could observe a not-yet-assigned binding our exports close over. See
+    /// `init_symbol_value`.
+    pub body_unsafe: bool,
+    /// A hoisted function declaration of this body (or of a block below it)
+    /// has been referenced from executed code. From that point on, any
+    /// executed statement may reach it — directly, transitively, or through
+    /// an escaped closure — so a lexical declarator recorded after this
+    /// point may have reads that run inside its temporal dead zone.
+    /// References from inside a hoisted function of the same body don't set
+    /// this: that function can only run if an earlier reference already did.
+    /// See `SymbolValue::lexical_unsafe_prelude`.
+    pub hoisted_fn_referenced: bool,
 }
 
 impl<'a> MinifierState<'a> {
@@ -124,7 +138,11 @@ impl<'a> MinifierState<'a> {
             symbol_values: SymbolValues::new(scoping.symbols_len()),
             class_symbols_stack: ClassSymbolsStack::new(),
             symbol_facts: PersistentSymbolFacts::default(),
-            body_unsafe_stack: NonEmptyStack::new((scoping.root_scope_id(), false)),
+            body_unsafe_stack: NonEmptyStack::new(BodyFrame {
+                scope: scoping.root_scope_id(),
+                body_unsafe: false,
+                hoisted_fn_referenced: false,
+            }),
             mutated: false,
             dirty: PassDirty::new(scoping.references_len(), allocator),
             concat_scratch: String::new(),

--- a/crates/oxc_minifier/src/symbol_value.rs
+++ b/crates/oxc_minifier/src/symbol_value.rs
@@ -59,6 +59,21 @@ pub struct SymbolValue<'a> {
     /// object/array/function/class literals. See `FreshValueKind`.
     pub kind: FreshValueKind,
 
+    /// A hoisted function called before this `let`/`const`/`class`
+    /// declarator executes could observe the binding's temporal dead zone.
+    /// Module sources: set from `BodyFrame::hoisted_fn_referenced` (see its
+    /// doc for the reachability model, including declarators inside blocks).
+    /// Script top-level declarators: any executable statement precedes the
+    /// declarator, or the declarator sits inside a block — a script's
+    /// top-level hoisted functions are global-object-reachable without a
+    /// local reference. Script nested bodies are closed namespaces and use
+    /// the same bit as modules. Consumers must not
+    /// resolve `initialized_constant` for a read inside a hoisted function
+    /// declaration below the binding's scope; the position test (and why
+    /// arrows / function expressions are exempt) lives on
+    /// `inside_hoisted_function_below`.
+    pub lexical_unsafe_prelude: bool,
+
     /// The symbol is provably falsy in **boolean context** but not necessarily
     /// foldable in value context. Set for a write-once binding with a falsy
     /// constant initializer whose `initialized_constant` was withheld (a hoisted
@@ -66,6 +81,12 @@ pub struct SymbolValue<'a> {
     /// initializer sees `undefined`, but `undefined` and the falsy init are
     /// indistinguishable inside `if (x)` / `x ? …` / `!x`, so such reads fold to
     /// `false` there. See `minimize_expression_in_boolean_context` / #14001.
+    ///
+    /// Never set for TDZ-lexicals: their value-context constant is never
+    /// withheld (`falsy_init` requires `value_withheld`), which is why the
+    /// boolean-context fold consuming this flag carries no TDZ gate. If
+    /// withholding is ever extended to lexicals, that fold must adopt the
+    /// `lexical_unsafe_prelude` gate.
     pub boolean_falsy: bool,
 }
 

--- a/crates/oxc_minifier/src/traverse_context/ecma_context.rs
+++ b/crates/oxc_minifier/src/traverse_context/ecma_context.rs
@@ -12,7 +12,10 @@ use oxc_ecmascript::{
 };
 use oxc_semantic::{IsGlobalReference, SymbolId};
 use oxc_str::format_str;
-use oxc_syntax::{reference::ReferenceId, scope::ScopeFlags};
+use oxc_syntax::{
+    reference::ReferenceId,
+    scope::{ScopeFlags, ScopeId},
+};
 
 use crate::{
     generated::ancestor::Ancestor,
@@ -176,12 +179,72 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
         &self,
         reference_id: ReferenceId,
     ) -> Option<&ConstantValue<'a>> {
-        self.scoping()
-            .get_reference(reference_id)
-            .symbol_id()
-            .and_then(|symbol_id| self.state.symbol_values.get_symbol_value(symbol_id))
-            .filter(|sv| sv.write_references_count == 0)
-            .and_then(|sv| sv.initialized_constant.as_ref())
+        let symbol_id = self.scoping().get_reference(reference_id).symbol_id()?;
+        let sv = self.state.symbol_values.get_symbol_value(symbol_id)?;
+        if sv.write_references_count != 0 {
+            return None;
+        }
+        // A read inside a hoisted function declaration may run inside the
+        // binding's temporal dead zone (see `SymbolValue::lexical_unsafe_prelude`).
+        if sv.lexical_unsafe_prelude
+            && self.inside_hoisted_function_below(self.scoping().symbol_scope_id(symbol_id))
+        {
+            return None;
+        }
+        sv.initialized_constant.as_ref()
+    }
+
+    /// Whether a read of `symbol_id` may execute inside its temporal dead
+    /// zone when reached from a hoisted function: the binding is
+    /// block-scoped (TS `enum` is included conservatively; it is erased
+    /// before minification) and its declarator is either recorded as
+    /// hazardous (`lexical_unsafe_prelude`) or not yet visited this pass —
+    /// it sits later in source, so a call between the read's function and
+    /// the declarator observes the TDZ. Position-independent: combine with
+    /// `inside_hoisted_function_below` (or a scan-scope check) at the call
+    /// site. Callers that already hold the `SymbolValue` inline the flag
+    /// read instead — do not add a third shape. Sibling hazard for `var` /
+    /// class heritage: `UNINIT_RISK` in `remove_unused_expression`.
+    pub fn lexical_read_is_tdz_hazardous(&self, symbol_id: SymbolId) -> bool {
+        if !self.scoping().symbol_flags(symbol_id).is_block_scoped() {
+            return false;
+        }
+        match self.state.symbol_values.get_symbol_value(symbol_id) {
+            None => true,
+            Some(sv) => sv.lexical_unsafe_prelude,
+        }
+    }
+
+    /// Whether the current traversal position sits inside a hoisted function
+    /// declaration whose scope is strictly below `symbol_scope`. Such a
+    /// function is callable before the symbol's declarator executes, so a
+    /// read of the binding here may run inside its temporal dead zone and
+    /// must throw rather than fold: in
+    /// `g(); let a = 1; function g() { return a * 2 }` folding `a * 2`
+    /// (and then dropping the now-pure `g()` call) erases the
+    /// ReferenceError. Arrows use a different ancestor link and function
+    /// expressions are created after the declarator (a fold-reachable read
+    /// is always source-after it), so neither can run inside the TDZ; the
+    /// walk stops once a function no longer sits below the binding's scope.
+    /// Reads in a hoisted declaration's default parameters are TDZ-reachable
+    /// the same way, hence the `FunctionParams` arm.
+    pub fn inside_hoisted_function_below(&self, symbol_scope: ScopeId) -> bool {
+        for ancestor in self.ancestors() {
+            let (r#type, scope_id) = match &ancestor {
+                Ancestor::FunctionBody(f) => (*f.r#type(), f.scope_id().get()),
+                Ancestor::FunctionParams(f) => (*f.r#type(), f.scope_id().get()),
+                _ => continue,
+            };
+            // Conservatively treat a missing scope id as hazardous.
+            let Some(scope_id) = scope_id else { return true };
+            if !self.scoping().scope_is_descendant_of(scope_id, symbol_scope) {
+                return false;
+            }
+            if r#type == FunctionType::FunctionDeclaration {
+                return true;
+            }
+        }
+        false
     }
 
     pub fn eval_binary(&self, e: &BinaryExpression<'a>) -> Option<Expression<'a>> {
@@ -341,6 +404,29 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
         let implicit_undefined =
             init_absent && initialized_constant.as_ref().is_some_and(ConstantValue::is_undefined);
 
+        // See `SymbolValue::lexical_unsafe_prelude`.
+        let lexical_unsafe_prelude = self.scoping().symbol_flags(symbol_id).is_block_scoped() && {
+            let frame = self.state.body_unsafe_stack.last();
+            if self.source_type().is_script() && frame.scope == self.scoping().root_scope_id() {
+                // A script's TOP-LEVEL hoisted functions are properties of
+                // the global object (Annex-B block functions included): any
+                // executed statement can reach them without a local
+                // reference having escaped. Nested bodies are closed
+                // namespaces like modules and take the precise branch below.
+                frame.body_unsafe || self.scoping.current_scope_id() != frame.scope
+            } else {
+                // A hoisted function of this body was referenced from
+                // executed code before this declarator, so later
+                // statements can reach it. Accepted limitation: a
+                // cyclic importer calling an exported function before
+                // the body runs can still observe the TDZ; folding
+                // erases that deterministic ReferenceError. Guarding
+                // it would withhold every flag-constant
+                // specialization in any module with imports.
+                frame.hoisted_fn_referenced
+            }
+        };
+
         let symbol_value = SymbolValue {
             initialized_constant,
             implicit_undefined,
@@ -349,6 +435,7 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
             write_references_count,
             member_write_target_read_count,
             kind,
+            lexical_unsafe_prelude,
             boolean_falsy,
         };
         self.state.symbol_values.init_value(symbol_id, symbol_value);

--- a/crates/oxc_minifier/tests/peephole/inline.rs
+++ b/crates/oxc_minifier/tests/peephole/inline.rs
@@ -1,8 +1,128 @@
 use oxc_span::SourceType;
 
 use crate::{
-    CompressOptions, test_options, test_options_source_type, test_same_options, test_smallest,
+    CompressOptions, test, test_options, test_options_source_type, test_same, test_same_options,
+    test_same_options_source_type, test_smallest,
 };
+
+// A hoisted function called before a `let`/`const` executes reads the
+// binding inside its temporal dead zone and must throw a ReferenceError.
+// Folding the read to the recorded constant (and then dropping the now-pure
+// call) erases the throw. The constant is only recorded when the declarator
+// sits in its body's clean declarative prelude, where nothing can have run.
+#[test]
+fn lexical_tdz_read_not_folded() {
+    // Arithmetic fold over the implicit undefined.
+    test_same("g();\nlet a;\nfunction g() {\n\treturn a * 2;\n}");
+    // Explicit initializer via the single-read inliner.
+    test_same("g();\nlet a = 1;\nfunction g() {\n\treturn a * 2;\n}");
+    // Nullish fold.
+    test_same("g();\nlet a;\nfunction g() {\n\treturn a ?? 'x';\n}");
+}
+
+#[test]
+fn lexical_prelude_reads_still_fold() {
+    // Declarator first: nothing can run before it, so a function created
+    // later cannot observe the TDZ.
+    test("let a = 1; function g() { return a * 2 } g();", "let a = 1; function g() { return 2 }");
+    test("let a; window.f = () => a ?? 'x';", "let a; window.f = () => 'x';");
+    // Function expressions and arrows created after the declarator cannot
+    // run inside the TDZ, even past an executable prelude — only hoisted
+    // function declarations can.
+    test(
+        "k(); let a = 1; NOOP(function() { return a * 2 });",
+        "k(); let a = 1; NOOP(function() { return 2 });",
+    );
+    test("k(); let a = 1; NOOP(() => a * 2);", "k(); let a = 1; NOOP(() => 2);");
+    // Same inside a block, which has no prelude tracking at all.
+    test("{ let a = 1; NOOP(() => a * 2); }", "{ let a = 1; NOOP(() => 2); }");
+    // A hoisted function referenced only after the declarator cannot have
+    // run before it, even past an executable prelude — the shape of
+    // generated code that specializes on top-level flag constants.
+    test(
+        "k(); let a = 1; function g() { return a * 2 } NOOP(g);",
+        "k(); let a = 1; function g() { return 2 } NOOP(g);",
+    );
+}
+
+// The purity pre-scan walks a function's body from the statement position
+// and its side-effect analysis does not model the TDZ, so a read of an outer
+// lexical looked pure with the value completely unknown; the never-reset
+// cache then let a later pass drop the pre-declaration `g()` call. The
+// `if (1) h()` forces that second pass.
+#[test]
+fn lexical_tdz_read_not_pure_cached() {
+    test_smallest(
+        "g(); let a = 1; function g() { return a * 2 } if (1) h();",
+        "g();\nlet a = 1;\nfunction g() {\n\treturn a * 2;\n}\nh();",
+    );
+    // Same with the declarator after the function: at scan time the
+    // declarator hasn't been visited, so the cache must also bail.
+    test_smallest(
+        "function g() { return a * 2 } g(); let a = 1; if (1) h();",
+        "function g() {\n\treturn a * 2;\n}\ng();\nlet a = 1;\nh();",
+    );
+    // Classes have the same temporal dead zone; the bare `C;` read must
+    // survive too — dropping it would empty `g` into the pure-call cache.
+    test_smallest(
+        "g(); class C {} function g() { C; } if (1) h();",
+        "g();\nclass C {}\nfunction g() {\n\tC;\n}\nh();",
+    );
+    test_smallest(
+        "g(); let a = 1; function g() { a; } if (1) h();",
+        "g();\nlet a = 1;\nfunction g() {\n\ta;\n}\nh();",
+    );
+    // The hazard is scope-relative: a declaration nested in another function
+    // body binds its symbol in that body's `Function`-flagged scope, which
+    // must not be mistaken for a named function expression's self-binding.
+    test_smallest(
+        "function outer() { g(); let a = 1; function g() { return a * 2 } } outer();",
+        "function outer() {\n\tg();\n\tlet a = 1;\n\tfunction g() {\n\t\treturn a * 2;\n\t}\n}\nouter();",
+    );
+}
+
+// Script sources: only TOP-LEVEL hoisted functions are global-object
+// properties reachable without a local reference. A nested body (a UMD
+// factory, an IIFE) is a closed namespace like a module, so it uses the
+// precise reference bit instead of the blunt prelude rule.
+#[test]
+fn script_nested_body_uses_reference_bit() {
+    let script = SourceType::cjs().with_script(true);
+    let options = CompressOptions::smallest();
+    // No hoisted-function reference before the declarator: folds.
+    test_options_source_type(
+        "function outer() { k(); let a = 1; function g() { return a * 2 } NOOP(g); } outer();",
+        "function outer() {\n\tk();\n\tfunction g() {\n\t\treturn 2;\n\t}\n\tNOOP(g);\n}\nouter();",
+        script,
+        &options,
+    );
+    // Hoisted call before the declarator: still withheld.
+    test_same_options_source_type(
+        "function outer() {\n\tg();\n\tlet a = 1;\n\tfunction g() {\n\t\treturn a * 2;\n\t}\n}\nouter();",
+        script,
+        &options,
+    );
+    // Top level of the script stays blunt: an executable statement before
+    // the declarator withholds even without a local hoisted reference.
+    test_same_options_source_type(
+        "k();\nlet a = 1;\nfunction g() {\n\treturn a * 2;\n}\nNOOP(g);",
+        script,
+        &options,
+    );
+}
+
+// Accepted limitation: a cyclic importer can call an exported function —
+// and transitively any hoisted function — before the module body runs, so
+// this fold erases a deterministic ReferenceError under an import cycle.
+// Guarding it would withhold every flag-constant specialization in any
+// module with imports (the generated deserializers, bundler chunks).
+#[test]
+fn lexical_tdz_import_cycle_accepted_limitation() {
+    test(
+        "import 'm'; let a = 1; function g() { return a * 2 } NOOP(g);",
+        "import 'm'; let a = 1; function g() { return 2 } NOOP(g);",
+    );
+}
 
 // https://github.com/oxc-project/oxc/issues/13051
 #[test]

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -11,9 +11,9 @@ Original   | minified   | minified   | gzip       | gzip       | Iterations | Fi
 
 544.10 kB  | 70.92 kB   | 72.48 kB   | 25.73 kB   | 26.20 kB   |          2 | lodash.js  
 
-555.77 kB  | 267.38 kB  | 270.13 kB  | 88.00 kB   | 90.80 kB   |          2 | d3.js      
+555.77 kB  | 267.41 kB  | 270.13 kB  | 88.03 kB   | 90.80 kB   |          2 | d3.js      
 
-1.01 MB    | 439.33 kB  | 458.89 kB  | 122.04 kB  | 126.71 kB  |          2 | bundle.min.js 
+1.01 MB    | 439.39 kB  | 458.89 kB  | 122.10 kB  | 126.71 kB  |          2 | bundle.min.js 
 
 1.25 MB    | 642.61 kB  | 646.76 kB  | 159.40 kB  | 163.73 kB  |          2 | three.js   
 

--- a/tasks/track_memory_allocations/allocs_minifier.snap
+++ b/tasks/track_memory_allocations/allocs_minifier.snap
@@ -6,11 +6,11 @@ App.tsx                    | 415.34 kB      ||             63 |              8 |
 
 RadixUIAdoptionSection.jsx | 2.52 kB        ||             21 |              0 ||             32 |              6
 
-pdf.mjs                    | 567.30 kB      ||           2469 |            205 ||          47471 |           7742
+pdf.mjs                    | 567.30 kB      ||           2463 |            205 ||          47437 |           7748
 
 antd.js                    | 6.69 MB        ||           1044 |             56 ||         372632 |          76745
 
 binder.ts                  | 193.08 kB      ||             33 |              1 ||           7076 |            824
 
-kitchen-sink.tsx           | 732.90 kB      ||           2309 |            175 ||          88129 |          15654
+kitchen-sink.tsx           | 732.90 kB      ||           2309 |            175 ||          88271 |          15654
 


### PR DESCRIPTION
A hoisted function called before a `let`/`const` declaration executes reads the binding inside its temporal dead zone and must throw a ReferenceError. The tracked constant recorded at the declarator made such reads fold — and the caller, now pure, got dropped: `g(); let a = 1; function g() { return a * 2 }` minifies to code that runs nothing where the original throws.

The hole is as old as the constant tracking itself (#11788, #12488) and reproduces on main without the parent PR:

- `g(); let a = 1; function g() { return a * 2 }` — folds via the single-read inliner
- `g(); let a; function g() { return a ?? "x" }` — folds via the `??` fold

The arithmetic fold in #24485 widened the reachable shapes, which is how review surfaced it.

The hazard needs the hoisted function to be invokable before the declarator runs, and in a module that requires a reference to it from executed code first: module scope is not reachable from the environment, so a getter or call in earlier statements cannot conjure the function unless an even earlier statement escaped it. Each body frame therefore tracks, in traversal order, whether one of its hoisted functions has been referenced from executed code (references from inside a hoisted function of the same body don't count — that function can only run if an earlier reference already set the bit, which also covers transitive calls). A lexical declarator records its constant as TDZ-hazardous when the bit is already set; consumption then withholds it only for reads inside a hoisted function declaration below the binding's scope, including its default parameters. Enclosing arrows and function expressions are created after the declarator — a fold-reachable read is always source-after it — and cannot observe the TDZ; the declaration test needs AST ancestry, since scope flags cannot tell a function expression from a declaration. Script top-level declarators keep a blunter rule (any executable statement before the declarator): a script's top-level hoisted functions are properties of the global object, reachable without a local reference. Script nested bodies — UMD factories, IIFEs — are closed namespaces and use the same reference bit as modules.

Reference-order precision matters in practice: generated and bundled modules specialize on top-level flag constants read inside hoisted functions that are only referenced at the bottom of the file — the repo's own raw-transfer deserializers minify byte-identically with this change, where a coarser prelude-based gate de-specialized them. Accepted limitation, documented in the tests: a cyclic importer calling an exported function before the module body runs can still observe the TDZ, and folding erases that deterministic throw; guarding it would withhold every flag-constant specialization in any module with imports.

The constant gate alone is not enough: `try_save_pure_function` evaluates a function body from the statement position, its side-effect analysis does not model the TDZ (a read of an outer lexical is "pure" with the value completely unknown), and the `pure_functions` cache is never reset — so a later pass dropped the pre-declaration `g()` call even with the fold withheld. The purity scan now refuses to cache a function that reads an outer `let`/`const`/`class` binding whose declarator is either recorded as TDZ-hazardous or not yet visited (it sits later in source, so a call between the function and the declarator observes the TDZ); a visited, unhazardous declarator precedes the function with no hoisted-function reference before it, so no call of the function can run inside the TDZ and the cache stays sound. Class declarations have the same dead zone, so `class` bindings are stamped alongside `let`/`const`. And the unused-expression pass now keeps a bare read of a hazardous binding inside such a function: dropping it erases the throw directly and, by emptying the body, would feed the pure-call cache — mirroring the existing `this`-before-`super()` keep.

Costs 90 B across the minsize corpus (d3 +30 B, bundle.min +60 B), which is minified in script mode: reads inside genuinely hoisted declarations past an executable prelude, indistinguishable from sound uses without call-graph analysis (a span test fails on transitive calls: `h(); let a; function h() { g() } function g() { return a * 2 }`). For comparison, esbuild attempts none of these folds.

## Example

```js
g();
let a = 1;
function g() {
	return a * 2;
}
```

Before — the ReferenceError is erased and the minified program runs nothing:

```js
let a = 1;
function g() {
	return 2;
}
```

After — the input is left unchanged and still throws.

Verified with the minifier unit suite (560 passing: the three TDZ shapes locked as unchanged, both orderings of the purity-cache shape and its class and bare-read variants, the nested-function-body variant, plus expression, arrow, block, and referenced-after folds that must keep working), byte-identical `just ast` output, and regenerated minsize and allocation snapshots.

Implemented with AI assistance (Claude Code); design, review, and verification driven by the author per the repo AI-usage policy.
