### PR TITLE
perf(transformer): outline rare expression exits

### DIFF
--- a/crates/oxc_transformer/src/common/arrow_function_converter.rs
+++ b/crates/oxc_transformer/src/common/arrow_function_converter.rs
@@ -432,6 +432,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for ArrowFunctionConverter<'a> {
         }
     }
 
+    #[inline]
     fn exit_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         if self.is_disabled() {
             return;
@@ -444,12 +445,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for ArrowFunctionConverter<'a> {
                 return;
             }
 
-            expr.replace_with(|expr| {
-                let Expression::ArrowFunctionExpression(arrow_function_expr) = expr else {
-                    unreachable!()
-                };
-                Self::transform_arrow_function_expression(arrow_function_expr, ctx)
-            });
+            Self::transform_arrow_function_expression_on_exit(expr, ctx);
         }
     }
 
@@ -485,6 +481,19 @@ impl<'a> Traverse<'a, TransformState<'a>> for ArrowFunctionConverter<'a> {
 }
 
 impl<'a> ArrowFunctionConverter<'a> {
+    #[inline(never)]
+    fn transform_arrow_function_expression_on_exit(
+        expr: &mut Expression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        expr.replace_with(|expr| {
+            let Expression::ArrowFunctionExpression(arrow_function_expr) = expr else {
+                unreachable!()
+            };
+            Self::transform_arrow_function_expression(arrow_function_expr, ctx)
+        });
+    }
+
     /// Check if arrow function conversion is disabled
     fn is_disabled(&self) -> bool {
         self.mode == ArrowFunctionConverterMode::Disabled

--- a/crates/oxc_transformer/src/jsx/jsx_impl.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_impl.rs
@@ -551,15 +551,19 @@ impl<'a> Traverse<'a, TransformState<'a>> for JsxImpl<'a> {
         if !expr.is_jsx() {
             return;
         }
+        self.transform_jsx_expression(expr, ctx);
+    }
+}
+
+impl<'a> JsxImpl<'a> {
+    #[inline(never)]
+    fn transform_jsx_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         expr.replace_with(|expr| match expr {
             Expression::JSXElement(e) => self.transform_jsx_element(e, ctx),
             Expression::JSXFragment(e) => self.transform_jsx(e.span, None, e.unbox().children, ctx),
             _ => unreachable!(),
         });
     }
-}
-
-impl<'a> JsxImpl<'a> {
     fn insert_filename_var_statement(&self, ctx: &mut TraverseCtx<'a>) {
         let Some(declarator) = self.jsx_source.get_filename_var_declarator(ctx) else { return };
 

--- a/crates/oxc_transformer/src/jsx/refresh.rs
+++ b/crates/oxc_transformer/src/jsx/refresh.rs
@@ -217,74 +217,16 @@ impl<'a> Traverse<'a, TransformState<'a>> for ReactRefresh<'a> {
         var_decl.declarations = variable_declarator_items;
     }
 
+    #[inline]
     fn exit_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
-        let signature = match expr {
-            Expression::FunctionExpression(func) => self.create_signature_call_expression(
-                func.scope_id(),
-                func.body.as_mut().unwrap(),
-                ctx,
-            ),
-            Expression::ArrowFunctionExpression(arrow) => {
-                let call_fn =
-                    self.create_signature_call_expression(arrow.scope_id(), &mut arrow.body, ctx);
-
-                // If the signature is found, we will push a new statement to the arrow function body. So it's not an expression anymore.
-                if call_fn.is_some() {
-                    Self::transform_arrow_function_to_block(arrow, ctx);
-                }
-                call_fn
-            }
-            // hoc(_c = function() { })
-            Expression::AssignmentExpression(_) => return,
-            // hoc1(hoc2(...))
-            Expression::CallExpression(_) => self.last_signature.take(),
-            _ => None,
-        };
-
-        let Some((binding_identifier, mut arguments)) = signature else {
-            return;
-        };
-        let binding = BoundIdentifier::from_binding_ident(&binding_identifier);
-
-        if !matches!(expr, Expression::CallExpression(_)) {
-            // Try to get binding from parent VariableDeclarator
-            if let Ancestor::VariableDeclaratorInit(declarator) = ctx.parent()
-                && let Some(ident) = declarator.id().get_binding_identifier()
-            {
-                let id_binding = BoundIdentifier::from_binding_ident(ident);
-                self.handle_function_in_variable_declarator(&id_binding, &binding, arguments, ctx);
-                return;
-            }
+        if matches!(
+            expr,
+            Expression::FunctionExpression(_)
+                | Expression::ArrowFunctionExpression(_)
+                | Expression::CallExpression(_)
+        ) {
+            self.exit_expression_impl(expr, ctx);
         }
-
-        let mut found_call_expression = false;
-        for ancestor in ctx.ancestors() {
-            if ancestor.is_assignment_expression() {
-                continue;
-            }
-            if ancestor.is_call_expression() {
-                found_call_expression = true;
-            }
-            break;
-        }
-
-        if found_call_expression {
-            self.last_signature =
-                Some((binding_identifier.clone(), arguments.clone_in(ctx.allocator())));
-        }
-
-        let span = expr.span();
-        expr.replace_with(|expr| {
-            arguments.insert(0, Argument::from(expr));
-            Expression::new_call_expression(
-                span,
-                binding.create_read_expression(ctx),
-                NONE,
-                arguments,
-                false,
-                ctx,
-            )
-        });
     }
 
     fn exit_function(&mut self, func: &mut Function<'a>, ctx: &mut TraverseCtx<'a>) {
@@ -464,6 +406,75 @@ impl<'a> Traverse<'a, TransformState<'a>> for ReactRefresh<'a> {
 
 // Internal Methods
 impl<'a> ReactRefresh<'a> {
+    #[inline(never)]
+    fn exit_expression_impl(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
+        let signature = match expr {
+            Expression::FunctionExpression(func) => self.create_signature_call_expression(
+                func.scope_id(),
+                func.body.as_mut().unwrap(),
+                ctx,
+            ),
+            Expression::ArrowFunctionExpression(arrow) => {
+                let call_fn =
+                    self.create_signature_call_expression(arrow.scope_id(), &mut arrow.body, ctx);
+
+                // If the signature is found, we will push a new statement to the arrow function body. So it's not an expression anymore.
+                if call_fn.is_some() {
+                    Self::transform_arrow_function_to_block(arrow, ctx);
+                }
+                call_fn
+            }
+            // hoc1(hoc2(...))
+            Expression::CallExpression(_) => self.last_signature.take(),
+            _ => unreachable!(),
+        };
+
+        let Some((binding_identifier, mut arguments)) = signature else {
+            return;
+        };
+        let binding = BoundIdentifier::from_binding_ident(&binding_identifier);
+
+        if !matches!(expr, Expression::CallExpression(_)) {
+            // Try to get binding from parent VariableDeclarator
+            if let Ancestor::VariableDeclaratorInit(declarator) = ctx.parent()
+                && let Some(ident) = declarator.id().get_binding_identifier()
+            {
+                let id_binding = BoundIdentifier::from_binding_ident(ident);
+                self.handle_function_in_variable_declarator(&id_binding, &binding, arguments, ctx);
+                return;
+            }
+        }
+
+        let mut found_call_expression = false;
+        for ancestor in ctx.ancestors() {
+            if ancestor.is_assignment_expression() {
+                continue;
+            }
+            if ancestor.is_call_expression() {
+                found_call_expression = true;
+            }
+            break;
+        }
+
+        if found_call_expression {
+            self.last_signature =
+                Some((binding_identifier.clone(), arguments.clone_in(ctx.allocator())));
+        }
+
+        let span = expr.span();
+        expr.replace_with(|expr| {
+            arguments.insert(0, Argument::from(expr));
+            Expression::new_call_expression(
+                span,
+                binding.create_read_expression(ctx),
+                NONE,
+                arguments,
+                false,
+                ctx,
+            )
+        });
+    }
+
     fn create_registration(
         &mut self,
         persistent_id: Str<'a>,


### PR DESCRIPTION
## Summary

- inline cheap expression-kind guards for arrow, JSX, and React Refresh exit hooks
- outline only the rare mutation bodies that use ReplaceWith
- reduce work in the generated expression walker without adding an unconditional exit call

## Assembly

Using the same release configuration and codspeed cfg as CI, walk_expression changes from:

- 7,911 to 7,131 instructions
- 421 to 372 calls
- 398 to 355 branches

The earlier whole-exit outlining approach only moved work and was neutral in CodSpeed. This revision removes that change and uses targeted hot/cold splits instead.

