### PR TITLE
docs(ast): document FormalParameters span

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1831,6 +1831,11 @@ pub enum FunctionType {
 }
 
 /// <https://tc39.es/ecma262/#prod-FormalParameters>
+/// `span` includes parentheses, except for unparenthesized arrow parameters.
+/// ```js
+/// function foo(a) {} // `params.span` is `(a)`
+/// const bar = x => x // `params.span` is `x`
+/// ```
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, ReplaceWith, TakeIn)]

--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1833,8 +1833,8 @@ pub enum FunctionType {
 /// <https://tc39.es/ecma262/#prod-FormalParameters>
 /// `span` includes parentheses, except for unparenthesized arrow parameters.
 /// ```js
-/// function foo(a) {} // `params.span` is `(a)`
-/// const bar = x => x // `params.span` is `x`
+/// function foo(a) {}
+/// //          ^^^ params
 /// ```
 #[ast(visit)]
 #[derive(Debug)]


### PR DESCRIPTION
## Summary

- document that FormalParameters spans include parentheses when present
- show the unparenthesized arrow parameter exception
