### PR TITLE
feat(track-memory-allocations): add total heap allocated bytes

### DIFF
--- a/tasks/track_memory_allocations/allocs_formatter.snap
+++ b/tasks/track_memory_allocations/allocs_formatter.snap
@@ -2,6 +2,7 @@ checker.ts
   file size: 2.92 MB
   sys allocs: 11013
   sys reallocs: 492
+  sys alloc bytes: 5967253 (5.97 MB)
   arena allocs: 1081815
   arena reallocs: 118690
   arena size: 138513120 (138.51 MB)
@@ -10,6 +11,7 @@ App.tsx
   file size: 415.34 kB
   sys allocs: 2532
   sys reallocs: 80
+  sys alloc bytes: 993614 (993.61 kB)
   arena allocs: 212668
   arena reallocs: 25343
   arena size: 29608728 (29.61 MB)
@@ -18,6 +20,7 @@ RadixUIAdoptionSection.jsx
   file size: 2.52 kB
   sys allocs: 54
   sys reallocs: 26
+  sys alloc bytes: 13624 (13.62 kB)
   arena allocs: 1155
   arena reallocs: 157
   arena size: 210080 (210.08 kB)
@@ -26,6 +29,7 @@ pdf.mjs
   file size: 567.30 kB
   sys allocs: 4019
   sys reallocs: 172
+  sys alloc bytes: 2632904 (2.63 MB)
   arena allocs: 437639
   arena reallocs: 43489
   arena size: 44872280 (44.87 MB)
@@ -34,6 +38,7 @@ antd.js
   file size: 6.69 MB
   sys allocs: 34121
   sys reallocs: 3994
+  sys alloc bytes: 27684464 (27.68 MB)
   arena allocs: 2586207
   arena reallocs: 302459
   arena size: 525725120 (525.73 MB)
@@ -42,6 +47,7 @@ binder.ts
   file size: 193.08 kB
   sys allocs: 457
   sys reallocs: 35
+  sys alloc bytes: 293645 (293.64 kB)
   arena allocs: 64083
   arena reallocs: 6932
   arena size: 8574792 (8.57 MB)
@@ -50,6 +56,7 @@ kitchen-sink.tsx
   file size: 732.90 kB
   sys allocs: 9565
   sys reallocs: 2815
+  sys alloc bytes: 3979499 (3.98 MB)
   arena allocs: 569911
   arena reallocs: 60147
   arena size: 57887152 (57.89 MB)

--- a/tasks/track_memory_allocations/allocs_minifier.snap
+++ b/tasks/track_memory_allocations/allocs_minifier.snap
@@ -2,6 +2,7 @@ checker.ts
   file size: 2.92 MB
   sys allocs: 155
   sys reallocs: 5
+  sys alloc bytes: 15437268 (15.44 MB)
   arena allocs: 152755
   arena reallocs: 28253
   arena size: 19046592 (19.05 MB)
@@ -10,6 +11,7 @@ App.tsx
   file size: 415.34 kB
   sys allocs: 63
   sys reallocs: 8
+  sys alloc bytes: 2202365 (2.20 MB)
   arena allocs: 17028
   arena reallocs: 2702
   arena size: 2915632 (2.92 MB)
@@ -18,6 +20,7 @@ RadixUIAdoptionSection.jsx
   file size: 2.52 kB
   sys allocs: 21
   sys reallocs: 0
+  sys alloc bytes: 17368 (17.37 kB)
   arena allocs: 32
   arena reallocs: 6
   arena size: 35792 (35.79 kB)
@@ -26,6 +29,7 @@ pdf.mjs
   file size: 567.30 kB
   sys allocs: 2469
   sys reallocs: 205
+  sys alloc bytes: 5864075 (5.86 MB)
   arena allocs: 47471
   arena reallocs: 7742
   arena size: 6356576 (6.36 MB)
@@ -34,6 +38,7 @@ antd.js
   file size: 6.69 MB
   sys allocs: 1044
   sys reallocs: 56
