### PR TITLE
feat(track-memory-allocations): track deallocations, peak heap growth, arena growth, and all-arena totals

### DIFF
--- a/crates/oxc_allocator/src/arena/drop.rs
+++ b/crates/oxc_allocator/src/arena/drop.rs
@@ -149,6 +149,9 @@ unsafe fn dealloc_chunk(footer_ptr: NonNull<ChunkFooter>) {
         }
     }
 
+    #[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]
+    crate::tracking::record_chunk_deallocation(layout.size());
+
     // SAFETY: Each `ChunkFooter`'s `backing_alloc_ptr` and `layout` describe its backing allocation.
     // `is_fixed_size` is `false`, so backing allocation was made via global allocator.
     unsafe { alloc::dealloc(backing_alloc_ptr, layout) };

--- a/crates/oxc_allocator/src/tracking.rs
+++ b/crates/oxc_allocator/src/tracking.rs
@@ -28,12 +28,42 @@ static NUM_CHUNK_ALLOC: AtomicUsize = AtomicUsize::new(0);
 /// A global counter, for the same reason as [`NUM_CHUNK_ALLOC`].
 static NUM_CHUNK_ALLOC_BYTES: AtomicUsize = AtomicUsize::new(0);
 
+/// Number of chunks all [`Arena`]s have returned to the system allocator, in total.
+///
+/// A global counter, for the same reason as [`NUM_CHUNK_ALLOC`].
+static NUM_CHUNK_DEALLOC: AtomicUsize = AtomicUsize::new(0);
+
+/// Total size in bytes of all chunks [`Arena`]s have returned to the system allocator.
+///
+/// A global counter, for the same reason as [`NUM_CHUNK_ALLOC`].
+static NUM_CHUNK_DEALLOC_BYTES: AtomicUsize = AtomicUsize::new(0);
+
+/// Number of allocations made in all [`Arena`]s, in total.
+///
+/// A global counter, unlike the per-arena [`AllocationStats`], so that allocations made in
+/// short-lived arenas (which are dropped inside the operation being measured) are still visible.
+static NUM_ARENA_ALLOC: AtomicUsize = AtomicUsize::new(0);
+
+/// Number of reallocations made in all [`Arena`]s, in total.
+///
+/// A global counter, for the same reason as [`NUM_ARENA_ALLOC`].
+static NUM_ARENA_REALLOC: AtomicUsize = AtomicUsize::new(0);
+
 /// Record that a chunk of `size` bytes was allocated from the system allocator.
 pub fn record_chunk_allocation(size: usize) {
     // Counters max out at `usize::MAX`, but if there's that many allocations,
     // the exact number is not important
     NUM_CHUNK_ALLOC.update(Ordering::Relaxed, Ordering::Relaxed, |count| count.saturating_add(1));
     NUM_CHUNK_ALLOC_BYTES
+        .update(Ordering::Relaxed, Ordering::Relaxed, |total| total.saturating_add(size));
+}
+
+/// Record that a chunk of `size` bytes was returned to the system allocator.
+pub fn record_chunk_deallocation(size: usize) {
+    // Counters max out at `usize::MAX`, but if there's that many allocations,
+    // the exact number is not important
+    NUM_CHUNK_DEALLOC.update(Ordering::Relaxed, Ordering::Relaxed, |count| count.saturating_add(1));
+    NUM_CHUNK_DEALLOC_BYTES
         .update(Ordering::Relaxed, Ordering::Relaxed, |total| total.saturating_add(size));
 }
 
@@ -52,6 +82,7 @@ impl AllocationStats {
         // Counter maxes out at `usize::MAX`, but if there's that many allocations,
         // the exact number is not important
         self.num_alloc.set(self.num_alloc.get().saturating_add(1));
+        NUM_ARENA_ALLOC.update(Ordering::Relaxed, Ordering::Relaxed, |n| n.saturating_add(1));
     }
 
     /// Record that a reallocation was made.
@@ -59,6 +90,7 @@ impl AllocationStats {
         // Counter maxes out at `usize::MAX`, but if there's that many allocations,
         // the exact number is not important
         self.num_realloc.set(self.num_realloc.get().saturating_add(1));
+        NUM_ARENA_REALLOC.update(Ordering::Relaxed, Ordering::Relaxed, |n| n.saturating_add(1));
     }
 
     /// Record that a reallocation was made, after it was initially recorded as an allocation.
@@ -69,10 +101,14 @@ impl AllocationStats {
         if num_alloc != usize::MAX {
             self.num_alloc.set(num_alloc - 1);
         }
+        NUM_ARENA_ALLOC.update(Ordering::Relaxed, Ordering::Relaxed, |n| {
+            if n == usize::MAX { n } else { n - 1 }
+        });
 
         // Counter maxes out at `usize::MAX`, but if there's that many allocations,
         // the exact number is not important
         self.num_realloc.set(self.num_realloc.get().saturating_add(1));
+        NUM_ARENA_REALLOC.update(Ordering::Relaxed, Ordering::Relaxed, |n| n.saturating_add(1));
     }
 
     /// Reset allocation counters.
