### PR TITLE
refactor(react_compiler): merge lowering pre-pass visitors into one walk

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -22,12 +22,11 @@ use oxc_span::{GetSpan, Span};
 use oxc_str::{Ident, Str, format_ident};
 
 use crate::react_compiler_lowering::FunctionNode;
-use crate::react_compiler_lowering::find_context_identifiers::find_context_identifiers;
 use crate::react_compiler_lowering::hir_builder::HirBuilder;
 use crate::react_compiler_lowering::hir_builder::is_always_reserved_word;
 use crate::react_compiler_lowering::hir_builder::reserved_identifier_diagnostic;
 use crate::react_compiler_lowering::identifier_loc_index::IdentifierLocIndex;
-use crate::react_compiler_lowering::identifier_loc_index::build_identifier_loc_index;
+use crate::react_compiler_lowering::pre_pass::run_pre_passes;
 
 fn validate_ts_this_parameter(
     scope: &ScopeResolver<'_, '_>,
@@ -567,11 +566,10 @@ pub fn lower<'a>(
 
     validate_ts_this_parameters_within(scope, scope_id)?;
 
-    // Build identifier location index from the AST (replaces serialized referenceLocs/jsxReferencePositions)
-    let identifier_spans = build_identifier_loc_index(func);
-
-    // Pre-compute context identifiers: variables captured across function boundaries
-    let context_identifiers = find_context_identifiers(func, scope, &identifier_spans)?;
+    // Build the identifier location index from the AST (replaces serialized
+    // referenceLocs/jsxReferencePositions) and pre-compute context identifiers
+    // (variables captured across function boundaries) in one shared walk.
+    let (identifier_spans, context_identifiers) = run_pre_passes(func, scope)?;
 
     // For top-level functions, context is empty (no captured refs)
     let context_map: FxIndexMap<SymbolId, Option<Span>> = FxIndexMap::default();

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/find_context_identifiers.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/find_context_identifiers.rs
@@ -13,16 +13,19 @@
 //! * a `function_stack` of the inner function scopes currently being walked
 //!   (empty at the top level of the function being compiled).
 //!
-//! The `VisitJs` impl below reproduces both stacks exactly: the generic stack is
-//! pushed for every scope-creating node the original `AstWalker` pushed for
-//! (functions, arrows, blocks, for-loops, switch, catch, class static blocks),
-//! while the function stack is pushed only for nested function nodes — mirroring
-//! the original `enter_function_*` / `enter_object_method` hooks.
+//! The shared walk in [`super::pre_pass`] reproduces both stacks exactly: the
+//! generic stack is pushed for every scope-creating node the original
+//! `AstWalker` pushed for (functions, arrows, blocks, for-loops, switch, catch,
+//! class static blocks), while the function stack is pushed only for nested
+//! function nodes — mirroring the original `enter_function_*` /
+//! `enter_object_method` hooks.
 //!
 //! Identifiers inside TS type subtrees are deliberately NOT visited here: the
 //! original walker walked type positions as opaque `RawNode`s, which never fired
-//! `enter_identifier`. `VisitJs` skips type-space natively; enum and namespace
-//! bodies — runtime JS which it WOULD walk — are stubbed out to match the same
+//! `enter_identifier`. This pass was previously driven by `VisitJs`, which skips
+//! type-space natively; the shared driver reproduces that by forwarding events
+//! to this pass only outside TS type subtrees. Enum and namespace bodies —
+//! runtime JS which `VisitJs` WOULD walk — are stubbed out to match the same
 //! RawNode treatment. The post-walk supplement loop (driven by
 //! `ref_node_id_to_binding`, which DOES include type references) recovers any
 //! captured references hiding inside type annotations, matching the TS pass.
@@ -33,17 +36,15 @@ use rustc_hash::FxHashSet;
 use oxc_ast::ast::AssignmentTargetMaybeDefault;
 use oxc_ast::ast::*;
 use oxc_ast::match_assignment_target;
-use oxc_ast_visit::VisitJs;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::Span;
-use oxc_syntax::scope::ScopeFlags;
 
 use crate::diagnostics::ErrorCategory;
 use crate::scope::ScopeId;
 use crate::scope::ScopeResolver;
 use crate::scope::SymbolId;
 
-use crate::react_compiler_lowering::FunctionNode;
+use crate::react_compiler_lowering::identifier_loc_index::IdentifierLocIndex;
 
 #[derive(Default)]
 struct BindingInfo {
@@ -52,7 +53,10 @@ struct BindingInfo {
     referenced_by_inner_fn: bool,
 }
 
-struct ContextIdentifierVisitor<'a> {
+/// State for the `FindContextIdentifiers` pre-pass. The AST walk driving it
+/// lives in [`super::pre_pass`], where it shares a single traversal (and a
+/// single generated-walk instantiation) with the identifier-loc pre-pass.
+pub(super) struct ContextIdentifierVisitor<'a> {
     scope: &'a ScopeResolver<'a, 'a>,
     /// The active scope stack. Initialized with the function-being-compiled's
     /// scope and pushed/popped for every scope-creating node, mirroring the
@@ -66,13 +70,23 @@ struct ContextIdentifierVisitor<'a> {
 }
 
 impl<'a> ContextIdentifierVisitor<'a> {
-    fn current_scope(&self) -> ScopeId {
+    pub(super) fn new(scope: &'a ScopeResolver<'a, 'a>, function_scope: ScopeId) -> Self {
+        Self {
+            scope,
+            scope_stack: vec![function_scope],
+            function_stack: Vec::new(),
+            binding_info: FxHashMap::default(),
+            error: None,
+        }
+    }
+
+    pub(super) fn current_scope(&self) -> ScopeId {
         self.scope_stack.last().copied().unwrap_or_else(|| self.scope.program_scope())
     }
 
     /// Push the generic scope a node creates (its `scope_id` cell), if any.
     /// Returns whether a scope was pushed, so the caller knows whether to pop.
-    fn enter_scope(&mut self, scope: Option<ScopeId>) -> bool {
+    pub(super) fn enter_scope(&mut self, scope: Option<ScopeId>) -> bool {
         if let Some(scope) = scope {
             self.scope_stack.push(scope);
             true
@@ -81,13 +95,13 @@ impl<'a> ContextIdentifierVisitor<'a> {
         }
     }
 
-    fn exit_scope(&mut self, pushed: bool) {
+    pub(super) fn exit_scope(&mut self, pushed: bool) {
         if pushed {
             self.scope_stack.pop();
         }
     }
 
-    fn push_function_scope(&mut self, scope: Option<ScopeId>) -> bool {
+    pub(super) fn push_function_scope(&mut self, scope: Option<ScopeId>) -> bool {
         if let Some(scope) = scope {
             self.function_stack.push(scope);
             true
@@ -96,9 +110,54 @@ impl<'a> ContextIdentifierVisitor<'a> {
         }
     }
 
-    fn pop_function_scope(&mut self, pushed: bool) {
+    pub(super) fn pop_function_scope(&mut self, pushed: bool) {
         if pushed {
             self.function_stack.pop();
+        }
+    }
+
+    pub(super) fn has_error(&self) -> bool {
+        self.error.is_some()
+    }
+
+    /// The captured-reference check for a resolved identifier reference.
+    pub(super) fn enter_identifier_reference(&mut self, it: &IdentifierReference<'_>) {
+        self.check_captured_symbol(self.scope.resolve_reference(it));
+    }
+
+    /// Mirrors the original `enter_identifier`, which fired on pattern
+    /// binding identifiers too. Only the declaration site of a captured
+    /// binding resolves; everything else is a no-op.
+    pub(super) fn enter_binding_identifier(&mut self, it: &BindingIdentifier<'_>) {
+        self.check_captured_symbol(self.scope.resolve_binding_identifier(it));
+    }
+
+    /// Fire the capture check for the identifier references in a JSX element
+    /// name, mirroring `walk_js::walk_jsx_element_name` combined with this
+    /// pass's original overrides: `JSXIdentifier`s (lowercase tag names,
+    /// member-expression parts) carry no reference, namespaced names were
+    /// explicitly skipped, and `this` never resolves — all no-ops. Used for
+    /// closing elements, which only this pass's original `VisitJs` walk
+    /// visited (the identifier-loc walk has no closing-element handling).
+    pub(super) fn check_jsx_element_name(&mut self, name: &JSXElementName<'_>) {
+        match name {
+            JSXElementName::IdentifierReference(id) => self.enter_identifier_reference(id),
+            JSXElementName::MemberExpression(m) => self.check_jsx_member_expression(m),
+            JSXElementName::Identifier(_)
+            | JSXElementName::ThisExpression(_)
+            | JSXElementName::NamespacedName(_) => {}
+        }
+    }
+
+    fn check_jsx_member_expression(&mut self, expr: &JSXMemberExpression<'_>) {
+        match &expr.object {
+            JSXMemberExpressionObject::IdentifierReference(id) => {
+                self.enter_identifier_reference(id);
+            }
+            JSXMemberExpressionObject::ThisExpression(_) => {}
+            JSXMemberExpressionObject::MemberExpression(inner) => {
+                self.check_jsx_member_expression(inner);
+            }
         }
     }
 
@@ -117,7 +176,7 @@ impl<'a> ContextIdentifierVisitor<'a> {
         }
     }
 
-    fn handle_reassignment_identifier(&mut self, name: &str, current_scope: ScopeId) {
+    pub(super) fn handle_reassignment_identifier(&mut self, name: &str, current_scope: ScopeId) {
         if let Some(symbol_id) = self.scope.find_binding(current_scope, name) {
             let info = self.binding_info.entry(symbol_id).or_default();
             info.reassigned = true;
@@ -139,166 +198,10 @@ impl<'a> ContextIdentifierVisitor<'a> {
     }
 }
 
-impl<'a> VisitJs<'a> for ContextIdentifierVisitor<'a> {
-    // ---- function scopes (push BOTH the generic scope and the function stack) ----
-
-    fn visit_function(&mut self, it: &Function<'a>, _flags: ScopeFlags) {
-        let scope_pushed = self.enter_scope(it.scope_id.get());
-        let fn_pushed = self.push_function_scope(it.scope_id.get());
-        // The original Babel walker never visited the function NAME identifier
-        // (`it.id`); it only walked the type-bearing parts (as opaque RawNodes),
-        // then params, then body. oxc's `walk_js::walk_function` DOES visit
-        // `it.id` via `visit_binding_identifier`, which — with the inner function
-        // already on `function_stack` — would spuriously mark a hoisted
-        // nested-function name as referenced_by_inner_fn. Walk the parts
-        // manually, skipping `it.id`.
-        self.visit_formal_parameters(&it.params);
-        if let Some(body) = &it.body {
-            self.visit_function_body(body);
-        }
-        self.pop_function_scope(fn_pushed);
-        self.exit_scope(scope_pushed);
-    }
-
-    fn visit_arrow_function_expression(&mut self, it: &ArrowFunctionExpression<'a>) {
-        let scope_pushed = self.enter_scope(it.scope_id.get());
-        let fn_pushed = self.push_function_scope(it.scope_id.get());
-        oxc_ast_visit::walk_js::walk_arrow_function_expression(self, it);
-        self.pop_function_scope(fn_pushed);
-        self.exit_scope(scope_pushed);
-    }
-
-    // ---- non-function scope-creating nodes (push only the generic scope) ----
-
-    fn visit_block_statement(&mut self, it: &BlockStatement<'a>) {
-        let pushed = self.enter_scope(it.scope_id.get());
-        oxc_ast_visit::walk_js::walk_block_statement(self, it);
-        self.exit_scope(pushed);
-    }
-
-    fn visit_for_statement(&mut self, it: &ForStatement<'a>) {
-        let pushed = self.enter_scope(it.scope_id.get());
-        oxc_ast_visit::walk_js::walk_for_statement(self, it);
-        self.exit_scope(pushed);
-    }
-
-    fn visit_for_in_statement(&mut self, it: &ForInStatement<'a>) {
-        let pushed = self.enter_scope(it.scope_id.get());
-        oxc_ast_visit::walk_js::walk_for_in_statement(self, it);
-        self.exit_scope(pushed);
-    }
-
-    fn visit_for_of_statement(&mut self, it: &ForOfStatement<'a>) {
-        let pushed = self.enter_scope(it.scope_id.get());
-        oxc_ast_visit::walk_js::walk_for_of_statement(self, it);
-        self.exit_scope(pushed);
-    }
-
-    fn visit_switch_statement(&mut self, it: &SwitchStatement<'a>) {
-        let pushed = self.enter_scope(it.scope_id.get());
-        oxc_ast_visit::walk_js::walk_switch_statement(self, it);
-        self.exit_scope(pushed);
-    }
-
-    fn visit_catch_clause(&mut self, it: &CatchClause<'a>) {
-        let pushed = self.enter_scope(it.scope_id.get());
-        oxc_ast_visit::walk_js::walk_catch_clause(self, it);
-        self.exit_scope(pushed);
-    }
-
-    fn visit_static_block(&mut self, it: &StaticBlock<'a>) {
-        let pushed = self.enter_scope(it.scope_id.get());
-        oxc_ast_visit::walk_js::walk_static_block(self, it);
-        self.exit_scope(pushed);
-    }
-
-    // ---- identifier references (the captured-reference check) ----
-
-    fn visit_identifier_reference(&mut self, it: &IdentifierReference<'a>) {
-        self.check_captured_symbol(self.scope.resolve_reference(it));
-    }
-
-    fn visit_binding_identifier(&mut self, it: &BindingIdentifier<'a>) {
-        // Mirrors the original `enter_identifier`, which fired on pattern
-        // binding identifiers too. Only the declaration site of a captured
-        // binding resolves; everything else is a no-op.
-        self.check_captured_symbol(self.scope.resolve_binding_identifier(it));
-    }
-
-    fn visit_jsx_identifier(&mut self, _it: &JSXIdentifier<'a>) {
-        // JSXIdentifiers (lowercase tag names, member-expression parts) carry no
-        // reference and never resolved to a binding in the old position map, so
-        // this is a no-op.
-    }
-
-    fn visit_jsx_attribute(&mut self, it: &JSXAttribute<'a>) {
-        // The original `AstWalker.walk_jsx_element` walked only attribute VALUES;
-        // the attribute NAME was never visited. oxc's `walk_jsx_attribute` would
-        // otherwise fire `visit_jsx_identifier` on the name. Visit only the value.
-        if let Some(value) = &it.value {
-            self.visit_jsx_attribute_value(value);
-        }
-    }
-
-    fn visit_jsx_namespaced_name(&mut self, _it: &JSXNamespacedName<'a>) {
-        // The original explicitly skipped JSXNamespacedName (both as an element
-        // name and as an attribute name), never visiting its namespace/name
-        // identifiers. oxc's `walk_jsx_namespaced_name` would visit both.
-    }
-
-    // ---- reassignment tracking ----
-
-    fn visit_assignment_expression(&mut self, it: &AssignmentExpression<'a>) {
-        let current_scope = self.current_scope();
-        if self.error.is_none() {
-            self.walk_assignment_target_for_reassignment(&it.left, current_scope);
-        }
-        oxc_ast_visit::walk_js::walk_assignment_expression(self, it);
-    }
-
-    fn visit_update_expression(&mut self, it: &UpdateExpression<'a>) {
-        if let SimpleAssignmentTarget::AssignmentTargetIdentifier(ident) = &it.argument {
-            let current_scope = self.current_scope();
-            self.handle_reassignment_identifier(&ident.name, current_scope);
-        }
-        oxc_ast_visit::walk_js::walk_update_expression(self, it);
-    }
-
-    // ---- positions deliberately NOT visited, matching the original walker ----
-
-    fn visit_static_member_expression(&mut self, it: &StaticMemberExpression<'a>) {
-        // Non-computed member property names (`a.b` → `b`) were never visited.
-        self.visit_expression(&it.object);
-    }
-
-    fn visit_object_property(&mut self, it: &ObjectProperty<'a>) {
-        // Non-computed object keys were never visited.
-        if it.computed {
-            self.visit_property_key(&it.key);
-        }
-        self.visit_expression(&it.value);
-    }
-
-    fn visit_class(&mut self, _it: &Class<'a>) {
-        // The original walker did not recurse into a class's `super_class`
-        // (extends) clause nor its body members; only the type-bearing parts
-        // were walked, and those carried no `enter_identifier` calls. So the
-        // class contributes nothing to the walker-based capture analysis.
-    }
-
-    // ---- skip enum/namespace bodies (the original walked them as opaque RawNodes) ----
-    // `VisitJs` already prunes type-space, but these two TS containers carry
-    // runtime JS which it WOULD walk, so they still need explicit stubs.
-
-    fn visit_ts_enum_declaration(&mut self, _it: &TSEnumDeclaration<'a>) {}
-
-    fn visit_ts_module_declaration(&mut self, _it: &TSModuleDeclaration<'a>) {}
-}
-
 impl<'a> ContextIdentifierVisitor<'a> {
     /// Recursively walk an assignment target to find all reassignment target
     /// identifiers, mirroring the original `walk_lval_for_reassignment`.
-    fn walk_assignment_target_for_reassignment(
+    pub(super) fn walk_assignment_target_for_reassignment(
         &mut self,
         target: &AssignmentTarget<'a>,
         current_scope: ScopeId,
@@ -405,45 +308,15 @@ fn is_captured_by_function(
 ///   (`reassigned && referencedByInnerFn`)
 ///
 /// This is the Rust equivalent of the TypeScript `FindContextIdentifiers` pass.
-pub fn find_context_identifiers(
-    func: &FunctionNode<'_, '_>,
-    scope: &ScopeResolver<'_, '_>,
-    identifier_spans: &crate::react_compiler_lowering::identifier_loc_index::IdentifierLocIndex,
+/// The AST walk feeding `visitor` runs in [`super::pre_pass`]; this finishes
+/// the analysis from the walk's collected state.
+pub(super) fn find_context_identifiers(
+    visitor: ContextIdentifierVisitor<'_>,
+    identifier_spans: &IdentifierLocIndex,
 ) -> Result<FxHashSet<SymbolId>, OxcDiagnostic> {
-    let func_scope = func.scope_id().unwrap_or_else(|| scope.program_scope());
+    let ContextIdentifierVisitor { scope, mut binding_info, error, .. } = visitor;
 
-    let mut visitor = ContextIdentifierVisitor {
-        scope,
-        scope_stack: vec![func_scope],
-        function_stack: Vec::new(),
-        binding_info: FxHashMap::default(),
-        error: None,
-    };
-
-    // Walk params and body (like Babel's func.traverse()): the function node
-    // itself is not re-entered, so it is never pushed onto `function_stack`.
-    match func {
-        FunctionNode::Function(f) => {
-            visitor.visit_formal_parameters(&f.params);
-            if let Some(body) = &f.body {
-                visitor.visit_function_body(body);
-            }
-        }
-        FunctionNode::Arrow(arrow) => {
-            visitor.visit_formal_parameters(&arrow.params);
-            if arrow.expression {
-                if let Some(Statement::ExpressionStatement(es)) = arrow.body.statements.first() {
-                    visitor.visit_expression(&es.expression);
-                } else {
-                    visitor.visit_function_body(&arrow.body);
-                }
-            } else {
-                visitor.visit_function_body(&arrow.body);
-            }
-        }
-    }
-
-    if let Some(error) = visitor.error {
+    if let Some(error) = error {
         return Err(error);
     }
 
@@ -456,8 +329,7 @@ pub fn find_context_identifiers(
     // nested function scope.
     //
     // Declaration sites are excluded structurally: they are not references.
-    let candidates: Vec<SymbolId> = visitor
-        .binding_info
+    let candidates: Vec<SymbolId> = binding_info
         .iter()
         .filter(|(_, info)| info.reassigned && !info.referenced_by_inner_fn)
         .map(|(&sid, _)| sid)
@@ -475,7 +347,7 @@ pub fn find_context_identifiers(
             let ref_node = scope.reference_node_id(ref_id);
             for fn_scope in scope.containing_function_scopes(ref_node) {
                 if is_captured_by_function(scope, binding_scope, fn_scope) {
-                    visitor.binding_info.get_mut(&symbol_id).unwrap().referenced_by_inner_fn = true;
+                    binding_info.get_mut(&symbol_id).unwrap().referenced_by_inner_fn = true;
                     break 'refs;
                 }
             }
@@ -483,8 +355,7 @@ pub fn find_context_identifiers(
     }
 
     // Collect results
-    Ok(visitor
-        .binding_info
+    Ok(binding_info
         .into_iter()
         .filter(|(_, info)| {
             info.reassigned_by_inner_fn || (info.reassigned && info.referenced_by_inner_fn)

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/identifier_loc_index.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/identifier_loc_index.rs
@@ -9,9 +9,11 @@
 //! (`crate::react_compiler_ast::visitor`). That walker deliberately visited only
 //! a NARROW set of identifier positions, and TS type identifiers came from
 //! `collect_type_idents`, which collected only `IdentifierReference` /
-//! `IdentifierName` (never `BindingIdentifier`). The overrides below restrict the
-//! oxc walk to match those positions instead of relying on oxc's default
-//! full-AST traversal. The traversal records:
+//! `IdentifierName` (never `BindingIdentifier`). The oxc walk driving this pass
+//! lives in [`super::pre_pass`], where it shares a single traversal with
+//! `FindContextIdentifiers`; its overrides restrict the walk to match those
+//! positions instead of relying on oxc's default full-AST traversal. The
+//! traversal records:
 //!
 //! * every identifier reference and (declaration-map) binding identifier
 //! * function / class declaration & expression names, into the declaration map
@@ -32,11 +34,8 @@
 use rustc_hash::FxHashMap;
 
 use oxc_ast::ast::*;
-use oxc_ast_visit::Visit;
 
 use crate::scope::{ReferenceId, SymbolId};
-
-use crate::react_compiler_lowering::FunctionNode;
 
 /// Source location data for a resolved identifier reference.
 pub struct IdentifierLocEntry {
@@ -85,19 +84,23 @@ impl IdentifierLocIndex {
     }
 }
 
-struct IdentifierLocVisitor {
-    index: IdentifierLocIndex,
+/// State for the identifier-loc pre-pass. The AST walk driving it lives in
+/// [`super::pre_pass`], where it shares a single traversal (and a single
+/// generated-walk instantiation) with the `FindContextIdentifiers` pre-pass.
+#[derive(Default)]
+pub(super) struct IdentifierLocVisitor {
+    pub(super) index: IdentifierLocIndex,
     /// Tracks the current JSXOpeningElement's span while walking its name.
-    current_opening_element_span: Option<Span>,
+    pub(super) current_opening_element_span: Option<Span>,
     /// Depth of TS type subtrees currently being walked. Identifiers recorded
     /// while this is non-zero get `in_type_annotation = true`.
-    type_depth: u32,
+    pub(super) type_depth: u32,
 }
 
 impl IdentifierLocVisitor {
     /// `current_opening_element_span` is set only while walking a JSX
     /// element name, so it doubles as the is-JSX signal.
-    fn record_reference(&mut self, ident: &IdentifierReference<'_>) {
+    pub(super) fn record_reference(&mut self, ident: &IdentifierReference<'_>) {
         let Some(reference_id) = ident.reference_id.get() else { return };
         self.index.refs.entry(reference_id).or_insert(IdentifierLocEntry {
             span: ident.span,
@@ -106,211 +109,8 @@ impl IdentifierLocVisitor {
         });
     }
 
-    fn record_declaration(&mut self, ident: &BindingIdentifier<'_>) {
+    pub(super) fn record_declaration(&mut self, ident: &BindingIdentifier<'_>) {
         let Some(symbol_id) = ident.symbol_id.get() else { return };
         self.index.decl_spans.entry(symbol_id).or_insert(ident.span);
     }
-
-    /// Record the JSX element name identifiers (and only those) while the
-    /// `current_opening_element_span` is set, mirroring the original
-    /// `walk_jsx_element_name` / `walk_jsx_member_expression`. Lowercase tag
-    /// names, `this`, and member-property parts carry no reference and are
-    /// never looked up, so only `IdentifierReference` names are recorded.
-    fn record_jsx_element_name<'a>(&mut self, name: &JSXElementName<'a>) {
-        match name {
-            JSXElementName::IdentifierReference(id) => self.record_reference(id),
-            JSXElementName::MemberExpression(m) => self.record_jsx_member_expression(m),
-            JSXElementName::Identifier(_)
-            | JSXElementName::ThisExpression(_)
-            | JSXElementName::NamespacedName(_) => {}
-        }
-    }
-
-    fn record_jsx_member_expression<'a>(&mut self, expr: &JSXMemberExpression<'a>) {
-        match &expr.object {
-            JSXMemberExpressionObject::IdentifierReference(id) => {
-                self.record_reference(id);
-            }
-            JSXMemberExpressionObject::ThisExpression(_) => {}
-            JSXMemberExpressionObject::MemberExpression(inner) => {
-                self.record_jsx_member_expression(inner);
-            }
-        }
-    }
-}
-
-impl<'a> Visit<'a> for IdentifierLocVisitor {
-    fn visit_identifier_reference(&mut self, it: &IdentifierReference<'a>) {
-        self.record_reference(it);
-    }
-
-    fn visit_binding_identifier(&mut self, it: &BindingIdentifier<'a>) {
-        // `collect_type_idents` only collected IdentifierReference / IdentifierName,
-        // never BindingIdentifier, so type-parameter declaration names (`<T>`) and
-        // other binding positions inside type subtrees must not be recorded.
-        if self.type_depth > 0 {
-            return;
-        }
-        self.record_declaration(it);
-    }
-
-    fn visit_class(&mut self, it: &Class<'a>) {
-        // The original immutable walker recorded only the class name and then the
-        // class's type-bearing parts (decorators / implements / type params) as
-        // RawNodes (type idents only). It did NOT walk `super_class` (the extends
-        // clause) nor the class body's method/property members.
-        if let Some(id) = &it.id {
-            self.record_declaration(id);
-        }
-        if let Some(type_parameters) = &it.type_parameters {
-            self.visit_ts_type_parameter_declaration(type_parameters);
-        }
-        if let Some(super_type_arguments) = &it.super_type_arguments {
-            self.visit_ts_type_parameter_instantiation(super_type_arguments);
-        }
-        self.type_depth += 1;
-        self.visit_ts_class_implements_list(&it.implements);
-        self.type_depth -= 1;
-    }
-
-    fn visit_static_member_expression(&mut self, it: &StaticMemberExpression<'a>) {
-        // Original walked the property only when computed; a static member is
-        // non-computed, so the property name is never recorded.
-        self.visit_expression(&it.object);
-    }
-
-    fn visit_object_property(&mut self, it: &ObjectProperty<'a>) {
-        // Original walked the key only when computed.
-        if it.computed {
-            self.visit_property_key(&it.key);
-        }
-        self.visit_expression(&it.value);
-    }
-
-    fn visit_jsx_element(&mut self, it: &JSXElement<'a>) {
-        // Mirror the original walker: the opening element's span is active only
-        // while walking the element name (and its type arguments); it is cleared
-        // before attributes and children.
-        self.current_opening_element_span = Some(it.opening_element.span);
-        self.record_jsx_element_name(&it.opening_element.name);
-        self.current_opening_element_span = None;
-        if let Some(type_args) = &it.opening_element.type_arguments {
-            self.visit_ts_type_parameter_instantiation(type_args);
-        }
-
-        // The original walker visited only attribute VALUES and spread arguments,
-        // never attribute names, and had no closing-element handling.
-        for attr in &it.opening_element.attributes {
-            match attr {
-                JSXAttributeItem::Attribute(a) => {
-                    if let Some(value) = &a.value {
-                        match value {
-                            JSXAttributeValue::ExpressionContainer(c) => {
-                                self.visit_jsx_expression_container(c);
-                            }
-                            JSXAttributeValue::Element(el) => self.visit_jsx_element(el),
-                            JSXAttributeValue::Fragment(f) => self.visit_jsx_fragment(f),
-                            JSXAttributeValue::StringLiteral(_) => {}
-                        }
-                    }
-                }
-                JSXAttributeItem::SpreadAttribute(a) => {
-                    self.visit_expression(&a.argument);
-                }
-            }
-        }
-        for child in &it.children {
-            self.visit_jsx_child(child);
-        }
-    }
-
-    fn visit_ts_type(&mut self, it: &TSType<'a>) {
-        self.type_depth += 1;
-        oxc_ast_visit::walk::walk_ts_type(self, it);
-        self.type_depth -= 1;
-    }
-
-    fn visit_ts_type_annotation(&mut self, it: &TSTypeAnnotation<'a>) {
-        self.type_depth += 1;
-        oxc_ast_visit::walk::walk_ts_type_annotation(self, it);
-        self.type_depth -= 1;
-    }
-
-    fn visit_ts_type_parameter_instantiation(&mut self, it: &TSTypeParameterInstantiation<'a>) {
-        self.type_depth += 1;
-        oxc_ast_visit::walk::walk_ts_type_parameter_instantiation(self, it);
-        self.type_depth -= 1;
-    }
-
-    fn visit_ts_type_parameter_declaration(&mut self, it: &TSTypeParameterDeclaration<'a>) {
-        self.type_depth += 1;
-        oxc_ast_visit::walk::walk_ts_type_parameter_declaration(self, it);
-        self.type_depth -= 1;
-    }
-
-    // The original immutable walker treated these TS declaration statements as
-    // no-ops (nothing inside them was recorded). Override to skip entirely.
-    fn visit_ts_type_alias_declaration(&mut self, _it: &TSTypeAliasDeclaration<'a>) {}
-
-    fn visit_ts_interface_declaration(&mut self, _it: &TSInterfaceDeclaration<'a>) {}
-
-    fn visit_ts_enum_declaration(&mut self, _it: &TSEnumDeclaration<'a>) {}
-
-    fn visit_ts_module_declaration(&mut self, _it: &TSModuleDeclaration<'a>) {}
-}
-
-/// Build an index of the resolved identifier references and binding
-/// declarations in a function's AST.
-///
-/// Walks the function's params (`FormalParameters`) and body, mirroring the
-/// original Babel `IdentifierLocVisitor`: the function node itself is not
-/// re-entered (its own name, if any, is recorded explicitly).
-pub fn build_identifier_loc_index(func: &FunctionNode<'_, '_>) -> IdentifierLocIndex {
-    let mut visitor = IdentifierLocVisitor {
-        index: IdentifierLocIndex::default(),
-        current_opening_element_span: None,
-        type_depth: 0,
-    };
-
-    match func {
-        FunctionNode::Function(f) => {
-            // The function's own name is a declaration name.
-            if let Some(id) = &f.id {
-                visitor.record_declaration(id);
-            }
-            if let Some(type_parameters) = &f.type_parameters {
-                visitor.visit_ts_type_parameter_declaration(type_parameters);
-            }
-            if let Some(this_param) = &f.this_param {
-                visitor.visit_ts_this_parameter(this_param);
-            }
-            visitor.visit_formal_parameters(&f.params);
-            if let Some(return_type) = &f.return_type {
-                visitor.visit_ts_type_annotation(return_type);
-            }
-            if let Some(body) = &f.body {
-                visitor.visit_function_body(body);
-            }
-        }
-        FunctionNode::Arrow(arrow) => {
-            if let Some(type_parameters) = &arrow.type_parameters {
-                visitor.visit_ts_type_parameter_declaration(type_parameters);
-            }
-            visitor.visit_formal_parameters(&arrow.params);
-            if let Some(return_type) = &arrow.return_type {
-                visitor.visit_ts_type_annotation(return_type);
-            }
-            if arrow.expression {
-                if let Some(Statement::ExpressionStatement(es)) = arrow.body.statements.first() {
-                    visitor.visit_expression(&es.expression);
-                } else {
-                    visitor.visit_function_body(&arrow.body);
-                }
-            } else {
-                visitor.visit_function_body(&arrow.body);
-            }
-        }
-    }
-
-    visitor.index
 }

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/mod.rs
@@ -2,6 +2,7 @@ pub mod build_hir;
 pub mod find_context_identifiers;
 pub mod hir_builder;
 pub mod identifier_loc_index;
+pub mod pre_pass;
 
 use oxc_ast::ast::*;
 

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/pre_pass.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/pre_pass.rs
@@ -1,0 +1,433 @@
+//! Shared AST walk driving lowering's two pre-passes in a single traversal.
+//!
+//! Before BuildHIR, lowering runs two pre-passes over the compiled function:
+//!
+//! * [`identifier_loc_index`]: builds the location index for resolved
+//!   identifier references and binding declarations.
+//! * [`find_context_identifiers`]: finds bindings that cross function
+//!   boundaries and need StoreContext/LoadContext semantics.
+//!
+//! Every type that implements an `oxc_ast_visit` visitor trait monomorphizes
+//! the entire generated AST walk, so driving these passes separately paid for
+//! two full walk instantiations in the binary (and traversed the function
+//! twice). [`PrePassVisitor`] owns both passes' state and implements [`Visit`]
+//! once, forwarding each node event to both, so they share one walk.
+//!
+//! Each pass must keep observing exactly the nodes its own walk observed:
+//!
+//! * The identifier-loc pass used the full [`Visit`] walk. It must keep seeing
+//!   identifiers inside TS type subtrees: `find_context_identifiers`'s
+//!   post-walk supplement loop and BuildHIR's `gather_captured_context` both
+//!   rely on type-space references being present in the index.
+//! * The context-identifier pass used the JS-only [`VisitJs`] walk, which
+//!   prunes pure type grammar (but walks TS constructs carrying runtime JS —
+//!   decorators, `x as T` casts, `import x = require(..)` — exactly like
+//!   [`Visit`] does). Under the full walk, pure type grammar is entered only
+//!   via `visit_ts_type`, `visit_ts_type_annotation`,
+//!   `visit_ts_type_parameter_declaration` and
+//!   `visit_ts_type_parameter_instantiation` — each of which bumps
+//!   `type_depth` below — plus the TS type alias / interface declarations
+//!   stubbed to no-ops. Forwarding context events only while `type_depth == 0`
+//!   therefore reproduces the `VisitJs` event stream exactly.
+//!
+//! The per-node behavior (and the comments explaining it) is carried over
+//! unchanged from the two separate visitor impls this replaces; see the module
+//! docs of [`identifier_loc_index`] and [`find_context_identifiers`] for what
+//! each pass records and deliberately skips.
+//!
+//! [`VisitJs`]: oxc_ast_visit::VisitJs
+//! [`identifier_loc_index`]: super::identifier_loc_index
+//! [`find_context_identifiers`]: super::find_context_identifiers
+
+use rustc_hash::FxHashSet;
+
+use oxc_ast::ast::*;
+use oxc_ast_visit::{Visit, walk};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_syntax::scope::ScopeFlags;
+
+use crate::scope::{ScopeResolver, SymbolId};
+
+use crate::react_compiler_lowering::FunctionNode;
+use crate::react_compiler_lowering::find_context_identifiers::{
+    ContextIdentifierVisitor, find_context_identifiers,
+};
+use crate::react_compiler_lowering::identifier_loc_index::{
+    IdentifierLocIndex, IdentifierLocVisitor,
+};
+
+/// Driver owning both pre-passes' state. Its [`Visit`] impl is lowering's only
+/// full-AST walk instantiation: each overridden method forwards the node to
+/// the identifier-loc pass and — when outside TS type subtrees — to the
+/// context-identifier pass, preserving both original event streams.
+struct PrePassVisitor<'a> {
+    loc: IdentifierLocVisitor,
+    ctx: ContextIdentifierVisitor<'a>,
+}
+
+impl PrePassVisitor<'_> {
+    /// True while inside a TS type subtree. The context-identifier pass's
+    /// original `VisitJs` walk never entered these, so its events are
+    /// suppressed while this holds.
+    fn in_type_space(&self) -> bool {
+        self.loc.type_depth > 0
+    }
+}
+
+impl<'a> PrePassVisitor<'a> {
+    /// Visit the JSX element name identifiers (and only those) while the
+    /// loc pass's `current_opening_element_span` is set, mirroring the
+    /// original `walk_jsx_element_name` / `walk_jsx_member_expression`.
+    /// Lowercase tag names, `this`, and member-property parts carry no
+    /// reference and are never looked up, so only `IdentifierReference` names
+    /// are visited — which is also exactly the set of name nodes that fired
+    /// the context pass's capture check under `walk_js`.
+    fn visit_jsx_element_name_refs(&mut self, name: &JSXElementName<'a>) {
+        match name {
+            JSXElementName::IdentifierReference(id) => self.visit_identifier_reference(id),
+            JSXElementName::MemberExpression(m) => self.visit_jsx_member_expression_refs(m),
+            JSXElementName::Identifier(_)
+            | JSXElementName::ThisExpression(_)
+            | JSXElementName::NamespacedName(_) => {}
+        }
+    }
+
+    fn visit_jsx_member_expression_refs(&mut self, expr: &JSXMemberExpression<'a>) {
+        match &expr.object {
+            JSXMemberExpressionObject::IdentifierReference(id) => {
+                self.visit_identifier_reference(id);
+            }
+            JSXMemberExpressionObject::ThisExpression(_) => {}
+            JSXMemberExpressionObject::MemberExpression(inner) => {
+                self.visit_jsx_member_expression_refs(inner);
+            }
+        }
+    }
+}
+
+impl<'a> Visit<'a> for PrePassVisitor<'a> {
+    // ---- identifiers (both passes) ----
+
+    fn visit_identifier_reference(&mut self, it: &IdentifierReference<'a>) {
+        self.loc.record_reference(it);
+        if !self.in_type_space() {
+            self.ctx.enter_identifier_reference(it);
+        }
+    }
+
+    fn visit_binding_identifier(&mut self, it: &BindingIdentifier<'a>) {
+        // loc: `collect_type_idents` only collected IdentifierReference /
+        // IdentifierName, never BindingIdentifier, so type-parameter declaration
+        // names (`<T>`) and other binding positions inside type subtrees must not
+        // be recorded. ctx: `VisitJs` never walked type subtrees at all.
+        if self.in_type_space() {
+            return;
+        }
+        self.loc.record_declaration(it);
+        self.ctx.enter_binding_identifier(it);
+    }
+
+    // ---- function scopes (ctx pushes BOTH the generic scope and the function stack) ----
+
+    fn visit_function(&mut self, it: &Function<'a>, _flags: ScopeFlags) {
+        let scope_pushed = self.ctx.enter_scope(it.scope_id.get());
+        let fn_pushed = self.ctx.push_function_scope(it.scope_id.get());
+        // The original Babel walker driving the context pass never visited the
+        // function NAME identifier (`it.id`); visiting it — with the inner
+        // function already on `function_stack` — would spuriously mark a hoisted
+        // nested-function name as referenced_by_inner_fn. The loc pass DOES
+        // record it (function declaration & expression names go into the
+        // declaration map), so the name is forwarded to the loc pass only.
+        // Functions cannot sit inside pure type grammar, so no type-depth check
+        // is needed (the previous loc walk fired `visit_binding_identifier` here
+        // with `type_depth == 0` always).
+        if let Some(id) = &it.id {
+            self.loc.record_declaration(id);
+        }
+        // Same field order as the generated `walk_function`, which the loc pass
+        // previously used unmodified.
+        if let Some(type_parameters) = &it.type_parameters {
+            self.visit_ts_type_parameter_declaration(type_parameters);
+        }
+        if let Some(this_param) = &it.this_param {
+            self.visit_ts_this_parameter(this_param);
+        }
+        self.visit_formal_parameters(&it.params);
+        if let Some(return_type) = &it.return_type {
+            self.visit_ts_type_annotation(return_type);
+        }
+        if let Some(body) = &it.body {
+            self.visit_function_body(body);
+        }
+        self.ctx.pop_function_scope(fn_pushed);
+        self.ctx.exit_scope(scope_pushed);
+    }
+
+    fn visit_arrow_function_expression(&mut self, it: &ArrowFunctionExpression<'a>) {
+        let scope_pushed = self.ctx.enter_scope(it.scope_id.get());
+        let fn_pushed = self.ctx.push_function_scope(it.scope_id.get());
+        // Same field order as the generated `walk_arrow_function_expression`.
+        if let Some(type_parameters) = &it.type_parameters {
+            self.visit_ts_type_parameter_declaration(type_parameters);
+        }
+        self.visit_formal_parameters(&it.params);
+        if let Some(return_type) = &it.return_type {
+            self.visit_ts_type_annotation(return_type);
+        }
+        self.visit_function_body(&it.body);
+        self.ctx.pop_function_scope(fn_pushed);
+        self.ctx.exit_scope(scope_pushed);
+    }
+
+    // ---- non-function scope-creating nodes (ctx pushes only the generic scope) ----
+
+    fn visit_block_statement(&mut self, it: &BlockStatement<'a>) {
+        let pushed = self.ctx.enter_scope(it.scope_id.get());
+        walk::walk_block_statement(self, it);
+        self.ctx.exit_scope(pushed);
+    }
+
+    fn visit_for_statement(&mut self, it: &ForStatement<'a>) {
+        let pushed = self.ctx.enter_scope(it.scope_id.get());
+        walk::walk_for_statement(self, it);
+        self.ctx.exit_scope(pushed);
+    }
+
+    fn visit_for_in_statement(&mut self, it: &ForInStatement<'a>) {
+        let pushed = self.ctx.enter_scope(it.scope_id.get());
+        walk::walk_for_in_statement(self, it);
+        self.ctx.exit_scope(pushed);
+    }
+
+    fn visit_for_of_statement(&mut self, it: &ForOfStatement<'a>) {
+        let pushed = self.ctx.enter_scope(it.scope_id.get());
+        walk::walk_for_of_statement(self, it);
+        self.ctx.exit_scope(pushed);
+    }
+
+    fn visit_switch_statement(&mut self, it: &SwitchStatement<'a>) {
+        let pushed = self.ctx.enter_scope(it.scope_id.get());
+        walk::walk_switch_statement(self, it);
+        self.ctx.exit_scope(pushed);
+    }
+
+    fn visit_catch_clause(&mut self, it: &CatchClause<'a>) {
+        let pushed = self.ctx.enter_scope(it.scope_id.get());
+        walk::walk_catch_clause(self, it);
+        self.ctx.exit_scope(pushed);
+    }
+
+    fn visit_static_block(&mut self, it: &StaticBlock<'a>) {
+        let pushed = self.ctx.enter_scope(it.scope_id.get());
+        walk::walk_static_block(self, it);
+        self.ctx.exit_scope(pushed);
+    }
+
+    // ---- reassignment tracking (ctx) ----
+
+    fn visit_assignment_expression(&mut self, it: &AssignmentExpression<'a>) {
+        if !self.in_type_space() && !self.ctx.has_error() {
+            let current_scope = self.ctx.current_scope();
+            self.ctx.walk_assignment_target_for_reassignment(&it.left, current_scope);
+        }
+        walk::walk_assignment_expression(self, it);
+    }
+
+    fn visit_update_expression(&mut self, it: &UpdateExpression<'a>) {
+        if !self.in_type_space()
+            && let SimpleAssignmentTarget::AssignmentTargetIdentifier(ident) = &it.argument
+        {
+            let current_scope = self.ctx.current_scope();
+            self.ctx.handle_reassignment_identifier(&ident.name, current_scope);
+        }
+        walk::walk_update_expression(self, it);
+    }
+
+    // ---- positions deliberately NOT visited, matching BOTH original walkers ----
+
+    fn visit_static_member_expression(&mut self, it: &StaticMemberExpression<'a>) {
+        // Both originals walked the property only when computed; a static member
+        // is non-computed, so the property name is never visited.
+        self.visit_expression(&it.object);
+    }
+
+    fn visit_object_property(&mut self, it: &ObjectProperty<'a>) {
+        // Both originals walked the key only when computed.
+        if it.computed {
+            self.visit_property_key(&it.key);
+        }
+        self.visit_expression(&it.value);
+    }
+
+    fn visit_class(&mut self, it: &Class<'a>) {
+        // loc: the original immutable walker recorded only the class name and
+        // then the class's type-bearing parts (decorators / implements / type
+        // params) as RawNodes (type idents only). It did NOT walk `super_class`
+        // (the extends clause) nor the class body's method/property members.
+        // ctx: the original walker did not recurse into the class at all — the
+        // type-bearing parts carried no `enter_identifier` calls, so the class
+        // contributes nothing to the walker-based capture analysis. Everything
+        // below is therefore loc-only (type subtrees suppress ctx events).
+        if let Some(id) = &it.id {
+            self.loc.record_declaration(id);
+        }
+        if let Some(type_parameters) = &it.type_parameters {
+            self.visit_ts_type_parameter_declaration(type_parameters);
+        }
+        if let Some(super_type_arguments) = &it.super_type_arguments {
+            self.visit_ts_type_parameter_instantiation(super_type_arguments);
+        }
+        self.loc.type_depth += 1;
+        self.visit_ts_class_implements_list(&it.implements);
+        self.loc.type_depth -= 1;
+    }
+
+    // ---- JSX ----
+
+    fn visit_jsx_element(&mut self, it: &JSXElement<'a>) {
+        // loc: the opening element's span is active only while walking the
+        // element name; it is cleared before the type arguments, attributes,
+        // and children.
+        self.loc.current_opening_element_span = Some(it.opening_element.span);
+        self.visit_jsx_element_name_refs(&it.opening_element.name);
+        self.loc.current_opening_element_span = None;
+        if let Some(type_args) = &it.opening_element.type_arguments {
+            self.visit_ts_type_parameter_instantiation(type_args);
+        }
+
+        // Both originals visited only attribute VALUES and spread arguments,
+        // never attribute names (nor namespaced names).
+        for attr in &it.opening_element.attributes {
+            match attr {
+                JSXAttributeItem::Attribute(a) => {
+                    if let Some(value) = &a.value {
+                        match value {
+                            JSXAttributeValue::ExpressionContainer(c) => {
+                                self.visit_jsx_expression_container(c);
+                            }
+                            JSXAttributeValue::Element(el) => self.visit_jsx_element(el),
+                            JSXAttributeValue::Fragment(f) => self.visit_jsx_fragment(f),
+                            JSXAttributeValue::StringLiteral(_) => {}
+                        }
+                    }
+                }
+                JSXAttributeItem::SpreadAttribute(a) => {
+                    self.visit_expression(&a.argument);
+                }
+            }
+        }
+        for child in &it.children {
+            self.visit_jsx_child(child);
+        }
+        // The loc pass had no closing-element handling, but the context pass's
+        // `walk_js` walk DID visit the closing element name — keep firing its
+        // capture check for `</Foo>` references (context-only).
+        if let Some(closing_element) = &it.closing_element {
+            self.ctx.check_jsx_element_name(&closing_element.name);
+        }
+    }
+
+    // ---- TS type subtrees (loc-only; ctx events are suppressed inside) ----
+
+    fn visit_ts_type(&mut self, it: &TSType<'a>) {
+        self.loc.type_depth += 1;
+        walk::walk_ts_type(self, it);
+        self.loc.type_depth -= 1;
+    }
+
+    fn visit_ts_type_annotation(&mut self, it: &TSTypeAnnotation<'a>) {
+        self.loc.type_depth += 1;
+        walk::walk_ts_type_annotation(self, it);
+        self.loc.type_depth -= 1;
+    }
+
+    fn visit_ts_type_parameter_instantiation(&mut self, it: &TSTypeParameterInstantiation<'a>) {
+        self.loc.type_depth += 1;
+        walk::walk_ts_type_parameter_instantiation(self, it);
+        self.loc.type_depth -= 1;
+    }
+
+    fn visit_ts_type_parameter_declaration(&mut self, it: &TSTypeParameterDeclaration<'a>) {
+        self.loc.type_depth += 1;
+        walk::walk_ts_type_parameter_declaration(self, it);
+        self.loc.type_depth -= 1;
+    }
+
+    // The original loc walker treated these TS declaration statements as no-ops
+    // (nothing inside them was recorded), and the original ctx walker treated
+    // enum/namespace bodies — runtime JS which `VisitJs` WOULD walk — as opaque
+    // RawNodes (alias/interface it never walked at all). Skip entirely.
+
+    fn visit_ts_type_alias_declaration(&mut self, _it: &TSTypeAliasDeclaration<'a>) {}
+
+    fn visit_ts_interface_declaration(&mut self, _it: &TSInterfaceDeclaration<'a>) {}
+
+    fn visit_ts_enum_declaration(&mut self, _it: &TSEnumDeclaration<'a>) {}
+
+    fn visit_ts_module_declaration(&mut self, _it: &TSModuleDeclaration<'a>) {}
+}
+
+/// Run lowering's two AST pre-passes over a function in one traversal:
+/// build the identifier location index and find the context identifiers
+/// (variables captured across function boundaries).
+///
+/// Walks the function's params (`FormalParameters`) and body, mirroring the
+/// original Babel walks (like Babel's `func.traverse()`): the function node
+/// itself is not re-entered — its own name, if any, is recorded explicitly
+/// (loc-only), and it is never pushed onto the context pass's `function_stack`.
+pub fn run_pre_passes(
+    func: &FunctionNode<'_, '_>,
+    scope: &ScopeResolver<'_, '_>,
+) -> Result<(IdentifierLocIndex, FxHashSet<SymbolId>), OxcDiagnostic> {
+    let func_scope = func.scope_id().unwrap_or_else(|| scope.program_scope());
+
+    let mut visitor = PrePassVisitor {
+        loc: IdentifierLocVisitor::default(),
+        ctx: ContextIdentifierVisitor::new(scope, func_scope),
+    };
+
+    match func {
+        FunctionNode::Function(f) => {
+            // The function's own name is a declaration name (loc-only).
+            if let Some(id) = &f.id {
+                visitor.loc.record_declaration(id);
+            }
+            if let Some(type_parameters) = &f.type_parameters {
+                visitor.visit_ts_type_parameter_declaration(type_parameters);
+            }
+            if let Some(this_param) = &f.this_param {
+                visitor.visit_ts_this_parameter(this_param);
+            }
+            visitor.visit_formal_parameters(&f.params);
+            if let Some(return_type) = &f.return_type {
+                visitor.visit_ts_type_annotation(return_type);
+            }
+            if let Some(body) = &f.body {
+                visitor.visit_function_body(body);
+            }
+        }
+        FunctionNode::Arrow(arrow) => {
+            if let Some(type_parameters) = &arrow.type_parameters {
+                visitor.visit_ts_type_parameter_declaration(type_parameters);
+            }
+            visitor.visit_formal_parameters(&arrow.params);
+            if let Some(return_type) = &arrow.return_type {
+                visitor.visit_ts_type_annotation(return_type);
+            }
+            if arrow.expression {
+                if let Some(Statement::ExpressionStatement(es)) = arrow.body.statements.first() {
+                    visitor.visit_expression(&es.expression);
+                } else {
+                    visitor.visit_function_body(&arrow.body);
+                }
+            } else {
+                visitor.visit_function_body(&arrow.body);
+            }
+        }
+    }
+
+    let PrePassVisitor { loc, ctx } = visitor;
+    let identifier_spans = loc.index;
+    let context_identifiers = find_context_identifiers(ctx, &identifier_spans)?;
+    Ok((identifier_spans, context_identifiers))
+}


### PR DESCRIPTION
Each type that implements an `oxc_ast_visit` visitor trait monomorphizes the entire generated AST walk, so lowering's two pre-passes — `IdentifierLocVisitor` (`Visit`, ~17 KB of walk code) and `ContextIdentifierVisitor` (`VisitJs`, ~16 KB) — each paid for their own full walk instantiation and traversed the compiled function twice; they now share a single walk.

The new `react_compiler_lowering/pre_pass.rs` adds a `PrePassVisitor` that owns both passes' state and implements `Visit` once, forwarding each node to both. The two pass modules keep their structs, state helpers, and per-node semantics (with their original comments); only the traversal is centralized. `build_hir` now calls `run_pre_passes(func, scope)` in place of the two separate entry points.

Notes on preserving each pass's event stream:

- The TS-type walk stays. The loc index must include references inside type annotations: `find_context_identifiers`' post-walk supplement loop only considers references present in the index and exists precisely to recover captured references hiding inside type annotations, and `gather_captured_context` reads `in_type_annotation` from the same entries.
- The context pass previously used the JS-only `VisitJs` walk. Diffing the generated `walk` and `walk_js` bodies shows the only divergences reachable from a function are pure type grammar, entered exclusively via `visit_ts_type`, `visit_ts_type_annotation`, `visit_ts_type_parameter_declaration`, `visit_ts_type_parameter_instantiation` (plus the type alias / interface declarations both passes already stub out) — so suppressing context events while `type_depth > 0` reproduces the `VisitJs` stream exactly.
- One asymmetry is kept explicitly: `walk_js` visits JSX closing-element names (`</Foo>`), which the loc pass never did; the driver forwards those to the context pass only.

Size: **−16,560 bytes (−16.2 KiB)** measured on `cargo build -p oxc_react_compiler --release --example react_compiler` (fat LTO, stripped) on this branch vs `main`, matching the ~15 KB estimated from symbol-level analysis of the release napi binary. Traversing the function once instead of twice is also a minor runtime win for lowering.

Behavior is verified unchanged on the full fixture snapshot corpus (1,736 upstream fixture snapshots plus the transform integration tests) with zero snapshot diffs, and `cargo clippy -p oxc_react_compiler --all-targets` is clean.

Since these files are a port kept close to upstream: this deviation from upstream structure (the shared walk driver in `pre_pass.rs`, with the per-node semantics still documented in the two pass modules) should be preserved when re-syncing with upstream `react_compiler_oxc`.

Authored with Claude Code; reviewed by a human before merge.
