### PR TITLE
feat(track-memory-allocations): add arena size

### DIFF
--- a/tasks/track_memory_allocations/allocs_formatter.snap
+++ b/tasks/track_memory_allocations/allocs_formatter.snap
@@ -4,6 +4,7 @@ checker.ts
   sys reallocs: 492
   arena allocs: 1081815
   arena reallocs: 118690
+  arena size: 138513120 (138.51 MB)
 
 App.tsx
   file size: 415.34 kB
@@ -11,6 +12,7 @@ App.tsx
   sys reallocs: 80
   arena allocs: 212668
   arena reallocs: 25343
+  arena size: 29608728 (29.61 MB)
 
 RadixUIAdoptionSection.jsx
   file size: 2.52 kB
@@ -18,6 +20,7 @@ RadixUIAdoptionSection.jsx
   sys reallocs: 26
   arena allocs: 1155
   arena reallocs: 157
+  arena size: 210080 (210.08 kB)
 
 pdf.mjs
   file size: 567.30 kB
@@ -25,6 +28,7 @@ pdf.mjs
   sys reallocs: 172
   arena allocs: 437639
   arena reallocs: 43489
+  arena size: 44872280 (44.87 MB)
 
 antd.js
   file size: 6.69 MB
@@ -32,6 +36,7 @@ antd.js
   sys reallocs: 3994
   arena allocs: 2586207
   arena reallocs: 302459
+  arena size: 525725120 (525.73 MB)
 
 binder.ts
   file size: 193.08 kB
@@ -39,6 +44,7 @@ binder.ts
   sys reallocs: 35
   arena allocs: 64083
   arena reallocs: 6932
+  arena size: 8574792 (8.57 MB)
 
 kitchen-sink.tsx
   file size: 732.90 kB
@@ -46,4 +52,5 @@ kitchen-sink.tsx
   sys reallocs: 2815
   arena allocs: 569911
   arena reallocs: 60147
+  arena size: 57887152 (57.89 MB)
 

--- a/tasks/track_memory_allocations/allocs_minifier.snap
+++ b/tasks/track_memory_allocations/allocs_minifier.snap
@@ -4,6 +4,7 @@ checker.ts
   sys reallocs: 5
   arena allocs: 152755
   arena reallocs: 28253
+  arena size: 19046592 (19.05 MB)
 
 App.tsx
   file size: 415.34 kB
@@ -11,6 +12,7 @@ App.tsx
   sys reallocs: 8
   arena allocs: 17028
   arena reallocs: 2702
+  arena size: 2915632 (2.92 MB)
 
 RadixUIAdoptionSection.jsx
   file size: 2.52 kB
@@ -18,6 +20,7 @@ RadixUIAdoptionSection.jsx
   sys reallocs: 0
   arena allocs: 32
   arena reallocs: 6
+  arena size: 35792 (35.79 kB)
 
 pdf.mjs
   file size: 567.30 kB
@@ -25,6 +28,7 @@ pdf.mjs
   sys reallocs: 205
   arena allocs: 47471
   arena reallocs: 7742
+  arena size: 6356576 (6.36 MB)
 
 antd.js
   file size: 6.69 MB
@@ -32,6 +36,7 @@ antd.js
   sys reallocs: 56
   arena allocs: 372632
   arena reallocs: 76745
+  arena size: 49033120 (49.03 MB)
 
 binder.ts
   file size: 193.08 kB
@@ -39,6 +44,7 @@ binder.ts
   sys reallocs: 1
   arena allocs: 7076
   arena reallocs: 824
+  arena size: 1157992 (1.16 MB)
 
 kitchen-sink.tsx
   file size: 732.90 kB
@@ -46,4 +52,5 @@ kitchen-sink.tsx
   sys reallocs: 175
   arena allocs: 88129
   arena reallocs: 15654
+  arena size: 10190448 (10.19 MB)
 