@@ -103,5 +139,19 @@ impl Allocator {
     #[doc(hidden)]
     pub fn global_chunk_allocation_stats() -> (usize, usize) {
         (NUM_CHUNK_ALLOC.load(Ordering::Relaxed), NUM_CHUNK_ALLOC_BYTES.load(Ordering::Relaxed))
+    }
+
+    /// Get number and total size in bytes of chunks all [`Arena`]s have returned to
+    /// the system allocator, as `(count, bytes)`.
+    #[doc(hidden)]
+    pub fn global_chunk_deallocation_stats() -> (usize, usize) {
+        (NUM_CHUNK_DEALLOC.load(Ordering::Relaxed), NUM_CHUNK_DEALLOC_BYTES.load(Ordering::Relaxed))
+    }
+
+    /// Get number of allocations and reallocations made in all [`Arena`]s, in total,
+    /// including arenas that have since been dropped.
+    #[doc(hidden)]
+    pub fn global_arena_allocation_stats() -> (usize, usize) {
+        (NUM_ARENA_ALLOC.load(Ordering::Relaxed), NUM_ARENA_REALLOC.load(Ordering::Relaxed))
     }
 }

--- a/tasks/track_memory_allocations/allocs_formatter.snap
+++ b/tasks/track_memory_allocations/allocs_formatter.snap
@@ -2,62 +2,104 @@ checker.ts
   file size: 2.92 MB
   sys allocs: 11013
   sys reallocs: 492
+  sys deallocs: 11012
   sys alloc bytes: 5967253 (5.97 MB)
+  sys dealloc bytes: 3045099 (3.05 MB)
+  peak heap growth: 2998258 (3.00 MB)
   arena allocs: 1081815
   arena reallocs: 118690
+  total arena allocs: 1081815
+  total arena reallocs: 118690
+  arena growth: 125621448 (125.62 MB)
   arena size: 138513120 (138.51 MB)
 
 App.tsx
   file size: 415.34 kB
   sys allocs: 2532
   sys reallocs: 80
+  sys deallocs: 2531
   sys alloc bytes: 993614 (993.61 kB)
+  sys dealloc bytes: 578272 (578.27 kB)
+  peak heap growth: 444582 (444.58 kB)
   arena allocs: 212668
   arena reallocs: 25343
+  total arena allocs: 212668
+  total arena reallocs: 25343
+  arena growth: 27376040 (27.38 MB)
   arena size: 29608728 (29.61 MB)
 
 RadixUIAdoptionSection.jsx
   file size: 2.52 kB
   sys allocs: 54
   sys reallocs: 26
+  sys deallocs: 53
   sys alloc bytes: 13624 (13.62 kB)
+  sys dealloc bytes: 11104 (11.10 kB)
+  peak heap growth: 2904 (2.90 kB)
   arena allocs: 1155
   arena reallocs: 157
+  total arena allocs: 1155
+  total arena reallocs: 157
+  arena growth: 188880 (188.88 kB)
   arena size: 210080 (210.08 kB)
 
 pdf.mjs
   file size: 567.30 kB
   sys allocs: 4019
   sys reallocs: 172
+  sys deallocs: 4018
   sys alloc bytes: 2632904 (2.63 MB)
+  sys dealloc bytes: 1498312 (1.50 MB)
+  peak heap growth: 1731864 (1.73 MB)
   arena allocs: 437639
   arena reallocs: 43489
+  total arena allocs: 437639
+  total arena reallocs: 43489
+  arena growth: 40351832 (40.35 MB)
   arena size: 44872280 (44.87 MB)
 
 antd.js
   file size: 6.69 MB
   sys allocs: 34121
   sys reallocs: 3994
+  sys deallocs: 34120
   sys alloc bytes: 27684464 (27.68 MB)
+  sys dealloc bytes: 14311832 (14.31 MB)
+  peak heap growth: 768588092 (768.59 MB)
   arena allocs: 2586207
   arena reallocs: 302459
+  total arena allocs: 2586207
+  total arena reallocs: 302459
+  arena growth: 496652424 (496.65 MB)
   arena size: 525725120 (525.73 MB)
 
 binder.ts
   file size: 193.08 kB
   sys allocs: 457
   sys reallocs: 35
+  sys deallocs: 456
   sys alloc bytes: 293645 (293.64 kB)
+  sys dealloc bytes: 100568 (100.57 kB)
+  peak heap growth: 195925 (195.93 kB)
   arena allocs: 64083
   arena reallocs: 6932
+  total arena allocs: 64083
+  total arena reallocs: 6932
+  arena growth: 7661336 (7.66 MB)
   arena size: 8574792 (8.57 MB)
 
 kitchen-sink.tsx
   file size: 732.90 kB
   sys allocs: 9565
   sys reallocs: 2815
+  sys deallocs: 9564
   sys alloc bytes: 3979499 (3.98 MB)
+  sys dealloc bytes: 2513703 (2.51 MB)
+  peak heap growth: 2232894 (2.23 MB)
   arena allocs: 569911
   arena reallocs: 60147
+  total arena allocs: 569911
+  total arena reallocs: 60147
+  arena growth: 51458368 (51.46 MB)
   arena size: 57887152 (57.89 MB)
 

--- a/tasks/track_memory_allocations/allocs_minifier.snap
+++ b/tasks/track_memory_allocations/allocs_minifier.snap
@@ -2,62 +2,104 @@ checker.ts
   file size: 2.92 MB
   sys allocs: 155
   sys reallocs: 5
+  sys deallocs: 155
   sys alloc bytes: 15437268 (15.44 MB)
