### PR TITLE
perf(parser): build AST lists in thread-local scratch buffers

### DIFF
--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -9,6 +9,7 @@ use crate::{
     Context, ParserConfig as Config, ParserImpl, diagnostics,
     error_handler::FatalError,
     lexer::{Kind, LexerCheckpoint, Token, cold_branch},
+    scratch::{ScratchBuffers, ScratchFor},
 };
 
 #[derive(Clone)]
@@ -387,10 +388,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ) -> ArenaVec<'a, T>
     where
         F: FnMut(&mut Self) -> T,
+        ScratchBuffers<'a>: ScratchFor<T>,
     {
         let opening_span = self.cur_token().span();
         self.expect(open);
-        let mut list = ArenaVec::new_in(self);
+        let mark = self.scratch_mark::<T>();
         loop {
             let kind = self.cur_kind();
             if kind == close
@@ -399,10 +401,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             {
                 break;
             }
-            list.push(f(self));
+            let element = f(self);
+            self.scratch_push(element);
         }
         self.expect_closing(close, opening_span);
-        list
+        self.scratch_take(mark)
     }
 
     pub(crate) fn parse_normal_list_breakable<F, T>(
@@ -413,22 +416,65 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ) -> ArenaVec<'a, T>
     where
         F: Fn(&mut Self) -> Option<T>,
+        ScratchBuffers<'a>: ScratchFor<T>,
     {
         let opening_span = self.cur_token().span();
         self.expect(open);
-        let mut list = ArenaVec::new_in(self);
+        let mark = self.scratch_mark::<T>();
         loop {
             if self.at(close) || self.has_fatal_error() {
                 break;
             }
             if let Some(e) = f(self) {
-                list.push(e);
+                self.scratch_push(e);
             } else {
                 break;
             }
         }
         self.expect_closing(close, opening_span);
-        list
+        self.scratch_take(mark)
+    }
+
+    /// Parse a list of at least one item separated by `separator`, ending at the first
+    /// token that is not a separator (there is no closing token).
+    pub(crate) fn parse_separated_list<F, T>(
+        &mut self,
+        separator: Kind,
+        mut f: F,
+    ) -> ArenaVec<'a, T>
+    where
+        F: FnMut(&mut Self) -> T,
+        ScratchBuffers<'a>: ScratchFor<T>,
+    {
+        let mark = self.scratch_mark::<T>();
+        loop {
+            let element = f(self);
+            self.scratch_push(element);
+            if !self.eat(separator) {
+                break;
+            }
+        }
+        self.scratch_take(mark)
+    }
+
+    /// Like [`Self::parse_separated_list`], but seeded with an already-parsed first element.
+    pub(crate) fn parse_separated_list_from<F, T>(
+        &mut self,
+        first: T,
+        separator: Kind,
+        mut f: F,
+    ) -> ArenaVec<'a, T>
+    where
+        F: FnMut(&mut Self) -> T,
+        ScratchBuffers<'a>: ScratchFor<T>,
+    {
+        let mark = self.scratch_mark::<T>();
+        self.scratch_push(first);
+        while self.eat(separator) {
+            let element = f(self);
+            self.scratch_push(element);
+        }
+        self.scratch_take(mark)
     }
 
     pub(crate) fn parse_delimited_list<F, T>(
@@ -436,51 +482,23 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         close: Kind,
         separator: Kind,
         opening_span: Span,
-        mut f: F,
+        f: F,
     ) -> (ArenaVec<'a, T>, Option<u32>)
     where
         F: FnMut(&mut Self) -> T,
+        ScratchBuffers<'a>: ScratchFor<T>,
     {
-        let mut list = ArenaVec::new_in(self);
-        // Cache cur_kind() to avoid redundant calls in compound checks
-        let kind = self.cur_kind();
-        if kind == close
-            || matches!(kind, Kind::Eof | Kind::Undetermined)
-            || self.fatal_error.is_some()
-        {
-            return (list, None);
-        }
-        list.push(f(self));
-        loop {
-            let kind = self.cur_kind();
-            if kind == close
-                || matches!(kind, Kind::Eof | Kind::Undetermined)
-                || self.fatal_error.is_some()
-            {
-                return (list, None);
-            }
-            if kind != separator {
-                self.set_fatal_error(diagnostics::expect_closing_or_separator(
-                    close.to_str(),
-                    separator.to_str(),
-                    kind.to_str(),
-                    self.cur_token().span(),
-                    opening_span,
-                ));
-                return (list, None);
-            }
-            self.advance(separator);
-            if self.cur_kind() == close {
-                let trailing_separator = self.prev_token_end - 1;
-                return (list, Some(trailing_separator));
-            }
-            list.push(f(self));
-        }
+        let mark = self.scratch_mark::<T>();
+        let trailing_separator =
+            self.parse_delimited_list_append(close, separator, opening_span, f);
+        (self.scratch_take(mark), trailing_separator)
     }
 
-    pub(crate) fn parse_delimited_list_into<F, T>(
+    /// Like [`Self::parse_delimited_list`], but appends the elements to the scratch list
+    /// for `T` which the caller has already started: the caller owns the mark, and drains
+    /// its elements and these combined with one `scratch_take`.
+    pub(crate) fn parse_delimited_list_append<F, T>(
         &mut self,
-        list: &mut ArenaVec<'a, T>,
         close: Kind,
         separator: Kind,
         opening_span: Span,
@@ -488,6 +506,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ) -> Option<u32>
     where
         F: FnMut(&mut Self) -> T,
+        ScratchBuffers<'a>: ScratchFor<T>,
     {
         // Cache cur_kind() to avoid redundant calls in compound checks
         let kind = self.cur_kind();
@@ -497,7 +516,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         {
             return None;
         }
-        list.push(f(self));
+        let element = f(self);
+        self.scratch_push(element);
         loop {
             let kind = self.cur_kind();
             if kind == close
@@ -521,7 +541,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 let trailing_separator = self.prev_token_end - 1;
                 return Some(trailing_separator);
             }
-            list.push(f(self));
+            let element = f(self);
+            self.scratch_push(element);
         }
     }
 
@@ -537,8 +558,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         E: Fn(&mut Self) -> A,
         R: Fn(&mut Self) -> ArenaBox<'a, BindingRestElement<'a>>,
         D: Fn(Span) -> OxcDiagnostic,
+        ScratchBuffers<'a>: ScratchFor<A>,
     {
-        let mut list = ArenaVec::new_in(self);
+        let mark = self.scratch_mark::<A>();
         let mut rest: Option<ArenaBox<'a, BindingRestElement<'a>>> = None;
         let mut first = true;
         loop {
@@ -585,10 +607,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             if kind == Kind::Dot3 {
                 rest.replace(parse_rest(self));
             } else {
-                list.push(parse_element(self));
+                let element = parse_element(self);
+                self.scratch_push(element);
             }
         }
 
-        (list, rest)
+        (self.scratch_take(mark), rest)
     }
 }

