### PR TITLE
feat(minifier): configure module side effects

### DIFF
--- a/crates/oxc_minifier/src/options.rs
+++ b/crates/oxc_minifier/src/options.rs
@@ -211,6 +211,15 @@ pub struct TreeShakeOptions {
     ///
     /// Default `false`
     pub invalid_import_side_effects: bool,
+
+    /// Which imported modules may have side effects when loaded.
+    ///
+    /// This allows callers with module-graph knowledge to remove an import declaration once all
+    /// of its bindings are unused. Matching uses the module specifier exactly as written in the
+    /// source code.
+    ///
+    /// Default [`ModuleSideEffects::All`]
+    pub module_side_effects: ModuleSideEffects,
 }
 
 impl Default for TreeShakeOptions {
@@ -222,6 +231,28 @@ impl Default for TreeShakeOptions {
             property_write_side_effects: true,
             unknown_global_side_effects: true,
             invalid_import_side_effects: false,
+            module_side_effects: ModuleSideEffects::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub enum ModuleSideEffects {
+    /// Every imported module may have side effects.
+    #[default]
+    All,
+    /// Only the listed module specifiers may have side effects.
+    Only(FxHashSet<String>),
+    /// Every imported module except the listed module specifiers may have side effects.
+    AllExcept(FxHashSet<String>),
+}
+
+impl ModuleSideEffects {
+    pub fn has_side_effects(&self, source: &str) -> bool {
+        match self {
+            Self::All => true,
+            Self::Only(sources) => sources.contains(source),
+            Self::AllExcept(sources) => !sources.contains(source),
         }
     }
 }

--- a/crates/oxc_minifier/src/peephole/remove_unused_declaration.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_declaration.rs
@@ -154,9 +154,9 @@ impl<'a> PeepholeOptimizations {
 
     /// Remove unused specifiers from import declarations.
     ///
-    /// Since we don't know if an import has side effects, we convert imports
-    /// with all unused specifiers to side-effect-only imports (`import 'x'`)
-    /// rather than removing them entirely.
+    /// By default, imports with all unused specifiers become side-effect-only imports
+    /// (`import 'x'`). Callers can provide module side-effect information to remove the whole
+    /// declaration when loading the imported module is known to be side-effect-free.
     ///
     /// ## Example
     ///
@@ -202,7 +202,17 @@ impl<'a> PeepholeOptimizations {
             return;
         }
 
+        let source_has_side_effects = ctx
+            .options()
+            .treeshake
+            .module_side_effects
+            .has_side_effects(import_decl.source.value.as_str());
+
         let Some(specifiers) = &mut import_decl.specifiers else {
+            if !source_has_side_effects {
+                let new_stmt = Statement::new_empty_statement(import_decl.span, ctx);
+                ctx.replace_statement(stmt, new_stmt);
+            }
             return;
         };
 
@@ -224,8 +234,13 @@ impl<'a> PeepholeOptimizations {
         }
 
         if specifiers.is_empty() {
-            import_decl.specifiers = None;
-            ctx.notice_change();
+            if source_has_side_effects {
+                import_decl.specifiers = None;
+                ctx.notice_change();
+            } else {
+                let new_stmt = Statement::new_empty_statement(import_decl.span, ctx);
+                ctx.replace_statement(stmt, new_stmt);
+            }
         }
     }
 }