+  sys dealloc bytes: 15437268 (15.44 MB)
+  peak heap growth: 17190776 (17.19 MB)
   arena allocs: 152755
   arena reallocs: 28253
+  total arena allocs: 242856
+  total arena reallocs: 70239
+  arena growth: 5972688 (5.97 MB)
   arena size: 19046592 (19.05 MB)
 
 App.tsx
   file size: 415.34 kB
   sys allocs: 63
   sys reallocs: 8
+  sys deallocs: 63
   sys alloc bytes: 2202365 (2.20 MB)
+  sys dealloc bytes: 2202365 (2.20 MB)
+  peak heap growth: 2303045 (2.30 MB)
   arena allocs: 17028
   arena reallocs: 2702
+  total arena allocs: 28708
+  total arena reallocs: 6953
+  arena growth: 637808 (637.81 kB)
   arena size: 2915632 (2.92 MB)
 
 RadixUIAdoptionSection.jsx
   file size: 2.52 kB
   sys allocs: 21
   sys reallocs: 0
+  sys deallocs: 21
   sys alloc bytes: 17368 (17.37 kB)
+  sys dealloc bytes: 17368 (17.37 kB)
+  peak heap growth: 43620 (43.62 kB)
   arena allocs: 32
   arena reallocs: 6
+  total arena allocs: 134
+  total arena reallocs: 30
+  arena growth: 1144 (1.14 kB)
   arena size: 35792 (35.79 kB)
 
 pdf.mjs
   file size: 567.30 kB
   sys allocs: 2469
   sys reallocs: 205
+  sys deallocs: 2469
   sys alloc bytes: 5864075 (5.86 MB)
+  sys dealloc bytes: 5864075 (5.86 MB)
+  peak heap growth: 4888303 (4.89 MB)
   arena allocs: 47471
   arena reallocs: 7742
+  total arena allocs: 75485
+  total arena reallocs: 18074
+  arena growth: 1796632 (1.80 MB)
   arena size: 6356576 (6.36 MB)
 
 antd.js
   file size: 6.69 MB
   sys allocs: 1044
   sys reallocs: 56
+  sys deallocs: 1044
   sys alloc bytes: 32022901 (32.02 MB)
+  sys dealloc bytes: 32022901 (32.02 MB)
+  peak heap growth: 30476085 (30.48 MB)
   arena allocs: 372632
   arena reallocs: 76745
+  total arena allocs: 577591
+  total arena reallocs: 135233
+  arena growth: 19611176 (19.61 MB)
   arena size: 49033120 (49.03 MB)
 
 binder.ts
   file size: 193.08 kB
   sys allocs: 33
   sys reallocs: 1
+  sys deallocs: 33
   sys alloc bytes: 988478 (988.48 kB)
+  sys dealloc bytes: 988478 (988.48 kB)
+  peak heap growth: 916474 (916.47 kB)
   arena allocs: 7076
   arena reallocs: 824
+  total arena allocs: 13204
+  total arena reallocs: 3391
+  arena growth: 233696 (233.70 kB)
   arena size: 1157992 (1.16 MB)
 
 kitchen-sink.tsx
   file size: 732.90 kB
   sys allocs: 2309
   sys reallocs: 175
+  sys deallocs: 2309
   sys alloc bytes: 5779412 (5.78 MB)
+  sys dealloc bytes: 5779412 (5.78 MB)
+  peak heap growth: 5404998 (5.40 MB)
   arena allocs: 88129
   arena reallocs: 15654
+  total arena allocs: 117424
+  total arena reallocs: 24425
+  arena growth: 3360496 (3.36 MB)
   arena size: 10190448 (10.19 MB)
 

--- a/tasks/track_memory_allocations/allocs_parser.snap
+++ b/tasks/track_memory_allocations/allocs_parser.snap
@@ -2,62 +2,104 @@ checker.ts
   file size: 2.92 MB
   sys allocs: 1818
   sys reallocs: 10
+  sys deallocs: 1818
   sys alloc bytes: 69339 (69.34 kB)
+  sys dealloc bytes: 69339 (69.34 kB)
+  peak heap growth: 2952 (2.95 kB)
   arena allocs: 264366
   arena reallocs: 22860
+  total arena allocs: 264366
+  total arena reallocs: 22860
+  arena growth: 12985208 (12.99 MB)
   arena size: 12985208 (12.99 MB)
 
 App.tsx
   file size: 415.34 kB
   sys allocs: 360
   sys reallocs: 13
+  sys deallocs: 360
   sys alloc bytes: 52555 (52.55 kB)
+  sys dealloc bytes: 52555 (52.55 kB)
+  peak heap growth: 26436 (26.44 kB)
   arena allocs: 44464
   arena reallocs: 3537
+  total arena allocs: 44464
+  total arena reallocs: 3537
+  arena growth: 2244536 (2.24 MB)
   arena size: 2244536 (2.24 MB)
 
 RadixUIAdoptionSection.jsx
   file size: 2.52 kB
   sys allocs: 1
   sys reallocs: 0
+  sys deallocs: 1
   sys alloc bytes: 116 (116 B)
+  sys dealloc bytes: 116 (116 B)
+  peak heap growth: 116 (116 B)
   arena allocs: 367
   arena reallocs: 66
