### PR TITLE
perf(react_compiler): use IndexVec for dense id-keyed maps

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler_hir/dominator.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/dominator.rs
@@ -9,9 +9,10 @@
 //! Uses the Cooper/Harvey/Kennedy algorithm from
 //! https://www.cs.rice.edu/~keith/Embed/dom.pdf
 
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashSet;
 
 use oxc_diagnostics::OxcDiagnostic;
+use oxc_index::{IndexSlice, IndexVec};
 
 use crate::diagnostics::ErrorCategory;
 
@@ -26,15 +27,16 @@ use crate::react_compiler_hir::{BlockId, HirFunction, Terminal};
 pub struct PostDominator {
     /// The exit node (synthetic node representing function exit).
     pub exit: BlockId,
-    nodes: FxHashMap<BlockId, BlockId>,
+    /// Immediate post-dominator per block, indexed densely by block id.
+    nodes: IndexVec<BlockId, Option<BlockId>>,
 }
 
 impl PostDominator {
     /// Returns the immediate post-dominator of the given block, or None if
     /// the block post-dominates itself (i.e., it is the exit node).
     pub fn get(&self, id: BlockId) -> Option<BlockId> {
-        let dominator = self.nodes.get(&id).expect("Unknown node in post-dominator tree");
-        if *dominator == id { None } else { Some(*dominator) }
+        let dominator = self.nodes[id].expect("Unknown node in post-dominator tree");
+        if dominator == id { None } else { Some(dominator) }
     }
 }
 
@@ -53,13 +55,13 @@ struct Graph {
     entry: BlockId,
     /// Nodes stored in iteration order (RPO for reverse graph).
     nodes: Vec<Node>,
-    /// Map from BlockId to index in the nodes vec.
-    node_index: FxHashMap<BlockId, usize>,
+    /// Map from BlockId to index in the nodes vec, indexed densely by block id.
+    node_index: IndexVec<BlockId, Option<usize>>,
 }
 
 impl Graph {
     fn get_node(&self, id: BlockId) -> &Node {
-        let idx = self.node_index[&id];
+        let idx = self.node_index[id].expect("Unknown node in dominator graph");
         &self.nodes[idx]
     }
 }