--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -190,7 +190,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     {
         self.bump_any(); // bump `extends`
 
-        let mut extends = ArenaVec::with_capacity_in(1, self);
+        let mark = self
+            .scratch_mark::<(Expression<'a>, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)>();
         loop {
             let mut extend = self.parse_lhs_expression_or_higher();
             if self.fatal_error.is_some() {
@@ -205,14 +206,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 type_argument = self.try_parse_type_arguments();
             }
 
-            extends.push((extend, type_argument));
+            self.scratch_push((extend, type_argument));
 
             if !self.eat(Kind::Comma) {
                 break;
             }
         }
 
-        extends
+        self.scratch_take(mark)
     }
 
     fn parse_class_body(&mut self) -> ArenaBox<'a, ClassBody<'a>> {

--- a/crates/oxc_parser/src/js/declaration.rs
+++ b/crates/oxc_parser/src/js/declaration.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{ArenaBox, ArenaVec};
+use oxc_allocator::ArenaBox;
 use oxc_ast::ast::*;
 use oxc_span::{GetSpan, Span};
 
@@ -83,14 +83,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         decl_parent: VariableDeclarationParent,
         declare: bool,
     ) -> ArenaBox<'a, VariableDeclaration<'a>> {
-        let mut declarations = ArenaVec::new_in(self);
-        loop {
-            let declaration = self.parse_variable_declarator(decl_parent, kind);
-            declarations.push(declaration);
-            if !self.eat(Kind::Comma) {
-                break;
-            }
-        }
+        let declarations = self
+            .parse_separated_list(Kind::Comma, |p| p.parse_variable_declarator(decl_parent, kind));
 
         if matches!(decl_parent, VariableDeclarationParent::Statement) {
             self.asi();
@@ -204,26 +198,20 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
 
         // BindingList[?In, ?Yield, ?Await, ~Pattern]
-        let mut declarations = ArenaVec::new_in(self);
-        loop {
-            let decl_parent = if matches!(statement_ctx, StatementContext::For) {
-                VariableDeclarationParent::For
-            } else {
-                VariableDeclarationParent::Statement
-            };
-            let declaration = self.parse_variable_declarator(decl_parent, kind);
-
+        let decl_parent = if matches!(statement_ctx, StatementContext::For) {
+            VariableDeclarationParent::For
+        } else {
+            VariableDeclarationParent::Statement
+        };
+        let declarations = self.parse_separated_list(Kind::Comma, |p| {
+            let declaration = p.parse_variable_declarator(decl_parent, kind);
             if !matches!(declaration.id, BindingPattern::BindingIdentifier(_)) {
-                self.error(diagnostics::invalid_identifier_in_using_declaration(
+                p.error(diagnostics::invalid_identifier_in_using_declaration(
                     declaration.id.span(),
                 ));
             }
-
-            declarations.push(declaration);
-            if !self.eat(Kind::Comma) {
-                break;
-            }
-        }
+            declaration
+        });
 
         VariableDeclaration::boxed(self.end_span(span), kind, declarations, false, self)
     }

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -563,25 +563,28 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 (quasis, ArenaVec::new_in(self))
             }
             Kind::TemplateHead => {
-                let mut expressions = ArenaVec::with_capacity_in(1, self);
-                let mut quasis = ArenaVec::with_capacity_in(2, self);
+                let expressions_mark = self.scratch_mark::<Expression<'a>>();
+                let quasis_mark = self.scratch_mark::<TemplateElement<'a>>();
 
-                quasis.push(self.parse_template_element(tagged));
+                let quasi = self.parse_template_element(tagged);
+                self.scratch_push(quasi);
                 // TemplateHead Expression[+In, ?Yield, ?Await]
                 let expr = self.context_add(Context::In, Self::parse_expr);
-                expressions.push(expr);
+                self.scratch_push(expr);
                 self.re_lex_template_substitution_tail();
                 while self.fatal_error.is_none() {
                     match self.cur_kind() {
                         Kind::TemplateTail => {
-                            quasis.push(self.parse_template_element(tagged));
+                            let quasi = self.parse_template_element(tagged);
+                            self.scratch_push(quasi);
                             break;
                         }
                         Kind::TemplateMiddle => {
-                            quasis.push(self.parse_template_element(tagged));
+                            let quasi = self.parse_template_element(tagged);
+                            self.scratch_push(quasi);
                             // TemplateMiddle Expression[+In, ?Yield, ?Await]
                             let expr = self.context_add(Context::In, Self::parse_expr);
-                            expressions.push(expr);
+                            self.scratch_push(expr);
                             self.re_lex_template_substitution_tail();
                         }
                         _ => {
@@ -591,6 +594,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     }
                 }
 
+                let quasis = self.scratch_take(quasis_mark);
+                let expressions = self.scratch_take(expressions_mark);
                 (quasis, expressions)
             }
             _ => unreachable!("parse_template_literal"),
@@ -1648,12 +1653,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         span: u32,
         first_expression: Expression<'a>,
     ) -> Expression<'a> {
-        let mut expressions = ArenaVec::with_capacity_in(2, self);
-        expressions.push(first_expression);
-        while self.eat(Kind::Comma) {
-            let expression = self.parse_assignment_expression_or_higher();
-            expressions.push(expression);
-        }
+        let expressions = self.parse_separated_list_from(
+            first_expression,
+            Kind::Comma,
+            Self::parse_assignment_expression_or_higher,
+        );
         Expression::new_sequence_expression(self.end_span(span), expressions, self)
     }
 
@@ -1757,11 +1761,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     pub(crate) fn parse_decorators(&mut self) -> ArenaVec<'a, Decorator<'a>> {
         if self.at(Kind::At) {
-            let mut decorators = ArenaVec::with_capacity_in(1, self);
+            let mark = self.scratch_mark::<Decorator<'a>>();
             while self.at(Kind::At) {
-                decorators.push(self.parse_decorator());
+                let decorator = self.parse_decorator();
+                self.scratch_push(decorator);
             }
-            decorators
+            self.scratch_take(mark)
         } else {
             ArenaVec::new_in(self)
         }

--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -70,7 +70,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         func_kind: FunctionKind,
         opening_span: Span,
     ) -> (ArenaVec<'a, FormalParameter<'a>>, Option<ArenaBox<'a, FormalParameterRest<'a>>>) {
-        let mut list = ArenaVec::new_in(self);
+        let mark = self.scratch_mark::<FormalParameter<'a>>();
         let mut rest: Option<ArenaBox<'a, FormalParameterRest<'a>>> = None;
         let mut first = true;
 
@@ -143,11 +143,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     self,
                 ));
             } else {
-                list.push(self.parse_formal_parameter_with_decorators(func_kind, span, decorators));
+                let parameter =
+                    self.parse_formal_parameter_with_decorators(func_kind, span, decorators);
+                self.scratch_push(parameter);
             }
         }
 