+  total arena allocs: 367
+  total arena reallocs: 66
+  arena growth: 21232 (21.23 kB)
   arena size: 21232 (21.23 kB)
 
 pdf.mjs
   file size: 567.30 kB
   sys allocs: 337
   sys reallocs: 67
+  sys deallocs: 337
   sys alloc bytes: 49230 (49.23 kB)
+  sys dealloc bytes: 49230 (49.23 kB)
+  peak heap growth: 16244 (16.24 kB)
   arena allocs: 90583
   arena reallocs: 8153
+  total arena allocs: 90583
+  total arena reallocs: 8153
+  arena growth: 4559920 (4.56 MB)
   arena size: 4559920 (4.56 MB)
 
 antd.js
   file size: 6.69 MB
   sys allocs: 3661
   sys reallocs: 221
+  sys deallocs: 3661
   sys alloc bytes: 304001 (304.00 kB)
+  sys dealloc bytes: 304001 (304.00 kB)
+  peak heap growth: 64656 (64.66 kB)
   arena allocs: 528577
   arena reallocs: 55355
+  total arena allocs: 528577
+  total arena reallocs: 55355
+  arena growth: 29421920 (29.42 MB)
   arena size: 29421920 (29.42 MB)
 
 binder.ts
   file size: 193.08 kB
   sys allocs: 85
   sys reallocs: 0
+  sys deallocs: 85
   sys alloc bytes: 3024 (3.02 kB)
+  sys dealloc bytes: 3024 (3.02 kB)
+  peak heap growth: 259 (259 B)
   arena allocs: 16620
   arena reallocs: 1476
+  total arena allocs: 16620
+  total arena reallocs: 1476
+  arena growth: 917456 (917.46 kB)
   arena size: 917456 (917.46 kB)
 
 kitchen-sink.tsx
   file size: 732.90 kB
   sys allocs: 2051
   sys reallocs: 160
+  sys deallocs: 2051
   sys alloc bytes: 140276 (140.28 kB)
+  sys dealloc bytes: 140276 (140.28 kB)
+  peak heap growth: 14684 (14.68 kB)
   arena allocs: 138059
   arena reallocs: 11905
+  total arena allocs: 138059
+  total arena reallocs: 11905
+  arena growth: 6495856 (6.50 MB)
   arena size: 6495856 (6.50 MB)
 

--- a/tasks/track_memory_allocations/allocs_semantic.snap
+++ b/tasks/track_memory_allocations/allocs_semantic.snap
@@ -2,62 +2,104 @@ checker.ts
   file size: 2.92 MB
   sys allocs: 46
   sys reallocs: 0
+  sys deallocs: 46
   sys alloc bytes: 3867118 (3.87 MB)
+  sys dealloc bytes: 3867118 (3.87 MB)
+  peak heap growth: 7542910 (7.54 MB)
   arena allocs: 0
   arena reallocs: 0
+  total arena allocs: 37851
+  total arena reallocs: 22022
+  arena growth: 0 (0 B)
   arena size: 12985208 (12.99 MB)
 
 App.tsx
   file size: 415.34 kB
   sys allocs: 7
   sys reallocs: 0
+  sys deallocs: 7
   sys alloc bytes: 360848 (360.85 kB)
+  sys dealloc bytes: 360848 (360.85 kB)
+  peak heap growth: 852304 (852.30 kB)
   arena allocs: 0
   arena reallocs: 0
+  total arena allocs: 4936
+  total arena reallocs: 2229
+  arena growth: 0 (0 B)
   arena size: 2244536 (2.24 MB)
 
 RadixUIAdoptionSection.jsx
   file size: 2.52 kB
   sys allocs: 7
   sys reallocs: 0
+  sys deallocs: 7
   sys alloc bytes: 2748 (2.75 kB)
+  sys dealloc bytes: 2748 (2.75 kB)
+  peak heap growth: 19116 (19.12 kB)
   arena allocs: 0
   arena reallocs: 0
+  total arena allocs: 25
+  total arena reallocs: 14
+  arena growth: 0 (0 B)
   arena size: 21232 (21.23 kB)
 
 pdf.mjs
   file size: 567.30 kB
   sys allocs: 12
   sys reallocs: 0
+  sys deallocs: 12
   sys alloc bytes: 833750 (833.75 kB)
+  sys dealloc bytes: 833750 (833.75 kB)
+  peak heap growth: 1938634 (1.94 MB)
   arena allocs: 0
   arena reallocs: 0
+  total arena allocs: 11977
+  total arena reallocs: 5101
+  arena growth: 0 (0 B)
   arena size: 4559920 (4.56 MB)
 
 antd.js
   file size: 6.69 MB
   sys allocs: 24
   sys reallocs: 0
+  sys deallocs: 24
   sys alloc bytes: 5513070 (5.51 MB)
+  sys dealloc bytes: 5513070 (5.51 MB)
+  peak heap growth: 15947478 (15.95 MB)
   arena allocs: 0
   arena reallocs: 0
+  total arena allocs: 100200
+  total arena reallocs: 30529
+  arena growth: 0 (0 B)
   arena size: 29421920 (29.42 MB)
 
 binder.ts
   file size: 193.08 kB
   sys allocs: 14
   sys reallocs: 0
+  sys deallocs: 14
   sys alloc bytes: 247066 (247.07 kB)
+  sys dealloc bytes: 247066 (247.07 kB)
+  peak heap growth: 553774 (553.77 kB)
   arena allocs: 0
   arena reallocs: 0