--- a/tasks/track_memory_allocations/allocs_parser.snap
+++ b/tasks/track_memory_allocations/allocs_parser.snap
@@ -4,6 +4,7 @@ checker.ts
   sys reallocs: 10
   arena allocs: 264366
   arena reallocs: 22860
+  arena size: 12985208 (12.99 MB)
 
 App.tsx
   file size: 415.34 kB
@@ -11,6 +12,7 @@ App.tsx
   sys reallocs: 13
   arena allocs: 44464
   arena reallocs: 3537
+  arena size: 2244536 (2.24 MB)
 
 RadixUIAdoptionSection.jsx
   file size: 2.52 kB
@@ -18,6 +20,7 @@ RadixUIAdoptionSection.jsx
   sys reallocs: 0
   arena allocs: 367
   arena reallocs: 66
+  arena size: 21232 (21.23 kB)
 
 pdf.mjs
   file size: 567.30 kB
@@ -25,6 +28,7 @@ pdf.mjs
   sys reallocs: 67
   arena allocs: 90583
   arena reallocs: 8153
+  arena size: 4559920 (4.56 MB)
 
 antd.js
   file size: 6.69 MB
@@ -32,6 +36,7 @@ antd.js
   sys reallocs: 221
   arena allocs: 528577
   arena reallocs: 55355
+  arena size: 29421920 (29.42 MB)
 
 binder.ts
   file size: 193.08 kB
@@ -39,6 +44,7 @@ binder.ts
   sys reallocs: 0
   arena allocs: 16620
   arena reallocs: 1476
+  arena size: 917456 (917.46 kB)
 
 kitchen-sink.tsx
   file size: 732.90 kB
@@ -46,4 +52,5 @@ kitchen-sink.tsx
   sys reallocs: 160
   arena allocs: 138059
   arena reallocs: 11905
+  arena size: 6495856 (6.50 MB)
 

--- a/tasks/track_memory_allocations/allocs_semantic.snap
+++ b/tasks/track_memory_allocations/allocs_semantic.snap
@@ -4,6 +4,7 @@ checker.ts
   sys reallocs: 0
   arena allocs: 0
   arena reallocs: 0
+  arena size: 12985208 (12.99 MB)
 
 App.tsx
   file size: 415.34 kB
@@ -11,6 +12,7 @@ App.tsx
   sys reallocs: 0
   arena allocs: 0
   arena reallocs: 0
+  arena size: 2244536 (2.24 MB)
 
 RadixUIAdoptionSection.jsx
   file size: 2.52 kB
@@ -18,6 +20,7 @@ RadixUIAdoptionSection.jsx
   sys reallocs: 0
   arena allocs: 0
   arena reallocs: 0
+  arena size: 21232 (21.23 kB)
 
 pdf.mjs
   file size: 567.30 kB
@@ -25,6 +28,7 @@ pdf.mjs
   sys reallocs: 0
   arena allocs: 0
   arena reallocs: 0
+  arena size: 4559920 (4.56 MB)
 
 antd.js
   file size: 6.69 MB
@@ -32,6 +36,7 @@ antd.js
   sys reallocs: 0
   arena allocs: 0
   arena reallocs: 0
+  arena size: 29421920 (29.42 MB)
 
 binder.ts
   file size: 193.08 kB
@@ -39,6 +44,7 @@ binder.ts
   sys reallocs: 0
   arena allocs: 0
   arena reallocs: 0
+  arena size: 917456 (917.46 kB)
 
 kitchen-sink.tsx
   file size: 732.90 kB
@@ -46,4 +52,5 @@ kitchen-sink.tsx
   sys reallocs: 0
   arena allocs: 0
   arena reallocs: 0
+  arena size: 6495856 (6.50 MB)
 

--- a/tasks/track_memory_allocations/allocs_transformer.snap
+++ b/tasks/track_memory_allocations/allocs_transformer.snap
@@ -4,6 +4,7 @@ checker.ts
   sys reallocs: 0
   arena allocs: 1959
   arena reallocs: 5