+  sys alloc bytes: 32022901 (32.02 MB)
   arena allocs: 372632
   arena reallocs: 76745
   arena size: 49033120 (49.03 MB)
@@ -42,6 +47,7 @@ binder.ts
   file size: 193.08 kB
   sys allocs: 33
   sys reallocs: 1
+  sys alloc bytes: 988478 (988.48 kB)
   arena allocs: 7076
   arena reallocs: 824
   arena size: 1157992 (1.16 MB)
@@ -50,6 +56,7 @@ kitchen-sink.tsx
   file size: 732.90 kB
   sys allocs: 2309
   sys reallocs: 175
+  sys alloc bytes: 5779412 (5.78 MB)
   arena allocs: 88129
   arena reallocs: 15654
   arena size: 10190448 (10.19 MB)

--- a/tasks/track_memory_allocations/allocs_parser.snap
+++ b/tasks/track_memory_allocations/allocs_parser.snap
@@ -2,6 +2,7 @@ checker.ts
   file size: 2.92 MB
   sys allocs: 1818
   sys reallocs: 10
+  sys alloc bytes: 69339 (69.34 kB)
   arena allocs: 264366
   arena reallocs: 22860
   arena size: 12985208 (12.99 MB)
@@ -10,6 +11,7 @@ App.tsx
   file size: 415.34 kB
   sys allocs: 360
   sys reallocs: 13
+  sys alloc bytes: 52555 (52.55 kB)
   arena allocs: 44464
   arena reallocs: 3537
   arena size: 2244536 (2.24 MB)
@@ -18,6 +20,7 @@ RadixUIAdoptionSection.jsx
   file size: 2.52 kB
   sys allocs: 1
   sys reallocs: 0
+  sys alloc bytes: 116 (116 B)
   arena allocs: 367
   arena reallocs: 66
   arena size: 21232 (21.23 kB)
@@ -26,6 +29,7 @@ pdf.mjs
   file size: 567.30 kB
   sys allocs: 337
   sys reallocs: 67
+  sys alloc bytes: 49230 (49.23 kB)
   arena allocs: 90583
   arena reallocs: 8153
   arena size: 4559920 (4.56 MB)
@@ -34,6 +38,7 @@ antd.js
   file size: 6.69 MB
   sys allocs: 3661
   sys reallocs: 221
+  sys alloc bytes: 304001 (304.00 kB)
   arena allocs: 528577
   arena reallocs: 55355
   arena size: 29421920 (29.42 MB)
@@ -42,6 +47,7 @@ binder.ts
   file size: 193.08 kB
   sys allocs: 85
   sys reallocs: 0
+  sys alloc bytes: 3024 (3.02 kB)
   arena allocs: 16620
   arena reallocs: 1476
   arena size: 917456 (917.46 kB)
@@ -50,6 +56,7 @@ kitchen-sink.tsx
   file size: 732.90 kB
   sys allocs: 2051
   sys reallocs: 160
+  sys alloc bytes: 140276 (140.28 kB)
   arena allocs: 138059
   arena reallocs: 11905
   arena size: 6495856 (6.50 MB)

--- a/tasks/track_memory_allocations/allocs_semantic.snap
+++ b/tasks/track_memory_allocations/allocs_semantic.snap
@@ -2,6 +2,7 @@ checker.ts
   file size: 2.92 MB
   sys allocs: 46
   sys reallocs: 0
+  sys alloc bytes: 3867118 (3.87 MB)
   arena allocs: 0
   arena reallocs: 0
   arena size: 12985208 (12.99 MB)
@@ -10,6 +11,7 @@ App.tsx
   file size: 415.34 kB
   sys allocs: 7
   sys reallocs: 0
+  sys alloc bytes: 360848 (360.85 kB)
   arena allocs: 0
   arena reallocs: 0
   arena size: 2244536 (2.24 MB)
