### PR TITLE
refactor(react_compiler): use unstable sorts

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -2715,7 +2715,7 @@ fn ox_add_imports_to_program<'a>(
     }
 
     let mut sorted_modules: Vec<_> = imports.iter().collect();
-    sorted_modules.sort_by_key(|(a, _)| a.cow_to_lowercase());
+    sorted_modules.sort_unstable_by_key(|(a, _)| a.cow_to_lowercase());
 
     let is_module = matches!(program.source_type.module_kind(), oxc_span::ModuleKind::Module);
 
@@ -2723,7 +2723,7 @@ fn ox_add_imports_to_program<'a>(
 
     for (module_name, imports_map) in sorted_modules {
         let mut sorted_imports: Vec<_> = imports_map.values().collect();
-        sorted_imports.sort_by(|a, b| a.imported.as_str().cmp(b.imported.as_str()));
+        sorted_imports.sort_unstable_by(|a, b| a.imported.as_str().cmp(b.imported.as_str()));
 
         if let Some(&idx) = existing_import_indices.get(module_name.as_str()) {
             // Merge into the existing import declaration.

--- a/crates/oxc_react_compiler/src/react_compiler_inference/build_reactive_scope_terminals_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/build_reactive_scope_terminals_hir.rs
@@ -110,7 +110,7 @@ fn collect_scope_rewrites(func: &HirFunction, env: &mut Environment) -> Vec<Term
 
     // Sort: ascending by start, descending by end for ties
     let mut items: Vec<ScopeId> = scope_ids;
-    items.sort_by(|a, b| {
+    items.sort_unstable_by(|a, b| {
         let a_range = &env.scopes[*a].range;
         let b_range = &env.scopes[*b].range;
         let start_diff = a_range.start.cmp(&b_range.start);

--- a/crates/oxc_react_compiler/src/react_compiler_inference/merge_overlapping_reactive_scopes_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/merge_overlapping_reactive_scopes_hir.rs
@@ -153,11 +153,11 @@ fn collect_scope_info(func: &HirFunction, env: &Environment) -> ScopeInfo {
     // Convert to sorted vecs (descending by id for pop-from-end)
     let mut scope_starts: Vec<ScopeStartEntry> =
         scope_starts_map.into_iter().map(|(id, scopes)| ScopeStartEntry { id, scopes }).collect();
-    scope_starts.sort_by_key(|a| std::cmp::Reverse(a.id));
+    scope_starts.sort_unstable_by_key(|a| std::cmp::Reverse(a.id));
 
     let mut scope_ends: Vec<ScopeEndEntry> =
         scope_ends_map.into_iter().map(|(id, scopes)| ScopeEndEntry { id, scopes }).collect();
-    scope_ends.sort_by_key(|a| std::cmp::Reverse(a.id));
+    scope_ends.sort_unstable_by_key(|a| std::cmp::Reverse(a.id));
 
     ScopeInfo { scope_starts, scope_ends, place_scopes }
 }
@@ -176,7 +176,7 @@ fn visit_instruction_id(
     if let Some(scope_end_entry) = scope_info.scope_ends.pop_if(|top| top.id <= id) {
         // Sort scopes by start descending (matching active_scopes order)
         let mut scopes_sorted = scope_end_entry.scopes;
-        scopes_sorted.sort_by(|a, b| {
+        scopes_sorted.sort_unstable_by(|a, b| {
             let a_start = env.scopes[*a].range.start;
             let b_start = env.scopes[*b].range.start;
             b_start.cmp(&a_start)
@@ -200,7 +200,7 @@ fn visit_instruction_id(
     if let Some(scope_start_entry) = scope_info.scope_starts.pop_if(|top| top.id <= id) {
         // Sort by end descending
         let mut scopes_sorted = scope_start_entry.scopes;
-        scopes_sorted.sort_by(|a, b| {
+        scopes_sorted.sort_unstable_by(|a, b| {
             let a_end = env.scopes[*a].range.end;
             let b_end = env.scopes[*b].range.end;
             b_end.cmp(&a_end)

--- a/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
@@ -1435,7 +1435,7 @@ impl<'a> ReactiveScopeDependencyTreeHIR<'a> {
         // instruction-based entries, and the first insertion determines the
         // root access type.
         let mut sorted_deps: Vec<&ReactiveScopeDependency> = hoistable_objects.collect();
-        sorted_deps.sort_by(|a, b| {
+        sorted_deps.sort_unstable_by(|a, b| {
             let a_optional = !a.path.is_empty() && a.path[0].optional;
             let b_optional = !b.path.is_empty() && b.path[0].optional;
             b_optional.cmp(&a_optional)

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -419,7 +419,7 @@ fn lower_block_statement_inner<'a>(
         }
 
         // Sort by first reference position to match TS traversal order
-        will_hoist.sort_by_key(|h| h.first_ref_span.start);
+        will_hoist.sort_unstable_by_key(|h| h.first_ref_span.start);
 
         // Emit DeclareContext for hoisted bindings
         for info in &will_hoist {
@@ -3343,7 +3343,7 @@ fn gather_captured_context(
     // Sort captured entries by source position so context declarations appear
     // in source order, matching the TS compiler's position-ordered traversal.
     let mut sorted: Vec<_> = captured.into_iter().collect();
-    sorted.sort_by_key(|(_, (pos, _))| *pos);
+    sorted.sort_unstable_by_key(|(_, (pos, _))| *pos);
 
     sorted.into_iter().map(|(sid, (_, span))| (sid, span)).collect()
 }

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/outline_jsx.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/outline_jsx.rs
@@ -204,7 +204,7 @@ fn process_and_outline_jsx<'a>(
         return;
     }
     // Sort by eval order ascending (TS: sort by a.id - b.id)
-    jsx_group.sort_by_key(|j| j.eval_order);
+    jsx_group.sort_unstable_by_key(|j| j.eval_order);
 
     let result = process_jsx_group(func, env, jsx_group, globals);
     if let Some(result) = result {

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
@@ -682,7 +682,7 @@ fn ox_codegen_reactive_scope<'a>(
     let mut change_exprs: Vec<oxc::Expression<'a>> = Vec::new();
 
     let mut deps = scope_deps;
-    deps.sort_by(|a, b| compare_scope_dependency(a, b, cx.env));
+    deps.sort_unstable_by(|a, b| compare_scope_dependency(a, b, cx.env));
 
     for dep in &deps {
         let index = cx.alloc_cache_index();
@@ -716,7 +716,7 @@ fn ox_codegen_reactive_scope<'a>(
     let mut first_output_index: Option<u32> = None;
 
     let mut decls = scope_decls;
-    decls.sort_by(|(_id_a, a), (_id_b, b)| compare_scope_declaration(a, b, cx.env));
+    decls.sort_unstable_by(|(_id_a, a), (_id_b, b)| compare_scope_declaration(a, b, cx.env));
 
     for (_ident_id, decl) in &decls {
         let index = cx.alloc_cache_index();

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_exhaustive_dependencies.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_exhaustive_dependencies.rs
@@ -1098,7 +1098,7 @@ fn validate_dependencies(
     types: &IndexSlice<TypeId, [Type<'_>]>,
 ) -> Result<Option<OxcDiagnostic>, OxcDiagnostic> {
     // Sort dependencies by name and path
-    inferred.sort_by(|a, b| {
+    inferred.sort_unstable_by(|a, b| {
         match (a, b) {
             (
                 InferredDependency::Global { binding: ab },


### PR DESCRIPTION
Mechanical migration of all 14 stable sort calls in `oxc_react_compiler` to their unstable variants: 8 `.sort_by()` to `.sort_unstable_by()` and 6 `.sort_by_key()` to `.sort_unstable_by_key()`.

Unstable sort avoids the stable sort's temporary allocation and is the repo-wide convention where stability isn't required. Sorted outputs were checked against the full fixture snapshot corpus (`cargo test -p oxc_react_compiler`, insta-based over the upstream fixtures) and are unchanged, so no call site observably relies on stable-sort tie ordering. All sites were migrated; none needed to be kept stable.

Binary size is unchanged (measured at opt-level 3 with fat LTO); this is a code hygiene/consistency change, not a size optimization.

Note for future re-syncs with upstream `react_compiler_oxc`: this is a systematic porting rule — JS `Array.prototype.sort` (stable) becomes Rust `sort_unstable*` unless tie order is observable in output, in which case the stable variant is kept with a comment. Re-apply the rule when re-vendoring.

Authored with Claude Code; reviewed by a human before merge.