+  arena size: 13073904 (13.07 MB)
 
 App.tsx
   file size: 415.34 kB
@@ -11,6 +12,7 @@ App.tsx
   sys reallocs: 2
   arena allocs: 618
   arena reallocs: 17
+  arena size: 2277824 (2.28 MB)
 
 RadixUIAdoptionSection.jsx
   file size: 2.52 kB
@@ -18,6 +20,7 @@ RadixUIAdoptionSection.jsx
   sys reallocs: 2
   arena allocs: 258
   arena reallocs: 13
+  arena size: 34648 (34.65 kB)
 
 pdf.mjs
   file size: 567.30 kB
@@ -25,6 +28,7 @@ pdf.mjs
   sys reallocs: 0
   arena allocs: 2
   arena reallocs: 0
+  arena size: 4559944 (4.56 MB)
 
 antd.js
   file size: 6.69 MB
@@ -32,6 +36,7 @@ antd.js
   sys reallocs: 0
   arena allocs: 2
   arena reallocs: 0
+  arena size: 29421944 (29.42 MB)
 
 binder.ts
   file size: 193.08 kB
@@ -39,6 +44,7 @@ binder.ts
   sys reallocs: 0
   arena allocs: 154
   arena reallocs: 0
+  arena size: 924296 (924.30 kB)
 
 kitchen-sink.tsx
   file size: 732.90 kB
@@ -46,4 +52,5 @@ kitchen-sink.tsx
   sys reallocs: 3
   arena allocs: 6132
   arena reallocs: 280
+  arena size: 6829952 (6.83 MB)
 

--- a/tasks/track_memory_allocations/src/lib.rs
+++ b/tasks/track_memory_allocations/src/lib.rs
@@ -12,7 +12,7 @@ use oxc_formatter::{JsFormatOptions, format_program, parse_for_format};
 use oxc_minifier::{CompressOptions, MangleOptions, Minifier, MinifierOptions};
 use oxc_parser::{ParseOptions, Parser};
 use oxc_semantic::SemanticBuilder;
-use oxc_tasks_common::{TestFiles, project_root};
+use oxc_tasks_common::{TestFile, TestFiles, project_root};
 use oxc_transformer::{TransformOptions, Transformer};
 
 use std::alloc::{GlobalAlloc, Layout};
@@ -25,8 +25,8 @@ struct TrackedAllocator;
 
 /// Atomic counter.
 ///
-/// Mainly just a wrapper around `AtomicUsize`, but `increment` method ensures that counter value
-/// doesn't wrap around if counter reaches `usize::MAX`.
+/// Mainly just a wrapper around `AtomicUsize`, but its methods saturate at `usize::MAX`
+/// instead of wrapping around.
 /// This is practically infeasible on 64-bit systems, but might just be possible on 32-bit.
 ///
 /// Note: `SeqCst` ordering may be stronger than required, but performance is not the primary concern here,
@@ -52,11 +52,8 @@ impl AtomicCounter {
 }
 
 /// Number of system allocations
-// NOTE: We are only tracking the number of system allocations here, and not the number of bytes that are allocated.
-// The original version of this tool did track the number of bytes, but there was some variance between platforms that
-// made it less reliable as a measurement. In general, the number of allocations is closely correlated with the size of
-// allocations, so just tracking the number of allocations is sufficient for our purposes.
 static NUM_ALLOC: AtomicCounter = AtomicCounter::new();
