### PR TITLE
refactor(track-memory-allocations): switch snapshots to vertical per-file blocks

### DIFF
--- a/tasks/track_memory_allocations/allocs_formatter.snap
+++ b/tasks/track_memory_allocations/allocs_formatter.snap
@@ -1,16 +1,49 @@
-File                       | File size      || Sys allocs     | Sys reallocs   || Arena allocs   | Arena reallocs 
----------------------------------------------------------------------------------------------------------------------------
-checker.ts                 | 2.92 MB        ||          11013 |            492 ||        1081815 |         118690
+checker.ts
+  file size: 2.92 MB
+  sys allocs: 11013
+  sys reallocs: 492
+  arena allocs: 1081815
+  arena reallocs: 118690
 
-App.tsx                    | 415.34 kB      ||           2532 |             80 ||         212668 |          25343
+App.tsx
+  file size: 415.34 kB
+  sys allocs: 2532
+  sys reallocs: 80
+  arena allocs: 212668
+  arena reallocs: 25343
 
-RadixUIAdoptionSection.jsx | 2.52 kB        ||             54 |             26 ||           1155 |            157
+RadixUIAdoptionSection.jsx
+  file size: 2.52 kB
+  sys allocs: 54
+  sys reallocs: 26
+  arena allocs: 1155
+  arena reallocs: 157
 
-pdf.mjs                    | 567.30 kB      ||           4019 |            172 ||         437639 |          43489
+pdf.mjs
+  file size: 567.30 kB
+  sys allocs: 4019
+  sys reallocs: 172
+  arena allocs: 437639
+  arena reallocs: 43489
 
-antd.js                    | 6.69 MB        ||          34121 |           3994 ||        2586207 |         302459
+antd.js
+  file size: 6.69 MB
+  sys allocs: 34121
+  sys reallocs: 3994
+  arena allocs: 2586207
+  arena reallocs: 302459
 
-binder.ts                  | 193.08 kB      ||            457 |             35 ||          64083 |           6932
+binder.ts
+  file size: 193.08 kB
+  sys allocs: 457
+  sys reallocs: 35
+  arena allocs: 64083
+  arena reallocs: 6932
 
-kitchen-sink.tsx           | 732.90 kB      ||           9565 |           2815 ||         569911 |          60147
+kitchen-sink.tsx
+  file size: 732.90 kB
+  sys allocs: 9565
+  sys reallocs: 2815
+  arena allocs: 569911
+  arena reallocs: 60147
 

--- a/tasks/track_memory_allocations/allocs_minifier.snap
+++ b/tasks/track_memory_allocations/allocs_minifier.snap
@@ -1,16 +1,49 @@
-File                       | File size      || Sys allocs     | Sys reallocs   || Arena allocs   | Arena reallocs 
----------------------------------------------------------------------------------------------------------------------------
-checker.ts                 | 2.92 MB        ||            155 |              5 ||         152755 |          28253
+checker.ts
+  file size: 2.92 MB
+  sys allocs: 155
+  sys reallocs: 5
+  arena allocs: 152755
+  arena reallocs: 28253
 
-App.tsx                    | 415.34 kB      ||             63 |              8 ||          17028 |           2702
+App.tsx
+  file size: 415.34 kB
+  sys allocs: 63
+  sys reallocs: 8
+  arena allocs: 17028
+  arena reallocs: 2702
 
-RadixUIAdoptionSection.jsx | 2.52 kB        ||             21 |              0 ||             32 |              6
+RadixUIAdoptionSection.jsx
+  file size: 2.52 kB
+  sys allocs: 21
+  sys reallocs: 0
+  arena allocs: 32
+  arena reallocs: 6
 
-pdf.mjs                    | 567.30 kB      ||           2469 |            205 ||          47471 |           7742
+pdf.mjs
+  file size: 567.30 kB
+  sys allocs: 2469
+  sys reallocs: 205
+  arena allocs: 47471
+  arena reallocs: 7742
 
-antd.js                    | 6.69 MB        ||           1044 |             56 ||         372632 |          76745
+antd.js
+  file size: 6.69 MB
+  sys allocs: 1044
+  sys reallocs: 56
+  arena allocs: 372632
+  arena reallocs: 76745
 
-binder.ts                  | 193.08 kB      ||             33 |              1 ||           7076 |            824
+binder.ts
+  file size: 193.08 kB
+  sys allocs: 33
+  sys reallocs: 1
+  arena allocs: 7076
+  arena reallocs: 824
 
