### PR TITLE
feat(minifier): drop empty switch statements 

### DIFF
--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -775,6 +775,15 @@ impl<'a> PeepholeOptimizations {
             }
         }
 
+        if switch_stmt.cases.is_empty() {
+            result.push(Statement::new_expression_statement(
+                switch_stmt.span,
+                switch_stmt.discriminant.take_in(ctx),
+                ctx,
+            ));
+            return;
+        }
+
         result.push(Statement::SwitchStatement(switch_stmt));
     }
 

--- a/crates/oxc_minifier/tests/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/tests/peephole/minimize_statements.rs
@@ -126,7 +126,7 @@ fn test_object_property_shorthand_normalisation_skips_proto_setter() {
 
 #[test]
 fn test_handle_switch_statement() {
-    test_same("switch (a()){}"); // a()
+    test("switch (a()){}", "a()"); // a()
     test_same("switch (a) { default: }"); // a;
     test_same("switch (a) { default: break;}"); // a;
     test_same("switch (a) { default: var b; break;}"); // a; var b;

--- a/crates/oxc_minifier/tests/peephole/statement_fusion.rs
+++ b/crates/oxc_minifier/tests/peephole/statement_fusion.rs
@@ -39,7 +39,8 @@ fn fold_block_throw() {
 
 #[test]
 fn fold_switch() {
-    test("a;b;c;switch(x){}", "switch(a,b,c,x){}");
+    test("a;b;c;switch(x){}", "a,b,c,x");
+    test("a;b;c;switch(x){case a:b();case b:c()}", "switch(a,b,c,x){case a:b();case b:c()}");
 }
 
 #[test]


### PR DESCRIPTION
Replaces empty switch statements with its discriminant as expression statement

based on findings from #17523

ref #17544