### PR TITLE
fix(oxlint): don't discard regular lint results when tsgolint fails

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -521,6 +521,14 @@ impl CliRunner {
             }
             Err(err) => {
                 print_and_flush_stdout(stdout, &format!("{err}\n"));
+                // Regular (non-type-aware) diagnostics were already queued on
+                // `tx_error` before the type-aware linter failed above (e.g. a
+                // crash in the vendored `tsgolint` subprocess). Drain and report
+                // them here instead of dropping `diagnostic_service` unread,
+                // which would silently discard every already-computed lint
+                // result for the whole run.
+                drop(tx_error);
+                diagnostic_service.run(stdout);
                 return CliRunResult::TsGoLintError;
             }
         }


### PR DESCRIPTION
## Summary

When the type-aware (`tsgolint`) subprocess exits non-zero for any reason - a crash in tsgolint, an OOM kill, any subprocess failure - `lint_files()` returns `Err`, and the CLI (`apps/oxlint/src/lint.rs`) printed only the raw error message and returned immediately, without ever calling `diagnostic_service.run(stdout)`.

`diagnostic_service.run()` is the only place that drains the mpsc channel diagnostics are sent on (`oxc_diagnostics::DiagnosticService`), and the regular (non-type-aware) linter already runs and sends its diagnostics through that same channel *before* the type-aware linter runs. So on any tsgolint failure, every already-computed regular lint diagnostic for the whole run was silently discarded - the user sees only the raw subprocess error and nothing else, even in a project where the regular linter found real issues in files completely unrelated to whatever made tsgolint fail.

## Repro

Ran oxlint with `options.typeAware: true` against `next/dist/compiled` (99MB of bundled/minified JS from a real project's node_modules) with a tsgolint crash forced (a relative-path panic in tsconfig resolution - a separate, pre-existing tsgolint bug I'm fixing upstream in oxc-project/tsgolint):

- Before this fix: 0 diagnostics printed, just the raw panic dump from the tsgolint subprocess.
- After this fix: all 57346 regular diagnostics print (matching a plain, non-type-aware run of the same files) alongside the tsgolint error. Exit code is still non-zero since type-aware checking genuinely failed, but nothing else is lost.

## Fix

On the `Err` branch after `lint_files`, drop the sender and call `diagnostic_service.run(stdout)` before returning - same as the success path already does - so whatever was already queued gets flushed instead of dropped.

## Testing

`cargo test -p oxlint --lib`. One pre-existing test (`lint::suppression::test_only_non_fixed_diagnostics_are_reported`) aborts with `STATUS_STACK_BUFFER_OVERRUN` in my local environment; confirmed via revert-and-rebuild that it crashes identically without this change, so it's unrelated to this fix (looks like a GNU-toolchain-on-Windows-specific issue in my local build environment - MSVC isn't available here - not something CI building the MSVC target would hit).

## Disclosure

Found and fixed with Claude's (Anthropic) assistance while stress-testing oxlint against a large real `node_modules` tree - reviewed and verified locally (repro before/after, diagnostic counts, test suite) before submitting.