-kitchen-sink.tsx           | 732.90 kB      ||           2309 |            175 ||          88129 |          15654
+kitchen-sink.tsx
+  file size: 732.90 kB
+  sys allocs: 2309
+  sys reallocs: 175
+  arena allocs: 88129
+  arena reallocs: 15654
 

--- a/tasks/track_memory_allocations/allocs_parser.snap
+++ b/tasks/track_memory_allocations/allocs_parser.snap
@@ -1,16 +1,49 @@
-File                       | File size      || Sys allocs     | Sys reallocs   || Arena allocs   | Arena reallocs 
----------------------------------------------------------------------------------------------------------------------------
-checker.ts                 | 2.92 MB        ||           1818 |             10 ||         264366 |          22860
+checker.ts
+  file size: 2.92 MB
+  sys allocs: 1818
+  sys reallocs: 10
+  arena allocs: 264366
+  arena reallocs: 22860
 
-App.tsx                    | 415.34 kB      ||            360 |             13 ||          44464 |           3537
+App.tsx
+  file size: 415.34 kB
+  sys allocs: 360
+  sys reallocs: 13
+  arena allocs: 44464
+  arena reallocs: 3537
 
-RadixUIAdoptionSection.jsx | 2.52 kB        ||              1 |              0 ||            367 |             66
+RadixUIAdoptionSection.jsx
+  file size: 2.52 kB
+  sys allocs: 1
+  sys reallocs: 0
+  arena allocs: 367
+  arena reallocs: 66
 
-pdf.mjs                    | 567.30 kB      ||            337 |             67 ||          90583 |           8153
+pdf.mjs
+  file size: 567.30 kB
+  sys allocs: 337
+  sys reallocs: 67
+  arena allocs: 90583
+  arena reallocs: 8153
 
-antd.js                    | 6.69 MB        ||           3661 |            221 ||         528577 |          55355
+antd.js
+  file size: 6.69 MB
+  sys allocs: 3661
+  sys reallocs: 221
+  arena allocs: 528577
+  arena reallocs: 55355
 
-binder.ts                  | 193.08 kB      ||             85 |              0 ||          16620 |           1476
+binder.ts
+  file size: 193.08 kB
+  sys allocs: 85
+  sys reallocs: 0
+  arena allocs: 16620
+  arena reallocs: 1476
 
-kitchen-sink.tsx           | 732.90 kB      ||           2051 |            160 ||         138059 |          11905
+kitchen-sink.tsx
+  file size: 732.90 kB
+  sys allocs: 2051
+  sys reallocs: 160
+  arena allocs: 138059
+  arena reallocs: 11905
 

--- a/tasks/track_memory_allocations/allocs_semantic.snap
+++ b/tasks/track_memory_allocations/allocs_semantic.snap
@@ -1,16 +1,49 @@
-File                       | File size      || Sys allocs     | Sys reallocs   || Arena allocs   | Arena reallocs 
----------------------------------------------------------------------------------------------------------------------------
-checker.ts                 | 2.92 MB        ||             46 |              0 ||              0 |              0
+checker.ts
+  file size: 2.92 MB
+  sys allocs: 46
+  sys reallocs: 0
+  arena allocs: 0
+  arena reallocs: 0
 
-App.tsx                    | 415.34 kB      ||              7 |              0 ||              0 |              0
+App.tsx
+  file size: 415.34 kB
+  sys allocs: 7
+  sys reallocs: 0
+  arena allocs: 0
+  arena reallocs: 0
 
-RadixUIAdoptionSection.jsx | 2.52 kB        ||              7 |              0 ||              0 |              0
+RadixUIAdoptionSection.jsx
+  file size: 2.52 kB
+  sys allocs: 7
+  sys reallocs: 0
+  arena allocs: 0
+  arena reallocs: 0
 
-pdf.mjs                    | 567.30 kB      ||             12 |              0 ||              0 |              0
+pdf.mjs
+  file size: 567.30 kB
+  sys allocs: 12
+  sys reallocs: 0
+  arena allocs: 0
+  arena reallocs: 0
 
-antd.js                    | 6.69 MB        ||             24 |              0 ||              0 |              0
+antd.js
+  file size: 6.69 MB
+  sys allocs: 24
+  sys reallocs: 0
+  arena allocs: 0
+  arena reallocs: 0
 
-binder.ts                  | 193.08 kB      ||             14 |              0 ||              0 |              0
+binder.ts
+  file size: 193.08 kB
+  sys allocs: 14
+  sys reallocs: 0
+  arena allocs: 0
+  arena reallocs: 0
 