--- a/crates/oxc_minifier/tests/mod.rs
+++ b/crates/oxc_minifier/tests/mod.rs
@@ -11,7 +11,8 @@ use oxc_parser::{ParseOptions, Parser};
 use oxc_span::SourceType;
 
 pub(crate) use oxc_minifier::{
-    CompressOptions, CompressOptionsKeepNames, CompressOptionsUnused, Compressor, TreeShakeOptions,
+    CompressOptions, CompressOptionsKeepNames, CompressOptionsUnused, Compressor,
+    ModuleSideEffects, TreeShakeOptions,
 };
 
 pub(crate) fn default_options() -> CompressOptions {

--- a/crates/oxc_minifier/tests/peephole/remove_unused_declaration.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_declaration.rs
@@ -1,8 +1,8 @@
 use oxc_span::SourceType;
 
 use crate::{
-    CompressOptions, TreeShakeOptions, test_options, test_options_source_type, test_same_options,
-    test_same_options_source_type, test_same_smallest, test_smallest,
+    CompressOptions, ModuleSideEffects, TreeShakeOptions, test_options, test_options_source_type,
+    test_same_options, test_same_options_source_type, test_same_smallest, test_smallest,
 };
 
 // Leak regression: dropping an unused declarator must walk the whole
@@ -464,6 +464,47 @@ fn remove_unused_import_specifiers() {
     test_same_options("import a from 'a'; eval('a');", &options);
     test_same_options("import * as a from 'a'; eval('a');", &options);
     test_same_options("import { a } from 'a'; function f() { eval('a'); }", &options);
+}
+
+#[test]
+fn remove_side_effect_free_imports() {
+    use rustc_hash::FxHashSet;
+
+    let only_a = CompressOptions {
+        treeshake: TreeShakeOptions {
+            module_side_effects: ModuleSideEffects::Only(FxHashSet::from_iter(["a".to_string()])),
+            ..TreeShakeOptions::default()
+        },
+        ..CompressOptions::smallest()
+    };
+    test_options("import a from 'a'; import b from 'b';", "import 'a';", &only_a);
+    test_options("import 'a'; import 'b';", "import 'a';", &only_a);
+    test_same_options("import a from 'a'; foo(a);", &only_a);
+    test_same_options("import b from 'b'; eval('b');", &only_a);
+
+    let validate_imports = CompressOptions {
+        treeshake: TreeShakeOptions {
+            invalid_import_side_effects: true,
+            module_side_effects: ModuleSideEffects::Only(FxHashSet::default()),
+            ..TreeShakeOptions::default()
+        },
+        ..CompressOptions::smallest()
+    };
+    test_same_options("import b from 'b';", &validate_imports);
+
+    let all_except_b = CompressOptions {
+        treeshake: TreeShakeOptions {
+            module_side_effects: ModuleSideEffects::AllExcept(FxHashSet::from_iter([
+                "b".to_string()
+            ])),
+            ..TreeShakeOptions::default()
+        },
+        ..CompressOptions::smallest()
+    };
+    test_options("import a from 'a'; import b from 'b';", "import 'a';", &all_except_b);
+    test_options("import {} from 'b' with { type: 'json' };", "", &all_except_b);
+
+    test_options("import value from 'b'; if (false) console.log(value);", "", &all_except_b);
 }
 
 #[test]

--- a/napi/minify/index.d.ts
+++ b/napi/minify/index.d.ts
@@ -197,6 +197,13 @@ export interface MinifyResult {
 /** Minify synchronously. */
 export declare function minifySync(filename: string, sourceText: string, options?: MinifyOptions | undefined | null): MinifyResult
 
+export interface ModuleSideEffects {
+  /** Only these module specifiers may have side effects. */
+  only?: Array<string>
+  /** These module specifiers are side-effect-free; all others may have side effects. */
+  allExcept?: Array<string>
+}
+
 export interface TreeShakeOptions {
   /**
    * Whether to respect the pure annotations.
@@ -247,6 +254,11 @@ export interface TreeShakeOptions {
    * @default true
    */
   invalidImportSideEffects?: boolean
+  /**
+   * Declare which module specifiers may have side effects when loaded.
+   * Module specifiers are matched exactly as written in the source.
+   */
+  moduleSideEffects?: ModuleSideEffects
 }
 export interface Comment {
   type: 'Line' | 'Block'

--- a/napi/minify/src/options.rs
+++ b/napi/minify/src/options.rs
@@ -5,6 +5,32 @@ use oxc_compat::EngineTargets;
 use oxc_str::CompactStr;
 
 #[napi(object)]
+pub struct ModuleSideEffects {
+    /// Only these module specifiers may have side effects.
+    pub only: Option<Vec<String>>,
+
+    /// These module specifiers are side-effect-free; all others may have side effects.
+    pub all_except: Option<Vec<String>>,
+}
+
+impl TryFrom<&ModuleSideEffects> for oxc_minifier::ModuleSideEffects {
+    type Error = String;
+
+    fn try_from(options: &ModuleSideEffects) -> Result<Self, Self::Error> {
+        match (&options.only, &options.all_except) {
+            (Some(sources), None) => Ok(Self::Only(sources.iter().cloned().collect())),
+            (None, Some(sources)) => Ok(Self::AllExcept(sources.iter().cloned().collect())),
+            (Some(_), Some(_)) => {
+                Err("moduleSideEffects cannot specify both 'only' and 'allExcept'.".to_string())
+            }
+            (None, None) => {
+                Err("moduleSideEffects must specify either 'only' or 'allExcept'.".to_string())
+            }
+        }
+    }
+}
+
+#[napi(object)]
 pub struct TreeShakeOptions {
     /// Whether to respect the pure annotations.
     ///
@@ -49,6 +75,10 @@ pub struct TreeShakeOptions {
     ///
     /// @default true
     pub invalid_import_side_effects: Option<bool>,
+
+    /// Declare which module specifiers may have side effects when loaded.
+    /// Module specifiers are matched exactly as written in the source.
+    pub module_side_effects: Option<ModuleSideEffects>,
 }
 
 impl TryFrom<&TreeShakeOptions> for oxc_minifier::TreeShakeOptions {
@@ -82,6 +112,10 @@ impl TryFrom<&TreeShakeOptions> for oxc_minifier::TreeShakeOptions {
             invalid_import_side_effects: o
                 .invalid_import_side_effects
                 .unwrap_or(default.invalid_import_side_effects),
+            module_side_effects: match &o.module_side_effects {
+                Some(options) => oxc_minifier::ModuleSideEffects::try_from(options)?,
+                None => default.module_side_effects,
+            },
         })
     }
 }

--- a/napi/minify/test/minify.test.ts
+++ b/napi/minify/test/minify.test.ts
@@ -51,6 +51,33 @@ describe("simple", () => {
 });
 
 describe("treeshake options", () => {
+  it("removes imports declared side-effect-free", () => {
+    const code = "import a from 'a'; import b from 'b'; console.log(a);";
+    const ret = minifySync("test.mjs", code, {
+      compress: {
+        treeshake: {
+          moduleSideEffects: { allExcept: ["b"] },
+        },
+      },
+    });
+    expect(ret.code).toBe('import e from"a";console.log(e);');
+    expect(ret.errors.length).toBe(0);
+  });
+
+  it("validates module side-effect configuration", () => {
+    const ret = minifySync("test.mjs", "import 'a';", {
+      compress: {
+        treeshake: {
+          moduleSideEffects: { only: [], allExcept: [] },
+        },
+      },
+    });
+    expect(ret.code).toBe("");
+    expect(ret.errors[0]?.message).toContain(
+      "moduleSideEffects cannot specify both 'only' and 'allExcept'",
+    );
+  });
+
   it("respects annotations by default", () => {
     const code = "/* @__PURE__ */ foo(); bar();";
     const ret = minifySync("test.js", code, {


### PR DESCRIPTION
## Summary

- add a declarative `ModuleSideEffects` option with conservative `All`, allowlist `Only`, and denylist `AllExcept` modes
- remove side-effect-free import declarations once all imported bindings become unused, including after fixed-point dead-code elimination
- expose the option through `oxc-minify` as `{ only: string[] }` or `{ allExcept: string[] }`, with validation and generated TypeScript types

## Motivation

Bundlers and other callers already know whether loading a module has side effects, but the minifier currently cannot consume that information. It therefore has to preserve `import "x"` after eliminating every imported binding. This change lets callers pass exact module-specifier verdicts while keeping the default behavior unchanged.

Matching is an exact comparison against the source specifier. `invalid_import_side_effects` and direct `eval` remain conservative boundaries. Re-exports, dynamic imports, and `require` calls remain out of scope.

Closes #24505.

## Validation

- `cargo test -p oxc_minifier` (555 passed, 39 ignored; doctests passed)
- `pnpm --dir napi/minify test` (864 passed, 14 skipped, 1 todo)
- `cargo clippy -p oxc_minifier -p oxc_minify_napi --all-targets -- -D warnings`
- `just minsize`
- full workspace `cargo test --all-features` with only `sourcemap::stacktrace_is_correct` skipped because the local bundled Node is v24.14.0 while that snapshot records v26.5.0
- `just lint`, `just doc`, and `just ast`

## AI disclosure

This contribution was developed with OpenAI Codex assistance. I reviewed the implementation and test coverage and take responsibility for the submitted changes.