+  total arena allocs: 2557
+  total arena reallocs: 1447
+  arena growth: 0 (0 B)
   arena size: 917456 (917.46 kB)
 
 kitchen-sink.tsx
   file size: 732.90 kB
   sys allocs: 33
   sys reallocs: 0
+  sys deallocs: 33
   sys alloc bytes: 1104078 (1.10 MB)
+  sys dealloc bytes: 1104078 (1.10 MB)
+  peak heap growth: 2821994 (2.82 MB)
   arena allocs: 0
   arena reallocs: 0
+  total arena allocs: 18651
+  total arena reallocs: 6363
+  arena growth: 0 (0 B)
   arena size: 6495856 (6.50 MB)
 

--- a/tasks/track_memory_allocations/allocs_transformer.snap
+++ b/tasks/track_memory_allocations/allocs_transformer.snap
@@ -2,62 +2,104 @@ checker.ts
   file size: 2.92 MB
   sys allocs: 18
   sys reallocs: 0
+  sys deallocs: 44
   sys alloc bytes: 2375 (2.38 kB)
+  sys dealloc bytes: 6103213 (6.10 MB)
+  peak heap growth: 2259 (2.26 kB)
   arena allocs: 1959
   arena reallocs: 5
+  total arena allocs: 2018
+  total arena reallocs: 80
+  arena growth: 88696 (88.70 kB)
   arena size: 13073904 (13.07 MB)
 
 App.tsx
   file size: 415.34 kB
   sys allocs: 23
   sys reallocs: 2
+  sys deallocs: 28
   sys alloc bytes: 2900 (2.90 kB)
+  sys dealloc bytes: 628620 (628.62 kB)
+  peak heap growth: 2608 (2.61 kB)
   arena allocs: 618
   arena reallocs: 17
+  total arena allocs: 627
+  total arena reallocs: 25
+  arena growth: 33288 (33.29 kB)
   arena size: 2277824 (2.28 MB)
 
 RadixUIAdoptionSection.jsx
   file size: 2.52 kB
   sys allocs: 19
   sys reallocs: 2
+  sys deallocs: 24
   sys alloc bytes: 2296 (2.30 kB)
+  sys dealloc bytes: 4784 (4.78 kB)
+  peak heap growth: 2160 (2.16 kB)
   arena allocs: 258
   arena reallocs: 13
+  total arena allocs: 264
+  total arena reallocs: 20
+  arena growth: 13416 (13.42 kB)
   arena size: 34648 (34.65 kB)
 
 pdf.mjs
   file size: 567.30 kB
   sys allocs: 13
   sys reallocs: 0
+  sys deallocs: 18
   sys alloc bytes: 1610 (1.61 kB)
+  sys dealloc bytes: 1509288 (1.51 MB)
+  peak heap growth: 1610 (1.61 kB)
   arena allocs: 2
   arena reallocs: 0
+  total arena allocs: 2
+  total arena reallocs: 0
+  arena growth: 24 (24 B)
   arena size: 4559944 (4.56 MB)
 
 antd.js
   file size: 6.69 MB
   sys allocs: 13
   sys reallocs: 0
+  sys deallocs: 19
   sys alloc bytes: 1611 (1.61 kB)
+  sys dealloc bytes: 9132437 (9.13 MB)
+  peak heap growth: 1611 (1.61 kB)
   arena allocs: 2
   arena reallocs: 0
+  total arena allocs: 2
+  total arena reallocs: 0
+  arena growth: 24 (24 B)
   arena size: 29421944 (29.42 MB)
 
 binder.ts
   file size: 193.08 kB
   sys allocs: 15
   sys reallocs: 0
+  sys deallocs: 25
   sys alloc bytes: 1625 (1.62 kB)
+  sys dealloc bytes: 391843 (391.84 kB)
+  peak heap growth: 1625 (1.62 kB)
   arena allocs: 154
   arena reallocs: 0
+  total arena allocs: 161
+  total arena reallocs: 8
+  arena growth: 6840 (6.84 kB)
   arena size: 924296 (924.30 kB)
 
 kitchen-sink.tsx
   file size: 732.90 kB
   sys allocs: 182
   sys reallocs: 3
+  sys deallocs: 196
   sys alloc bytes: 17698 (17.70 kB)
+  sys dealloc bytes: 2017056 (2.02 MB)
+  peak heap growth: 3250 (3.25 kB)
   arena allocs: 6132
   arena reallocs: 280
+  total arena allocs: 6258
+  total arena reallocs: 331
+  arena growth: 334096 (334.10 kB)
   arena size: 6829952 (6.83 MB)
 

--- a/tasks/track_memory_allocations/src/lib.rs
+++ b/tasks/track_memory_allocations/src/lib.rs
@@ -50,6 +50,18 @@ impl AtomicCounter {
         self.0.update(SeqCst, SeqCst, |count| count.saturating_add(n));
     }
 
+    fn sub(&self, n: usize) {
+        self.0.update(SeqCst, SeqCst, |count| count.saturating_sub(n));
+    }
+
+    fn set(&self, n: usize) {
+        self.0.store(n, SeqCst);
+    }
+
+    fn fetch_max(&self, n: usize) {
+        self.0.fetch_max(n, SeqCst);
+    }
+
     fn reset(&self) {
         self.0.store(0, SeqCst);
     }