-kitchen-sink.tsx           | 732.90 kB      ||             33 |              0 ||              0 |              0
+kitchen-sink.tsx
+  file size: 732.90 kB
+  sys allocs: 33
+  sys reallocs: 0
+  arena allocs: 0
+  arena reallocs: 0
 

--- a/tasks/track_memory_allocations/allocs_transformer.snap
+++ b/tasks/track_memory_allocations/allocs_transformer.snap
@@ -1,16 +1,49 @@
-File                       | File size      || Sys allocs     | Sys reallocs   || Arena allocs   | Arena reallocs 
----------------------------------------------------------------------------------------------------------------------------
-checker.ts                 | 2.92 MB        ||             18 |              0 ||           1959 |              5
+checker.ts
+  file size: 2.92 MB
+  sys allocs: 18
+  sys reallocs: 0
+  arena allocs: 1959
+  arena reallocs: 5
 
-App.tsx                    | 415.34 kB      ||             23 |              2 ||            618 |             17
+App.tsx
+  file size: 415.34 kB
+  sys allocs: 23
+  sys reallocs: 2
+  arena allocs: 618
+  arena reallocs: 17
 
-RadixUIAdoptionSection.jsx | 2.52 kB        ||             19 |              2 ||            258 |             13
+RadixUIAdoptionSection.jsx
+  file size: 2.52 kB
+  sys allocs: 19
+  sys reallocs: 2
+  arena allocs: 258
+  arena reallocs: 13
 
-pdf.mjs                    | 567.30 kB      ||             13 |              0 ||              2 |              0
+pdf.mjs
+  file size: 567.30 kB
+  sys allocs: 13
+  sys reallocs: 0
+  arena allocs: 2
+  arena reallocs: 0
 
-antd.js                    | 6.69 MB        ||             13 |              0 ||              2 |              0
+antd.js
+  file size: 6.69 MB
+  sys allocs: 13
+  sys reallocs: 0
+  arena allocs: 2
+  arena reallocs: 0
 
-binder.ts                  | 193.08 kB      ||             15 |              0 ||            154 |              0
+binder.ts
+  file size: 193.08 kB
+  sys allocs: 15
+  sys reallocs: 0
+  arena allocs: 154
+  arena reallocs: 0
 
-kitchen-sink.tsx           | 732.90 kB      ||            182 |              3 ||           6132 |            280
+kitchen-sink.tsx
+  file size: 732.90 kB
+  sys allocs: 182
+  sys reallocs: 3
+  arena allocs: 6132
+  arena reallocs: 280
 

--- a/tasks/track_memory_allocations/src/lib.rs
+++ b/tasks/track_memory_allocations/src/lib.rs
@@ -1,4 +1,5 @@
 use std::{
+    fmt::Write as _,
     fs::File,
     io::{self, Write},
 };
