### PR TITLE
perf(linter/reporter/stylish): compute diagnostic Info once per diagnostic

### DIFF
--- a/apps/oxlint/src/output_formatter/stylish.rs
+++ b/apps/oxlint/src/output_formatter/stylish.rs
@@ -57,31 +57,29 @@ impl StylishReporter {
         let mut total_errors = 0;
         let mut total_warnings = 0;
 
-        let mut grouped: FxHashMap<String, Vec<&Error>> = FxHashMap::default();
-        let mut sorted = self.diagnostics.iter().collect::<Vec<_>>();
+        let mut entries: Vec<(Info, &Error)> =
+            self.diagnostics.iter().map(|diagnostic| (Info::new(diagnostic), diagnostic)).collect();
 
-        sorted.sort_by_key(|diagnostic| Info::new(diagnostic).start.line);
+        entries.sort_by_key(|(info, _)| info.start.line);
 
-        for diagnostic in sorted {
-            let info = Info::new(diagnostic);
-            grouped.entry(info.filename).or_default().push(diagnostic);
+        let mut grouped: FxHashMap<String, Vec<(Info, &Error)>> = FxHashMap::default();
+        for (info, diagnostic) in entries {
+            grouped.entry(info.filename.clone()).or_default().push((info, diagnostic));
         }
 
         for diagnostics in grouped.values() {
-            let diagnostic = diagnostics[0];
-            let info = Info::new(diagnostic);
-            let filename = info.filename;
+            let filename = &diagnostics[0].0.filename;
             let filename = if let Some(path) =
-                std::env::current_dir().ok().and_then(|d| d.join(&filename).canonicalize().ok())
+                std::env::current_dir().ok().and_then(|d| d.join(filename).canonicalize().ok())
             {
                 path.display().to_string()
             } else {
-                filename
+                filename.clone()
             };
             let max_len_width = diagnostics
                 .iter()
-                .map(|diagnostic| {
-                    let start = Info::new(diagnostic).start;
+                .map(|(info, _)| {
+                    let start = &info.start;
                     format!("{}:{}", start.line, start.column).len()
                 })
                 .max()
@@ -93,7 +91,7 @@ impl StylishReporter {
                 writeln!(output, "\n\u{1b}[4m{filename}\u{1b}[0m").unwrap();
             }
 
-            for diagnostic in diagnostics {
+            for (info, diagnostic) in diagnostics {
                 match diagnostic.severity() {
                     Some(Severity::Error) => total_errors += 1,
                     _ => total_warnings += 1,
@@ -105,7 +103,6 @@ impl StylishReporter {
                     if no_color { "warning" } else { "\u{1b}[33mwarning\u{1b}[0m" }
                 };
 
-                let info = Info::new(diagnostic);
                 let rule = diagnostic.code().map_or_else(String::new, |code| code.to_string());
                 let position = format!("{}:{}", info.start.line, info.start.column);
                 if no_color {


### PR DESCRIPTION
AI Disclosure: This was generated with Claude Code, Fable 5. It has been tested and reviewed by me for correctness.

`format_stylish` recomputed `Info::new` for every diagnostic in multiple passes — inside `sort_by_key` (which re-evaluates its key on every comparison), then again when grouping by filename, measuring the position column width, and rendering. Each `Info::new` call performs two `read_span` calls, which scan the file's source text from offset 0 to compute line/column, so `--format=stylish` output time grew quadratically with the number of diagnostics in a file.

This change computes `Info` once per diagnostic into a `Vec<(Info, &Error)>` and reuses it for sorting, grouping, and rendering. Output is byte-identical (all output-formatter snapshot tests pass unchanged).

This does have a downside in that it uses more peak memory in storing the `Info` objects in the Vec. I think the time savings are worth it, and it'd only be a problem for the (less likely) case where there are thousands of diagnostics. Though that's also the case where the optimization is most notable, obviously.

## Benchmark

Fixture: a single 1.4MB file with 20k `debugger;` statements interleaved with filler lines (and a 10× smaller variant), release build, macOS.

| Command | Before | After |
|---|---|---|
| `--format=stylish`, 20k diagnostics | 98.5s | 18.9s (5.2× faster) |
| `--format=stylish`, 2k diagnostics | 1.09s | 0.22s |
| `--format=unix`, 20k diagnostics (unchanged reference) | 20.6s | 20.6s |

The fixed `stylish` now matches the streaming `unix` formatter on the same input. The remaining ~19s is a separate, shared issue: `Info::new` scans the source linearly per diagnostic, making every formatter that uses it quadratic in diagnostics-per-file — that would need a fix in `oxc_diagnostics` (e.g. computing positions for all of a file's diagnostics in one scan) and is not addressed here.