@@ -18,6 +20,7 @@ RadixUIAdoptionSection.jsx
   file size: 2.52 kB
   sys allocs: 7
   sys reallocs: 0
+  sys alloc bytes: 2748 (2.75 kB)
   arena allocs: 0
   arena reallocs: 0
   arena size: 21232 (21.23 kB)
@@ -26,6 +29,7 @@ pdf.mjs
   file size: 567.30 kB
   sys allocs: 12
   sys reallocs: 0
+  sys alloc bytes: 833750 (833.75 kB)
   arena allocs: 0
   arena reallocs: 0
   arena size: 4559920 (4.56 MB)
@@ -34,6 +38,7 @@ antd.js
   file size: 6.69 MB
   sys allocs: 24
   sys reallocs: 0
+  sys alloc bytes: 5513070 (5.51 MB)
   arena allocs: 0
   arena reallocs: 0
   arena size: 29421920 (29.42 MB)
@@ -42,6 +47,7 @@ binder.ts
   file size: 193.08 kB
   sys allocs: 14
   sys reallocs: 0
+  sys alloc bytes: 247066 (247.07 kB)
   arena allocs: 0
   arena reallocs: 0
   arena size: 917456 (917.46 kB)
@@ -50,6 +56,7 @@ kitchen-sink.tsx
   file size: 732.90 kB
   sys allocs: 33
   sys reallocs: 0
+  sys alloc bytes: 1104078 (1.10 MB)
   arena allocs: 0
   arena reallocs: 0
   arena size: 6495856 (6.50 MB)

--- a/tasks/track_memory_allocations/allocs_transformer.snap
+++ b/tasks/track_memory_allocations/allocs_transformer.snap
@@ -2,6 +2,7 @@ checker.ts
   file size: 2.92 MB
   sys allocs: 18
   sys reallocs: 0
+  sys alloc bytes: 2375 (2.38 kB)
   arena allocs: 1959
   arena reallocs: 5
   arena size: 13073904 (13.07 MB)
@@ -10,6 +11,7 @@ App.tsx
   file size: 415.34 kB
   sys allocs: 23
   sys reallocs: 2
+  sys alloc bytes: 2900 (2.90 kB)
   arena allocs: 618
   arena reallocs: 17
   arena size: 2277824 (2.28 MB)
@@ -18,6 +20,7 @@ RadixUIAdoptionSection.jsx
   file size: 2.52 kB
   sys allocs: 19
   sys reallocs: 2
+  sys alloc bytes: 2296 (2.30 kB)
   arena allocs: 258
   arena reallocs: 13
   arena size: 34648 (34.65 kB)
@@ -26,6 +29,7 @@ pdf.mjs
   file size: 567.30 kB
   sys allocs: 13
   sys reallocs: 0
+  sys alloc bytes: 1610 (1.61 kB)
   arena allocs: 2
   arena reallocs: 0
   arena size: 4559944 (4.56 MB)
@@ -34,6 +38,7 @@ antd.js
   file size: 6.69 MB
   sys allocs: 13
   sys reallocs: 0
+  sys alloc bytes: 1611 (1.61 kB)
   arena allocs: 2
   arena reallocs: 0
   arena size: 29421944 (29.42 MB)
@@ -42,6 +47,7 @@ binder.ts
   file size: 193.08 kB
   sys allocs: 15
   sys reallocs: 0
+  sys alloc bytes: 1625 (1.62 kB)
   arena allocs: 154
   arena reallocs: 0
   arena size: 924296 (924.30 kB)
@@ -50,6 +56,7 @@ kitchen-sink.tsx
   file size: 732.90 kB
   sys allocs: 182
   sys reallocs: 3
+  sys alloc bytes: 17698 (17.70 kB)
   arena allocs: 6132
   arena reallocs: 280
   arena size: 6829952 (6.83 MB)

