### PR TITLE
test(prettier_conformance): add YAML formatter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2451,6 +2451,7 @@ dependencies = [
  "oxc_formatter_css",
  "oxc_formatter_graphql",
  "oxc_formatter_json",
+ "oxc_formatter_yaml",
  "oxc_parser",
  "oxc_span",
  "oxc_tasks_common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -276,13 +276,7 @@ unicode-width = "0.2"
 website_common = { path = "tasks/website_common" }
 
 [workspace.metadata.cargo-shear]
-ignored = [
-  "oxc_transform_napi",
-  "oxc_parser_napi",
-  "oxc_minify_napi",
-  # TEMPORARY: `oxc_formatter_yaml` is consumed by the stacked PR; remove the ignore there.
-  "oxc_formatter_yaml",
-]
+ignored = ["oxc_transform_napi", "oxc_parser_napi", "oxc_minify_napi"]
 
 # `oxc_allocator` is both dogfooded here (workspace path) and published to crates.io.
 # External workspace-dependencies (e.g. `oxc-css-parser`) pull it from the registry,

--- a/tasks/prettier_conformance/Cargo.toml
+++ b/tasks/prettier_conformance/Cargo.toml
@@ -31,6 +31,7 @@ oxc_formatter_core = { workspace = true }
 oxc_formatter_css = { workspace = true }
 oxc_formatter_graphql = { workspace = true }
 oxc_formatter_json = { workspace = true }
+oxc_formatter_yaml = { workspace = true }
 oxc_parser = { workspace = true }
 oxc_span = { workspace = true }
 oxc_tasks_common = { workspace = true }

--- a/tasks/prettier_conformance/snapshots/prettier.yaml.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.yaml.snap.md
@@ -1,0 +1,14 @@
+yaml compatibility: 346/354 (97.74%), 0 files skipped
+
+# Failed
+
+| Spec path | Failed or Passed | Match ratio |
+| :-------- | :--------------: | :---------: |
+| yaml/flow-mapping/comments/key.yml | 💥 | 43.75% |
+| yaml/mapping/duplicated-keys/flow-mapping.yml | 💥 | 85.71% |
+| yaml/spec/anchors-and-tags.yml | 💥💥 | 75.00% |
+| yaml/spec/node-anchor-and-tag-on-seperate-lines.yml | 💥💥 | 50.00% |
+| yaml/spec/spec-example-6-1-indentation-spaces.yml | 💥💥 | 84.62% |
+| yaml/spec/spec-example-7-20-single-pair-explicit-entry.yml | 💥✨ | 12.50% |
+| yaml/spec/spec-example-9-4-explicit-documents.yml | 💥✨ | 33.33% |
+| yaml/spec/various-combinations-of-tags-and-anchors.yml | 💥💥 | 75.00% |

--- a/tasks/prettier_conformance/src/ignore_list.rs
+++ b/tasks/prettier_conformance/src/ignore_list.rs
@@ -117,4 +117,12 @@ pub const IGNORE_TESTS: &[&str] = &[
     "typescript/decorators-ts/angular.ts",
     // postcss-conditionals (archived: https://github.com/andyjansson/postcss-conditionals).
     "css/atrule/if-else.css",
+    // Prettier's yaml parser rejects these (https://github.com/eemeli/yaml/issues/646),
+    // so no snapshot exists (`3-style.yml` is even marked `errors` in its format.test.js).
+    // oxc-yaml-parser parses them fine, but there is nothing to compare against.
+    "yaml/mapping/3-style.yml",
+    "yaml/spec/spec-example-2-11-mapping-between-sequences.yml",
+    // Pragma support (`@format` insertion / require)
+    "yaml/insert-pragma/",
+    "yaml/require-pragma/",
 ];

--- a/tasks/prettier_conformance/src/lib.rs
+++ b/tasks/prettier_conformance/src/lib.rs
@@ -20,6 +20,7 @@ use oxc_formatter::JsFormatOptions;
 use oxc_formatter_css::CssFormatOptions;
 use oxc_formatter_graphql::GraphqlFormatOptions;
 use oxc_formatter_json::JsonFormatOptions;
+use oxc_formatter_yaml::YamlFormatOptions;
 use oxc_span::SourceType;
 
 use crate::{
@@ -248,7 +249,10 @@ impl TestRunner {
                     !options.experimental_operator_position.is_start()
                         && !options.experimental_ternaries
                 }
-                SpecOptions::Json(_) | SpecOptions::Graphql(_) | SpecOptions::Css(_) => true,
+                SpecOptions::Json(_)
+                | SpecOptions::Graphql(_)
+                | SpecOptions::Css(_)
+                | SpecOptions::Yaml(_) => true,
             })
             .collect::<Vec<_>>();
 
