### PR TITLE
feat(allocator): record byte size of arena chunk allocations

### DIFF
--- a/crates/oxc_allocator/src/arena/create.rs
+++ b/crates/oxc_allocator/src/arena/create.rs
@@ -415,7 +415,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         let start_ptr = NonNull::new(start_ptr)?;
 
         #[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]
-        crate::tracking::record_chunk_allocation();
+        crate::tracking::record_chunk_allocation(layout.size());
 
         // The `ChunkFooter` is at the end of the chunk.
         // SAFETY: We allocated `new_size_without_footer + CHUNK_FOOTER_SIZE` bytes, starting at `start_ptr`,

--- a/crates/oxc_allocator/src/tracking.rs
+++ b/crates/oxc_allocator/src/tracking.rs
@@ -23,11 +23,18 @@ use crate::{Allocator, arena::Arena};
 /// the operation being measured, so their counters cannot be read after the operation completes.
 static NUM_CHUNK_ALLOC: AtomicUsize = AtomicUsize::new(0);
 
-/// Record that a chunk was allocated from the system allocator.
-pub fn record_chunk_allocation() {
-    // Counter maxes out at `usize::MAX`, but if there's that many allocations,
+/// Total size in bytes of all chunks [`Arena`]s have requested from the system allocator.
+///
+/// A global counter, for the same reason as [`NUM_CHUNK_ALLOC`].
+static NUM_CHUNK_ALLOC_BYTES: AtomicUsize = AtomicUsize::new(0);
+
+/// Record that a chunk of `size` bytes was allocated from the system allocator.
+pub fn record_chunk_allocation(size: usize) {
+    // Counters max out at `usize::MAX`, but if there's that many allocations,
     // the exact number is not important
     NUM_CHUNK_ALLOC.update(Ordering::Relaxed, Ordering::Relaxed, |count| count.saturating_add(1));
+    NUM_CHUNK_ALLOC_BYTES
+        .update(Ordering::Relaxed, Ordering::Relaxed, |total| total.saturating_add(size));
 }
 
 /// Counters of allocations and reallocations made in an [`Allocator`].
@@ -91,9 +98,10 @@ impl Allocator {
         self.arena().get_allocation_stats()
     }
 
-    /// Get number of chunks all [`Arena`]s have requested from the system allocator, in total.
+    /// Get number and total size in bytes of chunks all [`Arena`]s have requested from
+    /// the system allocator, as `(count, bytes)`.
     #[doc(hidden)]
-    pub fn global_chunk_allocation_count() -> usize {
-        NUM_CHUNK_ALLOC.load(Ordering::Relaxed)
+    pub fn global_chunk_allocation_stats() -> (usize, usize) {
+        (NUM_CHUNK_ALLOC.load(Ordering::Relaxed), NUM_CHUNK_ALLOC_BYTES.load(Ordering::Relaxed))
     }
 }

--- a/tasks/track_memory_allocations/src/lib.rs
+++ b/tasks/track_memory_allocations/src/lib.rs
@@ -266,10 +266,11 @@ fn record_stats(allocator: &Allocator) -> AllocatorStats {
     let sys_allocs = NUM_ALLOC.get();
     let sys_reallocs = NUM_REALLOC.get();
     #[cfg(not(feature = "is_all_features"))]
-    let ((arena_allocs, arena_reallocs), arena_chunk_allocs) =
-        (allocator.get_allocation_stats(), Allocator::global_chunk_allocation_count());
+    let ((arena_allocs, arena_reallocs), (arena_chunk_allocs, _arena_chunk_alloc_bytes)) =
+        (allocator.get_allocation_stats(), Allocator::global_chunk_allocation_stats());
     #[cfg(feature = "is_all_features")]
-    let ((arena_allocs, arena_reallocs), arena_chunk_allocs) = ((0, 0), 0);
+    let ((arena_allocs, arena_reallocs), (arena_chunk_allocs, _arena_chunk_alloc_bytes)) =
+        ((0, 0), (0, 0));
 
     AllocatorStats { sys_allocs, sys_reallocs, arena_chunk_allocs, arena_allocs, arena_reallocs }
 }


### PR DESCRIPTION
Second of three PRs splitting the byte-metrics work (stacked on the arena-size PR); no snapshot changes.

The `track_allocations` tracking already counts how many chunks arenas request from the system allocator, so `tasks/track_memory_allocations` can exclude them from its system-allocator counts — chunk requests would otherwise make the counts platform-dependent (see #22621). This records the total byte size of those chunks too, and extends the accessor to `Allocator::global_chunk_allocation_stats() -> (count, bytes)`, matching the existing `get_allocation_stats()` shape.

This enables the next PR to exclude chunk bytes from a new total-heap-allocated-bytes metric, the same way chunk counts are excluded from `sys allocs` today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)