### PR TITLE
fix(linter): detect React components from returned JSX

### DIFF
--- a/crates/oxc_linter/src/rules/react/display_name.rs
+++ b/crates/oxc_linter/src/rules/react/display_name.rs
@@ -21,8 +21,8 @@ use crate::{
     context::LintContext,
     rule::{DefaultRuleConfig, Rule},
     utils::{
-        InnermostFunction, expression_contains_jsx, find_innermost_function_with_jsx,
-        function_body_contains_jsx, function_contains_jsx, is_hoc_call, is_react_component_name,
+        InnermostFunction, arrow_function_returns, expression_returns,
+        find_innermost_function_with_jsx, function_returns, is_hoc_call, is_react_component_name,
     },
 };
 
@@ -209,7 +209,7 @@ impl Rule for DisplayName {
             for stmt in &program.body {
                 if let oxc_ast::ast::Statement::ExportDefaultDeclaration(export) = stmt {
                     if let Some(component_info) =
-                        is_anonymous_export_component(export, ignore_transpiler_name)
+                        is_anonymous_export_component(export, ctx, ignore_transpiler_name)
                     {
                         components_to_report.push((component_info.span, component_info.is_context));
                     }
@@ -233,6 +233,7 @@ impl Rule for DisplayName {
                             assign,
                             ignore_transpiler_name,
                             check_context_objects,
+                            ctx,
                         ) {
                             components_to_report
                                 .push((component_info.span, component_info.is_context));
@@ -489,9 +490,9 @@ fn is_react_component_node<'a>(
 
             // Check for function/arrow function components with JSX
             if let Some(expr) = &decl.init {
-                // Check if it's a direct component (has JSX directly)
-                let contains_jsx = expression_contains_jsx(expr);
-                if contains_jsx
+                // Check if it's a direct component (returns JSX directly)
+                let returns_jsx = expression_returns(expr, ctx).has_jsx();
+                if returns_jsx
                     && name.as_ref().is_some_and(|name| is_react_component_name(name.as_str()))
                 {
                     return Some(ReactComponentInfo {
@@ -502,8 +503,7 @@ fn is_react_component_node<'a>(
                 }
 
                 // Check if it's a HOF pattern
-                if !contains_jsx
-                    && let Some(innermost) = find_innermost_function_with_jsx(expr, ctx)
+                if !returns_jsx && let Some(innermost) = find_innermost_function_with_jsx(expr, ctx)
                 {
                     let inner_has_name = match innermost {
                         InnermostFunction::Function(func) => func.id.is_some(),
@@ -526,7 +526,7 @@ fn is_react_component_node<'a>(
             // Check for object expressions with methods
             if let Some(Expression::ObjectExpression(obj_expr)) = &decl.init
                 && let Some(name) = &name
-                && has_component_methods_in_object(obj_expr, ignore_transpiler_name)
+                && has_component_methods_in_object(obj_expr, ctx, ignore_transpiler_name)
             {
                 return Some(ReactComponentInfo {
                     span: decl.id.span(),
@@ -545,7 +545,7 @@ fn is_react_component_node<'a>(
                     return None; // Has static displayName
                 }
 
-                if class_contains_jsx(class) {
+                if class_returns_jsx(class, ctx) {
                     return Some(ReactComponentInfo {
                         span: class.span,
                         is_context: false,
@@ -559,8 +559,8 @@ fn is_react_component_node<'a>(
             if let Some(name) = &func.id
                 && is_react_component_name(&name.name)
             {
-                // Check if function directly contains JSX
-                if function_contains_jsx(func) {
+                // Check if function directly returns JSX
+                if function_returns(func, ctx).has_jsx() {
                     return Some(ReactComponentInfo {
                         span: func.span,
                         is_context: false,
@@ -615,6 +615,7 @@ fn is_react_component_node<'a>(
 /// Check if an object expression has component methods
 fn has_component_methods_in_object(
     obj_expr: &ObjectExpression,
+    ctx: &LintContext,
     ignore_transpiler_name: bool,
 ) -> bool {
     for prop in &obj_expr.properties {
@@ -623,7 +624,7 @@ fn has_component_methods_in_object(
             && obj_prop.method
             && ignore_transpiler_name
             && is_react_component_name(&ident.name)
-            && matches!(&obj_prop.value, Expression::FunctionExpression(f) if function_contains_jsx(f))
+            && matches!(&obj_prop.value, Expression::FunctionExpression(f) if function_returns(f, ctx).has_jsx())
         {
             return true;
         }
@@ -634,31 +635,25 @@ fn has_component_methods_in_object(
 /// Handle anonymous export default components
 fn is_anonymous_export_component(
     export: &oxc_ast::ast::ExportDefaultDeclaration,
+    ctx: &LintContext,
     ignore_transpiler_name: bool,
 ) -> Option<ReactComponentInfo> {
     match &export.declaration {
         ExportDefaultDeclarationKind::ArrowFunctionExpression(func)
-            // Uses visitor pattern to handle JSX in nested control flow
-            if function_body_contains_jsx(&func.body) => {
-                return Some(ReactComponentInfo {
-                    span: export.span,
-                    is_context: false,
-                    name: None,
-                });
-            }
+            if arrow_function_returns(func, ctx).has_jsx() =>
+        {
+            return Some(ReactComponentInfo { span: export.span, is_context: false, name: None });
+        }
         ExportDefaultDeclarationKind::FunctionExpression(func)
-            // Uses visitor pattern to handle JSX in nested control flow
-            if function_contains_jsx(func) && (func.id.is_none() || ignore_transpiler_name) => {
-                return Some(ReactComponentInfo {
-                    span: export.span,
-                    is_context: false,
-                    name: None,
-                });
-            }
+            if function_returns(func, ctx).has_jsx()
+                && (func.id.is_none() || ignore_transpiler_name) =>
+        {
+            return Some(ReactComponentInfo { span: export.span, is_context: false, name: None });
+        }
         ExportDefaultDeclarationKind::FunctionDeclaration(func) => {
             // Named default-export functions are handled in phase 1 via symbols/references.
             // Keep this path for anonymous default-export functions only.
-            if func.id.is_none() && function_contains_jsx(func) {
+            if func.id.is_none() && function_returns(func, ctx).has_jsx() {
                 return Some(ReactComponentInfo {
                     span: export.span,
                     is_context: false,
@@ -667,7 +662,7 @@ fn is_anonymous_export_component(
             }
         }
         ExportDefaultDeclarationKind::ClassDeclaration(class) => {
-            return check_class_component(class, export.span, ignore_transpiler_name);
+            return check_class_component(class, export.span, ctx, ignore_transpiler_name);
         }
         _ => {}
     }
@@ -678,6 +673,7 @@ fn is_anonymous_export_component(
 fn check_class_component(
     class: &oxc_ast::ast::Class,
     span: Span,
+    ctx: &LintContext,
     ignore_transpiler_name: bool,
 ) -> Option<ReactComponentInfo> {
     // Named default-export classes are handled in phase 1 via symbols/references.
@@ -690,7 +686,7 @@ fn check_class_component(
         return None;
     }
 
-    if !class_contains_jsx(class) {
+    if !class_returns_jsx(class, ctx) {
         return None;
     }
 
@@ -711,6 +707,7 @@ fn is_module_exports_component(
     assign: &oxc_ast::ast::AssignmentExpression,
     ignore_transpiler_name: bool,
     check_context_objects: bool,
+    ctx: &LintContext,
 ) -> Option<ReactComponentInfo> {
     if let AssignmentTarget::StaticMemberExpression(member) = &assign.left
         && let Expression::Identifier(ident) = &member.object
@@ -719,23 +716,24 @@ fn is_module_exports_component(
     {
         match &assign.right {
             Expression::ArrowFunctionExpression(func)
-                // Uses visitor pattern to handle JSX in nested control flow
-                if function_body_contains_jsx(&func.body) => {
-                    return Some(ReactComponentInfo {
-                        span: assign.span,
-                        is_context: false,
-                        name: None,
-                    });
-                }
+                if arrow_function_returns(func, ctx).has_jsx() =>
+            {
+                return Some(ReactComponentInfo {
+                    span: assign.span,
+                    is_context: false,
+                    name: None,
+                });
+            }
             Expression::FunctionExpression(func)
-                // Uses visitor pattern to handle JSX in nested control flow
-                if function_contains_jsx(func) && (func.id.is_none() || ignore_transpiler_name) => {
-                    return Some(ReactComponentInfo {
-                        span: assign.span,
-                        is_context: false,
-                        name: None,
-                    });
-                }
+                if function_returns(func, ctx).has_jsx()
+                    && (func.id.is_none() || ignore_transpiler_name) =>
+            {
+                return Some(ReactComponentInfo {
+                    span: assign.span,
+                    is_context: false,
+                    name: None,
+                });
+            }
             Expression::CallExpression(call) => {
                 if let Some(callee_name) = call.callee_name() {
                     if callee_name == "createClass" || callee_name == "createReactClass" {
@@ -843,11 +841,11 @@ fn class_has_static_display_name(class: &oxc_ast::ast::Class) -> bool {
     })
 }
 
-/// Check if a class contains JSX in any of its methods
-fn class_contains_jsx(class: &oxc_ast::ast::Class) -> bool {
+/// Check if a class returns JSX from any of its methods.
+fn class_returns_jsx(class: &oxc_ast::ast::Class, ctx: &LintContext) -> bool {
     class.body.body.iter().any(|element| {
         if let ClassElement::MethodDefinition(method_def) = element {
-            return function_contains_jsx(&method_def.value);
+            return function_returns(&method_def.value, ctx).has_jsx();
         }
         false
     })
@@ -858,6 +856,11 @@ fn test() {
     use crate::tester::Tester;
 
     let pass = vec![
+        (
+            "const createHandler = () => () => { someGlobalFunc(<div />); };",
+            None,
+            None,
+        ),
         (
             "
                     var Hello = createReactClass({
@@ -1783,6 +1786,11 @@ fn test() {
     ];
 
     let fail = vec![
+        (
+            "export default () => { const view = <div/>; return view; };",
+            None,
+            None,
+        ),
         (
             r#"
                     var Hello = createReactClass({

--- a/crates/oxc_linter/src/rules/react/function_component_definition.rs
+++ b/crates/oxc_linter/src/rules/react/function_component_definition.rs
@@ -1,16 +1,20 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use oxc_ast::{AstKind, ast::FunctionType};
+use oxc_ast::{
+    AstKind,
+    ast::{AssignmentTarget, FunctionType, VariableDeclarator},
+};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
 use crate::{
     AstNode,
+    ast_util::iter_outer_expressions,
     context::LintContext,
     rule::{DefaultRuleConfig, Rule},
-    utils::{function_body_contains_jsx, function_contains_jsx},
+    utils::{arrow_function_returns, function_returns, is_hoc_call, is_react_component_name},
 };
 
 fn function_component_definition_diagnostic(span: Span, expected: FunctionStyle) -> OxcDiagnostic {
@@ -108,24 +112,17 @@ impl Rule for FunctionComponentDefinition {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let (actual, is_component) = match node.kind() {
-            AstKind::Function(function) => {
-                let actual = match function.r#type {
-                    FunctionType::FunctionDeclaration => FunctionStyle::Declaration,
-                    FunctionType::FunctionExpression => FunctionStyle::Expression,
-                    _ => return,
-                };
-
-                (actual, function_contains_jsx(function))
-            }
-            AstKind::ArrowFunctionExpression(arrow) => {
-                (FunctionStyle::Arrow, function_body_contains_jsx(&arrow.body))
-            }
+        let actual = match node.kind() {
+            AstKind::Function(function) => match function.r#type {
+                FunctionType::FunctionDeclaration => FunctionStyle::Declaration,
+                FunctionType::FunctionExpression => FunctionStyle::Expression,
+                _ => return,
+            },
+            AstKind::ArrowFunctionExpression(_) => FunctionStyle::Arrow,
             _ => return,
         };
 
-        if !is_component || matches!(ctx.nodes().parent_kind(node.id()), AstKind::ObjectProperty(_))
-        {
+        if !is_function_component(node, ctx) {
             return;
         }
 
@@ -148,6 +145,97 @@ impl Rule for FunctionComponentDefinition {
         } else {
             ctx.diagnostic(diagnostic);
         }
+    }
+}
+
+fn is_function_component<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {
+    if matches!(component_parent_kind(node, ctx), Some(AstKind::ObjectProperty(_))) {
+        return false;
+    }
+
+    match node.kind() {
+        AstKind::Function(function) if function.r#type == FunctionType::FunctionDeclaration => {
+            function.id.as_ref().is_none_or(|id| is_react_component_name(&id.name))
+                && function_returns(function, ctx).has_jsx_or_null()
+        }
+        AstKind::Function(function) => {
+            if !is_component_expression_position(node, ctx) {
+                return false;
+            }
+            function_returns(function, ctx).has_jsx_or_null()
+        }
+        AstKind::ArrowFunctionExpression(arrow) => {
+            if !is_component_expression_position(node, ctx) {
+                return false;
+            }
+            arrow_function_returns(arrow, ctx).has_jsx_or_null()
+        }
+        _ => false,
+    }
+}
+
+fn is_component_expression_position<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {
+    let Some(parent) = component_parent_kind(node, ctx) else {
+        return false;
+    };
+    match parent {
+        AstKind::VariableDeclarator(declaration) => {
+            declaration.id.get_identifier_name().is_some_and(|name| is_react_component_name(&name))
+        }
+        AstKind::ExportDefaultDeclaration(_)
+        | AstKind::ReturnStatement(_)
+        | AstKind::ArrowFunctionExpression(_) => true,
+        AstKind::AssignmentExpression(assignment) => match &assignment.left {
+            AssignmentTarget::AssignmentTargetIdentifier(id)
+                if is_react_component_name(&id.name) =>
+            {
+                true
+            }
+            AssignmentTarget::StaticMemberExpression(member) => {
+                is_react_component_name(&member.property.name)
+                    || member.object.is_specific_id("module") && member.property.name == "exports"
+            }
+            _ => false,
+        },
+        AstKind::CallExpression(call) => {
+            let is_first_argument = call.arguments.first().is_some_and(|argument| {
+                argument.as_expression().is_some_and(|expression| {
+                    expression.get_inner_expression().span() == node.span()
+                })
+            });
+            is_first_argument && call.callee_name().is_some_and(|name| is_hoc_call(name, ctx))
+        }
+        _ => false,
+    }
+}
+
+fn component_parent_kind<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> Option<AstKind<'a>> {
+    let mut parents = iter_outer_expressions(ctx.nodes(), node.id());
+    let mut inner_span = node.span();
+    loop {
+        let parent = parents.next()?;
+        if let AstKind::SequenceExpression(sequence) = parent {
+            let is_last = sequence
+                .expressions
+                .last()
+                .is_some_and(|expression| expression.get_inner_expression().span() == inner_span);
+            if !is_last {
+                return None;
+            }
+            inner_span = sequence.span;
+        } else {
+            return Some(parent);
+        }
+    }
+}
+
+fn variable_declarator<'a, 'c>(
+    node: &AstNode<'a>,
+    ctx: &'c LintContext<'a>,
+) -> Option<&'c VariableDeclarator<'a>> {
+    match component_parent_kind(node, ctx) {
+        Some(AstKind::VariableDeclarator(declaration)) => Some(declaration),
+        _ => None,
     }
 }
 
@@ -223,9 +311,9 @@ impl UnnamedComponentStyle {
     }
 }
 
-fn is_named(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
+fn is_named<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {
     matches!(node.kind(), AstKind::Function(function) if function.r#type == FunctionType::FunctionDeclaration)
-        || matches!(ctx.nodes().parent_kind(node.id()), AstKind::VariableDeclarator(_))
+        || variable_declarator(node, ctx).is_some()
 }
 
 mod fix {
@@ -238,7 +326,7 @@ mod fix {
     };
     use oxc_span::{GetSpan, Span};
 
-    use super::FunctionStyle;
+    use super::{FunctionStyle, variable_declarator};
     use crate::{AstNode, context::LintContext};
 
     pub(super) fn can_fix<'a>(
@@ -246,6 +334,10 @@ mod fix {
         ctx: &LintContext<'a>,
         expected: FunctionStyle,
     ) -> bool {
+        if has_unsafe_outer_expression(node, ctx) {
+            return false;
+        }
+
         let declaration = variable_declarator(node, ctx);
         if declaration.is_some_and(|declaration| {
             matches!(
@@ -301,22 +393,28 @@ mod fix {
         true
     }
 
+    fn has_unsafe_outer_expression(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
+        for parent in ctx.nodes().ancestor_kinds(node.id()) {
+            match parent {
+                AstKind::ParenthesizedExpression(_) => {}
+                AstKind::SequenceExpression(_)
+                | AstKind::TSAsExpression(_)
+                | AstKind::TSSatisfiesExpression(_)
+                | AstKind::TSInstantiationExpression(_)
+                | AstKind::TSNonNullExpression(_)
+                | AstKind::TSTypeAssertion(_) => return true,
+                _ => return false,
+            }
+        }
+        false
+    }
+
     fn has_one_unconstrained_type_parameter(
         parameters: Option<&TSTypeParameterDeclaration<'_>>,
     ) -> bool {
         parameters.is_some_and(|parameters| {
             parameters.params.len() == 1 && parameters.params[0].constraint.is_none()
         })
-    }
-
-    fn variable_declarator<'a, 'c>(
-        node: &AstNode<'a>,
-        ctx: &'c LintContext<'a>,
-    ) -> Option<&'c VariableDeclarator<'a>> {
-        match ctx.nodes().parent_kind(node.id()) {
-            AstKind::VariableDeclarator(declaration) => Some(declaration),
-            _ => None,
-        }
     }
 
     pub(super) fn replacement<'a>(
@@ -916,6 +1014,16 @@ fn test() {
                   ",
             None,
         ),
+        ("items.map(item => <div>{item}</div>);", None),
+        ("const renderItem = item => <div>{item}</div>;", None),
+        (
+            "class Hello extends React.Component { render() { return <div/>; } }",
+            Some(serde_json::json!([{ "unnamedComponents": "arrow-function" }])),
+        ),
+        (
+            "function Helper() { const element = <div/>; consume(element); }",
+            Some(serde_json::json!([{ "namedComponents": "arrow-function" }])),
+        ),
     ];
 
     let fail = vec![
@@ -1331,6 +1439,18 @@ fn test() {
         ),
         (
             "const Hello = () => <div/>, keep = sideEffect();",
+            Some(serde_json::json!([{ "namedComponents": "function-declaration" }])),
+        ),
+        (
+            "const Component = (() => <div/>) as React.FC;",
+            Some(serde_json::json!([{ "namedComponents": "function-declaration" }])),
+        ),
+        (
+            "const Component = (sideEffect(), () => <div/>);",
+            Some(serde_json::json!([{ "namedComponents": "function-declaration" }])),
+        ),
+        (
+            "const Component = (sideEffect(), (otherEffect(), () => <div/>));",
             Some(serde_json::json!([{ "namedComponents": "function-declaration" }])),
         ),
     ];
@@ -1933,6 +2053,31 @@ fn test() {
             "const Hello = props => <div/>;",
             "function Hello(props) {\n return <div/>\n}",
             Some(serde_json::json!([{ "namedComponents": "function-declaration" }])),
+        ),
+        (
+            "function NullComponent() { return null; }",
+            "const NullComponent = () => { return null; }",
+            Some(serde_json::json!([{ "namedComponents": "arrow-function" }])),
+        ),
+        (
+            "const Component = () => { const view = <div/>; return view; };",
+            "function Component() { const view = <div/>; return view; }",
+            Some(serde_json::json!([{ "namedComponents": "function-declaration" }])),
+        ),
+        (
+            "const Component = (() => <div/>);",
+            "function Component() {\n return <div/>\n}",
+            Some(serde_json::json!([{ "namedComponents": "function-declaration" }])),
+        ),
+        (
+            "export default () => null;",
+            "export default function() {\n return null\n};",
+            Some(serde_json::json!([{ "unnamedComponents": "function-expression" }])),
+        ),
+        (
+            "function make() { return () => null; }",
+            "function make() { return function() {\n return null\n}; }",
+            Some(serde_json::json!([{ "unnamedComponents": "function-expression" }])),
         ),
     ];
 

--- a/crates/oxc_linter/src/snapshots/react_display_name.snap
+++ b/crates/oxc_linter/src/snapshots/react_display_name.snap
@@ -3,6 +3,13 @@ source: crates/oxc_linter/src/tester.rs
 ---
 
   ⚠ react(display-name): Component definition is missing display name.
+   ╭─[display_name.tsx:1:1]
+ 1 │ export default () => { const view = <div/>; return view; };
+   · ───────────────────────────────────────────────────────────
+   ╰────
+  help: Add a `displayName` property to the component.
+
+  ⚠ react(display-name): Component definition is missing display name.
    ╭─[display_name.tsx:2:25]
  1 │ 
  2 │                     var Hello = createReactClass({

--- a/crates/oxc_linter/src/snapshots/react_function_component_definition.snap
+++ b/crates/oxc_linter/src/snapshots/react_function_component_definition.snap
@@ -645,3 +645,21 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const Hello = () => <div/>, keep = sideEffect();
    ·               ────────────
    ╰────
+
+  ⚠ react(function-component-definition): Function component is not a function declaration
+   ╭─[function_component_definition.tsx:1:20]
+ 1 │ const Component = (() => <div/>) as React.FC;
+   ·                    ────────────
+   ╰────
+
+  ⚠ react(function-component-definition): Function component is not a function declaration
+   ╭─[function_component_definition.tsx:1:34]
+ 1 │ const Component = (sideEffect(), () => <div/>);
+   ·                                  ────────────
+   ╰────
+
+  ⚠ react(function-component-definition): Function component is not a function declaration
+   ╭─[function_component_definition.tsx:1:50]
+ 1 │ const Component = (sideEffect(), (otherEffect(), () => <div/>));
+   ·                                                  ────────────
+   ╰────

--- a/crates/oxc_linter/src/utils/react.rs
+++ b/crates/oxc_linter/src/utils/react.rs
@@ -1,5 +1,7 @@
 use std::borrow::Cow;
 
+use rustc_hash::FxHashSet;
+
 use oxc_ast::{
     AstKind,
     ast::{
@@ -10,8 +12,13 @@ use oxc_ast::{
     },
 };
 use oxc_ast_visit::{VisitJs, walk_js};
+use oxc_cfg::{
+    EdgeType, InstructionKind, ReturnInstructionKind,
+    graph::{Direction, visit::EdgeRef},
+};
 use oxc_ecmascript::{ToBoolean, WithoutGlobalReferenceInformation};
-use oxc_semantic::AstNode;
+use oxc_semantic::{AstNode, SymbolId};
+use oxc_syntax::node::NodeId;
 use oxc_syntax::operator::UnaryOperator;
 use oxc_syntax::scope::ScopeFlags;
 
@@ -839,6 +846,127 @@ pub fn is_hoc_call(callee_name: &str, ctx: &LintContext) -> bool {
     ctx.settings().react.is_component_wrapper_function(callee_name)
 }
 
+#[derive(Debug, Default, Clone, Copy)]
+pub struct FunctionReturns {
+    jsx: bool,
+    null: bool,
+}
+
+impl FunctionReturns {
+    pub fn has_jsx(self) -> bool {
+        self.jsx
+    }
+
+    pub fn has_jsx_or_null(self) -> bool {
+        self.jsx || self.null
+    }
+
+    fn add_expression(
+        &mut self,
+        expression: &Expression<'_>,
+        ctx: &LintContext<'_>,
+        visited: &mut FxHashSet<SymbolId>,
+    ) {
+        match expression.get_inner_expression() {
+            Expression::JSXElement(_) | Expression::JSXFragment(_) => self.jsx = true,
+            Expression::CallExpression(call) if is_create_element_call(call) => self.jsx = true,
+            Expression::NullLiteral(_) => self.null = true,
+            Expression::ConditionalExpression(expression) => {
+                self.add_expression(&expression.consequent, ctx, visited);
+                self.add_expression(&expression.alternate, ctx, visited);
+            }
+            Expression::LogicalExpression(expression) => {
+                self.add_expression(&expression.left, ctx, visited);
+                self.add_expression(&expression.right, ctx, visited);
+            }
+            Expression::SequenceExpression(expression) => {
+                if let Some(last) = expression.expressions.last() {
+                    self.add_expression(last, ctx, visited);
+                }
+            }
+            Expression::Identifier(identifier) => {
+                let Some(symbol_id) =
+                    ctx.scoping().get_reference(identifier.reference_id()).symbol_id()
+                else {
+                    return;
+                };
+                if !visited.insert(symbol_id) {
+                    return;
+                }
+                let declaration = ctx.nodes().get_node(ctx.scoping().symbol_declaration(symbol_id));
+                if let AstKind::VariableDeclarator(declaration) = declaration.kind()
+                    && let Some(initializer) = &declaration.init
+                {
+                    self.add_expression(initializer, ctx, visited);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+pub fn function_returns(function: &Function<'_>, ctx: &LintContext<'_>) -> FunctionReturns {
+    cfg_returns(function.node_id(), ctx)
+}
+
+pub fn arrow_function_returns(
+    arrow: &ArrowFunctionExpression<'_>,
+    ctx: &LintContext<'_>,
+) -> FunctionReturns {
+    if let Some(expression) = arrow.get_expression() {
+        let mut returns = FunctionReturns::default();
+        returns.add_expression(expression, ctx, &mut FxHashSet::default());
+        returns
+    } else {
+        cfg_returns(arrow.node_id(), ctx)
+    }
+}
+
+pub fn expression_returns(expression: &Expression<'_>, ctx: &LintContext<'_>) -> FunctionReturns {
+    match expression {
+        Expression::FunctionExpression(function) => function_returns(function, ctx),
+        Expression::ArrowFunctionExpression(arrow) => arrow_function_returns(arrow, ctx),
+        _ => FunctionReturns::default(),
+    }
+}
+
+fn cfg_returns(node_id: NodeId, ctx: &LintContext<'_>) -> FunctionReturns {
+    let cfg = ctx.cfg();
+    let mut returns = FunctionReturns::default();
+    let mut visited_symbols = FxHashSet::default();
+    let mut stack = vec![ctx.nodes().cfg_id(node_id)];
+    let mut seen = FxHashSet::default();
+
+    while let Some(block_id) = stack.pop() {
+        if !seen.insert(block_id) || cfg.basic_block(block_id).is_unreachable() {
+            continue;
+        }
+
+        for instruction in cfg.basic_block(block_id).instructions() {
+            if instruction.kind
+                == InstructionKind::Return(ReturnInstructionKind::NotImplicitUndefined)
+                && let Some(return_node_id) = instruction.node_id
+                && let AstKind::ReturnStatement(statement) =
+                    ctx.nodes().get_node(return_node_id).kind()
+                && let Some(argument) = &statement.argument
+            {
+                returns.add_expression(argument, ctx, &mut visited_symbols);
+            }
+        }
+
+        stack.extend(
+            cfg.graph()
+                .edges_directed(block_id, Direction::Outgoing)
+                .filter(|edge| {
+                    !matches!(edge.weight(), EdgeType::NewFunction | EdgeType::Unreachable)
+                })
+                .map(|edge| edge.target()),
+        );
+    }
+
+    returns
+}
+
 /// Finds the innermost function with JSX in a chain of HOC calls
 #[derive(Debug)]
 pub enum InnermostFunction<'a> {
@@ -867,12 +995,14 @@ pub fn find_innermost_function_with_jsx<'a>(
             None
         }
         Expression::FunctionExpression(func) => {
-            // Check if this function contains JSX
-            if function_contains_jsx(func) { Some(InnermostFunction::Function(func)) } else { None }
+            if function_returns(func, ctx).has_jsx() {
+                Some(InnermostFunction::Function(func))
+            } else {
+                None
+            }
         }
         Expression::ArrowFunctionExpression(arrow_func) => {
-            // Check if this arrow function contains JSX
-            if expression_contains_jsx(expr) {
+            if arrow_function_returns(arrow_func, ctx).has_jsx() {
                 Some(InnermostFunction::ArrowFunction)
             } else {
                 // Check if this arrow function returns another function that contains JSX


### PR DESCRIPTION
## Summary

- detect React function components from reachable JSX/null returns using a shared CFG utility
- avoid function-component-definition false positives for callbacks, lowercase helpers, class methods, and functions that only contain JSX
- avoid display-name false positives for higher-order functions that contain but do not return JSX

fixes  [https://github.com/oxc-project/oxc/issues/22685](https://github.com/oxc-project/oxc/issues/22685)

closes [oxc-project/oxc#22755](https://github.com/oxc-project/oxc/pull/22755)

follow up to #24471