@@ -454,7 +458,7 @@ impl TestRunner {
     }
 
     /// Dispatches by language: JS/TS via `oxc_formatter`, JSON via `oxc_formatter_json`,
-    /// GraphQL via `oxc_formatter_graphql`.
+    /// GraphQL via `oxc_formatter_graphql`, YAML via `oxc_formatter_yaml`.
     fn run_formatter(
         path: &Path,
         source_text: &str,
@@ -465,6 +469,7 @@ impl TestRunner {
             SpecOptions::Json(opts) => Self::run_json_formatter(source_text, opts),
             SpecOptions::Graphql(opts) => Self::run_graphql_formatter(source_text, opts),
             SpecOptions::Css(opts) => Self::run_css_formatter(source_text, opts),
+            SpecOptions::Yaml(opts) => Self::run_yaml_formatter(source_text, opts),
         }
     }
 
@@ -504,6 +509,13 @@ impl TestRunner {
         let allocator = Allocator::default();
         let formatted =
             oxc_formatter_css::format(&allocator, source_text, format_options, None).ok()?;
+        let printed = formatted.print().ok()?;
+        Some(printed.into_code())
+    }
+
+    fn run_yaml_formatter(source_text: &str, format_options: YamlFormatOptions) -> Option<String> {
+        let allocator = Allocator::default();
+        let formatted = oxc_formatter_yaml::format(&allocator, source_text, format_options).ok()?;
         let printed = formatted.print().ok()?;
         Some(printed.into_code())
     }

--- a/tasks/prettier_conformance/src/main.rs
+++ b/tasks/prettier_conformance/src/main.rs
@@ -25,6 +25,7 @@ fn main() {
         TestLanguage::Css,
         TestLanguage::Scss,
         TestLanguage::Less,
+        TestLanguage::Yaml,
     ] {
         TestRunner::new(TestRunnerOptions { language, debug, filter: filter.clone() }).run();
     }

--- a/tasks/prettier_conformance/src/options.rs
+++ b/tasks/prettier_conformance/src/options.rs
@@ -20,6 +20,7 @@ pub enum TestLanguage {
     Css,
     Scss,
     Less,
+    Yaml,
 }
 
 impl TestLanguage {
@@ -35,6 +36,7 @@ impl TestLanguage {
             Self::Css => "css",
             Self::Scss => "scss",
             Self::Less => "less",
+            Self::Yaml => "yaml",
         }
     }
 
@@ -69,6 +71,7 @@ impl TestLanguage {
             Self::Css => vec![base.join("css")],
             Self::Scss => vec![base.join("scss")],
             Self::Less => vec![base.join("less")],
+            Self::Yaml => vec![base.join("yaml")],
         }
     }
 }

--- a/tasks/prettier_conformance/src/spec.rs
+++ b/tasks/prettier_conformance/src/spec.rs
@@ -14,6 +14,7 @@ use oxc_formatter_core::{IndentStyle, IndentWidth, LineEnding, LineWidth};
 use oxc_formatter_css::{CssFormatOptions, CssVariant};
 use oxc_formatter_graphql::GraphqlFormatOptions;
 use oxc_formatter_json::{JsonFormatOptions, JsonVariant, QuoteProps};
+use oxc_formatter_yaml::{ProseWrap, YamlFormatOptions};
 use oxc_parser::Parser;
 use oxc_span::{GetSpan, SourceType};
 
@@ -33,6 +34,7 @@ pub enum SpecOptions {
     Json(JsonFormatOptions),
     Graphql(GraphqlFormatOptions),
     Css(CssFormatOptions),
+    Yaml(YamlFormatOptions),
 }
 
 pub fn parse_spec(spec: &Path, language: TestLanguage) -> Vec<(SpecOptions, SnapshotOptions)> {
@@ -143,6 +145,7 @@ impl VisitMut<'_> for SpecParser {
                 | TestLanguage::Css
                 | TestLanguage::Scss
                 | TestLanguage::Less
+                | TestLanguage::Yaml
         );
         if is_exact_parser_language && !parsers.iter().any(|p| p == self.language.as_str()) {
             return;
@@ -176,6 +179,10 @@ impl VisitMut<'_> for SpecParser {
             },
             ..Default::default()
         };
