### PR TITLE
fix(linter/eslint/no-useless-computed-key): allow TS syntax in computed keys

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_useless_computed_key.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_computed_key.rs
@@ -130,7 +130,7 @@ impl Rule for NoUselessComputedKey {
         match node.kind() {
             AstKind::ObjectProperty(property) if property.computed => {
                 if let Some(expr) =
-                    property.key.as_expression().map(Expression::get_inner_expression)
+                    property.key.as_expression().map(Expression::without_parentheses)
                 {
                     check_computed_class_member(
                         ctx,
@@ -145,7 +145,7 @@ impl Rule for NoUselessComputedKey {
             }
             AstKind::BindingProperty(binding_prop) if binding_prop.computed => {
                 if let Some(expr) =
-                    binding_prop.key.as_expression().map(Expression::get_inner_expression)
+                    binding_prop.key.as_expression().map(Expression::without_parentheses)
                 {
                     check_computed_class_member(
                         ctx,
@@ -162,7 +162,7 @@ impl Rule for NoUselessComputedKey {
                 if self.enforce_for_class_members && prop_def.computed =>
             {
                 if let Some(expr) =
-                    prop_def.key.as_expression().map(Expression::get_inner_expression)
+                    prop_def.key.as_expression().map(Expression::without_parentheses)
                 {
                     check_computed_class_member(
                         ctx,
@@ -179,7 +179,7 @@ impl Rule for NoUselessComputedKey {
                 if self.enforce_for_class_members && method_def.computed =>
             {
                 if let Some(expr) =
-                    method_def.key.as_expression().map(Expression::get_inner_expression)
+                    method_def.key.as_expression().map(Expression::without_parentheses)
                 {
                     check_computed_class_member(
                         ctx,
@@ -335,6 +335,7 @@ fn test() {
             Some(serde_json::json!([{ "enforceForClassMembers": true }])),
         ),
         ("({ [99999999999999999n]: 0 })", None), // { "ecmaVersion": 2020 }
+        ("({ ['myKey' as CustomType]: 2 })", None),
     ];
 
     let fail = vec![


### PR DESCRIPTION
## Description

`no-useless-computed-key` deviates from the Eslint implementation, marking typecast keys (e.g. `({ ['myKey' as CustomType]: 2 })`) as violations. Flagging these as violations requires more verbose code and is less ergonomic. Changing from `get_inner_expression` (which strips typecasting) to `without_parentheses` when evaluating keys makes typecast strings not violations of `no-useless-computed-key`.

## Linter playgrounds to demo current behavior

- [Eslint playground](https://eslint.org/play/#eyJ0ZXh0IjoiLyplc2xpbnQgbm8tdXNlbGVzcy1jb21wdXRlZC1rZXk6IFwiZXJyb3JcIiovXG5jb25zdCBmb28gPSAoe1xuICBbJ215S2V5JyBhcyBDdXN0b21UeXBlXTogMlxufSkiLCJvcHRpb25zIjp7InJ1bGVzIjp7fSwibGFuZ3VhZ2VPcHRpb25zIjp7InBhcnNlck9wdGlvbnMiOnsiZWNtYUZlYXR1cmVzIjp7fX0sInBhcnNlciI6IkB0eXBlc2NyaXB0LWVzbGludC9wYXJzZXIifX19)
- [Oxc Playground](https://playground.oxc.rs/?lintRules=eslint%2Fno-useless-computed-key&options=%7B%22run%22%3A%7B%22lint%22%3Atrue%2C%22formatter%22%3Afalse%2C%22transform%22%3Afalse%2C%22isolatedDeclarations%22%3Afalse%2C%22whitespace%22%3Afalse%2C%22mangle%22%3Afalse%2C%22compress%22%3Afalse%2C%22scope%22%3Atrue%2C%22symbol%22%3Atrue%2C%22cfg%22%3Afalse%7D%2C%22parser%22%3A%7B%22extension%22%3A%22tsx%22%2C%22allowReturnOutsideFunction%22%3Atrue%2C%22preserveParens%22%3Atrue%2C%22allowV8Intrinsics%22%3Atrue%2C%22semanticErrors%22%3Atrue%7D%2C%22linter%22%3A%7B%7D%2C%22formatter%22%3A%7B%22useTabs%22%3Afalse%2C%22tabWidth%22%3A2%2C%22endOfLine%22%3A%22lf%22%2C%22printWidth%22%3A80%2C%22singleQuote%22%3Afalse%2C%22jsxSingleQuote%22%3Afalse%2C%22quoteProps%22%3A%22as-needed%22%2C%22trailingComma%22%3A%22all%22%2C%22semi%22%3Atrue%2C%22arrowParens%22%3A%22always%22%2C%22bracketSpacing%22%3Atrue%2C%22bracketSameLine%22%3Afalse%2C%22objectWrap%22%3A%22preserve%22%2C%22singleAttributePerLine%22%3Afalse%7D%2C%22transformer%22%3A%7B%22target%22%3A%22es2015%22%2C%22useDefineForClassFields%22%3Atrue%2C%22experimentalDecorators%22%3Atrue%2C%22emitDecoratorMetadata%22%3Atrue%2C%22optimizeEnums%22%3Atrue%2C%22optimizeConstEnums%22%3Atrue%7D%2C%22isolatedDeclarations%22%3A%7B%22stripInternal%22%3Afalse%7D%2C%22codegen%22%3A%7B%22normal%22%3Atrue%2C%22jsdoc%22%3Atrue%2C%22annotation%22%3Atrue%2C%22legal%22%3Atrue%7D%2C%22compress%22%3A%7B%7D%2C%22mangle%22%3A%7B%22topLevel%22%3Atrue%2C%22keepNames%22%3Afalse%7D%2C%22controlFlow%22%3A%7B%22verbose%22%3Afalse%7D%2C%22inject%22%3A%7B%22inject%22%3A%7B%7D%7D%2C%22define%22%3A%7B%22define%22%3A%7B%7D%7D%7D&code=export+const+foo+%3D+%28%7B%0A++%5B%27myKey%27+as+CustomType%5D%3A+2%0A%7D%29)