### PR TITLE
chore(deny): drop stale RUSTSEC-2026-0049 suppression (patched in resolved 0.103.13)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -21,8 +21,7 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
-ignore = [
-]
+ignore = []
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories
 # will still output a note when they are encountered.

--- a/deny.toml
+++ b/deny.toml
@@ -22,8 +22,6 @@ yanked = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-  # Low impact: requires compromising a trusted issuing authority. No fix in stable rustls-webpki yet.
-  "RUSTSEC-2026-0049",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories


### PR DESCRIPTION
## What this does

`deny.toml` suppresses `RUSTSEC-2026-0049` (rustls-webpki) with the comment *"No fix in stable rustls-webpki yet."* That's no longer true, so this drops the stale suppression.

## Why it's safe

- The advisory is patched: `patched = [">= 0.103.10"]` ([RUSTSEC-2026-0049](https://rustsec.org/advisories/RUSTSEC-2026-0049), dated 2026-03-20).
- `Cargo.lock` already resolves `rustls-webpki` to `0.103.13`, which is `>= 0.103.10`.

So `cargo deny` won't flag the advisory anymore, and keeping the ignore just hides future regressions in that crate. `RUSTSEC-2026-0049` was the only entry, so the list becomes `ignore = []`.

## Verification

```
grep -A1 'name = "rustls-webpki"' Cargo.lock            # version = "0.103.13"
# advisory: patched = [">= 0.103.10"]  → 0.103.13 satisfies it
```

One-line config change.

---

*Disclosure: I used an AI tool to help spot this and prepare the change; I verified the resolved version and the advisory's patched range myself and take responsibility for it.*