@@ -85,7 +87,7 @@ pub fn compute_post_dominator_tree(
     // with themselves as dominator.
     if !include_throws_as_exit_node {
         for (id, _) in &func.body.blocks {
-            nodes.entry(*id).or_insert(*id);
+            nodes[*id].get_or_insert(*id);
         }
     }
 
@@ -102,15 +104,20 @@ fn build_reverse_graph(
     include_throws_as_exit_node: bool,
 ) -> Graph {
     let exit_id = BlockId::from_usize(next_block_id_counter as usize);
+    // All block ids are below `next_block_id_counter`; add one slot for the exit node.
+    let num_ids = next_block_id_counter as usize + 1;
 
     // Build initial nodes with reversed edges
-    let mut raw_nodes: FxHashMap<BlockId, Node> = FxHashMap::default();
+    let mut raw_nodes: IndexVec<BlockId, Option<Node>> =
+        IndexVec::from_vec((0..num_ids).map(|_| None).collect());
 
     // Create exit node
-    raw_nodes.insert(
-        exit_id,
-        Node { id: exit_id, index: 0, preds: FxHashSet::default(), succs: FxHashSet::default() },
-    );
+    raw_nodes[exit_id] = Some(Node {
+        id: exit_id,
+        index: 0,
+        preds: FxHashSet::default(),
+        succs: FxHashSet::default(),
+    });
 
     for (id, block) in &func.body.blocks {
         let successors = each_terminal_successor(&block.terminal);
@@ -122,10 +129,10 @@ fn build_reverse_graph(
 
         if is_return || (is_throw && include_throws_as_exit_node) {
             preds_set.insert(exit_id);
-            raw_nodes.get_mut(&exit_id).unwrap().succs.insert(*id);
+            raw_nodes[exit_id].as_mut().unwrap().succs.insert(*id);
         }
 
-        raw_nodes.insert(*id, Node { id: *id, index: 0, preds: preds_set, succs: succs_set });
+        raw_nodes[*id] = Some(Node { id: *id, index: 0, preds: preds_set, succs: succs_set });
     }
 
     // DFS from exit to compute RPO
@@ -137,11 +144,11 @@ fn build_reverse_graph(
     postorder.reverse();
 
     let mut nodes = Vec::with_capacity(postorder.len());
-    let mut node_index = FxHashMap::default();
+    let mut node_index: IndexVec<BlockId, Option<usize>> = IndexVec::from_vec(vec![None; num_ids]);
     for (idx, id) in postorder.into_iter().enumerate() {
-        let mut node = raw_nodes.remove(&id).unwrap();
+        let mut node = raw_nodes[id].take().unwrap();
         node.index = idx;
-        node_index.insert(id, idx);
+        node_index[id] = Some(idx);
         nodes.push(node);
     }
 
@@ -150,14 +157,14 @@ fn build_reverse_graph(
 
 fn dfs_postorder(
     id: BlockId,
-    nodes: &FxHashMap<BlockId, Node>,
+    nodes: &IndexSlice<BlockId, [Option<Node>]>,
     visited: &mut FxHashSet<BlockId>,
     postorder: &mut Vec<BlockId>,
 ) {
     if !visited.insert(id) {
         return;
     }
-    if let Some(node) = nodes.get(&id) {
+    if let Some(node) = &nodes[id] {
         for &succ in &node.succs {
             dfs_postorder(succ, nodes, visited, postorder);
         }
@@ -171,9 +178,10 @@ fn dfs_postorder(
 
 fn compute_immediate_dominators(
     graph: &Graph,
-) -> Result<FxHashMap<BlockId, BlockId>, OxcDiagnostic> {
-    let mut doms: FxHashMap<BlockId, BlockId> = FxHashMap::default();
-    doms.insert(graph.entry, graph.entry);
+) -> Result<IndexVec<BlockId, Option<BlockId>>, OxcDiagnostic> {
+    let mut doms: IndexVec<BlockId, Option<BlockId>> =
+        IndexVec::from_vec(vec![None; graph.node_index.len()]);
+    doms[graph.entry] = Some(graph.entry);
 
     let mut changed = true;
     while changed {
@@ -186,7 +194,7 @@ fn compute_immediate_dominators(
             // Find first processed predecessor
             let mut new_idom: Option<BlockId> = None;
             for &pred in &node.preds {
-                if doms.contains_key(&pred) {
+                if doms[pred].is_some() {
                     new_idom = Some(pred);
                     break;
                 }
@@ -206,13 +214,13 @@ fn compute_immediate_dominators(
                 if pred == new_idom {
                     continue;
                 }
-                if doms.contains_key(&pred) {
+                if doms[pred].is_some() {
                     new_idom = intersect(pred, new_idom, graph, &doms);
                 }
             }
 
-            if doms.get(&node.id) != Some(&new_idom) {
-                doms.insert(node.id, new_idom);
+            if doms[node.id] != Some(new_idom) {
+                doms[node.id] = Some(new_idom);
                 changed = true;
             }
         }
@@ -220,16 +228,21 @@ fn compute_immediate_dominators(
     Ok(doms)
 }
 
-fn intersect(a: BlockId, b: BlockId, graph: &Graph, doms: &FxHashMap<BlockId, BlockId>) -> BlockId {
+fn intersect(
+    a: BlockId,
+    b: BlockId,
+    graph: &Graph,
+    doms: &IndexSlice<BlockId, [Option<BlockId>]>,
+) -> BlockId {
     let mut block1 = graph.get_node(a);
     let mut block2 = graph.get_node(b);
     while block1.id != block2.id {
         while block1.index > block2.index {
-            let dom = doms[&block1.id];
+            let dom = doms[block1.id].expect("Expected dominator to be set for processed node");
             block1 = graph.get_node(dom);
         }
         while block2.index > block1.index {
-            let dom = doms[&block2.id];
+            let dom = doms[block2.id].expect("Expected dominator to be set for processed node");
             block2 = graph.get_node(dom);
         }
     }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
@@ -13,6 +13,7 @@
 //! - `src/HIR/DeriveMinimalDependenciesHIR.ts`
 
 use crate::react_compiler_utils::FxIndexMap;
+use oxc_index::IndexVec;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::BTreeSet;
 use std::ptr::eq;
@@ -31,6 +32,10 @@ use oxc_span::Span;
 // =============================================================================
 // Public entry point
 // =============================================================================
+
+/// Sidemap from temporary identifiers to the dependency they represent,
+/// indexed densely by identifier id.
+type TemporariesMap<'a> = IndexVec<IdentifierId, Option<ReactiveScopeDependency<'a>>>;
 
 /// Main entry point: propagate scope dependencies through the HIR.
 /// Corresponds to TS `propagateScopeDependenciesHIR(fn)`.
@@ -63,8 +68,10 @@ pub fn propagate_scope_dependencies_hir<'a>(func: &mut HirFunction<'a>, env: &mu
 
     // Merge temporaries + temporariesReadInOptional
     let mut merged_temporaries = temporaries;
-    for (k, v) in temporaries_read_in_optional {
-        merged_temporaries.insert(k, v);
+    for (k, v) in temporaries_read_in_optional.into_iter_enumerated() {
+        if v.is_some() {
+            merged_temporaries[k] = v;
+        }
     }
 
     let scope_deps =
@@ -119,19 +126,22 @@ fn find_temporaries_used_outside_declaring_scope(
     func: &HirFunction,
     env: &Environment,
 ) -> FxHashSet<DeclarationId> {
-    let mut declarations: FxHashMap<DeclarationId, ScopeId> = FxHashMap::default();
+    // Declaring scope per declaration, indexed densely by declaration id
+    // (declaration ids share the identifier id space).
+    let mut declarations: IndexVec<DeclarationId, Option<ScopeId>> =
+        IndexVec::from_vec(vec![None; env.identifiers.len()]);
     let mut pruned_scopes: FxHashSet<ScopeId> = FxHashSet::default();
     let mut traversal = ScopeBlockTraversal::new();
     let mut used_outside_declaring_scope: FxHashSet<DeclarationId> = FxHashSet::default();
 
     let handle_place = |place_id: IdentifierId,
-                        declarations: &FxHashMap<DeclarationId, ScopeId>,
+                        declarations: &IndexVec<DeclarationId, Option<ScopeId>>,
                         traversal: &ScopeBlockTraversal,
                         pruned_scopes: &FxHashSet<ScopeId>,
                         used_outside: &mut FxHashSet<DeclarationId>,
                         env: &Environment| {
         let decl_id = env.identifiers[place_id].declaration_id;
-        if let Some(&declaring_scope) = declarations.get(&decl_id)
+        if let Some(declaring_scope) = declarations[decl_id]
             && !traversal.is_scope_active(declaring_scope)
             && !pruned_scopes.contains(&declaring_scope)
         {
@@ -175,7 +185,7 @@ fn find_temporaries_used_outside_declaring_scope(
                     | InstructionValue::LoadContext { .. }
                     | InstructionValue::PropertyLoad { .. } => {
                         let decl_id = env.identifiers[instr.lvalue.identifier].declaration_id;
-                        declarations.insert(decl_id, scope);
+                        declarations[decl_id] = Some(scope);
                     }
                     _ => {}
                 }
@@ -211,8 +221,8 @@ fn collect_temporaries_sidemap<'a>(
     func: &HirFunction<'a>,
     env: &Environment<'a>,
     used_outside_declaring_scope: &FxHashSet<DeclarationId>,
-) -> FxHashMap<IdentifierId, ReactiveScopeDependency<'a>> {
-    let mut temporaries = FxHashMap::default();
+) -> TemporariesMap<'a> {
+    let mut temporaries = IndexVec::from_vec(vec![None; env.identifiers.len()]);
     collect_temporaries_sidemap_impl(
         func,
         env,
@@ -253,7 +263,7 @@ fn collect_temporaries_sidemap_impl<'a>(
     func: &HirFunction<'a>,
     env: &Environment<'a>,
     used_outside_declaring_scope: &FxHashSet<DeclarationId>,
-    temporaries: &mut FxHashMap<IdentifierId, ReactiveScopeDependency<'a>>,
+    temporaries: &mut TemporariesMap<'a>,
     inner_fn_context: Option<EvaluationOrder>,
 ) {
     for (_block_id, block) in &func.body.blocks {
@@ -266,9 +276,9 @@ fn collect_temporaries_sidemap_impl<'a>(
 
             match &instr.value {
                 InstructionValue::PropertyLoad { object, property, span, .. } if !used_outside => {
-                    if inner_fn_context.is_none() || temporaries.contains_key(&object.identifier) {
+                    if inner_fn_context.is_none() || temporaries[object.identifier].is_some() {
                         let prop = get_property(object, property, false, *span, temporaries);
-                        temporaries.insert(instr.lvalue.identifier, prop);
+                        temporaries[instr.lvalue.identifier] = Some(prop);
                     }
                 }
                 InstructionValue::LoadLocal { place, span, .. }
@@ -279,15 +289,12 @@ fn collect_temporaries_sidemap_impl<'a>(
                     if inner_fn_context.is_none()
                         || func.context.iter().any(|ctx| ctx.identifier == place.identifier)
                     {
-                        temporaries.insert(
-                            instr.lvalue.identifier,
-                            ReactiveScopeDependency {
-                                identifier: place.identifier,
-                                reactive: place.reactive,
-                                path: vec![],
-                                span: *span,
-                            },
-                        );
+                        temporaries[instr.lvalue.identifier] = Some(ReactiveScopeDependency {
+                            identifier: place.identifier,
+                            reactive: place.reactive,
+                            path: vec![],
+                            span: *span,
+                        });
                     }
                 }
                 value @ InstructionValue::LoadContext { place, span, .. }
@@ -299,15 +306,12 @@ fn collect_temporaries_sidemap_impl<'a>(
                     if inner_fn_context.is_none()
                         || func.context.iter().any(|ctx| ctx.identifier == place.identifier)
                     {
-                        temporaries.insert(
-                            instr.lvalue.identifier,
-                            ReactiveScopeDependency {
-                                identifier: place.identifier,
-                                reactive: place.reactive,
-                                path: vec![],
-                                span: *span,
-                            },
-                        );
+                        temporaries[instr.lvalue.identifier] = Some(ReactiveScopeDependency {
+                            identifier: place.identifier,
+                            reactive: place.reactive,
+                            path: vec![],
+                            span: *span,
+                        });
                     }
                 }
                 InstructionValue::FunctionExpression { lowered_func, .. }
@@ -334,9 +338,9 @@ fn get_property<'a>(
     property_name: &PropertyLiteral<'a>,
     optional: bool,
     span: Option<Span>,
-    temporaries: &FxHashMap<IdentifierId, ReactiveScopeDependency<'a>>,
+    temporaries: &TemporariesMap<'a>,
 ) -> ReactiveScopeDependency<'a> {
-    let resolved = temporaries.get(&object.identifier);
+    let resolved = temporaries[object.identifier].as_ref();
     if let Some(resolved) = resolved {
         let mut path = resolved.path.clone();
         path.push(DependencyPathEntry { property: *property_name, optional, span });
@@ -361,7 +365,7 @@ fn get_property<'a>(
 // =============================================================================
 
 struct OptionalChainSidemap<'a> {
-    temporaries_read_in_optional: FxHashMap<IdentifierId, ReactiveScopeDependency<'a>>,
+    temporaries_read_in_optional: TemporariesMap<'a>,
     processed_instrs_in_optional: FxHashSet<ProcessedInstr>,
     hoistable_objects: FxHashMap<BlockId, ReactiveScopeDependency<'a>>,
 }
@@ -384,7 +388,7 @@ fn collect_optional_chain_sidemap<'a>(
     let mut ctx = OptionalTraversalContext {
         seen_optionals: FxHashSet::default(),
         processed_instrs_in_optional: FxHashSet::default(),
-        temporaries_read_in_optional: FxHashMap::default(),
+        temporaries_read_in_optional: IndexVec::from_vec(vec![None; env.identifiers.len()]),
         hoistable_objects: FxHashMap::default(),
     };
 
@@ -400,7 +404,7 @@ fn collect_optional_chain_sidemap<'a>(
 struct OptionalTraversalContext<'a> {
     seen_optionals: FxHashSet<BlockId>,
     processed_instrs_in_optional: FxHashSet<ProcessedInstr>,
-    temporaries_read_in_optional: FxHashMap<IdentifierId, ReactiveScopeDependency<'a>>,
+    temporaries_read_in_optional: TemporariesMap<'a>,
     hoistable_objects: FxHashMap<BlockId, ReactiveScopeDependency<'a>>,
 }
 
@@ -604,12 +608,13 @@ fn traverse_optional_block<'a>(
 
             if !is_optional {
                 // Non-optional load: record that PropertyLoads from inner optional are hoistable
-                if let Some(inner_dep) = ctx.temporaries_read_in_optional.get(&inner_optional_id) {
-                    ctx.hoistable_objects.insert(optional_block.id, inner_dep.clone());
+                if let Some(inner_dep) = &ctx.temporaries_read_in_optional[inner_optional_id] {
+                    let inner_dep = inner_dep.clone();
+                    ctx.hoistable_objects.insert(optional_block.id, inner_dep);
                 }
             }
 
-            let base = ctx.temporaries_read_in_optional.get(&inner_optional_id)?.clone();
+            let base = ctx.temporaries_read_in_optional[inner_optional_id].clone()?;
             (&test_block.terminal, base)
         }
         _ => return None,
@@ -697,8 +702,8 @@ fn traverse_optional_block<'a>(
         }
         _ => BlockId::from_usize(0),
     }));
-    ctx.temporaries_read_in_optional.insert(match_result.consequent_id, load.clone());
-    ctx.temporaries_read_in_optional.insert(match_result.property_id, load);
+    ctx.temporaries_read_in_optional[match_result.consequent_id] = Some(load.clone());
+    ctx.temporaries_read_in_optional[match_result.property_id] = Some(load);
 
     Some(match_result.consequent_id)
 }
@@ -864,7 +869,7 @@ struct BlockInfo {
 }
 
 struct CollectHoistableContext<'a, 'e> {
-    temporaries: &'e FxHashMap<IdentifierId, ReactiveScopeDependency<'a>>,
+    temporaries: &'e TemporariesMap<'a>,
     known_immutable_identifiers: &'e FxHashSet<IdentifierId>,
     hoistable_from_optionals: &'e FxHashMap<BlockId, ReactiveScopeDependency<'a>>,
     nested_fn_immutable_context: Option<&'e FxHashSet<IdentifierId>>,
@@ -895,11 +900,11 @@ fn in_range(id: EvaluationOrder, range: &MutableRange) -> bool {
 
 fn get_maybe_non_null_in_instruction<'a>(
     value: &InstructionValue<'a>,
-    temporaries: &FxHashMap<IdentifierId, ReactiveScopeDependency<'a>>,
+    temporaries: &TemporariesMap<'a>,
 ) -> Option<ReactiveScopeDependency<'a>> {
     match value {
         InstructionValue::PropertyLoad { object, .. } => {
-            Some(temporaries.get(&object.identifier).cloned().unwrap_or_else(|| {
+            Some(temporaries[object.identifier].clone().unwrap_or_else(|| {
                 ReactiveScopeDependency {
                     identifier: object.identifier,
                     reactive: object.reactive,
@@ -908,12 +913,8 @@ fn get_maybe_non_null_in_instruction<'a>(
                 }
             }))
         }
-        InstructionValue::Destructure { value: val, .. } => {
-            temporaries.get(&val.identifier).cloned()
-        }
-        InstructionValue::ComputedLoad { object, .. } => {
-            temporaries.get(&object.identifier).cloned()
-        }
+        InstructionValue::Destructure { value: val, .. } => temporaries[val.identifier].clone(),
+        InstructionValue::ComputedLoad { object, .. } => temporaries[object.identifier].clone(),
         _ => None,
     }
 }
@@ -1322,7 +1323,7 @@ fn recursively_propagate_non_null(
 fn collect_hoistable_and_propagate<'a>(
     func: &HirFunction<'a>,
     env: &Environment<'a>,
-    temporaries: &FxHashMap<IdentifierId, ReactiveScopeDependency<'a>>,
+    temporaries: &TemporariesMap<'a>,
     hoistable_from_optionals: &FxHashMap<BlockId, ReactiveScopeDependency<'a>>,
 ) -> (FxHashMap<BlockId, BTreeSet<usize>>, PropertyPathRegistry<'a>) {
     let mut registry = PropertyPathRegistry::new();
@@ -1573,24 +1574,28 @@ struct Decl {
 
 /// Context for dependency collection.
 struct DependencyCollectionContext<'a, 'e> {
-    declarations: FxHashMap<DeclarationId, Decl>,
-    reassignments: FxHashMap<IdentifierId, Decl>,
+    /// Declaration record per declaration id (declaration ids share the
+    /// identifier id space).
+    declarations: IndexVec<DeclarationId, Option<Decl>>,
+    /// Latest reassignment record per identifier id.
+    reassignments: IndexVec<IdentifierId, Option<Decl>>,
     scope_stack: Vec<ScopeId>,
     dep_stack: Vec<Vec<ReactiveScopeDependency<'a>>>,
     deps: FxIndexMap<ScopeId, Vec<ReactiveScopeDependency<'a>>>,
-    temporaries: &'e FxHashMap<IdentifierId, ReactiveScopeDependency<'a>>,
+    temporaries: &'e TemporariesMap<'a>,
     processed_instrs_in_optional: &'e FxHashSet<ProcessedInstr>,
     inner_fn_context: Option<EvaluationOrder>,
 }
 
 impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
     fn new(
-        temporaries: &'e FxHashMap<IdentifierId, ReactiveScopeDependency<'a>>,
+        num_identifiers: usize,
+        temporaries: &'e TemporariesMap<'a>,
         processed_instrs_in_optional: &'e FxHashSet<ProcessedInstr>,
     ) -> Self {
         Self {
-            declarations: FxHashMap::default(),
-            reassignments: FxHashMap::default(),
+            declarations: IndexVec::from_vec(vec![None; num_identifiers]),
+            reassignments: IndexVec::from_vec(vec![None; num_identifiers]),
             scope_stack: Vec::new(),
             dep_stack: Vec::new(),
             deps: FxIndexMap::default(),
@@ -1633,13 +1638,16 @@ impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
             return;
         }
         let decl_id = env.identifiers[identifier_id].declaration_id;
-        self.declarations.entry(decl_id).or_insert_with(|| decl.clone());
-        self.reassignments.insert(identifier_id, decl);
+        let slot = &mut self.declarations[decl_id];
+        if slot.is_none() {
+            *slot = Some(decl.clone());
+        }
+        self.reassignments[identifier_id] = Some(decl);
     }
 
     fn has_declared(&self, identifier_id: IdentifierId, env: &Environment) -> bool {
         let decl_id = env.identifiers[identifier_id].declaration_id;
-        self.declarations.contains_key(&decl_id)
+        self.declarations[decl_id].is_some()
     }
 
     fn check_valid_dependency(&self, dep: &ReactiveScopeDependency, env: &Environment) -> bool {
@@ -1654,10 +1662,9 @@ impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
         }
 
         let ident = &env.identifiers[dep.identifier];
-        let current_declaration = self
-            .reassignments
-            .get(&dep.identifier)
-            .or_else(|| self.declarations.get(&ident.declaration_id));
+        let current_declaration = self.reassignments[dep.identifier]
+            .as_ref()
+            .or(self.declarations[ident.declaration_id].as_ref());
 
         if let Some(current_scope) = self.current_scope()
             && let Some(decl) = current_declaration
@@ -1669,14 +1676,13 @@ impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
     }
 
     fn visit_operand(&mut self, place: &Place, env: &mut Environment) {
-        let dep = self.temporaries.get(&place.identifier).cloned().unwrap_or_else(|| {
-            ReactiveScopeDependency {
+        let dep =
+            self.temporaries[place.identifier].clone().unwrap_or_else(|| ReactiveScopeDependency {
                 identifier: place.identifier,
                 reactive: place.reactive,
                 path: vec![],
                 span: place.span,
-            }
-        });
+            });
         self.visit_dependency(dep, env);
     }
 
@@ -1697,7 +1703,7 @@ impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
         let decl_id = ident.declaration_id;
 
         // Record scope declarations for values used outside their declaring scope
-        if let Some(original_decl) = self.declarations.get(&decl_id)
+        if let Some(original_decl) = &self.declarations[decl_id]
             && !original_decl.scope_stack.is_empty()
         {
             let orig_scope_stack = original_decl.scope_stack.clone();
@@ -1768,7 +1774,7 @@ impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
     fn is_deferred_dependency_instr(&self, instr: &Instruction) -> bool {
         self.processed_instrs_in_optional
             .contains(&ProcessedInstr::Instruction(instr.lvalue.identifier))
-            || self.temporaries.contains_key(&instr.lvalue.identifier)
+            || self.temporaries[instr.lvalue.identifier].is_some()
     }
 
     fn is_deferred_dependency_terminal(&self, block_id: BlockId) -> bool {
@@ -1804,8 +1810,9 @@ fn visit_inner_function_blocks<'a>(
 
     for (inner_bid, inner_instr_ids, inner_phis, inner_terminal) in &inner_blocks {
         for &(_pred_id, op_id) in inner_phis {
-            if let Some(maybe_optional) = ctx.temporaries.get(&op_id) {
-                ctx.visit_dependency(maybe_optional.clone(), env);
+            if let Some(maybe_optional) = &ctx.temporaries[op_id] {
+                let maybe_optional = maybe_optional.clone();
+                ctx.visit_dependency(maybe_optional, env);
             }
         }
 
@@ -1913,10 +1920,14 @@ fn handle_instruction<'a>(
 fn collect_dependencies<'a>(
     func: &HirFunction<'a>,
     env: &mut Environment<'a>,
-    temporaries: &FxHashMap<IdentifierId, ReactiveScopeDependency<'a>>,
+    temporaries: &TemporariesMap<'a>,
     processed_instrs_in_optional: &FxHashSet<ProcessedInstr>,
 ) -> FxIndexMap<ScopeId, Vec<ReactiveScopeDependency<'a>>> {
-    let mut ctx = DependencyCollectionContext::new(temporaries, processed_instrs_in_optional);
+    let mut ctx = DependencyCollectionContext::new(
+        env.identifiers.len(),
+        temporaries,
+        processed_instrs_in_optional,
+    );
 
     // Declare params
     for param in &func.params {
@@ -1969,8 +1980,9 @@ fn handle_function_deps<'a>(
         // Record phi operands
         for phi in &block.phis {
             for (_pred_id, operand) in &phi.operands {
-                if let Some(maybe_optional_chain) = ctx.temporaries.get(&operand.identifier) {
-                    ctx.visit_dependency(maybe_optional_chain.clone(), env);
+                if let Some(maybe_optional_chain) = &ctx.temporaries[operand.identifier] {
+                    let maybe_optional_chain = maybe_optional_chain.clone();
+                    ctx.visit_dependency(maybe_optional_chain, env);
                 }
             }
         }

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/prune_maybe_throws.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/prune_maybe_throws.rs
@@ -10,9 +10,7 @@
 //!
 //! Analogous to TS `Optimization/PruneMaybeThrows.ts`.
 
-use rustc_hash::FxHashMap;
-
-use oxc_index::IndexSlice;
+use oxc_index::{IndexSlice, IndexVec};
 
 use oxc_diagnostics::OxcDiagnostic;
 
@@ -53,7 +51,7 @@ pub fn prune_maybe_throws(
                 for (predecessor, _) in &phi.operands {
                     if !preds.contains(predecessor) {
                         let mapped_terminal =
-                            terminal_mapping.get(predecessor).copied().ok_or_else(|| {
+                            terminal_mapping.get(*predecessor).copied().flatten().ok_or_else(|| {
                                 ErrorCategory::Invariant
                                     .diagnostic("Expected non-existing phi operand's predecessor to have been mapped to a new terminal")
                                     .with_help(format!(
@@ -80,8 +78,13 @@ pub fn prune_maybe_throws(
     Ok(())
 }
 
-fn prune_maybe_throws_impl(func: &mut HirFunction) -> Option<FxHashMap<BlockId, BlockId>> {
-    let mut terminal_mapping: FxHashMap<BlockId, BlockId> = FxHashMap::default();
+fn prune_maybe_throws_impl(func: &mut HirFunction) -> Option<IndexVec<BlockId, Option<BlockId>>> {
+    // Both keys (continuations) and values (source blocks) are ids of blocks present
+    // in the function body, so the maximum present id bounds the id space.
+    let num_ids = func.body.blocks.keys().map(|id| id.index() + 1).max().unwrap_or(0);
+    let mut terminal_mapping: IndexVec<BlockId, Option<BlockId>> =
+        IndexVec::from_vec(vec![None; num_ids]);
+    let mut mapped_any = false;
     let instructions = &func.instructions;
 
     for block in func.body.blocks.values_mut() {
@@ -96,8 +99,9 @@ fn prune_maybe_throws_impl(func: &mut HirFunction) -> Option<FxHashMap<BlockId, 
             .any(|instr_id| instruction_may_throw(&instructions[instr_id.index()]));
 
         if !can_throw {
-            let source = terminal_mapping.get(&block.id).copied().unwrap_or(block.id);
-            terminal_mapping.insert(continuation, source);
+            let source = terminal_mapping[block.id].unwrap_or(block.id);
+            terminal_mapping[continuation] = Some(source);
+            mapped_any = true;
             // Null out the handler rather than replacing with Goto.
             // Preserving the MaybeThrow makes the continuations clear for
             // BuildReactiveFunction, while nulling out the handler tells us
@@ -108,7 +112,7 @@ fn prune_maybe_throws_impl(func: &mut HirFunction) -> Option<FxHashMap<BlockId, 
         }
     }
 
-    if terminal_mapping.is_empty() { None } else { Some(terminal_mapping) }
+    if mapped_any { Some(terminal_mapping) } else { None }
 }
 
 fn instruction_may_throw(instr: &Instruction) -> bool {

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/merge_reactive_scopes_that_invalidate_together.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/merge_reactive_scopes_that_invalidate_together.rs
@@ -10,9 +10,10 @@
 
 use std::mem::take;
 
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashSet;
 
 use oxc_diagnostics::OxcDiagnostic;
+use oxc_index::IndexVec;
 
 use crate::diagnostics::ErrorCategory;
 use crate::react_compiler_hir::{
@@ -32,19 +33,32 @@ use crate::react_compiler_reactive_scopes::visitors::{
 // Public entry point
 // =============================================================================
 
+/// Last usage per declaration, indexed densely by declaration id
+/// (declaration ids share the identifier id space).
+type LastUsageMap = IndexVec<DeclarationId, Option<EvaluationOrder>>;
+
+/// Temporary-to-source declaration mapping, indexed densely by declaration id.
+type TemporariesMap = IndexVec<DeclarationId, Option<DeclarationId>>;
+
 /// Merges adjacent reactive scopes that share dependencies (invalidate together).
 /// TS: `mergeReactiveScopesThatInvalidateTogether`
 pub fn merge_reactive_scopes_that_invalidate_together<'a>(
     func: &mut ReactiveFunction<'a>,
     env: &mut Environment<'a>,
 ) -> Result<(), OxcDiagnostic> {
+    let num_identifiers = env.identifiers.len();
+
     // Pass 1: find last usage of each declaration
     let visitor = FindLastUsageVisitor { env: &*env };
-    let mut last_usage: FxHashMap<DeclarationId, EvaluationOrder> = FxHashMap::default();
+    let mut last_usage: LastUsageMap = IndexVec::from_vec(vec![None; num_identifiers]);
     visit_reactive_function(func, &visitor, &mut last_usage);
 
     // Pass 2+3: merge scopes
-    let mut transform = MergeTransform { env, last_usage, temporaries: FxHashMap::default() };
+    let mut transform = MergeTransform {
+        env,
+        last_usage,
+        temporaries: IndexVec::from_vec(vec![None; num_identifiers]),
+    };
     let mut state: Option<Vec<ReactiveScopeDependency>> = None;
     transform_reactive_function(func, &mut transform, &mut state)
 }
@@ -59,7 +73,7 @@ struct FindLastUsageVisitor<'a, 'e> {
 }
 
 impl<'a, 'e> ReactiveFunctionVisitor<'a> for FindLastUsageVisitor<'a, 'e> {
-    type State = FxHashMap<DeclarationId, EvaluationOrder>;
+    type State = LastUsageMap;
 
     fn env(&self) -> &Environment<'a> {
         self.env
@@ -67,9 +81,9 @@ impl<'a, 'e> ReactiveFunctionVisitor<'a> for FindLastUsageVisitor<'a, 'e> {
 
     fn visit_place(&self, id: EvaluationOrder, place: &Place, state: &mut Self::State) {
         let decl_id = self.env.identifiers[place.identifier].declaration_id;
-        let entry = state.entry(decl_id).or_insert(id);
-        if id > *entry {
-            *entry = id;
+        let slot = &mut state[decl_id];
+        if slot.is_none_or(|last| id > last) {
+            *slot = Some(id);
         }
     }
 }
@@ -81,8 +95,8 @@ impl<'a, 'e> ReactiveFunctionVisitor<'a> for FindLastUsageVisitor<'a, 'e> {
 /// TS: `class Transform extends ReactiveFunctionTransform<ReactiveScopeDependencies | null>`
 struct MergeTransform<'a, 'e> {
     env: &'e mut Environment<'a>,
-    last_usage: FxHashMap<DeclarationId, EvaluationOrder>,
-    temporaries: FxHashMap<DeclarationId, DeclarationId>,
+    last_usage: LastUsageMap,
+    temporaries: TemporariesMap,
 }
 
 impl<'a, 'e> ReactiveFunctionTransform<'a> for MergeTransform<'a, 'e> {
@@ -187,7 +201,7 @@ impl<'a, 'e> MergeTransform<'a, 'e> {
                                         if let InstructionValue::LoadLocal { place, .. } = iv {
                                             let src_decl = self.env.identifiers[place.identifier]
                                                 .declaration_id;
-                                            self.temporaries.insert(decl_id, src_decl);
+                                            self.temporaries[decl_id] = Some(src_decl);
                                         }
                                     }
                                 }
@@ -209,12 +223,9 @@ impl<'a, 'e> MergeTransform<'a, 'e> {
                                             // Track temporary mapping
                                             let value_decl = self.env.identifiers[value.identifier]
                                                 .declaration_id;
-                                            let mapped = self
-                                                .temporaries
-                                                .get(&value_decl)
-                                                .copied()
-                                                .unwrap_or(value_decl);
-                                            self.temporaries.insert(store_decl, mapped);
+                                            let mapped =
+                                                self.temporaries[value_decl].unwrap_or(value_decl);
+                                            self.temporaries[store_decl] = Some(mapped);
                                         } else {
                                             // Non-const StoreLocal — reset
                                             let c = current.take().unwrap();
@@ -385,14 +396,14 @@ impl<'a, 'e> MergeTransform<'a, 'e> {
 /// Updates scope declarations to remove any that are not used after the scope.
 fn update_scope_declarations<'a>(
     scope_id: ScopeId,
-    last_usage: &FxHashMap<DeclarationId, EvaluationOrder>,
+    last_usage: &LastUsageMap,
     env: &mut Environment<'a>,
 ) {
     let range_end = env.scopes[scope_id].range.end;
     env.scopes[scope_id].declarations.retain(|(_id, decl)| {
         let decl_declaration_id = env.identifiers[decl.identifier].declaration_id;
-        match last_usage.get(&decl_declaration_id) {
-            Some(last_used_at) => *last_used_at >= range_end,
+        match last_usage[decl_declaration_id] {
+            Some(last_used_at) => last_used_at >= range_end,
             // If not tracked, keep the declaration (conservative)
             None => true,
         }
@@ -403,12 +414,12 @@ fn update_scope_declarations<'a>(
 fn are_lvalues_last_used_by_scope<'a>(
     scope_id: ScopeId,
     lvalues: &FxHashSet<DeclarationId>,
-    last_usage: &FxHashMap<DeclarationId, EvaluationOrder>,
+    last_usage: &LastUsageMap,
     env: &Environment<'a>,
 ) -> bool {
     let range_end = env.scopes[scope_id].range.end;
-    for lvalue in lvalues {
-        if let Some(&last_used_at) = last_usage.get(lvalue)
+    for &lvalue in lvalues {
+        if let Some(last_used_at) = last_usage[lvalue]
             && last_used_at >= range_end
         {
             return false;
@@ -422,7 +433,7 @@ fn can_merge_scopes<'a>(
     current_id: ScopeId,
     next_id: ScopeId,
     env: &Environment<'a>,
-    temporaries: &FxHashMap<DeclarationId, DeclarationId>,
+    temporaries: &TemporariesMap,
 ) -> bool {
     let current = &env.scopes[current_id];
     let next = &env.scopes[next_id];
@@ -468,8 +479,7 @@ fn can_merge_scopes<'a>(
             let dep_decl = env.identifiers[dep.identifier].declaration_id;
             current.declarations.iter().any(|(_key, decl)| {
                 let decl_decl_id = env.identifiers[decl.identifier].declaration_id;
-                decl_decl_id == dep_decl
-                    || temporaries.get(&dep_decl).copied() == Some(decl_decl_id)
+                decl_decl_id == dep_decl || temporaries[dep_decl] == Some(decl_decl_id)
             })
         })
     {

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/promote_used_temporaries.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/promote_used_temporaries.rs
@@ -8,9 +8,9 @@
 //!
 //! Corresponds to `src/ReactiveScopes/PromoteUsedTemporaries.ts`.
 
-use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 
+use oxc_index::IndexVec;
 use oxc_str::format_ident;
 
 use crate::react_compiler_hir::DeclarationId;
@@ -40,13 +40,19 @@ use crate::react_compiler_hir::visitors::{each_instruction_value_operand, each_p
 struct State {
     tags: FxHashSet<DeclarationId>,
     promoted: FxHashSet<DeclarationId>,
-    pruned: FxHashMap<DeclarationId, PrunedInfo>,
+    /// Pruned-scope info per declaration, indexed densely by declaration id
+    /// (declaration ids share the identifier id space).
+    pruned: IndexVec<DeclarationId, Option<PrunedInfo>>,
 }
 
 struct PrunedInfo {
     active_scopes: Vec<ScopeId>,
     used_outside_scope: bool,
 }
+
+/// Interposed-temporary tracking state, indexed densely by identifier id.
+/// Each entry holds the tracked identifier and whether it needs promotion.
+type InterState = IndexVec<IdentifierId, Option<(IdentifierId, bool)>>;
 
 // =============================================================================
 // Public entry point
@@ -58,7 +64,7 @@ pub fn promote_used_temporaries(func: &mut ReactiveFunction, env: &mut Environme
     let mut state = State {
         tags: FxHashSet::default(),
         promoted: FxHashSet::default(),
-        pruned: FxHashMap::default(),
+        pruned: IndexVec::from_vec((0..env.identifiers.len()).map(|_| None).collect()),
     };
 
     // Phase 1: collect promotable temporaries (jsx tags, pruned scope usage)
@@ -93,7 +99,7 @@ pub fn promote_used_temporaries(func: &mut ReactiveFunction, env: &mut Environme
             }
         }
     }
-    let mut inter_state: FxHashMap<IdentifierId, (IdentifierId, bool)> = FxHashMap::default();
+    let mut inter_state: InterState = IndexVec::from_vec(vec![None; env.identifiers.len()]);
     promote_interposed_block(
         &func.body,
         &mut state,
@@ -133,13 +139,10 @@ fn collect_promotable_block(
                 let scope_data = &env.scopes[scope.scope];
                 for (_id, decl) in &scope_data.declarations {
                     let identifier = &env.identifiers[decl.identifier];
-                    state.pruned.insert(
-                        identifier.declaration_id,
-                        PrunedInfo {
-                            active_scopes: active_scopes.clone(),
-                            used_outside_scope: false,
-                        },
-                    );
+                    state.pruned[identifier.declaration_id] = Some(PrunedInfo {
+                        active_scopes: active_scopes.clone(),
+                        used_outside_scope: false,
+                    });
                 }
                 collect_promotable_block(&scope.instructions, state, active_scopes, env);
             }
@@ -158,7 +161,7 @@ fn collect_promotable_place(
 ) {
     if !active_scopes.is_empty() {
         let identifier = &env.identifiers[place.identifier];
-        if let Some(pruned) = state.pruned.get_mut(&identifier.declaration_id)
+        if let Some(pruned) = state.pruned[identifier.declaration_id].as_mut()
             && let Some(last) = active_scopes.last()
             && !pruned.active_scopes.contains(last)
         {
@@ -321,7 +324,7 @@ fn promote_temporaries_block(block: &ReactiveBlock, state: &mut State, env: &mut
                 for (id, decl_id) in decls {
                     let identifier = &env.identifiers[id];
                     if identifier.name.is_none()
-                        && let Some(pruned) = state.pruned.get(&decl_id)
+                        && let Some(pruned) = &state.pruned[decl_id]
                         && pruned.used_outside_scope
                     {
                         promote_identifier(id, state, env);
@@ -484,7 +487,7 @@ fn visit_hir_function_for_promotion(func_id: FunctionId, state: &mut State, env:
 fn promote_interposed_block(
     block: &ReactiveBlock,
     state: &mut State,
-    inter_state: &mut FxHashMap<IdentifierId, (IdentifierId, bool)>,
+    inter_state: &mut InterState,
     consts: &mut FxHashSet<IdentifierId>,
     globals: &mut FxHashSet<IdentifierId>,
     env: &mut Environment,
@@ -524,11 +527,11 @@ fn promote_interposed_block(
 fn promote_interposed_place(
     place: &Place,
     state: &mut State,
-    inter_state: &mut FxHashMap<IdentifierId, (IdentifierId, bool)>,
+    inter_state: &mut InterState,
     consts: &FxHashSet<IdentifierId>,
     env: &mut Environment,
 ) {
-    if let Some(&(id, needs_promotion)) = inter_state.get(&place.identifier) {
+    if let Some((id, needs_promotion)) = inter_state[place.identifier] {
         let identifier = &env.identifiers[id];
         if needs_promotion && identifier.name.is_none() && !consts.contains(&id) {
             promote_identifier(id, state, env);
@@ -539,7 +542,7 @@ fn promote_interposed_place(
 fn promote_interposed_instruction(
     instr: &ReactiveInstruction,
     state: &mut State,
-    inter_state: &mut FxHashMap<IdentifierId, (IdentifierId, bool)>,
+    inter_state: &mut InterState,
     consts: &mut FxHashSet<IdentifierId>,
     globals: &mut FxHashSet<IdentifierId>,
     env: &mut Environment,
@@ -602,17 +605,14 @@ fn promote_interposed_instruction(
                                 .is_some())
                     {
                         // Mark all tracked temporaries as needing promotion
-                        let keys: Vec<IdentifierId> = inter_state.keys().cloned().collect();
-                        for key in keys {
-                            if let Some(entry) = inter_state.get_mut(&key) {
-                                entry.1 = true;
-                            }
+                        for entry in inter_state.iter_mut().flatten() {
+                            entry.1 = true;
                         }
                     }
                     if let Some(lvalue) = &instr.lvalue {
                         let identifier = &env.identifiers[lvalue.identifier];
                         if identifier.name.is_none() {
-                            inter_state.insert(lvalue.identifier, (lvalue.identifier, false));
+                            inter_state[lvalue.identifier] = Some((lvalue.identifier, false));
                         }
                     }
                 }
@@ -636,7 +636,7 @@ fn promote_interposed_instruction(
                             if consts.contains(&load_place.identifier) {
                                 consts.insert(lvalue.identifier);
                             }
-                            inter_state.insert(lvalue.identifier, (lvalue.identifier, false));
+                            inter_state[lvalue.identifier] = Some((lvalue.identifier, false));
                         }
                     }
                     // Visit operands
@@ -653,7 +653,7 @@ fn promote_interposed_instruction(
                         }
                         let identifier = &env.identifiers[lvalue.identifier];
                         if identifier.name.is_none() {
-                            inter_state.insert(lvalue.identifier, (lvalue.identifier, false));
+                            inter_state[lvalue.identifier] = Some((lvalue.identifier, false));
                         }
                     }
                     // Visit operands
@@ -702,7 +702,7 @@ fn promote_interposed_instruction(
 fn promote_interposed_value(
     value: &ReactiveValue,
     state: &mut State,
-    inter_state: &mut FxHashMap<IdentifierId, (IdentifierId, bool)>,
+    inter_state: &mut InterState,
     consts: &mut FxHashSet<IdentifierId>,
     globals: &mut FxHashSet<IdentifierId>,
     env: &mut Environment,
@@ -737,7 +737,7 @@ fn promote_interposed_value(
 fn promote_interposed_terminal(
     stmt: &ReactiveTerminalStatement,
     state: &mut State,
-    inter_state: &mut FxHashMap<IdentifierId, (IdentifierId, bool)>,
+    inter_state: &mut InterState,
     consts: &mut FxHashSet<IdentifierId>,
     globals: &mut FxHashSet<IdentifierId>,
     env: &mut Environment,

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/stabilize_block_ids.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/stabilize_block_ids.rs
@@ -10,9 +10,8 @@
 //!
 //! Corresponds to `src/ReactiveScopes/StabilizeBlockIds.ts`.
 
-use rustc_hash::FxHashMap;
-
 use oxc_diagnostics::OxcDiagnostic;
+use oxc_index::IndexVec;
 
 use crate::react_compiler_hir::{
     BlockId, ReactiveFunction, ReactiveScopeBlock, ReactiveTerminal, ReactiveTerminalStatement,
@@ -25,6 +24,30 @@ use crate::react_compiler_reactive_scopes::visitors::{
     visit_reactive_function,
 };
 
+/// Mapping from original block ids to stable sequential ids, indexed densely by
+/// block id. `next` is the next sequential id to assign (i.e. the number of ids
+/// mapped so far).
+struct BlockIdMappings {
+    map: IndexVec<BlockId, Option<BlockId>>,
+    next: u32,
+}
+
+impl BlockIdMappings {
+    fn new(num_block_ids: usize) -> Self {
+        Self { map: IndexVec::from_vec(vec![None; num_block_ids]), next: 0 }
+    }
+
+    fn get_or_insert(&mut self, id: BlockId) -> BlockId {
+        if let Some(mapped) = self.map[id] {
+            return mapped;
+        }
+        let mapped = BlockId::from_usize(self.next as usize);
+        self.next += 1;
+        self.map[id] = Some(mapped);
+        mapped
+    }
+}
+
 /// Rewrites block IDs to sequential values.
 /// TS: `stabilizeBlockIds`
 pub fn stabilize_block_ids<'a>(func: &mut ReactiveFunction<'a>, env: &mut Environment<'a>) {
@@ -34,10 +57,9 @@ pub fn stabilize_block_ids<'a>(func: &mut ReactiveFunction<'a>, env: &mut Enviro
     visit_reactive_function(func, &collector, &mut referenced);
 
     // Build mappings: referenced block IDs -> sequential IDs (insertion-order deterministic)
-    let mut mappings: FxHashMap<BlockId, BlockId> = FxHashMap::default();
+    let mut mappings = BlockIdMappings::new(env.next_block_id_counter as usize);
     for block_id in &referenced {
-        let len = mappings.len();
-        mappings.entry(*block_id).or_insert(BlockId::from_usize(len));
+        mappings.get_or_insert(*block_id);
     }
 
     // Pass 2: Rewrite block IDs using ReactiveFunctionTransform
@@ -82,18 +104,13 @@ impl<'a, 'e> ReactiveFunctionVisitor<'a> for CollectReferencedLabels<'a, 'e> {
 // Pass 2: RewriteBlockIds
 // =============================================================================
 
-fn get_or_insert_mapping(mappings: &mut FxHashMap<BlockId, BlockId>, id: BlockId) -> BlockId {
-    let len = mappings.len();
-    *mappings.entry(id).or_insert(BlockId::from_usize(len))
-}
-
 /// TS: `class RewriteBlockIds extends ReactiveFunctionVisitor<Map<BlockId, BlockId>>`
 struct RewriteBlockIds<'a, 'e> {
     env: &'e mut Environment<'a>,
 }
 
 impl<'a, 'e> ReactiveFunctionTransform<'a> for RewriteBlockIds<'a, 'e> {
-    type State = FxHashMap<BlockId, BlockId>;
+    type State = BlockIdMappings;
 
     fn env(&self) -> &Environment<'a> {
         self.env
@@ -106,7 +123,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for RewriteBlockIds<'a, 'e> {
     ) -> Result<(), OxcDiagnostic> {
         let scope_data = &mut self.env.scopes[scope.scope];
         if let Some(ref mut early_return) = scope_data.early_return_value {
-            early_return.label = get_or_insert_mapping(state, early_return.label);
+            early_return.label = state.get_or_insert(early_return.label);
         }
         self.traverse_scope(scope, state)
     }
@@ -117,12 +134,12 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for RewriteBlockIds<'a, 'e> {
         state: &mut Self::State,
     ) -> Result<(), OxcDiagnostic> {
         if let Some(ref mut label) = stmt.label {
-            label.id = get_or_insert_mapping(state, label.id);
+            label.id = state.get_or_insert(label.id);
         }
 
         match &mut stmt.terminal {
             ReactiveTerminal::Break { target, .. } | ReactiveTerminal::Continue { target, .. } => {
-                *target = get_or_insert_mapping(state, *target);
+                *target = state.get_or_insert(*target);
             }
             _ => {}
         }

--- a/crates/oxc_react_compiler/src/react_compiler_ssa/eliminate_redundant_phi.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_ssa/eliminate_redundant_phi.rs
@@ -1,6 +1,8 @@
 use std::mem::replace;
 
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashSet;
+
+use oxc_index::IndexVec;
 
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::visitors;
@@ -9,11 +11,30 @@ use crate::react_compiler_hir::*;
 use crate::react_compiler_ssa::enter_ssa::placeholder_function;
 
 // =============================================================================
-// Helper: rewrite_place
+// Rewrite map
 // =============================================================================
 
-fn rewrite_place(place: &mut Place, rewrites: &FxHashMap<IdentifierId, IdentifierId>) {
-    if let Some(&rewrite) = rewrites.get(&place.identifier) {
+/// Rewrites from eliminated phi ids to their canonical ids, indexed densely by
+/// identifier id. `len` counts mapped entries (used for fixpoint detection).
+struct Rewrites {
+    map: IndexVec<IdentifierId, Option<IdentifierId>>,
+    len: usize,
+}
+
+impl Rewrites {
+    fn new(num_identifiers: usize) -> Self {
+        Self { map: IndexVec::from_vec(vec![None; num_identifiers]), len: 0 }
+    }
+
+    fn insert(&mut self, key: IdentifierId, value: IdentifierId) {
+        if self.map[key].replace(value).is_none() {
+            self.len += 1;
+        }
+    }
+}
+
+fn rewrite_place(place: &mut Place, rewrites: &Rewrites) {
+    if let Some(rewrite) = rewrites.map[place.identifier] {
         place.identifier = rewrite;
     }
 }
@@ -23,7 +44,7 @@ fn rewrite_place(place: &mut Place, rewrites: &FxHashMap<IdentifierId, Identifie
 // =============================================================================
 
 pub fn eliminate_redundant_phi(func: &mut HirFunction, env: &mut Environment) {
-    let mut rewrites: FxHashMap<IdentifierId, IdentifierId> = FxHashMap::default();
+    let mut rewrites = Rewrites::new(env.identifiers.len());
     eliminate_redundant_phi_impl(func, env, &mut rewrites);
 }
 
@@ -34,7 +55,7 @@ pub fn eliminate_redundant_phi(func: &mut HirFunction, env: &mut Environment) {
 fn eliminate_redundant_phi_impl(
     func: &mut HirFunction,
     env: &mut Environment,
-    rewrites: &mut FxHashMap<IdentifierId, IdentifierId>,
+    rewrites: &mut Rewrites,
 ) {
     let ir = &mut func.body;
 
@@ -43,7 +64,7 @@ fn eliminate_redundant_phi_impl(
 
     let mut size;
     loop {
-        size = rewrites.len();
+        size = rewrites.len;
 
         let block_ids: Vec<BlockId> = ir.blocks.keys().copied().collect();
         for block_id in &block_ids {
@@ -148,7 +169,7 @@ fn eliminate_redundant_phi_impl(
             });
         }
 
-        if !(rewrites.len() > size && has_back_edge) {
+        if !(rewrites.len > size && has_back_edge) {
             break;
         }
     }

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_hooks_usage.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_hooks_usage.rs
@@ -12,8 +12,6 @@
 
 use std::iter::once;
 
-use rustc_hash::FxHashMap;
-
 use oxc_diagnostics::OxcDiagnostic;
 
 use crate::diagnostics::ErrorCategory;
@@ -26,7 +24,7 @@ use crate::react_compiler_hir::{
     PlaceOrSpread, PropertyLiteral, Type, TypeId, visitors,
 };
 use crate::react_compiler_utils::FxIndexMap;
-use oxc_index::IndexSlice;
+use oxc_index::{IndexSlice, IndexVec};
 use oxc_span::Span;
 
 /// Value classification for hook validation.
@@ -38,6 +36,9 @@ enum Kind {
     Global,
     Local,
 }
+
+/// Value classification per identifier, indexed densely by identifier id.
+type ValueKinds = IndexVec<IdentifierId, Option<Kind>>;
 
 fn join_kinds(a: Kind, b: Kind) -> Kind {
     if a == Kind::Error || b == Kind::Error {
@@ -55,10 +56,10 @@ fn join_kinds(a: Kind, b: Kind) -> Kind {
 
 fn get_kind_for_place(
     place: &Place,
-    value_kinds: &FxHashMap<IdentifierId, Kind>,
+    value_kinds: &ValueKinds,
     identifiers: &IndexSlice<IdentifierId, [Identifier]>,
 ) -> Kind {
-    let known_kind = value_kinds.get(&place.identifier).copied();
+    let known_kind = value_kinds[place.identifier];
     let ident = &identifiers[place.identifier];
     if let Some(ref name) = ident.name
         && is_hook_name(name.value())
@@ -89,11 +90,11 @@ fn get_hook_kind_for_id<'a>(
 
 fn visit_place(
     place: &Place,
-    value_kinds: &FxHashMap<IdentifierId, Kind>,
+    value_kinds: &ValueKinds,
     errors_by_span: &mut FxIndexMap<Span, OxcDiagnostic>,
     env: &mut Environment,
 ) -> Result<(), OxcDiagnostic> {
-    let kind = value_kinds.get(&place.identifier).copied();
+    let kind = value_kinds[place.identifier];
     if kind == Some(Kind::KnownHook) {
         record_invalid_hook_usage_error(place, errors_by_span, env)?;
     }
@@ -102,11 +103,11 @@ fn visit_place(
 
 fn record_conditional_hook_error(
     place: &Place,
-    value_kinds: &mut FxHashMap<IdentifierId, Kind>,
+    value_kinds: &mut ValueKinds,
     errors_by_span: &mut FxIndexMap<Span, OxcDiagnostic>,
     env: &mut Environment,
 ) -> Result<(), OxcDiagnostic> {
-    value_kinds.insert(place.identifier, Kind::Error);
+    value_kinds[place.identifier] = Some(Kind::Error);
     let reason = "Hooks must always be called in a consistent order, and may not be called conditionally. See the Rules of Hooks (https://react.dev/warnings/invalid-hook-call-warning)";
     if let Some(span) = place.span {
         let diagnostic = ErrorCategory::Hooks.diagnostic(reason).with_label(span);
@@ -160,7 +161,7 @@ pub fn validate_hooks_usage(
     let unconditional_blocks =
         compute_unconditional_blocks(func, env.next_block_id().index() as u32)?;
     let mut errors_by_span: FxIndexMap<Span, OxcDiagnostic> = FxIndexMap::default();
-    let mut value_kinds: FxHashMap<IdentifierId, Kind> = FxHashMap::default();
+    let mut value_kinds: ValueKinds = IndexVec::from_vec(vec![None; env.identifiers.len()]);
 
     // Process params
     for param in &func.params {
@@ -169,7 +170,7 @@ pub fn validate_hooks_usage(
             ParamPattern::Spread(s) => &s.place,
         };
         let kind = get_kind_for_place(place, &value_kinds, &env.identifiers);
-        value_kinds.insert(place.identifier, kind);
+        value_kinds[place.identifier] = Some(kind);
     }
 
     // Process blocks
@@ -182,11 +183,11 @@ pub fn validate_hooks_usage(
                 Kind::Local
             };
             for (_, operand) in &phi.operands {
-                if let Some(&operand_kind) = value_kinds.get(&operand.identifier) {
+                if let Some(operand_kind) = value_kinds[operand.identifier] {
                     kind = join_kinds(kind, operand_kind);
                 }
             }
-            value_kinds.insert(phi.place.identifier, kind);
+            value_kinds[phi.place.identifier] = Some(kind);
         }
 
         // Process instructions
@@ -198,16 +199,16 @@ pub fn validate_hooks_usage(
                 InstructionValue::LoadGlobal { .. } => {
                     if get_hook_kind_for_id(lvalue_id, &env.identifiers, &env.types, env)?.is_some()
                     {
-                        value_kinds.insert(lvalue_id, Kind::KnownHook);
+                        value_kinds[lvalue_id] = Some(Kind::KnownHook);
                     } else {
-                        value_kinds.insert(lvalue_id, Kind::Global);
+                        value_kinds[lvalue_id] = Some(Kind::Global);
                     }
                 }
                 InstructionValue::LoadContext { place, .. }
                 | InstructionValue::LoadLocal { place, .. } => {
                     visit_place(place, &value_kinds, &mut errors_by_span, env)?;
                     let kind = get_kind_for_place(place, &value_kinds, &env.identifiers);
-                    value_kinds.insert(lvalue_id, kind);
+                    value_kinds[lvalue_id] = Some(kind);
                 }
                 InstructionValue::StoreLocal { lvalue, value, .. }
                 | InstructionValue::StoreContext { lvalue, value, .. } => {
@@ -216,15 +217,15 @@ pub fn validate_hooks_usage(
                         get_kind_for_place(value, &value_kinds, &env.identifiers),
                         get_kind_for_place(&lvalue.place, &value_kinds, &env.identifiers),
                     );
-                    value_kinds.insert(lvalue.place.identifier, kind);
-                    value_kinds.insert(lvalue_id, kind);
+                    value_kinds[lvalue.place.identifier] = Some(kind);
+                    value_kinds[lvalue_id] = Some(kind);
                 }
                 InstructionValue::ComputedLoad { object, .. } => {
                     visit_place(object, &value_kinds, &mut errors_by_span, env)?;
                     let kind = get_kind_for_place(object, &value_kinds, &env.identifiers);
                     let lvalue_kind =
                         get_kind_for_place(&instr.lvalue, &value_kinds, &env.identifiers);
-                    value_kinds.insert(lvalue_id, join_kinds(lvalue_kind, kind));
+                    value_kinds[lvalue_id] = Some(join_kinds(lvalue_kind, kind));
                 }
                 InstructionValue::PropertyLoad { object, property, .. } => {
                     let object_kind = get_kind_for_place(object, &value_kinds, &env.identifiers);
@@ -257,7 +258,7 @@ pub fn validate_hooks_usage(
                             }
                         }
                     };
-                    value_kinds.insert(lvalue_id, kind);
+                    value_kinds[lvalue_id] = Some(kind);
                 }
                 InstructionValue::CallExpression { callee, args, .. } => {
                     let callee_kind = get_kind_for_place(callee, &value_kinds, &env.identifiers);
@@ -334,7 +335,7 @@ pub fn validate_hooks_usage(
                                 }
                             }
                         };
-                        value_kinds.insert(place.identifier, kind);
+                        value_kinds[place.identifier] = Some(kind);
                     }
                 }
                 InstructionValue::ObjectMethod { lowered_func, .. }
@@ -347,11 +348,11 @@ pub fn validate_hooks_usage(
                     visit_all_operands(&instr.value, &value_kinds, &mut errors_by_span, env)?;
                     // Set kind for instr.lvalue
                     let kind = get_kind_for_place(&instr.lvalue, &value_kinds, &env.identifiers);
-                    value_kinds.insert(lvalue_id, kind);
+                    value_kinds[lvalue_id] = Some(kind);
                     // Also set kind for value-level lvalues (e.g. DeclareLocal, PrefixUpdate, PostfixUpdate)
                     for lv in visitors::each_instruction_value_lvalue(&instr.value) {
                         let lv_kind = get_kind_for_place(&lv, &value_kinds, &env.identifiers);
-                        value_kinds.insert(lv.identifier, lv_kind);
+                        value_kinds[lv.identifier] = Some(lv_kind);
                     }
                 }
             }
@@ -465,7 +466,7 @@ fn hook_kind_display(kind: &HookKind) -> &'static str {
 /// Uses the canonical `each_instruction_value_operand` from visitors.
 fn visit_all_operands(
     value: &InstructionValue,
-    value_kinds: &FxHashMap<IdentifierId, Kind>,
+    value_kinds: &ValueKinds,
     errors_by_span: &mut FxIndexMap<Span, OxcDiagnostic>,
     env: &mut Environment,
 ) -> Result<(), OxcDiagnostic> {


### PR DESCRIPTION
Each distinct `FxHashMap<K, V>` monomorphizes its own copy of hashbrown; maps keyed by the dense u32 newtype ids become direct-indexed `IndexVec<Id, Option<V>>`s, removing those instantiations and the per-lookup hashing.

### Migration criteria

A map was migrated only when all of these hold:

1. The key is a dense id (`IdentifierId`, `DeclarationId`, `BlockId`) with a sound bound available at construction time: `env.identifiers.len()` (declaration ids share the identifier id index space — `DeclarationId::from_usize(id.index())` at allocation), `env.next_block_id_counter` (+1 for the synthetic exit node in the dominator), or the max block id present in the function body.
2. The map is only accessed by key (`get`/`insert`/`contains_key`); it is never iterated in a way that can reach the output. The one iterated map (the optional-chain temporaries merge) writes into another map with distinct keys, so iteration order is not observable.
3. `Option<V>` slots preserve the exact presence semantics, including "insert twice keeps latest" and `entry().or_insert()` first-wins. Where `map.len()` carried meaning, it was replaced with an explicit counter (`Rewrites::len` for the phi-elimination fixpoint, `BlockIdMappings::next` for sequential id assignment).
4. The map is allocated once per pass, not per inner loop iteration.

### Migrated maps

| File | Map |
| --- | --- |
| `react_compiler_hir/dominator.rs` | `PostDominator::nodes`, `Graph::node_index`, `raw_nodes`, `doms` (kills `FxHashMap<BlockId, BlockId>`, `<BlockId, Node>`, `<BlockId, usize>`) |
| `react_compiler_reactive_scopes/stabilize_block_ids.rs` | block id `mappings` (new `BlockIdMappings` with explicit `next` counter) |
| `react_compiler_optimization/prune_maybe_throws.rs` | `terminal_mapping` |
| `react_compiler_ssa/eliminate_redundant_phi.rs` | `rewrites` (new `Rewrites` with explicit entry count for the fixpoint check) |
| `react_compiler_validation/validate_hooks_usage.rs` | `value_kinds` (`Option<Kind>` is 1 byte) |
| `react_compiler_reactive_scopes/promote_used_temporaries.rs` | `State::pruned`, `inter_state` |
| `react_compiler_reactive_scopes/merge_reactive_scopes_that_invalidate_together.rs` | `last_usage`, `temporaries` |
| `react_compiler_inference/propagate_scope_dependencies_hir.rs` | `temporaries` + `temporaries_read_in_optional` (the crate's most-instantiated map type, ×11), the declaring-scope map in `find_temporaries_used_outside_declaring_scope`, and `DependencyCollectionContext::{declarations, reassignments}` |

This eliminates 11 distinct id-keyed hashbrown instantiations from the crate.

### Deliberately skipped

- `outline_jsx.rs` `globals` and `infer_types.rs` / `name_anonymous_functions.rs` `names`: these create a fresh map per nested function, so a dense vec sized by the env-wide identifier count would allocate O(identifiers) for a handful of entries on every nested function.
- `outline_jsx.rs` `rewrite_instr` and other `EvaluationOrder`-keyed maps: no clean bound at the construction site and keys are sparse.
- `get_assumed_invoked_functions` temporaries in `propagate_scope_dependencies_hir.rs`: allocated per inner function (same per-iteration concern).
- `FxIndexMap` uses: insertion order is semantic there.
- Maps whose iteration feeds diagnostics or output ordering (e.g. `validate_no_derived_computations_in_effects.rs`).

### Measured effect

Release example binary (`examples/react_compiler`, macOS arm64): `__text` (machine code) shrinks 2,767,800 → 2,756,116 bytes (**−11,684 bytes, −0.42%**). The on-disk file size only changes by 16 bytes because the `__TEXT` segment is page-aligned; the machine-code section is the meaningful metric. The example links the full parser/codegen stack, so the relative saving within this crate's own code is larger. The main win is runtime: every migrated lookup is now a bounds-checked array index instead of a hash + probe.

The upstream fixture corpus (1,736 snapshots) is byte-for-byte unchanged, and `cargo clippy -p oxc_react_compiler --all-targets` is clean.

### Note for upstream re-syncs

This intentionally deviates from the upstream TypeScript structure (`Map`-based sidemaps in `PropagateScopeDependenciesHIR.ts`, `Dominator.ts`, etc.). When re-syncing this crate with upstream via `react_compiler_oxc`, please preserve the `IndexVec` representation for these maps.

Authored with Claude Code; reviewed by a human before merge.