--- a/tasks/track_memory_allocations/src/lib.rs
+++ b/tasks/track_memory_allocations/src/lib.rs
@@ -43,7 +43,11 @@ impl AtomicCounter {
     }
 
     fn increment(&self) {
-        self.0.update(SeqCst, SeqCst, |count| count.saturating_add(1));
+        self.add(1);
+    }
+
+    fn add(&self, n: usize) {
+        self.0.update(SeqCst, SeqCst, |count| count.saturating_add(n));
     }
 
     fn reset(&self) {
@@ -55,10 +59,19 @@ impl AtomicCounter {
 static NUM_ALLOC: AtomicCounter = AtomicCounter::new();
 /// Number of system reallocations
 static NUM_REALLOC: AtomicCounter = AtomicCounter::new();
+/// Total number of bytes requested from the system allocator.
+/// Each `realloc` counts its full `new_size`, not just the growth.
+// NOTE: Byte totals vary between platforms (allocation sizes depend on target type layout,
+// e.g. hashbrown tables are wider on x86_64 than aarch64), while allocation *counts* are
+// identical everywhere. Snapshots record the byte values from CI's platform (Linux x64).
+// After regenerating on another platform, expect diffs on byte-value lines only, and take
+// those lines from the CI job's diff output.
+static NUM_ALLOC_BYTES: AtomicCounter = AtomicCounter::new();
 
 fn reset_global_allocs() {
     NUM_ALLOC.reset();
     NUM_REALLOC.reset();
+    NUM_ALLOC_BYTES.reset();
 }
 
 // SAFETY: Methods simply delegate to `MiMalloc` allocator to ensure that the allocator
@@ -69,6 +82,7 @@ unsafe impl GlobalAlloc for TrackedAllocator {
         let ret = unsafe { MiMalloc.alloc(layout) };
         if !ret.is_null() {
             NUM_ALLOC.increment();
+            NUM_ALLOC_BYTES.add(layout.size());
         }
         ret
     }
@@ -81,6 +95,7 @@ unsafe impl GlobalAlloc for TrackedAllocator {
         let ret = unsafe { MiMalloc.alloc_zeroed(layout) };
         if !ret.is_null() {
             NUM_ALLOC.increment();
+            NUM_ALLOC_BYTES.add(layout.size());
         }
         ret
     }
@@ -89,6 +104,7 @@ unsafe impl GlobalAlloc for TrackedAllocator {
         let ret = unsafe { MiMalloc.realloc(ptr, layout, new_size) };
         if !ret.is_null() {
             NUM_REALLOC.increment();
+            NUM_ALLOC_BYTES.add(new_size);
         }
         ret
     }
@@ -114,10 +130,17 @@ struct AllocatorStats {
     sys_allocs: usize,
     /// Number of reallocations made by system allocator
     sys_reallocs: usize,
+    /// Total bytes allocated by system allocator, excluding arena chunk allocations.
+    /// Each reallocation counts its full new size, not just the growth.
+    sys_alloc_bytes: usize,
     /// Number of chunks arenas have requested from the system allocator.
     /// Tracked separately so chunk allocations can be excluded from `sys_allocs`
     /// (see `record_stats_diff`). Not printed in snapshots because the count is platform-dependent.
     arena_chunk_allocs: usize,
+    /// Total bytes of chunks arenas have requested from the system allocator.
+    /// Tracked separately so chunk bytes can be excluded from `sys_alloc_bytes`,
+    /// for the same reason as `arena_chunk_allocs`. Not printed in snapshots.
+    arena_chunk_alloc_bytes: usize,
     /// Number of allocations made by arena allocator
     arena_allocs: usize,
     /// Number of reallocations made by arena allocator
@@ -265,14 +288,23 @@ pub fn run() -> Result<(), io::Error> {
 fn record_stats(allocator: &Allocator) -> AllocatorStats {
     let sys_allocs = NUM_ALLOC.get();
     let sys_reallocs = NUM_REALLOC.get();
+    let sys_alloc_bytes = NUM_ALLOC_BYTES.get();
     #[cfg(not(feature = "is_all_features"))]
-    let ((arena_allocs, arena_reallocs), (arena_chunk_allocs, _arena_chunk_alloc_bytes)) =
+    let ((arena_allocs, arena_reallocs), (arena_chunk_allocs, arena_chunk_alloc_bytes)) =
         (allocator.get_allocation_stats(), Allocator::global_chunk_allocation_stats());
     #[cfg(feature = "is_all_features")]
-    let ((arena_allocs, arena_reallocs), (arena_chunk_allocs, _arena_chunk_alloc_bytes)) =
+    let ((arena_allocs, arena_reallocs), (arena_chunk_allocs, arena_chunk_alloc_bytes)) =
         ((0, 0), (0, 0));
 
-    AllocatorStats { sys_allocs, sys_reallocs, arena_chunk_allocs, arena_allocs, arena_reallocs }
+    AllocatorStats {
+        sys_allocs,
+        sys_reallocs,
+        sys_alloc_bytes,
+        arena_chunk_allocs,
+        arena_chunk_alloc_bytes,
+        arena_allocs,
+        arena_reallocs,
+    }
 }
 
 /// Record current allocation stats since the last recorded stats in `prev`. This is useful
@@ -287,13 +319,20 @@ fn record_stats_diff(allocator: &Allocator, prev: &AllocatorStats) -> AllocatorS
     // close to a chunk boundary on one platform (see #22621 for a previous instance).
     // All other allocation classes grow on element counts, which are identical on all platforms.
     let arena_chunk_allocs = stats.arena_chunk_allocs.saturating_sub(prev.arena_chunk_allocs);
+    let arena_chunk_alloc_bytes =
+        stats.arena_chunk_alloc_bytes.saturating_sub(prev.arena_chunk_alloc_bytes);
     AllocatorStats {
         sys_allocs: stats
             .sys_allocs
             .saturating_sub(prev.sys_allocs)
             .saturating_sub(arena_chunk_allocs),
         sys_reallocs: stats.sys_reallocs.saturating_sub(prev.sys_reallocs),
+        sys_alloc_bytes: stats
+            .sys_alloc_bytes
+            .saturating_sub(prev.sys_alloc_bytes)
+            .saturating_sub(arena_chunk_alloc_bytes),
         arena_chunk_allocs,
+        arena_chunk_alloc_bytes,
         arena_allocs: stats.arena_allocs.saturating_sub(prev.arena_allocs),
         arena_reallocs: stats.arena_reallocs.saturating_sub(prev.arena_reallocs),
     }
@@ -323,6 +362,7 @@ fn format_stats(file: &TestFile, stats: &StageStats) -> String {
         ("file size", format_size(file.source_text.len(), DECIMAL)),
         ("sys allocs", counters.sys_allocs.to_string()),
         ("sys reallocs", counters.sys_reallocs.to_string()),
+        ("sys alloc bytes", format_bytes(counters.sys_alloc_bytes)),
         ("arena allocs", counters.arena_allocs.to_string()),
         ("arena reallocs", counters.arena_reallocs.to_string()),
         ("arena size", format_bytes(stats.arena_used_bytes)),


### PR DESCRIPTION
Third of three PRs splitting the byte-metrics work (stacked on the chunk-alloc-bytes PR).

Adds a `sys alloc bytes` value to each per-file block: total bytes requested from the system allocator during the stage. Each `realloc` counts its full new size. Arena chunk allocations are excluded using the chunk byte totals from the previous PR, mirroring the existing exclusion of chunk counts from `sys allocs`.

```
checker.ts
  file size: 2.92 MB
  sys allocs: 1818
  sys reallocs: 10
  sys alloc bytes: 69339 (69.34 kB)
  arena allocs: 264366
  arena reallocs: 22860
  arena size: 12985208 (12.99 MB)
```

Byte-value lines record Linux x64 (CI) values per the policy established in the arena-size PR; the cross-platform behavior is documented in the source next to the byte counter. The first CI run of the combined change confirmed only byte lines differ between platforms — counts are identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)