### PR TITLE
refactor(transformer,minifier,react_compiler): switch JS-only visitors from Visit to VisitJs

### DIFF
--- a/crates/oxc_minifier/src/keep_var.rs
+++ b/crates/oxc_minifier/src/keep_var.rs
@@ -3,7 +3,7 @@ use oxc_ast::{
     ast::*,
     builder::{GetAstBuilder, NONE},
 };
-use oxc_ast_visit::Visit;
+use oxc_ast_visit::VisitJs;
 use oxc_ecmascript::BoundNames;
 use oxc_span::{SPAN, Span};
 use oxc_str::Str;
@@ -14,7 +14,7 @@ pub struct KeepVar<'a> {
     all_hoisted: bool,
 }
 
-impl<'a> Visit<'a> for KeepVar<'a> {
+impl<'a> VisitJs<'a> for KeepVar<'a> {
     fn visit_statement(&mut self, it: &Statement<'a>) {
         // Only visit blocks where vars could be hoisted
         match it {

--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -3,7 +3,7 @@ use std::{iter, ops::ControlFlow};
 use crate::generated::ancestor::Ancestor;
 use oxc_allocator::{ArenaBox, ArenaVec, TakeIn};
 use oxc_ast::ast::*;
-use oxc_ast_visit::Visit;
+use oxc_ast_visit::VisitJs;
 use oxc_ecmascript::{
     constant_evaluation::{DetermineValueType, IsLiteralValue, ValueType},
     side_effects::MayHaveSideEffects,

--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -17,7 +17,7 @@ mod remove_unused_private_members;
 mod replace_known_methods;
 mod substitute_alternate_syntax;
 
-use oxc_ast_visit::{Visit, walk::walk_call_expression};
+use oxc_ast_visit::{Visit, VisitJs, walk_js::walk_call_expression};
 use oxc_semantic::Scoping;
 use oxc_syntax::{
     scope::{ScopeFlags, ScopeId},
@@ -360,7 +360,7 @@ impl<'a> PeepholeOptimizations {
         struct DirectEvalFlagCheck<'s> {
             scoping: &'s Scoping,
         }
-        impl<'a> Visit<'a> for DirectEvalFlagCheck<'_> {
+        impl<'a> VisitJs<'a> for DirectEvalFlagCheck<'_> {
             fn visit_call_expression(&mut self, it: &CallExpression<'a>) {
                 if let Some(ident) = as_direct_eval_call(it)
                     && let Some(reference_id) = ident.reference_id.get()
@@ -903,7 +903,7 @@ impl<'s> LiveDirectEvalCollector<'s> {
     }
 }
 
-impl<'a> Visit<'a> for LiveDirectEvalCollector<'_> {
+impl<'a> VisitJs<'a> for LiveDirectEvalCollector<'_> {
     fn visit_call_expression(&mut self, it: &CallExpression<'a>) {
         if let Some(ident) = as_direct_eval_call(it)
             && let Some(reference_id) = ident.reference_id.get()

--- a/crates/oxc_minifier/src/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/src/peephole/remove_dead_code.rs
@@ -1,7 +1,7 @@
 use crate::generated::ancestor::Ancestor;
 use oxc_allocator::{ArenaVec, TakeIn};
 use oxc_ast::ast::*;
-use oxc_ast_visit::Visit;
+use oxc_ast_visit::VisitJs;
 use oxc_ecmascript::{
     constant_evaluation::{ConstantEvaluation, ConstantValue},
     side_effects::MayHaveSideEffects,

--- a/crates/oxc_minifier/tests/ecmascript/prop_name.rs
+++ b/crates/oxc_minifier/tests/ecmascript/prop_name.rs
@@ -1,6 +1,6 @@
 use oxc_allocator::Allocator;
 use oxc_ast::ast::ObjectExpression;
-use oxc_ast_visit::Visit;
+use oxc_ast_visit::VisitJs;
 use oxc_ecmascript::PropName;
 use oxc_parser::Parser;
 use oxc_span::SourceType;
@@ -10,7 +10,7 @@ fn test_prop_name() {
     #[derive(Debug, Default)]
     struct TestVisitor;
 
-    impl<'a> Visit<'a> for TestVisitor {
+    impl<'a> VisitJs<'a> for TestVisitor {
         fn visit_object_expression(&mut self, obj_expr: &ObjectExpression<'a>) {
             assert_eq!("a", obj_expr.properties[0].prop_name().unwrap().0);
             assert_eq!("b", obj_expr.properties[1].prop_name().unwrap().0);

--- a/crates/oxc_parser/examples/regular_expression.rs
+++ b/crates/oxc_parser/examples/regular_expression.rs
@@ -3,7 +3,7 @@ use std::{env, fs, path::Path, sync::Arc};
 
 use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
-use oxc_ast_visit::Visit;
+use oxc_ast_visit::VisitJs;
 use oxc_parser::{ParseOptions, Parser};
 use oxc_regular_expression::{ConstructorParser as RegExpParser, Options as RegExpParserOptions};
 use oxc_span::SourceType;
@@ -43,7 +43,7 @@ struct RegularExpressionVisitor {
     source_text: Arc<str>,
 }
 
-impl<'a> Visit<'a> for RegularExpressionVisitor {
+impl<'a> VisitJs<'a> for RegularExpressionVisitor {
     fn visit_reg_exp_literal(&mut self, re: &RegExpLiteral<'a>) {
         println!("🍀 {}", re.span.source_text(self.source_text.as_ref()));
 

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -2467,7 +2467,7 @@ fn ox_clone_original_fn_as_expression<'a>(
         scope_id: ScopeId,
         found: Option<Expression<'a>>,
     }
-    impl<'a, 'b> oxc_ast_visit::Visit<'a> for Finder<'a, 'b> {
+    impl<'a, 'b> oxc_ast_visit::VisitJs<'a> for Finder<'a, 'b> {
         fn visit_function(&mut self, func: &Function<'a>, flags: oxc_syntax::scope::ScopeFlags) {
             if self.found.is_some() {
                 return;
@@ -2490,7 +2490,7 @@ fn ox_clone_original_fn_as_expression<'a>(
                 self.found = Some(Expression::FunctionExpression(f));
                 return;
             }
-            oxc_ast_visit::walk::walk_function(self, func, flags);
+            oxc_ast_visit::walk_js::walk_function(self, func, flags);
         }
         fn visit_arrow_function_expression(&mut self, arrow: &ArrowFunctionExpression<'a>) {
             if self.found.is_some() {
@@ -2503,11 +2503,11 @@ fn ox_clone_original_fn_as_expression<'a>(
                 )));
                 return;
             }
-            oxc_ast_visit::walk::walk_arrow_function_expression(self, arrow);
+            oxc_ast_visit::walk_js::walk_arrow_function_expression(self, arrow);
         }
     }
     let mut finder = Finder { ast, scope_id, found: None };
-    oxc_ast_visit::Visit::visit_program(&mut finder, program);
+    oxc_ast_visit::VisitJs::visit_program(&mut finder, program);
     finder.found.map(|e| e.clone_in_with_semantic_ids(ast.allocator()))
 }
 

--- a/crates/oxc_transformer/src/decorator/legacy/mod.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/mod.rs
@@ -53,7 +53,7 @@ use oxc_allocator::{
     UnstableAddress,
 };
 use oxc_ast::{ast::*, builder::NONE};
-use oxc_ast_visit::{Visit, VisitMut};
+use oxc_ast_visit::{VisitJs, VisitMut};
 use oxc_data_structures::stack::NonEmptyStack;
 use oxc_semantic::{ScopeFlags, ScopeId, SymbolFlags};
 use oxc_span::SPAN;
@@ -1481,7 +1481,7 @@ struct PrivateInExpressionDetector {
     has_private_in_expression: bool,
 }
 
-impl Visit<'_> for PrivateInExpressionDetector {
+impl VisitJs<'_> for PrivateInExpressionDetector {
     fn visit_private_in_expression(&mut self, _it: &PrivateInExpression<'_>) {
         self.has_private_in_expression = true;
     }

--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -55,7 +55,7 @@ use std::{borrow::Cow, mem};
 
 use oxc_allocator::{ArenaBox, ArenaStringBuilder, ArenaVec, GetAllocator, ReplaceWith, TakeIn};
 use oxc_ast::{ast::*, builder::NONE};
-use oxc_ast_visit::Visit;
+use oxc_ast_visit::VisitJs;
 use oxc_semantic::{ReferenceFlags, ScopeFlags, ScopeId, SymbolFlags};
 use oxc_span::{GetSpan, SPAN};
 use oxc_str::{Ident, static_ident};
@@ -1012,7 +1012,7 @@ impl<'a, 'ctx> BindingMover<'a, 'ctx> {
     }
 }
 
-impl<'a> Visit<'a> for BindingMover<'a, '_> {
+impl<'a> VisitJs<'a> for BindingMover<'a, '_> {
     fn visit_formal_parameter(&mut self, param: &FormalParameter<'a>) {
         // Move the parameter binding itself, then only reparent direct scopes from the initializer.
         // Initializer expressions can contain function/class bindings that must stay in their own

--- a/crates/oxc_transformer/src/jsx/refresh.rs
+++ b/crates/oxc_transformer/src/jsx/refresh.rs
@@ -17,8 +17,8 @@ use oxc_ast::{
     match_expression,
 };
 use oxc_ast_visit::{
-    Visit,
-    walk::{walk_call_expression, walk_declaration},
+    VisitJs,
+    walk_js::{walk_call_expression, walk_declaration},
 };
 use oxc_semantic::{ReferenceFlags, ScopeFlags, ScopeId, SymbolFlags, SymbolId};
 use oxc_span::{GetSpan, SPAN};
@@ -1008,7 +1008,7 @@ impl<'a, 'b> UsedInJSXBindingsCollector<'a, 'b> {
     }
 }
 
-impl<'a> Visit<'a> for UsedInJSXBindingsCollector<'a, '_> {
+impl<'a> VisitJs<'a> for UsedInJSXBindingsCollector<'a, '_> {
     fn visit_call_expression(&mut self, it: &CallExpression<'a>) {
         walk_call_expression(self, it);
 
@@ -1036,11 +1036,6 @@ impl<'a> Visit<'a> for UsedInJSXBindingsCollector<'a, '_> {
         {
             self.bindings.insert(symbol_id);
         }
-    }
-
-    #[inline]
-    fn visit_ts_type_annotation(&mut self, _it: &TSTypeAnnotation<'a>) {
-        // Skip type annotations because it definitely doesn't have any JSX bindings
     }
 
     #[inline]

--- a/tasks/coverage/src/driver.rs
+++ b/tasks/coverage/src/driver.rs
@@ -9,7 +9,7 @@ use oxc::{
         Comment,
         ast::{Program, RegExpLiteral},
     },
-    ast_visit::{Visit, walk},
+    ast_visit::{VisitJs, walk_js},
     codegen::{CodegenOptions, CodegenReturn},
     diagnostics::{Diagnostics, OxcDiagnostic},
     minifier::CompressOptions,
@@ -185,7 +185,7 @@ impl<'a> CheckASTNodes<'a> {
     }
 }
 
-impl<'a> Visit<'a> for CheckASTNodes<'a> {
+impl<'a> VisitJs<'a> for CheckASTNodes<'a> {
     // TODO: This is too slow
     // fn visit_span(&mut self, span: &Span) {
     // let Span { start, end, .. } = span;
@@ -198,7 +198,7 @@ impl<'a> Visit<'a> for CheckASTNodes<'a> {
 
     /// Idempotency test for printing regular expressions.
     fn visit_reg_exp_literal(&mut self, literal: &RegExpLiteral<'a>) {
-        walk::walk_reg_exp_literal(self, literal);
+        walk_js::walk_reg_exp_literal(self, literal);
 
         let Some(pattern) = &literal.regex.pattern.pattern else {
             return;


### PR DESCRIPTION
Migrate the transform-pipeline `Visit` implementors to `VisitJs` (#24499): `oxc_transformer` (3), `oxc_minifier` (4), `oxc_react_compiler` (1), plus the parser regex example and the coverage driver. Part of #24317; linter half in #24530. Behavior is unchanged.

Together with #24530: `oxlint` −129.4 KiB (−0.94%) stripped, `oxc_transform` napi −16.2 KiB (−0.46%).

## Why each visitor can switch

A visitor is safe on `VisitJs` when its hooks cannot observe anything inside the pruned type grammar — either the hooked node kinds are value-space-only, or the AST it walks cannot contain type nodes at that pipeline stage.

| Visitor | File | Why equivalent |
|---|---|---|
| `PrivateInExpressionDetector` | `crates/oxc_transformer/src/decorator/legacy/mod.rs` | Hooks `visit_private_in_expression` (+`visit_decorators`); `#x in y` is runtime-only and cannot occur in type grammar, even inside decorator expressions carrying casts. |
| `BindingMover` | `crates/oxc_transformer/src/es2017/async_to_generator.rs` | Its formal-parameter overrides visit only pattern + initializer (`BindingPattern` carries no type field — annotations are sibling fields it never touches); runs in the exit phase after TS strip. |
| `UsedInJSXBindingsCollector` | `crates/oxc_transformer/src/jsx/refresh.rs` | Runs on un-stripped TSX, but its hooks (JSX-shaped calls, `visit_jsx_opening_element`, declarations/imports) cannot fire inside type grammar; its hand-written `visit_ts_type_annotation` skip-stub is deleted — `VisitJs` prunes that natively. |
| `Finder` | `crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs` | Matches functions by `scope_id`; real JS function scopes never live in pure type grammar, and `VisitJs` still walks the places one could hide (enum initializers, namespace bodies, cast inner expressions). |
| `KeepVar` | `crates/oxc_minifier/src/keep_var.rs` | Hooks `visit_statement`/`visit_variable_declaration`; statements and `var` declarations don't exist in type space, and namespace/enum bodies (which can contain them) are still walked by `VisitJs`. |
| `DirectEvalFlagCheck` | `crates/oxc_minifier/src/peephole/mod.rs` | Debug-only; hooks `visit_call_expression` only — call expressions cannot occur in valid type grammar. |
| `LiveDirectEvalCollector` | `crates/oxc_minifier/src/peephole/mod.rs` | Same single call-expression hook; type-space-immune regardless of input. |
| `TestVisitor` | `crates/oxc_minifier/tests/ecmascript/prop_name.rs` | Test helper parsing `SourceType::default()` (plain JS); single non-recursing `visit_object_expression` hook. |
| `RegularExpressionVisitor` | `crates/oxc_parser/examples/regular_expression.rs` | Finds `RegExpLiteral` / `new RegExp(...)`; neither node kind can occur in type grammar. |
| `CheckASTNodes` | `tasks/coverage/src/driver.rs` | Its only active override is `visit_reg_exp_literal` (regex print idempotency); `RegExpLiteral` cannot occur in type space. (The commented-out `visit_span` full-AST check would need `Visit` if ever revived.) |

Left on `Visit`: the minifier's incremental-scoping bookkeeping (`DropDiff`, `OverPruneCheck`, `LiveRefCollector`) — dropping `let x: Foo = …` must unmark the type-space `Foo` reference, which the `peephole::remove_unused_declaration` tests verify (they fail under `VisitJs`; confirmed and reverted during this work). `ChildScopeCollector` also stays: TS type nodes (mapped/conditional/function types) carry real `scope_id`s it must collect.

---

🤖 This PR was written with the assistance of Claude Code (Claude Fable 5).