@@ -67,11 +79,29 @@ static NUM_REALLOC: AtomicCounter = AtomicCounter::new();
 // After regenerating on another platform, expect diffs on byte-value lines only, and take
 // those lines from the CI job's diff output.
 static NUM_ALLOC_BYTES: AtomicCounter = AtomicCounter::new();
+/// Number of system deallocations
+static NUM_DEALLOC: AtomicCounter = AtomicCounter::new();
+/// Total number of bytes returned to the system allocator.
+/// Each `realloc` counts its old size as freed (its new size is counted in `NUM_ALLOC_BYTES`),
+/// so `NUM_ALLOC_BYTES - NUM_DEALLOC_BYTES` nets out correctly across reallocations.
+static NUM_DEALLOC_BYTES: AtomicCounter = AtomicCounter::new();
+/// Number of bytes currently live in the system allocator (allocated minus freed).
+/// Unlike the counters above, arena chunks are included — this feeds a heap footprint
+/// metric, and chunk memory is real footprint. Tracks the process from its start.
+static LIVE_BYTES: AtomicCounter = AtomicCounter::new();
+/// High-water mark of [`LIVE_BYTES`]. Re-anchored to the current live level at the start of
+/// each measured operation (see `record_stats_in`), so `peak - start` is the operation's
+/// peak heap growth.
+static PEAK_LIVE_BYTES: AtomicCounter = AtomicCounter::new();
 
 fn reset_global_allocs() {
     NUM_ALLOC.reset();
     NUM_REALLOC.reset();
     NUM_ALLOC_BYTES.reset();
+    NUM_DEALLOC.reset();
+    NUM_DEALLOC_BYTES.reset();
+    // `LIVE_BYTES` and `PEAK_LIVE_BYTES` are deliberately not reset:
+    // live bytes track reality, and the peak is re-anchored per measured operation.
 }
 
 // SAFETY: Methods simply delegate to `MiMalloc` allocator to ensure that the allocator
@@ -83,12 +113,17 @@ unsafe impl GlobalAlloc for TrackedAllocator {
         if !ret.is_null() {
             NUM_ALLOC.increment();
             NUM_ALLOC_BYTES.add(layout.size());
+            LIVE_BYTES.add(layout.size());
+            PEAK_LIVE_BYTES.fetch_max(LIVE_BYTES.get());
         }
         ret
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
         unsafe { MiMalloc.dealloc(ptr, layout) };
+        NUM_DEALLOC.increment();
+        NUM_DEALLOC_BYTES.add(layout.size());
+        LIVE_BYTES.sub(layout.size());
     }
 
     unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
@@ -96,6 +131,8 @@ unsafe impl GlobalAlloc for TrackedAllocator {
         if !ret.is_null() {
             NUM_ALLOC.increment();
             NUM_ALLOC_BYTES.add(layout.size());
+            LIVE_BYTES.add(layout.size());
+            PEAK_LIVE_BYTES.fetch_max(LIVE_BYTES.get());
         }
         ret
     }
@@ -105,6 +142,12 @@ unsafe impl GlobalAlloc for TrackedAllocator {
         if !ret.is_null() {
             NUM_REALLOC.increment();
             NUM_ALLOC_BYTES.add(new_size);
+            NUM_DEALLOC_BYTES.add(layout.size());
+            // Model realloc as alloc-copy-free: both blocks are counted live momentarily,
+            // matching the worst case where the allocator cannot grow in place.
+            LIVE_BYTES.add(new_size);
+            PEAK_LIVE_BYTES.fetch_max(LIVE_BYTES.get());
+            LIVE_BYTES.sub(layout.size());
         }
         ret
     }
