### PR TITLE
refactor(linter): streamline AST pattern matching

### DIFF
--- a/crates/oxc_linter/src/rules/nextjs/next_script_for_ga.rs
+++ b/crates/oxc_linter/src/rules/nextjs/next_script_for_ga.rs
@@ -148,21 +148,16 @@ fn get_dangerously_set_inner_html_prop_value<'a>(
         return None;
     };
 
-    if let Some(html_prop) = object_expr.properties.iter().find_map(|prop| {
-        if let ObjectPropertyKind::ObjectProperty(html_prop) = prop {
-            if let PropertyKey::StaticIdentifier(html_prop_ident) = &html_prop.key {
-                if html_prop_ident.name == "__html" { Some(html_prop) } else { None }
-            } else {
-                None
-            }
+    object_expr.properties.iter().find_map(|prop| {
+        if let ObjectPropertyKind::ObjectProperty(html_prop) = prop
+            && let PropertyKey::StaticIdentifier(html_prop_ident) = &html_prop.key
+            && html_prop_ident.name == "__html"
+        {
+            Some(&**html_prop)
         } else {
             None
         }
-    }) {
-        return Some(html_prop);
-    }
-
-    None
+    })
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/react/checked_requires_onchange_or_readonly.rs
+++ b/crates/oxc_linter/src/rules/react/checked_requires_onchange_or_readonly.rs
@@ -155,27 +155,23 @@ impl Rule for CheckedRequiresOnchangeOrReadonly {
                     obj_expr.properties.iter().fold(
                         (None, None, true),
                         |(checked_span, default_checked_span, is_missing_property), prop| {
-                            if let ObjectPropertyKind::ObjectProperty(object_prop) = prop {
-                                if let Some(name) = object_prop.key.static_name() {
-                                    (
-                                        if checked_span.is_none() && name == "checked" {
-                                            Some(object_prop.span)
-                                        } else {
-                                            checked_span
-                                        },
-                                        if default_checked_span.is_none()
-                                            && name == "defaultChecked"
-                                        {
-                                            Some(object_prop.span)
-                                        } else {
-                                            default_checked_span
-                                        },
-                                        is_missing_property
-                                            && !(name == "onChange" || name == "readOnly"),
-                                    )
-                                } else {
-                                    (checked_span, default_checked_span, is_missing_property)
-                                }
+                            if let ObjectPropertyKind::ObjectProperty(object_prop) = prop
+                                && let Some(name) = object_prop.key.static_name()
+                            {
+                                (
+                                    if checked_span.is_none() && name == "checked" {
+                                        Some(object_prop.span)
+                                    } else {
+                                        checked_span
+                                    },
+                                    if default_checked_span.is_none() && name == "defaultChecked" {
+                                        Some(object_prop.span)
+                                    } else {
+                                        default_checked_span
+                                    },
+                                    is_missing_property
+                                        && !(name == "onChange" || name == "readOnly"),
+                                )
                             } else {
                                 (checked_span, default_checked_span, is_missing_property)
                             }

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/no_disabled_tests.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/no_disabled_tests.rs
@@ -76,49 +76,11 @@ pub fn run_on_jest_node<'a, 'c>(
     ctx: &'c LintContext<'a>,
 ) {
     let node = possible_jest_node.node;
-    if let AstKind::CallExpression(call_expr) = node.kind() {
-        if let Some(jest_fn_call) = parse_general_jest_fn_call(call_expr, possible_jest_node, ctx) {
-            let ParsedGeneralJestFnCall { kind, members, name, .. } = jest_fn_call;
-            // `test('foo')`
-            let kind = match kind {
-                JestFnKind::Expect
-                | JestFnKind::ExpectTypeOf
-                | JestFnKind::Unknown
-                | JestFnKind::VitestFixture => return,
-                JestFnKind::General(kind) => kind,
-            };
-            if matches!(kind, JestGeneralFnKind::Test)
-                && call_expr.arguments.len() < 2
-                && members.iter().all(|member| member.is_name_unequal("todo"))
-            {
-                let (error, help) = Message::MissingFunction.details();
-                ctx.diagnostic(no_disabled_tests_diagnostic(error, help, call_expr.span));
-                return;
-            }
-
-            // the only jest functions that are with "x" are "xdescribe", "xtest", and "xit"
-            // `xdescribe('foo', () => {})`
-            if name.starts_with('x') {
-                let (error, help) = if matches!(kind, JestGeneralFnKind::Describe) {
-                    Message::DisabledSuiteWithX.details()
-                } else {
-                    Message::DisabledTestWithX.details()
-                };
-                ctx.diagnostic(no_disabled_tests_diagnostic(error, help, call_expr.callee.span()));
-                return;
-            }
-
-            // `it.skip('foo', function () {})'`
-            // `describe.skip('foo', function () {})'`
-            if members.iter().any(|member| member.is_name_equal("skip")) {
-                let (error, help) = if matches!(kind, JestGeneralFnKind::Describe) {
-                    Message::DisabledSuiteWithSkip.details()
-                } else {
-                    Message::DisabledTestWithSkip.details()
-                };
-                ctx.diagnostic(no_disabled_tests_diagnostic(error, help, call_expr.callee.span()));
-            }
-        } else if let Expression::Identifier(ident) = &call_expr.callee
+    let AstKind::CallExpression(call_expr) = node.kind() else {
+        return;
+    };
+    let Some(jest_fn_call) = parse_general_jest_fn_call(call_expr, possible_jest_node, ctx) else {
+        if let Expression::Identifier(ident) = &call_expr.callee
             && ident.name.as_str() == "pending"
             && ctx.is_reference_to_global_variable(ident)
         {
@@ -126,5 +88,47 @@ pub fn run_on_jest_node<'a, 'c>(
             let (error, help) = Message::Pending.details();
             ctx.diagnostic(no_disabled_tests_diagnostic(error, help, call_expr.span));
         }
+        return;
+    };
+
+    let ParsedGeneralJestFnCall { kind, members, name, .. } = jest_fn_call;
+    // `test('foo')`
+    let kind = match kind {
+        JestFnKind::Expect
+        | JestFnKind::ExpectTypeOf
+        | JestFnKind::Unknown
+        | JestFnKind::VitestFixture => return,
+        JestFnKind::General(kind) => kind,
+    };
+    if matches!(kind, JestGeneralFnKind::Test)
+        && call_expr.arguments.len() < 2
+        && members.iter().all(|member| member.is_name_unequal("todo"))
+    {
+        let (error, help) = Message::MissingFunction.details();
+        ctx.diagnostic(no_disabled_tests_diagnostic(error, help, call_expr.span));
+        return;
+    }
+
+    // the only jest functions that are with "x" are "xdescribe", "xtest", and "xit"
+    // `xdescribe('foo', () => {})`
+    if name.starts_with('x') {
+        let (error, help) = if matches!(kind, JestGeneralFnKind::Describe) {
+            Message::DisabledSuiteWithX.details()
+        } else {
+            Message::DisabledTestWithX.details()
+        };
+        ctx.diagnostic(no_disabled_tests_diagnostic(error, help, call_expr.callee.span()));
+        return;
+    }
+
+    // `it.skip('foo', function () {})'`
+    // `describe.skip('foo', function () {})'`
+    if members.iter().any(|member| member.is_name_equal("skip")) {
+        let (error, help) = if matches!(kind, JestGeneralFnKind::Describe) {
+            Message::DisabledSuiteWithSkip.details()
+        } else {
+            Message::DisabledTestWithSkip.details()
+        };
+        ctx.diagnostic(no_disabled_tests_diagnostic(error, help, call_expr.callee.span()));
     }
 }

--- a/crates/oxc_linter/src/rules/typescript/consistent_generic_constructors.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_generic_constructors.rs
@@ -139,15 +139,13 @@ impl ConsistentGenericConstructors {
             return;
         }
         if let Some(type_annotation) = type_annotation {
-            if let TSType::TSTypeReference(type_annotation) = &type_annotation.type_annotation {
-                if let TSTypeName::IdentifierReference(ident) = &type_annotation.type_name {
-                    if ident.name != identifier.name {
-                        return;
-                    }
-                } else {
-                    return;
-                }
-            } else {
+            let TSType::TSTypeReference(type_annotation) = &type_annotation.type_annotation else {
+                return;
+            };
+            let TSTypeName::IdentifierReference(ident) = &type_annotation.type_name else {
+                return;
+            };
+            if ident.name != identifier.name {
                 return;
             }
         }

--- a/crates/oxc_linter/src/rules/typescript/no_misused_new.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_misused_new.rs
@@ -1,6 +1,9 @@
 use oxc_ast::{
     AstKind,
-    ast::{ClassElement, PropertyKey, TSSignature, TSType, TSTypeName},
+    ast::{
+        ClassElement, IdentifierReference, PropertyKey, TSSignature, TSType, TSTypeAnnotation,
+        TSTypeName,
+    },
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
@@ -18,6 +21,19 @@ fn no_misused_new_class_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Class cannot have method named `new`.")
         .with_help("This method name is confusing, consider renaming the method to `constructor`")
         .with_label(span)
+}
+
+fn get_return_type_identifier<'a, 'b>(
+    return_type: Option<&'b TSTypeAnnotation<'a>>,
+) -> Option<&'b IdentifierReference<'a>> {
+    if let Some(return_type) = return_type
+        && let TSType::TSTypeReference(type_ref) = &return_type.type_annotation
+        && let TSTypeName::IdentifierReference(id) = &type_ref.type_name
+    {
+        Some(id)
+    } else {
+        None
+    }
 }
 
 #[derive(Debug, Default, Clone)]
@@ -94,13 +110,7 @@ impl Rule for NoMisusedNew {
                     let TSSignature::TSConstructSignatureDeclaration(sig) = signature else {
                         continue;
                     };
-                    let Some(return_type) = &sig.return_type else {
-                        continue;
-                    };
-                    let TSType::TSTypeReference(type_ref) = &return_type.type_annotation else {
-                        continue;
-                    };
-                    if let TSTypeName::IdentifierReference(id) = &type_ref.type_name
+                    if let Some(id) = get_return_type_identifier(sig.return_type.as_deref())
                         && id.name == decl_name
                     {
                         ctx.diagnostic(no_misused_new_interface_diagnostic(Span::sized(
@@ -127,18 +137,13 @@ impl Rule for NoMisusedNew {
                     let ClassElement::MethodDefinition(method) = element else {
                         continue;
                     };
-                    if method.key.is_specific_id("new") && method.value.body.is_none() {
-                        let Some(return_type) = &method.value.return_type else {
-                            continue;
-                        };
-                        let TSType::TSTypeReference(type_ref) = &return_type.type_annotation else {
-                            continue;
-                        };
-                        if let TSTypeName::IdentifierReference(current_id) = &type_ref.type_name
-                            && current_id.name == cls_name
-                        {
-                            ctx.diagnostic(no_misused_new_class_diagnostic(method.key.span()));
-                        }
+                    if method.key.is_specific_id("new")
+                        && method.value.body.is_none()
+                        && let Some(current_id) =
+                            get_return_type_identifier(method.value.return_type.as_deref())
+                        && current_id.name == cls_name
+                    {
+                        ctx.diagnostic(no_misused_new_class_diagnostic(method.key.span()));
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- flatten nested AST shape checks into let-chains and guard clauses across five linter rules
- extract shared return-type identifier matching in `no-misused-new`
- keep rule behavior and top-level node-kind filtering unchanged while reducing nesting
