### PR TITLE
refactor(linter): migrate JS-only visitors to VisitJs

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/array_callback_return/return_checker.rs
+++ b/crates/oxc_linter/src/rules/eslint/array_callback_return/return_checker.rs
@@ -1,6 +1,6 @@
 use oxc_allocator::ArenaVec;
 use oxc_ast::ast::{ArrowFunctionExpression, Function, FunctionBody, ReturnStatement, Statement};
-use oxc_ast_visit::Visit;
+use oxc_ast_visit::VisitJs;
 use oxc_cfg::{
     EdgeType, InstructionKind, ReturnInstructionKind,
     graph::{Direction, visit::EdgeRef},
@@ -210,7 +210,7 @@ struct ReturnStatementFinder {
     has_void_expression: bool,
 }
 
-impl Visit<'_> for ReturnStatementFinder {
+impl VisitJs<'_> for ReturnStatementFinder {
     fn visit_return_statement(&mut self, return_statement: &ReturnStatement) {
         let Some(argument) = &return_statement.argument else {
             return;

--- a/crates/oxc_linter/src/rules/eslint/complexity.rs
+++ b/crates/oxc_linter/src/rules/eslint/complexity.rs
@@ -1,5 +1,5 @@
 use oxc_ast::AstKind;
-use oxc_ast_visit::{Visit, walk};
+use oxc_ast_visit::{VisitJs, walk_js};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::ScopeFlags;
@@ -242,76 +242,76 @@ impl ComplexityVisitor {
     }
 }
 
-impl Visit<'_> for ComplexityVisitor {
+impl VisitJs<'_> for ComplexityVisitor {
     fn visit_catch_clause(&mut self, it: &oxc_ast::ast::CatchClause<'_>) {
         self.complexity += 1;
-        walk::walk_catch_clause(self, it);
+        walk_js::walk_catch_clause(self, it);
     }
 
     fn visit_conditional_expression(&mut self, it: &oxc_ast::ast::ConditionalExpression<'_>) {
         self.complexity += 1;
-        walk::walk_conditional_expression(self, it);
+        walk_js::walk_conditional_expression(self, it);
     }
 
     fn visit_logical_expression(&mut self, it: &oxc_ast::ast::LogicalExpression<'_>) {
         self.complexity += 1;
-        walk::walk_logical_expression(self, it);
+        walk_js::walk_logical_expression(self, it);
     }
 
     fn visit_for_statement(&mut self, it: &oxc_ast::ast::ForStatement<'_>) {
         self.complexity += 1;
-        walk::walk_for_statement(self, it);
+        walk_js::walk_for_statement(self, it);
     }
 
     fn visit_for_in_statement(&mut self, it: &oxc_ast::ast::ForInStatement<'_>) {
         self.complexity += 1;
-        walk::walk_for_in_statement(self, it);
+        walk_js::walk_for_in_statement(self, it);
     }
 
     fn visit_for_of_statement(&mut self, it: &oxc_ast::ast::ForOfStatement<'_>) {
         self.complexity += 1;
-        walk::walk_for_of_statement(self, it);
+        walk_js::walk_for_of_statement(self, it);
     }
 
     fn visit_if_statement(&mut self, it: &oxc_ast::ast::IfStatement<'_>) {
         self.complexity += 1;
-        walk::walk_if_statement(self, it);
+        walk_js::walk_if_statement(self, it);
     }
 
     fn visit_while_statement(&mut self, it: &oxc_ast::ast::WhileStatement<'_>) {
         self.complexity += 1;
-        walk::walk_while_statement(self, it);
+        walk_js::walk_while_statement(self, it);
     }
 
     fn visit_do_while_statement(&mut self, it: &oxc_ast::ast::DoWhileStatement<'_>) {
         self.complexity += 1;
-        walk::walk_do_while_statement(self, it);
+        walk_js::walk_do_while_statement(self, it);
     }
 
     fn visit_assignment_pattern(&mut self, it: &oxc_ast::ast::AssignmentPattern<'_>) {
         self.complexity += 1;
-        walk::walk_assignment_pattern(self, it);
+        walk_js::walk_assignment_pattern(self, it);
     }
 
     fn visit_formal_parameter(&mut self, it: &oxc_ast::ast::FormalParameter<'_>) {
         if it.initializer.is_some() {
             self.complexity += 1;
         }
-        walk::walk_formal_parameter(self, it);
+        walk_js::walk_formal_parameter(self, it);
     }
 
     fn visit_switch_case(&mut self, it: &oxc_ast::ast::SwitchCase<'_>) {
         if self.variant == Variant::Classic && it.test.is_some() {
             self.complexity += 1;
         }
-        walk::walk_switch_case(self, it);
+        walk_js::walk_switch_case(self, it);
     }
 
     fn visit_switch_statement(&mut self, it: &oxc_ast::ast::SwitchStatement<'_>) {
         if self.variant == Variant::Modified {
             self.complexity += 1;
         }
-        walk::walk_switch_statement(self, it);
+        walk_js::walk_switch_statement(self, it);
     }
 
     fn visit_assignment_expression(&mut self, it: &oxc_ast::ast::AssignmentExpression<'_>) {
@@ -323,27 +323,27 @@ impl Visit<'_> for ComplexityVisitor {
         ) {
             self.complexity += 1;
         }
-        walk::walk_assignment_expression(self, it);
+        walk_js::walk_assignment_expression(self, it);
     }
 
     fn visit_member_expression(&mut self, it: &oxc_ast::ast::MemberExpression<'_>) {
         if it.optional() {
             self.complexity += 1;
         }
-        walk::walk_member_expression(self, it);
+        walk_js::walk_member_expression(self, it);
     }
 
     fn visit_call_expression(&mut self, it: &oxc_ast::ast::CallExpression<'_>) {
         if it.optional {
             self.complexity += 1;
         }
-        walk::walk_call_expression(self, it);
+        walk_js::walk_call_expression(self, it);
     }
 
     fn visit_function(&mut self, it: &oxc_ast::ast::Function<'_>, flags: oxc_semantic::ScopeFlags) {
         if !self.has_entered_complexity_evaluation {
             self.has_entered_complexity_evaluation = true;
-            walk::walk_function(self, it, flags);
+            walk_js::walk_function(self, it, flags);
         }
         // Do not enter function if we already started evaluating complexity
     }
@@ -351,7 +351,7 @@ impl Visit<'_> for ComplexityVisitor {
     fn visit_arrow_function_expression(&mut self, it: &oxc_ast::ast::ArrowFunctionExpression<'_>) {
         if !self.has_entered_complexity_evaluation {
             self.has_entered_complexity_evaluation = true;
-            walk::walk_arrow_function_expression(self, it);
+            walk_js::walk_arrow_function_expression(self, it);
         }
         // Do not enter function if we already started evaluating complexity
     }
@@ -359,7 +359,7 @@ impl Visit<'_> for ComplexityVisitor {
     fn visit_static_block(&mut self, it: &oxc_ast::ast::StaticBlock<'_>) {
         if !self.has_entered_complexity_evaluation {
             self.has_entered_complexity_evaluation = true;
-            walk::walk_static_block(self, it);
+            walk_js::walk_static_block(self, it);
         }
         // Do not enter static block if we already started evaluating complexity
     }
@@ -373,9 +373,6 @@ impl Visit<'_> for ComplexityVisitor {
             self.visit_span(&it.span);
             self.visit_decorators(&it.decorators);
             self.visit_property_key(&it.key);
-            if let Some(type_annotation) = &it.type_annotation {
-                self.visit_ts_type_annotation(type_annotation);
-            }
             // Intentionally skip `it.value` - do not enter value expression
             // if we already started evaluating complexity
             self.leave_node(kind);

--- a/crates/oxc_linter/src/rules/eslint/max_statements.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_statements.rs
@@ -1,8 +1,8 @@
 use oxc_ast::ast::{
     ArrowFunctionExpression, BlockStatement, Class, Function, FunctionBody, StaticBlock,
 };
-use oxc_ast_visit::Visit;
-use oxc_ast_visit::walk::{
+use oxc_ast_visit::VisitJs;
+use oxc_ast_visit::walk_js::{
     walk_arrow_function_expression, walk_class, walk_function, walk_function_body,
     walk_static_block,
 };
@@ -298,7 +298,7 @@ impl<'a> StatementCounter<'a> {
     }
 }
 
-impl<'a> Visit<'a> for StatementCounter<'a> {
+impl<'a> VisitJs<'a> for StatementCounter<'a> {
     fn visit_function(&mut self, func: &Function<'a>, flags: ScopeFlags) {
         self.start_function();
         walk_function(self, func, flags);

--- a/crates/oxc_linter/src/rules/eslint/no_constant_condition.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constant_condition.rs
@@ -5,7 +5,7 @@ use oxc_ast::{
     AstKind,
     ast::{ArrowFunctionExpression, Expression, Function, YieldExpression},
 };
-use oxc_ast_visit::Visit;
+use oxc_ast_visit::VisitJs;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
@@ -246,7 +246,7 @@ struct YieldBeforeLoopExitFinder {
     after_span: Option<Span>,
 }
 
-impl<'a> Visit<'a> for YieldBeforeLoopExitFinder {
+impl<'a> VisitJs<'a> for YieldBeforeLoopExitFinder {
     fn visit_yield_expression(&mut self, expr: &YieldExpression<'a>) {
         if self.after_span.is_none_or(|after_span| expr.span.start > after_span.start) {
             self.found = true;

--- a/crates/oxc_linter/src/rules/eslint/no_loop_func.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_loop_func.rs
@@ -7,7 +7,7 @@ use oxc_ast::{
         Function, IdentifierReference, Statement, WhileStatement,
     },
 };
-use oxc_ast_visit::{Visit, walk};
+use oxc_ast_visit::{Visit, VisitJs, walk};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::{AstNode, NodeId, ScopeId, SymbolId};
@@ -521,7 +521,7 @@ struct LoopFunctionCollector {
     function_node_ids: Vec<NodeId>,
 }
 
-impl<'a> Visit<'a> for LoopFunctionCollector {
+impl<'a> VisitJs<'a> for LoopFunctionCollector {
     fn visit_function(&mut self, function: &Function<'a>, _flags: ScopeFlags) {
         if function.is_expression() || function.is_declaration() {
             self.function_node_ids.push(function.node_id());

--- a/crates/oxc_linter/src/rules/eslint/no_promise_executor_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_promise_executor_return.rs
@@ -2,7 +2,7 @@ use oxc_ast::{
     AstKind,
     ast::{Argument, Expression, FunctionBody},
 };
-use oxc_ast_visit::Visit;
+use oxc_ast_visit::VisitJs;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
@@ -193,7 +193,7 @@ impl ReturnStatementFinder {
     }
 }
 
-impl Visit<'_> for ReturnStatementFinder {
+impl VisitJs<'_> for ReturnStatementFinder {
     fn visit_return_statement(&mut self, it: &oxc_ast::ast::ReturnStatement<'_>) {
         // Empty return is allowed
         let Some(argument) = &it.argument else {

--- a/crates/oxc_linter/src/rules/eslint/preserve_caught_error.rs
+++ b/crates/oxc_linter/src/rules/eslint/preserve_caught_error.rs
@@ -3,7 +3,7 @@ use oxc_ast::ast::{
     Argument, BindingPattern, CatchClause, Expression, Function, IdentifierReference,
     ObjectExpression, ObjectPropertyKind, PropertyKey, ThrowStatement, TryStatement,
 };
-use oxc_ast_visit::Visit;
+use oxc_ast_visit::VisitJs;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::{IsGlobalReference, ScopeFlags};
@@ -53,7 +53,7 @@ struct ThrowFinder<'a, 'ctx> {
     ctx: &'ctx LintContext<'a>,
 }
 
-impl<'a> Visit<'a> for ThrowFinder<'a, '_> {
+impl<'a> VisitJs<'a> for ThrowFinder<'a, '_> {
     fn visit_throw_statement(&mut self, throw_stmt: &ThrowStatement<'a>) {
         let (callee, args) = match &throw_stmt.argument {
             Expression::NewExpression(new_expr) => (&new_expr.callee, &new_expr.arguments),

--- a/crates/oxc_linter/src/rules/eslint/require_await.rs
+++ b/crates/oxc_linter/src/rules/eslint/require_await.rs
@@ -5,7 +5,7 @@ use oxc_ast::{
         MethodDefinition, ObjectProperty, PropertyKey,
     },
 };
-use oxc_ast_visit::{Visit, walk::walk_for_of_statement};
+use oxc_ast_visit::{VisitJs, walk_js::walk_for_of_statement};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::ScopeFlags;
@@ -191,7 +191,7 @@ struct AwaitFinder {
     found: bool,
 }
 
-impl<'a> Visit<'a> for AwaitFinder {
+impl<'a> VisitJs<'a> for AwaitFinder {
     fn visit_await_expression(&mut self, _expr: &AwaitExpression) {
         if self.found {
             return;

--- a/crates/oxc_linter/src/rules/import/newline_after_import.rs
+++ b/crates/oxc_linter/src/rules/import/newline_after_import.rs
@@ -5,7 +5,7 @@ use oxc_ast::{
         ExportDefaultDeclarationKind, Function, ObjectExpression, Statement,
     },
 };
-use oxc_ast_visit::{Visit, walk};
+use oxc_ast_visit::{VisitJs, walk_js};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::ScopeFlags;
@@ -408,7 +408,7 @@ impl<'a, 'ctx> RequireCallScanner<'a, 'ctx> {
     }
 }
 
-impl<'a> Visit<'a> for RequireCallScanner<'a, '_> {
+impl<'a> VisitJs<'a> for RequireCallScanner<'a, '_> {
     fn visit_call_expression(&mut self, call_expr: &CallExpression<'a>) {
         if self.found {
             return;
@@ -421,7 +421,7 @@ impl<'a> Visit<'a> for RequireCallScanner<'a, '_> {
             return;
         }
 
-        walk::walk_call_expression(self, call_expr);
+        walk_js::walk_call_expression(self, call_expr);
     }
 
     fn visit_function(&mut self, _func: &Function<'a>, _flags: ScopeFlags) {}

--- a/crates/oxc_linter/src/rules/oxc/no_this_in_exported_function.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_this_in_exported_function.rs
@@ -2,7 +2,7 @@ use oxc_ast::{
     AstKind,
     ast::{Declaration, ExportDefaultDeclarationKind, Expression, Function, ModuleExportName},
 };
-use oxc_ast_visit::Visit;
+use oxc_ast_visit::VisitJs;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;

--- a/crates/oxc_linter/src/rules/promise/no_multiple_resolved.rs
+++ b/crates/oxc_linter/src/rules/promise/no_multiple_resolved.rs
@@ -4,7 +4,7 @@ use oxc_ast::{
     AstKind,
     ast::{BindingIdentifier, CallExpression, Expression},
 };
-use oxc_ast_visit::Visit;
+use oxc_ast_visit::VisitJs;
 use oxc_cfg::{
     BlockNodeId, ControlFlowGraph, EdgeType, ErrorEdgeKind, InstructionKind,
     graph::{
@@ -707,7 +707,7 @@ impl<'a> ResolveFinder<'a> {
     }
 }
 
-impl<'a> Visit<'a> for ResolveFinder<'a> {
+impl<'a> VisitJs<'a> for ResolveFinder<'a> {
     fn leave_node(&mut self, kind: AstKind<'a>) {
         match kind {
             AstKind::NewExpression(new_expr) => {

--- a/crates/oxc_linter/src/rules/promise/no_return_wrap.rs
+++ b/crates/oxc_linter/src/rules/promise/no_return_wrap.rs
@@ -11,7 +11,7 @@ use oxc_ast::{
         ReturnStatement, Statement,
     },
 };
-use oxc_ast_visit::Visit;
+use oxc_ast_visit::VisitJs;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
@@ -258,7 +258,7 @@ struct ReturnWrapFinder<'a, 'b> {
     allow_reject: bool,
 }
 
-impl<'a> Visit<'a> for ReturnWrapFinder<'a, '_> {
+impl<'a> VisitJs<'a> for ReturnWrapFinder<'a, '_> {
     fn visit_return_statement(&mut self, it: &ReturnStatement<'a>) {
         if let Some(Expression::CallExpression(call_expr)) = &it.argument {
             check_for_resolve_reject(self.ctx, self.allow_reject, call_expr);

--- a/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
+++ b/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
@@ -11,14 +11,13 @@ use oxc_ast::{
     ast::{
         Argument, ArrayExpressionElement, ArrowFunctionExpression, BindingPattern, CallExpression,
         ChainElement, Expression, FormalParameters, Function, FunctionBody, IdentifierReference,
-        StaticMemberExpression, TSTypeAnnotation, TSTypeParameterInstantiation, TSTypeQuery,
-        TSTypeReference, VariableDeclarationKind, VariableDeclarator,
+        StaticMemberExpression, VariableDeclarationKind, VariableDeclarator,
     },
     match_expression,
 };
 use oxc_ast_visit::{
-    Visit,
-    walk::{walk_arrow_function_expression, walk_function, walk_function_body},
+    VisitJs,
+    walk_js::{walk_arrow_function_expression, walk_function, walk_function_body},
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
@@ -1325,29 +1324,13 @@ impl<'a, 'b> ExhaustiveDepsVisitor<'a, 'b> {
     }
 }
 
-impl<'a> Visit<'a> for ExhaustiveDepsVisitor<'a, '_> {
+impl<'a> VisitJs<'a> for ExhaustiveDepsVisitor<'a, '_> {
     fn enter_node(&mut self, kind: AstKind<'a>) {
         self.stack.push(kind.ty());
     }
 
     fn leave_node(&mut self, _kind: AstKind<'a>) {
         self.stack.pop();
-    }
-
-    fn visit_ts_type_annotation(&mut self, _it: &TSTypeAnnotation<'a>) {
-        // noop
-    }
-
-    fn visit_ts_type_reference(&mut self, _it: &TSTypeReference<'a>) {
-        // noop
-    }
-
-    fn visit_ts_type_query(&mut self, _it: &TSTypeQuery<'a>) {
-        // noop
-    }
-
-    fn visit_ts_type_parameter_instantiation(&mut self, _it: &TSTypeParameterInstantiation<'a>) {
-        // noop
     }
 
     fn visit_variable_declarator(&mut self, decl: &VariableDeclarator<'a>) {

--- a/crates/oxc_linter/src/rules/react/no_multi_comp.rs
+++ b/crates/oxc_linter/src/rules/react/no_multi_comp.rs
@@ -6,7 +6,7 @@ use oxc_ast::{
         ObjectProperty, PropertyKey, Statement, VariableDeclarator,
     },
 };
-use oxc_ast_visit::{Visit, walk};
+use oxc_ast_visit::{VisitJs, walk_js};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
@@ -138,7 +138,7 @@ impl<'a, 'ctx> ComponentFinder<'a, 'ctx> {
     }
 }
 
-impl<'a> Visit<'a> for ComponentFinder<'a, '_> {
+impl<'a> VisitJs<'a> for ComponentFinder<'a, '_> {
     fn visit_class(&mut self, class: &Class<'a>) {
         if is_es6_component_class(class) {
             let name = class
@@ -147,10 +147,10 @@ impl<'a> Visit<'a> for ComponentFinder<'a, '_> {
                 .map_or_else(|| "UnnamedComponent".into(), |id| id.name.to_string());
             self.record_component(name, class.span, false);
             self.component_depth += 1;
-            walk::walk_class(self, class);
+            walk_js::walk_class(self, class);
             self.component_depth -= 1;
         } else {
-            walk::walk_class(self, class);
+            walk_js::walk_class(self, class);
         }
     }
 
@@ -162,10 +162,10 @@ impl<'a> Visit<'a> for ComponentFinder<'a, '_> {
         {
             self.record_component(func_id.name.to_string(), func.span, true);
             self.component_depth += 1;
-            walk::walk_function(self, func, flags);
+            walk_js::walk_function(self, func, flags);
             self.component_depth -= 1;
         } else {
-            walk::walk_function(self, func, flags);
+            walk_js::walk_function(self, func, flags);
         }
     }
 
@@ -175,14 +175,14 @@ impl<'a> Visit<'a> for ComponentFinder<'a, '_> {
             // Store var name for potential createReactClass detection in nested call
             self.current_var_name = decl.id.get_identifier_name().map(|s| s.to_string());
             self.component_depth += 1;
-            walk::walk_variable_declarator(self, decl);
+            walk_js::walk_variable_declarator(self, decl);
             self.component_depth -= 1;
             self.current_var_name = None;
         } else {
             // Check if this might contain a createReactClass call
             let old_name = self.current_var_name.take();
             self.current_var_name = decl.id.get_identifier_name().map(|s| s.to_string());
-            walk::walk_variable_declarator(self, decl);
+            walk_js::walk_variable_declarator(self, decl);
             self.current_var_name = old_name;
         }
     }
@@ -193,10 +193,10 @@ impl<'a> Visit<'a> for ComponentFinder<'a, '_> {
             let name = self.current_var_name.clone().unwrap_or_else(|| "UnnamedComponent".into());
             self.record_component(name, call.span, false);
             self.component_depth += 1;
-            walk::walk_call_expression(self, call);
+            walk_js::walk_call_expression(self, call);
             self.component_depth -= 1;
         } else {
-            walk::walk_call_expression(self, call);
+            walk_js::walk_call_expression(self, call);
         }
     }
 
@@ -207,10 +207,10 @@ impl<'a> Visit<'a> for ComponentFinder<'a, '_> {
         {
             self.record_component("UnnamedComponent".into(), export_decl.span, true);
             self.component_depth += 1;
-            walk::walk_export_default_declaration(self, export_decl);
+            walk_js::walk_export_default_declaration(self, export_decl);
             self.component_depth -= 1;
         } else {
-            walk::walk_export_default_declaration(self, export_decl);
+            walk_js::walk_export_default_declaration(self, export_decl);
         }
     }
 
@@ -225,10 +225,10 @@ impl<'a> Visit<'a> for ComponentFinder<'a, '_> {
         {
             self.record_component(id.name.to_string(), prop.span, true);
             self.component_depth += 1;
-            walk::walk_object_property(self, prop);
+            walk_js::walk_object_property(self, prop);
             self.component_depth -= 1;
         } else {
-            walk::walk_object_property(self, prop);
+            walk_js::walk_object_property(self, prop);
         }
     }
 
@@ -245,13 +245,13 @@ impl<'a> Visit<'a> for ComponentFinder<'a, '_> {
                 if is_component {
                     self.record_component(prop_name.to_string(), assign.span, true);
                     self.component_depth += 1;
-                    walk::walk_assignment_expression(self, assign);
+                    walk_js::walk_assignment_expression(self, assign);
                     self.component_depth -= 1;
                     return;
                 }
             }
         }
-        walk::walk_assignment_expression(self, assign);
+        walk_js::walk_assignment_expression(self, assign);
     }
 }
 

--- a/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
+++ b/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
@@ -7,7 +7,7 @@ use oxc_ast::{
     AstKind,
     ast::{ArrowFunctionExpression, CallExpression, Function},
 };
-use oxc_ast_visit::{Visit, walk};
+use oxc_ast_visit::{VisitJs, walk_js};
 use oxc_cfg::{ControlFlowGraph, EdgeType, ErrorEdgeKind, InstructionKind, graph::visit::EdgeRef};
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::{AstNodes, NodeId, SymbolId};
@@ -718,7 +718,7 @@ impl<'a> MayThrowBeforeHook {
     }
 }
 
-impl<'a> Visit<'a> for MayThrowBeforeHook {
+impl<'a> VisitJs<'a> for MayThrowBeforeHook {
     fn enter_node(&mut self, kind: AstKind<'a>) {
         if self.found {
             return;
@@ -750,14 +750,14 @@ impl<'a> Visit<'a> for MayThrowBeforeHook {
     fn visit_call_expression(&mut self, expr: &oxc_ast::ast::CallExpression<'a>) {
         self.enter_node(AstKind::CallExpression(expr));
         if !self.found {
-            walk::walk_call_expression(self, expr);
+            walk_js::walk_call_expression(self, expr);
         }
     }
 
     fn visit_new_expression(&mut self, expr: &oxc_ast::ast::NewExpression<'a>) {
         self.enter_node(AstKind::NewExpression(expr));
         if !self.found {
-            walk::walk_new_expression(self, expr);
+            walk_js::walk_new_expression(self, expr);
         }
     }
 }

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/expect_expect.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/expect_expect.rs
@@ -6,7 +6,7 @@ use oxc_ast::{
     AstKind,
     ast::{CallExpression, Expression, FormalParameter, Function, Statement},
 };
-use oxc_ast_visit::{Visit, walk};
+use oxc_ast_visit::{VisitJs, walk_js};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::{GetSpan, Span};
 use oxc_str::CompactStr;
@@ -315,7 +315,7 @@ impl<'a, 'b> AssertionVisitor<'a, 'b> {
     }
 }
 
-impl<'a> Visit<'a> for AssertionVisitor<'a, '_> {
+impl<'a> VisitJs<'a> for AssertionVisitor<'a, '_> {
     fn visit_call_expression(&mut self, call_expr: &CallExpression<'a>) {
         let name = get_node_name(&call_expr.callee);
         if self.assert_function_matchers.iter().any(|matcher| matcher.is_match(&name)) {
@@ -332,13 +332,13 @@ impl<'a> Visit<'a> for AssertionVisitor<'a, '_> {
             }
         }
 
-        walk::walk_call_expression(self, call_expr);
+        walk_js::walk_call_expression(self, call_expr);
     }
 
     fn visit_expression_statement(&mut self, stmt: &oxc_ast::ast::ExpressionStatement<'a>) {
         self.check_expression(&stmt.expression);
         if !self.found_assertion {
-            walk::walk_expression_statement(self, stmt);
+            walk_js::walk_expression_statement(self, stmt);
         }
     }
 

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/prefer_expect_assertions.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/prefer_expect_assertions.rs
@@ -12,7 +12,7 @@ use oxc_ast::{
     AstKind,
     ast::{Argument, CallExpression, Expression, FunctionBody, Statement},
 };
-use oxc_ast_visit::Visit;
+use oxc_ast_visit::VisitJs;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_semantic::NodeId;
 use oxc_span::{GetSpan, Span};
@@ -416,7 +416,7 @@ impl HookScanner {
     }
 }
 
-impl<'a> Visit<'a> for HookScanner {
+impl<'a> VisitJs<'a> for HookScanner {
     fn visit_call_expression(&mut self, call_expr: &CallExpression<'a>) {
         if get_node_name(&call_expr.callee) == self.expected_name.as_str() {
             self.has_expect_has_assertions = true;
@@ -425,7 +425,7 @@ impl<'a> Visit<'a> for HookScanner {
                 self.has_assertions_call_span = Some(call_expr.span);
             }
         }
-        oxc_ast_visit::walk::walk_call_expression(self, call_expr);
+        oxc_ast_visit::walk_js::walk_call_expression(self, call_expr);
     }
 }
 
@@ -465,7 +465,7 @@ impl BodyScanner {
     }
 }
 
-impl<'a> Visit<'a> for BodyScanner {
+impl<'a> VisitJs<'a> for BodyScanner {
     fn visit_call_expression(&mut self, call_expr: &CallExpression<'a>) {
         if self.is_expect_call(call_expr) {
             if self.expression_depth > 0 {
@@ -475,29 +475,29 @@ impl<'a> Visit<'a> for BodyScanner {
                 self.has_expect_in_loop = true;
             }
         }
-        oxc_ast_visit::walk::walk_call_expression(self, call_expr);
+        oxc_ast_visit::walk_js::walk_call_expression(self, call_expr);
     }
 
     fn visit_function_body(&mut self, body: &FunctionBody<'a>) {
         self.expression_depth += 1;
-        oxc_ast_visit::walk::walk_function_body(self, body);
+        oxc_ast_visit::walk_js::walk_function_body(self, body);
         self.expression_depth -= 1;
     }
 
     fn visit_for_statement(&mut self, it: &oxc_ast::ast::ForStatement<'a>) {
-        self.visit_loop(|s| oxc_ast_visit::walk::walk_for_statement(s, it));
+        self.visit_loop(|s| oxc_ast_visit::walk_js::walk_for_statement(s, it));
     }
     fn visit_for_in_statement(&mut self, it: &oxc_ast::ast::ForInStatement<'a>) {
-        self.visit_loop(|s| oxc_ast_visit::walk::walk_for_in_statement(s, it));
+        self.visit_loop(|s| oxc_ast_visit::walk_js::walk_for_in_statement(s, it));
     }
     fn visit_for_of_statement(&mut self, it: &oxc_ast::ast::ForOfStatement<'a>) {
-        self.visit_loop(|s| oxc_ast_visit::walk::walk_for_of_statement(s, it));
+        self.visit_loop(|s| oxc_ast_visit::walk_js::walk_for_of_statement(s, it));
     }
     fn visit_while_statement(&mut self, it: &oxc_ast::ast::WhileStatement<'a>) {
-        self.visit_loop(|s| oxc_ast_visit::walk::walk_while_statement(s, it));
+        self.visit_loop(|s| oxc_ast_visit::walk_js::walk_while_statement(s, it));
     }
     fn visit_do_while_statement(&mut self, it: &oxc_ast::ast::DoWhileStatement<'a>) {
-        self.visit_loop(|s| oxc_ast_visit::walk::walk_do_while_statement(s, it));
+        self.visit_loop(|s| oxc_ast_visit::walk_js::walk_do_while_statement(s, it));
     }
 }
 

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/prefer_mock_return_shorthand.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/prefer_mock_return_shorthand.rs
@@ -5,7 +5,7 @@ use oxc_ast::{
         Statement, TaggedTemplateExpression, VariableDeclarationKind,
     },
 };
-use oxc_ast_visit::Visit;
+use oxc_ast_visit::{Visit, VisitJs};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_semantic::{ReferenceId, SymbolId};
 use oxc_span::{GetSpan, Span};
@@ -225,7 +225,7 @@ struct CallLikeExpressionVisitor {
     contains_call_like_expression: bool,
 }
 
-impl<'a> Visit<'a> for CallLikeExpressionVisitor {
+impl<'a> VisitJs<'a> for CallLikeExpressionVisitor {
     fn visit_call_expression(&mut self, _it: &CallExpression<'a>) {
         self.contains_call_like_expression = true;
     }

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/valid_expect_in_promise.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/valid_expect_in_promise.rs
@@ -6,7 +6,7 @@ use oxc_ast::{
         SimpleAssignmentTarget, Statement,
     },
 };
-use oxc_ast_visit::{Visit, walk};
+use oxc_ast_visit::{Visit, VisitJs, walk_js};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::{GetSpan, Span};
 use oxc_str::CompactStr;
@@ -371,7 +371,7 @@ fn is_promise_call_expression(call_expr: &CallExpression<'_>) -> bool {
         .is_some_and(|prop| matches!(prop, "then" | "catch" | "finally"))
 }
 
-impl<'a> Visit<'a> for PromiseExpectScanner {
+impl<'a> VisitJs<'a> for PromiseExpectScanner {
     fn visit_call_expression(&mut self, call_expr: &CallExpression<'a>) {
         // Check for `expect(promise).resolves/rejects` — resolves the promise variable
         let callee_name = get_node_name_vec(&call_expr.callee);
@@ -411,14 +411,14 @@ impl<'a> Visit<'a> for PromiseExpectScanner {
             return;
         }
 
-        walk::walk_call_expression(self, call_expr);
+        walk_js::walk_call_expression(self, call_expr);
     }
 
     fn visit_await_expression(&mut self, await_expr: &oxc_ast::ast::AwaitExpression<'a>) {
         self.resolve_ident(&await_expr.argument);
         let was_in_await = self.in_await;
         self.in_await = true;
-        walk::walk_await_expression(self, await_expr);
+        walk_js::walk_await_expression(self, await_expr);
         self.in_await = was_in_await;
     }
 }

--- a/crates/oxc_linter/src/rules/typescript/class_literal_property_style.rs
+++ b/crates/oxc_linter/src/rules/typescript/class_literal_property_style.rs
@@ -8,7 +8,7 @@ use oxc_ast::{
         Statement,
     },
 };
-use oxc_ast_visit::Visit;
+use oxc_ast_visit::VisitJs;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::ScopeFlags;
@@ -268,7 +268,7 @@ struct ConstructorAssignmentCollector<'set, 'a> {
     excluded_properties: &'set mut FxHashSet<Str<'a>>,
 }
 
-impl<'a> Visit<'a> for ConstructorAssignmentCollector<'_, 'a> {
+impl<'a> VisitJs<'a> for ConstructorAssignmentCollector<'_, 'a> {
     fn visit_assignment_expression(&mut self, assignment: &AssignmentExpression<'a>) {
         if let Some(name) = assigned_this_property_name(&assignment.left) {
             self.excluded_properties.insert(name);

--- a/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
@@ -5,7 +5,7 @@ use oxc_ast::{
         ReturnStatement, TSType, TSTypeName,
     },
 };
-use oxc_ast_visit::Visit;
+use oxc_ast_visit::VisitJs;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
@@ -654,7 +654,7 @@ struct ReturnStatementChecker {
     all_returns_are_functions: bool,
 }
 
-impl<'a> Visit<'a> for ReturnStatementChecker {
+impl<'a> VisitJs<'a> for ReturnStatementChecker {
     fn visit_return_statement(&mut self, return_statement: &ReturnStatement<'a>) {
         self.has_return = true;
         self.all_returns_are_functions &=

--- a/crates/oxc_linter/src/rules/typescript/explicit_module_boundary_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_module_boundary_types.rs
@@ -3,8 +3,8 @@ use std::{borrow::Cow, ops::Deref};
 use oxc_allocator::{Address, ArenaVec, UnstableAddress};
 use oxc_ast::{AstKind, ast::*};
 use oxc_ast_visit::{
-    Visit,
-    walk::{self, walk_expression},
+    VisitJs,
+    walk_js::{self, walk_expression},
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
@@ -188,7 +188,7 @@ impl Rule for ExplicitModuleBoundaryTypes {
                 }
                 if let Some(decl) = &export.declaration {
                     let mut checker = ExplicitTypesChecker::new(self, ctx);
-                    walk::walk_declaration(&mut checker, decl);
+                    walk_js::walk_declaration(&mut checker, decl);
                 } else {
                     let mut checker = ExplicitTypesChecker::new(self, ctx);
                     for specifier in &export.specifiers {
@@ -209,7 +209,7 @@ impl Rule for ExplicitModuleBoundaryTypes {
                     }
                     ExportDefaultDeclarationKind::ClassDeclaration(class) => {
                         let mut checker = ExplicitTypesChecker::new(self, ctx);
-                        walk::walk_class(&mut checker, class);
+                        walk_js::walk_class(&mut checker, class);
                     }
                     ExportDefaultDeclarationKind::TSInterfaceDeclaration(_) => {
                         // nada
@@ -278,16 +278,16 @@ impl ExplicitModuleBoundaryTypes {
         let decl = ctx.nodes().get_node(s.symbol_declaration(symbol_id));
         match decl.kind() {
             AstKind::VariableDeclaration(it) => {
-                walk::walk_variable_declaration(checker, it);
+                walk_js::walk_variable_declaration(checker, it);
             }
             AstKind::VariableDeclarator(it) => {
                 checker.visit_variable_declarator(it);
-                // walk::walk_variable_declarator(&mut checker, it)
+                // walk_js::walk_variable_declarator(&mut checker, it)
             }
             AstKind::Function(it) => {
                 checker.visit_function(it, ScopeFlags::Function);
             }
-            AstKind::Class(it) => walk::walk_class(checker, it),
+            AstKind::Class(it) => walk_js::walk_class(checker, it),
             _ => {}
         }
     }
@@ -415,7 +415,7 @@ impl<'a, 'c> ExplicitTypesChecker<'a, 'c> {
             return;
         };
 
-        walk::walk_function_body(self, body);
+        walk_js::walk_function_body(self, body);
 
         // AST is immutable in linter, so `unstable_address` produces stable `Address`es
         let is_hof = self.is_higher_order_function(func.unstable_address());
@@ -535,7 +535,7 @@ impl<'a, 'c> ExplicitTypesChecker<'a, 'c> {
                     // `export const foo = () => () => (): number => 1`
                     Expression::ArrowFunctionExpression(_) | Expression::FunctionExpression(_) => {
                         debug_assert!(self.rule.allow_higher_order_functions);
-                        walk::walk_function_body(self, &arrow.body);
+                        walk_js::walk_function_body(self, &arrow.body);
                         return;
                     }
                     _ => {
@@ -545,7 +545,7 @@ impl<'a, 'c> ExplicitTypesChecker<'a, 'c> {
                 }
             }
         } else {
-            walk::walk_function_body(self, &arrow.body);
+            walk_js::walk_function_body(self, &arrow.body);
 
             // AST is immutable in linter, so `unstable_address` produces stable `Address`es
             let is_hof = self.is_higher_order_function(arrow.unstable_address());
@@ -568,7 +568,7 @@ impl<'a, 'c> ExplicitTypesChecker<'a, 'c> {
     }
 }
 
-impl<'a> Visit<'a> for ExplicitTypesChecker<'a, '_> {
+impl<'a> VisitJs<'a> for ExplicitTypesChecker<'a, '_> {
     fn enter_node(&mut self, kind: AstKind<'a>) {
         match kind {
             AstKind::Function(f) => self.fns.push(Fn::Fn(f)),
@@ -668,9 +668,6 @@ impl<'a> Visit<'a> for ExplicitTypesChecker<'a, '_> {
         // not part of the module boundary. Still inspect the callee so class
         // expressions used with `new` continue to be checked.
         self.visit_expression(&it.callee);
-        if let Some(type_arguments) = &it.type_arguments {
-            self.visit_ts_type_parameter_instantiation(type_arguments);
-        }
     }
 
     fn visit_jsx_element(&mut self, _it: &JSXElement<'a>) {
@@ -682,10 +679,10 @@ impl<'a> Visit<'a> for ExplicitTypesChecker<'a, '_> {
         if self.rule.allow_overload_functions {
             let prev_overloaded = std::mem::take(&mut self.overloaded_methods);
             self.collect_overloaded_methods(class.body.as_ref());
-            walk::walk_class_body(self, class.body.as_ref());
+            walk_js::walk_class_body(self, class.body.as_ref());
             self.overloaded_methods = prev_overloaded;
         } else {
-            walk::walk_class_body(self, class.body.as_ref());
+            walk_js::walk_class_body(self, class.body.as_ref());
         }
         self.reset_target(had_id);
     }
@@ -708,7 +705,7 @@ impl<'a> Visit<'a> for ExplicitTypesChecker<'a, '_> {
         }
 
         let is_target = self.with_target_property(el.property_key());
-        walk::walk_class_element(self, el);
+        walk_js::walk_class_element(self, el);
         self.reset_target(is_target);
     }
 
@@ -719,7 +716,7 @@ impl<'a> Visit<'a> for ExplicitTypesChecker<'a, '_> {
             self.scope_flags.set(ScopeFlags::SetAccessor, true);
         }
         let had_name = self.with_target_property(Some(&it.key));
-        walk::walk_object_property(self, it);
+        walk_js::walk_object_property(self, it);
         self.scope_flags = prev_flags;
         self.reset_target(had_name);
     }
@@ -743,7 +740,7 @@ impl<'a> Visit<'a> for ExplicitTypesChecker<'a, '_> {
                     self.reset_target(had_name);
                     return;
                 }
-                walk::walk_method_definition(self, m);
+                walk_js::walk_method_definition(self, m);
             }
         }
     }
@@ -815,21 +812,21 @@ impl<'a> Visit<'a> for ExplicitTypesChecker<'a, '_> {
         if is_skippable_typed_expression(&it.expression) {
             return;
         }
-        walk::walk_ts_as_expression(self, it);
+        walk_js::walk_ts_as_expression(self, it);
     }
 
     fn visit_ts_satisfies_expression(&mut self, it: &TSSatisfiesExpression<'a>) {
         if is_skippable_typed_expression(&it.expression) {
             return;
         }
-        walk::walk_ts_satisfies_expression(self, it);
+        walk_js::walk_ts_satisfies_expression(self, it);
     }
 
     fn visit_ts_type_assertion(&mut self, it: &TSTypeAssertion<'a>) {
         if is_skippable_typed_expression(&it.expression) {
             return;
         }
-        walk::walk_ts_type_assertion(self, it);
+        walk_js::walk_ts_type_assertion(self, it);
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_parameter_property_assignment.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_parameter_property_assignment.rs
@@ -5,7 +5,7 @@ use oxc_ast::{
         FormalParameter, Function, MethodDefinitionKind, Statement,
     },
 };
-use oxc_ast_visit::Visit;
+use oxc_ast_visit::VisitJs;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::ScopeFlags;
@@ -114,7 +114,7 @@ struct AssignmentVisitor<'a, 'b> {
     assigned_before_constructor: FxHashSet<Str<'a>>,
 }
 
-impl<'a> Visit<'a> for AssignmentVisitor<'a, '_> {
+impl<'a> VisitJs<'a> for AssignmentVisitor<'a, '_> {
     fn visit_function(&mut self, _it: &Function<'a>, _flags: ScopeFlags) {
         // don't continue walking into functions as they have a different scoped "this"
     }

--- a/crates/oxc_linter/src/rules/vue/no_expose_after_await.rs
+++ b/crates/oxc_linter/src/rules/vue/no_expose_after_await.rs
@@ -6,7 +6,7 @@ use oxc_ast::{
         Program, Statement,
     },
 };
-use oxc_ast_visit::{Visit, walk};
+use oxc_ast_visit::{VisitJs, walk_js};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::{ScopeFlags, Scoping, SymbolId};
@@ -187,7 +187,7 @@ struct AwaitDetector {
     found: bool,
 }
 
-impl<'a> Visit<'a> for AwaitDetector {
+impl<'a> VisitJs<'a> for AwaitDetector {
     fn visit_await_expression(&mut self, _: &AwaitExpression) {
         self.found = true;
     }
@@ -246,14 +246,14 @@ impl<'a> ExposeAfterAwaitVisitor<'a> {
     }
 }
 
-impl<'a> Visit<'a> for ExposeAfterAwaitVisitor<'a> {
+impl<'a> VisitJs<'a> for ExposeAfterAwaitVisitor<'a> {
     fn visit_await_expression(&mut self, _expr: &AwaitExpression) {
         self.found = true;
     }
 
     fn visit_call_expression(&mut self, call_expr: &CallExpression<'a>) {
         if !self.found {
-            walk::walk_call_expression(self, call_expr);
+            walk_js::walk_call_expression(self, call_expr);
             return;
         }
 
@@ -261,7 +261,7 @@ impl<'a> Visit<'a> for ExposeAfterAwaitVisitor<'a> {
             self.errors.push((call_expr.span, "expose".to_string()));
         }
 
-        walk::walk_call_expression(self, call_expr);
+        walk_js::walk_call_expression(self, call_expr);
     }
 
     fn visit_function(&mut self, _func: &Function<'a>, _flags: ScopeFlags) {}

--- a/crates/oxc_linter/src/rules/vue/no_lifecycle_after_await.rs
+++ b/crates/oxc_linter/src/rules/vue/no_lifecycle_after_await.rs
@@ -5,7 +5,7 @@ use oxc_ast::{
         ObjectExpression,
     },
 };
-use oxc_ast_visit::{Visit, walk};
+use oxc_ast_visit::{VisitJs, walk_js};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::{ScopeFlags, Scoping, SymbolId};
@@ -181,7 +181,7 @@ impl<'a> LifecycleAfterAwaitVisitor<'a> {
     }
 }
 
-impl<'a> Visit<'a> for LifecycleAfterAwaitVisitor<'a> {
+impl<'a> VisitJs<'a> for LifecycleAfterAwaitVisitor<'a> {
     fn visit_await_expression(&mut self, _expr: &AwaitExpression) {
         if !self.found {
             self.found = true;
@@ -190,23 +190,23 @@ impl<'a> Visit<'a> for LifecycleAfterAwaitVisitor<'a> {
 
     fn visit_call_expression(&mut self, call_expr: &CallExpression<'a>) {
         if !self.found {
-            walk::walk_call_expression(self, call_expr);
+            walk_js::walk_call_expression(self, call_expr);
             return;
         }
 
         if call_expr.arguments.len() >= 2 {
-            walk::walk_call_expression(self, call_expr);
+            walk_js::walk_call_expression(self, call_expr);
             return;
         }
 
         let Some(ident) = call_expr.callee.get_inner_expression().get_identifier_reference() else {
-            walk::walk_call_expression(self, call_expr);
+            walk_js::walk_call_expression(self, call_expr);
             return;
         };
 
         let reference = self.scoping.get_reference(ident.reference_id());
         let Some(symbol_id) = reference.symbol_id() else {
-            walk::walk_call_expression(self, call_expr);
+            walk_js::walk_call_expression(self, call_expr);
             return;
         };
 
@@ -215,7 +215,7 @@ impl<'a> Visit<'a> for LifecycleAfterAwaitVisitor<'a> {
         {
             self.errors.push((call_expr.span, name_span.name().to_string()));
         }
-        walk::walk_call_expression(self, call_expr);
+        walk_js::walk_call_expression(self, call_expr);
     }
 
     fn visit_function(&mut self, _func: &Function<'a>, _flags: ScopeFlags) {}

--- a/crates/oxc_linter/src/rules/vue/no_this_in_before_route_enter.rs
+++ b/crates/oxc_linter/src/rules/vue/no_this_in_before_route_enter.rs
@@ -2,7 +2,7 @@ use oxc_ast::{
     AstKind,
     ast::{ExportDefaultDeclarationKind, Expression},
 };
-use oxc_ast_visit::Visit;
+use oxc_ast_visit::VisitJs;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;

--- a/crates/oxc_linter/src/rules/vue/no_watch_after_await.rs
+++ b/crates/oxc_linter/src/rules/vue/no_watch_after_await.rs
@@ -7,7 +7,7 @@ use oxc_ast::{
         Expression, ExpressionStatement, Function, ObjectExpression,
     },
 };
-use oxc_ast_visit::{Visit, walk};
+use oxc_ast_visit::{VisitJs, walk_js};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::{ScopeFlags, Scoping, SymbolId};
@@ -164,7 +164,7 @@ impl<'a> WatchAfterAwaitVisitor<'a> {
     }
 }
 
-impl<'a> Visit<'a> for WatchAfterAwaitVisitor<'a> {
+impl<'a> VisitJs<'a> for WatchAfterAwaitVisitor<'a> {
     fn visit_await_expression(&mut self, _expr: &AwaitExpression) {
         self.found = true;
     }
@@ -174,7 +174,7 @@ impl<'a> Visit<'a> for WatchAfterAwaitVisitor<'a> {
     // `[watch()]` are wrapped in another expression and are intentionally ignored.
     fn visit_expression_statement(&mut self, stmt: &ExpressionStatement<'a>) {
         if !self.found {
-            walk::walk_expression_statement(self, stmt);
+            walk_js::walk_expression_statement(self, stmt);
             return;
         }
 
@@ -183,25 +183,25 @@ impl<'a> Visit<'a> for WatchAfterAwaitVisitor<'a> {
             Expression::CallExpression(c) => c,
             Expression::ChainExpression(chain) => {
                 let ChainElement::CallExpression(c) = &chain.expression else {
-                    walk::walk_expression_statement(self, stmt);
+                    walk_js::walk_expression_statement(self, stmt);
                     return;
                 };
                 c
             }
             _ => {
-                walk::walk_expression_statement(self, stmt);
+                walk_js::walk_expression_statement(self, stmt);
                 return;
             }
         };
 
         let Some(ident) = call_expr.callee.get_inner_expression().get_identifier_reference() else {
-            walk::walk_expression_statement(self, stmt);
+            walk_js::walk_expression_statement(self, stmt);
             return;
         };
 
         let reference = self.scoping.get_reference(ident.reference_id());
         let Some(symbol_id) = reference.symbol_id() else {
-            walk::walk_expression_statement(self, stmt);
+            walk_js::walk_expression_statement(self, stmt);
             return;
         };
 
@@ -210,7 +210,7 @@ impl<'a> Visit<'a> for WatchAfterAwaitVisitor<'a> {
         {
             self.errors.push((call_expr.span, name_span.name().to_string()));
         }
-        walk::walk_expression_statement(self, stmt);
+        walk_js::walk_expression_statement(self, stmt);
     }
 
     fn visit_function(&mut self, _func: &Function<'a>, _flags: ScopeFlags) {}

--- a/crates/oxc_linter/src/rules/vue/require_direct_export.rs
+++ b/crates/oxc_linter/src/rules/vue/require_direct_export.rs
@@ -9,7 +9,7 @@ use oxc_ast::{
     },
     match_expression,
 };
-use oxc_ast_visit::Visit;
+use oxc_ast_visit::VisitJs;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::ScopeFlags;
@@ -218,7 +218,7 @@ impl ReturnFinder {
     }
 }
 
-impl<'a> Visit<'a> for ReturnFinder {
+impl<'a> VisitJs<'a> for ReturnFinder {
     fn visit_return_statement(&mut self, it: &ReturnStatement<'a>) {
         if self.found {
             return;

--- a/crates/oxc_linter/src/rules/vue/return_in_emits_validator.rs
+++ b/crates/oxc_linter/src/rules/vue/return_in_emits_validator.rs
@@ -2,7 +2,7 @@ use oxc_ast::{
     AstKind,
     ast::{ArrowFunctionExpression, Expression, Function, ReturnStatement, Statement},
 };
-use oxc_ast_visit::{Visit, walk};
+use oxc_ast_visit::{VisitJs, walk_js};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::ScopeFlags;
@@ -191,16 +191,16 @@ struct ReturnVisitor {
     possible_of_return_true: bool,
 }
 
-impl<'a> Visit<'a> for ReturnVisitor {
+impl<'a> VisitJs<'a> for ReturnVisitor {
     fn visit_function(&mut self, func: &Function<'a>, flags: ScopeFlags) {
         self.nested_depth += 1;
-        walk::walk_function(self, func, flags);
+        walk_js::walk_function(self, func, flags);
         self.nested_depth -= 1;
     }
 
     fn visit_arrow_function_expression(&mut self, arrow: &ArrowFunctionExpression<'a>) {
         self.nested_depth += 1;
-        walk::walk_arrow_function_expression(self, arrow);
+        walk_js::walk_arrow_function_expression(self, arrow);
         self.nested_depth -= 1;
     }
 
@@ -213,7 +213,7 @@ impl<'a> Visit<'a> for ReturnVisitor {
                 self.possible_of_return_true = true;
             }
         }
-        walk::walk_return_statement(self, stmt);
+        walk_js::walk_return_statement(self, stmt);
     }
 }
 

--- a/crates/oxc_linter/src/rules/vue/valid_define_options.rs
+++ b/crates/oxc_linter/src/rules/vue/valid_define_options.rs
@@ -1,8 +1,8 @@
 use oxc_ast::{
     AstKind,
-    ast::{CallExpression, Expression, IdentifierReference, ObjectPropertyKind, TSType},
+    ast::{CallExpression, Expression, IdentifierReference, ObjectPropertyKind},
 };
-use oxc_ast_visit::{Visit, walk};
+use oxc_ast_visit::{VisitJs, walk_js};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
@@ -153,14 +153,14 @@ impl<'a> DefineOptionsChecker<'a, '_> {
     }
 }
 
-impl<'a> Visit<'a> for DefineOptionsChecker<'a, '_> {
+impl<'a> VisitJs<'a> for DefineOptionsChecker<'a, '_> {
     fn visit_call_expression(&mut self, call: &CallExpression<'a>) {
         if let Some(ident) = call.callee.get_identifier_reference()
             && ident.name == "defineOptions"
         {
             self.check_call(call);
         }
-        walk::walk_call_expression(self, call);
+        walk_js::walk_call_expression(self, call);
     }
 }
 
@@ -176,15 +176,12 @@ impl<'a> LocalReferenceChecker<'a, '_> {
     }
 }
 
-impl<'a> Visit<'a> for LocalReferenceChecker<'a, '_> {
+impl<'a> VisitJs<'a> for LocalReferenceChecker<'a, '_> {
     fn visit_identifier_reference(&mut self, ident: &IdentifierReference<'a>) {
         if !is_non_local_reference(ident, self.ctx, self.options_span) {
             self.errors.push(ident.span);
         }
     }
-
-    // Skip TS type nodes. `as X` and `typeof str` are statically resolvable.
-    fn visit_ts_type(&mut self, _ty: &TSType<'a>) {}
 }
 
 fn is_non_local_reference(

--- a/crates/oxc_linter/src/utils/react.rs
+++ b/crates/oxc_linter/src/utils/react.rs
@@ -9,7 +9,7 @@ use oxc_ast::{
         JSXOpeningElement, Statement, StaticMemberExpression,
     },
 };
-use oxc_ast_visit::{Visit, walk};
+use oxc_ast_visit::{VisitJs, walk_js};
 use oxc_ecmascript::{ToBoolean, WithoutGlobalReferenceInformation};
 use oxc_semantic::AstNode;
 use oxc_syntax::operator::UnaryOperator;
@@ -913,7 +913,7 @@ impl JsxFinder {
     }
 }
 
-impl<'a> Visit<'a> for JsxFinder {
+impl<'a> VisitJs<'a> for JsxFinder {
     fn visit_jsx_element(&mut self, _elem: &JSXElement<'a>) {
         self.found = true;
         // Don't walk children - we found what we need
@@ -928,7 +928,7 @@ impl<'a> Visit<'a> for JsxFinder {
             self.found = true;
         }
         if !self.found {
-            walk::walk_call_expression(self, call);
+            walk_js::walk_call_expression(self, call);
         }
     }
 

--- a/crates/oxc_linter/src/utils/this_expression.rs
+++ b/crates/oxc_linter/src/utils/this_expression.rs
@@ -5,7 +5,7 @@ use oxc_ast::{
         ThisExpression, VariableDeclarationKind,
     },
 };
-use oxc_ast_visit::{Visit, walk};
+use oxc_ast_visit::{VisitJs, walk_js};
 use oxc_semantic::ScopeFlags;
 use oxc_span::Span;
 
@@ -42,7 +42,7 @@ impl ThisExpressionFinder {
     }
 }
 
-impl<'a> Visit<'a> for ThisExpressionFinder {
+impl<'a> VisitJs<'a> for ThisExpressionFinder {
     fn visit_this_expression(&mut self, expr: &ThisExpression) {
         self.spans.push(expr.span);
     }
@@ -51,7 +51,7 @@ impl<'a> Visit<'a> for ThisExpressionFinder {
 
     fn visit_static_block(&mut self, block: &StaticBlock<'a>) {
         if !self.skip_static_blocks {
-            walk::walk_static_block(self, block);
+            walk_js::walk_static_block(self, block);
         }
     }
 
@@ -59,7 +59,7 @@ impl<'a> Visit<'a> for ThisExpressionFinder {
         if self.skip_property_definition_values {
             self.visit_property_key(&prop.key);
         } else {
-            walk::walk_property_definition(self, prop);
+            walk_js::walk_property_definition(self, prop);
         }
     }
 }

--- a/tasks/rulegen/src/main.rs
+++ b/tasks/rulegen/src/main.rs
@@ -19,7 +19,7 @@ use oxc_ast::ast::{
     ObjectPropertyKind, Program, PropertyKey, Statement, StaticMemberExpression, StringLiteral,
     TaggedTemplateExpression, TemplateLiteral,
 };
-use oxc_ast_visit::Visit;
+use oxc_ast_visit::VisitJs;
 use oxc_parser::Parser;
 use oxc_span::{GetSpan, SourceType, Span};
 use oxc_tasks_common::project_root;
@@ -250,7 +250,7 @@ fn format_tagged_template_expression(tag_expr: &TaggedTemplateExpression) -> Opt
     }
 }
 
-impl<'a> Visit<'a> for TestCase {
+impl<'a> VisitJs<'a> for TestCase {
     fn visit_expression(&mut self, expr: &Expression<'a>) {
         match expr {
             Expression::StringLiteral(lit) => self.visit_string_literal(lit),
@@ -520,7 +520,7 @@ impl<'a> State<'a> {
     }
 }
 
-impl<'a> Visit<'a> for State<'a> {
+impl<'a> VisitJs<'a> for State<'a> {
     fn visit_program(&mut self, program: &Program<'a>) {
         for stmt in &program.body {
             self.visit_statement(stmt);
@@ -1151,7 +1151,7 @@ impl<'a> RuleConfig<'a> {
     }
 }
 
-impl<'a> Visit<'a> for RuleConfig<'a> {
+impl<'a> VisitJs<'a> for RuleConfig<'a> {
     fn visit_program(&mut self, program: &Program<'a>) {
         for stmt in &program.body {
             self.visit_statement(stmt);


### PR DESCRIPTION
Migrate 33 JS-only `Visit` implementors in `oxc_linter` (plus the 3 in `tasks/rulegen`) to `VisitJs` (#24499). Part of #24317; transformer/minifier half in #24532. Behavior is unchanged — all 1169 rule tests pass with identical snapshots.

Together with #24532: `oxlint` −129.4 KiB (−0.94%) stripped, `oxc_transform` napi −16.2 KiB (−0.46%).

## Why each visitor can switch

A visitor is safe on `VisitJs` when its hooks cannot observe anything inside the pruned type grammar. The three ways that holds here: the hooked node kinds are value-space-only (`return`, `throw`, `await`, calls, real functions — none exist inside `TSType`), the visitor already skipped type space via hand-written `visit_ts_*` stubs, or its type inspection is by direct field access rather than walking.

| Visitor | File (`crates/oxc_linter/src/`) | Why equivalent |
|---|---|---|
| `ReturnStatementFinder` | `rules/eslint/array_callback_return/return_checker.rs` | Hooks only `visit_return_statement`; `return` cannot occur in type grammar. |
| `ComplexityVisitor` | `rules/eslint/complexity.rs` | All scoring hooks are value-space; the one explicit walk into property type annotations is deleted — valid type grammar contains no complexity-scoring constructs (no `?:`/`&&`/`?.`/default params). |
| `StatementCounter` | `rules/eslint/max_statements.rs` | Counts statements via function/class/static-block body hooks; type declarations contain no statements. |
| `YieldBeforeLoopExitFinder` | `rules/eslint/no_constant_condition.rs` | Hooks only `visit_yield_expression`; `yield` cannot occur in type grammar. |
| `LoopFunctionCollector` | `rules/eslint/no_loop_func.rs` | Hooks `visit_function`/`visit_arrow_function_expression`; those nodes never appear in type grammar (`TSFunctionType` is a distinct node). |
| `ReturnStatementFinder` | `rules/eslint/no_promise_executor_return.rs` | `return`-statement hook only. |
| `ThrowFinder` | `rules/eslint/preserve_caught_error.rs` | Hooks only `visit_throw_statement`; `throw` cannot occur in type grammar. |
| `AwaitFinder` | `rules/eslint/require_await.rs` | Hooks `visit_await_expression`/`visit_for_of_statement`; `await`/`for await` are runtime-only. |
| `RequireCallScanner` | `rules/import/newline_after_import.rs` | Matches `require(...)` calls; calls cannot occur in valid type grammar. |
| `ResolveFinder` | `rules/promise/no_multiple_resolved.rs` | `leave_node` records only value-space kinds (new/import/yield/member); its `visit_call_expression` doesn't descend. |
| `ReturnWrapFinder` | `rules/promise/no_return_wrap.rs` | `return`-statement hook only. |
| `AssertionVisitor` | `rules/shared/jest_vitest/expect_expect.rs` | Call/if/block hooks hunting assertion calls; none can fire in type space. |
| `HookScanner`, `BodyScanner` | `rules/shared/jest_vitest/prefer_expect_assertions.rs` | Call + loop/function-body hooks; `expect.hasAssertions()` calls and loops cannot occur in types. |
| `CallLikeExpressionVisitor` | `rules/shared/jest_vitest/prefer_mock_return_shorthand.rs` | call/new/tagged-template/import hooks — value-space only. (Sibling `IdentifierCollectorVisitor` stays on `Visit`: it collects identifiers, which do leak through type space.) |
| `PromiseExpectScanner` | `rules/shared/jest_vitest/valid_expect_in_promise.rs` | call/await hooks. (Sibling `IdentifierFinder` stays on `Visit` for the same reason as above.) |
| `AwaitDetector`, `ExposeAfterAwaitVisitor` | `rules/vue/no_expose_after_await.rs` | await/call hooks. |
| `LifecycleAfterAwaitVisitor` | `rules/vue/no_lifecycle_after_await.rs` | await/call hooks. |
| `WatchAfterAwaitVisitor` | `rules/vue/no_watch_after_await.rs` | await/expression-statement hooks. |
| `ReturnFinder` | `rules/vue/require_direct_export.rs` | `return`-statement hook only. |
| `ReturnVisitor` | `rules/vue/return_in_emits_validator.rs` | function/arrow depth tracking + return hook; none fire for `TSFunctionType`. |
| `DefineOptionsChecker` | `rules/vue/valid_define_options.rs` | Matches `defineOptions()` calls; reads `type_arguments` by field access, not by walking. |
| `LocalReferenceChecker` | `rules/vue/valid_define_options.rs` | Already skipped type space via a hand-written `visit_ts_type` stub ("`as X`/`typeof str` are statically resolvable") — `VisitJs` subsumes it; stub deleted. |
| `ExhaustiveDepsVisitor` | `rules/react/exhaustive_deps.rs` | Already skipped type space via 4 noop `visit_ts_*` stubs (deleted). The `visit_ts_type_query` stub shows `typeof x` deps were deliberately not collected — `VisitJs` preserves exactly that. |
| `ComponentFinder` | `rules/react/no_multi_comp.rs` | Component-defining hooks (class/function/call/object-property/assignment) are all value-space kinds. |
| `MayThrowBeforeHook` | `rules/react/rules_of_hooks.rs` | `enter_node` treats only Call/New/Member kinds as may-throw; type annotations are erased at runtime and cannot throw. |
| `ConstructorAssignmentCollector` | `rules/typescript/class_literal_property_style.rs` | Assignment-expression hook; assignments cannot occur in type grammar. |
| `ReturnStatementChecker` | `rules/typescript/explicit_function_return_type.rs` | `return`-statement hook only. |
| `ExplicitTypesChecker` | `rules/typescript/explicit_module_boundary_types.rs` | Inspects types by direct field access (`.return_type.is_none()`, `is_const_type_reference()`), never by walking; its 3 cast overrides survive on `VisitJs`. The deleted walk into `new` type args could only produce spurious "missing argument type" reports from function-typed type arguments. |
| `AssignmentVisitor` | `rules/typescript/no_unnecessary_parameter_property_assignment.rs` | Assignment hook; RHS casts are unwrapped via `get_inner_expression`, not walker descent. |
| `JsxFinder` | `utils/react.rs` | JSX/createElement hooks; JSX cannot occur in type grammar. All consumers pass value-space function bodies. |
| `ThisExpressionFinder` | `utils/this_expression.rs` | The `this` type is `TSThisType`, which never fires `visit_this_expression`; the only leak path is a `typeof this.X` qualified name, invalid at the entry scopes its two consumers scan, and nested functions are already cut off by the `visit_function` stub. |
| `TestCase`, `State`, `RuleConfig` | `tasks/rulegen/src/main.rs` | Extract value-space data (test `code` strings, schema object literals) via manual recursion/structural matching; `as`/`satisfies` wrappers are unwrapped with `get_inner_expression`, and `VisitJs` still walks those. |

Left on `Visit` (results would change): `consistent_function_scoping`, `branches_sharing_code`, `prefer_arrow_callback`, `object_shorthand`, `class_methods_use_this`, the two jest identifier collectors above — their identifier/`this` hooks fire inside type space today (`typeof this`, type references) and that input feeds reports or autofixes. Also `no_loop_func`'s `NestedFunctionFinder`/`UnsafeReferenceFinder`, which share a `V: Visit<'a>` generic driver with one of them.

---

🤖 This PR was written with the assistance of Claude Code (Claude Fable 5).