-        (list, rest)
+        (self.scratch_take(mark), rest)
     }
 
     fn parse_formal_parameter_with_decorators(

--- a/crates/oxc_parser/src/js/grammar.rs
+++ b/crates/oxc_parser/src/js/grammar.rs
@@ -97,7 +97,8 @@ impl<'a, C: Config> CoverGrammar<'a, ArrayExpression<'a>, C> for ArrayAssignment
     // would otherwise carry this body's large stack frame + callee-saved spills on every call.
     #[inline(never)]
     fn cover(expr: ArrayExpression<'a>, p: &mut ParserImpl<'a, C>) -> Self {
-        let mut elements = ArenaVec::new_in(p);
+        // Exact-size except for a trailing rest element (at most 1 slack slot).
+        let mut elements = ArenaVec::with_capacity_in(expr.elements.len(), p);
         let mut rest = None;
 
         let len = expr.elements.len();
@@ -174,7 +175,8 @@ impl<'a, C: Config> CoverGrammar<'a, ObjectExpression<'a>, C> for ObjectAssignme
     // inlining this large body into the hot `AssignmentTarget::cover` dispatcher.
     #[inline(never)]
     fn cover(expr: ObjectExpression<'a>, p: &mut ParserImpl<'a, C>) -> Self {
-        let mut properties = ArenaVec::new_in(p);
+        // Exact-size except for a trailing rest property (at most 1 slack slot).
+        let mut properties = ArenaVec::with_capacity_in(expr.properties.len(), p);
         let mut rest = None;
 
         let len = expr.properties.len();

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -257,17 +257,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         default_specifier: Option<BindingIdentifier<'a>>,
         import_kind: ImportOrExportKind,
     ) -> ArenaVec<'a, ImportDeclarationSpecifier<'a>> {
-        // If there is a default specifier, create a Vec with the default specifier in it,
-        // otherwise, create an empty Vec.
-        let mut specifiers = if default_specifier.is_some() {
-            ArenaVec::with_capacity_in(1, self)
-        } else {
-            ArenaVec::new_in(self)
-        };
+        let mark = self.scratch_mark::<ImportDeclarationSpecifier<'a>>();
 
         if let Some(default_specifier) = default_specifier {
             let default_span = default_specifier.span;
-            specifiers.push(ImportDeclarationSpecifier::new_import_default_specifier(
+            // For the `import type from 'source'` check below.
+            let default_name_is_type = default_specifier.name == "type";
+            self.scratch_push(ImportDeclarationSpecifier::new_import_default_specifier(
                 default_specifier.span,
                 default_specifier,
                 self,
@@ -281,7 +277,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                                 default_span,
                             ));
                         }
-                        specifiers.push(self.parse_import_namespace_specifier());
+                        let specifier = self.parse_import_namespace_specifier();
+                        self.scratch_push(specifier);
                     }
                     // import defaultExport, { export1 [ , [...] ] } from "module-name";
                     Kind::LCurly => {
@@ -290,9 +287,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                                 default_span,
                             ));
                         }
-                        self.parse_import_specifiers_into(&mut specifiers, import_kind);
+                        self.parse_import_specifiers_append(import_kind);
                     }
-                    _ => return self.unexpected(),
+                    _ => {
+                        // Discard the specifiers pushed so far — `unexpected` returns a dummy.
+                        self.scratch_discard::<ImportDeclarationSpecifier<'a>>(mark);
+                        return self.unexpected();
+                    }
                 }
             }
 
@@ -301,21 +302,22 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             // like: `import type from 'source'`
             if self.is_ts
                 && import_kind == ImportOrExportKind::Value
-                && specifiers.len() == 1
-                && specifiers[0].name() == "type"
+                && default_name_is_type
+                && self.scratch_mark::<ImportDeclarationSpecifier<'a>>() - mark == 1
             {
-                return specifiers;
+                return self.scratch_take(mark);
             }
         } else if self.at(Kind::Star) {
             // import * as name from "module-name";
-            specifiers.push(self.parse_import_namespace_specifier());
+            let specifier = self.parse_import_namespace_specifier();
+            self.scratch_push(specifier);
         } else if self.at(Kind::LCurly) {
             // import { export1 , export2 as alias2 , [...] } from "module-name";
-            self.parse_import_specifiers_into(&mut specifiers, import_kind);
+            self.parse_import_specifiers_append(import_kind);
         }
 
         self.expect(Kind::From);
-        specifiers
+        self.scratch_take(mark)
     }
 
     // import * as name from "module-name"
@@ -329,21 +331,17 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     // import { export1 , export2 as alias2 , [...] } from "module-name";
-    fn parse_import_specifiers_into(
-        &mut self,
-        specifiers: &mut ArenaVec<'a, ImportDeclarationSpecifier<'a>>,
-        import_kind: ImportOrExportKind,
-    ) {
+    //
+    // Appends the specifiers to the scratch list the caller has already started
+    // (which holds the default import specifier, if there was one).
+    fn parse_import_specifiers_append(&mut self, import_kind: ImportOrExportKind) {
         let opening_span = self.cur_token().span();
         self.expect(Kind::LCurly);
         self.context_remove(self.ctx, |p| {
-            let _ = p.parse_delimited_list_into(
-                specifiers,
-                Kind::RCurly,
-                Kind::Comma,
-                opening_span,
-                |parser| parser.parse_import_specifier(import_kind),
-            );
+            let _ =
+                p.parse_delimited_list_append(Kind::RCurly, Kind::Comma, opening_span, |parser| {
+                    parser.parse_import_specifier(import_kind)
+                });
         });
         self.expect(Kind::RCurly);
     }

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -34,8 +34,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
         in_ts_namespace_body: bool,
     ) -> (ArenaVec<'a, Directive<'a>>, ArenaVec<'a, Statement<'a>>) {
-        let mut directives = ArenaVec::new_in(self);
-        let mut statements = ArenaVec::new_in(self);
+        let directives_mark = self.scratch_mark::<Directive<'a>>();
+        let statements_mark = self.scratch_mark::<Statement<'a>>();
 
         let is_top_level = self.ctx.has_top_level();
         let stmt_ctx = StatementContext::StatementList;
@@ -62,7 +62,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     None
                 } else {
                     self.state.encountered_await_identifier = false;
-                    Some((statements.len(), self.checkpoint()))
+                    let stmt_index = self.scratch_mark::<Statement<'a>>() - statements_mark;
+                    Some((stmt_index, self.checkpoint()))
                 }
             } else {
                 None
@@ -93,7 +94,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                             [string.span.start as usize + 1..string.span.end as usize - 1];
                         let directive =
                             Directive::new(expr.span, (*string).clone(), Str::from(src), self);
-                        directives.push(directive);
+                        self.scratch_push(directive);
                         continue;
                     }
                 }
@@ -112,9 +113,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 self.error(diagnostics::statement_in_ambient_context(stmt.span()));
                 reported_ambient_statement = true;
             }
-            statements.push(stmt);
+            self.scratch_push(stmt);
         }
 
+        let directives = self.scratch_take(directives_mark);
+        let statements = self.scratch_take(statements_mark);
         (directives, statements)
     }
 
@@ -731,7 +734,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             }
         };
         self.expect(Kind::Colon);
-        let mut consequent = ArenaVec::new_in(self);
+        let mark = self.scratch_mark::<Statement<'a>>();
         loop {
             let kind = self.cur_kind();
             if matches!(
@@ -751,8 +754,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     stmt.span(),
                 ));
             }
-            consequent.push(stmt);
+            self.scratch_push(stmt);
         }
+        let consequent = self.scratch_take(mark);
         SwitchCase::new(self.end_span(span), test, consequent, self)
     }
 