@@ -123,19 +124,12 @@ fn test() {
 /// # Errors
 pub fn run() -> Result<(), io::Error> {
     let files = TestFiles::complicated();
-    // Width of each column in the output table
-    let width = 14;
-    // Width of the longest file name, used for formatting the first column
-    let fixture_width = files.files().iter().map(|file| file.file_name.len()).max().unwrap();
 
-    // Table header, which should be same for each file
-    let table_header = format_table_header(fixture_width, width);
-
-    let mut parser_out = table_header.clone();
-    let mut semantic_out = table_header.clone();
-    let mut transformer_out = table_header.clone();
-    let mut minifier_out = table_header.clone();
-    let mut formatter_out = table_header;
+    let mut parser_out = String::new();
+    let mut semantic_out = String::new();
+    let mut transformer_out = String::new();
+    let mut minifier_out = String::new();
+    let mut formatter_out = String::new();
 
     let mut allocator = Allocator::default();
 
@@ -193,24 +187,20 @@ pub fn run() -> Result<(), io::Error> {
             parsed
         });
 
-        parser_out.push_str(&format_table_row(
+        parser_out.push_str(&format_stats(
             file.file_name.as_str(),
             file.source_text.len(),
             &parser_stats,
-            fixture_width,
-            width,
         ));
 
         let ((), semantic_stats) = record_stats_in(&allocator, || {
             let _ = SemanticBuilder::new().with_enum_eval(true).build(&parsed.program);
         });
 
-        semantic_out.push_str(&format_table_row(
+        semantic_out.push_str(&format_stats(
             file.file_name.as_str(),
             file.source_text.len(),
             &semantic_stats,
-            fixture_width,
-            width,
         ));
 
         // Match the production compiler path for transforms: transformers add scopes, symbols, and
@@ -233,24 +223,20 @@ pub fn run() -> Result<(), io::Error> {
             .build_with_scoping(scoping, &mut parsed.program);
         });
 
-        transformer_out.push_str(&format_table_row(
+        transformer_out.push_str(&format_stats(
             file.file_name.as_str(),
             file.source_text.len(),
             &transformer_stats,
-            fixture_width,
-            width,
         ));
 
         let ((), minifier_stats) = record_stats_in(&allocator, || {
             Minifier::new(minifier_options).minify(&allocator, &mut parsed.program);
         });
 
-        minifier_out.push_str(&format_table_row(
+        minifier_out.push_str(&format_stats(
             file.file_name.as_str(),
             file.source_text.len(),
             &minifier_stats,
-            fixture_width,
-            width,
         ));
 
         // Formatter runs on a freshly-parsed AST (not after transformer/minifier),
@@ -268,12 +254,10 @@ pub fn run() -> Result<(), io::Error> {
                 .into_code()
         });
 
-        formatter_out.push_str(&format_table_row(
+        formatter_out.push_str(&format_stats(
             file.file_name.as_str(),
             file.source_text.len(),
             &formatter_stats,
-            fixture_width,
-            width,
         ));
     }
 
@@ -339,40 +323,26 @@ where
     (result, diff_stats)
 }
 
-/// Formats a single row of the allocator stats table
-fn format_table_row(
-    file_name: &str,
-    file_size: usize,
-    stats: &AllocatorStats,
-    fixture_width: usize,
-    width: usize,
-) -> String {
-    format!(
-        "{:fixture_width$} | {:width$} || {:width$} | {:width$} || {:width$} | {:width$}\n\n",
-        file_name,
-        format_size(file_size, DECIMAL),
-        stats.sys_allocs,
-        stats.sys_reallocs,
-        stats.arena_allocs,
-        stats.arena_reallocs,
-        fixture_width = fixture_width,
-        width = width
-    )
-}
+/// Formats the allocator stats for one file as a block of `label: value` lines.
+///
+/// One value per line, with no column alignment, so that a change to one value produces
+/// a one-line diff, and adding a new value later doesn't reformat existing lines.
+/// File names stay at column 0 so they appear in git hunk headers.
+fn format_stats(file_name: &str, file_size: usize, stats: &AllocatorStats) -> String {
+    let values = [
+        ("file size", format_size(file_size, DECIMAL)),
+        ("sys allocs", stats.sys_allocs.to_string()),
+        ("sys reallocs", stats.sys_reallocs.to_string()),
+        ("arena allocs", stats.arena_allocs.to_string()),
+        ("arena reallocs", stats.arena_reallocs.to_string()),
+    ];
 
-fn format_table_header(fixture_width: usize, width: usize) -> String {
-    let mut out = format!(
-        "{:fixture_width$} | {:width$} || {:width$} | {:width$} || {:width$} | {:width$} \n",
-        "File",
-        "File size",
-        "Sys allocs",
-        "Sys reallocs",
-        "Arena allocs",
-        "Arena reallocs",
-        fixture_width = fixture_width,
-        width = width
-    );
-    out.push_str(&str::repeat("-", width * 6 + fixture_width + 13));
+    let mut out = String::new();
+    out.push_str(file_name);
+    out.push('\n');
+    for (label, value) in values {
+        writeln!(out, "  {label}: {value}").unwrap();
+    }
     out.push('\n');
     out
 }


### PR DESCRIPTION
Replaces the wide table in `tasks/track_memory_allocations/allocs_*.snap` with one vertical block per file, one `label: value` line per metric:

```
checker.ts
  file size: 2.92 MB
  sys allocs: 1818
  sys reallocs: 10
  arena allocs: 264366
  arena reallocs: 22860
```

Motivation:

- A changed counter now produces a one-line diff for exactly that metric, instead of a rewritten table row where you have to spot which of six columns moved. File names stay at column 0 so they show up in git hunk headers.
- No column alignment means adding a metric never reformats existing lines. New values are a single entry in the `(label, value)` array in `format_stats`, so the format extends without churn — more values coming later.

Snapshot values are byte-identical to before; only the layout changed. The header/width plumbing in `lib.rs` is gone (net −30 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)