+/// Number of system reallocations
 static NUM_REALLOC: AtomicCounter = AtomicCounter::new();
 
 fn reset_global_allocs() {
@@ -98,6 +95,19 @@ unsafe impl GlobalAlloc for TrackedAllocator {
 }
 
 /// Stores all of the memory allocation stats that will be printed for each file.
+#[derive(Debug)]
+struct StageStats {
+    /// Deltas of the allocation counters across the measured operation
+    counters: AllocatorStats,
+    /// Bytes used in the measured `Allocator`'s arena at the end of the measured operation.
+    /// A point-in-time gauge read after the operation completes, not a diffed counter.
+    /// The arena is not reset between stages, so this includes content from earlier stages
+    /// (e.g. the AST the parser built).
+    arena_used_bytes: usize,
+}
+
+/// Counters of allocations, captured from the global and arena allocators.
+/// Used both as a raw snapshot and as per-operation deltas (see `record_stats_diff`).
 #[derive(Debug)]
 struct AllocatorStats {
     /// Number of allocations made by system allocator, excluding arena chunk allocations
@@ -187,21 +197,13 @@ pub fn run() -> Result<(), io::Error> {
             parsed
         });
 
-        parser_out.push_str(&format_stats(
-            file.file_name.as_str(),
-            file.source_text.len(),
-            &parser_stats,
-        ));
+        parser_out.push_str(&format_stats(file, &parser_stats));
 
         let ((), semantic_stats) = record_stats_in(&allocator, || {
             let _ = SemanticBuilder::new().with_enum_eval(true).build(&parsed.program);
         });
 
-        semantic_out.push_str(&format_stats(
-            file.file_name.as_str(),
-            file.source_text.len(),
-            &semantic_stats,
-        ));
+        semantic_out.push_str(&format_stats(file, &semantic_stats));
 
         // Match the production compiler path for transforms: transformers add scopes, symbols, and
         // references, so semantic analysis reserves excess capacity up front.
@@ -223,21 +225,13 @@ pub fn run() -> Result<(), io::Error> {
             .build_with_scoping(scoping, &mut parsed.program);
         });
 
-        transformer_out.push_str(&format_stats(
-            file.file_name.as_str(),
-            file.source_text.len(),
-            &transformer_stats,
-        ));
+        transformer_out.push_str(&format_stats(file, &transformer_stats));
 
         let ((), minifier_stats) = record_stats_in(&allocator, || {
             Minifier::new(minifier_options).minify(&allocator, &mut parsed.program);
         });
 
-        minifier_out.push_str(&format_stats(
-            file.file_name.as_str(),
-            file.source_text.len(),
-            &minifier_stats,
-        ));
+        minifier_out.push_str(&format_stats(file, &minifier_stats));
 
         // Formatter runs on a freshly-parsed AST (not after transformer/minifier),
         // so re-parse with the formatter's parse options before measuring the formatter
@@ -254,11 +248,7 @@ pub fn run() -> Result<(), io::Error> {
                 .into_code()
         });
 
-        formatter_out.push_str(&format_stats(
-            file.file_name.as_str(),
-            file.source_text.len(),
-            &formatter_stats,
-        ));
+        formatter_out.push_str(&format_stats(file, &formatter_stats));
     }
 
     write_snapshot("tasks/track_memory_allocations/allocs_parser.snap", &parser_out)?;
@@ -276,13 +266,10 @@ fn record_stats(allocator: &Allocator) -> AllocatorStats {
     let sys_allocs = NUM_ALLOC.get();
     let sys_reallocs = NUM_REALLOC.get();
     #[cfg(not(feature = "is_all_features"))]
-    let (arena_allocs, arena_reallocs) = allocator.get_allocation_stats();
+    let ((arena_allocs, arena_reallocs), arena_chunk_allocs) =
+        (allocator.get_allocation_stats(), Allocator::global_chunk_allocation_count());
     #[cfg(feature = "is_all_features")]
-    let (arena_allocs, arena_reallocs) = (0, 0);
-    #[cfg(not(feature = "is_all_features"))]
-    let arena_chunk_allocs = Allocator::global_chunk_allocation_count();
-    #[cfg(feature = "is_all_features")]
-    let arena_chunk_allocs = 0;
+    let ((arena_allocs, arena_reallocs), arena_chunk_allocs) = ((0, 0), 0);
 
     AllocatorStats { sys_allocs, sys_reallocs, arena_chunk_allocs, arena_allocs, arena_reallocs }
 }