--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -243,12 +243,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
         in_jsx_child: bool,
     ) -> (ArenaVec<'a, JSXChild<'a>>, JSXClosing<'a>) {
-        let mut children = ArenaVec::new_in(self);
+        let mark = self.scratch_mark::<JSXChild<'a>>();
         loop {
             if self.fatal_error.is_some() {
                 // Return dummy closing fragment on fatal error
                 let closing = JSXClosingFragment::new(self.cur_token().span(), self);
-                return (children, JSXClosing::Fragment(closing));
+                return (self.scratch_take(mark), JSXClosing::Fragment(closing));
             }
 
             match self.cur_kind() {
@@ -259,13 +259,15 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
                     // <> open nested fragment
                     if kind == Kind::RAngle {
-                        children.push(JSXChild::Fragment(self.parse_jsx_fragment(span, true)));
+                        let child = JSXChild::Fragment(self.parse_jsx_fragment(span, true));
+                        self.scratch_push(child);
                         continue;
                     }
 
                     // <ident open nested element
                     if kind == Kind::Ident || kind.is_any_keyword() {
-                        children.push(JSXChild::Element(self.parse_jsx_element(span, true)));
+                        let child = JSXChild::Element(self.parse_jsx_element(span, true));
+                        self.scratch_push(child);
                         continue;
                     }
 
@@ -273,11 +275,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     if kind == Kind::Slash {
                         self.bump_any(); // bump `/`
                         let closing = self.parse_jsx_closing_inline(span, in_jsx_child);
-                        return (children, closing);
+                        return (self.scratch_take(mark), closing);
                     }
 
                     // Unexpected token after `<`
-                    return (children, self.unexpected());
+                    return (self.scratch_take(mark), self.unexpected());
                 }
                 Kind::LCurly => {
                     let span_start = self.start_span();
@@ -285,23 +287,25 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
                     // {...expr}
                     if self.eat(Kind::Dot3) {
-                        children.push(JSXChild::Spread(self.parse_jsx_spread_child(span_start)));
+                        let child = JSXChild::Spread(self.parse_jsx_spread_child(span_start));
+                        self.scratch_push(child);
                         continue;
                     }
                     // {expr}
-                    children.push(JSXChild::ExpressionContainer(
-                        self.parse_jsx_expression_container(
+                    let child =
+                        JSXChild::ExpressionContainer(self.parse_jsx_expression_container(
                             span_start, /* in_jsx_child */ true,
-                        ),
-                    ));
+                        ));
+                    self.scratch_push(child);
                 }
                 // text
                 Kind::JSXText => {
-                    children.push(JSXChild::Text(self.parse_jsx_text()));
+                    let child = JSXChild::Text(self.parse_jsx_text());
+                    self.scratch_push(child);
                 }
                 _ => {
                     // Unexpected token in JSX children
-                    return (children, self.unexpected());
+                    return (self.scratch_take(mark), self.unexpected());
                 }
             }
         }
@@ -391,7 +395,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ///   `JSXSpreadAttribute` `JSXAttributes_opt`
     ///   `JSXAttribute` `JSXAttributes_opt`
     fn parse_jsx_attributes(&mut self) -> ArenaVec<'a, JSXAttributeItem<'a>> {
-        let mut attributes = ArenaVec::new_in(self);
+        let mark = self.scratch_mark::<JSXAttributeItem<'a>>();
         loop {
             let kind = self.cur_kind();
             if matches!(kind, Kind::LAngle | Kind::RAngle | Kind::Slash)
@@ -405,9 +409,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 }
                 _ => JSXAttributeItem::Attribute(self.parse_jsx_attribute()),
             };
-            attributes.push(attribute);
+            self.scratch_push(attribute);
         }
-        attributes
+        self.scratch_take(mark)
     }
 
     /// `JSXAttribute` :

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -72,6 +72,7 @@ mod cursor;
 mod error_handler;
 mod modifiers;
 mod module_record;
+mod scratch;
 mod state;
 
 mod js;
@@ -105,6 +106,7 @@ use crate::{
     error_handler::FatalError,
     lexer::Lexer,
     module_record::ModuleRecordBuilder,
+    scratch::ScratchGuard,
     state::ParserState,
 };
 
@@ -642,6 +644,9 @@ struct ParserImpl<'a, C: ParserConfig> {
 
     /// Precomputed typescript detection
     is_ts: bool,
+
+    /// Scratch buffers for building AST lists, checked out of this thread's cache
+    scratch: ScratchGuard<'a>,
 }
 
 impl<'a, C: ParserConfig> ParserImpl<'a, C> {
@@ -674,6 +679,7 @@ impl<'a, C: ParserConfig> ParserImpl<'a, C> {
             ast: AstBuilder::new(allocator),
             module_record_builder: ModuleRecordBuilder::new(allocator, source_type),
             is_ts: source_type.is_typescript(),
+            scratch: ScratchGuard::checkout(),
         }
     }
 