@@ -115,6 +158,15 @@ unsafe impl GlobalAlloc for TrackedAllocator {
 struct StageStats {
     /// Deltas of the allocation counters across the measured operation
     counters: AllocatorStats,
+    /// Largest rise of live system-allocator bytes above the operation's starting level,
+    /// at any moment during the operation. Catches transient balloons (e.g. a large scratch
+    /// buffer freed before the operation ends) that the cumulative counters cannot see.
+    /// Unlike `sys_alloc_bytes`, arena chunks are included — this is a footprint number —
+    /// so values move in chunk-sized steps when transient arenas are created.
+    peak_heap_growth: usize,
+    /// Bytes the measured `Allocator`'s arena grew during the operation
+    /// (used-bytes delta), attributing arena consumption to the stage that caused it.
+    arena_growth: usize,
     /// Bytes used in the measured `Allocator`'s arena at the end of the measured operation.
     /// A point-in-time gauge read after the operation completes, not a diffed counter.
     /// The arena is not reset between stages, so this includes content from earlier stages
@@ -130,9 +182,15 @@ struct AllocatorStats {
     sys_allocs: usize,
     /// Number of reallocations made by system allocator
     sys_reallocs: usize,
+    /// Number of deallocations made by system allocator, excluding arena chunk deallocations
+    sys_deallocs: usize,
     /// Total bytes allocated by system allocator, excluding arena chunk allocations.
     /// Each reallocation counts its full new size, not just the growth.
     sys_alloc_bytes: usize,
+    /// Total bytes freed via system allocator, excluding arena chunk deallocations.
+    /// Each reallocation counts its old size as freed, so `sys_alloc_bytes - sys_dealloc_bytes`
+    /// is the net bytes an operation retains.
+    sys_dealloc_bytes: usize,
     /// Number of chunks arenas have requested from the system allocator.
     /// Tracked separately so chunk allocations can be excluded from `sys_allocs`
     /// (see `record_stats_diff`). Not printed in snapshots because the count is platform-dependent.
@@ -141,10 +199,24 @@ struct AllocatorStats {
     /// Tracked separately so chunk bytes can be excluded from `sys_alloc_bytes`,
     /// for the same reason as `arena_chunk_allocs`. Not printed in snapshots.
     arena_chunk_alloc_bytes: usize,
-    /// Number of allocations made by arena allocator
+    /// Number of chunks arenas have returned to the system allocator.
+    /// Tracked separately so chunk deallocations can be excluded from `sys_deallocs`,
+    /// for the same reason as `arena_chunk_allocs`. Not printed in snapshots.
+    arena_chunk_deallocs: usize,
+    /// Total bytes of chunks arenas have returned to the system allocator.
+    /// Tracked separately so chunk bytes can be excluded from `sys_dealloc_bytes`.
+    /// Not printed in snapshots.
+    arena_chunk_dealloc_bytes: usize,
+    /// Number of allocations made in the measured `Allocator`'s arena
     arena_allocs: usize,
-    /// Number of reallocations made by arena allocator
+    /// Number of reallocations made in the measured `Allocator`'s arena
     arena_reallocs: usize,
+    /// Number of allocations made in ALL arenas, including short-lived arenas created and
+    /// dropped inside the operation (e.g. the arena backing `oxc_semantic`'s `Scoping`),
+    /// which are invisible to `arena_allocs`.
+    total_arena_allocs: usize,
+    /// Number of reallocations made in ALL arenas (see `total_arena_allocs`)
+    total_arena_reallocs: usize,
 }
 
 #[test]
@@ -288,22 +360,43 @@ pub fn run() -> Result<(), io::Error> {
 fn record_stats(allocator: &Allocator) -> AllocatorStats {
     let sys_allocs = NUM_ALLOC.get();
     let sys_reallocs = NUM_REALLOC.get();
+    let sys_deallocs = NUM_DEALLOC.get();
     let sys_alloc_bytes = NUM_ALLOC_BYTES.get();
+    let sys_dealloc_bytes = NUM_DEALLOC_BYTES.get();
     #[cfg(not(feature = "is_all_features"))]
-    let ((arena_allocs, arena_reallocs), (arena_chunk_allocs, arena_chunk_alloc_bytes)) =
-        (allocator.get_allocation_stats(), Allocator::global_chunk_allocation_stats());
+    let (
+        (arena_allocs, arena_reallocs),
+        (arena_chunk_allocs, arena_chunk_alloc_bytes),
+        (arena_chunk_deallocs, arena_chunk_dealloc_bytes),
+        (total_arena_allocs, total_arena_reallocs),
+    ) = (
+        allocator.get_allocation_stats(),
+        Allocator::global_chunk_allocation_stats(),
+        Allocator::global_chunk_deallocation_stats(),
+        Allocator::global_arena_allocation_stats(),
+    );
     #[cfg(feature = "is_all_features")]
-    let ((arena_allocs, arena_reallocs), (arena_chunk_allocs, arena_chunk_alloc_bytes)) =
-        ((0, 0), (0, 0));
+    let (
+        (arena_allocs, arena_reallocs),
+        (arena_chunk_allocs, arena_chunk_alloc_bytes),
+        (arena_chunk_deallocs, arena_chunk_dealloc_bytes),
+        (total_arena_allocs, total_arena_reallocs),
+    ) = ((0, 0), (0, 0), (0, 0), (0, 0));
 
     AllocatorStats {
         sys_allocs,
         sys_reallocs,
+        sys_deallocs,
         sys_alloc_bytes,
+        sys_dealloc_bytes,
         arena_chunk_allocs,
         arena_chunk_alloc_bytes,
+        arena_chunk_deallocs,
+        arena_chunk_dealloc_bytes,
         arena_allocs,
         arena_reallocs,
+        total_arena_allocs,
+        total_arena_reallocs,
     }
 }
 
@@ -321,20 +414,35 @@ fn record_stats_diff(allocator: &Allocator, prev: &AllocatorStats) -> AllocatorS
     let arena_chunk_allocs = stats.arena_chunk_allocs.saturating_sub(prev.arena_chunk_allocs);
     let arena_chunk_alloc_bytes =
         stats.arena_chunk_alloc_bytes.saturating_sub(prev.arena_chunk_alloc_bytes);
+    let arena_chunk_deallocs = stats.arena_chunk_deallocs.saturating_sub(prev.arena_chunk_deallocs);
+    let arena_chunk_dealloc_bytes =
+        stats.arena_chunk_dealloc_bytes.saturating_sub(prev.arena_chunk_dealloc_bytes);
     AllocatorStats {
         sys_allocs: stats
             .sys_allocs
             .saturating_sub(prev.sys_allocs)
             .saturating_sub(arena_chunk_allocs),
         sys_reallocs: stats.sys_reallocs.saturating_sub(prev.sys_reallocs),
+        sys_deallocs: stats
+            .sys_deallocs
+            .saturating_sub(prev.sys_deallocs)
+            .saturating_sub(arena_chunk_deallocs),
         sys_alloc_bytes: stats
             .sys_alloc_bytes
             .saturating_sub(prev.sys_alloc_bytes)
             .saturating_sub(arena_chunk_alloc_bytes),
+        sys_dealloc_bytes: stats
+            .sys_dealloc_bytes
+            .saturating_sub(prev.sys_dealloc_bytes)
+            .saturating_sub(arena_chunk_dealloc_bytes),
         arena_chunk_allocs,
         arena_chunk_alloc_bytes,
+        arena_chunk_deallocs,
+        arena_chunk_dealloc_bytes,
         arena_allocs: stats.arena_allocs.saturating_sub(prev.arena_allocs),
         arena_reallocs: stats.arena_reallocs.saturating_sub(prev.arena_reallocs),
+        total_arena_allocs: stats.total_arena_allocs.saturating_sub(prev.total_arena_allocs),
+        total_arena_reallocs: stats.total_arena_reallocs.saturating_sub(prev.total_arena_reallocs),
     }
 }
 
@@ -344,9 +452,22 @@ where
     F: FnOnce() -> R,
 {
     let before_stats = record_stats(allocator);
+    let arena_used_before = allocator.used_bytes();
+    // Anchor the high-water mark to the current live level, so that after `f` runs,
+    // `peak - live_before` is the largest heap growth at any moment during `f`.
+    let live_before = LIVE_BYTES.get();
+    PEAK_LIVE_BYTES.set(live_before);
+
     let result = f();
+
     let counters = record_stats_diff(allocator, &before_stats);
-    let stats = StageStats { counters, arena_used_bytes: allocator.used_bytes() };
+    let arena_used_bytes = allocator.used_bytes();
+    let stats = StageStats {
+        counters,
+        peak_heap_growth: PEAK_LIVE_BYTES.get().saturating_sub(live_before),
+        arena_growth: arena_used_bytes.saturating_sub(arena_used_before),
+        arena_used_bytes,
+    };
 
     (result, stats)
 }
@@ -362,9 +483,15 @@ fn format_stats(file: &TestFile, stats: &StageStats) -> String {
         ("file size", format_size(file.source_text.len(), DECIMAL)),
         ("sys allocs", counters.sys_allocs.to_string()),
         ("sys reallocs", counters.sys_reallocs.to_string()),
+        ("sys deallocs", counters.sys_deallocs.to_string()),
         ("sys alloc bytes", format_bytes(counters.sys_alloc_bytes)),
+        ("sys dealloc bytes", format_bytes(counters.sys_dealloc_bytes)),
+        ("peak heap growth", format_bytes(stats.peak_heap_growth)),
         ("arena allocs", counters.arena_allocs.to_string()),
         ("arena reallocs", counters.arena_reallocs.to_string()),
+        ("total arena allocs", counters.total_arena_allocs.to_string()),
+        ("total arena reallocs", counters.total_arena_reallocs.to_string()),
+        ("arena growth", format_bytes(stats.arena_growth)),
         ("arena size", format_bytes(stats.arena_used_bytes)),
     ];
 


### PR DESCRIPTION
Stacked on #24543. Adds six values to each per-file block, extending the snapshots with deallocation, footprint, and attribution metrics:

```
checker.ts                          (semantic stage)
  file size: 2.92 MB
  sys allocs: 46
  sys reallocs: 0
  sys deallocs: 46
  sys alloc bytes: 3866958 (3.87 MB)
  sys dealloc bytes: 3866958 (3.87 MB)
  peak heap growth: 7542870 (7.54 MB)
  arena allocs: 0
  arena reallocs: 0
  total arena allocs: 37851
  total arena reallocs: 22022
  arena growth: 0 (0 B)
  arena size: 12985152 (12.99 MB)
```

- **`sys deallocs` / `sys dealloc bytes`** — deallocations via the system allocator, with arena chunk deallocations excluded (mirroring the alloc-side exclusion). Each `realloc` counts its old size as freed, so `sys alloc bytes − sys dealloc bytes` is the net bytes a stage retains. The semantic block above shows its value: semantic's 3.87 MB of SoA tables are pure churn — allocated and fully freed within the stage.
- **`peak heap growth`** — the largest rise of live heap bytes above the stage's starting level at any moment during the stage. Catches transient balloons the cumulative counters can't see (semantic's true transient footprint is 7.54 MB, previously invisible). Arena chunks are *included* here — it's a footprint number — so values move in chunk-sized steps when transient arenas are created.
- **`total arena allocs` / `total arena reallocs`** — allocations in ALL arenas via new global counters. Fixes a blind spot: short-lived arenas dropped inside a stage (e.g. the arena backing semantic's `Scoping`) had per-arena stats that died with them — the semantic stage claimed `arena allocs: 0` while building an entire arena (actual: 37851).
- **`arena growth`** — used-bytes delta of the measured `Allocator`, attributing arena consumption to the stage that caused it; the existing `arena size` gauge stays as the cumulative view (parser: growth == size, built from empty).

`oxc_allocator`'s feature-gated tracking now also records chunk deallocation count/bytes (`global_chunk_deallocation_stats`) and global all-arena alloc/realloc counts (`global_arena_allocation_stats`).

Byte-value lines follow the established policy from #24543: snapshots record Linux x64 (CI) values. All count lines — including the new `sys deallocs` and `total arena` lines — are expected to be platform-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)