+        let mut yaml_options = YamlFormatOptions {
+            line_width: LineWidth::try_from(80).unwrap(),
+            ..Default::default()
+        };
 
         // Get options
         if let Some(Argument::ObjectExpression(obj_expr)) = expr.arguments.get(2) {
@@ -194,6 +201,7 @@ impl VisitMut<'_> for SpecParser {
                             } else if name == "bracketSpacing" {
                                 js_options.bracket_spacing = BracketSpacing::from(literal.value);
                                 graphql_options.bracket_spacing = literal.value.into();
+                                yaml_options.bracket_spacing = literal.value.into();
                             } else if matches!(
                                 name.as_ref(),
                                 "jsxBracketSameLine" | "bracketSameLine"
@@ -208,6 +216,7 @@ impl VisitMut<'_> for SpecParser {
                                 };
                                 json_options.single_quote = literal.value.into();
                                 css_options.single_quote = literal.value.into();
+                                yaml_options.single_quote = literal.value.into();
                             } else if name == "jsxSingleQuote" {
                                 js_options.jsx_quote_style = if literal.value {
                                     QuoteStyle::Single
@@ -224,6 +233,7 @@ impl VisitMut<'_> for SpecParser {
                                 json_options.indent_style = style;
                                 graphql_options.indent_style = style;
                                 css_options.indent_style = style;
+                                yaml_options.indent_style = style;
                             } else if name == "experimentalTernaries" {
                                 js_options.experimental_ternaries = literal.value;
                             } else if name == "singleAttributePerLine" {
@@ -242,6 +252,7 @@ impl VisitMut<'_> for SpecParser {
                                 json_options.line_width = width;
                                 graphql_options.line_width = width;
                                 css_options.line_width = width;
+                                yaml_options.line_width = width;
                             }
                             "tabWidth" => {
                                 let w = IndentWidth::try_from(literal.value as u8).unwrap();
@@ -249,6 +260,7 @@ impl VisitMut<'_> for SpecParser {
                                 json_options.indent_width = w;
                                 graphql_options.indent_width = w;
                                 css_options.indent_width = w;
+                                yaml_options.indent_width = w;
                             }
                             _ => {}
                         },
@@ -268,6 +280,11 @@ impl VisitMut<'_> for SpecParser {
                                         "none" => oxc_formatter_css::TrailingCommas::Never,
                                         _ => unreachable!("Prettier's trailingComma should be 'all' | 'es5' | 'none'"),
                                     };
+                                    yaml_options.trailing_commas = match s {
+                                        "all" | "es5" => oxc_formatter_yaml::TrailingCommas::Always,
+                                        "none" => oxc_formatter_yaml::TrailingCommas::Never,
+                                        _ => unreachable!("Prettier's trailingComma should be 'all' | 'es5' | 'none'"),
+                                    };
                                 }
                                 "endOfLine" => {
                                     // TODO: change `unwrap_or_default` to `unwrap`
@@ -276,6 +293,14 @@ impl VisitMut<'_> for SpecParser {
                                     json_options.line_ending = ending;
                                     graphql_options.line_ending = ending;
                                     css_options.line_ending = ending;
+                                    yaml_options.line_ending = ending;
+                                }
+                                "proseWrap" => {
+                                    yaml_options.prose_wrap = match s {
+                                        "always" => ProseWrap::Always,
+                                        "never" => ProseWrap::Never,
+                                        _ => ProseWrap::Preserve,
+                                    };
                                 }
                                 "quoteProps" => {
                                     // TODO: change `unwrap_or_default` to `unwrap`
@@ -349,6 +374,7 @@ impl VisitMut<'_> for SpecParser {
             TestLanguage::Css | TestLanguage::Scss | TestLanguage::Less => {
                 SpecOptions::Css(css_options)
             }
+            TestLanguage::Yaml => SpecOptions::Yaml(yaml_options),
             TestLanguage::Js | TestLanguage::Ts => SpecOptions::Js(Box::new(js_options)),
         };
         self.calls.push((options, snapshot_options));


### PR DESCRIPTION
> yaml compatibility: 346/354 (97.74%), 0 files skipped

This is currently the limit, as we have fixed several bugs in Prettier, ensuring consistent behavior.