--- a/crates/oxc_parser/src/scratch.rs
+++ b/crates/oxc_parser/src/scratch.rs
@@ -1,0 +1,325 @@
+//! Thread-persistent scratch buffers for building AST lists.
+//!
+//! Building a list by pushing into an [`ArenaVec`] reallocates within the arena as the vec grows.
+//! Child AST nodes are allocated in between pushes, so the growing vec's buffer is almost never
+//! the arena's most recent allocation, and every growth allocates a new buffer and abandons the
+//! old one as dead space in the arena.
+//!
+//! Instead, the parser builds every list in a scratch `std::Vec`, and moves the completed list
+//! into the arena with a single exact-sized allocation ([`ParserImpl::scratch_take`]).
+//!
+//! There is one scratch vec per list element type ([`ScratchBuffers`]). Nested lists with the
+//! same element type (statements of nested blocks, arguments of nested calls) share one scratch
+//! vec, used like a stack: a list records the vec's length (its "mark") when it starts, pushes
+//! elements on the end, and drains everything from its mark upwards when it completes. List
+//! parsing is strictly LIFO — every list-building code path exits by normal return (parse errors
+//! are stored, not thrown; element closures cannot early-exit their caller) — so a list always
+//! drains its own elements before its enclosing list resumes. This is the scratch pattern used
+//! by Zig's `std.zig` parser, split per element type since our lists are heterogeneous.
+//!
+//! The buffers are checked out of a thread-local cache when the parser is created and returned
+//! (emptied) when it is dropped ([`ScratchGuard`]), so they persist for the lifetime of the
+//! thread. Once a thread is warm, list building performs no heap allocation at all.
+
+use std::{
+    cell::Cell,
+    mem::ManuallyDrop,
+    ops::{Deref, DerefMut},
+};
+
+use oxc_allocator::{ArenaBox, ArenaVec, GetAllocator};
+use oxc_ast::ast::{
+    Argument, ArrayExpressionElement, BindingPattern, BindingProperty, ClassElement, Decorator,
+    Directive, ExportSpecifier, Expression, FormalParameter, ImportAttribute,
+    ImportDeclarationSpecifier, JSXAttributeItem, JSXChild, ObjectPropertyKind, Statement,
+    SwitchCase, TSClassImplements, TSEnumMember, TSIndexSignatureName, TSInterfaceHeritage,
+    TSSignature, TSTupleElement, TSType, TSTypeParameter, TSTypeParameterInstantiation,
+    TemplateElement, VariableDeclarator,
+};
+
+use crate::{ParserConfig, ParserImpl};
+
+/// Access to the scratch buffer holding `T`s in [`ScratchBuffers`].
+pub trait ScratchFor<T> {
+    fn buf(&mut self) -> &mut Vec<T>;
+}
+
+macro_rules! scratch_buffers {
+    ($($field:ident: $ty:ty),* $(,)?) => {
+        /// Scratch vecs for building AST lists — one per list element type.
+        ///
+        /// See module docs for the usage pattern.
+        #[derive(Default)]
+        pub struct ScratchBuffers<'a> {
+            $(pub(crate) $field: Vec<$ty>,)*
+        }
+
+        impl ScratchBuffers<'_> {
+            /// Empty every buffer.
+            ///
+            /// Element types never need `Drop` (asserted in [`ScratchFor::buf`]),
+            /// so this only resets lengths.
+            fn clear_all(&mut self) {
+                $(self.$field.clear();)*
+            }
+
+            /// `true` if every buffer is empty.
+            fn is_all_empty(&self) -> bool {
+                $(self.$field.is_empty() &&)* true
+            }
+        }
+
+        $(
+            impl<'a> ScratchFor<$ty> for ScratchBuffers<'a> {
+                #[inline(always)]
+                fn buf(&mut self) -> &mut Vec<$ty> {
+                    // Elements are materialized into `ArenaVec`s, whose arena never runs `Drop`,
+                    // and `scratch_take` moves them out bytewise. `ArenaVec` asserts the same
+                    // requirement; asserting it here too reports errors at the offending buffer.
+                    const { assert!(!std::mem::needs_drop::<$ty>()) };
+                    &mut self.$field
+                }
+            }
+        )*
+    };
+}
+
+scratch_buffers! {
+    statements: Statement<'a>,
+    directives: Directive<'a>,
+    switch_cases: SwitchCase<'a>,
+    variable_declarators: VariableDeclarator<'a>,
+    formal_parameters: FormalParameter<'a>,
+    arguments: Argument<'a>,
+    expressions: Expression<'a>,
+    array_expression_elements: ArrayExpressionElement<'a>,
+    object_property_kinds: ObjectPropertyKind<'a>,
+    class_elements: ClassElement<'a>,
+    binding_properties: BindingProperty<'a>,
+    array_binding_elements: Option<BindingPattern<'a>>,
+    template_elements: TemplateElement<'a>,
+    import_declaration_specifiers: ImportDeclarationSpecifier<'a>,
+    import_attributes: ImportAttribute<'a>,
+    export_specifiers: ExportSpecifier<'a>,
+    ts_types: TSType<'a>,
+    ts_signatures: TSSignature<'a>,
+    ts_enum_members: TSEnumMember<'a>,
+    ts_type_parameters: TSTypeParameter<'a>,
+    ts_tuple_elements: TSTupleElement<'a>,
+    ts_index_signature_names: TSIndexSignatureName<'a>,
+    ts_class_implements: TSClassImplements<'a>,
+    ts_interface_heritages: TSInterfaceHeritage<'a>,
+    class_extends: (Expression<'a>, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>),
+    decorators: Decorator<'a>,
+    jsx_children: JSXChild<'a>,
+    jsx_attribute_items: JSXAttributeItem<'a>,
+}
+
+thread_local! {
+    /// This thread's cached scratch buffers.
+    /// `None` before first use on the thread, or while a parser has them checked out.
+    static CACHE: Cell<Option<Box<ScratchBuffers<'static>>>> = const { Cell::new(None) };
+}
+
+/// Change the lifetime parameter of `ScratchBuffers`.
+///
+/// # SAFETY
+///
+/// Every vec must be empty, so that no element typed with the old lifetime survives.
+/// The lifetime parameter does not affect layout, so an empty vec's allocation (a length,
+/// a capacity, and a buffer of uninitialized elements) is valid for the new lifetime.
+unsafe fn change_lifetime<'to>(buffers: Box<ScratchBuffers<'_>>) -> Box<ScratchBuffers<'to>> {
+    debug_assert!(buffers.is_all_empty());
+    // SAFETY: same layout (see above); the `Box` is recreated from the pointer it was split into.
+    unsafe { Box::from_raw(Box::into_raw(buffers).cast::<ScratchBuffers<'to>>()) }
+}
+
+/// Owner of [`ScratchBuffers`] for the duration of one parse.
+///
+/// Checks the buffers out of this thread's cache on creation, and returns them (emptied) on
+/// drop — including a drop during panic unwinding — so the buffers survive for the thread's
+/// lifetime and stay grown to their high-water capacity across parses.
+pub struct ScratchGuard<'a>(ManuallyDrop<Box<ScratchBuffers<'a>>>);
+
+impl<'a> ScratchGuard<'a> {
+    /// Take this thread's scratch buffers out of the cache.
+    ///
+    /// Falls back to fresh (empty, unallocated) buffers if the cache is unavailable: on the
+    /// thread's first parse, while another parser on this thread has the buffers checked out
+    /// (only possible in tests — see `UniquePromise`), or during thread teardown.
+    pub(crate) fn checkout() -> Self {
+        let buffers = CACHE.try_with(Cell::take).ok().flatten().unwrap_or_default();
+        // SAFETY: cached buffers are emptied before being cached in `drop` below,
+        // and fresh buffers start empty.
+        let buffers: Box<ScratchBuffers<'a>> = unsafe { change_lifetime(buffers) };
+        Self(ManuallyDrop::new(buffers))
+    }
+}
+
+impl Drop for ScratchGuard<'_> {
+    fn drop(&mut self) {
+        // SAFETY: `self.0` is only taken here, and drop runs at most once.
+        let mut buffers = unsafe { ManuallyDrop::take(&mut self.0) };
+        // On normal completion, every list site has drained the elements it pushed.
+        // Anything left over means a list site broke the mark/push/drain discipline —
+        // except when unwinding from a panic, which abandons in-progress lists (harmless,
+        // elements have no `Drop`).
+        #[cfg(debug_assertions)]
+        if !std::thread::panicking() {
+            assert!(
+                buffers.is_all_empty(),
+                "scratch buffers must be empty at end of parse — \
+                 a list site pushed elements without draining them"
+            );
+        }
+        buffers.clear_all();
+        // SAFETY: all vecs were just emptied.
+        let buffers: Box<ScratchBuffers<'static>> = unsafe { change_lifetime(buffers) };
+        // Cache for the next parse on this thread.
+        // If the thread-local is already destroyed (thread teardown), drop the buffers instead.
+        let _ = CACHE.try_with(|cache| cache.set(Some(buffers)));
+    }
+}
+
+impl<'a> Deref for ScratchGuard<'a> {
+    type Target = ScratchBuffers<'a>;
+
+    #[inline]
+    fn deref(&self) -> &ScratchBuffers<'a> {
+        &self.0
+    }
+}
+
+impl<'a> DerefMut for ScratchGuard<'a> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut ScratchBuffers<'a> {
+        &mut self.0
+    }
+}
+
+impl<'a, C: ParserConfig> ParserImpl<'a, C> {
+    /// Current length of the scratch buffer for `T`.
+    ///
+    /// Take a mark before pushing a list's elements with [`scratch_push`], and pass it to
+    /// [`scratch_take`] once the list is complete. Elements pushed by nested lists in between
+    /// are always drained again before this list resumes (see module docs of [`crate::scratch`]).
+    ///
+    /// [`scratch_push`]: Self::scratch_push
+    /// [`scratch_take`]: Self::scratch_take
+    #[inline]
+    pub(crate) fn scratch_mark<T>(&mut self) -> usize
+    where
+        ScratchBuffers<'a>: ScratchFor<T>,
+    {
+        ScratchFor::<T>::buf(&mut *self.scratch).len()
+    }
+
+    /// Push a list element onto the scratch buffer for `T`.
+    #[inline]
+    pub(crate) fn scratch_push<T>(&mut self, element: T)
+    where
+        ScratchBuffers<'a>: ScratchFor<T>,
+    {
+        ScratchFor::<T>::buf(&mut *self.scratch).push(element);
+    }
+
+    /// Move the elements pushed since `mark` into an exact-sized arena vec.
+    #[inline]
+    pub(crate) fn scratch_take<T>(&mut self, mark: usize) -> ArenaVec<'a, T>
+    where
+        ScratchBuffers<'a>: ScratchFor<T>,
+    {
+        let allocator = self.allocator();
+        let buf = ScratchFor::<T>::buf(&mut *self.scratch);
+        let len = buf.len() - mark;
+        let mut vec = ArenaVec::with_capacity_in(len, &allocator);
+        // SAFETY: `vec` has capacity for `len` elements, and `buf[mark..]` are initialized `T`s.
+        // The copy is a move: `buf`'s length is cut back to `mark`, so the moved elements are
+        // never touched through `buf` again, and `T` never needs `Drop` (asserted in `buf`),
+        // so skipping their destructors is sound.
+        unsafe {
+            std::ptr::copy_nonoverlapping(buf.as_ptr().add(mark), vec.as_mut_ptr(), len);
+            vec.set_len(len);
+            buf.set_len(mark);
+        }
+        vec
+    }
+
+    /// Discard the elements pushed since `mark` — for abandoning a list part-way
+    /// (e.g. bailing out with [`Self::unexpected`]).
+    #[inline]
+    pub(crate) fn scratch_discard<T>(&mut self, mark: usize)
+    where
+        ScratchBuffers<'a>: ScratchFor<T>,
+    {
+        ScratchFor::<T>::buf(&mut *self.scratch).truncate(mark);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use oxc_allocator::Allocator;
+    use oxc_ast::builder::AstBuilder;
+    use oxc_span::SPAN;
+
+    use super::*;
+
+    fn statement(allocator: &Allocator) -> Statement<'_> {
+        Statement::new_empty_statement(SPAN, &AstBuilder::new(allocator))
+    }
+
+    #[test]
+    fn warm_across_checkouts() {
+        let allocator = Allocator::default();
+        // Buffer capacity must survive a checkout/checkin cycle on the same thread.
+        let high_water = {
+            let mut guard = ScratchGuard::checkout();
+            for _ in 0..64 {
+                guard.statements.push(statement(&allocator));
+            }
+            let capacity = guard.statements.capacity();
+            assert!(capacity >= 64);
+            guard.statements.clear();
+            capacity
+        };
+        let guard = ScratchGuard::checkout();
+        assert!(guard.statements.is_empty());
+        assert!(guard.statements.capacity() >= high_water);
+    }
+
+    #[test]
+    fn nested_marks() {
+        let allocator = Allocator::default();
+        let mut guard = ScratchGuard::checkout();
+        let outer_mark = guard.statements.len();
+        guard.statements.push(statement(&allocator));
+        guard.statements.push(statement(&allocator));
+        // A nested list starts, pushes, and drains its own tail.
+        let inner_mark = guard.statements.len();
+        guard.statements.push(statement(&allocator));
+        guard.statements.push(statement(&allocator));
+        assert_eq!(guard.statements.drain(inner_mark..).count(), 2);
+        // The outer list still sees exactly its own elements.
+        guard.statements.push(statement(&allocator));
+        assert_eq!(guard.statements.drain(outer_mark..).count(), 3);
+        assert!(guard.statements.is_empty());
+    }
+
+    #[test]
+    fn cached_even_on_panic() {
+        let result = std::panic::catch_unwind(|| {
+            let allocator = Allocator::default();
+            let mut guard = ScratchGuard::checkout();
+            for _ in 0..32 {
+                guard.statements.push(statement(&allocator));
+            }
+            // Panic with the buffer non-empty, mid-"parse".
+            panic!("boom");
+        });
+        assert!(result.is_err());
+        // The buffers were emptied and returned to the cache by the guard's drop.
+        let guard = ScratchGuard::checkout();
+        assert!(guard.statements.is_empty());
+        assert!(guard.statements.capacity() >= 32);
+    }
+}

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -271,7 +271,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     fn parse_ts_interface_extends_clause(&mut self) -> ArenaVec<'a, TSInterfaceHeritage<'a>> {
         self.bump_any(); // bump `extends`
 
-        let mut extends = ArenaVec::with_capacity_in(1, self);
+        let mark = self.scratch_mark::<TSInterfaceHeritage<'a>>();
         loop {
             let span = self.start_span();
             let mut extend = self.parse_lhs_expression_or_higher();
@@ -287,7 +287,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 type_argument = self.try_parse_type_arguments();
             }
 
-            extends.push(TSInterfaceHeritage::new(
+            self.scratch_push(TSInterfaceHeritage::new(
                 self.end_span(span),
                 extend,
                 type_argument,
@@ -299,7 +299,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             }
         }
 
-        extends
+        self.scratch_take(mark)
     }
 
     fn parse_ts_interface_body(&mut self) -> ArenaBox<'a, TSInterfaceBody<'a>> {

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -204,12 +204,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     pub(crate) fn parse_ts_implements_clause(&mut self) -> ArenaVec<'a, TSClassImplements<'a>> {
         self.expect(Kind::Implements);
-        let first = self.parse_ts_implement_name();
-        let mut implements = ArenaVec::from_value_in(first, self);
-        while self.eat(Kind::Comma) {
-            implements.push(self.parse_ts_implement_name());
-        }
-        implements
+        self.parse_separated_list(Kind::Comma, Self::parse_ts_implement_name)
     }
 
     fn parse_ts_type_parameter(&mut self, allow_variance: bool) -> TSTypeParameter<'a> {
@@ -277,13 +272,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         /* hasLeadingOperator && parseFunctionOrConstructorTypeToError(isUnionType) ||*/
         let mut ty = parse_constituent_type(self);
         if self.at(kind) || has_leading_operator {
-            let mut types = ArenaVec::from_value_in(ty, self);
-            while self.eat(kind) {
-                types.push(
-                    /*parseFunctionOrConstructorTypeToError(isUnionType) || */
-                    parse_constituent_type(self),
-                );
-            }
+            /*parseFunctionOrConstructorTypeToError(isUnionType) || */
+            let types = self.parse_separated_list_from(ty, kind, parse_constituent_type);
             let span = self.end_span(span);
             ty = match kind {
                 Kind::Pipe => TSType::new_ts_union_type(span, types, self),
@@ -776,31 +766,37 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     fn parse_template_type(&mut self, tagged: bool) -> TSType<'a> {
         let span = self.start_span();
-        let mut types = ArenaVec::new_in(self);
-        let mut quasis = ArenaVec::new_in(self);
+        let types_mark = self.scratch_mark::<TSType<'a>>();
+        let quasis_mark = self.scratch_mark::<TemplateElement<'a>>();
         match self.cur_kind() {
             Kind::NoSubstitutionTemplate => {
-                quasis.push(self.parse_template_element(tagged));
+                let quasi = self.parse_template_element(tagged);
+                self.scratch_push(quasi);
             }
             Kind::TemplateHead => {
-                quasis.push(self.parse_template_element(tagged));
-                types.push(self.parse_ts_type());
+                let quasi = self.parse_template_element(tagged);
+                self.scratch_push(quasi);
+                let ty = self.parse_ts_type();
+                self.scratch_push(ty);
                 self.re_lex_template_substitution_tail();
                 while self.fatal_error.is_none() {
                     match self.cur_kind() {
                         Kind::TemplateTail => {
-                            quasis.push(self.parse_template_element(tagged));
+                            let quasi = self.parse_template_element(tagged);
+                            self.scratch_push(quasi);
                             break;
                         }
                         Kind::TemplateMiddle => {
-                            quasis.push(self.parse_template_element(tagged));
+                            let quasi = self.parse_template_element(tagged);
+                            self.scratch_push(quasi);
                         }
                         Kind::Eof => {
                             self.expect(Kind::TemplateTail);
                             break;
                         }
                         _ => {
-                            types.push(self.parse_ts_type());
+                            let ty = self.parse_ts_type();
+                            self.scratch_push(ty);
                             self.re_lex_template_substitution_tail();
                         }
                     }
@@ -809,6 +805,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             _ => unreachable!("parse_template_literal"),
         }
 
+        let quasis = self.scratch_take(quasis_mark);
+        let types = self.scratch_take(types_mark);
         TSType::new_ts_template_literal_type(self.end_span(span), quasis, types, self)
     }
 
@@ -1249,7 +1247,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let span = self.start_span();
         self.expect(Kind::LCurly);
 
-        let mut properties = ArenaVec::new_in(self);
+        let mark = self.scratch_mark::<ObjectPropertyKind<'a>>();
         let mut first = true;
         while !self.at(Kind::RCurly) && !self.at(Kind::Eof) {
             if first {
@@ -1284,7 +1282,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 self.expect(Kind::Colon);
                 let value = self.parse_assignment_expression_or_higher();
                 let key = PropertyKey::new_string_literal(bracket_span, "", None, self);
-                properties.push(ObjectPropertyKind::new_object_property(
+                self.scratch_push(ObjectPropertyKind::new_object_property(
                     self.end_span(prop_span),
                     PropertyKind::Init,
                     key,
@@ -1309,7 +1307,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.expect(Kind::Colon);
             let value = self.parse_assignment_expression_or_higher();
 
-            properties.push(ObjectPropertyKind::new_object_property(
+            self.scratch_push(ObjectPropertyKind::new_object_property(
                 self.end_span(prop_span),
                 PropertyKind::Init,
                 key,
@@ -1322,6 +1320,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
 
         self.expect(Kind::RCurly);
+        let properties = self.scratch_take(mark);
         ObjectExpression::boxed(self.end_span(span), properties, self)
     }
 

--- a/tasks/track_memory_allocations/allocs_formatter.snap
+++ b/tasks/track_memory_allocations/allocs_formatter.snap
@@ -4,7 +4,7 @@ checker.ts
   sys reallocs: 492
   arena allocs: 1081815
   arena reallocs: 118690
-  arena size: 138513120 (138.51 MB)
+  arena size: 137361912 (137.36 MB)
 
 App.tsx
   file size: 415.34 kB
@@ -12,7 +12,7 @@ App.tsx
   sys reallocs: 80
   arena allocs: 212668
   arena reallocs: 25343
-  arena size: 29608728 (29.61 MB)
+  arena size: 29456464 (29.46 MB)
 
 RadixUIAdoptionSection.jsx
   file size: 2.52 kB
@@ -20,7 +20,7 @@ RadixUIAdoptionSection.jsx
   sys reallocs: 26
   arena allocs: 1155
   arena reallocs: 157
-  arena size: 210080 (210.08 kB)
+  arena size: 207792 (207.79 kB)
 
 pdf.mjs
   file size: 567.30 kB
@@ -28,7 +28,7 @@ pdf.mjs
   sys reallocs: 172
   arena allocs: 437639
   arena reallocs: 43489
-  arena size: 44872280 (44.87 MB)
+  arena size: 44450504 (44.45 MB)
 
 antd.js
   file size: 6.69 MB
@@ -36,7 +36,7 @@ antd.js
   sys reallocs: 3994
   arena allocs: 2586207
   arena reallocs: 302459
-  arena size: 525725120 (525.73 MB)
+  arena size: 522529648 (522.53 MB)
 
 binder.ts
   file size: 193.08 kB
@@ -44,7 +44,7 @@ binder.ts
   sys reallocs: 35
   arena allocs: 64083
   arena reallocs: 6932
-  arena size: 8574792 (8.57 MB)
+  arena size: 8472920 (8.47 MB)
 
 kitchen-sink.tsx
   file size: 732.90 kB
@@ -52,5 +52,5 @@ kitchen-sink.tsx
   sys reallocs: 2815
   arena allocs: 569911
   arena reallocs: 60147
-  arena size: 57887152 (57.89 MB)
+  arena size: 57307576 (57.31 MB)
 

--- a/tasks/track_memory_allocations/allocs_minifier.snap
+++ b/tasks/track_memory_allocations/allocs_minifier.snap
@@ -4,7 +4,7 @@ checker.ts
   sys reallocs: 5
   arena allocs: 152755
   arena reallocs: 28253
-  arena size: 19046592 (19.05 MB)
+  arena size: 17895384 (17.90 MB)
 
 App.tsx
   file size: 415.34 kB
@@ -12,7 +12,7 @@ App.tsx
   sys reallocs: 8
   arena allocs: 17028
   arena reallocs: 2702
-  arena size: 2915632 (2.92 MB)
+  arena size: 2763368 (2.76 MB)
 
 RadixUIAdoptionSection.jsx
   file size: 2.52 kB
@@ -20,7 +20,7 @@ RadixUIAdoptionSection.jsx
   sys reallocs: 0
   arena allocs: 32
   arena reallocs: 6
-  arena size: 35792 (35.79 kB)
+  arena size: 33664 (33.66 kB)
 
 pdf.mjs
   file size: 567.30 kB
@@ -28,7 +28,7 @@ pdf.mjs
   sys reallocs: 205
   arena allocs: 47471
   arena reallocs: 7742
-  arena size: 6356576 (6.36 MB)
+  arena size: 5934816 (5.93 MB)
 
 antd.js
   file size: 6.69 MB
@@ -36,7 +36,7 @@ antd.js
   sys reallocs: 56
   arena allocs: 372632
   arena reallocs: 76745
-  arena size: 49033120 (49.03 MB)
+  arena size: 45837648 (45.84 MB)
 
 binder.ts
   file size: 193.08 kB
@@ -44,7 +44,7 @@ binder.ts
   sys reallocs: 1
   arena allocs: 7076
   arena reallocs: 824
-  arena size: 1157992 (1.16 MB)
+  arena size: 1056120 (1.06 MB)
 
 kitchen-sink.tsx
   file size: 732.90 kB
@@ -52,5 +52,5 @@ kitchen-sink.tsx
   sys reallocs: 175
   arena allocs: 88129
   arena reallocs: 15654
-  arena size: 10190448 (10.19 MB)
+  arena size: 9621208 (9.62 MB)
 

--- a/tasks/track_memory_allocations/allocs_parser.snap
+++ b/tasks/track_memory_allocations/allocs_parser.snap
@@ -3,54 +3,54 @@ checker.ts
   sys allocs: 1818
   sys reallocs: 10
   arena allocs: 264366
-  arena reallocs: 22860
-  arena size: 12985208 (12.99 MB)
+  arena reallocs: 59
+  arena size: 11834000 (11.83 MB)
 
 App.tsx
   file size: 415.34 kB
   sys allocs: 360
   sys reallocs: 13
   arena allocs: 44464
-  arena reallocs: 3537
-  arena size: 2244536 (2.24 MB)
+  arena reallocs: 64
+  arena size: 2092272 (2.09 MB)
 
 RadixUIAdoptionSection.jsx
   file size: 2.52 kB
   sys allocs: 1
   sys reallocs: 0
   arena allocs: 367
-  arena reallocs: 66
-  arena size: 21232 (21.23 kB)
+  arena reallocs: 4
+  arena size: 18944 (18.94 kB)
 
 pdf.mjs
   file size: 567.30 kB
   sys allocs: 337
   sys reallocs: 67
   arena allocs: 90583
-  arena reallocs: 8153
-  arena size: 4559920 (4.56 MB)
+  arena reallocs: 112
+  arena size: 4138160 (4.14 MB)
 
 antd.js
   file size: 6.69 MB
   sys allocs: 3661
   sys reallocs: 221
   arena allocs: 528577
-  arena reallocs: 55355
-  arena size: 29421920 (29.42 MB)
+  arena reallocs: 1285
+  arena size: 26226448 (26.23 MB)
 
 binder.ts
   file size: 193.08 kB
   sys allocs: 85
   sys reallocs: 0
   arena allocs: 16620
-  arena reallocs: 1476
-  arena size: 917456 (917.46 kB)
+  arena reallocs: 24
+  arena size: 815584 (815.58 kB)
 
 kitchen-sink.tsx
   file size: 732.90 kB
   sys allocs: 2051
   sys reallocs: 160
   arena allocs: 138059
-  arena reallocs: 11905
-  arena size: 6495856 (6.50 MB)
+  arena reallocs: 249
+  arena size: 5916280 (5.92 MB)
 

--- a/tasks/track_memory_allocations/allocs_semantic.snap
+++ b/tasks/track_memory_allocations/allocs_semantic.snap
@@ -4,7 +4,7 @@ checker.ts
   sys reallocs: 0
   arena allocs: 0
   arena reallocs: 0
-  arena size: 12985208 (12.99 MB)
+  arena size: 11834000 (11.83 MB)
 
 App.tsx
   file size: 415.34 kB
@@ -12,7 +12,7 @@ App.tsx
   sys reallocs: 0
   arena allocs: 0
   arena reallocs: 0
-  arena size: 2244536 (2.24 MB)
+  arena size: 2092272 (2.09 MB)
 
 RadixUIAdoptionSection.jsx
   file size: 2.52 kB
@@ -20,7 +20,7 @@ RadixUIAdoptionSection.jsx
   sys reallocs: 0
   arena allocs: 0
   arena reallocs: 0
-  arena size: 21232 (21.23 kB)
+  arena size: 18944 (18.94 kB)
 
 pdf.mjs
   file size: 567.30 kB
@@ -28,7 +28,7 @@ pdf.mjs
   sys reallocs: 0
   arena allocs: 0
   arena reallocs: 0
-  arena size: 4559920 (4.56 MB)
+  arena size: 4138160 (4.14 MB)
 
 antd.js
   file size: 6.69 MB
@@ -36,7 +36,7 @@ antd.js
   sys reallocs: 0
   arena allocs: 0
   arena reallocs: 0
-  arena size: 29421920 (29.42 MB)
+  arena size: 26226448 (26.23 MB)
 
 binder.ts
   file size: 193.08 kB
@@ -44,7 +44,7 @@ binder.ts
   sys reallocs: 0
   arena allocs: 0
   arena reallocs: 0
-  arena size: 917456 (917.46 kB)
+  arena size: 815584 (815.58 kB)
 
 kitchen-sink.tsx
   file size: 732.90 kB
@@ -52,5 +52,5 @@ kitchen-sink.tsx
   sys reallocs: 0
   arena allocs: 0
   arena reallocs: 0
-  arena size: 6495856 (6.50 MB)
+  arena size: 5916280 (5.92 MB)
 

--- a/tasks/track_memory_allocations/allocs_transformer.snap
+++ b/tasks/track_memory_allocations/allocs_transformer.snap
@@ -4,7 +4,7 @@ checker.ts
   sys reallocs: 0
   arena allocs: 1959
   arena reallocs: 5
-  arena size: 13073904 (13.07 MB)
+  arena size: 11922696 (11.92 MB)
 
 App.tsx
   file size: 415.34 kB
@@ -12,15 +12,15 @@ App.tsx
   sys reallocs: 2
   arena allocs: 618
   arena reallocs: 17
-  arena size: 2277824 (2.28 MB)
+  arena size: 2125560 (2.13 MB)
 
 RadixUIAdoptionSection.jsx
   file size: 2.52 kB
   sys allocs: 19
   sys reallocs: 2
   arena allocs: 258
-  arena reallocs: 13
-  arena size: 34648 (34.65 kB)
+  arena reallocs: 14
+  arena size: 32520 (32.52 kB)
 
 pdf.mjs
   file size: 567.30 kB
@@ -28,7 +28,7 @@ pdf.mjs
   sys reallocs: 0
   arena allocs: 2
   arena reallocs: 0
-  arena size: 4559944 (4.56 MB)
+  arena size: 4138184 (4.14 MB)
 
 antd.js
   file size: 6.69 MB
@@ -36,7 +36,7 @@ antd.js
   sys reallocs: 0
   arena allocs: 2
   arena reallocs: 0
-  arena size: 29421944 (29.42 MB)
+  arena size: 26226472 (26.23 MB)
 
 binder.ts
   file size: 193.08 kB
@@ -44,13 +44,13 @@ binder.ts
   sys reallocs: 0
   arena allocs: 154
   arena reallocs: 0
-  arena size: 924296 (924.30 kB)
+  arena size: 822424 (822.42 kB)
 
 kitchen-sink.tsx
   file size: 732.90 kB
   sys allocs: 182
   sys reallocs: 3
   arena allocs: 6132
-  arena reallocs: 280
-  arena size: 6829952 (6.83 MB)
+  arena reallocs: 316
+  arena size: 6260712 (6.26 MB)
 


### PR DESCRIPTION
Building a list by pushing into an `ArenaVec` reallocates within the arena as the vec grows. Child AST nodes are allocated between pushes, so the growing buffer is almost never the arena's most recent allocation — every doubling allocates a new buffer and abandons the old one as permanent dead space in the arena. A list of N elements costs ~⌈log2 N⌉ grow events and ~2-4× its final size in arena bytes.

This PR builds every list in a scratch `std::Vec` instead, and moves the completed list into the arena with a single exact-sized allocation (a memcpy).

## Design

- One scratch vec per list element type (`ScratchBuffers`, ~27 fields). Nested lists with the same element type (statements of nested blocks, arguments of nested calls) share one vec, used like a stack via watermarks: record the vec's length at list start, push elements, drain your own tail at completion. List parsing is strictly LIFO — parse errors are stored rather than thrown, and element closures cannot early-exit their caller — so a list always drains its own elements before its enclosing list resumes. (This is the scratch pattern used by Zig's `std.zig` parser, split per element type since our lists are heterogeneous.)
- The buffers are checked out of a thread-local cache when the parser is created and returned emptied when it is dropped (panics included, via a drop guard). They are never freed, staying grown to high-water capacity across parses on the same thread — once a thread is warm, list building performs no heap allocation at all. The only unsafe is an empty-struct lifetime cast at checkout/checkin.
- The cursor.rs list helpers carry the discipline for almost all sites; comma-separated lists with no closing token get new `parse_separated_list`/`parse_separated_list_from` helpers. A debug assert at parse end catches any future site that pushes without draining (checked by every conformance run, which uses `debug-assertions = true`).

## Results

`just allocs` (`Arena allocs`, `Sys allocs`, `Sys reallocs` are all unchanged):

| File | Arena reallocs |
|---|---|
| checker.ts | 22,860 → 59 |
| antd.js | 55,355 → 1,285 |
| kitchen-sink.tsx | 11,905 → 249 |
| pdf.mjs | 8,153 → 112 |
| App.tsx | 3,537 → 64 |
| binder.ts | 1,476 → 24 |

The residue is mostly lexer `StringBuilder` escape paths and the comments vec, which are not converted.

Parser benchmarks improve up to ~10% (`parser/App.tsx`, `parser/react.development.js`, `estree/checker.ts`) and regress nowhere; conformance output is byte-identical across all suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)