### PR TITLE
perf(allocator): mark `ReplaceWith` panic path cold

### DIFF
--- a/crates/oxc_allocator/src/replace_with.rs
+++ b/crates/oxc_allocator/src/replace_with.rs
@@ -232,6 +232,7 @@ impl<'a, T: Dummy<'a>> Drop for PanicGuard<'a, T> {
 /// This is the cold panic-path body of `PanicGuard::drop`, factored out as a free function that takes
 /// `ptr` *by value* so it can be `#[inline(never)]` while `PanicGuard::drop` stays an inlinable
 /// forwarder (see the comment there for why that matters).
+#[cold]
 #[inline(never)]
 fn write_dummy<'a, T: Dummy<'a>>(ptr: NonNull<T>) {
     // `replacer` panicked. Build a fresh dummy in its own dedicated `'static` allocator.


### PR DESCRIPTION
Mark `ReplaceWith`'s `write_dummy` helper as `#[cold]`.

The helper is only reached while unwinding from a panic in a replacer closure. Telling the optimizer that this path is cold may encourage it to place it in the "cold" section of the binary.