@@ -312,15 +299,16 @@ fn record_stats_diff(allocator: &Allocator, prev: &AllocatorStats) -> AllocatorS
 }
 
 /// Records the allocations stats before and after the given closure is executed.
-fn record_stats_in<F, R>(allocator: &Allocator, f: F) -> (R, AllocatorStats)
+fn record_stats_in<F, R>(allocator: &Allocator, f: F) -> (R, StageStats)
 where
     F: FnOnce() -> R,
 {
     let before_stats = record_stats(allocator);
     let result = f();
-    let diff_stats = record_stats_diff(allocator, &before_stats);
+    let counters = record_stats_diff(allocator, &before_stats);
+    let stats = StageStats { counters, arena_used_bytes: allocator.used_bytes() };
 
-    (result, diff_stats)
+    (result, stats)
 }
 
 /// Formats the allocator stats for one file as a block of `label: value` lines.
@@ -328,23 +316,32 @@ where
 /// One value per line, with no column alignment, so that a change to one value produces
 /// a one-line diff, and adding a new value later doesn't reformat existing lines.
 /// File names stay at column 0 so they appear in git hunk headers.
-fn format_stats(file_name: &str, file_size: usize, stats: &AllocatorStats) -> String {
+fn format_stats(file: &TestFile, stats: &StageStats) -> String {
+    let counters = &stats.counters;
     let values = [
-        ("file size", format_size(file_size, DECIMAL)),
-        ("sys allocs", stats.sys_allocs.to_string()),
-        ("sys reallocs", stats.sys_reallocs.to_string()),
-        ("arena allocs", stats.arena_allocs.to_string()),
-        ("arena reallocs", stats.arena_reallocs.to_string()),
+        ("file size", format_size(file.source_text.len(), DECIMAL)),
+        ("sys allocs", counters.sys_allocs.to_string()),
+        ("sys reallocs", counters.sys_reallocs.to_string()),
+        ("arena allocs", counters.arena_allocs.to_string()),
+        ("arena reallocs", counters.arena_reallocs.to_string()),
+        ("arena size", format_bytes(stats.arena_used_bytes)),
     ];
 
     let mut out = String::new();
-    out.push_str(file_name);
+    out.push_str(&file.file_name);
     out.push('\n');
     for (label, value) in values {
         writeln!(out, "  {label}: {value}").unwrap();
     }
     out.push('\n');
     out
+}
+
+/// Formats a byte count as the exact number followed by a human-readable size,
+/// e.g. `12582912 (12.58 MB)`. The exact number is what diffs; the human-readable
+/// form is only there for scanning.
+fn format_bytes(bytes: usize) -> String {
+    format!("{bytes} ({})", format_size(bytes, DECIMAL))
 }
 
 fn write_snapshot(file_path: &str, contents: &str) -> Result<(), io::Error> {


### PR DESCRIPTION
First of three PRs splitting the byte-metrics work (followed by chunk-alloc-bytes and heap-alloc-bytes).

Adds an `arena size` value to each per-file block: the measured `Allocator`'s used bytes (`Allocator::used_bytes()`) at the end of the stage. It is a point-in-time gauge read after the operation, not a diffed counter — the arena is not reset between stages, so e.g. the transformer's value includes the AST the parser built.

```
checker.ts
  file size: 2.92 MB
  sys allocs: 1818
  sys reallocs: 10
  arena allocs: 264366
  arena reallocs: 22860
  arena size: 12985208 (12.99 MB)
```

Structurally, this introduces the counter/gauge split (`StageStats` wraps the diffed `AllocatorStats` counters plus point-in-time gauges), and byte values print as the exact number plus a human-readable size.

**Platform note**: byte totals vary between platforms (type layouts differ, e.g. hashbrown tables are wider on x86_64 than aarch64) while counts are identical everywhere, so snapshots record byte values from CI's platform (Linux x64). Regenerating on another platform diffs byte-value lines only; take those lines from the CI job's output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)